### PR TITLE
[opt](be) Avoid redundant column copies

### DIFF
--- a/be/src/exec/operator/multi_cast_data_stream_source.cpp
+++ b/be/src/exec/operator/multi_cast_data_stream_source.cpp
@@ -110,7 +110,7 @@ Status MultiCastDataStreamerSourceOperatorX::get_block_impl(RuntimeState* state,
     if (!local_state._output_expr_contexts.empty() && output_block->rows() > 0) {
         SCOPED_TIMER(local_state._materialize_data_timer);
         RETURN_IF_ERROR(VExprContext::get_output_block_after_execute_exprs(
-                local_state._output_expr_contexts, *output_block, block, true));
+                local_state._output_expr_contexts, *output_block, block));
         materialize_block_inplace(*block);
     }
     return Status::OK();

--- a/be/src/exec/operator/schema_scan_operator.cpp
+++ b/be/src/exec/operator/schema_scan_operator.cpp
@@ -260,20 +260,19 @@ Status SchemaScanOperatorX::get_block_impl(RuntimeState* state, Block* block, bo
         if (src_block.rows()) {
             // block->check_number_of_rows();
             for (int i = 0; i < _slot_num; ++i) {
-                MutableColumnPtr column_ptr =
-                        IColumn::mutate(std::move(block->get_by_position(i).column));
+                const auto& output_column = block->get_by_position(i).column;
                 ColumnPtr src_column = src_block.safe_get_by_position(_slot_offsets[i])
                                                .column->convert_to_full_column_if_const();
-                if (is_column_nullable(*column_ptr) && !is_column_nullable(*src_column)) {
+                if (is_column_nullable(*output_column) && !is_column_nullable(*src_column)) {
                     src_column = make_nullable(src_column);
                 }
-                DORIS_CHECK(is_column_nullable(*column_ptr) == is_column_nullable(*src_column));
-                column_ptr->insert_range_from(*src_column, 0, src_block.rows());
-                block->replace_by_position(i, std::move(column_ptr));
+                DORIS_CHECK_EQ(src_column->size(), src_block.rows());
+                DORIS_CHECK_EQ(output_column->get_name(), src_column->get_name());
+                block->replace_by_position(i, std::move(src_column));
             }
             DCHECK_EQ(block->columns(), _dest_tuple_desc->slots().size());
-            RETURN_IF_ERROR(local_state.filter_block(local_state._conjuncts, block));
             src_block.clear();
+            RETURN_IF_ERROR(local_state.filter_block(local_state._conjuncts, block));
         }
     } while (block->rows() == 0 && !*eos);
 

--- a/be/src/exec/scan/file_scanner.cpp
+++ b/be/src/exec/scan/file_scanner.cpp
@@ -857,13 +857,14 @@ Status FileScanner::_convert_to_output_block(Block* block) {
             column_ptr = make_nullable(column_ptr);
         }
         DORIS_CHECK_EQ(column_ptr->size(), rows);
-        if (mutable_output_columns[j]->get_name() == column_ptr->get_name()) {
-            output_columns[j] = std::move(column_ptr);
-        } else {
-            // Some columns use specialized expression-result representations. For example, a
-            // scalar Variant must be inserted into the destination Variant column to normalize
-            // its internal structure before publication.
+        if (slot_desc->type()->get_primitive_type() == PrimitiveType::TYPE_VARIANT) {
+            DORIS_CHECK_EQ(ctx->root()->data_type()->get_primitive_type(),
+                           PrimitiveType::TYPE_VARIANT);
+            // CAST to Variant may produce a scalar Variant expression result. Insert it into the
+            // destination Variant column to normalize its internal structure before publication.
             mutable_output_columns[j]->insert_range_from(*column_ptr, 0, rows);
+        } else {
+            output_columns[j] = std::move(column_ptr);
         }
         ctx_idx++;
     }

--- a/be/src/exec/scan/file_scanner.cpp
+++ b/be/src/exec/scan/file_scanner.cpp
@@ -857,13 +857,21 @@ Status FileScanner::_convert_to_output_block(Block* block) {
             column_ptr = make_nullable(column_ptr);
         }
         DORIS_CHECK_EQ(column_ptr->size(), rows);
-        DORIS_CHECK_EQ(mutable_output_columns[j]->get_name(), column_ptr->get_name());
-        output_columns[j] = std::move(column_ptr);
+        if (mutable_output_columns[j]->get_name() == column_ptr->get_name()) {
+            output_columns[j] = std::move(column_ptr);
+        } else {
+            // Some columns use specialized expression-result representations. For example, a
+            // scalar Variant must be inserted into the destination Variant column to normalize
+            // its internal structure before publication.
+            mutable_output_columns[j]->insert_range_from(*column_ptr, 0, rows);
+        }
         ctx_idx++;
     }
     scoped_mutable_output_block.restore();
     for (size_t i = 0; i < output_columns.size(); ++i) {
-        block->replace_by_position(i, std::move(output_columns[i]));
+        if (output_columns[i]) {
+            block->replace_by_position(i, std::move(output_columns[i]));
+        }
     }
 
     // Clear the source references before filtering so directly published columns can become

