### PR TITLE
[fix](be) Preserve floating equality in Parquet Bloom pruning

### DIFF
--- a/be/src/exprs/expr_zonemap_filter.cpp
+++ b/be/src/exprs/expr_zonemap_filter.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cmath>
 #include <set>
+#include <type_traits>
 #include <utility>
 
 #include "common/check.h"
@@ -61,6 +62,24 @@ bool dictionary_contains(const DictionaryEvalContext::SlotDictionary& dictionary
     });
 }
 
+template <typename T>
+bool floating_point_bloom_filter_may_contain(const segment_v2::BloomFilter& bloom_filter, T value) {
+    static_assert(std::is_floating_point_v<T>);
+    // Doris equality collapses NaN payloads and signed zeros, while Parquet Bloom hashes physical
+    // bytes. A negative probe is safe only after covering the entire Doris-equivalent class.
+    if (std::isnan(value)) {
+        return true;
+    }
+    const auto test_value = [&](T candidate) {
+        return bloom_filter.test_bytes(reinterpret_cast<const char*>(&candidate),
+                                       sizeof(candidate));
+    };
+    if (test_value(value)) {
+        return true;
+    }
+    return value == T {0} && test_value(-value);
+}
+
 bool bloom_filter_may_contain(const BloomFilterEvalContext::SlotBloomFilter& slot_filter,
                               const Field& value) {
     DORIS_CHECK(slot_filter.data_type != nullptr);
@@ -85,21 +104,11 @@ bool bloom_filter_may_contain(const BloomFilterEvalContext::SlotBloomFilter& slo
     }
     case TYPE_FLOAT: {
         const float typed_value = value.get<TYPE_FLOAT>();
-        // Doris equates all NaN payloads, but Parquet Bloom hashes their physical bits, so a
-        // negative raw-byte probe cannot prove that an equivalent NaN is absent.
-        if (std::isnan(typed_value)) {
-            return true;
-        }
-        return slot_filter.bloom_filter->test_bytes(reinterpret_cast<const char*>(&typed_value),
-                                                    sizeof(typed_value));
+        return floating_point_bloom_filter_may_contain(*slot_filter.bloom_filter, typed_value);
     }
     case TYPE_DOUBLE: {
         const double typed_value = value.get<TYPE_DOUBLE>();
-        if (std::isnan(typed_value)) {
-            return true;
-        }
-        return slot_filter.bloom_filter->test_bytes(reinterpret_cast<const char*>(&typed_value),
-                                                    sizeof(typed_value));
+        return floating_point_bloom_filter_may_contain(*slot_filter.bloom_filter, typed_value);
     }
     case TYPE_CHAR:
     case TYPE_VARCHAR:

--- a/be/src/exprs/expr_zonemap_filter.cpp
+++ b/be/src/exprs/expr_zonemap_filter.cpp
@@ -279,6 +279,15 @@ ZoneMapFilterResult eval_in_zonemap(const ZoneMapEvalContext& ctx, const VExprSP
     DORIS_CHECK(field_types_compatible(min_value.get_type(), data_type->get_primitive_type()));
     DORIS_CHECK(field_types_compatible(max_value.get_type(), data_type->get_primitive_type()));
 
+    if (!is_not_in && ctx.floating_nan_count_unknown(slot->column_id()) &&
+        std::ranges::any_of(values, [&](const Field& value) {
+            return field_is_nan(value, data_type->get_primitive_type());
+        })) {
+        // Parquet range bounds may omit NaNs, so they cannot disprove an IN candidate containing
+        // one without a separate trustworthy NaN count.
+        return unsupported_zonemap_filter(ctx);
+    }
+
     // Re-check against the reader-schema type and the available zone map. Missing or unsupported
     // metadata must conservatively fall back to may-match.
     auto slot_type = fetch_compatible_slot_type(ctx, slot->column_id(), slot->data_type());

--- a/be/src/exprs/expr_zonemap_filter.cpp
+++ b/be/src/exprs/expr_zonemap_filter.cpp
@@ -169,6 +169,7 @@ Status materialize_hybrid_set_for_zonemap_filter(HybridSetBase& set, const DataT
     DORIS_CHECK(value_type != nullptr);
 
     result->contains_null = set.contain_null();
+    result->contains_nan = false;
     result->values.clear();
     result->min_value = Field();
     result->max_value = Field();
@@ -183,6 +184,7 @@ Status materialize_hybrid_set_for_zonemap_filter(HybridSetBase& set, const DataT
             auto literal = VLiteral::create_shared(literal_node);
             Field field;
             literal->get_column_ptr()->get(0, field);
+            result->contains_nan |= field_is_nan(field, value_type->get_primitive_type());
             result->values.emplace_back(std::move(field));
         }
         iterator->next();
@@ -262,7 +264,8 @@ ZoneMapFilterResult eval_null_zonemap(const ZoneMapEvalContext& ctx, const VExpr
 
 ZoneMapFilterResult eval_in_zonemap(const ZoneMapEvalContext& ctx, const VExprSPtr& slot_expr,
                                     bool is_not_in, const std::vector<Field>& values,
-                                    const Field& min_value, const Field& max_value) {
+                                    bool contains_nan, const Field& min_value,
+                                    const Field& max_value) {
     auto slot = std::dynamic_pointer_cast<VSlotRef>(slot_expr);
     DORIS_CHECK(slot != nullptr);
     // Empty IN has no candidate values, while NOT IN with an empty set cannot filter anything.
@@ -279,15 +282,6 @@ ZoneMapFilterResult eval_in_zonemap(const ZoneMapEvalContext& ctx, const VExprSP
     DORIS_CHECK(field_types_compatible(min_value.get_type(), data_type->get_primitive_type()));
     DORIS_CHECK(field_types_compatible(max_value.get_type(), data_type->get_primitive_type()));
 
-    if (!is_not_in && ctx.floating_nan_count_unknown(slot->column_id()) &&
-        std::ranges::any_of(values, [&](const Field& value) {
-            return field_is_nan(value, data_type->get_primitive_type());
-        })) {
-        // Parquet range bounds may omit NaNs, so they cannot disprove an IN candidate containing
-        // one without a separate trustworthy NaN count.
-        return unsupported_zonemap_filter(ctx);
-    }
-
     // Re-check against the reader-schema type and the available zone map. Missing or unsupported
     // metadata must conservatively fall back to may-match.
     auto slot_type = fetch_compatible_slot_type(ctx, slot->column_id(), slot->data_type());
@@ -302,6 +296,12 @@ ZoneMapFilterResult eval_in_zonemap(const ZoneMapEvalContext& ctx, const VExprSP
     // IN values are all non-null here, so an all-null zone cannot match.
     if (!zone_map.has_not_null) {
         return ZoneMapFilterResult::kNoMatch;
+    }
+
+    if (ctx.floating_nan_count_unknown(slot->column_id()) &&
+        ((!is_not_in && contains_nan) || (is_not_in && !contains_nan))) {
+        // Hidden Parquet NaNs can satisfy IN only when queried, and NOT IN only when omitted.
+        return unsupported_zonemap_filter(ctx);
     }
 
     if (!range_stats_usable_for_zonemap(zone_map, slot_type)) {

--- a/be/src/exprs/expr_zonemap_filter.cpp
+++ b/be/src/exprs/expr_zonemap_filter.cpp
@@ -18,6 +18,7 @@
 #include "exprs/expr_zonemap_filter.h"
 
 #include <algorithm>
+#include <cmath>
 #include <set>
 #include <utility>
 
@@ -84,11 +85,19 @@ bool bloom_filter_may_contain(const BloomFilterEvalContext::SlotBloomFilter& slo
     }
     case TYPE_FLOAT: {
         const float typed_value = value.get<TYPE_FLOAT>();
+        // Doris equates all NaN payloads, but Parquet Bloom hashes their physical bits, so a
+        // negative raw-byte probe cannot prove that an equivalent NaN is absent.
+        if (std::isnan(typed_value)) {
+            return true;
+        }
         return slot_filter.bloom_filter->test_bytes(reinterpret_cast<const char*>(&typed_value),
                                                     sizeof(typed_value));
     }
     case TYPE_DOUBLE: {
         const double typed_value = value.get<TYPE_DOUBLE>();
+        if (std::isnan(typed_value)) {
+            return true;
+        }
         return slot_filter.bloom_filter->test_bytes(reinterpret_cast<const char*>(&typed_value),
                                                     sizeof(typed_value));
     }

--- a/be/src/exprs/expr_zonemap_filter.h
+++ b/be/src/exprs/expr_zonemap_filter.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <compare>
 #include <map>
 #include <optional>
@@ -109,6 +110,19 @@ Status materialize_hybrid_set_for_zonemap_filter(HybridSetBase& set, const DataT
 
 inline bool field_types_compatible(PrimitiveType lhs, PrimitiveType rhs) {
     return lhs == rhs || (is_string_type(lhs) && is_string_type(rhs));
+}
+
+inline bool field_is_nan(const Field& field, PrimitiveType type) {
+    if (field.is_null()) {
+        return false;
+    }
+    if (type == TYPE_FLOAT) {
+        return std::isnan(field.get<TYPE_FLOAT>());
+    }
+    if (type == TYPE_DOUBLE) {
+        return std::isnan(field.get<TYPE_DOUBLE>());
+    }
+    return false;
 }
 
 inline bool data_types_compatible(const DataTypePtr& lhs, const DataTypePtr& rhs) {

--- a/be/src/exprs/expr_zonemap_filter.h
+++ b/be/src/exprs/expr_zonemap_filter.h
@@ -47,6 +47,7 @@ namespace doris::expr_zonemap {
 
 struct InZonemapMaterializedSet {
     bool contains_null = false;
+    bool contains_nan = false;
     std::vector<Field> values;
     Field min_value;
     Field max_value;
@@ -157,7 +158,8 @@ ZoneMapFilterResult eval_null_zonemap(const ZoneMapEvalContext& ctx, const VExpr
 
 ZoneMapFilterResult eval_in_zonemap(const ZoneMapEvalContext& ctx, const VExprSPtr& slot_expr,
                                     bool is_not_in, const std::vector<Field>& values,
-                                    const Field& min_value, const Field& max_value);
+                                    bool contains_nan, const Field& min_value,
+                                    const Field& max_value);
 
 ZoneMapFilterResult eval_eq_dictionary(const DictionaryEvalContext& ctx,
                                        const SlotLiteral& slot_literal);

--- a/be/src/exprs/function/functions_comparison.h
+++ b/be/src/exprs/function/functions_comparison.h
@@ -377,7 +377,14 @@ inline bool can_evaluate(const VExprSPtrs& arguments) {
 }
 
 inline bool can_evaluate_equality(const VExprSPtrs& arguments, Op op) {
-    return op == Op::EQ && can_evaluate(arguments);
+    if (op != Op::EQ || !can_evaluate(arguments)) {
+        return false;
+    }
+    const auto slot_literal = expr_zonemap::extract_slot_and_literal(arguments);
+    DORIS_CHECK(slot_literal.has_value());
+    // Bloom membership cannot disprove Doris NaN equality across different physical encodings.
+    return !expr_zonemap::field_is_nan(
+            slot_literal->literal, remove_nullable(slot_literal->slot_type)->get_primitive_type());
 }
 
 inline bool dictionary_value_matches(const Field& value, const Field& literal, Op op) {

--- a/be/src/exprs/function/functions_comparison.h
+++ b/be/src/exprs/function/functions_comparison.h
@@ -314,6 +314,11 @@ inline ZoneMapFilterResult evaluate(const ZoneMapEvalContext& ctx, const VExprSP
 
     const auto effective_op = slot_literal->literal_on_left ? symmetric_op(op) : op;
     const auto& literal = slot_literal->literal;
+    if (effective_op == Op::EQ && ctx.floating_nan_count_unknown(slot_literal->slot_index) &&
+        expr_zonemap::field_is_nan(literal, remove_nullable(slot_type)->get_primitive_type())) {
+        // Parquet min/max can describe only finite values from a mixed finite/NaN chunk.
+        return unsupported_zonemap_filter(ctx);
+    }
     switch (effective_op) {
     case Op::EQ:
         return literal < zone_map.min_value || zone_map.max_value < literal

--- a/be/src/exprs/function/functions_comparison.h
+++ b/be/src/exprs/function/functions_comparison.h
@@ -314,9 +314,14 @@ inline ZoneMapFilterResult evaluate(const ZoneMapEvalContext& ctx, const VExprSP
 
     const auto effective_op = slot_literal->literal_on_left ? symmetric_op(op) : op;
     const auto& literal = slot_literal->literal;
-    if (effective_op == Op::EQ && ctx.floating_nan_count_unknown(slot_literal->slot_index) &&
-        expr_zonemap::field_is_nan(literal, remove_nullable(slot_type)->get_primitive_type())) {
-        // Parquet min/max can describe only finite values from a mixed finite/NaN chunk.
+    const bool literal_is_nan =
+            expr_zonemap::field_is_nan(literal, remove_nullable(slot_type)->get_primitive_type());
+    const bool hidden_nan_can_match = (effective_op == Op::EQ && literal_is_nan) ||
+                                      (effective_op == Op::NE && !literal_is_nan) ||
+                                      (effective_op == Op::GT && !literal_is_nan) ||
+                                      effective_op == Op::GE;
+    if (ctx.floating_nan_count_unknown(slot_literal->slot_index) && hidden_nan_can_match) {
+        // Parquet bounds omit NaNs, so only operators that cannot match a hidden NaN may prune.
         return unsupported_zonemap_filter(ctx);
     }
     switch (effective_op) {

--- a/be/src/exprs/hybrid_set.h
+++ b/be/src/exprs/hybrid_set.h
@@ -144,6 +144,19 @@ struct IsBitSetContainer : std::false_type {};
 template <typename T>
 struct IsBitSetContainer<BitSetContainer<T>> : std::true_type {};
 
+template <typename T>
+struct DynamicContainerHash {
+    size_t operator()(const T& value) const {
+        if constexpr (std::is_floating_point_v<T>) {
+            T normalized = value;
+            // The hash must collapse NaN payloads and signed zeros exactly as Doris equality does.
+            NormalizeFloat(normalized);
+            return phmap::Hash<T> {}(normalized);
+        }
+        return phmap::Hash<T> {}(value);
+    }
+};
+
 /**
  * Dynamic Container uses phmap::flat_hash_set.
  * @tparam T Element Type
@@ -152,7 +165,8 @@ template <typename T>
 class DynamicContainer {
 public:
     using Self = DynamicContainer;
-    using Iterator = typename flat_hash_set<T>::iterator;
+    using Set = flat_hash_set<T, DynamicContainerHash<T>>;
+    using Iterator = typename Set::iterator;
     using ElementType = T;
 
     DynamicContainer() = default;
@@ -173,7 +187,7 @@ public:
     size_t size() const { return _set.size(); }
 
 private:
-    flat_hash_set<T> _set;
+    Set _set;
 };
 
 // TODO Maybe change void* parameter to template parameter better.

--- a/be/src/exprs/vdirect_in_predicate.h
+++ b/be/src/exprs/vdirect_in_predicate.h
@@ -41,6 +41,7 @@ class VDirectInPredicate final : public VExpr {
         std::once_flag materialize_once;
         Status materialization_status;
         bool zonemap_materialized = false;
+        bool seg_filter_contains_nan = false;
         std::vector<Field> seg_filter_values;
         Field seg_filter_min;
         Field seg_filter_max;
@@ -101,7 +102,8 @@ public:
     ZoneMapFilterResult evaluate_zonemap_filter(const ZoneMapEvalContext& ctx) const override {
         return expr_zonemap::eval_in_zonemap(
                 ctx, get_child(0), false, _pruning_state->seg_filter_values,
-                _pruning_state->seg_filter_min, _pruning_state->seg_filter_max);
+                _pruning_state->seg_filter_contains_nan, _pruning_state->seg_filter_min,
+                _pruning_state->seg_filter_max);
     }
 
     bool can_evaluate_zonemap_filter() const override {
@@ -329,6 +331,7 @@ private:
                 return;
             }
             pruning_state->seg_filter_values = std::move(materialized.values);
+            pruning_state->seg_filter_contains_nan = materialized.contains_nan;
             pruning_state->seg_filter_min = std::move(materialized.min_value);
             pruning_state->seg_filter_max = std::move(materialized.max_value);
             pruning_state->zonemap_materialized = true;

--- a/be/src/exprs/vin_predicate.cpp
+++ b/be/src/exprs/vin_predicate.cpp
@@ -220,7 +220,8 @@ ZoneMapFilterResult VInPredicate::evaluate_bloom_filter(const BloomFilterEvalCon
 }
 
 bool VInPredicate::can_evaluate_bloom_filter() const {
-    return _zonemap_materialized && !_is_not_in &&
+    // A NaN member forces conservative retention regardless of the remaining finite probes.
+    return _zonemap_materialized && !_is_not_in && !_seg_filter_contains_nan &&
            std::dynamic_pointer_cast<VSlotRef>(get_child(0)) != nullptr;
 }
 

--- a/be/src/exprs/vin_predicate.cpp
+++ b/be/src/exprs/vin_predicate.cpp
@@ -157,6 +157,7 @@ Status VInPredicate::evaluate_inverted_index(VExprContext* context, uint32_t seg
 Status VInPredicate::_materialize_for_zonemap_filter(VExprContext* context) {
     _seg_filter_values.clear();
     _seg_filter_contains_null = false;
+    _seg_filter_contains_nan = false;
     _zonemap_materialized = false;
     _direct_filter_set.reset();
     if (_children.size() < 2 || !_children[0]->is_slot_ref()) {
@@ -183,6 +184,7 @@ Status VInPredicate::_materialize_for_zonemap_filter(VExprContext* context) {
     RETURN_IF_ERROR(expr_zonemap::materialize_hybrid_set_for_zonemap_filter(
             *in_state->hybrid_set, data_type, &materialized));
     _seg_filter_contains_null = materialized.contains_null;
+    _seg_filter_contains_nan = materialized.contains_nan;
     _seg_filter_values = std::move(materialized.values);
     _seg_filter_min = std::move(materialized.min_value);
     _seg_filter_max = std::move(materialized.max_value);
@@ -195,7 +197,8 @@ ZoneMapFilterResult VInPredicate::evaluate_zonemap_filter(const ZoneMapEvalConte
         return ZoneMapFilterResult::kNoMatch;
     }
     return expr_zonemap::eval_in_zonemap(ctx, get_child(0), _is_not_in, _seg_filter_values,
-                                         _seg_filter_min, _seg_filter_max);
+                                         _seg_filter_contains_nan, _seg_filter_min,
+                                         _seg_filter_max);
 }
 
 bool VInPredicate::can_evaluate_zonemap_filter() const {

--- a/be/src/exprs/vin_predicate.h
+++ b/be/src/exprs/vin_predicate.h
@@ -102,6 +102,7 @@ private:
     bool _is_args_all_constant = false;
     bool _zonemap_materialized = false;
     bool _seg_filter_contains_null = false;
+    bool _seg_filter_contains_nan = false;
     std::shared_ptr<HybridSetBase> _direct_filter_set;
     std::vector<Field> _seg_filter_values;
     Field _seg_filter_min;

--- a/be/src/format/parquet/parquet_block_split_bloom_filter.h
+++ b/be/src/format/parquet/parquet_block_split_bloom_filter.h
@@ -19,6 +19,9 @@
 
 #include <stdint.h>
 
+#include <cmath>
+#include <type_traits>
+
 #include "storage/index/bloom_filter/bloom_filter.h"
 
 namespace doris {
@@ -40,6 +43,23 @@ public:
     Status init(const char* buf, size_t size, segment_v2::HashStrategyPB strategy) override;
     void add_bytes(const char* buf, size_t size) override;
     bool test_bytes(const char* buf, size_t size) const override;
+
+    template <typename T>
+    bool test_floating_point(T value) const {
+        static_assert(std::is_floating_point_v<T>);
+        // Doris equality collapses NaN payloads and signed zeros, so raw Parquet Bloom bytes may
+        // disprove membership only after every representable equivalent has been covered.
+        if (std::isnan(value)) {
+            return true;
+        }
+        if (test_bytes(reinterpret_cast<const char*>(&value), sizeof(value))) {
+            return true;
+        }
+        const T opposite_zero = -value;
+        return value == T {0} &&
+               test_bytes(reinterpret_cast<const char*>(&opposite_zero), sizeof(opposite_zero));
+    }
+
     void set_has_null(bool has_null) override;
     bool has_null() const override { return false; }
 

--- a/be/src/format/parquet/vparquet_reader.cpp
+++ b/be/src/format/parquet/vparquet_reader.cpp
@@ -1404,6 +1404,10 @@ Status ParquetReader::_process_expr_zonemap_page_filter(
             ZoneMapEvalContext ctx;
             ZoneMapEvalContext::SlotZoneMap slot_zone_map;
             slot_zone_map.data_type = slot->type();
+            const auto primitive_type =
+                    remove_nullable(stat->col_schema->data_type)->get_primitive_type();
+            slot_zone_map.floating_nan_count_unknown =
+                    primitive_type == TYPE_FLOAT || primitive_type == TYPE_DOUBLE;
             segment_v2::ZoneMap zone_map;
             zone_map.has_null = stat->has_null[page_id];
             zone_map.has_not_null = !stat->is_all_null[page_id];
@@ -1663,6 +1667,9 @@ Status ParquetReader::_process_expr_zonemap_filter(const tparquet::RowGroup& row
         const auto& file_col_name =
                 _table_info_node_ptr->children_file_column_name(slot->col_name());
         const FieldSchema* col_schema = _file_metadata->schema().get_column(file_col_name);
+        const auto primitive_type = remove_nullable(col_schema->data_type)->get_primitive_type();
+        slot_zone_map.floating_nan_count_unknown =
+                primitive_type == TYPE_FLOAT || primitive_type == TYPE_DOUBLE;
         int parquet_col_id = col_schema->physical_column_index;
         if (parquet_col_id < 0) {
             // Complex parent fields do not map to a physical Parquet column.

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -519,6 +519,9 @@ void add_slot_zonemap(ZoneMapEvalContext* ctx, int slot_index, const DataTypePtr
     ZoneMapEvalContext::SlotZoneMap slot_zone_map;
     slot_zone_map.data_type = data_type;
     slot_zone_map.zone_map = std::move(zone_map);
+    const auto primitive_type = remove_nullable(data_type)->get_primitive_type();
+    slot_zone_map.floating_nan_count_unknown =
+            primitive_type == TYPE_FLOAT || primitive_type == TYPE_DOUBLE;
     ctx->slots.emplace(slot_index, std::move(slot_zone_map));
 }
 

--- a/be/src/storage/index/zone_map/zonemap_eval_context.cpp
+++ b/be/src/storage/index/zone_map/zonemap_eval_context.cpp
@@ -37,6 +37,11 @@ DataTypePtr ZoneMapEvalContext::data_type(int slot_index) const {
     return it->second.data_type;
 }
 
+bool ZoneMapEvalContext::floating_nan_count_unknown(int slot_index) const {
+    auto it = slots.find(slot_index);
+    return it != slots.end() && it->second.floating_nan_count_unknown;
+}
+
 void ZoneMapEvalStats::merge_page_eval_stats(const ZoneMapEvalStats& src) {
     // Page-level evaluation repeats the same conjuncts for many pages. Keep structural
     // diagnostics once per column, while operation counters still reflect actual page checks.

--- a/be/src/storage/index/zone_map/zonemap_eval_context.h
+++ b/be/src/storage/index/zone_map/zonemap_eval_context.h
@@ -52,10 +52,13 @@ public:
     struct SlotZoneMap {
         DataTypePtr data_type;
         std::shared_ptr<const segment_v2::ZoneMap> zone_map;
+        // Parquet min/max does not expose whether a floating chunk also contains NaNs.
+        bool floating_nan_count_unknown = false;
     };
 
     std::shared_ptr<const segment_v2::ZoneMap> zone_map(int slot_index) const;
     DataTypePtr data_type(int slot_index) const;
+    bool floating_nan_count_unknown(int slot_index) const;
 
     phmap::flat_hash_map<int, SlotZoneMap> slots;
 

--- a/be/src/storage/predicate/comparison_predicate.h
+++ b/be/src/storage/predicate/comparison_predicate.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <cstdint>
 #include <type_traits>
 
@@ -167,6 +168,12 @@ public:
         T max_value = max_field.template get<Type>();
 
         if constexpr (PT == PredicateType::EQ) {
+            if constexpr (Type == TYPE_FLOAT || Type == TYPE_DOUBLE) {
+                // Parquet range bounds may exclude NaNs from a mixed-value chunk.
+                if (std::isnan(_value)) {
+                    return true;
+                }
+            }
             return Compare::less_equal(min_value, _value) &&
                    Compare::greater_equal(max_value, _value);
         } else if constexpr (PT == PredicateType::NE) {

--- a/be/src/storage/predicate/comparison_predicate.h
+++ b/be/src/storage/predicate/comparison_predicate.h
@@ -167,13 +167,19 @@ public:
         T min_value = min_field.template get<Type>();
         T max_value = max_field.template get<Type>();
 
-        if constexpr (PT == PredicateType::EQ) {
-            if constexpr (Type == TYPE_FLOAT || Type == TYPE_DOUBLE) {
-                // Parquet range bounds may exclude NaNs from a mixed-value chunk.
-                if (std::isnan(_value)) {
-                    return true;
-                }
+        if constexpr (Type == TYPE_FLOAT || Type == TYPE_DOUBLE) {
+            constexpr bool hidden_nan_can_match_non_nan =
+                    PT == PredicateType::NE || PT == PredicateType::GT || PT == PredicateType::GE;
+            constexpr bool hidden_nan_can_match_nan =
+                    PT == PredicateType::EQ || PT == PredicateType::GE;
+            // Parquet bounds omit NaNs, so only operators that cannot match a hidden NaN may prune.
+            if ((std::isnan(_value) && hidden_nan_can_match_nan) ||
+                (!std::isnan(_value) && hidden_nan_can_match_non_nan)) {
+                return true;
             }
+        }
+
+        if constexpr (PT == PredicateType::EQ) {
             return Compare::less_equal(min_value, _value) &&
                    Compare::greater_equal(max_value, _value);
         } else if constexpr (PT == PredicateType::NE) {

--- a/be/src/storage/predicate/comparison_predicate.h
+++ b/be/src/storage/predicate/comparison_predicate.h
@@ -211,7 +211,9 @@ public:
         }
 
         if constexpr (PT == PredicateType::EQ) {
-            if (result && statistic->get_bloom_filter_func != nullptr &&
+            // The legacy Parquet callback performs I/O, so apply value-specific capability first.
+            if (result && can_do_bloom_filter(false) &&
+                statistic->get_bloom_filter_func != nullptr &&
                 (*statistic->get_bloom_filter_func)(statistic, column_id())) {
                 if (!statistic->bloom_filter) {
                     return result;
@@ -342,6 +344,11 @@ public:
     }
 
     bool can_do_bloom_filter(bool ngram) const override {
+        if constexpr ((Type == PrimitiveType::TYPE_FLOAT || Type == PrimitiveType::TYPE_DOUBLE) &&
+                      PT == PredicateType::EQ) {
+            // NaN equality must remain a conservative match, so no Bloom payload can exclude it.
+            return !ngram && !std::isnan(_value);
+        }
         return PT == PredicateType::EQ && !ngram;
     }
 

--- a/be/src/storage/predicate/comparison_predicate.h
+++ b/be/src/storage/predicate/comparison_predicate.h
@@ -351,11 +351,9 @@ public:
                 // BIGINT -> hash as int64
                 return test_bytes(_value);
             } else if constexpr (Type == PrimitiveType::TYPE_FLOAT) {
-                // FLOAT -> hash as float
-                return test_bytes(_value);
+                return bf->test_floating_point(_value);
             } else if constexpr (Type == PrimitiveType::TYPE_DOUBLE) {
-                // DOUBLE -> hash as double
-                return test_bytes(_value);
+                return bf->test_floating_point(_value);
             } else if constexpr (is_string_type(Type)) {
                 // VARCHAR/STRING -> hash bytes
                 return bf->test_bytes(_value.data(), _value.size());

--- a/be/src/storage/predicate/in_list_predicate.h
+++ b/be/src/storage/predicate/in_list_predicate.h
@@ -280,7 +280,9 @@ public:
         }
 
         if constexpr (PT == PredicateType::IN_LIST) {
-            if (result && statistic->get_bloom_filter_func != nullptr &&
+            // The legacy Parquet callback performs I/O, so apply value-specific capability first.
+            if (result && can_do_bloom_filter(false) &&
+                statistic->get_bloom_filter_func != nullptr &&
                 (*statistic->get_bloom_filter_func)(statistic, column_id())) {
                 if (!statistic->bloom_filter) {
                     return result;
@@ -405,6 +407,11 @@ public:
     }
 
     bool can_do_bloom_filter(bool ngram) const override {
+        if constexpr ((Type == PrimitiveType::TYPE_FLOAT || Type == PrimitiveType::TYPE_DOUBLE) &&
+                      PT == PredicateType::IN_LIST) {
+            // One NaN makes the whole IN Bloom probe conservative, so skip loading the payload.
+            return !ngram && !_contains_nan;
+        }
         return PT == PredicateType::IN_LIST && !ngram;
     }
 

--- a/be/src/storage/predicate/in_list_predicate.h
+++ b/be/src/storage/predicate/in_list_predicate.h
@@ -436,11 +436,11 @@ public:
                             return true;
                         }
                     } else if constexpr (Type == PrimitiveType::TYPE_DOUBLE) {
-                        if (test_bytes(*value)) {
+                        if (bf->test_floating_point(*value)) {
                             return true;
                         }
                     } else if constexpr (Type == PrimitiveType::TYPE_FLOAT) {
-                        if (test_bytes(*value)) {
+                        if (bf->test_floating_point(*value)) {
                             return true;
                         }
                     } else {

--- a/be/src/storage/predicate/in_list_predicate.h
+++ b/be/src/storage/predicate/in_list_predicate.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <cstdint>
 #include <roaring/roaring.hh>
 
@@ -122,6 +123,7 @@ public:
         _values = other._values;
         _min_value = other._min_value;
         _max_value = other._max_value;
+        _contains_nan = other._contains_nan;
         DCHECK(_segment_id_to_value_in_dict_flags.empty());
     }
     InListPredicateBase(const InListPredicateBase<Type, PT, N>& other) = delete;
@@ -247,6 +249,10 @@ public:
 
     bool camp_field(const Field& min_field, const Field& max_field) const {
         if constexpr (PT == PredicateType::IN_LIST) {
+            // Parquet range bounds may exclude NaNs from a mixed-value chunk.
+            if (_contains_nan) {
+                return true;
+            }
             return Compare::less_equal(min_field.template get<Type>(), _max_value) &&
                    Compare::greater_equal(max_field.template get<Type>(), _min_value);
         } else {
@@ -623,6 +629,12 @@ private:
     }
 
     void _update_min_max(const T& value) {
+        if constexpr (Type == TYPE_FLOAT || Type == TYPE_DOUBLE) {
+            if (std::isnan(value)) {
+                _contains_nan = true;
+                return;
+            }
+        }
         if (Compare::greater(value, _max_value)) {
             _max_value = value;
         }
@@ -645,5 +657,6 @@ private:
             _segment_id_to_value_in_dict_flags;
     T _min_value;
     T _max_value;
+    bool _contains_nan = false;
 };
 } //namespace doris

--- a/be/src/storage/predicate/in_list_predicate.h
+++ b/be/src/storage/predicate/in_list_predicate.h
@@ -632,7 +632,6 @@ private:
         if constexpr (Type == TYPE_FLOAT || Type == TYPE_DOUBLE) {
             if (std::isnan(value)) {
                 _contains_nan = true;
-                return;
             }
         }
         if (Compare::greater(value, _max_value)) {

--- a/be/test/exprs/expr_zonemap_filter_test.cpp
+++ b/be/test/exprs/expr_zonemap_filter_test.cpp
@@ -443,6 +443,7 @@ TEST(ExprZonemapFilterTest, FloatingPointNanBloomProbeIsConservative) {
                 nan_field, remove_nullable(type)->get_primitive_type(), 0, 0));
         auto bloom_ctx = make_bloom_filter_context(bloom_filter.get(), type);
 
+        EXPECT_FALSE(equals.can_evaluate_bloom_filter({slot, literal}));
         EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
                   equals.evaluate_bloom_filter(bloom_ctx, {slot, literal}));
         EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
@@ -454,6 +455,7 @@ TEST(ExprZonemapFilterTest, FloatingPointNanBloomProbeIsConservative) {
                                             : Field::create_field<TYPE_DOUBLE>(2.0);
         auto finite_literal = std::make_shared<VLiteral>(
                 create_texpr_node_from(absent_finite, primitive_type, 0, 0));
+        EXPECT_TRUE(equals.can_evaluate_bloom_filter({slot, finite_literal}));
         EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
                   equals.evaluate_bloom_filter(bloom_ctx, {slot, finite_literal}));
     };
@@ -462,6 +464,21 @@ TEST(ExprZonemapFilterTest, FloatingPointNanBloomProbeIsConservative) {
                Field::create_field<TYPE_FLOAT>(std::numeric_limits<float>::quiet_NaN()));
     check_type(std::make_shared<DataTypeFloat64>(),
                Field::create_field<TYPE_DOUBLE>(std::numeric_limits<double>::quiet_NaN()));
+}
+
+TEST(ExprZonemapFilterTest, FloatingPointInWithNanIsNotBloomEligible) {
+    auto type = std::make_shared<DataTypeFloat64>();
+    auto predicate = std::make_shared<VInPredicate>(make_in_predicate_node(false, 2));
+    predicate->add_child(make_slot(0, type));
+    predicate->_zonemap_materialized = true;
+    predicate->_seg_filter_contains_nan = true;
+    predicate->_seg_filter_values = {
+            Field::create_field<TYPE_DOUBLE>(1.0),
+            Field::create_field<TYPE_DOUBLE>(std::numeric_limits<double>::quiet_NaN())};
+
+    EXPECT_FALSE(predicate->can_evaluate_bloom_filter());
+    predicate->_seg_filter_contains_nan = false;
+    EXPECT_TRUE(predicate->can_evaluate_bloom_filter());
 }
 
 TEST(ExprZonemapFilterTest, FloatingPointNanEqualityIgnoresFiniteOnlyRangeBounds) {

--- a/be/test/exprs/expr_zonemap_filter_test.cpp
+++ b/be/test/exprs/expr_zonemap_filter_test.cpp
@@ -20,6 +20,8 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <bit>
+#include <cstdint>
 #include <limits>
 #include <map>
 #include <memory>
@@ -460,6 +462,78 @@ TEST(ExprZonemapFilterTest, FloatingPointNanBloomProbeIsConservative) {
                Field::create_field<TYPE_FLOAT>(std::numeric_limits<float>::quiet_NaN()));
     check_type(std::make_shared<DataTypeFloat64>(),
                Field::create_field<TYPE_DOUBLE>(std::numeric_limits<double>::quiet_NaN()));
+}
+
+TEST(ExprZonemapFilterTest, FloatingPointNanEqualityIgnoresFiniteOnlyRangeBounds) {
+    const auto check_type =
+            []<PrimitiveType Type, typename DataType, typename UInt>(UInt nan_bits) {
+                using T = typename PrimitiveTypeTraits<Type>::CppType;
+                auto type = std::make_shared<DataType>();
+                auto slot = make_slot(0, type);
+                const auto nan_field = Field::create_field<Type>(std::bit_cast<T>(nan_bits));
+                auto nan_literal =
+                        std::make_shared<VLiteral>(create_texpr_node_from(nan_field, Type, 0, 0));
+
+                segment_v2::ZoneMap zone_map;
+                zone_map.min_value = Field::create_field<Type>(T {0});
+                zone_map.max_value = Field::create_field<Type>(T {0});
+                zone_map.has_not_null = true;
+                auto ctx = make_context(std::move(zone_map), type);
+                ctx.slots.at(0).floating_nan_count_unknown = true;
+
+                FunctionComparison<EqualsOp, NameEquals> equals;
+                EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
+                          equals.evaluate_zonemap_filter(ctx, {slot, nan_literal}));
+
+                const auto finite_field = Field::create_field<Type>(T {10});
+                EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
+                          expr_zonemap::eval_in_zonemap(ctx, slot, false, {finite_field, nan_field},
+                                                        finite_field, nan_field));
+
+                ctx.slots.at(0).floating_nan_count_unknown = false;
+                EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+                          equals.evaluate_zonemap_filter(ctx, {slot, nan_literal}));
+                EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+                          expr_zonemap::eval_in_zonemap(ctx, slot, false, {finite_field, nan_field},
+                                                        finite_field, nan_field));
+            };
+
+    check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(uint32_t {0x7fc00002U});
+    check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(uint64_t {0x7ff8000000000002ULL});
+}
+
+TEST(ExprZonemapFilterTest, DirectInRawFixedKeepsEqualNanPayloadFromLargeSet) {
+    const auto check_type = []<PrimitiveType Type, typename DataType, typename UInt>(
+                                    UInt stored_bits, UInt probe_bits) {
+        using T = typename PrimitiveTypeTraits<Type>::CppType;
+        auto type = std::make_shared<DataType>();
+        std::shared_ptr<HybridSetBase> filter(create_set(Type, false));
+        for (int value = 0; value < FIXED_CONTAINER_MAX_SIZE; ++value) {
+            T finite = static_cast<T>(value);
+            filter->insert(&finite);
+        }
+        const T stored_nan = std::bit_cast<T>(stored_bits);
+        filter->insert(&stored_nan);
+        ASSERT_EQ(FIXED_CONTAINER_MAX_SIZE + 1, filter->size());
+
+        VDirectInPredicate predicate(make_in_predicate_node(false, 1), filter, true);
+        predicate.add_child(make_slot(0, type));
+        ASSERT_TRUE(predicate.can_execute_on_raw_fixed_values(type, 0));
+
+        const T probe_nan = std::bit_cast<T>(probe_bits);
+        uint8_t match = 1;
+        ASSERT_TRUE(
+                predicate
+                        .execute_on_raw_fixed_values(reinterpret_cast<const uint8_t*>(&probe_nan),
+                                                     1, sizeof(T), type, 0, &match)
+                        .ok());
+        EXPECT_EQ(1, match);
+    };
+
+    check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(uint32_t {0x7fc00001U},
+                                                                uint32_t {0x7fc00002U});
+    check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(uint64_t {0x7ff8000000000001ULL},
+                                                                 uint64_t {0x7ff8000000000002ULL});
 }
 
 TEST(ExprZonemapFilterTest, FloatingPointSignedZeroBloomProbeChecksBothEncodings) {

--- a/be/test/exprs/expr_zonemap_filter_test.cpp
+++ b/be/test/exprs/expr_zonemap_filter_test.cpp
@@ -465,38 +465,72 @@ TEST(ExprZonemapFilterTest, FloatingPointNanBloomProbeIsConservative) {
 }
 
 TEST(ExprZonemapFilterTest, FloatingPointNanEqualityIgnoresFiniteOnlyRangeBounds) {
-    const auto check_type =
-            []<PrimitiveType Type, typename DataType, typename UInt>(UInt nan_bits) {
-                using T = typename PrimitiveTypeTraits<Type>::CppType;
-                auto type = std::make_shared<DataType>();
-                auto slot = make_slot(0, type);
-                const auto nan_field = Field::create_field<Type>(std::bit_cast<T>(nan_bits));
-                auto nan_literal =
-                        std::make_shared<VLiteral>(create_texpr_node_from(nan_field, Type, 0, 0));
+    const auto check_type = []<PrimitiveType Type, typename DataType, typename UInt>(
+                                    UInt nan_bits) {
+        using T = typename PrimitiveTypeTraits<Type>::CppType;
+        auto type = std::make_shared<DataType>();
+        auto slot = make_slot(0, type);
+        const auto nan_field = Field::create_field<Type>(std::bit_cast<T>(nan_bits));
+        auto nan_literal =
+                std::make_shared<VLiteral>(create_texpr_node_from(nan_field, Type, 0, 0));
 
-                segment_v2::ZoneMap zone_map;
-                zone_map.min_value = Field::create_field<Type>(T {0});
-                zone_map.max_value = Field::create_field<Type>(T {0});
-                zone_map.has_not_null = true;
-                auto ctx = make_context(std::move(zone_map), type);
-                ctx.slots.at(0).floating_nan_count_unknown = true;
+        segment_v2::ZoneMap zone_map;
+        zone_map.min_value = Field::create_field<Type>(T {0});
+        zone_map.max_value = Field::create_field<Type>(T {0});
+        zone_map.has_not_null = true;
+        auto ctx = make_context(std::move(zone_map), type);
+        ctx.slots.at(0).floating_nan_count_unknown = true;
 
-                FunctionComparison<EqualsOp, NameEquals> equals;
-                EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
-                          equals.evaluate_zonemap_filter(ctx, {slot, nan_literal}));
+        FunctionComparison<EqualsOp, NameEquals> equals;
+        EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
+                  equals.evaluate_zonemap_filter(ctx, {slot, nan_literal}));
 
-                const auto finite_field = Field::create_field<Type>(T {10});
-                EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
-                          expr_zonemap::eval_in_zonemap(ctx, slot, false, {finite_field, nan_field},
-                                                        finite_field, nan_field));
+        const auto finite_field = Field::create_field<Type>(T {10});
+        const auto zero_field = Field::create_field<Type>(T {0});
+        const auto one_field = Field::create_field<Type>(T {1});
+        auto zero_literal =
+                std::make_shared<VLiteral>(create_texpr_node_from(zero_field, Type, 0, 0));
+        auto one_literal =
+                std::make_shared<VLiteral>(create_texpr_node_from(one_field, Type, 0, 0));
+        FunctionComparison<NotEqualsOp, NameNotEquals> not_equals;
+        FunctionComparison<GreaterOp, NameGreater> greater;
+        FunctionComparison<GreaterOrEqualsOp, NameGreaterOrEquals> greater_equal;
+        FunctionComparison<LessOp, NameLess> less;
+        FunctionComparison<LessOrEqualsOp, NameLessOrEquals> less_equal;
+        EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
+                  not_equals.evaluate_zonemap_filter(ctx, {slot, zero_literal}));
+        EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
+                  greater.evaluate_zonemap_filter(ctx, {slot, one_literal}));
+        EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
+                  greater_equal.evaluate_zonemap_filter(ctx, {slot, one_literal}));
+        EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
+                  less.evaluate_zonemap_filter(ctx, {one_literal, slot}));
+        EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
+                  less_equal.evaluate_zonemap_filter(ctx, {one_literal, slot}));
+        EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
+                  expr_zonemap::eval_in_zonemap(ctx, slot, false, {finite_field, nan_field}, true,
+                                                finite_field, nan_field));
+        EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
+                  expr_zonemap::eval_in_zonemap(ctx, slot, true, {zero_field}, false, zero_field,
+                                                zero_field));
 
-                ctx.slots.at(0).floating_nan_count_unknown = false;
-                EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-                          equals.evaluate_zonemap_filter(ctx, {slot, nan_literal}));
-                EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-                          expr_zonemap::eval_in_zonemap(ctx, slot, false, {finite_field, nan_field},
-                                                        finite_field, nan_field));
-            };
+        segment_v2::ZoneMap all_null_zone_map;
+        all_null_zone_map.min_value = zero_field;
+        all_null_zone_map.max_value = zero_field;
+        auto all_null_ctx = make_context(std::move(all_null_zone_map), type);
+        all_null_ctx.slots.at(0).floating_nan_count_unknown = true;
+        EXPECT_EQ(
+                ZoneMapFilterResult::kNoMatch,
+                expr_zonemap::eval_in_zonemap(all_null_ctx, slot, false, {finite_field, nan_field},
+                                              true, finite_field, nan_field));
+
+        ctx.slots.at(0).floating_nan_count_unknown = false;
+        EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+                  equals.evaluate_zonemap_filter(ctx, {slot, nan_literal}));
+        EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+                  expr_zonemap::eval_in_zonemap(ctx, slot, false, {finite_field, nan_field}, true,
+                                                finite_field, nan_field));
+    };
 
     check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(uint32_t {0x7fc00002U});
     check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(uint64_t {0x7ff8000000000002ULL});
@@ -617,7 +651,7 @@ TEST(ExprZonemapFilterTest, MissingSlotTypeCountsUnsupportedZonemapEvalOnce) {
     std::vector<Field> values {int_field(10)};
     ZoneMapEvalContext in_ctx;
     EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
-              expr_zonemap::eval_in_zonemap(in_ctx, slot, false, values, int_field(10),
+              expr_zonemap::eval_in_zonemap(in_ctx, slot, false, values, false, int_field(10),
                                             int_field(10)));
     EXPECT_EQ(1, in_ctx.stats.unusable_zonemap_eval_count);
 }
@@ -680,20 +714,20 @@ TEST(ExprZonemapFilterTest, InZonemapSkipsZonesWithoutNonNullValues) {
     segment_v2::ZoneMap empty_zone;
     auto empty_ctx = make_context(empty_zone, type);
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-              expr_zonemap::eval_in_zonemap(empty_ctx, slot, false, values, int_field(10),
+              expr_zonemap::eval_in_zonemap(empty_ctx, slot, false, values, false, int_field(10),
                                             int_field(10)));
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-              expr_zonemap::eval_in_zonemap(empty_ctx, slot, true, values, int_field(10),
+              expr_zonemap::eval_in_zonemap(empty_ctx, slot, true, values, false, int_field(10),
                                             int_field(10)));
 
     segment_v2::ZoneMap only_null_zone;
     only_null_zone.has_null = true;
     auto only_null_ctx = make_context(only_null_zone, type);
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-              expr_zonemap::eval_in_zonemap(only_null_ctx, slot, false, values, int_field(10),
-                                            int_field(10)));
+              expr_zonemap::eval_in_zonemap(only_null_ctx, slot, false, values, false,
+                                            int_field(10), int_field(10)));
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-              expr_zonemap::eval_in_zonemap(only_null_ctx, slot, true, values, int_field(10),
+              expr_zonemap::eval_in_zonemap(only_null_ctx, slot, true, values, false, int_field(10),
                                             int_field(10)));
 }
 
@@ -783,8 +817,9 @@ TEST(ExprZonemapFilterTest, CharZonemapUsesTrimmedLogicalBounds) {
     auto in_value = Field::create_field<TYPE_STRING>("gamma");
     std::vector<Field> values {in_value};
     auto in_ctx = make_context(zone_map, char_type);
-    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-              expr_zonemap::eval_in_zonemap(in_ctx, slot, false, values, in_value, in_value));
+    EXPECT_EQ(
+            ZoneMapFilterResult::kNoMatch,
+            expr_zonemap::eval_in_zonemap(in_ctx, slot, false, values, false, in_value, in_value));
 }
 
 TEST(ExprZonemapFilterTest, InZonemapFallsBackToRangeWhenPointListIsLarge) {
@@ -797,7 +832,8 @@ TEST(ExprZonemapFilterTest, InZonemapFallsBackToRangeWhenPointListIsLarge) {
         values.emplace_back(int_field(value));
     }
     EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
-              expr_zonemap::eval_in_zonemap(ctx, slot, false, values, int_field(1), int_field(65)));
+              expr_zonemap::eval_in_zonemap(ctx, slot, false, values, false, int_field(1),
+                                            int_field(65)));
 
     EXPECT_EQ(0, ctx.stats.in_zonemap_point_check_count);
     EXPECT_EQ(1, ctx.stats.in_zonemap_range_only_count);
@@ -810,7 +846,8 @@ TEST(ExprZonemapFilterTest, InZonemapUsesPointChecksUnderThreshold) {
 
     std::vector<Field> values {int_field(1), int_field(30)};
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-              expr_zonemap::eval_in_zonemap(ctx, slot, false, values, int_field(1), int_field(30)));
+              expr_zonemap::eval_in_zonemap(ctx, slot, false, values, false, int_field(1),
+                                            int_field(30)));
     EXPECT_EQ(1, ctx.stats.in_zonemap_point_check_count);
 }
 
@@ -821,19 +858,19 @@ TEST(ExprZonemapFilterTest, InZonemapHandlesEmptyListAndNotInSingleValueRange) {
 
     std::vector<Field> empty_values;
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-              expr_zonemap::eval_in_zonemap(ctx, slot, false, empty_values, {}, {}));
+              expr_zonemap::eval_in_zonemap(ctx, slot, false, empty_values, false, {}, {}));
     EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
-              expr_zonemap::eval_in_zonemap(ctx, slot, true, empty_values, {}, {}));
+              expr_zonemap::eval_in_zonemap(ctx, slot, true, empty_values, false, {}, {}));
 
     auto single_value_ctx = make_context(make_int_zonemap(10, 10), type);
     std::vector<Field> values {int_field(10)};
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-              expr_zonemap::eval_in_zonemap(single_value_ctx, slot, true, values, int_field(10),
-                                            int_field(10)));
+              expr_zonemap::eval_in_zonemap(single_value_ctx, slot, true, values, false,
+                                            int_field(10), int_field(10)));
 
     std::vector<Field> other_values {int_field(11)};
     EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
-              expr_zonemap::eval_in_zonemap(single_value_ctx, slot, true, other_values,
+              expr_zonemap::eval_in_zonemap(single_value_ctx, slot, true, other_values, false,
                                             int_field(11), int_field(11)));
 }
 

--- a/be/test/exprs/expr_zonemap_filter_test.cpp
+++ b/be/test/exprs/expr_zonemap_filter_test.cpp
@@ -462,6 +462,36 @@ TEST(ExprZonemapFilterTest, FloatingPointNanBloomProbeIsConservative) {
                Field::create_field<TYPE_DOUBLE>(std::numeric_limits<double>::quiet_NaN()));
 }
 
+TEST(ExprZonemapFilterTest, FloatingPointSignedZeroBloomProbeChecksBothEncodings) {
+    FunctionComparison<EqualsOp, NameEquals> equals;
+    const auto check_type = [&]<PrimitiveType Type>(
+                                    const DataTypePtr& type,
+                                    typename PrimitiveTypeTraits<Type>::CppType stored_value,
+                                    typename PrimitiveTypeTraits<Type>::CppType predicate_value) {
+        auto bloom_filter = std::make_unique<segment_v2::BlockSplitBloomFilter>();
+        ASSERT_TRUE(bloom_filter->init(segment_v2::BloomFilter::MINIMUM_BYTES).ok());
+        bloom_filter->add_bytes(reinterpret_cast<const char*>(&stored_value), sizeof(stored_value));
+        ASSERT_FALSE(bloom_filter->test_bytes(reinterpret_cast<const char*>(&predicate_value),
+                                              sizeof(predicate_value)));
+
+        auto slot = make_slot(0, type);
+        const auto field = Field::create_field<Type>(predicate_value);
+        auto literal = std::make_shared<VLiteral>(create_texpr_node_from(field, Type, 0, 0));
+        auto bloom_ctx = make_bloom_filter_context(bloom_filter.get(), type);
+        EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+                  equals.evaluate_bloom_filter(bloom_ctx, {slot, literal}));
+        EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+                  expr_zonemap::eval_in_bloom_filter(bloom_ctx, slot, false, {field}));
+    };
+
+    const auto float_type = std::make_shared<DataTypeFloat32>();
+    check_type.template operator()<TYPE_FLOAT>(float_type, -0.0F, 0.0F);
+    check_type.template operator()<TYPE_FLOAT>(float_type, 0.0F, -0.0F);
+    const auto double_type = std::make_shared<DataTypeFloat64>();
+    check_type.template operator()<TYPE_DOUBLE>(double_type, -0.0, 0.0);
+    check_type.template operator()<TYPE_DOUBLE>(double_type, 0.0, -0.0);
+}
+
 TEST(ExprZonemapFilterTest, DefaultFunctionForwardsDictionaryAndBloomEvaluation) {
     auto type = int_type();
     auto slot = make_slot(0, type);

--- a/be/test/exprs/expr_zonemap_filter_test.cpp
+++ b/be/test/exprs/expr_zonemap_filter_test.cpp
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <limits>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -425,6 +426,40 @@ TEST(ExprZonemapFilterTest, ComparisonDictionarySupportsTypedRangesWhileBloomUse
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
               greater.evaluate_dictionary_filter(string_dictionary,
                                                  {string_slot, make_string_literal("delta")}));
+}
+
+TEST(ExprZonemapFilterTest, FloatingPointNanBloomProbeIsConservative) {
+    auto bloom_filter = std::make_unique<segment_v2::BlockSplitBloomFilter>();
+    ASSERT_TRUE(bloom_filter->init(segment_v2::BloomFilter::MINIMUM_BYTES).ok());
+    const double finite_value = 1.0;
+    bloom_filter->add_bytes(reinterpret_cast<const char*>(&finite_value), sizeof(finite_value));
+
+    FunctionComparison<EqualsOp, NameEquals> equals;
+    const auto check_type = [&](const DataTypePtr& type, Field nan_field) {
+        auto slot = make_slot(0, type);
+        auto literal = std::make_shared<VLiteral>(create_texpr_node_from(
+                nan_field, remove_nullable(type)->get_primitive_type(), 0, 0));
+        auto bloom_ctx = make_bloom_filter_context(bloom_filter.get(), type);
+
+        EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+                  equals.evaluate_bloom_filter(bloom_ctx, {slot, literal}));
+        EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+                  expr_zonemap::eval_in_bloom_filter(bloom_ctx, slot, false, {nan_field}));
+
+        const auto primitive_type = remove_nullable(type)->get_primitive_type();
+        const Field absent_finite = primitive_type == TYPE_FLOAT
+                                            ? Field::create_field<TYPE_FLOAT>(2.0F)
+                                            : Field::create_field<TYPE_DOUBLE>(2.0);
+        auto finite_literal = std::make_shared<VLiteral>(
+                create_texpr_node_from(absent_finite, primitive_type, 0, 0));
+        EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+                  equals.evaluate_bloom_filter(bloom_ctx, {slot, finite_literal}));
+    };
+
+    check_type(std::make_shared<DataTypeFloat32>(),
+               Field::create_field<TYPE_FLOAT>(std::numeric_limits<float>::quiet_NaN()));
+    check_type(std::make_shared<DataTypeFloat64>(),
+               Field::create_field<TYPE_DOUBLE>(std::numeric_limits<double>::quiet_NaN()));
 }
 
 TEST(ExprZonemapFilterTest, DefaultFunctionForwardsDictionaryAndBloomEvaluation) {

--- a/be/test/exprs/hybrid_set_test.cpp
+++ b/be/test/exprs/hybrid_set_test.cpp
@@ -19,6 +19,8 @@
 
 #include <gtest/gtest.h>
 
+#include <bit>
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -395,6 +397,33 @@ TEST_F(HybridSetTest, double) {
     a = 5.1;
     EXPECT_FALSE(set->find(&a));
 }
+
+TEST_F(HybridSetTest, DynamicFloatingSetFindsDorisEqualNanPayload) {
+    const auto check_type = []<PrimitiveType Type, typename UInt>(UInt stored_bits,
+                                                                  UInt probe_bits) {
+        using T = typename PrimitiveTypeTraits<Type>::CppType;
+        std::unique_ptr<HybridSetBase> set(create_set(Type, false));
+        for (int value = 0; value < FIXED_CONTAINER_MAX_SIZE; ++value) {
+            T finite = static_cast<T>(value);
+            set->insert(&finite);
+        }
+        const T stored_nan = std::bit_cast<T>(stored_bits);
+        set->insert(&stored_nan);
+        ASSERT_EQ(FIXED_CONTAINER_MAX_SIZE + 1, set->size());
+
+        const T probe_nan = std::bit_cast<T>(probe_bits);
+        EXPECT_TRUE(set->find(&probe_nan));
+        uint8_t match = 1;
+        set->find_batch_raw_fixed(reinterpret_cast<const uint8_t*>(&probe_nan), 1, sizeof(T),
+                                  &match);
+        EXPECT_EQ(1, match);
+    };
+
+    check_type.template operator()<TYPE_FLOAT>(uint32_t {0x7fc00001U}, uint32_t {0x7fc00002U});
+    check_type.template operator()<TYPE_DOUBLE>(uint64_t {0x7ff8000000000001ULL},
+                                                uint64_t {0x7ff8000000000002ULL});
+}
+
 TEST_F(HybridSetTest, string) {
     std::unique_ptr<HybridSetBase> set(create_set(PrimitiveType::TYPE_VARCHAR, false));
     StringRef a;

--- a/be/test/format/parquet/parquet_expr_test.cpp
+++ b/be/test/format/parquet/parquet_expr_test.cpp
@@ -2011,6 +2011,12 @@ TEST_F(ParquetExprTest, floating_nan_predicates_ignore_finite_only_parquet_range
 
         ComparisonPredicateBase<Type, PredicateType::EQ> eq_pred(col_idx, "",
                                                                  Field::create_field<Type>(nan));
+        ComparisonPredicateBase<Type, PredicateType::NE> ne_pred(col_idx, "",
+                                                                 Field::create_field<Type>(T {0}));
+        ComparisonPredicateBase<Type, PredicateType::GT> gt_pred(col_idx, "",
+                                                                 Field::create_field<Type>(T {1}));
+        ComparisonPredicateBase<Type, PredicateType::GE> ge_pred(col_idx, "",
+                                                                 Field::create_field<Type>(T {1}));
         auto set = std::make_shared<HybridSet<Type>>(false);
         for (int value = 10; value < 10 + FIXED_CONTAINER_MAX_SIZE; ++value) {
             T finite = static_cast<T>(value);
@@ -2018,8 +2024,13 @@ TEST_F(ParquetExprTest, floating_nan_predicates_ignore_finite_only_parquet_range
         }
         set->insert(&nan);
         InListPredicateBase<Type, PredicateType::IN_LIST, 0> in_pred(col_idx, "", set, false);
+        auto not_in_set = std::make_shared<HybridSet<Type>>(false);
+        const T zero = T {0};
+        not_in_set->insert(&zero);
+        InListPredicateBase<Type, PredicateType::NOT_IN_LIST, 0> not_in_pred(col_idx, "",
+                                                                             not_in_set, false);
 
-        const auto check_footer = [&](const auto& predicate) {
+        const auto check_footer = [&](const auto& predicate, int expected_bloom_loader_calls) {
             ParquetPredicate::ColumnStat stat;
             stat.ctz = &ctz;
             std::function<bool(ParquetPredicate::ColumnStat*, int)> get_stat_func =
@@ -2041,10 +2052,14 @@ TEST_F(ParquetExprTest, floating_nan_predicates_ignore_finite_only_parquet_range
                     };
             stat.get_bloom_filter_func = &get_bloom_filter_func;
             EXPECT_TRUE(predicate.evaluate_and(&stat));
-            EXPECT_EQ(1, bloom_loader_calls);
+            EXPECT_EQ(expected_bloom_loader_calls, bloom_loader_calls);
         };
-        check_footer(eq_pred);
-        check_footer(in_pred);
+        check_footer(eq_pred, 1);
+        check_footer(in_pred, 1);
+        check_footer(ne_pred, 0);
+        check_footer(gt_pred, 0);
+        check_footer(ge_pred, 0);
+        check_footer(not_in_pred, 0);
 
         ParquetPredicate::CachedPageIndexStat cached_page_index;
         cached_page_index.ctz = &ctz;
@@ -2067,6 +2082,18 @@ TEST_F(ParquetExprTest, floating_nan_predicates_ignore_finite_only_parquet_range
         RowRanges in_ranges;
         EXPECT_TRUE(in_pred.evaluate_and(&cached_page_index, &in_ranges));
         assert_single_range(&in_ranges, 0, 5);
+        RowRanges ne_ranges;
+        EXPECT_TRUE(ne_pred.evaluate_and(&cached_page_index, &ne_ranges));
+        assert_single_range(&ne_ranges, 0, 5);
+        RowRanges gt_ranges;
+        EXPECT_TRUE(gt_pred.evaluate_and(&cached_page_index, &gt_ranges));
+        assert_single_range(&gt_ranges, 0, 5);
+        RowRanges ge_ranges;
+        EXPECT_TRUE(ge_pred.evaluate_and(&cached_page_index, &ge_ranges));
+        assert_single_range(&ge_ranges, 0, 5);
+        RowRanges not_in_ranges;
+        EXPECT_TRUE(not_in_pred.evaluate_and(&cached_page_index, &not_in_ranges));
+        assert_single_range(&not_in_ranges, 0, 5);
     };
 
     check_type.template operator()<TYPE_FLOAT>(3, uint32_t {0x7fc00002U});

--- a/be/test/format/parquet/parquet_expr_test.cpp
+++ b/be/test/format/parquet/parquet_expr_test.cpp
@@ -2054,8 +2054,8 @@ TEST_F(ParquetExprTest, floating_nan_predicates_ignore_finite_only_parquet_range
             EXPECT_TRUE(predicate.evaluate_and(&stat));
             EXPECT_EQ(expected_bloom_loader_calls, bloom_loader_calls);
         };
-        check_footer(eq_pred, 1);
-        check_footer(in_pred, 1);
+        check_footer(eq_pred, 0);
+        check_footer(in_pred, 0);
         check_footer(ne_pred, 0);
         check_footer(gt_pred, 0);
         check_footer(ge_pred, 0);

--- a/be/test/format/parquet/parquet_expr_test.cpp
+++ b/be/test/format/parquet/parquet_expr_test.cpp
@@ -38,6 +38,7 @@
 #include <sys/types.h>
 
 #include <algorithm>
+#include <bit>
 #include <cmath>
 #include <cstdint>
 #include <memory>
@@ -1967,6 +1968,37 @@ TEST_F(ParquetExprTest, test_bloom_filter_accepts_value) {
 
     EXPECT_TRUE(eq_pred.evaluate_and(&stat));
     EXPECT_EQ(1, loader_calls);
+}
+
+TEST_F(ParquetExprTest, floating_point_bloom_filter_preserves_doris_equality) {
+    const auto check_type = []<PrimitiveType Type>(
+                                    typename PrimitiveTypeTraits<Type>::CppType stored_value,
+                                    typename PrimitiveTypeTraits<Type>::CppType predicate_value) {
+        ParquetBlockSplitBloomFilter bloom_filter;
+        ASSERT_TRUE(bloom_filter.init(256, segment_v2::HashStrategyPB::XX_HASH_64).ok());
+        bloom_filter.add_bytes(reinterpret_cast<const char*>(&stored_value), sizeof(stored_value));
+        ASSERT_FALSE(bloom_filter.test_bytes(reinterpret_cast<const char*>(&predicate_value),
+                                             sizeof(predicate_value)));
+
+        ComparisonPredicateBase<Type, PredicateType::EQ> eq_pred(
+                0, "", Field::create_field<Type>(predicate_value));
+        EXPECT_TRUE(eq_pred.evaluate_and(&bloom_filter));
+
+        auto set = std::make_shared<HybridSet<Type>>(false);
+        set->insert(&predicate_value);
+        InListPredicateBase<Type, PredicateType::IN_LIST, 1> in_pred(0, "", set, false);
+        EXPECT_TRUE(in_pred.evaluate_and(&bloom_filter));
+    };
+
+    check_type.template operator()<TYPE_FLOAT>(-0.0F, 0.0F);
+    check_type.template operator()<TYPE_FLOAT>(0.0F, -0.0F);
+    check_type.template operator()<TYPE_DOUBLE>(-0.0, 0.0);
+    check_type.template operator()<TYPE_DOUBLE>(0.0, -0.0);
+    check_type.template operator()<TYPE_FLOAT>(std::bit_cast<float>(uint32_t {0x7fc00001U}),
+                                               std::bit_cast<float>(uint32_t {0x7fc00002U}));
+    check_type.template operator()<TYPE_DOUBLE>(
+            std::bit_cast<double>(uint64_t {0x7ff8000000000001ULL}),
+            std::bit_cast<double>(uint64_t {0x7ff8000000000002ULL}));
 }
 
 TEST_F(ParquetExprTest, test_bloom_filter_skipped_when_min_max_evicts_rowgroup) {

--- a/be/test/format/parquet/parquet_expr_test.cpp
+++ b/be/test/format/parquet/parquet_expr_test.cpp
@@ -2001,6 +2001,78 @@ TEST_F(ParquetExprTest, floating_point_bloom_filter_preserves_doris_equality) {
             std::bit_cast<double>(uint64_t {0x7ff8000000000002ULL}));
 }
 
+TEST_F(ParquetExprTest, floating_nan_predicates_ignore_finite_only_parquet_ranges) {
+    const auto check_type = [this]<PrimitiveType Type, typename UInt>(int col_idx, UInt nan_bits) {
+        using T = typename PrimitiveTypeTraits<Type>::CppType;
+        const T nan = std::bit_cast<T>(nan_bits);
+        const T finite_bound = T {0};
+        const std::string encoded_bound(reinterpret_cast<const char*>(&finite_bound), sizeof(T));
+        const FieldSchema* col_schema = doris_file_metadata->schema().get_column(col_idx);
+
+        ComparisonPredicateBase<Type, PredicateType::EQ> eq_pred(col_idx, "",
+                                                                 Field::create_field<Type>(nan));
+        auto set = std::make_shared<HybridSet<Type>>(false);
+        for (int value = 10; value < 10 + FIXED_CONTAINER_MAX_SIZE; ++value) {
+            T finite = static_cast<T>(value);
+            set->insert(&finite);
+        }
+        set->insert(&nan);
+        InListPredicateBase<Type, PredicateType::IN_LIST, 0> in_pred(col_idx, "", set, false);
+
+        const auto check_footer = [&](const auto& predicate) {
+            ParquetPredicate::ColumnStat stat;
+            stat.ctz = &ctz;
+            std::function<bool(ParquetPredicate::ColumnStat*, int)> get_stat_func =
+                    [&](ParquetPredicate::ColumnStat* current_stat, int cid) {
+                        EXPECT_EQ(col_idx, cid);
+                        current_stat->col_schema = col_schema;
+                        current_stat->has_null = false;
+                        current_stat->is_all_null = false;
+                        current_stat->encoded_min_value = encoded_bound;
+                        current_stat->encoded_max_value = encoded_bound;
+                        return true;
+                    };
+            stat.get_stat_func = &get_stat_func;
+            int bloom_loader_calls = 0;
+            std::function<bool(ParquetPredicate::ColumnStat*, int)> get_bloom_filter_func =
+                    [&](ParquetPredicate::ColumnStat*, int) {
+                        ++bloom_loader_calls;
+                        return false;
+                    };
+            stat.get_bloom_filter_func = &get_bloom_filter_func;
+            EXPECT_TRUE(predicate.evaluate_and(&stat));
+            EXPECT_EQ(1, bloom_loader_calls);
+        };
+        check_footer(eq_pred);
+        check_footer(in_pred);
+
+        ParquetPredicate::CachedPageIndexStat cached_page_index;
+        cached_page_index.ctz = &ctz;
+        cached_page_index.row_group_range = {0, 5};
+        ParquetPredicate::PageIndexStat page_stat;
+        page_stat.available = true;
+        page_stat.num_of_pages = 1;
+        page_stat.encoded_min_value = {encoded_bound};
+        page_stat.encoded_max_value = {encoded_bound};
+        page_stat.has_null = {false};
+        page_stat.is_all_null = {false};
+        page_stat.col_schema = col_schema;
+        page_stat.ranges = {{0, 5}};
+        cached_page_index.stats.emplace(col_idx, std::move(page_stat));
+        install_page_index_getter(&cached_page_index);
+
+        RowRanges eq_ranges;
+        EXPECT_TRUE(eq_pred.evaluate_and(&cached_page_index, &eq_ranges));
+        assert_single_range(&eq_ranges, 0, 5);
+        RowRanges in_ranges;
+        EXPECT_TRUE(in_pred.evaluate_and(&cached_page_index, &in_ranges));
+        assert_single_range(&in_ranges, 0, 5);
+    };
+
+    check_type.template operator()<TYPE_FLOAT>(3, uint32_t {0x7fc00002U});
+    check_type.template operator()<TYPE_DOUBLE>(4, uint64_t {0x7ff8000000000002ULL});
+}
+
 TEST_F(ParquetExprTest, test_bloom_filter_skipped_when_min_max_evicts_rowgroup) {
     const int col_idx = 2;
     const int64_t predicate_value = 10000000001;

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 
+#include <bit>
 #include <cstdint>
 #include <cstring>
 #include <limits>
@@ -112,6 +113,37 @@ private:
     const std::string _expr_name = "BloomInExpr";
 };
 
+class BloomEqExpr final : public VExpr {
+public:
+    BloomEqExpr(int column_id, DataTypePtr data_type, Field value)
+            : VExpr(std::make_shared<DataTypeUInt8>(), false),
+              _slot(VSlotRef::create_shared(0, column_id, -1, std::move(data_type), "c0")),
+              _value(std::move(value)) {}
+
+    const std::string& expr_name() const override { return _expr_name; }
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
+                               ColumnPtr&) const override {
+        return Status::InternalError("BloomEqExpr is only used by parquet statistics tests");
+    }
+    bool can_evaluate_bloom_filter() const override { return true; }
+    ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const override {
+        return expr_zonemap::eval_eq_bloom_filter(
+                ctx, expr_zonemap::SlotLiteral {.slot_index = _slot->column_id(),
+                                                .slot_type = _slot->data_type(),
+                                                .literal = _value,
+                                                .literal_type = _slot->data_type(),
+                                                .literal_on_left = false});
+    }
+    void collect_slot_column_ids(std::set<int>& column_ids) const override {
+        _slot->collect_slot_column_ids(column_ids);
+    }
+
+private:
+    std::shared_ptr<VSlotRef> _slot;
+    Field _value;
+    const std::string _expr_name = "BloomEqExpr";
+};
+
 class DictionaryStringInExpr final : public VExpr {
 public:
     DictionaryStringInExpr() : VExpr(std::make_shared<DataTypeUInt8>(), false) {}
@@ -199,6 +231,11 @@ private:
 VExprContextSPtrs bloom_conjuncts(DataTypePtr data_type, std::vector<Field> values) {
     return {VExprContext::create_shared(
             std::make_shared<BloomInExpr>(0, std::move(data_type), std::move(values)))};
+}
+
+VExprContextSPtrs bloom_eq_conjunct(DataTypePtr data_type, Field value) {
+    return {VExprContext::create_shared(
+            std::make_shared<BloomEqExpr>(0, std::move(data_type), std::move(value)))};
 }
 
 format::FileScanRequest request_with_bloom_conjunct(DataTypePtr data_type,
@@ -384,6 +421,130 @@ TEST(ParquetBloomFilterPruningTest, NativeUint32BloomUsesPhysicalInt32Hash) {
             column_schema, 0,
             bloom_conjuncts(column_schema.type, {Field::create_field<TYPE_BIGINT>(-1)}),
             bloom_filter));
+}
+
+TEST(ParquetBloomFilterPruningTest, NativeFloatingBloomPreservesDorisEquality) {
+    const auto check_type = []<PrimitiveType Type, typename DataType>(
+                                    tparquet::Type::type physical_type,
+                                    typename PrimitiveTypeTraits<Type>::CppType stored_value,
+                                    typename PrimitiveTypeTraits<Type>::CppType predicate_value) {
+        format::parquet::ParquetColumnSchema column_schema;
+        column_schema.type = std::make_shared<DataType>();
+        column_schema.type_descriptor.doris_type = column_schema.type;
+        column_schema.type_descriptor.physical_type = physical_type;
+
+        format::parquet::native::BlockSplitBloomFilter bloom_filter;
+        ASSERT_TRUE(bloom_filter
+                            .init(segment_v2::BloomFilter::MINIMUM_BYTES,
+                                  segment_v2::HashStrategyPB::XX_HASH_64)
+                            .ok());
+        bloom_filter.add_bytes(reinterpret_cast<const char*>(&stored_value), sizeof(stored_value));
+        ASSERT_FALSE(bloom_filter.test_bytes(reinterpret_cast<const char*>(&predicate_value),
+                                             sizeof(predicate_value)));
+        const auto field = Field::create_field<Type>(predicate_value);
+
+        EXPECT_FALSE(format::parquet::ParquetStatisticsUtils::NativeBloomFilterExcludes(
+                column_schema, 0, bloom_eq_conjunct(column_schema.type, field), bloom_filter));
+        EXPECT_FALSE(format::parquet::ParquetStatisticsUtils::NativeBloomFilterExcludes(
+                column_schema, 0, bloom_conjuncts(column_schema.type, {field}), bloom_filter));
+    };
+
+    check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(tparquet::Type::FLOAT, -0.0F, 0.0F);
+    check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(tparquet::Type::FLOAT, 0.0F, -0.0F);
+    check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(tparquet::Type::DOUBLE, -0.0, 0.0);
+    check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(tparquet::Type::DOUBLE, 0.0, -0.0);
+    check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(
+            tparquet::Type::FLOAT, std::bit_cast<float>(uint32_t {0x7fc00001U}),
+            std::bit_cast<float>(uint32_t {0x7fc00002U}));
+    check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(
+            tparquet::Type::DOUBLE, std::bit_cast<double>(uint64_t {0x7ff8000000000001ULL}),
+            std::bit_cast<double>(uint64_t {0x7ff8000000000002ULL}));
+}
+
+TEST(ParquetBloomFilterPruningTest, NativeRowGroupKeepsDorisEqualFloatingValues) {
+    const auto check_type = []<PrimitiveType Type, typename DataType>(
+                                    tparquet::Type::type physical_type,
+                                    typename PrimitiveTypeTraits<Type>::CppType stored_value,
+                                    typename PrimitiveTypeTraits<Type>::CppType predicate_value) {
+        format::parquet::native::BlockSplitBloomFilter bloom_filter;
+        ASSERT_TRUE(bloom_filter
+                            .init(segment_v2::BloomFilter::MINIMUM_BYTES,
+                                  segment_v2::HashStrategyPB::XX_HASH_64)
+                            .ok());
+        bloom_filter.add_bytes(reinterpret_cast<const char*>(&stored_value), sizeof(stored_value));
+
+        tparquet::BloomFilterAlgorithm algorithm;
+        algorithm.__set_BLOCK(tparquet::SplitBlockAlgorithm());
+        tparquet::BloomFilterHash hash;
+        hash.__set_XXHASH(tparquet::XxHash());
+        tparquet::BloomFilterCompression compression;
+        compression.__set_UNCOMPRESSED(tparquet::Uncompressed());
+        tparquet::BloomFilterHeader bloom_header;
+        bloom_header.__set_numBytes(static_cast<int32_t>(bloom_filter.size()));
+        bloom_header.__set_algorithm(algorithm);
+        bloom_header.__set_hash(hash);
+        bloom_header.__set_compression(compression);
+        std::vector<uint8_t> bloom_bytes;
+        ThriftSerializer serializer(/*compact=*/true, 64);
+        ASSERT_TRUE(serializer.serialize(&bloom_header, &bloom_bytes).ok());
+        bloom_bytes.insert(bloom_bytes.end(), bloom_filter.data(),
+                           bloom_filter.data() + bloom_filter.size());
+
+        tparquet::ColumnMetaData column_metadata;
+        column_metadata.__set_type(physical_type);
+        column_metadata.__set_codec(tparquet::CompressionCodec::UNCOMPRESSED);
+        column_metadata.__set_num_values(1);
+        column_metadata.__set_total_compressed_size(0);
+        column_metadata.__set_data_page_offset(0);
+        column_metadata.__set_bloom_filter_offset(0);
+        column_metadata.__set_bloom_filter_length(static_cast<int32_t>(bloom_bytes.size()));
+        tparquet::ColumnChunk chunk;
+        chunk.__set_meta_data(column_metadata);
+        tparquet::RowGroup row_group;
+        row_group.__set_columns({chunk});
+        row_group.__set_total_byte_size(0);
+        row_group.__set_num_rows(1);
+        tparquet::FileMetaData metadata;
+        metadata.__set_version(1);
+        metadata.__set_num_rows(1);
+        metadata.__set_row_groups({row_group});
+
+        const auto field = Field::create_field<Type>(predicate_value);
+        for (const bool use_eq : {true, false}) {
+            auto column_schema = std::make_unique<format::parquet::ParquetColumnSchema>();
+            column_schema->type = std::make_shared<DataType>();
+            column_schema->type_descriptor.doris_type = column_schema->type;
+            column_schema->type_descriptor.physical_type = physical_type;
+            column_schema->local_id = 0;
+            column_schema->leaf_column_id = 0;
+
+            format::FileScanRequest request;
+            request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+            request.conjuncts = use_eq ? bloom_eq_conjunct(column_schema->type, field)
+                                       : bloom_conjuncts(column_schema->type, {field});
+            std::vector<std::unique_ptr<format::parquet::ParquetColumnSchema>> schema;
+            schema.push_back(std::move(column_schema));
+            format::parquet::ParquetFileContext file_context;
+            file_context.native_file = std::make_shared<StatisticsMemoryFileReader>(bloom_bytes);
+            std::vector<int> selected_row_groups;
+            format::parquet::ParquetPruningStats pruning_stats;
+            ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
+                                metadata, schema, request, nullptr, &selected_row_groups, true,
+                                &pruning_stats, nullptr, nullptr, &file_context)
+                                .ok());
+            EXPECT_EQ(selected_row_groups, std::vector<int>({0}));
+            EXPECT_EQ(pruning_stats.filtered_row_groups_by_bloom_filter, 0);
+        }
+    };
+
+    check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(tparquet::Type::FLOAT, -0.0F, 0.0F);
+    check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(tparquet::Type::DOUBLE, 0.0, -0.0);
+    check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(
+            tparquet::Type::FLOAT, std::bit_cast<float>(uint32_t {0x7fc00001U}),
+            std::bit_cast<float>(uint32_t {0x7fc00002U}));
+    check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(
+            tparquet::Type::DOUBLE, std::bit_cast<double>(uint64_t {0x7ff8000000000001ULL}),
+            std::bit_cast<double>(uint64_t {0x7ff8000000000002ULL}));
 }
 
 TEST(ParquetBloomFilterPruningTest, NativeRowGroupKeepsPresentUint32AboveInt32Max) {

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -148,7 +148,7 @@ private:
 
 class MetadataFloatingEqualityExpr final : public VExpr {
 public:
-    enum class Mode { EQ, IN };
+    enum class Mode { EQ, IN, NE, GT, GE, REVERSED_LT, REVERSED_LE, NOT_IN };
 
     MetadataFloatingEqualityExpr(int column_id, DataTypePtr data_type, Field nan_value, Mode mode)
             : VExpr(std::make_shared<DataTypeUInt8>(), false),
@@ -157,8 +157,20 @@ public:
                       nan_value, remove_nullable(data_type)->get_primitive_type(), 0, 0))),
               _mode(mode),
               _values {Field::create_field<TYPE_DOUBLE>(10.0), std::move(nan_value)} {
-        if (remove_nullable(data_type)->get_primitive_type() == TYPE_FLOAT) {
+        const auto primitive_type = remove_nullable(data_type)->get_primitive_type();
+        if (primitive_type == TYPE_FLOAT) {
             _values[0] = Field::create_field<TYPE_FLOAT>(10.0F);
+            _zero_literal = VLiteral::create_shared(create_texpr_node_from(
+                    Field::create_field<TYPE_FLOAT>(0.0F), TYPE_FLOAT, 0, 0));
+            _one_literal = VLiteral::create_shared(create_texpr_node_from(
+                    Field::create_field<TYPE_FLOAT>(1.0F), TYPE_FLOAT, 0, 0));
+            _not_in_values = {Field::create_field<TYPE_FLOAT>(0.0F)};
+        } else {
+            _zero_literal = VLiteral::create_shared(create_texpr_node_from(
+                    Field::create_field<TYPE_DOUBLE>(0.0), TYPE_DOUBLE, 0, 0));
+            _one_literal = VLiteral::create_shared(create_texpr_node_from(
+                    Field::create_field<TYPE_DOUBLE>(1.0), TYPE_DOUBLE, 0, 0));
+            _not_in_values = {Field::create_field<TYPE_DOUBLE>(0.0)};
         }
     }
 
@@ -169,11 +181,33 @@ public:
     }
     bool can_evaluate_zonemap_filter() const override { return true; }
     ZoneMapFilterResult evaluate_zonemap_filter(const ZoneMapEvalContext& ctx) const override {
-        if (_mode == Mode::EQ) {
+        switch (_mode) {
+        case Mode::EQ:
             return comparison_zonemap_detail::evaluate(ctx, {_slot, _nan_literal},
                                                        comparison_zonemap_detail::Op::EQ);
+        case Mode::IN:
+            return expr_zonemap::eval_in_zonemap(ctx, _slot, false, _values, true, _values[0],
+                                                 _values[1]);
+        case Mode::NE:
+            return comparison_zonemap_detail::evaluate(ctx, {_slot, _zero_literal},
+                                                       comparison_zonemap_detail::Op::NE);
+        case Mode::GT:
+            return comparison_zonemap_detail::evaluate(ctx, {_slot, _one_literal},
+                                                       comparison_zonemap_detail::Op::GT);
+        case Mode::GE:
+            return comparison_zonemap_detail::evaluate(ctx, {_slot, _one_literal},
+                                                       comparison_zonemap_detail::Op::GE);
+        case Mode::REVERSED_LT:
+            return comparison_zonemap_detail::evaluate(ctx, {_one_literal, _slot},
+                                                       comparison_zonemap_detail::Op::LT);
+        case Mode::REVERSED_LE:
+            return comparison_zonemap_detail::evaluate(ctx, {_one_literal, _slot},
+                                                       comparison_zonemap_detail::Op::LE);
+        case Mode::NOT_IN:
+            return expr_zonemap::eval_in_zonemap(ctx, _slot, true, _not_in_values, false,
+                                                 _not_in_values[0], _not_in_values[0]);
         }
-        return expr_zonemap::eval_in_zonemap(ctx, _slot, false, _values, _values[0], _values[1]);
+        __builtin_unreachable();
     }
     void collect_slot_column_ids(std::set<int>& column_ids) const override {
         _slot->collect_slot_column_ids(column_ids);
@@ -182,8 +216,11 @@ public:
 private:
     VExprSPtr _slot;
     VExprSPtr _nan_literal;
+    VExprSPtr _zero_literal;
+    VExprSPtr _one_literal;
     Mode _mode;
     std::vector<Field> _values;
+    std::vector<Field> _not_in_values;
     const std::string _expr_name = "MetadataFloatingEqualityExpr";
 };
 
@@ -368,7 +405,12 @@ TEST(NativeParquetStatisticsTest, FloatingNanEqualityKeepsFiniteOnlyFooterAndPag
 
         const auto nan_field = Field::create_field<Type>(std::bit_cast<T>(nan_bits));
         for (const auto mode :
-             {MetadataFloatingEqualityExpr::Mode::EQ, MetadataFloatingEqualityExpr::Mode::IN}) {
+             {MetadataFloatingEqualityExpr::Mode::EQ, MetadataFloatingEqualityExpr::Mode::IN,
+              MetadataFloatingEqualityExpr::Mode::NE, MetadataFloatingEqualityExpr::Mode::GT,
+              MetadataFloatingEqualityExpr::Mode::GE,
+              MetadataFloatingEqualityExpr::Mode::REVERSED_LT,
+              MetadataFloatingEqualityExpr::Mode::REVERSED_LE,
+              MetadataFloatingEqualityExpr::Mode::NOT_IN}) {
             format::FileScanRequest request;
             request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
             request.predicate_columns = {

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -40,8 +40,10 @@
 #include "core/data_type/data_type_time.h"
 #include "core/field.h"
 #include "exprs/expr_zonemap_filter.h"
+#include "exprs/function/functions_comparison.h"
 #include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
+#include "exprs/vliteral.h"
 #include "exprs/vslot_ref.h"
 #include "format_v2/file_reader.h"
 #include "format_v2/parquet/parquet_column_schema.h"
@@ -142,6 +144,47 @@ private:
     std::shared_ptr<VSlotRef> _slot;
     Field _value;
     const std::string _expr_name = "BloomEqExpr";
+};
+
+class MetadataFloatingEqualityExpr final : public VExpr {
+public:
+    enum class Mode { EQ, IN };
+
+    MetadataFloatingEqualityExpr(int column_id, DataTypePtr data_type, Field nan_value, Mode mode)
+            : VExpr(std::make_shared<DataTypeUInt8>(), false),
+              _slot(VSlotRef::create_shared(0, column_id, -1, data_type, "c0")),
+              _nan_literal(VLiteral::create_shared(create_texpr_node_from(
+                      nan_value, remove_nullable(data_type)->get_primitive_type(), 0, 0))),
+              _mode(mode),
+              _values {Field::create_field<TYPE_DOUBLE>(10.0), std::move(nan_value)} {
+        if (remove_nullable(data_type)->get_primitive_type() == TYPE_FLOAT) {
+            _values[0] = Field::create_field<TYPE_FLOAT>(10.0F);
+        }
+    }
+
+    const std::string& expr_name() const override { return _expr_name; }
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
+                               ColumnPtr&) const override {
+        return Status::InternalError("MetadataFloatingEqualityExpr is metadata-only");
+    }
+    bool can_evaluate_zonemap_filter() const override { return true; }
+    ZoneMapFilterResult evaluate_zonemap_filter(const ZoneMapEvalContext& ctx) const override {
+        if (_mode == Mode::EQ) {
+            return comparison_zonemap_detail::evaluate(ctx, {_slot, _nan_literal},
+                                                       comparison_zonemap_detail::Op::EQ);
+        }
+        return expr_zonemap::eval_in_zonemap(ctx, _slot, false, _values, _values[0], _values[1]);
+    }
+    void collect_slot_column_ids(std::set<int>& column_ids) const override {
+        _slot->collect_slot_column_ids(column_ids);
+    }
+
+private:
+    VExprSPtr _slot;
+    VExprSPtr _nan_literal;
+    Mode _mode;
+    std::vector<Field> _values;
+    const std::string _expr_name = "MetadataFloatingEqualityExpr";
 };
 
 class DictionaryStringInExpr final : public VExpr {
@@ -272,6 +315,91 @@ TEST(NativeParquetStatisticsTest, InvalidNullableDateBoundsDisableMinMax) {
     const auto result = format::parquet::ParquetStatisticsUtils::TransformColumnStatistics(
             column_schema, &statistics, 1, nullptr);
     EXPECT_FALSE(result.has_min_max);
+}
+
+TEST(NativeParquetStatisticsTest, FloatingNanEqualityKeepsFiniteOnlyFooterAndPageRanges) {
+    const auto check_type = []<PrimitiveType Type, typename DataType, typename UInt>(
+                                    tparquet::Type::type physical_type, UInt nan_bits) {
+        using T = typename PrimitiveTypeTraits<Type>::CppType;
+        auto column_schema = std::make_unique<format::parquet::ParquetColumnSchema>();
+        column_schema->kind = format::parquet::ParquetColumnSchemaKind::PRIMITIVE;
+        column_schema->local_id = 0;
+        column_schema->leaf_column_id = 0;
+        column_schema->type = std::make_shared<DataType>();
+        column_schema->type_descriptor.doris_type = column_schema->type;
+        column_schema->type_descriptor.physical_type = physical_type;
+        std::vector<std::unique_ptr<format::parquet::ParquetColumnSchema>> schema;
+        schema.push_back(std::move(column_schema));
+
+        const T finite_bound = T {0};
+        const std::string encoded_bound(reinterpret_cast<const char*>(&finite_bound), sizeof(T));
+        tparquet::Statistics statistics;
+        statistics.__set_min_value(encoded_bound);
+        statistics.__set_max_value(encoded_bound);
+        statistics.__set_null_count(0);
+        tparquet::ColumnMetaData column_metadata;
+        column_metadata.__set_type(physical_type);
+        column_metadata.__set_num_values(2);
+        column_metadata.__set_total_compressed_size(0);
+        column_metadata.__set_statistics(statistics);
+        tparquet::ColumnChunk chunk;
+        chunk.__set_meta_data(column_metadata);
+        tparquet::RowGroup row_group;
+        row_group.__set_columns({chunk});
+        row_group.__set_num_rows(2);
+        tparquet::ColumnOrder order;
+        order.__set_TYPE_ORDER(tparquet::TypeDefinedOrder());
+        tparquet::FileMetaData metadata;
+        metadata.__set_column_orders({order});
+        metadata.__set_row_groups({row_group});
+
+        format::parquet::NativeParquetPageIndex page_index;
+        page_index.column_index.__set_min_values({encoded_bound});
+        page_index.column_index.__set_max_values({encoded_bound});
+        page_index.column_index.__set_null_pages({false});
+        page_index.column_index.__set_null_counts({0});
+        tparquet::PageLocation location;
+        location.__set_offset(0);
+        location.__set_compressed_page_size(10);
+        location.__set_first_row_index(0);
+        page_index.offset_index.__set_page_locations({location});
+        std::unordered_map<int, format::parquet::NativeParquetPageIndex> page_indexes;
+        page_indexes.emplace(0, std::move(page_index));
+
+        const auto nan_field = Field::create_field<Type>(std::bit_cast<T>(nan_bits));
+        for (const auto mode :
+             {MetadataFloatingEqualityExpr::Mode::EQ, MetadataFloatingEqualityExpr::Mode::IN}) {
+            format::FileScanRequest request;
+            request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+            request.predicate_columns = {
+                    format::LocalColumnIndex::top_level(format::LocalColumnId(0))};
+            request.conjuncts = {
+                    VExprContext::create_shared(std::make_shared<MetadataFloatingEqualityExpr>(
+                            0, schema[0]->type, nan_field, mode))};
+
+            std::vector<int> selected_row_groups;
+            ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
+                                metadata, schema, request, nullptr, &selected_row_groups, false,
+                                nullptr)
+                                .ok());
+            EXPECT_EQ(selected_row_groups, std::vector<int>({0}));
+
+            std::vector<format::parquet::RowRange> selected_ranges;
+            std::map<int, format::parquet::ParquetPageSkipPlan> skip_plans;
+            ASSERT_TRUE(format::parquet::select_row_group_ranges_by_native_page_index(
+                                metadata, page_indexes, schema, request, 2, &selected_ranges,
+                                &skip_plans, nullptr)
+                                .ok());
+            ASSERT_EQ(1, selected_ranges.size());
+            EXPECT_EQ(0, selected_ranges[0].start);
+            EXPECT_EQ(2, selected_ranges[0].length);
+        }
+    };
+
+    check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(tparquet::Type::FLOAT,
+                                                                uint32_t {0x7fc00002U});
+    check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(tparquet::Type::DOUBLE,
+                                                                 uint64_t {0x7ff8000000000002ULL});
 }
 
 TEST(NativeParquetStatisticsTest, InvalidNullableDecimalBoundsDisableMinMax) {

--- a/be/test/storage/predicate/block_column_predicate_test.cpp
+++ b/be/test/storage/predicate/block_column_predicate_test.cpp
@@ -1249,6 +1249,35 @@ TEST_F(BlockColumnPredicateTest, test_double_single_column_predicate) {
     }
 }
 
+TEST_F(BlockColumnPredicateTest, floating_in_range_preserves_native_nan) {
+    const auto check_type = []<PrimitiveType Type>() {
+        using T = typename PrimitiveTypeTraits<Type>::CppType;
+        const T nan = std::numeric_limits<T>::quiet_NaN();
+        const T zero = T {0};
+
+        auto in_set = std::make_shared<HybridSet<Type>>(false);
+        in_set->insert(&nan);
+        InListPredicateBase<Type, PredicateType::IN_LIST, 0> in_predicate(0, "", in_set, false);
+
+        segment_v2::ZoneMap zone_map {.min_value = Field::create_field<Type>(T {100}),
+                                      .max_value = Field::create_field<Type>(nan),
+                                      .has_null = false,
+                                      .has_not_null = true,
+                                      .has_nan = true};
+        EXPECT_TRUE(in_predicate.evaluate_and(zone_map));
+
+        auto not_in_set = std::make_shared<HybridSet<Type>>(false);
+        not_in_set->insert(&zero);
+        not_in_set->insert(&nan);
+        InListPredicateBase<Type, PredicateType::NOT_IN_LIST, 0> not_in_predicate(0, "", not_in_set,
+                                                                                  false);
+        EXPECT_FALSE(not_in_predicate.evaluate_del(zone_map));
+    };
+
+    check_type.template operator()<TYPE_FLOAT>();
+    check_type.template operator()<TYPE_DOUBLE>();
+}
+
 // test timestamptz zonemap index
 TEST_F(BlockColumnPredicateTest, test_timestamptz_zonemap_index) {
     cctz::time_zone time_zone = cctz::fixed_time_zone(std::chrono::hours(0));


### PR DESCRIPTION
### What problem does this PR solve?

Doris floating-point equality treats all NaN payloads as equal and treats positive and negative zero as equal. Parquet metadata uses different semantics:

- Bloom filters hash the physical IEEE bytes, so equal NaN payloads or signed zeros can have different hashes.
- Parquet min/max statistics may omit NaN values.
- Large floating-point IN predicates use a hash set whose hash must remain consistent with Doris equality.

These differences could incorrectly prune a row group or reject a matching row during residual IN evaluation.

### What is changed?

- Keep NaN Bloom probes conservative for FLOAT and DOUBLE.
- Probe both signed-zero encodings in the legacy and FileScannerV2 Parquet readers.
- Bypass Parquet row-group and page min/max pruning for NaN EQ/IN predicates when NaN presence is unknown.
- Normalize NaN payloads and signed zero before hashing dynamic floating-point IN sets.
- Preserve normal pruning for finite nonzero values and Doris zonemaps with trustworthy NaN metadata.
- Add regression coverage for EQ/IN, FLOAT/DOUBLE, both Parquet readers, row-group/page statistics, signed zero, different NaN payloads, and large residual IN sets.

### Release note

Fix incorrect Parquet pruning and residual IN filtering for NaN and signed-zero equality.

### Check List

- [x] Unit tests
  - 105 focused BE tests passed.
- [x] Behavior changed
  - Floating-point equality is now preserved across Parquet statistics, Bloom filters, and residual IN evaluation.
- [x] No documentation change is required.