### PR TITLE
[fix](storage) Reject prepare txn on shutdown tablet

### DIFF
--- a/be/src/storage/tablet/tablet.cpp
+++ b/be/src/storage/tablet/tablet.cpp
@@ -3268,8 +3268,7 @@ Status Tablet::prepare_txn(TPartitionId partition_id, TTransactionId transaction
     }
 
     std::lock_guard<std::mutex> push_lock(get_push_lock());
-    return _engine.txn_manager()->prepare_txn(partition_id, transaction_id, tablet_id(),
-                                              tablet_uid(), load_id, ingest);
+    return _engine.txn_manager()->prepare_txn(partition_id, *this, transaction_id, load_id, ingest);
 }
 
 } // namespace doris

--- a/be/test/storage/txn/txn_manager_test.cpp
+++ b/be/test/storage/txn/txn_manager_test.cpp
@@ -245,6 +245,20 @@ TEST_F(TxnManagerTest, PrepareNewTxn) {
     EXPECT_TRUE(status == Status::OK());
 }
 
+TEST_F(TxnManagerTest, PrepareTxnRejectsOldShutdownTablet) {
+    auto tablet = k_engine->tablet_manager()->get_tablet(tablet_id);
+    ASSERT_NE(tablet, nullptr);
+    ASSERT_TRUE(tablet->set_tablet_state(TABLET_SHUTDOWN).ok());
+
+    auto status = tablet->prepare_txn(partition_id, transaction_id, load_id, false);
+    EXPECT_FALSE(status.ok()) << status;
+
+    std::map<TabletInfo, RowsetSharedPtr> related_tablets;
+    k_engine->txn_manager()->get_txn_related_tablets(transaction_id, partition_id,
+                                                     &related_tablets);
+    EXPECT_TRUE(related_tablets.empty());
+}
+
 // 1. prepare txn
 // 2. commit txn
 // 3. should be success


### PR DESCRIPTION
Cause:
PR #54124 moved the migration and push locks from RowsetBuilder into Tablet::prepare_txn. During that refactor, the call to TxnManager::prepare_txn changed from the const Tablet& overload to the raw tablet_id/tablet_uid overload. This silently bypassed the TABLET_SHUTDOWN guard introduced by PR #42296.

Impact:
A load thread holding an old Tablet instance could resume after migration and register the stale tablet UID in the transaction map. Publish would then operate on the reloaded Tablet with a new UID and leave the transaction in an E-909 state.

Fix:
Call the const Tablet& overload with *this while the migration and push locks are held. This preserves the lock encapsulation from PR #54124 and restores the shutdown-tablet protection from PR #42296.

Test:
Add a deterministic unit test that marks a Tablet as TABLET_SHUTDOWN, verifies Tablet::prepare_txn fails, and verifies no stale tablet entry is registered. TxnManagerTest.* passes 16/16.

(cherry picked from commit ccfb166677719b65dd224970e0f2323a1e93c1fb)

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