--- a/be/src/exec/scan/file_scanner.cpp
+++ b/be/src/exec/scan/file_scanner.cpp
@@ -765,12 +765,10 @@ Status FileScanner::_convert_to_output_block(Block* block) {
     auto filter_column = ColumnUInt8::create(rows, 1);
     auto& filter_map = filter_column->get_data();
 
-    // After convert, the column_ptr should be copied into output block.
-    // Can not use block->insert() because it may cause use_count() non-zero bug
     auto scoped_mutable_output_block =
             VectorizedUtils::build_scoped_mutable_mem_reuse_block(block, *_dest_row_desc);
-    auto& mutable_output_block = scoped_mutable_output_block.mutable_block();
-    auto& mutable_output_columns = mutable_output_block.mutable_columns();
+    auto& mutable_output_columns = scoped_mutable_output_block.mutable_columns();
+    Columns output_columns(mutable_output_columns.size());
 
     std::vector<BitmapValue>* skip_bitmaps {nullptr};
     MutableColumnPtr skip_bitmap_column;
@@ -858,12 +856,18 @@ Status FileScanner::_convert_to_output_block(Block* block) {
         } else if (slot_desc->is_nullable()) {
             column_ptr = make_nullable(column_ptr);
         }
-        mutable_output_columns[j]->insert_range_from(*column_ptr, 0, rows);
+        DORIS_CHECK_EQ(column_ptr->size(), rows);
+        DORIS_CHECK_EQ(mutable_output_columns[j]->get_name(), column_ptr->get_name());
+        output_columns[j] = std::move(column_ptr);
         ctx_idx++;
     }
     scoped_mutable_output_block.restore();
+    for (size_t i = 0; i < output_columns.size(); ++i) {
+        block->replace_by_position(i, std::move(output_columns[i]));
+    }
 
-    // after do the dest block insert operation, clear _src_block to remove the reference of origin column
+    // Clear the source references before filtering so directly published columns can become
+    // exclusive.
     _src_block_ptr->clear();
 
     size_t dest_size = block->columns();

--- a/be/src/exec/sink/writer/iceberg/viceberg_table_writer.cpp
+++ b/be/src/exec/sink/writer/iceberg/viceberg_table_writer.cpp
@@ -207,7 +207,7 @@ Status VIcebergTableWriter::write(RuntimeState* state, Block& block) {
     }
     Block output_block;
     RETURN_IF_ERROR(VExprContext::get_output_block_after_execute_exprs(_vec_output_expr_ctxs, block,
-                                                                       &output_block, false));
+                                                                       &output_block));
     materialize_block_inplace(output_block);
     return _write_prepared_block(output_block);
 }
@@ -437,23 +437,8 @@ Status VIcebergTableWriter::_write_prepared_block(Block& output_block) {
 
 Status VIcebergTableWriter::_filter_block(doris::Block& block, const IColumn::Filter* filter,
                                           doris::Block* output_block) {
-    const ColumnsWithTypeAndName& columns_with_type_and_name =
-            block.get_columns_with_type_and_name();
-    ColumnsWithTypeAndName result_columns;
-    for (const auto& col : columns_with_type_and_name) {
-        result_columns.emplace_back(col.column->clone_resized(col.column->size()), col.type,
-                                    col.name);
-    }
-    *output_block = {std::move(result_columns)};
-
-    std::vector<uint32_t> columns_to_filter;
-    int column_to_keep = output_block->columns();
-    columns_to_filter.resize(column_to_keep);
-    for (uint32_t i = 0; i < column_to_keep; ++i) {
-        columns_to_filter[i] = i;
-    }
-
-    Block::filter_block_internal(output_block, columns_to_filter, *filter);
+    *output_block = block;
+    Block::filter_block_internal(output_block, *filter);
     return Status::OK();
 }
 

--- a/be/src/exec/sink/writer/maxcompute/vmc_table_writer.cpp
+++ b/be/src/exec/sink/writer/maxcompute/vmc_table_writer.cpp
@@ -145,7 +145,7 @@ Status VMCTableWriter::write(RuntimeState* state, Block& block) {
 
     Block output_block;
     RETURN_IF_ERROR(VExprContext::get_output_block_after_execute_exprs(_vec_output_expr_ctxs, block,
-                                                                       &output_block, false));
+                                                                       &output_block));
     materialize_block_inplace(output_block);
 
     _row_count += output_block.rows();

