### PR TITLE
[opt](nereids) Eliminate consumed mark joins and put MERGE INTO target on the probe side

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleSet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/RuleSet.java
@@ -100,6 +100,7 @@ import org.apache.doris.nereids.rules.implementation.SplitAggMultiPhase;
 import org.apache.doris.nereids.rules.implementation.SplitAggMultiPhaseWithoutGbyKey;
 import org.apache.doris.nereids.rules.implementation.SplitAggWithoutDistinct;
 import org.apache.doris.nereids.rules.rewrite.EliminateFilter;
+import org.apache.doris.nereids.rules.rewrite.EliminateMarkJoin;
 import org.apache.doris.nereids.rules.rewrite.EliminateOuterJoin;
 import org.apache.doris.nereids.rules.rewrite.MaxMinFilterPushDown;
 import org.apache.doris.nereids.rules.rewrite.MergeFilters;
@@ -175,6 +176,7 @@ public class RuleSet {
             new PushDownProjectThroughLimit(),
             new PushDownProject(),
             new EliminateOuterJoin(),
+            new EliminateMarkJoin(),
             new MergeProjectable(),
             new MergeFilters(),
             new MergeGenerates(),

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateMarkJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateMarkJoin.java
@@ -54,6 +54,12 @@ import java.util.Set;
  * The literal-TRUE alias keeps the mark slot's ExprId alive for references above the filter
  * (after the filter the mark can only be TRUE); column pruning removes it when unused.
  *
+ * The rewrite fires ONLY when the mark slot appears as a bare top-level conjunct of that
+ * filter. Whenever it occurs inside a compound predicate the three-valued mark semantics
+ * is observable and the mark join must stay as it is: filter((m and rest) is null),
+ * filter(m is null), filter(m or x), filter(not m) and a projection outputting m all keep
+ * the mark join.
+ *
  * Besides being cheaper to execute, this matters because {@code RuntimeFilterGenerator}
  * refuses to generate runtime filters on mark joins, so a residual mark join needlessly
  * disables runtime filter pruning on the probe side scan. This shape typically arises from

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateMarkJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateMarkJoin.java
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite;
+
+import org.apache.doris.nereids.rules.Rule;
+import org.apache.doris.nereids.rules.RuleType;
+import org.apache.doris.nereids.trees.expressions.Alias;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.MarkJoinSlotReference;
+import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
+import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
+import org.apache.doris.nereids.util.ExpressionUtils;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Eliminate a mark join whose mark slot is only consumed, as a bare conjunct, by the filter
+ * directly above it.
+ *
+ * A LEFT SEMI mark join outputs every left row together with a three-valued mark slot
+ * (TRUE / FALSE / NULL) recording whether the semi condition matched. A filter that requires
+ * the mark slot to be TRUE discards NULL rows exactly like FALSE rows, so the pair degenerates
+ * to a plain LEFT SEMI JOIN over the same conjuncts:
+ * <pre>
+ * filter(m and rest)                     project(join output, TRUE as m)
+ * +--join(LEFT SEMI, mark slot m)  =>    +--filter(rest)
+ *                                           +--join(LEFT SEMI)
+ * </pre>
+ * The literal-TRUE alias keeps the mark slot's ExprId alive for references above the filter
+ * (after the filter the mark can only be TRUE); column pruning removes it when unused.
+ *
+ * Besides being cheaper to execute, this matters because {@code RuntimeFilterGenerator}
+ * refuses to generate runtime filters on mark joins, so a residual mark join needlessly
+ * disables runtime filter pruning on the probe side scan. This shape typically arises from
+ * an IN/EXISTS subquery written inside a join ON clause: the subquery is unnested into a mark
+ * join before predicate push down moves the mark conjunct, so the non-mark unnesting path
+ * never gets a chance to apply.
+ */
+public class EliminateMarkJoin extends OneRewriteRuleFactory {
+
+    @Override
+    public Rule build() {
+        return logicalFilter(logicalJoin()
+                .when(join -> join.isMarkJoin() && join.getJoinType() == JoinType.LEFT_SEMI_JOIN))
+                .when(EliminateMarkJoin::markSlotOnlyUsedAsBareConjunct)
+                .then(EliminateMarkJoin::eliminateMarkJoin)
+                .toRule(RuleType.ELIMINATE_MARK_JOIN);
+    }
+
+    private static boolean markSlotOnlyUsedAsBareConjunct(LogicalFilter<LogicalJoin<Plan, Plan>> filter) {
+        MarkJoinSlotReference markSlot = filter.child().getMarkJoinSlotReference().get();
+        boolean hasBareMarkConjunct = false;
+        for (Expression conjunct : filter.getConjuncts()) {
+            if (conjunct.equals(markSlot)) {
+                hasBareMarkConjunct = true;
+            } else if (conjunct.getInputSlots().contains(markSlot)) {
+                // the mark slot takes part in a compound expression, e.g. OR(m, x): FALSE and
+                // NULL marks are distinguishable there, so the mark join must be kept
+                return false;
+            }
+        }
+        return hasBareMarkConjunct;
+    }
+
+    private static Plan eliminateMarkJoin(LogicalFilter<LogicalJoin<Plan, Plan>> filter) {
+        LogicalJoin<Plan, Plan> join = filter.child();
+        MarkJoinSlotReference markSlot = join.getMarkJoinSlotReference().get();
+        // requiring mark = TRUE collapses the three-valued mark semantics (NULL is discarded
+        // just like FALSE), so mark conjuncts can be evaluated as ordinary join conjuncts
+        List<Expression> otherConjuncts = join.getMarkJoinConjuncts().isEmpty()
+                ? join.getOtherJoinConjuncts()
+                : ImmutableList.<Expression>builder()
+                        .addAll(join.getOtherJoinConjuncts())
+                        .addAll(join.getMarkJoinConjuncts())
+                        .build();
+        LogicalJoin<Plan, Plan> newJoin = new LogicalJoin<>(join.getJoinType(),
+                join.getHashJoinConjuncts(), otherConjuncts, ExpressionUtils.EMPTY_CONDITION,
+                join.getDistributeHint(), Optional.empty(), join.left(), join.right(),
+                join.getJoinReorderContext());
+        Set<Expression> remainingConjuncts = filter.getConjuncts().stream()
+                .filter(conjunct -> !conjunct.equals(markSlot))
+                .collect(ImmutableSet.toImmutableSet());
+        Plan child = remainingConjuncts.isEmpty()
+                ? newJoin : new LogicalFilter<>(remainingConjuncts, newJoin);
+        ImmutableList.Builder<NamedExpression> projects = ImmutableList.builder();
+        projects.addAll(newJoin.getOutput());
+        projects.add(new Alias(markSlot.getExprId(), BooleanLiteral.TRUE, markSlot.getName()));
+        return new LogicalProject<>(projects.build(), child);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExternalRowLevelMergePlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ExternalRowLevelMergePlanBuilder.java
@@ -29,7 +29,6 @@ import org.apache.doris.nereids.analyzer.UnboundStar;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.parser.LogicalPlanBuilderAssistant;
 import org.apache.doris.nereids.parser.NereidsParser;
-import org.apache.doris.nereids.rules.exploration.join.JoinReorderContext;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.Expression;
@@ -42,13 +41,12 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.If;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
-import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.commands.merge.MergeMatchedClause;
 import org.apache.doris.nereids.trees.plans.commands.merge.MergeNotMatchedClause;
 import org.apache.doris.nereids.trees.plans.commands.merge.MergeOperation;
+import org.apache.doris.nereids.trees.plans.commands.merge.MergeUtils;
 import org.apache.doris.nereids.trees.plans.logical.LogicalExternalRowLevelMergeSink;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
-import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSubQueryAlias;
@@ -122,13 +120,7 @@ public class ExternalRowLevelMergePlanBuilder {
         if (targetAlias.isPresent()) {
             targetPlan = new LogicalSubQueryAlias<>(targetAlias.get(), targetPlan);
         }
-        // Use INNER JOIN when there are no WHEN NOT MATCHED clauses, since unmatched
-        // source rows are not needed. This allows early filtering for better performance.
-        JoinType joinType = notMatchedClauses.isEmpty()
-                ? JoinType.INNER_JOIN : JoinType.LEFT_OUTER_JOIN;
-        return new LogicalJoin<>(joinType,
-                ImmutableList.of(), ImmutableList.of(onClause),
-                source, targetPlan, JoinReorderContext.EMPTY);
+        return MergeUtils.buildMergeJoin(targetPlan, source, onClause, !notMatchedClauses.isEmpty());
     }
 
     private NamedExpression generateBranchLabel(Expression rowIdExpr) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/merge/MergeIntoCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/merge/MergeIntoCommand.java
@@ -31,7 +31,6 @@ import org.apache.doris.nereids.analyzer.UnboundTableSinkCreator;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.parser.LogicalPlanBuilderAssistant;
 import org.apache.doris.nereids.parser.NereidsParser;
-import org.apache.doris.nereids.rules.exploration.join.JoinReorderContext;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.DefaultValueSlot;
@@ -47,7 +46,6 @@ import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
 import org.apache.doris.nereids.trees.plans.Explainable;
-import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.commands.Command;
@@ -62,7 +60,6 @@ import org.apache.doris.nereids.trees.plans.commands.UpdateCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.DMLCommandType;
 import org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
-import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSubQueryAlias;
@@ -188,7 +185,7 @@ public class MergeIntoCommand extends Command implements ForwardWithSync, Explai
     }
 
     /**
-     * generate target right outer join source.
+     * generate target (inner | right outer) join source, see {@link MergeUtils#buildMergeJoin}.
      */
     private LogicalPlan generateBasePlan() {
         LogicalPlan plan = LogicalPlanBuilderAssistant.withCheckPolicy(
@@ -200,9 +197,7 @@ public class MergeIntoCommand extends Command implements ForwardWithSync, Explai
         if (targetAlias.isPresent()) {
             plan = new LogicalSubQueryAlias<>(targetAlias.get(), plan);
         }
-        return new LogicalJoin<>(JoinType.LEFT_OUTER_JOIN,
-                ImmutableList.of(), ImmutableList.of(onClause),
-                source, plan, JoinReorderContext.EMPTY);
+        return MergeUtils.buildMergeJoin(plan, source, onClause, !notMatchedClauses.isEmpty());
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/merge/MergeUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/merge/MergeUtils.java
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands.merge;
+
+import org.apache.doris.nereids.rules.exploration.join.JoinReorderContext;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Shared plan-construction helpers for MERGE INTO, used by both the internal OLAP path
+ * ({@link MergeIntoCommand}) and the external path
+ * ({@link org.apache.doris.nereids.trees.plans.commands.ExternalRowLevelMergePlanBuilder}).
+ */
+public class MergeUtils {
+
+    private MergeUtils() {
+    }
+
+    /**
+     * Build the base join between merge target and source, with the target on the LEFT (probe)
+     * side. Doris builds the hash table on the right child, and the target side is structurally
+     * the wide one: it must carry every table column plus the row identity for the sink, while
+     * the source usually only carries join keys and new values. Keeping the target on the probe
+     * side also lets RuntimeFilterGenerator prune the target scan with runtime filters built
+     * from the source side: INNER and RIGHT_OUTER joins may produce runtime filters while
+     * LEFT_OUTER is in its denied list.
+     *
+     * <p>Unmatched source rows are only needed by WHEN NOT MATCHED clauses, so without them the
+     * join is INNER; with them, RIGHT OUTER preserves exactly the unmatched source rows, which
+     * is equivalent to the previous "source LEFT OUTER JOIN target" shape.
+     */
+    public static LogicalPlan buildMergeJoin(LogicalPlan targetPlan, LogicalPlan source,
+            Expression onClause, boolean hasNotMatchedClauses) {
+        JoinType joinType = hasNotMatchedClauses ? JoinType.RIGHT_OUTER_JOIN : JoinType.INNER_JOIN;
+        return new LogicalJoin<>(joinType,
+                ImmutableList.of(), ImmutableList.of(onClause),
+                targetPlan, source, JoinReorderContext.EMPTY);
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateMarkJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateMarkJoinTest.java
@@ -88,6 +88,27 @@ class EliminateMarkJoinTest extends TestWithFeService implements MemoPatternMatc
     }
 
     @Test
+    void markSlotInNullDistinguishingPredicate() {
+        // the consumer keeps rows whose mark is NULL, so three-valued mark semantics is
+        // observable and the mark join must stay as it is
+        String sql = "select t1.id from t1"
+                + " where (t1.score in (select score from t3) and t1.id > 0) is null";
+
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .matches(logicalJoin().when(LogicalJoin::isMarkJoin));
+
+        String bareIsNull = "select t1.id from t1"
+                + " where (t1.score in (select score from t3)) is null";
+
+        PlanChecker.from(connectContext)
+                .analyze(bareIsNull)
+                .rewrite()
+                .matches(logicalJoin().when(LogicalJoin::isMarkJoin));
+    }
+
+    @Test
     void markSlotInDisjunction() {
         // FALSE and NULL marks are distinguishable inside OR: must keep the mark join
         String sql = "select t1.id from t1 where t1.id = 1"

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateMarkJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateMarkJoinTest.java
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite;
+
+import org.apache.doris.nereids.trees.plans.JoinType;
+import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
+import org.apache.doris.nereids.util.MemoPatternMatchSupported;
+import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Test;
+
+class EliminateMarkJoinTest extends TestWithFeService implements MemoPatternMatchSupported {
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase("test");
+
+        connectContext.setDatabase("test");
+        // tables are empty in the ut env, keep the scans from collapsing to empty relations
+        connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+
+        createTable("CREATE TABLE t1 (id int not null, score int null)\n"
+                + "DISTRIBUTED BY HASH(id) BUCKETS 1\n"
+                + "PROPERTIES(\"replication_num\"=\"1\");");
+        createTable("CREATE TABLE t2 (id int not null)\n"
+                + "DISTRIBUTED BY HASH(id) BUCKETS 1\n"
+                + "PROPERTIES(\"replication_num\"=\"1\");");
+        createTable("CREATE TABLE t3 (id int not null, score int null)\n"
+                + "DISTRIBUTED BY HASH(id) BUCKETS 1\n"
+                + "PROPERTIES(\"replication_num\"=\"1\");");
+    }
+
+    @Test
+    void inSubqueryInJoinOnCondition() {
+        // the IN subquery sits in the join ON clause, so unnesting produces a mark join;
+        // the mark slot ends up consumed by a bare filter conjunct and must be eliminated
+        String sql = "select t1.id from t1 join t2 on t1.id = t2.id"
+                + " and t1.id in (select id from t3)";
+
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .nonMatch(logicalJoin().when(LogicalJoin::isMarkJoin))
+                .matches(logicalJoin().when(join ->
+                        join.getJoinType() == JoinType.LEFT_SEMI_JOIN && !join.isMarkJoin()));
+    }
+
+    @Test
+    void inSubqueryInJoinOnConditionNullableColumn() {
+        // nullable compare column: the mark conjuncts may stay separate from the hash
+        // conjuncts, the rule must fold them into the plain semi join as well
+        String sql = "select t1.id from t1 join t2 on t1.id = t2.id"
+                + " and t1.score in (select score from t3)";
+
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .nonMatch(logicalJoin().when(LogicalJoin::isMarkJoin))
+                .matches(logicalJoin().when(join ->
+                        join.getJoinType() == JoinType.LEFT_SEMI_JOIN && !join.isMarkJoin()));
+    }
+
+    @Test
+    void markSlotProjectedToOutput() {
+        // the mark slot is the query output, not a filter conjunct: must keep the mark join
+        String sql = "select t1.id, t1.id in (select id from t3) as flag from t1";
+
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .matches(logicalJoin().when(LogicalJoin::isMarkJoin));
+    }
+
+    @Test
+    void markSlotInDisjunction() {
+        // FALSE and NULL marks are distinguishable inside OR: must keep the mark join
+        String sql = "select t1.id from t1 where t1.id = 1"
+                + " or t1.score in (select score from t3)";
+
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .matches(logicalJoin().when(LogicalJoin::isMarkJoin));
+    }
+
+    @Test
+    void notInSubqueryInJoinOnCondition() {
+        // NOT IN unnests to an anti mark join: the rule only handles LEFT SEMI
+        String sql = "select t1.id from t1 join t2 on t1.id = t2.id"
+                + " and t1.score not in (select score from t3)";
+
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .rewrite()
+                .matches(logicalJoin().when(join -> join.isMarkJoin()
+                        && (join.getJoinType() == JoinType.LEFT_ANTI_JOIN
+                        || join.getJoinType() == JoinType.NULL_AWARE_LEFT_ANTI_JOIN)));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/merge/MergeIntoCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/merge/MergeIntoCommandTest.java
@@ -85,11 +85,36 @@ public class MergeIntoCommandTest {
         Assertions.assertEquals(1, logicalJoin.getOtherJoinConjuncts().size());
         Expression onClause = logicalJoin.getOtherJoinConjuncts().get(0);
         Assertions.assertEquals(new NullLiteral(), onClause);
-        Assertions.assertEquals(JoinType.LEFT_OUTER_JOIN, logicalJoin.getJoinType());
-        Assertions.assertEquals(source, logicalJoin.left());
-        Assertions.assertInstanceOf(LogicalSubQueryAlias.class, logicalJoin.right());
-        LogicalSubQueryAlias<?> alias = (LogicalSubQueryAlias<?>) logicalJoin.right();
+        // without WHEN NOT MATCHED clauses unmatched source rows are not needed, so the join
+        // is INNER, and the target stays on the left (probe) side
+        Assertions.assertEquals(JoinType.INNER_JOIN, logicalJoin.getJoinType());
+        Assertions.assertEquals(source, logicalJoin.right());
+        Assertions.assertInstanceOf(LogicalSubQueryAlias.class, logicalJoin.left());
+        LogicalSubQueryAlias<?> alias = (LogicalSubQueryAlias<?>) logicalJoin.left();
         Assertions.assertEquals("alias", alias.getAlias());
+    }
+
+    @Test
+    public void testGenerateBasePlanWithNotMatchedClause() throws Exception {
+        LogicalPlan source = new LogicalEmptyRelation(new RelationId(1), ImmutableList.of());
+        MergeIntoCommand command = new MergeIntoCommand(
+                ImmutableList.of("ctl", "db", "tbl"), Optional.of("alias"), Optional.empty(),
+                source, new NullLiteral(),
+                ImmutableList.of(),
+                ImmutableList.of(new MergeNotMatchedClause(
+                        Optional.empty(), ImmutableList.of(), ImmutableList.of()))
+        );
+
+        Class<?> clazz = Class.forName("org.apache.doris.nereids.trees.plans.commands.merge.MergeIntoCommand");
+        Method generateBasePlan = clazz.getDeclaredMethod("generateBasePlan");
+        generateBasePlan.setAccessible(true);
+        LogicalPlan result = (LogicalPlan) generateBasePlan.invoke(command);
+        Assertions.assertInstanceOf(LogicalJoin.class, result);
+        LogicalJoin<?, ?> logicalJoin = (LogicalJoin<?, ?>) result;
+        // WHEN NOT MATCHED needs the unmatched source rows: source is the preserved right side
+        Assertions.assertEquals(JoinType.RIGHT_OUTER_JOIN, logicalJoin.getJoinType());
+        Assertions.assertEquals(source, logicalJoin.right());
+        Assertions.assertInstanceOf(LogicalSubQueryAlias.class, logicalJoin.left());
     }
 
     @Test
@@ -111,11 +136,11 @@ public class MergeIntoCommandTest {
         Assertions.assertEquals(1, logicalJoin.getOtherJoinConjuncts().size());
         Expression onClause = logicalJoin.getOtherJoinConjuncts().get(0);
         Assertions.assertEquals(new NullLiteral(), onClause);
-        Assertions.assertEquals(JoinType.LEFT_OUTER_JOIN, logicalJoin.getJoinType());
-        Assertions.assertEquals(source, logicalJoin.left());
-        Assertions.assertInstanceOf(LogicalCheckPolicy.class, logicalJoin.right());
-        Assertions.assertInstanceOf(UnboundRelation.class, logicalJoin.right().child(0));
-        UnboundRelation unboundRelation = (UnboundRelation) logicalJoin.right().child(0);
+        Assertions.assertEquals(JoinType.INNER_JOIN, logicalJoin.getJoinType());
+        Assertions.assertEquals(source, logicalJoin.right());
+        Assertions.assertInstanceOf(LogicalCheckPolicy.class, logicalJoin.left());
+        Assertions.assertInstanceOf(UnboundRelation.class, logicalJoin.left().child(0));
+        UnboundRelation unboundRelation = (UnboundRelation) logicalJoin.left().child(0);
         Assertions.assertEquals(nameParts, unboundRelation.getNameParts());
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

An Iceberg `MERGE INTO` that is semantically equivalent to a 14s `UPDATE` ran for **18 minutes** on TPC-DS 10TB. `explain verbose` showed the target-side scan reading the whole table with **no predicates and no runtime filters**, caused by two planner defects:

**1. A mark join blocks runtime filters (general optimizer issue, not MERGE-specific).**

When an `IN`/`EXISTS` subquery is written inside a join `ON` clause, subquery unnesting produces a **mark join**. Predicate push-down later moves the mark conjunct down to the target branch as a bare filter conjunct — but the join itself stays a mark join, and `RuntimeFilterGenerator` refuses to generate runtime filters on mark joins (`RuntimeFilterGenerator.java`, the `isMarkJoin()` check). The decisive evidence: the `UPDATE` plan and the `MERGE` plan contain the *same* `LEFT SEMI JOIN(BROADCAST)` on `ss_sold_date_sk = d_date_sk` over the same tables — the only difference is `isMarkJoin: false` vs `true`, and only the former produces RFs, so only the `UPDATE` prunes the target scan from ~6 years of data down to 1 year.

The same condition written in `WHERE` is fine; written in `ON` it degrades — plain `SELECT`s are affected too.

**2. Both MERGE paths build `source LEFT OUTER JOIN target`.**

Doris builds the hash table on the right child, so the structurally wide side — the target must carry *all* columns plus the row identity (for Iceberg: `struct<file_path, row_position, ...>` with a full S3 URI per row) — always became the build side. Worse, `LEFT_OUTER_JOIN` is in `DENIED_JOIN_TYPES`, so the merge join could never produce runtime filters at all. The internal OLAP path (`MergeIntoCommand`) used `LEFT_OUTER_JOIN` unconditionally, even without `WHEN NOT MATCHED` clauses (the external path already had the INNER optimization). For reference, Trino plans MERGE as `target RIGHT JOIN source` and only allows dynamic filters on `INNER || RIGHT` — exactly complementary to Doris's denied list.

**Changes:**

1. **Add the `ELIMINATE_MARK_JOIN` rewrite rule** (the `RuleType` enum entry existed but was never implemented). When a `LEFT SEMI` mark join's mark slot is consumed only as a bare conjunct of the filter directly above it, requiring `TRUE` discards `NULL` exactly like `FALSE`, so the pair degenerates to a plain `LEFT SEMI JOIN` — which may produce runtime filters. A literal-`TRUE` alias keeps the mark slot's `ExprId` alive for any upper references (after the filter the mark can only be `TRUE`); column pruning removes it when unused. Registered in `PUSH_DOWN_FILTERS` next to `EliminateOuterJoin`; can be disabled with `set disable_nereids_rules='ELIMINATE_MARK_JOIN'`. Out of scope by design: mark slots consumed inside `OR`/projections, and `NOT IN` (anti mark joins).

2. **Extract `MergeUtils.buildMergeJoin()`**, shared by `MergeIntoCommand` (internal OLAP MOW) and `ExternalRowLevelMergePlanBuilder` (external): the target now stays on the **left (probe)** side. Without `WHEN NOT MATCHED` the join is `INNER`; with them it is `target RIGHT OUTER JOIN source`, which preserves exactly the same unmatched source rows as the previous shape while allowing runtime filters built from the (narrow) source side to prune the target scan — `RIGHT_OUTER_JOIN` is not in `DENIED_JOIN_TYPES`, and BE fully supports it. The internal path also gains the `INNER` optimization it previously lacked. `JoinCommute` remains in the search space, so the CBO can still swap sides when statistics justify it.

After this PR, the pathological MERGE plan gets: a non-mark semi join producing RFs onto the target scan (partition pruning), the merge join eligible for RFs, and the narrow source side as the hash-table build side.

**Quick verification**

TPC-DS 1TB on Iceberg (`store_sales`: 2,879,987,999 rows, ~141 GB parquet), single small node. Same binary and data; the new rule is toggled via `disable_nereids_rules` for an A/B comparison, so this isolates change 1 (the original MERGE case additionally benefits from change 2, which has no toggle):

```sql
SELECT count(*)
FROM store_sales ss
JOIN item i ON ss.ss_item_sk = i.i_item_sk
           AND ss.ss_sold_date_sk IN (SELECT d_date_sk FROM date_dim WHERE d_year = 2003);
```

| | rule disabled (old behavior) | rule enabled (this PR) |
|---|---|---|
| Latency | 15.80 s | **3.04 s (5.2x)** |
| Runtime filters on the `store_sales` scan | none | `RF000[min_max] -> ss_sold_date_sk`, `RF001[in_or_bloom] -> ss_sold_date_sk` |
| Result | 5,997,572 | 5,997,572 (identical) |

<details>
<summary>explain snippets of the store_sales scan node</summary>

Rule disabled — the semi join stays a mark join, no runtime filter reaches the scan:

```
4:VPluginDrivenScanNode(105)
   TABLE: iceberg_nessie.tpcds_sf1000_parquet.store_sales
   CONNECTOR: iceberg
   inputSplitNum=2352, totalFileSize=151751253376, scanRanges=2352
   cardinality=2879987999, numNodes=1
   final projections: ss_item_sk[#52], ss_sold_date_sk[#54]
```

Rule enabled — the mark join degenerates to a plain semi join and produces runtime filters:

```
4:VPluginDrivenScanNode(88)
   TABLE: iceberg_nessie.tpcds_sf1000_parquet.store_sales
   CONNECTOR: iceberg
   inputSplitNum=2352, totalFileSize=151751253376, scanRanges=2352
   cardinality=2879987999, numNodes=1
   runtime filters: RF000[min_max] -> ss_sold_date_sk[#54], RF001[in_or_bloom] -> ss_sold_date_sk[#54]
   final projections: ss_item_sk[#52], ss_sold_date_sk[#54]
```

</details>

### Release note

Improve MERGE INTO (and queries with IN/EXISTS subqueries in join ON clauses) performance: eliminate filter-consumed mark joins to unlock runtime filters, and put the MERGE target on the probe side of the join.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (see the "Quick verification" section above: TPC-DS 1TB on Iceberg, 15.80s -> 3.04s with identical results)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. Query results are unchanged; plan shapes change (`explain` output): filter-consumed mark joins become plain semi joins, and the MERGE base join becomes `INNER` / `target RIGHT OUTER JOIN source` instead of `source LEFT OUTER JOIN target`.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

