### PR TITLE
branch-4.1: [fix](fe) Fix concurrent truncate metadata access #66424

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/InternalCatalog.java
@@ -3720,17 +3720,18 @@ public class InternalCatalog implements CatalogIf<Database> {
                 // which is the right behavior.
                 long oldPartitionId = entry.getValue();
                 long newPartitionId = oldToNewPartitionId.get(oldPartitionId);
+                DataProperty dataProperty = copiedTbl.getPartitionInfo().getDataProperty(oldPartitionId);
                 Partition newPartition = createPartitionWithIndices(db.getId(), copiedTbl,
                         newPartitionId, entry.getKey(),
                         copiedTbl.getIndexIdToMeta(), partitionsDistributionInfo.get(oldPartitionId),
-                        copiedTbl.getPartitionInfo().getDataProperty(oldPartitionId),
+                        dataProperty,
                         copiedTbl.getPartitionInfo().getReplicaAllocation(oldPartitionId), null /* version info */,
                         copiedTbl.getCopiedBfColumns(), tabletIdSet,
                         copiedTbl.isInMemory(),
                         copiedTbl.getPartitionInfo().getTabletType(oldPartitionId),
-                        olapTable.getPartitionInfo().getDataProperty(oldPartitionId).getStoragePolicy(),
+                        dataProperty.getStoragePolicy(),
                         idGeneratorBuffer, binlogConfig,
-                        copiedTbl.getPartitionInfo().getDataProperty(oldPartitionId).isStorageMediumSpecified());
+                        dataProperty.isStorageMediumSpecified());
                 newPartitions.add(newPartition);
             }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/TruncateTableCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/TruncateTableCommandTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ExceptionChecker;
 import org.apache.doris.common.util.DebugPointUtil;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.info.PartitionNamesInfo;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
@@ -42,11 +43,18 @@ import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class TruncateTableCommandTest extends TestWithFeService {
     @Override
@@ -265,6 +273,88 @@ public class TruncateTableCommandTest extends TestWithFeService {
             }
         } finally {
             DebugPointUtil.removeDebugPoint("InternalCatalog.truncateTable.metaChanged");
+        }
+    }
+
+    @Test
+    public void testConcurrentTruncateTable() throws Exception {
+        String tableName = "concurrent_truncate_table";
+        createTable("CREATE TABLE internal.testcommand." + tableName + " (k1 INT) "
+                + "DUPLICATE KEY(k1) DISTRIBUTED BY HASH(k1) BUCKETS 1 "
+                + "PROPERTIES ('replication_num' = '1')");
+
+        InternalCatalog internalCatalog = Mockito.spy(Env.getCurrentInternalCatalog());
+        CountDownLatch firstTruncateReady = new CountDownLatch(1);
+        CountDownLatch resumeFirstTruncate = new CountDownLatch(1);
+        AtomicInteger beforeCreateCalls = new AtomicInteger();
+        Mockito.doAnswer(invocation -> {
+            if (beforeCreateCalls.incrementAndGet() == 1) {
+                firstTruncateReady.countDown();
+                if (!resumeFirstTruncate.await(10, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("Timed out waiting to resume the first truncate");
+                }
+            }
+            return null;
+        }).when(internalCatalog).beforeCreatePartitions(
+                Mockito.anyLong(), Mockito.anyLong(), Mockito.anyList(), Mockito.anyList(), Mockito.eq(true));
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<Throwable> firstTruncate = executor.submit(() -> {
+            try {
+                internalCatalog.truncateTable("testcommand", tableName, null, false, "TRUNCATE TABLE");
+                return null;
+            } catch (Throwable t) {
+                return t;
+            }
+        });
+
+        Throwable testFailure = null;
+        try {
+            Assertions.assertTrue(firstTruncateReady.await(10, TimeUnit.SECONDS));
+            internalCatalog.truncateTable("testcommand", tableName, null, false, "TRUNCATE TABLE");
+
+            Database db = Env.getCurrentInternalCatalog().getDbOrDdlException("testcommand");
+            OlapTable table = db.getOlapTableOrDdlException(tableName);
+            long partitionIdAfterSuccessfulTruncate = table.getPartitions().iterator().next().getId();
+            Map<Long, Set<Long>> tabletsAfterSuccessfulTruncate = Maps.newHashMap();
+            for (long backendId : Env.getCurrentSystemInfo().getAllBackendIds()) {
+                tabletsAfterSuccessfulTruncate.put(backendId,
+                        Sets.newHashSet(Env.getCurrentInvertedIndex().getTabletIdsByBackendId(backendId)));
+            }
+
+            resumeFirstTruncate.countDown();
+            Throwable firstTruncateFailure = firstTruncate.get(10, TimeUnit.SECONDS);
+            Assertions.assertInstanceOf(DdlException.class, firstTruncateFailure);
+            Assertions.assertEquals("Partition [" + tableName
+                    + "] is changed during truncating table, please retry", firstTruncateFailure.getMessage());
+            Assertions.assertEquals(partitionIdAfterSuccessfulTruncate,
+                    table.getPartitions().iterator().next().getId());
+            for (long backendId : Env.getCurrentSystemInfo().getAllBackendIds()) {
+                Assertions.assertEquals(tabletsAfterSuccessfulTruncate.get(backendId),
+                        Sets.newHashSet(Env.getCurrentInvertedIndex().getTabletIdsByBackendId(backendId)));
+            }
+        } catch (Exception | AssertionError e) {
+            testFailure = e;
+            throw e;
+        } finally {
+            resumeFirstTruncate.countDown();
+            executor.shutdownNow();
+            try {
+                if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+                    AssertionError terminationFailure =
+                            new AssertionError("Concurrent truncate executor did not terminate");
+                    if (testFailure == null) {
+                        throw terminationFailure;
+                    }
+                    testFailure.addSuppressed(terminationFailure);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                if (testFailure == null) {
+                    throw e;
+                }
+                testFailure.addSuppressed(e);
+            }
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Backport #66424 to `branch-4.1`.

When two `TRUNCATE TABLE` operations race, a stale request can read the live table's `PartitionInfo` with an old partition ID after the winning request has replaced that partition. This can cause an NPE before the existing concurrent-change check returns the intended retryable `DdlException`.

### What is changed and how does it work?

Use the copied table snapshot's `DataProperty` consistently while building replacement partitions. Add a deterministic unit test that forces two truncate operations through the race and verifies that the stale request receives the retryable error without deleting the winner's tablets.

This commit was cherry-picked from #66424 with `-x`; the only conflict resolution was adapting imports to the `branch-4.1` test APIs.

### Check List

- [x] `git diff --check`
- [x] Independent code review completed with no findings
- [ ] FE unit test executed locally (blocked before compilation because `thirdparty/installed/bin/protoc` is absent in the provided checkout)

Issue Number: N/A