--- a/be/src/exec/sink/writer/vhive_table_writer.cpp
+++ b/be/src/exec/sink/writer/vhive_table_writer.cpp
@@ -92,7 +92,7 @@ Status VHiveTableWriter::write(RuntimeState* state, Block& block) {
     }
     Block output_block;
     RETURN_IF_ERROR(VExprContext::get_output_block_after_execute_exprs(_vec_output_expr_ctxs, block,
-                                                                       &output_block, false));
+                                                                       &output_block));
     materialize_block_inplace(output_block);
 
     std::unordered_map<std::shared_ptr<VHivePartitionWriter>, IColumn::Filter> writer_positions;
@@ -220,24 +220,8 @@ Status VHiveTableWriter::write(RuntimeState* state, Block& block) {
 
 Status VHiveTableWriter::_filter_block(doris::Block& block, const IColumn::Filter* filter,
                                        doris::Block* output_block) {
-    const ColumnsWithTypeAndName& columns_with_type_and_name =
-            block.get_columns_with_type_and_name();
-    ColumnsWithTypeAndName result_columns;
-    for (int i = 0; i < columns_with_type_and_name.size(); ++i) {
-        const auto& col = columns_with_type_and_name[i];
-        result_columns.emplace_back(col.column->clone_resized(col.column->size()), col.type,
-                                    col.name);
-    }
-    *output_block = {std::move(result_columns)};
-
-    std::vector<uint32_t> columns_to_filter;
-    int column_to_keep = output_block->columns();
-    columns_to_filter.resize(column_to_keep);
-    for (uint32_t i = 0; i < column_to_keep; ++i) {
-        columns_to_filter[i] = i;
-    }
-
-    Block::filter_block_internal(output_block, columns_to_filter, *filter);
+    *output_block = block;
+    Block::filter_block_internal(output_block, *filter);
     return Status::OK();
 }
 

--- a/be/src/exprs/lambda_function/varray_map_function.cpp
+++ b/be/src/exprs/lambda_function/varray_map_function.cpp
@@ -107,7 +107,7 @@ public:
         auto outside_null_map = ColumnUInt8::create(
                 arguments[0].column->convert_to_full_column_if_const()->size(), 0);
         // offset column
-        MutableColumnPtr array_column_offset;
+        ColumnPtr array_column_offset;
         size_t nested_array_column_rows = 0;
         ColumnPtr first_array_offsets = nullptr;
         //2. get the result column from executed expr, and the needed is nested column of array
@@ -144,8 +144,7 @@ public:
             if (i == 0) {
                 nested_array_column_rows = col_array.get_data_ptr()->size();
                 first_array_offsets = col_array.get_offsets_ptr();
-                const auto& off_data = col_array.get_offsets_column();
-                array_column_offset = off_data.clone_resized(col_array.get_offsets_column().size());
+                array_column_offset = first_array_offsets;
                 args_info.offsets_ptr = &col_array.get_offsets();
             } else {
                 // select array_map((x,y)->x+y,c_array1,[0,1,2,3]) from array_test2;
@@ -242,8 +241,8 @@ public:
             auto empty_nested_column = assert_cast<const DataTypeArray*>(nested_type.get())
                                                ->get_nested_type()
                                                ->create_column();
-            auto result_array_column = ColumnArray::create(std::move(empty_nested_column),
-                                                           std::move(array_column_offset));
+            auto result_array_column =
+                    ColumnArray::create(std::move(empty_nested_column), array_column_offset);
 
             if (is_nullable) {
                 result_column = ColumnNullable::create(std::move(result_array_column),
@@ -335,7 +334,7 @@ public:
         if (result_type->is_nullable()) {
             if (res_type->is_nullable()) {
                 result_column = ColumnNullable::create(
-                        ColumnArray::create(std::move(result_col), std::move(array_column_offset)),
+                        ColumnArray::create(std::move(result_col), array_column_offset),
                         std::move(outside_null_map));
             } else {
                 // deal with eg: select array_map(x -> x is null, [null, 1, 2]);
@@ -345,19 +344,18 @@ public:
                 result_column = ColumnNullable::create(
                         ColumnArray::create(ColumnNullable::create(std::move(result_col),
                                                                    std::move(nested_null_map)),
-                                            std::move(array_column_offset)),
+                                            array_column_offset),
                         std::move(outside_null_map));
             }
         } else {
             if (res_type->is_nullable()) {
-                result_column =
-                        ColumnArray::create(std::move(result_col), std::move(array_column_offset));
+                result_column = ColumnArray::create(std::move(result_col), array_column_offset);
             } else {
                 auto nested_null_map = ColumnUInt8::create(result_col->size(), 0);
 
                 result_column = ColumnArray::create(
                         ColumnNullable::create(std::move(result_col), std::move(nested_null_map)),
-                        std::move(array_column_offset));
+                        array_column_offset);
             }
         }
         return Status::OK();

--- a/be/src/exprs/vcondition_expr.cpp
+++ b/be/src/exprs/vcondition_expr.cpp
@@ -369,7 +369,8 @@ Status VectorizedIfExpr::execute_for_null_condition(Block& block, const ColumnNu
     handled = false;
 
     if (cond_is_null) {
-        block.replace_by_position(result, arg_else.column->clone_resized(arg_cond.column->size()));
+        DCHECK_EQ(arg_else.column->size(), arg_cond.column->size());
+        block.replace_by_position(result, arg_else.column);
         handled = true;
         return Status::OK();
     }

--- a/be/src/exprs/vexpr_context.cpp
+++ b/be/src/exprs/vexpr_context.cpp
@@ -447,15 +447,8 @@ Status VExprContext::execute_conjuncts_and_filter_block(const VExprContextSPtrs&
     return Status::OK();
 }
 
-// do_projection: for some query(e.g. in MultiCastDataStreamerSourceOperator::get_block()),
-// output_vexpr_ctxs will output the same column more than once, and if the output_block
-// is mem-reused later, it will trigger DCHECK_EQ(d.column->use_count(), 1) failure when
-// doing Block::clear_column_data, set do_projection to true to copy the column data to
-// avoid this problem.
 Status VExprContext::get_output_block_after_execute_exprs(
-        const VExprContextSPtrs& output_vexpr_ctxs, const Block& input_block, Block* output_block,
-        bool do_projection) {
-    auto rows = input_block.rows();
+        const VExprContextSPtrs& output_vexpr_ctxs, const Block& input_block, Block* output_block) {
     ColumnsWithTypeAndName result_columns;
     _reset_memory_usage(output_vexpr_ctxs);
 
@@ -467,12 +460,7 @@ Status VExprContext::get_output_block_after_execute_exprs(
         const auto& name = vexpr_ctx->expr_name();
 
         vexpr_ctx->_memory_usage += result_column->allocated_bytes();
-        if (do_projection) {
-            result_columns.emplace_back(result_column->clone_resized(rows), type, name);
-
-        } else {
-            result_columns.emplace_back(result_column, type, name);
-        }
+        result_columns.emplace_back(result_column, type, name);
     }
     *output_block = {result_columns};
     return Status::OK();

--- a/be/src/exprs/vexpr_context.h
+++ b/be/src/exprs/vexpr_context.h
@@ -333,8 +333,7 @@ public:
                                                      int column_to_keep, IColumn::Filter& filter);
 
     [[nodiscard]] static Status get_output_block_after_execute_exprs(const VExprContextSPtrs&,
-                                                                     const Block&, Block*,
-                                                                     bool do_projection = false);
+                                                                     const Block&, Block*);
 
     int get_last_result_column_id() const {
         DCHECK(_last_result_column_id != -1);


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Several execution paths copied complete column data even though the source columns could remain immutable and rely on copy-on-write before later mutation. Reuse expression results and array offsets directly, publish scanner columns after validation, and let partition filtering create only the selected rows.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

