### PR TITLE
[chore](build) Add BE code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,8 @@
 # for more syntax help and usage example
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
+be/src/agent/be_exec_version_manager.cpp @HappenLee @mrhhsg
+be/**/CMakeLists.txt @HappenLee @mrhhsg
 fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java @dataroaring @CalvinKirs @morningman
 **/pom.xml @CalvinKirs @morningman
 fe/fe-common/src/main/java/org/apache/doris/common/FeMetaVersion.java @dataroaring @morningman @yiguolei @xiaokang


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Add HappenLee and mrhhsg as code owners for the BE execution version manager and BE CMake files so changes to these critical files request the appropriate reviewers.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test
    - [x] No need to test. This is a CODEOWNERS-only change.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Review assignments are updated for the affected paths.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
