### PR TITLE
[fix](fe) Fix concurrent truncate metadata access

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -3590,17 +3590,18 @@ public class InternalCatalog implements CatalogIf<Database> {
                 // which is the right behavior.
                 long oldPartitionId = entry.getValue();
                 long newPartitionId = oldToNewPartitionId.get(oldPartitionId);
+                DataProperty dataProperty = copiedTbl.getPartitionInfo().getDataProperty(oldPartitionId);
                 Partition newPartition = createPartitionWithIndices(db.getId(), copiedTbl,
                         newPartitionId, entry.getKey(),
                         copiedTbl.getIndexIdToMeta(), partitionsDistributionInfo.get(oldPartitionId),
-                        copiedTbl.getPartitionInfo().getDataProperty(oldPartitionId),
+                        dataProperty,
                         copiedTbl.getPartitionInfo().getReplicaAllocation(oldPartitionId), null /* version info */,
                         copiedTbl.getCopiedBfColumns(), tabletIdSet,
                         copiedTbl.isInMemory(),
                         copiedTbl.getPartitionInfo().getTabletType(oldPartitionId),
-                        olapTable.getPartitionInfo().getDataProperty(oldPartitionId).getStoragePolicy(),
+                        dataProperty.getStoragePolicy(),
                         idGeneratorBuffer, binlogConfig,
-                        copiedTbl.getPartitionInfo().getDataProperty(oldPartitionId).isStorageMediumSpecified());
+                        dataProperty.isStorageMediumSpecified());
                 newPartitions.add(newPartition);
             }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/TruncateTableCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/TruncateTableCommandTest.java
@@ -27,6 +27,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ExceptionChecker;
 import org.apache.doris.common.util.DebugPointUtil;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.parser.NereidsParser;
@@ -45,6 +46,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class TruncateTableCommandTest extends TestWithFeService {
     @Override
@@ -271,6 +278,88 @@ public class TruncateTableCommandTest extends TestWithFeService {
             }
         } finally {
             DebugPointUtil.removeDebugPoint("InternalCatalog.truncateTable.metaChanged");
+        }
+    }
+
+    @Test
+    public void testConcurrentTruncateTable() throws Exception {
+        String tableName = "concurrent_truncate_table";
+        createTable("CREATE TABLE internal.testcommand." + tableName + " (k1 INT) "
+                + "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 1 "
+                + "PROPERTIES ('replication_num' = '1')");
+
+        InternalCatalog internalCatalog = Mockito.spy(Env.getCurrentInternalCatalog());
+        CountDownLatch firstTruncateReady = new CountDownLatch(1);
+        CountDownLatch resumeFirstTruncate = new CountDownLatch(1);
+        AtomicInteger beforeCreateCalls = new AtomicInteger();
+        Mockito.doAnswer(invocation -> {
+            if (beforeCreateCalls.incrementAndGet() == 1) {
+                firstTruncateReady.countDown();
+                if (!resumeFirstTruncate.await(10, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("Timed out waiting to resume the first truncate");
+                }
+            }
+            return null;
+        }).when(internalCatalog).beforeCreatePartitions(
+                Mockito.anyLong(), Mockito.anyLong(), Mockito.anyList(), Mockito.anyList(), Mockito.eq(true));
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Throwable> firstTruncate = executor.submit(() -> {
+            try {
+                internalCatalog.truncateTable("testcommand", tableName, null, false, "TRUNCATE TABLE");
+                return null;
+            } catch (Throwable t) {
+                return t;
+            }
+        });
+
+        Throwable testFailure = null;
+        try {
+            Assertions.assertTrue(firstTruncateReady.await(10, TimeUnit.SECONDS));
+            internalCatalog.truncateTable("testcommand", tableName, null, false, "TRUNCATE TABLE");
+
+            Database db = Env.getCurrentInternalCatalog().getDbOrDdlException("testcommand");
+            OlapTable table = db.getOlapTableOrDdlException(tableName);
+            long partitionIdAfterSuccessfulTruncate = table.getPartitions().iterator().next().getId();
+            Map<Long, Set<Long>> tabletsAfterSuccessfulTruncate = Maps.newHashMap();
+            for (long backendId : Env.getCurrentSystemInfo().getAllBackendIds()) {
+                tabletsAfterSuccessfulTruncate.put(backendId,
+                        Sets.newHashSet(Env.getCurrentInvertedIndex().getTabletIdsByBackendId(backendId)));
+            }
+
+            resumeFirstTruncate.countDown();
+            Throwable firstTruncateFailure = firstTruncate.get(10, TimeUnit.SECONDS);
+            Assertions.assertInstanceOf(DdlException.class, firstTruncateFailure);
+            Assertions.assertEquals("Partition [" + tableName
+                    + "] is changed during truncating table, please retry", firstTruncateFailure.getMessage());
+            Assertions.assertEquals(partitionIdAfterSuccessfulTruncate,
+                    table.getPartitions().iterator().next().getId());
+            for (long backendId : Env.getCurrentSystemInfo().getAllBackendIds()) {
+                Assertions.assertEquals(tabletsAfterSuccessfulTruncate.get(backendId),
+                        Sets.newHashSet(Env.getCurrentInvertedIndex().getTabletIdsByBackendId(backendId)));
+            }
+        } catch (Exception | AssertionError e) {
+            testFailure = e;
+            throw e;
+        } finally {
+            resumeFirstTruncate.countDown();
+            executor.shutdownNow();
+            try {
+                if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+                    AssertionError terminationFailure =
+                            new AssertionError("Concurrent truncate executor did not terminate");
+                    if (testFailure == null) {
+                        throw terminationFailure;
+                    }
+                    testFailure.addSuppressed(terminationFailure);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                if (testFailure == null) {
+                    throw e;
+                }
+                testFailure.addSuppressed(e);
+            }
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

Concurrent `TRUNCATE TABLE` operations can snapshot the same original partition ID. If one operation replaces the partition first, the other operation currently reads the old partition's storage policy from the unlocked live `OlapTable`. The old ID has already been removed from `PartitionInfo`, so this lookup throws a null pointer exception before the existing stale-partition validation can return its retryable `DdlException`.

This change uses the `DataProperty` from the deep-copied table snapshot consistently while creating replacement partitions. The stale truncate can then finish temporary partition creation, reach the write-lock validation, return `Partition [...] is changed during truncating table, please retry`, and clean its temporary tablet metadata.

A deterministic FE unit test pauses one truncate after its snapshot, lets a second truncate replace the partition, resumes the first operation, and verifies the retryable error, surviving partition ID, and exact tablet metadata cleanup.

Please backport this fix to `branch-4.1` after merge.

### Release note

Fix a null pointer exception when truncating the same table concurrently.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - Added `TruncateTableCommandTest.testConcurrentTruncateTable`.
        - Local execution was attempted with `run-fe-ut.sh`, but generated-source creation stopped before test compilation because `thirdparty/installed/bin/protoc` is unavailable in the provided worktree. The standard `build.sh --fe -j 90` path is blocked by the same missing prerequisite. CI validation is required.
    - [ ] Manual test
    - [ ] No need to test or manual test

- Behavior changed:
    - [x] Yes. A stale concurrent truncate now returns the existing retryable partition-changed error instead of a null pointer exception.
    - [ ] No.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Review

An independent static review covered correctness, concurrency/locking, cleanup, performance, maintainability, and test determinism. The review found one teardown robustness issue in the initial test; it was fixed, and re-review reported no remaining findings. `git diff --check` passes.
