### PR TITLE
[improvement](be) Optimize IN filter pruning with native HybridSet operations

### DIFF
--- a/be/benchmark/benchmark_hybrid_set.hpp
+++ b/be/benchmark/benchmark_hybrid_set.hpp
@@ -354,7 +354,8 @@ static void BM_HybridSet_GetMinMaxInt32(benchmark::State& state) {
     for (auto _ : state) {
         Field min_value;
         Field max_value;
-        set.get_min_max(min_value, max_value);
+        bool contains_nan = false;
+        set.get_min_max(min_value, max_value, contains_nan);
         benchmark::DoNotOptimize(min_value);
         benchmark::DoNotOptimize(max_value);
     }
@@ -405,7 +406,8 @@ static void BM_StringSet_GetMinMaxLong(benchmark::State& state) {
     for (auto _ : state) {
         Field min_value;
         Field max_value;
-        set.get_min_max(min_value, max_value);
+        bool contains_nan = false;
+        set.get_min_max(min_value, max_value, contains_nan);
         benchmark::DoNotOptimize(min_value);
         benchmark::DoNotOptimize(max_value);
     }

--- a/be/benchmark/benchmark_hybrid_set.hpp
+++ b/be/benchmark/benchmark_hybrid_set.hpp
@@ -448,6 +448,9 @@ BENCHMARK(BM_StringSet_LegacyMaterializeLong)
 // Typed range lookup benchmark
 // ============================================================
 
+enum class InZonemapRangeLookup { POINT_HIT, FULL_MISS };
+
+template <InZonemapRangeLookup lookup>
 static void BM_HybridSet_ContainsAnyInRangeInt32(benchmark::State& state) {
     const auto set_size = static_cast<size_t>(state.range(0));
     HybridSet<TYPE_INT> set(false);
@@ -456,23 +459,49 @@ static void BM_HybridSet_ContainsAnyInRangeInt32(benchmark::State& state) {
         set.insert(&value);
     }
 
-    const int32_t hit_value = values[set_size / 2];
-    const auto hit = Field::create_field<TYPE_INT>(hit_value);
-    const auto miss_min = Field::create_field<TYPE_INT>(hit_value + 1);
-    const auto miss_max = Field::create_field<TYPE_INT>(hit_value + 6);
-    DORIS_CHECK(set.contains_any_in_range(hit, hit));
-    DORIS_CHECK(!set.contains_any_in_range(miss_min, miss_max));
+    const int32_t middle_value = values[set_size / 2];
+    const auto min_value = Field::create_field<TYPE_INT>(
+            lookup == InZonemapRangeLookup::POINT_HIT ? middle_value : middle_value + 1);
+    const auto max_value = Field::create_field<TYPE_INT>(
+            lookup == InZonemapRangeLookup::POINT_HIT ? middle_value : middle_value + 6);
+    constexpr bool expected = lookup == InZonemapRangeLookup::POINT_HIT;
+    DORIS_CHECK_EQ(set.contains_any_in_range(min_value, max_value), expected);
 
     for (auto _ : state) {
-        bool hit_result = set.contains_any_in_range(hit, hit);
-        bool miss_result = set.contains_any_in_range(miss_min, miss_max);
-        benchmark::DoNotOptimize(hit_result);
-        benchmark::DoNotOptimize(miss_result);
+        bool result = set.contains_any_in_range(min_value, max_value);
+        benchmark::DoNotOptimize(result);
     }
-    state.SetItemsProcessed(state.iterations() * 2);
+    state.SetItemsProcessed(state.iterations());
 }
 
-BENCHMARK(BM_HybridSet_ContainsAnyInRangeInt32)->Arg(8)->Arg(64)->Unit(benchmark::kNanosecond);
+static void BM_HybridSet_ContainsAnyInRangeInt32PointHit(benchmark::State& state) {
+    BM_HybridSet_ContainsAnyInRangeInt32<InZonemapRangeLookup::POINT_HIT>(state);
+}
+
+static void BM_HybridSet_ContainsAnyInRangeInt32FullMiss(benchmark::State& state) {
+    BM_HybridSet_ContainsAnyInRangeInt32<InZonemapRangeLookup::FULL_MISS>(state);
+}
+
+// kInZoneMapPointCheckThreshold gates on the total set size: a fixed 10,000-element set takes the
+// range-only path for every candidate below 10,000. Use each candidate as the set size to measure
+// the exact-lookup cost admitted at that boundary; 10,000 is an upper control rather than a
+// threshold candidate. FULL_MISS forces traversal of the whole set, while POINT_HIT measures the
+// early-exit case.
+#define REGISTER_IN_ZONEMAP_RANGE_LOOKUP(NAME) \
+    BENCHMARK(NAME)                            \
+            ->Arg(64)                          \
+            ->Arg(128)                         \
+            ->Arg(256)                         \
+            ->Arg(512)                         \
+            ->Arg(1024)                        \
+            ->Arg(2048)                        \
+            ->Arg(4096)                        \
+            ->Arg(8192)                        \
+            ->Arg(10000)                       \
+            ->Unit(benchmark::kNanosecond)
+
+REGISTER_IN_ZONEMAP_RANGE_LOOKUP(BM_HybridSet_ContainsAnyInRangeInt32PointHit);
+REGISTER_IN_ZONEMAP_RANGE_LOOKUP(BM_HybridSet_ContainsAnyInRangeInt32FullMiss);
 
 // Measure only the native HybridSet traversal used by Bloom pruning. The lightweight fingerprint
 // predicate keeps storage Bloom-filter implementation costs outside this microbenchmark; both the
@@ -581,6 +610,7 @@ REGISTER_RAW_BLOOM_PROBE(BM_StringSet_AnyMatchRawEmbeddedNulHit);
 #undef REGISTER_FIXED_INT64
 #undef REGISTER_FIXED_STRING
 #undef REGISTER_STRING_SET_LOOKUP
+#undef REGISTER_IN_ZONEMAP_RANGE_LOOKUP
 #undef REGISTER_RAW_BLOOM_PROBE
 
 } // namespace doris

--- a/be/benchmark/benchmark_hybrid_set.hpp
+++ b/be/benchmark/benchmark_hybrid_set.hpp
@@ -26,11 +26,21 @@
 
 #include <benchmark/benchmark.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_number.h"
+#include "core/data_type/data_type_string.h"
+#include "core/field.h"
+#include "exprs/create_predicate_function.h"
+#include "exprs/expr_zonemap_filter.h"
 #include "exprs/hybrid_set.h"
+#include "exprs/vliteral.h"
 
 namespace doris {
 
@@ -73,6 +83,105 @@ std::vector<std::string> generate_values<std::string>(size_t n) {
 
 // Number of find() calls per iteration to amortize loop overhead.
 static constexpr size_t FIND_ITERS = 10000;
+
+enum class StringSetWorkload { SHORT, LONG, EMBEDDED_NUL };
+enum class StringSetLookup { HIT, MISS };
+
+template <StringSetWorkload workload>
+static std::vector<std::string> generate_string_set_values(size_t n, bool misses) {
+    std::vector<std::string> values;
+    values.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+        const auto key = std::to_string(i);
+        if constexpr (workload == StringSetWorkload::SHORT) {
+            values.emplace_back((misses ? "miss_" : "hit_") + key);
+        } else if constexpr (workload == StringSetWorkload::LONG) {
+            std::string value(192, static_cast<char>('a' + i % 26));
+            value.append(misses ? "_miss_" : "_hit_");
+            value.append(key);
+            values.emplace_back(std::move(value));
+        } else {
+            std::string value = misses ? "miss" : "hit";
+            value.push_back('\0');
+            value.append("binary_");
+            value.append(key);
+            value.push_back('\0');
+            value.append(32, static_cast<char>('a' + i % 26));
+            values.emplace_back(std::move(value));
+        }
+    }
+    return values;
+}
+
+template <StringSetWorkload workload, StringSetLookup lookup>
+static void BM_StringSet_StringRefFind(benchmark::State& state) {
+    const auto set_size = static_cast<size_t>(state.range(0));
+    const auto hit_values = generate_string_set_values<workload>(set_size, false);
+    const auto miss_values = generate_string_set_values<workload>(set_size, true);
+
+    StringSet<> set(false);
+    std::vector<StringRef> hit_refs;
+    std::vector<StringRef> miss_refs;
+    hit_refs.reserve(set_size);
+    miss_refs.reserve(set_size);
+    for (size_t i = 0; i < set_size; ++i) {
+        StringRef value(hit_values[i]);
+        set.insert(&value);
+        hit_refs.emplace_back(hit_values[i]);
+        miss_refs.emplace_back(miss_values[i]);
+    }
+
+    const auto& lookup_refs = lookup == StringSetLookup::HIT ? hit_refs : miss_refs;
+    const size_t lookup_iters = std::max(FIND_ITERS, set_size);
+    const size_t expected_found = lookup == StringSetLookup::HIT ? lookup_iters : 0;
+    for (auto _ : state) {
+        size_t found = 0;
+        for (size_t i = 0; i < lookup_iters; ++i) {
+            const auto index = i % set_size;
+            found += set.find(&lookup_refs[index]);
+        }
+        benchmark::DoNotOptimize(found);
+        if (found != expected_found) {
+            state.SkipWithError("StringSet lookup returned an unexpected result");
+            break;
+        }
+    }
+    state.SetItemsProcessed(state.iterations() * lookup_iters);
+}
+
+static void BM_StringSet_StringRefFindShortHit(benchmark::State& state) {
+    BM_StringSet_StringRefFind<StringSetWorkload::SHORT, StringSetLookup::HIT>(state);
+}
+
+static void BM_StringSet_StringRefFindShortMiss(benchmark::State& state) {
+    BM_StringSet_StringRefFind<StringSetWorkload::SHORT, StringSetLookup::MISS>(state);
+}
+
+static void BM_StringSet_StringRefFindLongHit(benchmark::State& state) {
+    BM_StringSet_StringRefFind<StringSetWorkload::LONG, StringSetLookup::HIT>(state);
+}
+
+static void BM_StringSet_StringRefFindLongMiss(benchmark::State& state) {
+    BM_StringSet_StringRefFind<StringSetWorkload::LONG, StringSetLookup::MISS>(state);
+}
+
+static void BM_StringSet_StringRefFindEmbeddedNulHit(benchmark::State& state) {
+    BM_StringSet_StringRefFind<StringSetWorkload::EMBEDDED_NUL, StringSetLookup::HIT>(state);
+}
+
+static void BM_StringSet_StringRefFindEmbeddedNulMiss(benchmark::State& state) {
+    BM_StringSet_StringRefFind<StringSetWorkload::EMBEDDED_NUL, StringSetLookup::MISS>(state);
+}
+
+#define REGISTER_STRING_SET_LOOKUP(NAME) \
+    BENCHMARK(NAME)->Arg(64)->Arg(1024)->Arg(40960)->Unit(benchmark::kMicrosecond)
+
+REGISTER_STRING_SET_LOOKUP(BM_StringSet_StringRefFindShortHit);
+REGISTER_STRING_SET_LOOKUP(BM_StringSet_StringRefFindShortMiss);
+REGISTER_STRING_SET_LOOKUP(BM_StringSet_StringRefFindLongHit);
+REGISTER_STRING_SET_LOOKUP(BM_StringSet_StringRefFindLongMiss);
+REGISTER_STRING_SET_LOOKUP(BM_StringSet_StringRefFindEmbeddedNulHit);
+REGISTER_STRING_SET_LOOKUP(BM_StringSet_StringRefFindEmbeddedNulMiss);
 
 // ============================================================
 // FixedContainer benchmark: insert N values, then find them
@@ -130,11 +239,13 @@ static void BM_DynamicContainer_Find(benchmark::State& state) {
 // Register benchmarks for int32_t
 // ============================================================
 
-#define REGISTER_FIXED_INT32(N)                                                            \
-    BENCHMARK(BM_FixedContainer_Find<int32_t, N>)->Name("Fixed_Int32_N" #N)->Unit(         \
-            benchmark::kMicrosecond);                                                      \
-    BENCHMARK(BM_DynamicContainer_Find<int32_t, N>)->Name("Dynamic_Int32_N" #N)->Unit(     \
-            benchmark::kMicrosecond);
+#define REGISTER_FIXED_INT32(N)                     \
+    BENCHMARK(BM_FixedContainer_Find<int32_t, N>)   \
+            ->Name("Fixed_Int32_N" #N)              \
+            ->Unit(benchmark::kMicrosecond);        \
+    BENCHMARK(BM_DynamicContainer_Find<int32_t, N>) \
+            ->Name("Dynamic_Int32_N" #N)            \
+            ->Unit(benchmark::kMicrosecond);
 
 REGISTER_FIXED_INT32(1)
 REGISTER_FIXED_INT32(2)
@@ -149,11 +260,13 @@ REGISTER_FIXED_INT32(8)
 // Register benchmarks for int64_t
 // ============================================================
 
-#define REGISTER_FIXED_INT64(N)                                                            \
-    BENCHMARK(BM_FixedContainer_Find<int64_t, N>)->Name("Fixed_Int64_N" #N)->Unit(         \
-            benchmark::kMicrosecond);                                                      \
-    BENCHMARK(BM_DynamicContainer_Find<int64_t, N>)->Name("Dynamic_Int64_N" #N)->Unit(     \
-            benchmark::kMicrosecond);
+#define REGISTER_FIXED_INT64(N)                     \
+    BENCHMARK(BM_FixedContainer_Find<int64_t, N>)   \
+            ->Name("Fixed_Int64_N" #N)              \
+            ->Unit(benchmark::kMicrosecond);        \
+    BENCHMARK(BM_DynamicContainer_Find<int64_t, N>) \
+            ->Name("Dynamic_Int64_N" #N)            \
+            ->Unit(benchmark::kMicrosecond);
 
 REGISTER_FIXED_INT64(1)
 REGISTER_FIXED_INT64(2)
@@ -168,11 +281,13 @@ REGISTER_FIXED_INT64(8)
 // Register benchmarks for std::string
 // ============================================================
 
-#define REGISTER_FIXED_STRING(N)                                                               \
-    BENCHMARK(BM_FixedContainer_Find<std::string, N>)->Name("Fixed_String_N" #N)->Unit(        \
-            benchmark::kMicrosecond);                                                          \
-    BENCHMARK(BM_DynamicContainer_Find<std::string, N>)->Name("Dynamic_String_N" #N)->Unit(    \
-            benchmark::kMicrosecond);
+#define REGISTER_FIXED_STRING(N)                        \
+    BENCHMARK(BM_FixedContainer_Find<std::string, N>)   \
+            ->Name("Fixed_String_N" #N)                 \
+            ->Unit(benchmark::kMicrosecond);            \
+    BENCHMARK(BM_DynamicContainer_Find<std::string, N>) \
+            ->Name("Dynamic_String_N" #N)               \
+            ->Unit(benchmark::kMicrosecond);
 
 REGISTER_FIXED_STRING(1)
 REGISTER_FIXED_STRING(2)
@@ -183,8 +298,289 @@ REGISTER_FIXED_STRING(6)
 REGISTER_FIXED_STRING(7)
 REGISTER_FIXED_STRING(8)
 
+// ============================================================
+// Metadata-pruning snapshot benchmark
+// ============================================================
+
+struct LegacyInZonemapSnapshot {
+    bool contains_null = false;
+    std::vector<Field> values;
+    Field min_value;
+    Field max_value;
+};
+
+static void materialize_hybrid_set_legacy(HybridSetBase& set, const DataTypePtr& data_type,
+                                          LegacyInZonemapSnapshot* result) {
+    DORIS_CHECK(result != nullptr);
+    DORIS_CHECK(data_type != nullptr);
+    const auto value_type = remove_nullable(data_type);
+    DORIS_CHECK(value_type != nullptr);
+
+    result->contains_null = set.contain_null();
+    result->values.clear();
+    result->min_value = Field();
+    result->max_value = Field();
+
+    auto* iterator = set.begin();
+    while (iterator->has_next()) {
+        const void* value = iterator->get_value();
+        if (value != nullptr) {
+            TExprNode literal_node = expr_zonemap::create_texpr_node_from_hybrid_set_value(
+                    value, value_type->get_primitive_type(), value_type->get_precision(),
+                    value_type->get_scale());
+            auto literal = VLiteral::create_shared(literal_node);
+            Field field;
+            literal->get_column_ptr()->get(0, field);
+            result->values.emplace_back(std::move(field));
+        }
+        iterator->next();
+    }
+
+    if (!result->values.empty()) {
+        const auto minmax = std::ranges::minmax_element(
+                result->values, [](const Field& lhs, const Field& rhs) { return lhs < rhs; });
+        result->min_value = *minmax.min;
+        result->max_value = *minmax.max;
+    }
+}
+
+static void BM_HybridSet_GetMinMaxInt32(benchmark::State& state) {
+    HybridSet<TYPE_INT> set(false);
+    const auto values = generate_values<int32_t>(state.range(0));
+    for (const auto value : values) {
+        set.insert(&value);
+    }
+
+    for (auto _ : state) {
+        Field min_value;
+        Field max_value;
+        set.get_min_max(min_value, max_value);
+        benchmark::DoNotOptimize(min_value);
+        benchmark::DoNotOptimize(max_value);
+    }
+    state.SetItemsProcessed(state.iterations() * state.range(0));
+}
+
+BENCHMARK(BM_HybridSet_GetMinMaxInt32)
+        ->Arg(64)
+        ->Arg(65)
+        ->Arg(1024)
+        ->Arg(40960)
+        ->Unit(benchmark::kMicrosecond);
+
+static void BM_HybridSet_LegacyMaterializeInt32(benchmark::State& state) {
+    HybridSet<TYPE_INT> set(false);
+    const auto values = generate_values<int32_t>(state.range(0));
+    for (const auto value : values) {
+        set.insert(&value);
+    }
+    const auto data_type = std::make_shared<DataTypeInt32>();
+
+    for (auto _ : state) {
+        LegacyInZonemapSnapshot materialized;
+        materialize_hybrid_set_legacy(set, data_type, &materialized);
+        benchmark::DoNotOptimize(materialized.values);
+        benchmark::DoNotOptimize(materialized.min_value);
+        benchmark::DoNotOptimize(materialized.max_value);
+    }
+    state.SetItemsProcessed(state.iterations() * state.range(0));
+}
+
+BENCHMARK(BM_HybridSet_LegacyMaterializeInt32)
+        ->Arg(64)
+        ->Arg(65)
+        ->Arg(1024)
+        ->Arg(40960)
+        ->Unit(benchmark::kMicrosecond);
+
+static void BM_StringSet_GetMinMaxLong(benchmark::State& state) {
+    StringSet<> set(false);
+    const auto values = generate_string_set_values<StringSetWorkload::LONG>(
+            static_cast<size_t>(state.range(0)), false);
+    for (const auto& value : values) {
+        StringRef string_ref(value);
+        set.insert(&string_ref);
+    }
+
+    for (auto _ : state) {
+        Field min_value;
+        Field max_value;
+        set.get_min_max(min_value, max_value);
+        benchmark::DoNotOptimize(min_value);
+        benchmark::DoNotOptimize(max_value);
+    }
+    state.SetItemsProcessed(state.iterations() * state.range(0));
+}
+
+BENCHMARK(BM_StringSet_GetMinMaxLong)
+        ->Arg(65)
+        ->Arg(1024)
+        ->Arg(40960)
+        ->Unit(benchmark::kMicrosecond);
+
+static void BM_StringSet_LegacyMaterializeLong(benchmark::State& state) {
+    StringSet<> set(false);
+    const auto values = generate_string_set_values<StringSetWorkload::LONG>(
+            static_cast<size_t>(state.range(0)), false);
+    for (const auto& value : values) {
+        StringRef string_ref(value);
+        set.insert(&string_ref);
+    }
+    const auto data_type = std::make_shared<DataTypeString>();
+
+    for (auto _ : state) {
+        LegacyInZonemapSnapshot materialized;
+        materialize_hybrid_set_legacy(set, data_type, &materialized);
+        benchmark::DoNotOptimize(materialized.values);
+        benchmark::DoNotOptimize(materialized.min_value);
+        benchmark::DoNotOptimize(materialized.max_value);
+    }
+    state.SetItemsProcessed(state.iterations() * state.range(0));
+}
+
+BENCHMARK(BM_StringSet_LegacyMaterializeLong)
+        ->Arg(65)
+        ->Arg(1024)
+        ->Arg(40960)
+        ->Unit(benchmark::kMicrosecond);
+
+// ============================================================
+// Typed range lookup benchmark
+// ============================================================
+
+static void BM_HybridSet_ContainsAnyInRangeInt32(benchmark::State& state) {
+    const auto set_size = static_cast<size_t>(state.range(0));
+    HybridSet<TYPE_INT> set(false);
+    const auto values = generate_values<int32_t>(set_size);
+    for (const auto value : values) {
+        set.insert(&value);
+    }
+
+    const int32_t hit_value = values[set_size / 2];
+    const auto hit = Field::create_field<TYPE_INT>(hit_value);
+    const auto miss_min = Field::create_field<TYPE_INT>(hit_value + 1);
+    const auto miss_max = Field::create_field<TYPE_INT>(hit_value + 6);
+    DORIS_CHECK(set.contains_any_in_range(hit, hit));
+    DORIS_CHECK(!set.contains_any_in_range(miss_min, miss_max));
+
+    for (auto _ : state) {
+        bool hit_result = set.contains_any_in_range(hit, hit);
+        bool miss_result = set.contains_any_in_range(miss_min, miss_max);
+        benchmark::DoNotOptimize(hit_result);
+        benchmark::DoNotOptimize(miss_result);
+    }
+    state.SetItemsProcessed(state.iterations() * 2);
+}
+
+BENCHMARK(BM_HybridSet_ContainsAnyInRangeInt32)->Arg(8)->Arg(64)->Unit(benchmark::kNanosecond);
+
+// Measure only the native HybridSet traversal used by Bloom pruning. The lightweight fingerprint
+// predicate keeps storage Bloom-filter implementation costs outside this microbenchmark; both the
+// predicate and its captured fingerprint are constructed outside the timed loop.
+
+static uint64_t raw_bloom_fingerprint(const char* data, size_t size) {
+    uint64_t fingerprint = 14695981039346656037ULL;
+    for (size_t i = 0; i < size; ++i) {
+        fingerprint ^= static_cast<uint8_t>(data[i]);
+        fingerprint *= 1099511628211ULL;
+    }
+    return fingerprint;
+}
+
+enum class RawBloomProbeLookup { FULL_MISS, HIT };
+
+template <RawBloomProbeLookup lookup>
+static void BM_HybridSet_AnyMatchRawInt32(benchmark::State& state) {
+    const auto set_size = static_cast<size_t>(state.range(0));
+    std::shared_ptr<HybridSetBase> set(create_set(TYPE_INT, false));
+    const auto values = generate_values<int32_t>(set_size);
+    for (const auto value : values) {
+        set->insert(&value);
+    }
+
+    const int32_t target =
+            lookup == RawBloomProbeLookup::HIT ? values[set_size / 2] : values.back() + 1;
+    const auto target_fingerprint =
+            raw_bloom_fingerprint(reinterpret_cast<const char*>(&target), sizeof(target));
+    const auto predicate = [target_fingerprint](const char* data, size_t size) {
+        return raw_bloom_fingerprint(data, size) == target_fingerprint;
+    };
+    constexpr bool expected = lookup == RawBloomProbeLookup::HIT;
+    DORIS_CHECK_EQ(set->any_match_raw(TYPE_INT, predicate), expected);
+
+    for (auto _ : state) {
+        bool found = set->any_match_raw(TYPE_INT, predicate);
+        benchmark::DoNotOptimize(found);
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+
+static void BM_HybridSet_AnyMatchRawInt32FullMiss(benchmark::State& state) {
+    BM_HybridSet_AnyMatchRawInt32<RawBloomProbeLookup::FULL_MISS>(state);
+}
+
+static void BM_HybridSet_AnyMatchRawInt32Hit(benchmark::State& state) {
+    BM_HybridSet_AnyMatchRawInt32<RawBloomProbeLookup::HIT>(state);
+}
+
+template <StringSetWorkload workload, RawBloomProbeLookup lookup>
+static void BM_StringSet_AnyMatchRaw(benchmark::State& state) {
+    const auto set_size = static_cast<size_t>(state.range(0));
+    std::shared_ptr<HybridSetBase> set(create_set(TYPE_STRING, false));
+    const auto values = generate_string_set_values<workload>(set_size, false);
+    const auto misses = generate_string_set_values<workload>(set_size, true);
+    for (const auto& value : values) {
+        StringRef string_ref(value);
+        set->insert(&string_ref);
+    }
+
+    const auto& target =
+            lookup == RawBloomProbeLookup::HIT ? values[set_size / 2] : misses[set_size / 2];
+    const auto target_fingerprint = raw_bloom_fingerprint(target.data(), target.size());
+    const auto predicate = [target_fingerprint](const char* data, size_t size) {
+        return raw_bloom_fingerprint(data, size) == target_fingerprint;
+    };
+    constexpr bool expected = lookup == RawBloomProbeLookup::HIT;
+    DORIS_CHECK_EQ(set->any_match_raw(TYPE_STRING, predicate), expected);
+
+    for (auto _ : state) {
+        bool found = set->any_match_raw(TYPE_STRING, predicate);
+        benchmark::DoNotOptimize(found);
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+
+static void BM_StringSet_AnyMatchRawLongFullMiss(benchmark::State& state) {
+    BM_StringSet_AnyMatchRaw<StringSetWorkload::LONG, RawBloomProbeLookup::FULL_MISS>(state);
+}
+
+static void BM_StringSet_AnyMatchRawLongHit(benchmark::State& state) {
+    BM_StringSet_AnyMatchRaw<StringSetWorkload::LONG, RawBloomProbeLookup::HIT>(state);
+}
+
+static void BM_StringSet_AnyMatchRawEmbeddedNulFullMiss(benchmark::State& state) {
+    BM_StringSet_AnyMatchRaw<StringSetWorkload::EMBEDDED_NUL, RawBloomProbeLookup::FULL_MISS>(
+            state);
+}
+
+static void BM_StringSet_AnyMatchRawEmbeddedNulHit(benchmark::State& state) {
+    BM_StringSet_AnyMatchRaw<StringSetWorkload::EMBEDDED_NUL, RawBloomProbeLookup::HIT>(state);
+}
+
+#define REGISTER_RAW_BLOOM_PROBE(NAME) \
+    BENCHMARK(NAME)->Arg(64)->Arg(1024)->Arg(40960)->Unit(benchmark::kMicrosecond)
+
+REGISTER_RAW_BLOOM_PROBE(BM_HybridSet_AnyMatchRawInt32FullMiss);
+REGISTER_RAW_BLOOM_PROBE(BM_HybridSet_AnyMatchRawInt32Hit);
+REGISTER_RAW_BLOOM_PROBE(BM_StringSet_AnyMatchRawLongFullMiss);
+REGISTER_RAW_BLOOM_PROBE(BM_StringSet_AnyMatchRawLongHit);
+REGISTER_RAW_BLOOM_PROBE(BM_StringSet_AnyMatchRawEmbeddedNulFullMiss);
+REGISTER_RAW_BLOOM_PROBE(BM_StringSet_AnyMatchRawEmbeddedNulHit);
+
 #undef REGISTER_FIXED_INT32
 #undef REGISTER_FIXED_INT64
 #undef REGISTER_FIXED_STRING
+#undef REGISTER_STRING_SET_LOOKUP
+#undef REGISTER_RAW_BLOOM_PROBE
 
 } // namespace doris

--- a/be/benchmark/benchmark_main.cpp
+++ b/be/benchmark/benchmark_main.cpp
@@ -30,6 +30,7 @@
 #include "benchmark_fastunion.hpp"
 #include "benchmark_fmod.hpp"
 #include "benchmark_hll_merge.hpp"
+#include "benchmark_hybrid_set.hpp"
 #include "benchmark_json_extract.hpp"
 #include "benchmark_zone_map_index.hpp"
 #include "binary_cast_benchmark.hpp"

--- a/be/benchmark/parquet/benchmark_parquet_kernels.hpp
+++ b/be/benchmark/parquet/benchmark_parquet_kernels.hpp
@@ -236,8 +236,8 @@ inline void run_nullable_selection_kernel(benchmark::State& state,
             state.SkipWithError(status.to_string().c_str());
             return;
         }
-        benchmark::DoNotOptimize(scratch.physical_selection.ranges.data());
-        benchmark::DoNotOptimize(scratch.selected_nulls.data());
+        benchmark::DoNotOptimize(scratch.physical_selection.ranges);
+        benchmark::DoNotOptimize(scratch.selected_nulls);
         benchmark::ClobberMemory();
     }
 

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -946,6 +946,10 @@ DEFINE_String(thrift_server_type_of_fe, "THREAD_POOL");
 // disable zone map index when page row is too few
 DEFINE_mInt32(zone_map_row_num_threshold, "20");
 
+// Maximum number of IN values checked exactly against a zone map. For larger sets, only the
+// IN-set min/max range is checked.
+DEFINE_mInt32(in_zonemap_point_check_threshold, "8192");
+
 // aws sdk log level
 //    Off = 0,
 //    Fatal = 1,

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1027,6 +1027,10 @@ DECLARE_String(thrift_server_type_of_fe);
 // disable zone map index when page row is too few
 DECLARE_mInt32(zone_map_row_num_threshold);
 
+// Maximum number of IN values checked exactly against a zone map. For larger sets, only the
+// IN-set min/max range is checked.
+DECLARE_mInt32(in_zonemap_point_check_threshold);
+
 // aws sdk log level
 //    Off = 0,
 //    Fatal = 1,

--- a/be/src/exprs/expr_zonemap_filter.cpp
+++ b/be/src/exprs/expr_zonemap_filter.cpp
@@ -31,6 +31,7 @@
 #include "core/data_type/data_type_nullable.h"
 #include "core/string_ref.h"
 #include "exprs/hybrid_set.h"
+#include "exprs/hybrid_set_min_max.h"
 #include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
 #include "exprs/vliteral.h"

--- a/be/src/exprs/expr_zonemap_filter.cpp
+++ b/be/src/exprs/expr_zonemap_filter.cpp
@@ -25,6 +25,7 @@
 #include <utility>
 
 #include "common/check.h"
+#include "common/config.h"
 #include "common/logging.h"
 #include "core/column/column.h"
 #include "core/data_type/data_type_nullable.h"
@@ -39,8 +40,6 @@
 
 namespace doris::expr_zonemap {
 namespace {
-
-constexpr size_t kInZoneMapPointCheckThreshold = 64;
 
 std::optional<std::pair<Field, DataTypePtr>> field_from_literal_expr(const VExprSPtr& expr) {
     auto literal = std::dynamic_pointer_cast<VLiteral>(expr);
@@ -198,8 +197,7 @@ void get_hybrid_set_min_max_for_zonemap_filter(const std::shared_ptr<HybridSetBa
     const auto value_type = remove_nullable(data_type);
     DORIS_CHECK(value_type != nullptr);
 
-    result.contains_nan = set->contains_nan();
-    set->get_min_max(result.min_value, result.max_value);
+    set->get_min_max(result.min_value, result.max_value, result.contains_nan);
     const auto value_count = set->size();
     DORIS_CHECK_EQ(result.min_value.is_null(), result.max_value.is_null());
     if (result.min_value.is_null()) {
@@ -477,10 +475,8 @@ ZoneMapFilterResult eval_in_zonemap(const ZoneMapEvalContext& ctx, const VExprSP
         return ZoneMapFilterResult::kNoMatch;
     }
 
-    // For large IN sets and dense-domain containers, avoid exact checks on the scan hot path. A
-    // BitSet iterator may inspect its entire value domain even when the set itself is small.
-    if (!set.supports_fast_range_lookup() ||
-        std::cmp_greater(set.size(), kInZoneMapPointCheckThreshold)) {
+    // For large IN sets and dense-domain containers, avoid exact checks on the scan hot path.
+    if (set.size() > config::in_zonemap_point_check_threshold) {
         ++ctx.stats.in_zonemap_range_only_count;
         return ZoneMapFilterResult::kMayMatch;
     }
@@ -573,7 +569,12 @@ ZoneMapFilterResult eval_in_bloom_filter(const BloomFilterEvalContext& ctx,
     case TYPE_CHAR:
     case TYPE_VARCHAR:
     case TYPE_STRING:
-        break;
+        return values.any_match_raw(value_type,
+                                    [slot_filter](const char* data, size_t size) {
+                                        return slot_filter->bloom_filter->test_bytes(data, size);
+                                    })
+                       ? ZoneMapFilterResult::kMayMatch
+                       : ZoneMapFilterResult::kNoMatch;
     case TYPE_FLOAT:
         return values.any_match_raw(value_type,
                                     [slot_filter](const char* data, size_t size) {
@@ -597,12 +598,6 @@ ZoneMapFilterResult eval_in_bloom_filter(const BloomFilterEvalContext& ctx,
     default:
         return ZoneMapFilterResult::kMayMatch;
     }
-    return values.any_match_raw(value_type,
-                                [slot_filter](const char* data, size_t size) {
-                                    return slot_filter->bloom_filter->test_bytes(data, size);
-                                })
-                   ? ZoneMapFilterResult::kMayMatch
-                   : ZoneMapFilterResult::kNoMatch;
 }
 
 // Return the only slot ordinal referenced by a zonemap-evaluable expression. A negative result is

--- a/be/src/exprs/expr_zonemap_filter.cpp
+++ b/be/src/exprs/expr_zonemap_filter.cpp
@@ -79,10 +79,6 @@ std::optional<int32_t> struct_field_ordinal(const Field& field) {
     return static_cast<int32_t>(ordinal - 1);
 }
 
-bool value_in_range(const Field& value, const Field& min_value, const Field& max_value) {
-    return value >= min_value && value <= max_value;
-}
-
 bool dictionary_contains(const DictionaryEvalContext::SlotDictionary& dictionary,
                          const Field& value) {
     return std::ranges::any_of(dictionary.values, [&](const Field& dictionary_value) {
@@ -194,42 +190,30 @@ TExprNode create_texpr_node_from_hybrid_set_value(const void* data, const Primit
     return create_texpr_node_from(data, type, precision, scale);
 }
 
-Status materialize_hybrid_set_for_zonemap_filter(HybridSetBase& set, const DataTypePtr& data_type,
-                                                 InZonemapMaterializedSet* result) {
-    DORIS_CHECK(result != nullptr);
+void get_hybrid_set_min_max_for_zonemap_filter(const std::shared_ptr<HybridSetBase>& set,
+                                               const DataTypePtr& data_type,
+                                               InZonemapMinMax& result) {
+    DORIS_CHECK(set != nullptr);
     DORIS_CHECK(data_type != nullptr);
     const auto value_type = remove_nullable(data_type);
     DORIS_CHECK(value_type != nullptr);
 
-    result->contains_null = set.contain_null();
-    result->contains_nan = false;
-    result->values.clear();
-    result->min_value = Field();
-    result->max_value = Field();
-
-    auto* iterator = set.begin();
-    while (iterator->has_next()) {
-        const void* value = iterator->get_value();
-        if (value != nullptr) {
-            TExprNode literal_node = create_texpr_node_from_hybrid_set_value(
-                    value, value_type->get_primitive_type(), value_type->get_precision(),
-                    value_type->get_scale());
-            auto literal = VLiteral::create_shared(literal_node);
-            Field field;
-            literal->get_column_ptr()->get(0, field);
-            result->contains_nan |= field.is_nan();
-            result->values.emplace_back(std::move(field));
+    result.contains_nan = set->contains_nan();
+    set->get_min_max(result.min_value, result.max_value);
+    const auto value_count = set->size();
+    DORIS_CHECK_EQ(result.min_value.is_null(), result.max_value.is_null());
+    if (result.min_value.is_null()) {
+        if (value_count != 0) {
+            DORIS_CHECK(result.contains_nan);
+            DORIS_CHECK(is_float_or_double(value_type->get_primitive_type()));
         }
-        iterator->next();
+        return;
     }
-
-    if (!result->values.empty()) {
-        auto minmax = std::ranges::minmax_element(
-                result->values, [](const Field& lhs, const Field& rhs) { return lhs < rhs; });
-        result->min_value = *minmax.min;
-        result->max_value = *minmax.max;
-    }
-    return Status::OK();
+    DORIS_CHECK_NE(value_count, 0);
+    DORIS_CHECK(
+            field_types_compatible(result.min_value.get_type(), value_type->get_primitive_type()));
+    DORIS_CHECK(
+            field_types_compatible(result.max_value.get_type(), value_type->get_primitive_type()));
 }
 
 std::optional<SlotLiteral> extract_slot_and_literal(const VExprSPtrs& args) {
@@ -415,25 +399,25 @@ ZoneMapFilterResult eval_null_zonemap(const ZoneMapEvalContext& ctx, const VExpr
     return zone_map.has_not_null ? ZoneMapFilterResult::kMayMatch : ZoneMapFilterResult::kNoMatch;
 }
 
+// Keep the conservative fallback checks together so their evaluation order remains explicit.
+// NOLINTNEXTLINE(readability-function-size)
 ZoneMapFilterResult eval_in_zonemap(const ZoneMapEvalContext& ctx, const VExprSPtr& slot_expr,
-                                    bool is_not_in, const std::vector<Field>& values,
-                                    bool contains_nan, const Field& min_value,
-                                    const Field& max_value) {
+                                    bool is_not_in, const InZonemapMinMax& values,
+                                    const HybridSetBase& set) {
     auto slot = std::dynamic_pointer_cast<VSlotRef>(slot_expr);
     DORIS_CHECK(slot != nullptr);
+    // NOT IN with a NULL literal is UNKNOWN for every non-null value. Zone maps do not retain
+    // enough row-level information to recover a match in that case.
+    if (is_not_in && set.contain_null()) {
+        return ZoneMapFilterResult::kNoMatch;
+    }
     // Empty IN has no candidate values, while NOT IN with an empty set cannot filter anything.
-    if (values.empty()) {
+    if (set.size() == 0) { // NOLINT(readability-container-size-empty)
         return is_not_in ? ZoneMapFilterResult::kMayMatch : ZoneMapFilterResult::kNoMatch;
     }
 
-    // The caller has materialized the IN set and precomputed its non-null min/max. They must match
-    // the expression slot type before being compared with storage zone-map statistics.
-    DORIS_CHECK(!min_value.is_null());
-    DORIS_CHECK(!max_value.is_null());
     auto data_type = remove_nullable(slot->data_type());
     DORIS_CHECK(data_type != nullptr);
-    DORIS_CHECK(field_types_compatible(min_value.get_type(), data_type->get_primitive_type()));
-    DORIS_CHECK(field_types_compatible(max_value.get_type(), data_type->get_primitive_type()));
 
     // Re-check against the reader-schema type and the available zone map. Missing or unsupported
     // metadata must conservatively fall back to may-match.
@@ -452,7 +436,7 @@ ZoneMapFilterResult eval_in_zonemap(const ZoneMapEvalContext& ctx, const VExprSP
     }
 
     if (ctx.floating_nan_count_unknown(slot->column_id()) &&
-        ((!is_not_in && contains_nan) || (is_not_in && !contains_nan))) {
+        ((!is_not_in && values.contains_nan) || (is_not_in && !values.contains_nan))) {
         // Hidden Parquet NaNs can satisfy IN only when queried, and NOT IN only when omitted.
         return unsupported_zonemap_filter(ctx);
     }
@@ -461,43 +445,57 @@ ZoneMapFilterResult eval_in_zonemap(const ZoneMapEvalContext& ctx, const VExprSP
         return unsupported_zonemap_filter(ctx);
     }
 
+    // A non-empty set without ordered bounds contains only NaN values. Once the reader proves the
+    // data has no hidden NaNs, such an IN cannot match while NOT IN remains conservative.
+    if (values.min_value.is_null() || values.max_value.is_null()) {
+        DORIS_CHECK(values.contains_nan);
+        DORIS_CHECK(values.min_value.is_null());
+        DORIS_CHECK(values.max_value.is_null());
+        return is_not_in ? ZoneMapFilterResult::kMayMatch : ZoneMapFilterResult::kNoMatch;
+    }
+
+    // The caller has precomputed the IN set's owning non-NaN min/max. They must match the expression
+    // slot type before being compared with storage zone-map statistics.
+    DORIS_CHECK(
+            field_types_compatible(values.min_value.get_type(), data_type->get_primitive_type()));
+    DORIS_CHECK(
+            field_types_compatible(values.max_value.get_type(), data_type->get_primitive_type()));
+
     if (is_not_in) {
         // NOT IN can only prune when the whole zone contains exactly one non-null value and that
         // value is excluded by the set. Wider ranges may contain values that are not filtered.
         if (zone_map.min_value == zone_map.max_value) {
-            const bool only_value_is_filtered = std::ranges::any_of(
-                    values, [&](const Field& value) { return value == zone_map.min_value; });
+            const bool only_value_is_filtered = set.find(zone_map.min_value);
             return only_value_is_filtered ? ZoneMapFilterResult::kNoMatch
                                           : ZoneMapFilterResult::kMayMatch;
         }
         return ZoneMapFilterResult::kMayMatch;
     }
 
-    // First use the materialized IN-set min/max to rule out disjoint zone-map ranges.
-    if (zone_map.max_value < min_value || zone_map.min_value > max_value) {
+    // First use the IN-set min/max to rule out disjoint zone-map ranges.
+    if (zone_map.max_value < values.min_value || zone_map.min_value > values.max_value) {
         return ZoneMapFilterResult::kNoMatch;
     }
 
-    // For large IN sets, avoid checking every point on the scan hot path. The range overlap above
-    // is only a coarse may-match signal.
-    if (values.size() > kInZoneMapPointCheckThreshold) {
+    // For large IN sets and dense-domain containers, avoid exact checks on the scan hot path. A
+    // BitSet iterator may inspect its entire value domain even when the set itself is small.
+    if (!set.supports_fast_range_lookup() ||
+        std::cmp_greater(set.size(), kInZoneMapPointCheckThreshold)) {
         ++ctx.stats.in_zonemap_range_only_count;
         return ZoneMapFilterResult::kMayMatch;
     }
 
-    // For small IN sets, verify whether any candidate value can fall into the zone-map range.
+    // Convert the two zone-map bounds to the HybridSet's native type once, then compare them
+    // directly with the typed set values without retaining a Field copy of every IN candidate.
     ++ctx.stats.in_zonemap_point_check_count;
-    for (const auto& value : values) {
-        if (value_in_range(value, zone_map.min_value, zone_map.max_value)) {
-            return ZoneMapFilterResult::kMayMatch;
-        }
-    }
-    return ZoneMapFilterResult::kNoMatch;
+    return set.contains_any_in_range(zone_map.min_value, zone_map.max_value)
+                   ? ZoneMapFilterResult::kMayMatch
+                   : ZoneMapFilterResult::kNoMatch;
 }
 
 ZoneMapFilterResult eval_eq_dictionary(const DictionaryEvalContext& ctx,
                                        const SlotLiteral& slot_literal) {
-    auto dictionary = ctx.slot(slot_literal.slot_index);
+    const auto* dictionary = ctx.slot(slot_literal.slot_index);
     if (dictionary == nullptr || dictionary->data_type == nullptr) {
         return ZoneMapFilterResult::kUnsupported;
     }
@@ -510,22 +508,24 @@ ZoneMapFilterResult eval_eq_dictionary(const DictionaryEvalContext& ctx,
 }
 
 ZoneMapFilterResult eval_in_dictionary(const DictionaryEvalContext& ctx, const VExprSPtr& slot_expr,
-                                       bool is_not_in, const std::vector<Field>& values) {
+                                       bool is_not_in, const HybridSetBase& values) {
     if (is_not_in) {
         return ZoneMapFilterResult::kUnsupported;
     }
     auto slot = std::dynamic_pointer_cast<VSlotRef>(slot_expr);
     DORIS_CHECK(slot != nullptr);
-    auto dictionary = ctx.slot(slot->column_id());
+    const auto* dictionary = ctx.slot(slot->column_id());
     if (dictionary == nullptr || dictionary->data_type == nullptr) {
         return ZoneMapFilterResult::kUnsupported;
     }
     DORIS_CHECK(data_types_compatible(dictionary->data_type, slot->data_type()));
-    if (values.empty()) {
+    // HybridSetBase::empty() also treats a NULL literal as non-empty, but dictionary pruning needs
+    // to know whether there are any non-NULL candidates.
+    if (values.size() == 0) { // NOLINT(readability-container-size-empty)
         return ZoneMapFilterResult::kNoMatch;
     }
-    for (const auto& value : values) {
-        if (!value.is_null() && dictionary_contains(*dictionary, value)) {
+    for (const auto& value : dictionary->values) {
+        if (!value.is_null() && values.find(value)) {
             return ZoneMapFilterResult::kMayMatch;
         }
     }
@@ -534,7 +534,7 @@ ZoneMapFilterResult eval_in_dictionary(const DictionaryEvalContext& ctx, const V
 
 ZoneMapFilterResult eval_eq_bloom_filter(const BloomFilterEvalContext& ctx,
                                          const SlotLiteral& slot_literal) {
-    auto slot_filter = ctx.slot(slot_literal.slot_index);
+    const auto* slot_filter = ctx.slot(slot_literal.slot_index);
     if (slot_filter == nullptr || slot_filter->data_type == nullptr ||
         slot_filter->bloom_filter == nullptr) {
         return ZoneMapFilterResult::kUnsupported;
@@ -550,27 +550,59 @@ ZoneMapFilterResult eval_eq_bloom_filter(const BloomFilterEvalContext& ctx,
 
 ZoneMapFilterResult eval_in_bloom_filter(const BloomFilterEvalContext& ctx,
                                          const VExprSPtr& slot_expr, bool is_not_in,
-                                         const std::vector<Field>& values) {
+                                         const HybridSetBase& values) {
     if (is_not_in) {
         return ZoneMapFilterResult::kUnsupported;
     }
     auto probe = extract_bloom_filter_probe(slot_expr);
     DORIS_CHECK(probe.has_value());
-    auto slot_filter = ctx.slot(probe->slot_index);
+    const auto* slot_filter = ctx.slot(probe->slot_index);
     if (slot_filter == nullptr || slot_filter->data_type == nullptr ||
         slot_filter->bloom_filter == nullptr) {
         return ZoneMapFilterResult::kUnsupported;
     }
     DORIS_CHECK(data_types_compatible(slot_filter->data_type, probe->value_type));
-    if (values.empty()) {
+    if (values.size() == 0) { // NOLINT(readability-container-size-empty)
         return ZoneMapFilterResult::kNoMatch;
     }
-    for (const auto& value : values) {
-        if (!value.is_null() && bloom_filter_may_contain(*slot_filter, value)) {
-            return ZoneMapFilterResult::kMayMatch;
-        }
+    const auto value_type = remove_nullable(slot_filter->data_type)->get_primitive_type();
+    switch (value_type) {
+    case TYPE_BOOLEAN:
+    case TYPE_INT:
+    case TYPE_BIGINT:
+    case TYPE_CHAR:
+    case TYPE_VARCHAR:
+    case TYPE_STRING:
+        break;
+    case TYPE_FLOAT:
+        return values.any_match_raw(value_type,
+                                    [slot_filter](const char* data, size_t size) {
+                                        DORIS_CHECK_EQ(size, sizeof(float));
+                                        const auto value = *reinterpret_cast<const float*>(data);
+                                        return floating_point_bloom_filter_may_contain(
+                                                *slot_filter->bloom_filter, value);
+                                    })
+                       ? ZoneMapFilterResult::kMayMatch
+                       : ZoneMapFilterResult::kNoMatch;
+    case TYPE_DOUBLE:
+        return values.any_match_raw(value_type,
+                                    [slot_filter](const char* data, size_t size) {
+                                        DORIS_CHECK_EQ(size, sizeof(double));
+                                        const auto value = *reinterpret_cast<const double*>(data);
+                                        return floating_point_bloom_filter_may_contain(
+                                                *slot_filter->bloom_filter, value);
+                                    })
+                       ? ZoneMapFilterResult::kMayMatch
+                       : ZoneMapFilterResult::kNoMatch;
+    default:
+        return ZoneMapFilterResult::kMayMatch;
     }
-    return ZoneMapFilterResult::kNoMatch;
+    return values.any_match_raw(value_type,
+                                [slot_filter](const char* data, size_t size) {
+                                    return slot_filter->bloom_filter->test_bytes(data, size);
+                                })
+                   ? ZoneMapFilterResult::kMayMatch
+                   : ZoneMapFilterResult::kNoMatch;
 }
 
 // Return the only slot ordinal referenced by a zonemap-evaluable expression. A negative result is

--- a/be/src/exprs/expr_zonemap_filter.h
+++ b/be/src/exprs/expr_zonemap_filter.h
@@ -30,13 +30,13 @@
 #include "core/data_type/data_type_nullable.h"
 #include "core/data_type/define_primitive_type.h"
 #include "core/field.h"
-#include "exprs/hybrid_set_min_max.h"
 #include "exprs/vexpr_fwd.h"
 #include "storage/index/zone_map/zonemap_eval_context.h"
 #include "storage/index/zone_map/zonemap_filter_result.h"
 
 namespace doris {
 class HybridSetBase;
+struct HybridSetMinMax;
 class RuntimeState;
 class TExprNode;
 

--- a/be/src/exprs/expr_zonemap_filter.h
+++ b/be/src/exprs/expr_zonemap_filter.h
@@ -18,17 +18,19 @@
 #pragma once
 
 #include <compare>
+#include <cstddef>
 #include <map>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 
 #include "common/check.h"
-#include "common/status.h"
 #include "core/data_type/data_type.h"
 #include "core/data_type/data_type_nullable.h"
 #include "core/data_type/define_primitive_type.h"
 #include "core/field.h"
+#include "exprs/hybrid_set_min_max.h"
 #include "exprs/vexpr_fwd.h"
 #include "storage/index/zone_map/zonemap_eval_context.h"
 #include "storage/index/zone_map/zonemap_filter_result.h"
@@ -45,13 +47,7 @@ class BloomFilter;
 
 namespace doris::expr_zonemap {
 
-struct InZonemapMaterializedSet {
-    bool contains_null = false;
-    bool contains_nan = false;
-    std::vector<Field> values;
-    Field min_value;
-    Field max_value;
-};
+using InZonemapMinMax = HybridSetMinMax;
 
 // Dictionary pruning evaluates file-level dictionary values, not row-level data. A kNoMatch result
 // means no non-null dictionary entry can satisfy the expression, so the whole row group can be
@@ -135,8 +131,9 @@ bool can_evaluate_bloom_filter_equality(const VExprSPtrs& args);
 TExprNode create_texpr_node_from_hybrid_set_value(const void* data, const PrimitiveType& type,
                                                   int precision, int scale);
 
-Status materialize_hybrid_set_for_zonemap_filter(HybridSetBase& set, const DataTypePtr& data_type,
-                                                 InZonemapMaterializedSet* result);
+void get_hybrid_set_min_max_for_zonemap_filter(const std::shared_ptr<HybridSetBase>& set,
+                                               const DataTypePtr& data_type,
+                                               InZonemapMinMax& result);
 
 inline bool field_types_compatible(PrimitiveType lhs, PrimitiveType rhs) {
     return lhs == rhs || (is_string_type(lhs) && is_string_type(rhs));
@@ -173,22 +170,21 @@ ZoneMapFilterResult eval_null_zonemap(const ZoneMapEvalContext& ctx, const VExpr
                                       bool is_null);
 
 ZoneMapFilterResult eval_in_zonemap(const ZoneMapEvalContext& ctx, const VExprSPtr& slot_expr,
-                                    bool is_not_in, const std::vector<Field>& values,
-                                    bool contains_nan, const Field& min_value,
-                                    const Field& max_value);
+                                    bool is_not_in, const InZonemapMinMax& values,
+                                    const HybridSetBase& set);
 
 ZoneMapFilterResult eval_eq_dictionary(const DictionaryEvalContext& ctx,
                                        const SlotLiteral& slot_literal);
 
 ZoneMapFilterResult eval_in_dictionary(const DictionaryEvalContext& ctx, const VExprSPtr& slot_expr,
-                                       bool is_not_in, const std::vector<Field>& values);
+                                       bool is_not_in, const HybridSetBase& values);
 
 ZoneMapFilterResult eval_eq_bloom_filter(const BloomFilterEvalContext& ctx,
                                          const SlotLiteral& slot_literal);
 
 ZoneMapFilterResult eval_in_bloom_filter(const BloomFilterEvalContext& ctx,
                                          const VExprSPtr& slot_expr, bool is_not_in,
-                                         const std::vector<Field>& values);
+                                         const HybridSetBase& values);
 
 // Return the only slot ordinal referenced by a zonemap-evaluable expression in its current
 // binding. Expressions that are unsupported by zonemap pruning, reference multiple slots, or use an

--- a/be/src/exprs/hybrid_set.h
+++ b/be/src/exprs/hybrid_set.h
@@ -360,8 +360,8 @@ public:
 
     // Return owning non-NaN bounds, or two null Fields when the set has no orderable values.
     // Exact range checks continue to read the typed set directly.
-    virtual void get_min_max(Field& min_value, Field& max_value) const = 0;
-    virtual bool contains_nan() const = 0;
+    virtual void get_min_max(Field& min_value, Field& max_value, bool& contains_nan) const = 0;
+
     // Dense-domain containers may require scanning their whole value domain even for a small set.
     // Callers on metadata hot paths should use min/max-only pruning when this returns false.
     virtual bool supports_fast_range_lookup() const = 0;
@@ -499,7 +499,8 @@ public:
         return _set.find(value.template get<T>());
     }
 
-    void get_min_max(Field& min_value, Field& max_value) const override {
+    void get_min_max(Field& min_value, Field& max_value, bool& contains_nan) const override {
+        contains_nan = false;
         if constexpr (std::is_floating_point_v<ElementType>) {
             min_value = Field {};
             max_value = Field {};
@@ -508,6 +509,7 @@ public:
             ElementType typed_max {};
             for (const auto& value : _set) {
                 if (std::isnan(value)) {
+                    contains_nan = true;
                     continue;
                 }
                 if (!found_ordered_value) {
@@ -532,13 +534,6 @@ public:
                 },
                 [](const ElementType& value) { return Field::create_field<T>(value); }, min_value,
                 max_value);
-    }
-
-    bool contains_nan() const override {
-        if constexpr (std::is_floating_point_v<ElementType>) {
-            return std::ranges::any_of(_set, [](const auto& value) { return std::isnan(value); });
-        }
-        return false;
     }
 
     bool supports_fast_range_lookup() const override {
@@ -822,7 +817,8 @@ public:
         return find(string_value.data(), string_value.size());
     }
 
-    void get_min_max(Field& min_value, Field& max_value) const override {
+    void get_min_max(Field& min_value, Field& max_value, bool& contains_nan) const override {
+        contains_nan = false;
         detail::get_hybrid_set_min_max(
                 _set, [](const std::string& lhs, const std::string& rhs) { return lhs < rhs; },
                 [](const std::string& value) {
@@ -830,8 +826,6 @@ public:
                 },
                 min_value, max_value);
     }
-
-    bool contains_nan() const override { return false; }
 
     bool supports_fast_range_lookup() const override { return true; }
 
@@ -1067,7 +1061,8 @@ public:
         return find(string_value.data(), string_value.size());
     }
 
-    void get_min_max(Field& min_value, Field& max_value) const override {
+    void get_min_max(Field& min_value, Field& max_value, bool& contains_nan) const override {
+        contains_nan = false;
         detail::get_hybrid_set_min_max(
                 _set, [](const StringRef& lhs, const StringRef& rhs) { return lhs < rhs; },
                 [](const StringRef& value) {
@@ -1076,8 +1071,6 @@ public:
                 },
                 min_value, max_value);
     }
-
-    bool contains_nan() const override { return false; }
 
     bool supports_fast_range_lookup() const override { return true; }
 

--- a/be/src/exprs/hybrid_set.h
+++ b/be/src/exprs/hybrid_set.h
@@ -20,13 +20,24 @@
 #include <gen_cpp/internal_service.pb.h>
 #include <pdqsort.h>
 
+#include <algorithm>
+#include <array>
+#include <cmath>
 #include <cstring>
+#include <functional>
+#include <memory>
+#include <string_view>
+#include <vector>
 
+#include "common/check.h"
+#include "common/compare.h"
 #include "common/object_pool.h"
 #include "core/column/column_nullable.h"
 #include "core/column/column_string.h"
 #include "core/column/column_vector.h"
 #include "core/data_type/primitive_type.h"
+#include "core/field.h"
+#include "core/string_ref.h"
 #include "exec/common/hash_table/phmap_fwd_decl.h"
 #include "exec/runtime_filter/utils.h"
 #include "exprs/bitset_container.h"
@@ -34,6 +45,49 @@
 
 namespace doris {
 constexpr int FIXED_CONTAINER_MAX_SIZE = 8;
+
+namespace detail {
+
+template <typename Container, typename Less, typename FieldFactory>
+void get_hybrid_set_min_max(const Container& container, Less&& less, FieldFactory&& field_factory,
+                            Field& min_value, Field& max_value) {
+    min_value = Field {};
+    max_value = Field {};
+
+    auto iterator = container.begin();
+    const auto end = container.end();
+    if (iterator == end) {
+        return;
+    }
+
+    auto min_iterator = iterator;
+    auto max_iterator = iterator;
+    for (; iterator != end; ++iterator) {
+        const auto& value = *iterator;
+        if (less(value, *min_iterator)) {
+            min_iterator = iterator;
+        }
+        if (less(*max_iterator, value)) {
+            max_iterator = iterator;
+        }
+    }
+    min_value = field_factory(*min_iterator);
+    max_value = field_factory(*max_iterator);
+}
+
+template <PrimitiveType T>
+bool hybrid_set_value_less(const typename PrimitiveTypeTraits<T>::CppType& lhs,
+                           const typename PrimitiveTypeTraits<T>::CppType& rhs) {
+    if constexpr (T == TYPE_DATEV2 || T == TYPE_DATETIMEV2 || T == TYPE_TIMESTAMPTZ) {
+        return lhs.to_date_int_val() < rhs.to_date_int_val();
+    } else if constexpr (T == TYPE_FLOAT || T == TYPE_DOUBLE) {
+        return Compare::less(lhs, rhs);
+    } else {
+        return lhs < rhs;
+    }
+}
+
+} // namespace detail
 
 /**
  * Fix Container can use simd to improve performance. 1 <= N <= 8 can be improved performance by test. FIXED_CONTAINER_MAX_SIZE = 8.
@@ -47,6 +101,7 @@ public:
     using ElementType = T;
 
     class Iterator;
+    class ConstIterator;
 
     FixedContainer() { static_assert(N >= 0 && N <= FIXED_CONTAINER_MAX_SIZE); }
 
@@ -75,6 +130,14 @@ public:
     ALWAYS_INLINE bool find(const T& value) const {
         DCHECK_EQ(N, _size);
         return _find_impl(value, std::make_index_sequence<N> {});
+    }
+
+    template <typename Less>
+    bool contains_any_in_range(const T& min_value, const T& max_value, Less&& less) const {
+        DCHECK(!less(max_value, min_value));
+        return std::ranges::any_of(_data.begin(), _data.begin() + _size, [&](const T& value) {
+            return !less(value, min_value) && !less(max_value, value);
+        });
     }
 
 private:
@@ -122,6 +185,38 @@ public:
     Iterator begin() { return Iterator(_data, 0); }
     Iterator end() { return Iterator(_data, _size); }
 
+    class ConstIterator {
+    public:
+        ConstIterator() = default;
+        explicit ConstIterator(const std::array<T, N>& data, size_t index)
+                : _data(&data), _index(index) {}
+        ConstIterator& operator++() {
+            ++_index;
+            return *this;
+        }
+        ConstIterator operator++(int) {
+            ConstIterator ret_val = *this;
+            ++(*this);
+            return ret_val;
+        }
+        bool operator==(ConstIterator other) const { return _index == other._index; }
+        bool operator!=(ConstIterator other) const { return !(*this == other); }
+        const T& operator*() const { return (*_data)[_index]; }
+        const T* operator->() const { return &operator*(); }
+
+        using iterator_category = std::forward_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = T;
+        using pointer = const T*;
+        using reference = const T&;
+
+    private:
+        const std::array<T, N>* _data = nullptr;
+        size_t _index = 0;
+    };
+    ConstIterator begin() const { return ConstIterator(_data, 0); }
+    ConstIterator end() const { return ConstIterator(_data, _size); }
+
     void clear() {
         std::array<T, N> {}.swap(_data);
         _size = 0;
@@ -161,12 +256,13 @@ struct DynamicContainerHash {
  * Dynamic Container uses phmap::flat_hash_set.
  * @tparam T Element Type
  */
-template <typename T>
+template <typename T, typename Hash = DynamicContainerHash<T>, typename Eq = doris::EqualTo<T>>
 class DynamicContainer {
 public:
+    using Set = flat_hash_set<T, Hash, Eq>;
     using Self = DynamicContainer;
-    using Set = flat_hash_set<T, DynamicContainerHash<T>>;
     using Iterator = typename Set::iterator;
+    using ConstIterator = typename Set::const_iterator;
     using ElementType = T;
 
     DynamicContainer() = default;
@@ -176,7 +272,19 @@ public:
 
     void insert(Iterator begin, Iterator end) { _set.insert(begin, end); }
 
-    bool find(const T& value) const { return _set.contains(value); }
+    template <typename Key>
+        requires requires(const Set& set, const Key& key) { set.find(key); }
+    bool find(const Key& value) const {
+        return _set.find(value) != _set.end();
+    }
+
+    template <typename Less>
+    bool contains_any_in_range(const T& min_value, const T& max_value, Less&& less) const {
+        DCHECK(!less(max_value, min_value));
+        return std::ranges::any_of(_set, [&](const T& value) {
+            return !less(value, min_value) && !less(max_value, value);
+        });
+    }
 
     void clear() { _set.clear(); }
 
@@ -184,15 +292,44 @@ public:
 
     Iterator end() { return _set.end(); }
 
+    ConstIterator begin() const { return _set.begin(); }
+
+    ConstIterator end() const { return _set.end(); }
+
     size_t size() const { return _set.size(); }
 
 private:
     Set _set;
 };
 
+struct HybridSetStringHash {
+    using is_transparent = void;
+
+    size_t operator()(const StringRef& value) const { return StringRefHash {}(value); }
+    size_t operator()(const std::string& value) const {
+        return operator()(StringRef(value.data(), value.size()));
+    }
+};
+
+struct HybridSetStringEqual {
+    using is_transparent = void;
+
+    static std::string_view to_view(const StringRef& value) {
+        return {value.size == 0 ? "" : value.data, value.size};
+    }
+    static std::string_view to_view(const std::string& value) { return value; }
+
+    template <typename Lhs, typename Rhs>
+    bool operator()(const Lhs& lhs, const Rhs& rhs) const {
+        return to_view(lhs) == to_view(rhs);
+    }
+};
+
 // TODO Maybe change void* parameter to template parameter better.
 class HybridSetBase : public FilterBase {
 public:
+    using RawValuePredicate = std::function<bool(const char* data, size_t size)>;
+
     HybridSetBase(bool null_aware) : FilterBase(null_aware) {}
     virtual ~HybridSetBase() = default;
     virtual void insert(const void* data) = 0;
@@ -214,11 +351,27 @@ public:
     }
 
     virtual void clear() = 0;
-    bool empty() { return !_contain_null && size() == 0; }
-    virtual int size() = 0;
+    bool empty() const { return !_contain_null && size() == 0; }
+    virtual int size() const = 0;
     virtual bool find(const void* data) const = 0;
     // use in vectorize execute engine
     virtual bool find(const void* data, size_t) const = 0;
+    virtual bool find(const Field& value) const = 0;
+
+    // Return owning non-NaN bounds, or two null Fields when the set has no orderable values.
+    // Exact range checks continue to read the typed set directly.
+    virtual void get_min_max(Field& min_value, Field& max_value) const = 0;
+    virtual bool contains_nan() const = 0;
+    // Dense-domain containers may require scanning their whole value domain even for a small set.
+    // Callers on metadata hot paths should use min/max-only pruning when this returns false.
+    virtual bool supports_fast_range_lookup() const = 0;
+    virtual bool contains_any_in_range(const Field& min_value, const Field& max_value) const = 0;
+
+    // Apply a byte-oriented predicate directly to each non-null native value and stop at the first
+    // match. The predicate and raw bytes are consumed synchronously because string sets may borrow
+    // their storage.
+    virtual bool any_match_raw(PrimitiveType value_type,
+                               const RawValuePredicate& predicate) const = 0;
 
     virtual void find_batch_raw_fixed(const uint8_t* values, size_t rows, size_t value_width,
                                       uint8_t* matches) const {
@@ -333,7 +486,7 @@ public:
         }
     }
 
-    int size() override { return (int)_set.size(); }
+    int size() const override { return (int)_set.size(); }
 
     bool find(const void* data) const override {
         return _set.find(*reinterpret_cast<const ElementType*>(data));
@@ -341,8 +494,100 @@ public:
 
     bool find(const void* data, size_t /*unused*/) const override { return find(data); }
 
-    void find_batch_raw_fixed(const uint8_t* values, size_t rows, size_t value_width,
-                              uint8_t* matches) const override {
+    bool find(const Field& value) const override {
+        DORIS_CHECK_EQ(value.get_type(), T);
+        return _set.find(value.template get<T>());
+    }
+
+    void get_min_max(Field& min_value, Field& max_value) const override {
+        if constexpr (std::is_floating_point_v<ElementType>) {
+            min_value = Field {};
+            max_value = Field {};
+            bool found_ordered_value = false;
+            ElementType typed_min {};
+            ElementType typed_max {};
+            for (const auto& value : _set) {
+                if (std::isnan(value)) {
+                    continue;
+                }
+                if (!found_ordered_value) {
+                    typed_min = value;
+                    typed_max = value;
+                    found_ordered_value = true;
+                    continue;
+                }
+                typed_min = std::min(typed_min, value);
+                typed_max = std::max(typed_max, value);
+            }
+            if (found_ordered_value) {
+                min_value = Field::create_field<T>(typed_min);
+                max_value = Field::create_field<T>(typed_max);
+            }
+            return;
+        }
+        detail::get_hybrid_set_min_max(
+                _set,
+                [](const ElementType& lhs, const ElementType& rhs) {
+                    return detail::hybrid_set_value_less<T>(lhs, rhs);
+                },
+                [](const ElementType& value) { return Field::create_field<T>(value); }, min_value,
+                max_value);
+    }
+
+    bool contains_nan() const override {
+        if constexpr (std::is_floating_point_v<ElementType>) {
+            return std::ranges::any_of(_set, [](const auto& value) { return std::isnan(value); });
+        }
+        return false;
+    }
+
+    bool supports_fast_range_lookup() const override {
+        // BitSetContainer::Iterator searches the dense value domain for the next set bit. A
+        // SMALLINT lookup may therefore inspect up to 65,536 positions even for a tiny set.
+        return !IsBitSetContainer<ContainerType>::value;
+    }
+
+    bool contains_any_in_range(const Field& min_value, const Field& max_value) const override {
+        DORIS_CHECK_EQ(min_value.get_type(), T);
+        DORIS_CHECK_EQ(max_value.get_type(), T);
+        const auto& typed_min = min_value.template get<T>();
+        const auto& typed_max = max_value.template get<T>();
+        const auto less = [](const ElementType& lhs, const ElementType& rhs) {
+            return detail::hybrid_set_value_less<T>(lhs, rhs);
+        };
+        DORIS_CHECK(!less(typed_max, typed_min));
+        if constexpr (std::is_floating_point_v<ElementType>) {
+            return std::ranges::any_of(_set, [&](const auto& value) {
+                return !std::isnan(value) && !less(value, typed_min) && !less(typed_max, value);
+            });
+        }
+        if constexpr (requires { _set.contains_any_in_range(typed_min, typed_max, less); }) {
+            return _set.contains_any_in_range(typed_min, typed_max, less);
+        }
+        for (const auto& value : _set) {
+            if (!less(value, typed_min) && !less(typed_max, value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool any_match_raw(PrimitiveType value_type,
+                       const RawValuePredicate& predicate) const override {
+        DORIS_CHECK_EQ(value_type, T);
+        for (const auto& value : _set) {
+            if (predicate(reinterpret_cast<const char*>(&value), sizeof(value))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // matches is an in/out selection mask updated in place; the checker cannot see that contract
+    // through this templated override.
+    void find_batch_raw_fixed(
+            const uint8_t* values, size_t rows, size_t value_width,
+            uint8_t* matches) const override { // NOLINT(readability-non-const-parameter)
         DORIS_CHECK_EQ(value_width, sizeof(ElementType));
         for (size_t row = 0; row < rows; ++row) {
             ElementType value;
@@ -351,8 +596,11 @@ public:
         }
     }
 
-    void find_batch_raw_fixed_negative(const uint8_t* values, size_t rows, size_t value_width,
-                                       uint8_t* matches) const override {
+    // matches is an in/out selection mask updated in place; the checker cannot see that contract
+    // through this templated override.
+    void find_batch_raw_fixed_negative(
+            const uint8_t* values, size_t rows, size_t value_width,
+            uint8_t* matches) const override { // NOLINT(readability-non-const-parameter)
         DORIS_CHECK_EQ(value_width, sizeof(ElementType));
         for (size_t row = 0; row < rows; ++row) {
             ElementType value;
@@ -455,7 +703,7 @@ public:
     uint64_t get_digest(uint64_t seed) override {
         std::vector<ElementType> elems(_set.begin(), _set.end());
         pdqsort(elems.begin(), elems.end());
-        if constexpr (std::is_same<ElementType, bool>::value) {
+        if constexpr (std::is_same_v<ElementType, bool>) {
             for (bool v : elems) {
                 seed = HashUtil::crc_hash64(&v, sizeof(v), seed);
             }
@@ -472,7 +720,8 @@ private:
     ObjectPool _pool;
 };
 
-template <typename _ContainerType = DynamicContainer<std::string>>
+template <typename _ContainerType =
+                  DynamicContainer<std::string, HybridSetStringHash, HybridSetStringEqual>>
 class StringSet : public HybridSetBase {
 public:
     using ContainerType = _ContainerType;
@@ -547,17 +796,67 @@ public:
         }
     }
 
-    int size() override { return (int)_set.size(); }
+    int size() const override { return (int)_set.size(); }
 
     bool find(const void* data) const override {
         const auto* value = reinterpret_cast<const StringRef*>(data);
-        std::string str_value(value->data, value->size);
-        return _set.find(str_value);
+        if constexpr (requires { _set.find(*value); }) {
+            return _set.find(*value);
+        } else {
+            return _set.find(std::string(value->data, value->size));
+        }
     }
 
     bool find(const void* data, size_t size) const override {
-        std::string str_value(reinterpret_cast<const char*>(data), size);
-        return _set.find(str_value);
+        const StringRef value(reinterpret_cast<const char*>(data), size);
+        if constexpr (requires { _set.find(value); }) {
+            return _set.find(value);
+        } else {
+            return _set.find(std::string(value.data, value.size));
+        }
+    }
+
+    bool find(const Field& value) const override {
+        DORIS_CHECK(is_string_type(value.get_type()));
+        const auto string_value = value.as_string_view();
+        return find(string_value.data(), string_value.size());
+    }
+
+    void get_min_max(Field& min_value, Field& max_value) const override {
+        detail::get_hybrid_set_min_max(
+                _set, [](const std::string& lhs, const std::string& rhs) { return lhs < rhs; },
+                [](const std::string& value) {
+                    return Field::create_field<TYPE_STRING>(String(value.data(), value.size()));
+                },
+                min_value, max_value);
+    }
+
+    bool contains_nan() const override { return false; }
+
+    bool supports_fast_range_lookup() const override { return true; }
+
+    bool contains_any_in_range(const Field& min_value, const Field& max_value) const override {
+        DORIS_CHECK(is_string_type(min_value.get_type()));
+        DORIS_CHECK(is_string_type(max_value.get_type()));
+        const auto typed_min = min_value.as_string_view();
+        const auto typed_max = max_value.as_string_view();
+        DORIS_CHECK(typed_min <= typed_max);
+        return std::ranges::any_of(_set, [&](const std::string& value) {
+            const std::string_view typed_value(value.data(), value.size());
+            return typed_value >= typed_min && typed_value <= typed_max;
+        });
+    }
+
+    bool any_match_raw(PrimitiveType value_type,
+                       const RawValuePredicate& predicate) const override {
+        DORIS_CHECK(is_string_type(value_type));
+        for (const auto& value : _set) {
+            const char* data = value.empty() ? "" : value.data();
+            if (predicate(data, value.size())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     void find_batch(const doris::IColumn& column, size_t rows,
@@ -601,15 +900,15 @@ public:
         auto* __restrict result_data = results.data();
 
         auto update_value = [&](size_t i) {
-            const auto& string_data = col.get_data_at(i).to_string();
+            const auto string_data = col.get_data_at(i);
             if constexpr (!is_nullable && !is_negative) {
-                result_data[i] = _set.find(string_data);
+                result_data[i] = find(string_data.data, string_data.size);
             } else if constexpr (!is_nullable && is_negative) {
-                result_data[i] = !_set.find(string_data);
+                result_data[i] = !find(string_data.data, string_data.size);
             } else if constexpr (is_nullable && !is_negative) {
-                result_data[i] = _set.find(string_data) & (!null_map_data[i]);
+                result_data[i] = find(string_data.data, string_data.size) & (!null_map_data[i]);
             } else { // (is_nullable && is_negative)
-                result_data[i] = !(_set.find(string_data) & (!null_map_data[i]));
+                result_data[i] = !(find(string_data.data, string_data.size) & (!null_map_data[i]));
             }
         };
 
@@ -750,7 +1049,7 @@ public:
         }
     }
 
-    int size() override { return (int)_set.size(); }
+    int size() const override { return (int)_set.size(); }
 
     bool find(const void* data) const override {
         const auto* value = reinterpret_cast<const StringRef*>(data);
@@ -760,6 +1059,50 @@ public:
     bool find(const void* data, size_t size) const override {
         StringRef sv(reinterpret_cast<const char*>(data), size);
         return _set.find(sv);
+    }
+
+    bool find(const Field& value) const override {
+        DORIS_CHECK(is_string_type(value.get_type()));
+        const auto string_value = value.as_string_view();
+        return find(string_value.data(), string_value.size());
+    }
+
+    void get_min_max(Field& min_value, Field& max_value) const override {
+        detail::get_hybrid_set_min_max(
+                _set, [](const StringRef& lhs, const StringRef& rhs) { return lhs < rhs; },
+                [](const StringRef& value) {
+                    return Field::create_field<TYPE_STRING>(
+                            String(value.size == 0 ? "" : value.data, value.size));
+                },
+                min_value, max_value);
+    }
+
+    bool contains_nan() const override { return false; }
+
+    bool supports_fast_range_lookup() const override { return true; }
+
+    bool contains_any_in_range(const Field& min_value, const Field& max_value) const override {
+        DORIS_CHECK(is_string_type(min_value.get_type()));
+        DORIS_CHECK(is_string_type(max_value.get_type()));
+        const auto typed_min = min_value.as_string_view();
+        const auto typed_max = max_value.as_string_view();
+        DORIS_CHECK(typed_min <= typed_max);
+        return std::ranges::any_of(_set, [&](const StringRef& value) {
+            const std::string_view typed_value(value.size == 0 ? "" : value.data, value.size);
+            return typed_value >= typed_min && typed_value <= typed_max;
+        });
+    }
+
+    bool any_match_raw(PrimitiveType value_type,
+                       const RawValuePredicate& predicate) const override {
+        DORIS_CHECK(is_string_type(value_type));
+        for (const auto& value : _set) {
+            const char* data = value.size == 0 ? "" : value.data;
+            if (predicate(data, value.size)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     void find_batch(const doris::IColumn& column, size_t rows,

--- a/be/src/exprs/hybrid_set_min_max.h
+++ b/be/src/exprs/hybrid_set_min_max.h
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "core/field.h"
+
+namespace doris {
+
+// Owning non-NaN bounds used by zonemap pruning. Empty, null-only, and NaN-only sets leave both
+// Fields null; contains_nan distinguishes the last case.
+struct HybridSetMinMax {
+    bool contains_nan = false;
+    Field min_value;
+    Field max_value;
+};
+
+} // namespace doris

--- a/be/src/exprs/vdirect_in_predicate.h
+++ b/be/src/exprs/vdirect_in_predicate.h
@@ -17,9 +17,8 @@
 
 #pragma once
 
-#include <mutex>
+#include <memory>
 #include <utility>
-#include <vector>
 
 #include "common/logging.h"
 #include "common/status.h"
@@ -27,6 +26,7 @@
 #include "core/types.h"
 #include "exprs/expr_zonemap_filter.h"
 #include "exprs/hybrid_set.h"
+#include "exprs/hybrid_set_min_max.h"
 #include "exprs/vexpr.h"
 #include "exprs/vin_predicate.h"
 #include "exprs/vliteral.h"
@@ -37,16 +37,6 @@ namespace doris {
 class VDirectInPredicate final : public VExpr {
     ENABLE_FACTORY_CREATOR(VDirectInPredicate);
 
-    struct PruningState {
-        std::once_flag materialize_once;
-        Status materialization_status;
-        bool zonemap_materialized = false;
-        bool seg_filter_contains_nan = false;
-        std::vector<Field> seg_filter_values;
-        Field seg_filter_min;
-        Field seg_filter_max;
-    };
-
 public:
     // `hybrid_set_values_match_child_type` tells whether values in `filter` can be interpreted with
     // the child expression type. Parquet/ORC dictionary-filter rewrites evaluate the original
@@ -54,7 +44,7 @@ public:
     // dictionary codes, for example `col IN ('a', 'b')` becomes `dict_code IN (0, 1)`. In that
     // shape the HybridSet stores TYPE_INT dictionary codes while the child slot still has the
     // original logical type such as STRING. Callers must pass false to disable zonemap
-    // materialization and slot-IN rewrite that would otherwise rebuild child-typed literals from
+    // min/max preparation and slot-IN rewrite that would otherwise rebuild child-typed literals from
     // dictionary codes.
     VDirectInPredicate(const TExprNode& node, const std::shared_ptr<HybridSetBase>& filter,
                        bool hybrid_set_values_match_child_type = true)
@@ -71,7 +61,7 @@ public:
     Status prepare(RuntimeState* state, const RowDescriptor& row_desc,
                    VExprContext* context) override {
         RETURN_IF_ERROR_OR_PREPARED(VExpr::prepare(state, row_desc, context));
-        RETURN_IF_ERROR(_materialize_for_zonemap_filter());
+        _prepare_zonemap_min_max();
         _prepare_finished = true;
         return Status::OK();
     }
@@ -100,25 +90,24 @@ public:
     std::shared_ptr<HybridSetBase> get_set_func() const override { return _filter; }
 
     ZoneMapFilterResult evaluate_zonemap_filter(const ZoneMapEvalContext& ctx) const override {
-        return expr_zonemap::eval_in_zonemap(
-                ctx, get_child(0), false, _pruning_state->seg_filter_values,
-                _pruning_state->seg_filter_contains_nan, _pruning_state->seg_filter_min,
-                _pruning_state->seg_filter_max);
+        DORIS_CHECK(_zonemap_min_max != nullptr);
+        DORIS_CHECK(_filter != nullptr);
+        return expr_zonemap::eval_in_zonemap(ctx, get_child(0), false, *_zonemap_min_max, *_filter);
     }
 
     bool can_evaluate_zonemap_filter() const override {
-        return _pruning_state->zonemap_materialized &&
+        return _zonemap_min_max != nullptr &&
                std::dynamic_pointer_cast<VSlotRef>(get_child(0)) != nullptr;
     }
 
     ZoneMapFilterResult evaluate_dictionary_filter(
             const DictionaryEvalContext& ctx) const override {
-        return expr_zonemap::eval_in_dictionary(ctx, get_child(0), false,
-                                                _pruning_state->seg_filter_values);
+        DORIS_CHECK(_filter != nullptr);
+        return expr_zonemap::eval_in_dictionary(ctx, get_child(0), false, *_filter);
     }
 
     bool can_evaluate_dictionary_filter() const override {
-        return _pruning_state->zonemap_materialized &&
+        return _zonemap_min_max != nullptr &&
                std::dynamic_pointer_cast<VSlotRef>(get_child(0)) != nullptr;
     }
 
@@ -139,9 +128,11 @@ public:
         return _raw_fixed_value_size(raw_type->get_primitive_type()) != 0;
     }
 
-    Status execute_on_raw_fixed_values(const uint8_t* values, size_t num_values, size_t value_width,
-                                       const DataTypePtr& data_type, int column_id,
-                                       uint8_t* matches) const override {
+    // matches is an in/out selection mask forwarded to the HybridSet batch probe.
+    Status execute_on_raw_fixed_values(
+            const uint8_t* values, size_t num_values, size_t value_width,
+            const DataTypePtr& data_type, int column_id,
+            uint8_t* matches) const override { // NOLINT(readability-non-const-parameter)
         if (!can_execute_on_raw_fixed_values(data_type, column_id)) {
             return Status::NotSupported(
                     "Direct IN predicate cannot evaluate raw fixed-width values");
@@ -174,9 +165,10 @@ public:
                is_string_type(remove_nullable(slot->data_type())->get_primitive_type());
     }
 
-    Status execute_on_raw_binary_values(const StringRef* values, size_t num_values,
-                                        const DataTypePtr& data_type, int column_id,
-                                        uint8_t* matches) const override {
+    // matches is an in/out selection mask forwarded to the HybridSet batch probe.
+    Status execute_on_raw_binary_values(
+            const StringRef* values, size_t num_values, const DataTypePtr& data_type, int column_id,
+            uint8_t* matches) const override { // NOLINT(readability-non-const-parameter)
         if (!can_execute_on_raw_binary_values(data_type, column_id)) {
             return Status::NotSupported("Direct IN predicate cannot evaluate raw binary values");
         }
@@ -192,9 +184,9 @@ public:
         DORIS_CHECK(cloned_expr != nullptr);
         auto cloned = VDirectInPredicate::create_shared(clone_texpr_node(), _filter,
                                                         _hybrid_set_values_match_child_type);
-        // Runtime-filter sets are immutable after publication, and file-local rewrites preserve
-        // the predicate's logical child type, so every split clone must reuse this materialization.
-        cloned->_pruning_state = _pruning_state;
+        // clone_node is never concurrent with prepare. Copy already-prepared bounds so file-local
+        // split clones can prune without traversing the set again.
+        cloned->_zonemap_min_max = _zonemap_min_max;
         *cloned_expr = std::move(cloned);
         return Status::OK();
     }
@@ -281,9 +273,10 @@ private:
         }
     }
 
+    // arg_column optionally returns the fully materialized argument column to the caller.
     Status _do_execute(VExprContext* context, const Block* block, const uint8_t* __restrict filter,
                        const Selector* selector, size_t count, ColumnPtr& result_column,
-                       ColumnPtr* arg_column) const {
+                       ColumnPtr* arg_column) const { // NOLINT(readability-non-const-parameter)
         DCHECK(_open_finished || block == nullptr);
         DCHECK(!(filter != nullptr && selector != nullptr))
                 << "filter and selector can not be both set";
@@ -314,38 +307,29 @@ private:
         return Status::OK();
     }
 
-    Status _materialize_for_zonemap_filter() {
-        const auto pruning_state = _pruning_state;
-        std::call_once(pruning_state->materialize_once, [&] {
-            if (!_hybrid_set_values_match_child_type) {
-                return;
-            }
-            DORIS_CHECK(_filter != nullptr);
-            auto& filter = *_filter;
-            const auto& data_type = remove_nullable(get_child(0)->data_type());
-            expr_zonemap::InZonemapMaterializedSet materialized;
-            pruning_state->materialization_status =
-                    expr_zonemap::materialize_hybrid_set_for_zonemap_filter(filter, data_type,
-                                                                            &materialized);
-            if (!pruning_state->materialization_status.ok()) {
-                return;
-            }
-            pruning_state->seg_filter_values = std::move(materialized.values);
-            pruning_state->seg_filter_contains_nan = materialized.contains_nan;
-            pruning_state->seg_filter_min = std::move(materialized.min_value);
-            pruning_state->seg_filter_max = std::move(materialized.max_value);
-            pruning_state->zonemap_materialized = true;
-        });
-        return pruning_state->materialization_status;
+    void _prepare_zonemap_min_max() {
+        if (!_hybrid_set_values_match_child_type) {
+            _zonemap_min_max.reset();
+            return;
+        }
+        if (_zonemap_min_max != nullptr) {
+            return;
+        }
+        DORIS_CHECK(_filter != nullptr);
+        const auto& data_type = remove_nullable(get_child(0)->data_type());
+        auto zonemap_min_max = std::make_shared<HybridSetMinMax>();
+        expr_zonemap::get_hybrid_set_min_max_for_zonemap_filter(_filter, data_type,
+                                                                *zonemap_min_max);
+        _zonemap_min_max = std::move(zonemap_min_max);
     }
 
     std::shared_ptr<HybridSetBase> _filter;
     // Dictionary-filter rewrites may store physical dictionary codes in the HybridSet while the
-    // child slot keeps the original logical type. Such values must not be materialized as child-type
-    // literals for zonemap pruning or slot-IN rewrite.
+    // child slot keeps the original logical type. Such values must not be interpreted as child-type
+    // bounds for zonemap pruning or literals for slot-IN rewrite.
     bool _hybrid_set_values_match_child_type = true;
     std::string _expr_name;
-    std::shared_ptr<PruningState> _pruning_state = std::make_shared<PruningState>();
+    std::shared_ptr<const HybridSetMinMax> _zonemap_min_max;
 };
 
 } // namespace doris

--- a/be/src/exprs/vin_predicate.cpp
+++ b/be/src/exprs/vin_predicate.cpp
@@ -34,6 +34,8 @@
 #include "exprs/expr_zonemap_filter.h"
 #include "exprs/function/in.h"
 #include "exprs/function/simple_function_factory.h"
+#include "exprs/hybrid_set.h"
+#include "exprs/hybrid_set_min_max.h"
 #include "exprs/vexpr_context.h"
 #include "exprs/vslot_ref.h"
 #include "runtime/runtime_state.h"
@@ -83,6 +85,10 @@ size_t raw_in_value_size(PrimitiveType primitive_type) {
 
 VInPredicate::VInPredicate(const TExprNode& node)
         : VExpr(node), _is_not_in(node.in_predicate.is_not_in) {}
+
+#ifdef BE_TEST
+VInPredicate::VInPredicate() = default;
+#endif
 
 Status VInPredicate::prepare(RuntimeState* state, const RowDescriptor& desc,
                              VExprContext* context) {
@@ -137,8 +143,8 @@ Status VInPredicate::open(RuntimeState* state, VExprContext* context,
     _is_args_all_constant = std::all_of(_children.begin() + 1, _children.end(),
                                         [](const VExprSPtr& expr) { return expr->is_constant(); });
     if (scope == FunctionContext::FRAGMENT_LOCAL && _is_args_all_constant &&
-        !_zonemap_materialized) {
-        RETURN_IF_ERROR(_materialize_for_zonemap_filter(context));
+        _zonemap_min_max == nullptr) {
+        _prepare_zonemap_min_max(context);
     }
     _open_finished = true;
     return Status::OK();
@@ -154,26 +160,23 @@ Status VInPredicate::evaluate_inverted_index(VExprContext* context, uint32_t seg
     return _evaluate_inverted_index(context, _function, segment_num_rows);
 }
 
-Status VInPredicate::_materialize_for_zonemap_filter(VExprContext* context) {
-    _seg_filter_values.clear();
-    _seg_filter_contains_null = false;
-    _seg_filter_contains_nan = false;
-    _zonemap_materialized = false;
+void VInPredicate::_prepare_zonemap_min_max(VExprContext* context) {
+    _zonemap_min_max.reset();
     _direct_filter_set.reset();
     if (_children.size() < 2) {
-        return Status::OK();
+        return;
     }
 
     auto bloom_probe = expr_zonemap::extract_bloom_filter_probe(_children[0]);
     if (!bloom_probe.has_value()) {
-        return Status::OK();
+        return;
     }
     // Materialization is shared by all pruning paths. Their capability checks keep ZoneMap,
     // dictionary, and raw evaluation direct-slot-only while Bloom may consume a nested leaf.
     const auto data_type = remove_nullable(bloom_probe->value_type);
     DORIS_CHECK(data_type != nullptr);
     if (is_complex_type(data_type->get_primitive_type())) {
-        return Status::OK();
+        return;
     }
 
     DORIS_CHECK(context != nullptr);
@@ -186,54 +189,48 @@ Status VInPredicate::_materialize_for_zonemap_filter(VExprContext* context) {
     DORIS_CHECK(in_state->hybrid_set != nullptr);
     _direct_filter_set = in_state->hybrid_set;
 
-    expr_zonemap::InZonemapMaterializedSet materialized;
-    RETURN_IF_ERROR(expr_zonemap::materialize_hybrid_set_for_zonemap_filter(
-            *in_state->hybrid_set, data_type, &materialized));
-    _seg_filter_contains_null = materialized.contains_null;
-    _seg_filter_contains_nan = materialized.contains_nan;
-    _seg_filter_values = std::move(materialized.values);
-    _seg_filter_min = std::move(materialized.min_value);
-    _seg_filter_max = std::move(materialized.max_value);
-    _zonemap_materialized = true;
-    return Status::OK();
+    auto zonemap_min_max = std::make_shared<HybridSetMinMax>();
+    expr_zonemap::get_hybrid_set_min_max_for_zonemap_filter(in_state->hybrid_set, data_type,
+                                                            *zonemap_min_max);
+    _zonemap_min_max = std::move(zonemap_min_max);
 }
 
 ZoneMapFilterResult VInPredicate::evaluate_zonemap_filter(const ZoneMapEvalContext& ctx) const {
-    if (_is_not_in && _seg_filter_contains_null) {
-        return ZoneMapFilterResult::kNoMatch;
-    }
-    return expr_zonemap::eval_in_zonemap(ctx, get_child(0), _is_not_in, _seg_filter_values,
-                                         _seg_filter_contains_nan, _seg_filter_min,
-                                         _seg_filter_max);
+    DORIS_CHECK(_zonemap_min_max != nullptr);
+    DORIS_CHECK(_direct_filter_set != nullptr);
+    return expr_zonemap::eval_in_zonemap(ctx, get_child(0), _is_not_in, *_zonemap_min_max,
+                                         *_direct_filter_set);
 }
 
 bool VInPredicate::can_evaluate_zonemap_filter() const {
-    return _zonemap_materialized && std::dynamic_pointer_cast<VSlotRef>(get_child(0)) != nullptr;
+    return _zonemap_min_max != nullptr &&
+           std::dynamic_pointer_cast<VSlotRef>(get_child(0)) != nullptr;
 }
 
 ZoneMapFilterResult VInPredicate::evaluate_dictionary_filter(
         const DictionaryEvalContext& ctx) const {
-    return expr_zonemap::eval_in_dictionary(ctx, get_child(0), _is_not_in, _seg_filter_values);
+    DORIS_CHECK(_direct_filter_set != nullptr);
+    return expr_zonemap::eval_in_dictionary(ctx, get_child(0), _is_not_in, *_direct_filter_set);
 }
 
 bool VInPredicate::can_evaluate_dictionary_filter() const {
-    return _zonemap_materialized && !_is_not_in &&
+    return _zonemap_min_max != nullptr && !_is_not_in &&
            std::dynamic_pointer_cast<VSlotRef>(get_child(0)) != nullptr;
 }
 
 ZoneMapFilterResult VInPredicate::evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const {
-    return expr_zonemap::eval_in_bloom_filter(ctx, get_child(0), _is_not_in, _seg_filter_values);
+    DORIS_CHECK(_direct_filter_set != nullptr);
+    return expr_zonemap::eval_in_bloom_filter(ctx, get_child(0), _is_not_in, *_direct_filter_set);
 }
 
 bool VInPredicate::can_evaluate_bloom_filter() const {
-    // A NaN member forces conservative retention regardless of the remaining finite probes.
-    return _zonemap_materialized && !_is_not_in && !_seg_filter_contains_nan &&
+    return _zonemap_min_max != nullptr && !_is_not_in &&
            expr_zonemap::extract_bloom_filter_probe(get_child(0)).has_value();
 }
 
 bool VInPredicate::can_execute_on_raw_fixed_values(const DataTypePtr& data_type,
                                                    int column_id) const {
-    if (!_zonemap_materialized || _direct_filter_set == nullptr || data_type == nullptr ||
+    if (_zonemap_min_max == nullptr || _direct_filter_set == nullptr || data_type == nullptr ||
         !_is_args_all_constant) {
         return false;
     }
@@ -262,7 +259,7 @@ Status VInPredicate::execute_on_raw_fixed_values(const uint8_t* values, size_t n
     }
     // NOT IN with a NULL literal is UNKNOWN for every non-null physical value. Definition levels
     // handle input NULLs, while this guard preserves the remaining three-valued SQL invariant.
-    if (_is_not_in && _seg_filter_contains_null) {
+    if (_is_not_in && _direct_filter_set->contain_null()) {
         std::fill(matches, matches + num_values, uint8_t {0});
     } else if (_is_not_in) {
         _direct_filter_set->find_batch_raw_fixed_negative(values, num_values, value_width, matches);
@@ -274,7 +271,7 @@ Status VInPredicate::execute_on_raw_fixed_values(const uint8_t* values, size_t n
 
 bool VInPredicate::can_execute_on_raw_binary_values(const DataTypePtr& data_type,
                                                     int column_id) const {
-    if (!_zonemap_materialized || _direct_filter_set == nullptr || data_type == nullptr ||
+    if (_zonemap_min_max == nullptr || _direct_filter_set == nullptr || data_type == nullptr ||
         !_is_args_all_constant ||
         !is_string_type(remove_nullable(data_type)->get_primitive_type())) {
         return false;
@@ -292,7 +289,7 @@ Status VInPredicate::execute_on_raw_binary_values(const StringRef* values, size_
     }
     DORIS_CHECK(values != nullptr || num_values == 0);
     DORIS_CHECK(matches != nullptr || num_values == 0);
-    if (_is_not_in && _seg_filter_contains_null) {
+    if (_is_not_in && _direct_filter_set->contain_null()) {
         std::fill(matches, matches + num_values, uint8_t {0});
     } else if (_is_not_in) {
         _direct_filter_set->find_batch_raw_binary_negative(values, num_values, matches);

--- a/be/src/exprs/vin_predicate.h
+++ b/be/src/exprs/vin_predicate.h
@@ -17,12 +17,12 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
-#include <vector>
+#include <utility>
 
 #include "common/object_pool.h"
 #include "common/status.h"
-#include "core/field.h"
 #include "exprs/function/function.h"
 #include "exprs/function_context.h"
 #include "exprs/vexpr.h"
@@ -34,6 +34,7 @@ class TExprNode;
 class Block;
 class VExprContext;
 class HybridSetBase;
+struct HybridSetMinMax;
 } // namespace doris
 
 namespace doris {
@@ -43,7 +44,7 @@ class VInPredicate MOCK_REMOVE(final) : public VExpr {
 public:
     VInPredicate(const TExprNode& node);
 #ifdef BE_TEST
-    VInPredicate() = default;
+    VInPredicate();
 #endif
     ~VInPredicate() override = default;
     Status execute_column_impl(VExprContext* context, const Block* block, const Selector* selector,
@@ -57,7 +58,7 @@ public:
 
     std::string debug_string() const override;
 
-    const FunctionBasePtr function() { return _function; }
+    FunctionBasePtr function() const { return _function; }
 
     bool is_not_in() const { return _is_not_in; };
     Status evaluate_inverted_index(VExprContext* context, uint32_t segment_num_rows) override;
@@ -91,7 +92,7 @@ public:
     }
 
 private:
-    Status _materialize_for_zonemap_filter(VExprContext* context);
+    void _prepare_zonemap_min_max(VExprContext* context);
 
     FunctionBasePtr _function;
     std::string _expr_name;
@@ -100,12 +101,7 @@ private:
     static const constexpr char* function_name = "in";
     uint32_t _in_list_value_count_threshold = 10;
     bool _is_args_all_constant = false;
-    bool _zonemap_materialized = false;
-    bool _seg_filter_contains_null = false;
-    bool _seg_filter_contains_nan = false;
     std::shared_ptr<HybridSetBase> _direct_filter_set;
-    std::vector<Field> _seg_filter_values;
-    Field _seg_filter_min;
-    Field _seg_filter_max;
+    std::shared_ptr<const HybridSetMinMax> _zonemap_min_max;
 };
 } // namespace doris

--- a/be/src/storage/predicate/in_list_predicate.h
+++ b/be/src/storage/predicate/in_list_predicate.h
@@ -78,7 +78,7 @@ public:
         CHECK(hybrid_set != nullptr);
 
         // String types need a copy because:
-        // The caller's set is StringSet<DynamicContainer<std::string>>, but here we want
+        // The caller's set is an owning dynamic StringSet, but here we want
         // StringSet<FixedContainer<std::string, N>> for small-set optimization — different
         // C++ types, cannot share the pointer.
         //

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -1191,8 +1191,8 @@ Status SegmentIterator::_get_row_ranges_from_conditions(RowRanges* condition_row
     }
 
     {
-        SCOPED_RAW_TIMER(&_opts.stats->generate_row_ranges_by_zonemap_ns);
         if (!_common_expr_ctxs_push_down.empty()) {
+            SCOPED_RAW_TIMER(&_opts.stats->generate_row_ranges_by_zonemap_ns);
             const auto pre_expr_zonemap_size = condition_row_ranges->count();
             RETURN_IF_ERROR(_apply_expr_zonemap_to_row_ranges(_common_expr_ctxs_push_down, 0,
                                                               condition_row_ranges));

--- a/be/test/exprs/expr_zonemap_filter_test.cpp
+++ b/be/test/exprs/expr_zonemap_filter_test.cpp
@@ -25,7 +25,6 @@
 #include <limits>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <set>
 #include <string>
 #include <vector>
@@ -39,6 +38,7 @@
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
 #include "core/data_type/data_type_struct.h"
+#include "core/data_type/data_type_time.h"
 #include "core/field.h"
 #include "core/string_ref.h"
 #include "core/value/vdatetime_value.h"
@@ -47,6 +47,7 @@
 #include "exprs/function/functions_comparison.h"
 #include "exprs/function/simple_function_factory.h"
 #include "exprs/hybrid_set.h"
+#include "exprs/hybrid_set_min_max.h"
 #include "exprs/runtime_filter_expr.h"
 #include "exprs/vbloom_predicate.h"
 #include "exprs/vcompound_pred.h"
@@ -157,6 +158,16 @@ std::unique_ptr<segment_v2::BlockSplitBloomFilter> make_int_bloom_filter(
     return bloom_filter;
 }
 
+std::unique_ptr<segment_v2::BlockSplitBloomFilter> make_string_bloom_filter(
+        const std::vector<std::string>& values) {
+    auto bloom_filter = std::make_unique<segment_v2::BlockSplitBloomFilter>();
+    EXPECT_TRUE(bloom_filter->init(segment_v2::BloomFilter::MINIMUM_BYTES).ok());
+    for (const auto& value : values) {
+        bloom_filter->add_bytes(value.data(), value.size());
+    }
+    return bloom_filter;
+}
+
 BloomFilterEvalContext make_bloom_filter_context(const segment_v2::BloomFilter* bloom_filter,
                                                  const DataTypePtr& data_type) {
     BloomFilterEvalContext ctx;
@@ -165,6 +176,53 @@ BloomFilterEvalContext make_bloom_filter_context(const segment_v2::BloomFilter* 
                                  .bloom_filter = bloom_filter,
                          });
     return ctx;
+}
+
+struct MinMaxTestSet {
+    std::shared_ptr<HybridSetBase> set;
+    HybridSetMinMax min_max;
+};
+
+MinMaxTestSet make_int_set_with_min_max(const std::vector<int32_t>& values, bool null_aware = false,
+                                        bool contains_null = false) {
+    MinMaxTestSet result;
+    result.set.reset(create_set(TYPE_INT, null_aware));
+    for (const auto value : values) {
+        result.set->insert(&value);
+    }
+    if (contains_null) {
+        result.set->insert(static_cast<const void*>(nullptr));
+    }
+    expr_zonemap::get_hybrid_set_min_max_for_zonemap_filter(result.set, int_type(), result.min_max);
+    return result;
+}
+
+template <PrimitiveType T>
+MinMaxTestSet make_typed_set_with_min_max(
+        const std::vector<typename PrimitiveTypeTraits<T>::CppType>& values,
+        const DataTypePtr& data_type, bool null_aware = false, bool contains_null = false) {
+    MinMaxTestSet result;
+    result.set.reset(create_set(T, null_aware));
+    for (const auto& value : values) {
+        result.set->insert(&value);
+    }
+    if (contains_null) {
+        result.set->insert(static_cast<const void*>(nullptr));
+    }
+    expr_zonemap::get_hybrid_set_min_max_for_zonemap_filter(result.set, data_type, result.min_max);
+    return result;
+}
+
+MinMaxTestSet make_string_set_with_min_max(const std::vector<std::string>& values,
+                                           const DataTypePtr& data_type) {
+    MinMaxTestSet result;
+    result.set.reset(create_set(TYPE_STRING, false));
+    for (const auto& value : values) {
+        StringRef string_value(value);
+        result.set->insert(&string_value);
+    }
+    expr_zonemap::get_hybrid_set_min_max_for_zonemap_filter(result.set, data_type, result.min_max);
+    return result;
 }
 
 segment_v2::ZoneMap make_int_zonemap(int32_t min_value, int32_t max_value) {
@@ -183,11 +241,11 @@ segment_v2::ZoneMap make_string_zonemap(std::string min_value, std::string max_v
     return zone_map;
 }
 
-TDescriptorTable make_k2_scan_desc_tbl() {
+TDescriptorTable make_k2_scan_desc_tbl(PrimitiveType primitive_type = TYPE_INT) {
     TDescriptorTableBuilder desc_tbl_builder;
     TTupleDescriptorBuilder tuple_builder;
     auto k2_slot = TSlotDescriptorBuilder()
-                           .type(TYPE_INT)
+                           .type(primitive_type)
                            .column_name("k2")
                            .column_pos(0)
                            .nullable(false)
@@ -488,10 +546,16 @@ TEST(ExprZonemapFilterTest, FloatingPointNanBloomProbeIsConservative) {
         EXPECT_FALSE(equals.can_evaluate_bloom_filter({slot, literal}));
         EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
                   equals.evaluate_bloom_filter(bloom_ctx, {slot, literal}));
-        EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
-                  expr_zonemap::eval_in_bloom_filter(bloom_ctx, slot, false, {nan_field}));
-
         const auto primitive_type = remove_nullable(type)->get_primitive_type();
+        std::shared_ptr<HybridSetBase> nan_values(create_set(primitive_type, false));
+        if (primitive_type == TYPE_FLOAT) {
+            nan_values->insert(&nan_field.get<TYPE_FLOAT>());
+        } else {
+            nan_values->insert(&nan_field.get<TYPE_DOUBLE>());
+        }
+        EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+                  expr_zonemap::eval_in_bloom_filter(bloom_ctx, slot, false, *nan_values));
+
         const Field absent_finite = primitive_type == TYPE_FLOAT
                                             ? Field::create_field<TYPE_FLOAT>(2.0F)
                                             : Field::create_field<TYPE_DOUBLE>(2.0);
@@ -508,19 +572,21 @@ TEST(ExprZonemapFilterTest, FloatingPointNanBloomProbeIsConservative) {
                Field::create_field<TYPE_DOUBLE>(std::numeric_limits<double>::quiet_NaN()));
 }
 
-TEST(ExprZonemapFilterTest, FloatingPointInWithNanIsNotBloomEligible) {
+TEST(ExprZonemapFilterTest, FloatingPointInWithNanBloomProbeIsConservative) {
     auto type = std::make_shared<DataTypeFloat64>();
     auto predicate = std::make_shared<VInPredicate>(make_in_predicate_node(false, 2));
     predicate->add_child(make_slot(0, type));
-    predicate->_zonemap_materialized = true;
-    predicate->_seg_filter_contains_nan = true;
-    predicate->_seg_filter_values = {
-            Field::create_field<TYPE_DOUBLE>(1.0),
-            Field::create_field<TYPE_DOUBLE>(std::numeric_limits<double>::quiet_NaN())};
+    auto values = make_typed_set_with_min_max<TYPE_DOUBLE>(
+            {1.0, std::numeric_limits<double>::quiet_NaN()}, type);
+    predicate->_direct_filter_set = values.set;
+    predicate->_zonemap_min_max = std::make_shared<HybridSetMinMax>(values.min_max);
 
-    EXPECT_FALSE(predicate->can_evaluate_bloom_filter());
-    predicate->_seg_filter_contains_nan = false;
     EXPECT_TRUE(predicate->can_evaluate_bloom_filter());
+    auto bloom_filter = std::make_unique<segment_v2::BlockSplitBloomFilter>();
+    ASSERT_TRUE(bloom_filter->init(segment_v2::BloomFilter::MINIMUM_BYTES).ok());
+    EXPECT_EQ(
+            ZoneMapFilterResult::kMayMatch,
+            predicate->evaluate_bloom_filter(make_bloom_filter_context(bloom_filter.get(), type)));
 }
 
 TEST(ExprZonemapFilterTest, FloatingPointNanEqualityIgnoresFiniteOnlyRangeBounds) {
@@ -544,7 +610,6 @@ TEST(ExprZonemapFilterTest, FloatingPointNanEqualityIgnoresFiniteOnlyRangeBounds
         EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
                   equals.evaluate_zonemap_filter(ctx, {slot, nan_literal}));
 
-        const auto finite_field = Field::create_field<Type>(T {10});
         const auto zero_field = Field::create_field<Type>(T {0});
         const auto one_field = Field::create_field<Type>(T {1});
         auto zero_literal =
@@ -556,6 +621,9 @@ TEST(ExprZonemapFilterTest, FloatingPointNanEqualityIgnoresFiniteOnlyRangeBounds
         FunctionComparison<GreaterOrEqualsOp, NameGreaterOrEquals> greater_equal;
         FunctionComparison<LessOp, NameLess> less;
         FunctionComparison<LessOrEqualsOp, NameLessOrEquals> less_equal;
+        auto in_values =
+                make_typed_set_with_min_max<Type>({T {10}, nan_field.template get<Type>()}, type);
+        auto not_in_values = make_typed_set_with_min_max<Type>({T {0}}, type);
         EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
                   not_equals.evaluate_zonemap_filter(ctx, {slot, zero_literal}));
         EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
@@ -566,33 +634,66 @@ TEST(ExprZonemapFilterTest, FloatingPointNanEqualityIgnoresFiniteOnlyRangeBounds
                   less.evaluate_zonemap_filter(ctx, {one_literal, slot}));
         EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
                   less_equal.evaluate_zonemap_filter(ctx, {one_literal, slot}));
+        EXPECT_EQ(
+                ZoneMapFilterResult::kUnsupported,
+                expr_zonemap::eval_in_zonemap(ctx, slot, false, in_values.min_max, *in_values.set));
         EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
-                  expr_zonemap::eval_in_zonemap(ctx, slot, false, {finite_field, nan_field}, true,
-                                                finite_field, nan_field));
-        EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
-                  expr_zonemap::eval_in_zonemap(ctx, slot, true, {zero_field}, false, zero_field,
-                                                zero_field));
+                  expr_zonemap::eval_in_zonemap(ctx, slot, true, not_in_values.min_max,
+                                                *not_in_values.set));
 
         segment_v2::ZoneMap all_null_zone_map;
         all_null_zone_map.min_value = zero_field;
         all_null_zone_map.max_value = zero_field;
         auto all_null_ctx = make_context(std::move(all_null_zone_map), type);
         all_null_ctx.slots.at(0).floating_nan_count_unknown = true;
-        EXPECT_EQ(
-                ZoneMapFilterResult::kNoMatch,
-                expr_zonemap::eval_in_zonemap(all_null_ctx, slot, false, {finite_field, nan_field},
-                                              true, finite_field, nan_field));
+        EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+                  expr_zonemap::eval_in_zonemap(all_null_ctx, slot, false, in_values.min_max,
+                                                *in_values.set));
 
         ctx.slots.at(0).floating_nan_count_unknown = false;
         EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
                   equals.evaluate_zonemap_filter(ctx, {slot, nan_literal}));
-        EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-                  expr_zonemap::eval_in_zonemap(ctx, slot, false, {finite_field, nan_field}, true,
-                                                finite_field, nan_field));
+        EXPECT_EQ(
+                ZoneMapFilterResult::kNoMatch,
+                expr_zonemap::eval_in_zonemap(ctx, slot, false, in_values.min_max, *in_values.set));
     };
 
     check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(uint32_t {0x7fc00002U});
     check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(uint64_t {0x7ff8000000000002ULL});
+}
+
+TEST(ExprZonemapFilterTest, FloatingPointNanOnlyInHasNoOrderedBounds) {
+    const auto check_type = []<PrimitiveType Type, typename DataType>() {
+        using T = typename PrimitiveTypeTraits<Type>::CppType;
+        auto type = std::make_shared<DataType>();
+        auto slot = make_slot(0, type);
+        auto values =
+                make_typed_set_with_min_max<Type>({std::numeric_limits<T>::quiet_NaN()}, type);
+        EXPECT_TRUE(values.min_max.contains_nan);
+        EXPECT_TRUE(values.min_max.min_value.is_null());
+        EXPECT_TRUE(values.min_max.max_value.is_null());
+
+        segment_v2::ZoneMap zone_map;
+        zone_map.min_value = Field::create_field<Type>(T {0});
+        zone_map.max_value = Field::create_field<Type>(T {1});
+        zone_map.has_not_null = true;
+        auto ctx = make_context(std::move(zone_map), type);
+        ctx.slots.at(0).floating_nan_count_unknown = false;
+
+        EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+                  expr_zonemap::eval_in_zonemap(ctx, slot, false, values.min_max, *values.set));
+        EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+                  expr_zonemap::eval_in_zonemap(ctx, slot, true, values.min_max, *values.set));
+
+        auto nan_zone_map = *ctx.slots.at(0).zone_map;
+        nan_zone_map.has_nan = true;
+        auto nan_ctx = make_context(std::move(nan_zone_map), type);
+        EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
+                  expr_zonemap::eval_in_zonemap(nan_ctx, slot, false, values.min_max, *values.set));
+    };
+
+    check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>();
+    check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>();
 }
 
 TEST(ExprZonemapFilterTest, DirectInRawFixedKeepsEqualNanPayloadFromLargeSet) {
@@ -645,10 +746,11 @@ TEST(ExprZonemapFilterTest, FloatingPointSignedZeroBloomProbeChecksBothEncodings
         const auto field = Field::create_field<Type>(predicate_value);
         auto literal = std::make_shared<VLiteral>(create_texpr_node_from(field, Type, 0, 0));
         auto bloom_ctx = make_bloom_filter_context(bloom_filter.get(), type);
+        auto values = make_typed_set_with_min_max<Type>({predicate_value}, type);
         EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
                   equals.evaluate_bloom_filter(bloom_ctx, {slot, literal}));
         EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
-                  expr_zonemap::eval_in_bloom_filter(bloom_ctx, slot, false, {field}));
+                  expr_zonemap::eval_in_bloom_filter(bloom_ctx, slot, false, *values.set));
     };
 
     const auto float_type = std::make_shared<DataTypeFloat32>();
@@ -806,11 +908,10 @@ TEST(ExprZonemapFilterTest, MissingSlotTypeCountsUnsupportedZonemapEvalOnce) {
                                                    {string_slot, make_string_literal("ab")}));
     EXPECT_EQ(1, starts_with_ctx.stats.unusable_zonemap_eval_count);
 
-    std::vector<Field> values {int_field(10)};
+    auto values = make_int_set_with_min_max({10});
     ZoneMapEvalContext in_ctx;
     EXPECT_EQ(ZoneMapFilterResult::kUnsupported,
-              expr_zonemap::eval_in_zonemap(in_ctx, slot, false, values, false, int_field(10),
-                                            int_field(10)));
+              expr_zonemap::eval_in_zonemap(in_ctx, slot, false, values.min_max, *values.set));
     EXPECT_EQ(1, in_ctx.stats.unusable_zonemap_eval_count);
 }
 
@@ -867,26 +968,24 @@ TEST(ExprZonemapFilterTest, RangeStatsUnusableFlagsFallback) {
 TEST(ExprZonemapFilterTest, InZonemapSkipsZonesWithoutNonNullValues) {
     auto type = int_type();
     auto slot = make_slot(0, type);
-    std::vector<Field> values {int_field(10)};
+    auto values = make_int_set_with_min_max({10});
 
     segment_v2::ZoneMap empty_zone;
     auto empty_ctx = make_context(empty_zone, type);
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-              expr_zonemap::eval_in_zonemap(empty_ctx, slot, false, values, false, int_field(10),
-                                            int_field(10)));
+              expr_zonemap::eval_in_zonemap(empty_ctx, slot, false, values.min_max, *values.set));
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-              expr_zonemap::eval_in_zonemap(empty_ctx, slot, true, values, false, int_field(10),
-                                            int_field(10)));
+              expr_zonemap::eval_in_zonemap(empty_ctx, slot, true, values.min_max, *values.set));
 
     segment_v2::ZoneMap only_null_zone;
     only_null_zone.has_null = true;
     auto only_null_ctx = make_context(only_null_zone, type);
-    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-              expr_zonemap::eval_in_zonemap(only_null_ctx, slot, false, values, false,
-                                            int_field(10), int_field(10)));
-    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-              expr_zonemap::eval_in_zonemap(only_null_ctx, slot, true, values, false, int_field(10),
-                                            int_field(10)));
+    EXPECT_EQ(
+            ZoneMapFilterResult::kNoMatch,
+            expr_zonemap::eval_in_zonemap(only_null_ctx, slot, false, values.min_max, *values.set));
+    EXPECT_EQ(
+            ZoneMapFilterResult::kNoMatch,
+            expr_zonemap::eval_in_zonemap(only_null_ctx, slot, true, values.min_max, *values.set));
 }
 
 TEST(ExprZonemapFilterTest, FunctionStringStartsWithZonemapUsesPrefixRange) {
@@ -972,12 +1071,10 @@ TEST(ExprZonemapFilterTest, CharZonemapUsesTrimmedLogicalBounds) {
               starts_with->evaluate_zonemap_filter(starts_with_ctx,
                                                    {slot, make_string_literal("ga")}));
 
-    auto in_value = Field::create_field<TYPE_STRING>("gamma");
-    std::vector<Field> values {in_value};
+    auto values = make_string_set_with_min_max({"gamma"}, char_type);
     auto in_ctx = make_context(zone_map, char_type);
-    EXPECT_EQ(
-            ZoneMapFilterResult::kNoMatch,
-            expr_zonemap::eval_in_zonemap(in_ctx, slot, false, values, false, in_value, in_value));
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              expr_zonemap::eval_in_zonemap(in_ctx, slot, false, values.min_max, *values.set));
 }
 
 TEST(ExprZonemapFilterTest, InZonemapFallsBackToRangeWhenPointListIsLarge) {
@@ -985,13 +1082,26 @@ TEST(ExprZonemapFilterTest, InZonemapFallsBackToRangeWhenPointListIsLarge) {
     auto slot = make_slot(0, type);
     auto ctx = make_context(make_int_zonemap(10, 20), type);
 
-    std::vector<Field> values;
+    std::vector<int32_t> values;
     for (int value = 1; value <= 65; ++value) {
-        values.emplace_back(int_field(value));
+        values.emplace_back(value);
     }
+    auto values_with_min_max = make_int_set_with_min_max(values);
     EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
-              expr_zonemap::eval_in_zonemap(ctx, slot, false, values, false, int_field(1),
-                                            int_field(65)));
+              expr_zonemap::eval_in_zonemap(ctx, slot, false, values_with_min_max.min_max,
+                                            *values_with_min_max.set));
+    EXPECT_EQ(65, values_with_min_max.set->size());
+    EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+              expr_zonemap::eval_in_dictionary(make_dictionary_context({int_field(65)}, type), slot,
+                                               false, *values_with_min_max.set));
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              expr_zonemap::eval_in_dictionary(make_dictionary_context({int_field(100)}, type),
+                                               slot, false, *values_with_min_max.set));
+
+    auto singleton_ctx = make_context(make_int_zonemap(10, 10), type);
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              expr_zonemap::eval_in_zonemap(singleton_ctx, slot, true, values_with_min_max.min_max,
+                                            *values_with_min_max.set));
 
     EXPECT_EQ(0, ctx.stats.in_zonemap_point_check_count);
     EXPECT_EQ(1, ctx.stats.in_zonemap_range_only_count);
@@ -1002,11 +1112,27 @@ TEST(ExprZonemapFilterTest, InZonemapUsesPointChecksUnderThreshold) {
     auto slot = make_slot(0, type);
     auto ctx = make_context(make_int_zonemap(10, 20), type);
 
-    std::vector<Field> values {int_field(1), int_field(30)};
+    auto values = make_int_set_with_min_max({1, 30});
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-              expr_zonemap::eval_in_zonemap(ctx, slot, false, values, false, int_field(1),
-                                            int_field(30)));
+              expr_zonemap::eval_in_zonemap(ctx, slot, false, values.min_max, *values.set));
     EXPECT_EQ(1, ctx.stats.in_zonemap_point_check_count);
+}
+
+TEST(ExprZonemapFilterTest, InZonemapUsesRangeOnlyForDenseBitSetContainer) {
+    auto type = std::make_shared<DataTypeInt8>();
+    auto slot = make_slot(0, type);
+    segment_v2::ZoneMap zone_map;
+    zone_map.min_value = Field::create_field<TYPE_TINYINT>(int8_t {-10});
+    zone_map.max_value = Field::create_field<TYPE_TINYINT>(int8_t {10});
+    zone_map.has_not_null = true;
+    auto ctx = make_context(std::move(zone_map), type);
+
+    auto values = make_typed_set_with_min_max<TYPE_TINYINT>({int8_t {-100}, int8_t {100}}, type);
+    EXPECT_FALSE(values.set->supports_fast_range_lookup());
+    EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+              expr_zonemap::eval_in_zonemap(ctx, slot, false, values.min_max, *values.set));
+    EXPECT_EQ(0, ctx.stats.in_zonemap_point_check_count);
+    EXPECT_EQ(1, ctx.stats.in_zonemap_range_only_count);
 }
 
 TEST(ExprZonemapFilterTest, InZonemapHandlesEmptyListAndNotInSingleValueRange) {
@@ -1014,22 +1140,205 @@ TEST(ExprZonemapFilterTest, InZonemapHandlesEmptyListAndNotInSingleValueRange) {
     auto slot = make_slot(0, type);
     auto ctx = make_context(make_int_zonemap(10, 20), type);
 
-    std::vector<Field> empty_values;
+    auto empty_values = make_int_set_with_min_max({});
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-              expr_zonemap::eval_in_zonemap(ctx, slot, false, empty_values, false, {}, {}));
+              expr_zonemap::eval_in_zonemap(ctx, slot, false, empty_values.min_max,
+                                            *empty_values.set));
     EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
-              expr_zonemap::eval_in_zonemap(ctx, slot, true, empty_values, false, {}, {}));
+              expr_zonemap::eval_in_zonemap(ctx, slot, true, empty_values.min_max,
+                                            *empty_values.set));
 
     auto single_value_ctx = make_context(make_int_zonemap(10, 10), type);
-    std::vector<Field> values {int_field(10)};
+    auto values = make_int_set_with_min_max({10});
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
-              expr_zonemap::eval_in_zonemap(single_value_ctx, slot, true, values, false,
-                                            int_field(10), int_field(10)));
+              expr_zonemap::eval_in_zonemap(single_value_ctx, slot, true, values.min_max,
+                                            *values.set));
 
-    std::vector<Field> other_values {int_field(11)};
+    auto other_values = make_int_set_with_min_max({11});
     EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
-              expr_zonemap::eval_in_zonemap(single_value_ctx, slot, true, other_values, false,
-                                            int_field(11), int_field(11)));
+              expr_zonemap::eval_in_zonemap(single_value_ctx, slot, true, other_values.min_max,
+                                            *other_values.set));
+}
+
+// GTest assertion macros dominate the reported cognitive complexity of this linear scenario.
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST(ExprZonemapFilterTest, GetMinMaxHandlesEmptyNullOnlyAndSignedBitSetBounds) {
+    auto empty = make_int_set_with_min_max({});
+    EXPECT_EQ(0, empty.set->size());
+    EXPECT_FALSE(empty.set->contain_null());
+    EXPECT_TRUE(empty.min_max.min_value.is_null());
+    EXPECT_TRUE(empty.min_max.max_value.is_null());
+
+    auto null_only = make_int_set_with_min_max({}, true, true);
+    EXPECT_EQ(0, null_only.set->size());
+    EXPECT_TRUE(null_only.set->contain_null());
+    EXPECT_TRUE(null_only.min_max.min_value.is_null());
+    EXPECT_TRUE(null_only.min_max.max_value.is_null());
+
+    const std::vector<int8_t> values {127, -128, 0, -1};
+    auto tinyint =
+            make_typed_set_with_min_max<TYPE_TINYINT>(values, std::make_shared<DataTypeInt8>());
+    EXPECT_EQ(values.size(), tinyint.set->size());
+    EXPECT_EQ(Field::create_field<TYPE_TINYINT>(-128), tinyint.min_max.min_value);
+    EXPECT_EQ(Field::create_field<TYPE_TINYINT>(127), tinyint.min_max.max_value);
+
+    std::shared_ptr<HybridSetBase> smallint_set(create_set(TYPE_SMALLINT, false));
+    const int16_t smallint_min = std::numeric_limits<int16_t>::min();
+    const int16_t smallint_max = std::numeric_limits<int16_t>::max();
+    smallint_set->insert(&smallint_min);
+    smallint_set->insert(&smallint_max);
+    for (int16_t value = -31; value <= 31; ++value) {
+        smallint_set->insert(&value);
+    }
+    HybridSetMinMax smallint_min_max;
+    expr_zonemap::get_hybrid_set_min_max_for_zonemap_filter(
+            smallint_set, std::make_shared<DataTypeInt16>(), smallint_min_max);
+    EXPECT_EQ(65, smallint_set->size());
+    EXPECT_EQ(Field::create_field<TYPE_SMALLINT>(smallint_min), smallint_min_max.min_value);
+    EXPECT_EQ(Field::create_field<TYPE_SMALLINT>(smallint_max), smallint_min_max.max_value);
+
+    smallint_set->clear();
+    for (int16_t value = 100; value <= 164; ++value) {
+        smallint_set->insert(&value);
+    }
+    expr_zonemap::get_hybrid_set_min_max_for_zonemap_filter(
+            smallint_set, std::make_shared<DataTypeInt16>(), smallint_min_max);
+    EXPECT_EQ(65, smallint_set->size());
+    EXPECT_EQ(Field::create_field<TYPE_SMALLINT>(100), smallint_min_max.min_value);
+    EXPECT_EQ(Field::create_field<TYPE_SMALLINT>(164), smallint_min_max.max_value);
+}
+
+TEST(ExprZonemapFilterTest, StringSetHeterogeneousLookupPreservesBinaryValues) {
+    StringSet<> set(false);
+    const std::string empty;
+    const std::string binary("a\0b", 3);
+    StringRef empty_ref(empty);
+    StringRef binary_ref(binary);
+    set.insert(&empty_ref);
+    set.insert(&binary_ref);
+
+    EXPECT_TRUE(set.find(&empty_ref));
+    EXPECT_TRUE(set.find(empty.data(), empty.size()));
+    EXPECT_TRUE(set.find(Field::create_field<TYPE_STRING>(empty)));
+    EXPECT_TRUE(set.find(&binary_ref));
+    EXPECT_TRUE(set.find(binary.data(), binary.size()));
+    EXPECT_TRUE(set.find(Field::create_field<TYPE_STRING>(binary)));
+
+    const std::string prefix("a\0", 2);
+    EXPECT_FALSE(set.find(prefix.data(), prefix.size()));
+}
+
+TEST(ExprZonemapFilterTest, GetMinMaxPreservesDecimalAndDatetimeV2Values) {
+    const Decimal64 decimal_low(-1234);
+    const Decimal64 decimal_high(5678);
+    auto decimals = make_typed_set_with_min_max<TYPE_DECIMAL64>(
+            {decimal_high, decimal_low}, std::make_shared<DataTypeDecimal64>(18, 2));
+    EXPECT_EQ(Field::create_field<TYPE_DECIMAL64>(decimal_low), decimals.min_max.min_value);
+    EXPECT_EQ(Field::create_field<TYPE_DECIMAL64>(decimal_high), decimals.min_max.max_value);
+    EXPECT_TRUE(
+            decimals.set->contains_any_in_range(Field::create_field<TYPE_DECIMAL64>(decimal_low),
+                                                Field::create_field<TYPE_DECIMAL64>(decimal_low)));
+    EXPECT_FALSE(decimals.set->contains_any_in_range(
+            Field::create_field<TYPE_DECIMAL64>(Decimal64(-1000)),
+            Field::create_field<TYPE_DECIMAL64>(Decimal64(5000))));
+
+    DateV2Value<DateTimeV2ValueType> datetime_low;
+    datetime_low.unchecked_set_time(2024, 1, 2, 3, 4, 5, 123456);
+    DateV2Value<DateTimeV2ValueType> datetime_high;
+    datetime_high.unchecked_set_time(2025, 6, 7, 8, 9, 10, 654321);
+    auto datetimes = make_typed_set_with_min_max<TYPE_DATETIMEV2>(
+            {datetime_high, datetime_low}, std::make_shared<DataTypeDateTimeV2>(6));
+    EXPECT_EQ(Field::create_field<TYPE_DATETIMEV2>(datetime_low), datetimes.min_max.min_value);
+    EXPECT_EQ(Field::create_field<TYPE_DATETIMEV2>(datetime_high), datetimes.min_max.max_value);
+    EXPECT_TRUE(datetimes.set->contains_any_in_range(
+            Field::create_field<TYPE_DATETIMEV2>(datetime_high),
+            Field::create_field<TYPE_DATETIMEV2>(datetime_high)));
+    DateV2Value<DateTimeV2ValueType> datetime_hole;
+    datetime_hole.unchecked_set_time(2024, 6, 7, 8, 9, 10, 654321);
+    EXPECT_FALSE(datetimes.set->contains_any_in_range(
+            Field::create_field<TYPE_DATETIMEV2>(datetime_hole),
+            Field::create_field<TYPE_DATETIMEV2>(datetime_hole)));
+}
+
+TEST(ExprZonemapFilterTest, InBloomFilterHandlesEmptyAndNullOnlySets) {
+    auto type = int_type();
+    auto bloom_filter = make_int_bloom_filter({7});
+    auto bloom_ctx = make_bloom_filter_context(bloom_filter.get(), type);
+
+    std::shared_ptr<HybridSetBase> empty_values(create_set(TYPE_INT, false));
+    ASSERT_EQ(0, empty_values->size());
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              expr_zonemap::eval_in_bloom_filter(bloom_ctx, make_slot(0, type), false,
+                                                 *empty_values));
+
+    std::shared_ptr<HybridSetBase> null_only_values(create_set(TYPE_INT, true));
+    null_only_values->insert(static_cast<const void*>(nullptr));
+    ASSERT_EQ(0, null_only_values->size());
+    ASSERT_TRUE(null_only_values->contain_null());
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              expr_zonemap::eval_in_bloom_filter(bloom_ctx, make_slot(0, type), false,
+                                                 *null_only_values));
+}
+
+TEST(ExprZonemapFilterTest, InBloomFilterProbesInteriorNativeValues) {
+    auto type = int_type();
+    auto values = make_int_set_with_min_max({2, 4, 6});
+
+    auto missing_bloom_filter = make_int_bloom_filter({1, 3, 5});
+    auto missing_bloom_ctx = make_bloom_filter_context(missing_bloom_filter.get(), type);
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              expr_zonemap::eval_in_bloom_filter(missing_bloom_ctx, make_slot(0, type), false,
+                                                 *values.set));
+
+    // 4 is neither the IN-set minimum nor maximum, so this requires probing native set values.
+    auto matching_bloom_filter = make_int_bloom_filter({4});
+    auto matching_bloom_ctx = make_bloom_filter_context(matching_bloom_filter.get(), type);
+    EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+              expr_zonemap::eval_in_bloom_filter(matching_bloom_ctx, make_slot(0, type), false,
+                                                 *values.set));
+}
+
+TEST(ExprZonemapFilterTest, InBloomFilterPreservesEmptyAndEmbeddedNullStrings) {
+    auto type = std::make_shared<DataTypeString>();
+    const std::string empty;
+    const std::string binary("a\0b", 3);
+    for (const bool borrowed_values : {false, true}) {
+        SCOPED_TRACE(borrowed_values ? "StringValueSet" : "StringSet");
+        std::shared_ptr<HybridSetBase> values(borrowed_values ? create_string_value_set(false)
+                                                              : create_set(TYPE_STRING, false));
+        StringRef empty_ref(empty);
+        StringRef binary_ref(binary);
+        values->insert(&empty_ref);
+        values->insert(&binary_ref);
+
+        auto missing_bloom_filter = make_string_bloom_filter({});
+        auto missing_bloom_ctx = make_bloom_filter_context(missing_bloom_filter.get(), type);
+        EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+                  expr_zonemap::eval_in_bloom_filter(missing_bloom_ctx, make_slot(0, type), false,
+                                                     *values));
+
+        auto empty_bloom_filter = make_string_bloom_filter({empty});
+        auto empty_bloom_ctx = make_bloom_filter_context(empty_bloom_filter.get(), type);
+        EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+                  expr_zonemap::eval_in_bloom_filter(empty_bloom_ctx, make_slot(0, type), false,
+                                                     *values));
+
+        auto binary_bloom_filter = make_string_bloom_filter({binary});
+        auto binary_bloom_ctx = make_bloom_filter_context(binary_bloom_filter.get(), type);
+        EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+                  expr_zonemap::eval_in_bloom_filter(binary_bloom_ctx, make_slot(0, type), false,
+                                                     *values));
+    }
+}
+
+TEST(ExprZonemapFilterTest, InBloomFilterKeepsUnsupportedTypeConservative) {
+    auto type = std::make_shared<DataTypeInt8>();
+    auto values = make_typed_set_with_min_max<TYPE_TINYINT>({int8_t {7}}, type);
+    auto bloom_filter = make_int_bloom_filter({});
+    auto bloom_ctx = make_bloom_filter_context(bloom_filter.get(), type);
+    EXPECT_EQ(
+            ZoneMapFilterResult::kMayMatch,
+            expr_zonemap::eval_in_bloom_filter(bloom_ctx, make_slot(0, type), false, *values.set));
 }
 
 TEST(ExprZonemapFilterTest, UnsupportedSingleSlotExprDoesNotAdvertiseZonemapCapability) {
@@ -1047,7 +1356,7 @@ TEST(ExprZonemapFilterTest, UnsupportedSingleSlotExprDoesNotAdvertiseZonemapCapa
     EXPECT_FALSE(equals.can_evaluate_zonemap_filter({unsupported_expr, make_int_literal(10)}));
 }
 
-TEST(ExprZonemapFilterTest, VInPredicateMaterializesZonemapValues) {
+TEST(ExprZonemapFilterTest, VInPredicatePreparesZonemapMinMax) {
     auto type = int_type();
     ObjectPool obj_pool;
     DescriptorTbl* desc_tbl = nullptr;
@@ -1070,9 +1379,9 @@ TEST(ExprZonemapFilterTest, VInPredicateMaterializesZonemapValues) {
 
     auto ctx = make_context(make_int_zonemap(10, 20), type);
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch, in_predicate->evaluate_zonemap_filter(ctx));
-    EXPECT_TRUE(in_predicate->_zonemap_materialized);
-    EXPECT_EQ(int_field(1), in_predicate->_seg_filter_min);
-    EXPECT_EQ(int_field(30), in_predicate->_seg_filter_max);
+    ASSERT_NE(nullptr, in_predicate->_zonemap_min_max);
+    EXPECT_EQ(int_field(1), in_predicate->_zonemap_min_max->min_value);
+    EXPECT_EQ(int_field(30), in_predicate->_zonemap_min_max->max_value);
 
     auto not_in_with_null = std::make_shared<VInPredicate>(make_in_predicate_node(true, 3));
     auto not_in_slot = make_slot(0, type);
@@ -1087,10 +1396,11 @@ TEST(ExprZonemapFilterTest, VInPredicateMaterializesZonemapValues) {
     auto may_match_ctx = make_context(make_int_zonemap(11, 11), type);
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
               not_in_with_null->evaluate_zonemap_filter(may_match_ctx));
-    EXPECT_TRUE(not_in_with_null->_seg_filter_contains_null);
+    ASSERT_NE(nullptr, not_in_with_null->_direct_filter_set);
+    EXPECT_TRUE(not_in_with_null->_direct_filter_set->contain_null());
 }
 
-TEST(ExprZonemapFilterTest, VInPredicateDictionaryAndBloomUseMaterializedValues) {
+TEST(ExprZonemapFilterTest, VInPredicateDictionaryAndBloomProbePreparedSet) {
     auto type = int_type();
     ObjectPool obj_pool;
     DescriptorTbl* desc_tbl = nullptr;
@@ -1101,12 +1411,13 @@ TEST(ExprZonemapFilterTest, VInPredicateDictionaryAndBloomUseMaterializedValues)
     runtime_state.set_desc_tbl(desc_tbl);
     RowDescriptor row_desc(runtime_state.desc_tbl(), {0});
 
-    auto in_predicate = std::make_shared<VInPredicate>(make_in_predicate_node(false, 3));
+    auto in_predicate = std::make_shared<VInPredicate>(make_in_predicate_node(false, 4));
     auto in_slot = make_slot(0, type);
     std::static_pointer_cast<VSlotRef>(in_slot)->set_slot_id(0);
     in_predicate->add_child(in_slot);
     in_predicate->add_child(make_int_literal(2));
     in_predicate->add_child(make_int_literal(4));
+    in_predicate->add_child(make_int_literal(6));
     VExprContext in_context(in_predicate);
     ASSERT_TRUE(in_context.prepare(&runtime_state, row_desc).ok());
     ASSERT_TRUE(in_context.open(&runtime_state).ok());
@@ -1124,13 +1435,14 @@ TEST(ExprZonemapFilterTest, VInPredicateDictionaryAndBloomUseMaterializedValues)
     auto missing_bloom_ctx = make_bloom_filter_context(missing_bloom_filter.get(), type);
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
               in_predicate->evaluate_bloom_filter(missing_bloom_ctx));
+    // 4 is neither the IN-set minimum nor maximum. Bloom pruning must probe the full native set.
     auto matching_bloom_filter = make_int_bloom_filter({4});
     auto matching_bloom_ctx = make_bloom_filter_context(matching_bloom_filter.get(), type);
     EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
               in_predicate->evaluate_bloom_filter(matching_bloom_ctx));
 }
 
-TEST(ExprZonemapFilterTest, VInPredicateMaterializesNestedBloomValuesDuringOpen) {
+TEST(ExprZonemapFilterTest, VInPredicatePreparesNestedBloomValuesDuringOpen) {
     auto leaf_type = int_type();
     auto struct_type = std::make_shared<DataTypeStruct>(DataTypes {leaf_type}, Strings {"value"});
     auto slot = VSlotRef::create_shared(0, 0, -1, struct_type, "root");
@@ -1152,7 +1464,8 @@ TEST(ExprZonemapFilterTest, VInPredicateMaterializesNestedBloomValuesDuringOpen)
     ASSERT_TRUE(in_context.prepare(&runtime_state, row_desc).ok());
     ASSERT_TRUE(in_context.open(&runtime_state).ok());
 
-    EXPECT_TRUE(in_predicate->_zonemap_materialized);
+    EXPECT_NE(nullptr, in_predicate->_zonemap_min_max);
+    EXPECT_NE(nullptr, in_predicate->_direct_filter_set);
     EXPECT_TRUE(in_predicate->can_evaluate_bloom_filter());
     EXPECT_FALSE(in_predicate->can_evaluate_zonemap_filter());
     EXPECT_FALSE(in_predicate->can_evaluate_dictionary_filter());
@@ -1168,7 +1481,70 @@ TEST(ExprZonemapFilterTest, VInPredicateMaterializesNestedBloomValuesDuringOpen)
                       make_bloom_filter_context(matching_bloom_filter.get(), leaf_type)));
 }
 
-TEST(ExprZonemapFilterTest, DirectInPredicateMaterializesStringSetForZonemap) {
+// GoogleTest assertions inflate this linear ownership-lifetime test's complexity metric.
+TEST(ExprZonemapFilterTest, // NOLINT(readability-function-cognitive-complexity)
+     VInPredicatePreparesOwningStringZonemapMinMax) {
+    std::shared_ptr<const HybridSetMinMax> snapshot;
+    std::weak_ptr<HybridSetBase> borrowed_set;
+    {
+        auto type = std::make_shared<DataTypeString>();
+        ObjectPool obj_pool;
+        DescriptorTbl* desc_tbl = nullptr;
+        auto thrift_desc_tbl = make_k2_scan_desc_tbl(TYPE_STRING);
+        ASSERT_TRUE(DescriptorTbl::create(&obj_pool, thrift_desc_tbl, &desc_tbl).ok());
+
+        RuntimeState runtime_state;
+        runtime_state.set_desc_tbl(desc_tbl);
+        RowDescriptor row_desc(runtime_state.desc_tbl(), {0});
+
+        auto in_predicate = std::make_shared<VInPredicate>(make_in_predicate_node(false, 5));
+        auto in_slot = make_slot(0, type);
+        std::static_pointer_cast<VSlotRef>(in_slot)->set_slot_id(0);
+        in_predicate->add_child(in_slot);
+        in_predicate->add_child(make_string_literal("zzz"));
+        in_predicate->add_child(make_string_literal("aaa"));
+        in_predicate->add_child(make_string_literal("aaa"));
+        in_predicate->add_child(make_null_string_literal());
+        VExprContext in_context(in_predicate);
+        ASSERT_TRUE(in_context.prepare(&runtime_state, row_desc).ok());
+        ASSERT_TRUE(in_context.open(&runtime_state).ok());
+
+        ASSERT_NE(nullptr, in_predicate->_zonemap_min_max);
+        ASSERT_NE(nullptr, dynamic_cast<StringValueSet<>*>(in_predicate->_direct_filter_set.get()));
+        borrowed_set = in_predicate->_direct_filter_set;
+        EXPECT_EQ(2, in_predicate->_direct_filter_set->size());
+        EXPECT_TRUE(in_predicate->_direct_filter_set->contain_null());
+        EXPECT_EQ(Field::create_field<TYPE_STRING>("aaa"),
+                  in_predicate->_zonemap_min_max->min_value);
+        EXPECT_EQ(Field::create_field<TYPE_STRING>("zzz"),
+                  in_predicate->_zonemap_min_max->max_value);
+
+        EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+                  in_predicate->evaluate_dictionary_filter(make_dictionary_context(
+                          {Field::create_field<TYPE_STRING>("aaa")}, type)));
+        EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+                  in_predicate->evaluate_dictionary_filter(make_dictionary_context(
+                          {Field::create_field<TYPE_STRING>("mmm")}, type)));
+
+        auto missing_bloom_filter = make_string_bloom_filter({});
+        auto missing_bloom_ctx = make_bloom_filter_context(missing_bloom_filter.get(), type);
+        EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+                  in_predicate->evaluate_bloom_filter(missing_bloom_ctx));
+        auto matching_bloom_filter = make_string_bloom_filter({"aaa"});
+        auto matching_bloom_ctx = make_bloom_filter_context(matching_bloom_filter.get(), type);
+        EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+                  in_predicate->evaluate_bloom_filter(matching_bloom_ctx));
+
+        snapshot = in_predicate->_zonemap_min_max;
+    }
+
+    ASSERT_NE(nullptr, snapshot);
+    EXPECT_TRUE(borrowed_set.expired());
+    EXPECT_EQ(Field::create_field<TYPE_STRING>("aaa"), snapshot->min_value);
+    EXPECT_EQ(Field::create_field<TYPE_STRING>("zzz"), snapshot->max_value);
+}
+
+TEST(ExprZonemapFilterTest, DirectInPredicatePreparesStringMinMaxForZonemap) {
     auto type = std::make_shared<DataTypeString>();
     std::shared_ptr<HybridSetBase> filter(create_set(PrimitiveType::TYPE_STRING, false));
     StringRef aaa("aaa");
@@ -1179,17 +1555,14 @@ TEST(ExprZonemapFilterTest, DirectInPredicateMaterializesStringSetForZonemap) {
     auto slot = make_slot(0, type);
     VDirectInPredicate direct_in_expr(make_in_predicate_node(false, 2), filter, true);
     direct_in_expr.add_child(slot);
-    ASSERT_TRUE(direct_in_expr._materialize_for_zonemap_filter().ok());
+    direct_in_expr._prepare_zonemap_min_max();
 
-    EXPECT_TRUE(direct_in_expr._pruning_state->zonemap_materialized);
-    EXPECT_EQ(2, direct_in_expr._pruning_state->seg_filter_values.size());
-    EXPECT_EQ(Field::create_field<TYPE_STRING>("aaa"),
-              direct_in_expr._pruning_state->seg_filter_min);
-    EXPECT_EQ(Field::create_field<TYPE_STRING>("zzz"),
-              direct_in_expr._pruning_state->seg_filter_max);
+    ASSERT_NE(nullptr, direct_in_expr._zonemap_min_max);
+    EXPECT_EQ(Field::create_field<TYPE_STRING>("aaa"), direct_in_expr._zonemap_min_max->min_value);
+    EXPECT_EQ(Field::create_field<TYPE_STRING>("zzz"), direct_in_expr._zonemap_min_max->max_value);
 }
 
-TEST(ExprZonemapFilterTest, DirectInPredicateMaterializesZonemapValuesDuringPrepare) {
+TEST(ExprZonemapFilterTest, DirectInPredicatePreparesZonemapMinMax) {
     auto type = int_type();
     ObjectPool obj_pool;
     DescriptorTbl* desc_tbl = nullptr;
@@ -1215,14 +1588,13 @@ TEST(ExprZonemapFilterTest, DirectInPredicateMaterializesZonemapValuesDuringPrep
     VExprContext context(direct_in_expr);
     ASSERT_TRUE(context.prepare(&runtime_state, row_desc).ok());
 
-    EXPECT_TRUE(direct_in_expr->_pruning_state->zonemap_materialized);
     EXPECT_TRUE(direct_in_expr->can_evaluate_zonemap_filter());
-    EXPECT_EQ(2, direct_in_expr->_pruning_state->seg_filter_values.size());
-    EXPECT_EQ(int_field(1), direct_in_expr->_pruning_state->seg_filter_min);
-    EXPECT_EQ(int_field(30), direct_in_expr->_pruning_state->seg_filter_max);
+    ASSERT_NE(nullptr, direct_in_expr->_zonemap_min_max);
+    EXPECT_EQ(int_field(1), direct_in_expr->_zonemap_min_max->min_value);
+    EXPECT_EQ(int_field(30), direct_in_expr->_zonemap_min_max->max_value);
 }
 
-TEST(ExprZonemapFilterTest, DirectInPredicateDeepCloneReusesMaterializedPruningState) {
+TEST(ExprZonemapFilterTest, DirectInDeepCloneAfterMinMaxPreparationReusesSnapshot) {
     auto type = int_type();
     std::shared_ptr<HybridSetBase> filter(create_set(PrimitiveType::TYPE_INT, false));
     int32_t low_value = 1;
@@ -1233,16 +1605,52 @@ TEST(ExprZonemapFilterTest, DirectInPredicateDeepCloneReusesMaterializedPruningS
     auto direct_in_expr =
             std::make_shared<VDirectInPredicate>(make_in_predicate_node(false, 1), filter, true);
     direct_in_expr->add_child(make_slot(0, type));
-    ASSERT_TRUE(direct_in_expr->_materialize_for_zonemap_filter().ok());
+    direct_in_expr->_prepare_zonemap_min_max();
 
     VExprSPtr cloned_expr;
     ASSERT_TRUE(direct_in_expr->deep_clone(&cloned_expr).ok());
     auto cloned_direct_in = std::dynamic_pointer_cast<VDirectInPredicate>(cloned_expr);
     ASSERT_NE(cloned_direct_in, nullptr);
-    EXPECT_EQ(direct_in_expr->_pruning_state, cloned_direct_in->_pruning_state);
+    EXPECT_EQ(direct_in_expr->_zonemap_min_max.get(), cloned_direct_in->_zonemap_min_max.get());
     EXPECT_TRUE(cloned_direct_in->can_evaluate_zonemap_filter());
     EXPECT_EQ(ZoneMapFilterResult::kNoMatch, cloned_direct_in->evaluate_zonemap_filter(
                                                      make_context(make_int_zonemap(10, 20), type)));
+}
+
+TEST(ExprZonemapFilterTest, DirectInDeepCloneBeforeMinMaxPreparationBuildsIndependentSnapshots) {
+    auto type = int_type();
+    std::shared_ptr<HybridSetBase> filter(create_set(TYPE_INT, false));
+    int32_t low_value = 1;
+    int32_t high_value = 30;
+    filter->insert(&low_value);
+    filter->insert(&high_value);
+
+    auto direct_in_expr =
+            std::make_shared<VDirectInPredicate>(make_in_predicate_node(false, 1), filter, true);
+    direct_in_expr->add_child(make_slot(0, type));
+
+    VExprSPtr cloned_expr;
+    ASSERT_TRUE(direct_in_expr->deep_clone(&cloned_expr).ok());
+    auto cloned_direct_in = std::dynamic_pointer_cast<VDirectInPredicate>(cloned_expr);
+    ASSERT_NE(nullptr, cloned_direct_in);
+    EXPECT_EQ(nullptr, direct_in_expr->_zonemap_min_max);
+    EXPECT_EQ(nullptr, cloned_direct_in->_zonemap_min_max);
+
+    direct_in_expr->_prepare_zonemap_min_max();
+    cloned_direct_in->_prepare_zonemap_min_max();
+    ASSERT_NE(nullptr, direct_in_expr->_zonemap_min_max);
+    ASSERT_NE(nullptr, cloned_direct_in->_zonemap_min_max);
+    EXPECT_NE(direct_in_expr->_zonemap_min_max.get(), cloned_direct_in->_zonemap_min_max.get());
+    EXPECT_EQ(direct_in_expr->_zonemap_min_max->min_value,
+              cloned_direct_in->_zonemap_min_max->min_value);
+    EXPECT_EQ(direct_in_expr->_zonemap_min_max->max_value,
+              cloned_direct_in->_zonemap_min_max->max_value);
+
+    auto ctx = make_context(make_int_zonemap(10, 20), type);
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch, cloned_direct_in->evaluate_zonemap_filter(ctx));
+    EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+              cloned_direct_in->evaluate_dictionary_filter(
+                      make_dictionary_context({int_field(30)}, type)));
 }
 
 TEST(ExprZonemapFilterTest, DirectInPredicateRewritesStringSetToInPredicate) {
@@ -1260,7 +1668,28 @@ TEST(ExprZonemapFilterTest, DirectInPredicateRewritesStringSetToInPredicate) {
     EXPECT_NE(std::string::npos, in_expr->debug_string().find("iceberg"));
 }
 
-TEST(ExprZonemapFilterTest, DirectInPredicateSkipsMaterializationWhenSetTypeDiffersFromChild) {
+TEST(ExprZonemapFilterTest, DirectInPredicateRewritePreservesEmbeddedNullString) {
+    auto type = std::make_shared<DataTypeString>();
+    auto slot = make_slot(0, type);
+    std::shared_ptr<HybridSetBase> filter(create_set(PrimitiveType::TYPE_STRING, false));
+    const std::string binary_value("a\0b", 3);
+    StringRef value(binary_value);
+    filter->insert(&value);
+
+    VDirectInPredicate direct_in_expr(make_in_predicate_node(false, 1), filter, true);
+    direct_in_expr.add_child(slot);
+
+    VExprSPtr in_expr;
+    ASSERT_TRUE(direct_in_expr.get_slot_in_expr(in_expr));
+    ASSERT_EQ(2, in_expr->get_num_children());
+    auto literal = std::dynamic_pointer_cast<VLiteral>(in_expr->get_child(1));
+    ASSERT_NE(nullptr, literal);
+    Field materialized_value;
+    literal->get_column_ptr()->get(0, materialized_value);
+    EXPECT_EQ(binary_value, std::string(materialized_value.as_string_view()));
+}
+
+TEST(ExprZonemapFilterTest, DirectInPredicateSkipsMinMaxWhenSetTypeDiffersFromChild) {
     auto string_type = std::make_shared<DataTypeString>();
     auto slot = make_slot(0, string_type);
     std::shared_ptr<HybridSetBase> filter(create_set(PrimitiveType::TYPE_INT, false));
@@ -1270,8 +1699,8 @@ TEST(ExprZonemapFilterTest, DirectInPredicateSkipsMaterializationWhenSetTypeDiff
     VDirectInPredicate direct_in_expr(make_in_predicate_node(false, 1), filter, false);
     direct_in_expr.add_child(slot);
 
-    ASSERT_TRUE(direct_in_expr._materialize_for_zonemap_filter().ok());
-    EXPECT_FALSE(direct_in_expr._pruning_state->zonemap_materialized);
+    direct_in_expr._prepare_zonemap_min_max();
+    EXPECT_EQ(nullptr, direct_in_expr._zonemap_min_max);
     VExprSPtr in_expr;
     EXPECT_FALSE(direct_in_expr.get_slot_in_expr(in_expr));
 }
@@ -1288,7 +1717,7 @@ TEST(ExprZonemapFilterTest, RuntimeFilterExprNullAwareZonemapKeepsZonesWithNull)
     auto direct_in_expr =
             std::make_shared<VDirectInPredicate>(make_in_predicate_node(false, 1), filter, true);
     direct_in_expr->add_child(slot);
-    ASSERT_TRUE(direct_in_expr->_materialize_for_zonemap_filter().ok());
+    direct_in_expr->_prepare_zonemap_min_max();
 
     auto runtime_filter = RuntimeFilterExpr::create_shared(make_in_predicate_node(false, 1),
                                                            direct_in_expr, 0.0, true, 7);
@@ -1322,7 +1751,7 @@ TEST(ExprZonemapFilterTest, RuntimeFilterExprDelegatesDirectInDictionaryAndRawEv
     auto direct_in_expr =
             std::make_shared<VDirectInPredicate>(make_in_predicate_node(false, 1), filter, true);
     direct_in_expr->add_child(slot);
-    ASSERT_TRUE(direct_in_expr->_materialize_for_zonemap_filter().ok());
+    direct_in_expr->_prepare_zonemap_min_max();
 
     auto runtime_filter = RuntimeFilterExpr::create_shared(make_in_predicate_node(false, 1),
                                                            direct_in_expr, 0.0, false, 7);

--- a/be/test/exprs/expr_zonemap_filter_test.cpp
+++ b/be/test/exprs/expr_zonemap_filter_test.cpp
@@ -29,6 +29,7 @@
 #include <string>
 #include <vector>
 
+#include "common/config.h"
 #include "common/object_pool.h"
 #include "core/column/column_vector.h"
 #include "core/data_type/data_type_array.h"
@@ -62,6 +63,7 @@
 #include "storage/index/zone_map/zone_map_index.h"
 #include "storage/index/zone_map/zonemap_eval_context.h"
 #include "storage/segment/segment_iterator.h"
+#include "util/defer_op.h"
 
 #if defined(__clang__)
 #pragma clang diagnostic push
@@ -1077,7 +1079,12 @@ TEST(ExprZonemapFilterTest, CharZonemapUsesTrimmedLogicalBounds) {
               expr_zonemap::eval_in_zonemap(in_ctx, slot, false, values.min_max, *values.set));
 }
 
-TEST(ExprZonemapFilterTest, InZonemapFallsBackToRangeWhenPointListIsLarge) {
+TEST(ExprZonemapFilterTest, InZonemapUsesConfiguredPointCheckThreshold) {
+    const int32_t old_threshold = config::in_zonemap_point_check_threshold;
+    Defer restore_threshold {
+            [old_threshold]() { config::in_zonemap_point_check_threshold = old_threshold; }};
+    config::in_zonemap_point_check_threshold = 64;
+
     auto type = int_type();
     auto slot = make_slot(0, type);
     auto ctx = make_context(make_int_zonemap(10, 20), type);
@@ -1105,6 +1112,14 @@ TEST(ExprZonemapFilterTest, InZonemapFallsBackToRangeWhenPointListIsLarge) {
 
     EXPECT_EQ(0, ctx.stats.in_zonemap_point_check_count);
     EXPECT_EQ(1, ctx.stats.in_zonemap_range_only_count);
+
+    config::in_zonemap_point_check_threshold = 65;
+    auto point_ctx = make_context(make_int_zonemap(10, 20), type);
+    EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+              expr_zonemap::eval_in_zonemap(point_ctx, slot, false, values_with_min_max.min_max,
+                                            *values_with_min_max.set));
+    EXPECT_EQ(1, point_ctx.stats.in_zonemap_point_check_count);
+    EXPECT_EQ(0, point_ctx.stats.in_zonemap_range_only_count);
 }
 
 TEST(ExprZonemapFilterTest, InZonemapUsesPointChecksUnderThreshold) {
@@ -1129,10 +1144,10 @@ TEST(ExprZonemapFilterTest, InZonemapUsesRangeOnlyForDenseBitSetContainer) {
 
     auto values = make_typed_set_with_min_max<TYPE_TINYINT>({int8_t {-100}, int8_t {100}}, type);
     EXPECT_FALSE(values.set->supports_fast_range_lookup());
-    EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
               expr_zonemap::eval_in_zonemap(ctx, slot, false, values.min_max, *values.set));
-    EXPECT_EQ(0, ctx.stats.in_zonemap_point_check_count);
-    EXPECT_EQ(1, ctx.stats.in_zonemap_range_only_count);
+    EXPECT_EQ(1, ctx.stats.in_zonemap_point_check_count);
+    EXPECT_EQ(0, ctx.stats.in_zonemap_range_only_count);
 }
 
 TEST(ExprZonemapFilterTest, InZonemapHandlesEmptyListAndNotInSingleValueRange) {

--- a/be/test/exprs/hybrid_set_test.cpp
+++ b/be/test/exprs/hybrid_set_test.cpp
@@ -141,7 +141,8 @@ TEST_F(HybridSetTest, IntegerMinMaxAndRangeLookup) {
 
         Field min_value;
         Field max_value;
-        set.get_min_max(min_value, max_value);
+        bool contains_nan = false;
+        set.get_min_max(min_value, max_value, contains_nan);
         EXPECT_EQ(min_value.get<TYPE_INT>(), 1);
         EXPECT_EQ(max_value.get<TYPE_INT>(), 9);
 
@@ -152,7 +153,7 @@ TEST_F(HybridSetTest, IntegerMinMaxAndRangeLookup) {
         EXPECT_FALSE(set.contains_any_in_range(field(6), field(8)));
 
         set.clear();
-        set.get_min_max(min_value, max_value);
+        set.get_min_max(min_value, max_value, contains_nan);
         EXPECT_TRUE(min_value.is_null());
         EXPECT_TRUE(max_value.is_null());
     };
@@ -191,7 +192,8 @@ TEST_F(HybridSetTest, SignedBitSetRangeLookup) {
 
     Field min_field;
     Field max_field;
-    edge_set.get_min_max(min_field, max_field);
+    bool contains_nan = false;
+    edge_set.get_min_max(min_field, max_field, contains_nan);
     EXPECT_EQ(min_field.get<TYPE_SMALLINT>(), min_value);
     EXPECT_EQ(max_field.get<TYPE_SMALLINT>(), max_value);
     EXPECT_TRUE(
@@ -224,7 +226,8 @@ TEST_F(HybridSetTest, StringRangeLookupPreservesEmbeddedNull) {
     const auto verify = [&](HybridSetBase& set) {
         Field min_value;
         Field max_value;
-        set.get_min_max(min_value, max_value);
+        bool contains_nan = false;
+        set.get_min_max(min_value, max_value, contains_nan);
         EXPECT_EQ(min_value.get<TYPE_STRING>(), values.front());
         EXPECT_EQ(max_value.get<TYPE_STRING>(), values.back());
 
@@ -537,11 +540,12 @@ TEST_F(HybridSetTest, DynamicFloatingSetFindsDorisEqualNanPayload) {
         const T stored_nan = std::bit_cast<T>(stored_bits);
         set->insert(&stored_nan);
         ASSERT_EQ(FIXED_CONTAINER_MAX_SIZE + 1, set->size());
-        EXPECT_TRUE(set->contains_nan());
 
         Field min_value;
         Field max_value;
-        set->get_min_max(min_value, max_value);
+        bool contains_nan = false;
+        set->get_min_max(min_value, max_value, contains_nan);
+        EXPECT_TRUE(contains_nan);
         EXPECT_EQ(T {0}, min_value.get<Type>());
         EXPECT_EQ(T {FIXED_CONTAINER_MAX_SIZE - 1}, max_value.get<Type>());
 

--- a/be/test/exprs/hybrid_set_test.cpp
+++ b/be/test/exprs/hybrid_set_test.cpp
@@ -19,11 +19,14 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <bit>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
 
+#include "core/field.h"
 #include "exprs/create_predicate_function.h"
 #include "gtest/internal/gtest-internal.h"
 #include "testutil/column_helper.h"
@@ -127,6 +130,130 @@ TEST_F(HybridSetTest, Numeric) {
     TEST_NUMERIC(PrimitiveType::TYPE_DECIMAL32);
     TEST_NUMERIC(PrimitiveType::TYPE_DECIMAL64);
     TEST_NUMERIC(PrimitiveType::TYPE_DECIMAL128I);
+}
+
+TEST_F(HybridSetTest, IntegerMinMaxAndRangeLookup) {
+    const auto field = [](int32_t value) { return Field::create_field<TYPE_INT>(value); };
+    const auto verify = [&](HybridSetBase& set) {
+        for (int32_t value : {1, 5, 9}) {
+            set.insert(&value);
+        }
+
+        Field min_value;
+        Field max_value;
+        set.get_min_max(min_value, max_value);
+        EXPECT_EQ(min_value.get<TYPE_INT>(), 1);
+        EXPECT_EQ(max_value.get<TYPE_INT>(), 9);
+
+        EXPECT_TRUE(set.contains_any_in_range(field(1), field(1)));
+        EXPECT_TRUE(set.contains_any_in_range(field(4), field(5)));
+        EXPECT_TRUE(set.contains_any_in_range(field(9), field(10)));
+        EXPECT_FALSE(set.contains_any_in_range(field(2), field(4)));
+        EXPECT_FALSE(set.contains_any_in_range(field(6), field(8)));
+
+        set.clear();
+        set.get_min_max(min_value, max_value);
+        EXPECT_TRUE(min_value.is_null());
+        EXPECT_TRUE(max_value.is_null());
+    };
+
+    HybridSet<TYPE_INT> dynamic_set(false);
+    EXPECT_TRUE(dynamic_set.supports_fast_range_lookup());
+    verify(dynamic_set);
+
+    HybridSet<TYPE_INT, FixedContainer<int32_t, 3>> fixed_set(false);
+    EXPECT_TRUE(fixed_set.supports_fast_range_lookup());
+    verify(fixed_set);
+}
+
+TEST_F(HybridSetTest, SignedBitSetRangeLookup) {
+    const auto tinyint_field = [](int8_t value) {
+        return Field::create_field<TYPE_TINYINT>(value);
+    };
+    HybridSet<TYPE_TINYINT, BitSetContainer<int8_t>> tinyint_set(false);
+    EXPECT_FALSE(tinyint_set.supports_fast_range_lookup());
+    for (int8_t value : {int8_t {-100}, int8_t {-1}, int8_t {0}, int8_t {100}}) {
+        tinyint_set.insert(&value);
+    }
+    EXPECT_TRUE(tinyint_set.contains_any_in_range(tinyint_field(-2), tinyint_field(1)));
+    EXPECT_TRUE(tinyint_set.contains_any_in_range(tinyint_field(-100), tinyint_field(-100)));
+    EXPECT_FALSE(tinyint_set.contains_any_in_range(tinyint_field(-99), tinyint_field(-2)));
+    EXPECT_FALSE(tinyint_set.contains_any_in_range(tinyint_field(1), tinyint_field(99)));
+
+    const auto smallint_field = [](int16_t value) {
+        return Field::create_field<TYPE_SMALLINT>(value);
+    };
+    HybridSet<TYPE_SMALLINT, BitSetContainer<int16_t>> edge_set(false);
+    int16_t min_value = std::numeric_limits<int16_t>::min();
+    int16_t max_value = std::numeric_limits<int16_t>::max();
+    edge_set.insert(&min_value);
+    edge_set.insert(&max_value);
+
+    Field min_field;
+    Field max_field;
+    edge_set.get_min_max(min_field, max_field);
+    EXPECT_EQ(min_field.get<TYPE_SMALLINT>(), min_value);
+    EXPECT_EQ(max_field.get<TYPE_SMALLINT>(), max_value);
+    EXPECT_TRUE(
+            edge_set.contains_any_in_range(smallint_field(min_value), smallint_field(min_value)));
+    EXPECT_TRUE(
+            edge_set.contains_any_in_range(smallint_field(max_value), smallint_field(max_value)));
+    EXPECT_FALSE(
+            edge_set.contains_any_in_range(smallint_field(static_cast<int16_t>(min_value + 1)),
+                                           smallint_field(static_cast<int16_t>(max_value - 1))));
+
+    HybridSet<TYPE_SMALLINT, BitSetContainer<int16_t>> crossing_set(false);
+    for (int16_t value : {int16_t {-30000}, int16_t {-1}, int16_t {0}, int16_t {30000}}) {
+        crossing_set.insert(&value);
+    }
+    EXPECT_TRUE(crossing_set.contains_any_in_range(smallint_field(-2), smallint_field(1)));
+    EXPECT_TRUE(crossing_set.contains_any_in_range(smallint_field(-1), smallint_field(-1)));
+    EXPECT_TRUE(crossing_set.contains_any_in_range(smallint_field(0), smallint_field(0)));
+    EXPECT_FALSE(crossing_set.contains_any_in_range(smallint_field(-29999), smallint_field(-2)));
+    EXPECT_FALSE(crossing_set.contains_any_in_range(smallint_field(1), smallint_field(29999)));
+}
+
+TEST_F(HybridSetTest, StringRangeLookupPreservesEmbeddedNull) {
+    const std::array<std::string, 3> values = {std::string("a\0a", 3), std::string("a\0c", 3),
+                                               std::string("b\0b", 3)};
+    const std::string missing("a\0b", 3);
+    const std::string upper_hole("b\0a", 3);
+    const auto field = [](const std::string& value) {
+        return Field::create_field<TYPE_STRING>(String(value.data(), value.size()));
+    };
+    const auto verify = [&](HybridSetBase& set) {
+        Field min_value;
+        Field max_value;
+        set.get_min_max(min_value, max_value);
+        EXPECT_EQ(min_value.get<TYPE_STRING>(), values.front());
+        EXPECT_EQ(max_value.get<TYPE_STRING>(), values.back());
+
+        EXPECT_TRUE(set.contains_any_in_range(field(values.front()), field(values.front())));
+        EXPECT_TRUE(set.contains_any_in_range(field(missing), field(values[1])));
+        EXPECT_FALSE(set.contains_any_in_range(field(missing), field(missing)));
+        EXPECT_FALSE(set.contains_any_in_range(field(std::string("a\0d", 3)), field(upper_hole)));
+    };
+
+    StringSet<> owning_set(false);
+    for (const auto& value : values) {
+        StringRef ref(value);
+        owning_set.insert(&ref);
+    }
+    verify(owning_set);
+
+    StringSet<FixedContainer<std::string, 3>> fixed_owning_set(false);
+    for (const auto& value : values) {
+        StringRef ref(value);
+        fixed_owning_set.insert(&ref);
+    }
+    verify(fixed_owning_set);
+
+    StringValueSet<> borrowed_set(false);
+    for (const auto& value : values) {
+        StringRef ref(value);
+        borrowed_set.insert(&ref);
+    }
+    verify(borrowed_set);
 }
 
 #define TEST_DATE(primitive_type)                                                  \
@@ -410,6 +537,13 @@ TEST_F(HybridSetTest, DynamicFloatingSetFindsDorisEqualNanPayload) {
         const T stored_nan = std::bit_cast<T>(stored_bits);
         set->insert(&stored_nan);
         ASSERT_EQ(FIXED_CONTAINER_MAX_SIZE + 1, set->size());
+        EXPECT_TRUE(set->contains_nan());
+
+        Field min_value;
+        Field max_value;
+        set->get_min_max(min_value, max_value);
+        EXPECT_EQ(T {0}, min_value.get<Type>());
+        EXPECT_EQ(T {FIXED_CONTAINER_MAX_SIZE - 1}, max_value.get<Type>());
 
         const T probe_nan = std::bit_cast<T>(probe_bits);
         EXPECT_TRUE(set->find(&probe_nan));

--- a/be/test/format_v2/orc/orc_reader_test.cpp
+++ b/be/test/format_v2/orc/orc_reader_test.cpp
@@ -4568,7 +4568,7 @@ protected:
 
     struct DirectInScanResult {
         std::vector<int32_t> ids;
-        size_t materialize_calls = 0;
+        size_t begin_calls = 0;
         size_t prepare_literals_calls = 0;
         int64_t filtered_row_groups = 0;
         int64_t filtered_row_groups_by_min_max = 0;
@@ -4703,7 +4703,7 @@ protected:
             }
         }
 
-        result->materialize_calls = filter->begin_calls();
+        result->begin_calls = filter->begin_calls();
         result->filtered_row_groups = reader->reader_statistics().filtered_row_groups;
         result->filtered_row_groups_by_min_max =
                 reader->reader_statistics().filtered_row_groups_by_min_max;
@@ -7147,11 +7147,11 @@ TEST_F(NewOrcReaderTest, SargDirectInCompoundMaterializesLiteralsOnce) {
                                           shape, &disabled)
                             .ok());
 
-        EXPECT_EQ(enabled.materialize_calls, 1);
+        EXPECT_EQ(enabled.begin_calls, 1);
         EXPECT_EQ(enabled.prepare_literals_calls, 1);
         EXPECT_EQ(enabled.filtered_row_groups, 1);
         EXPECT_EQ(enabled.filtered_row_groups_by_min_max, 1);
-        EXPECT_EQ(disabled.materialize_calls, 0);
+        EXPECT_EQ(disabled.begin_calls, 0);
         EXPECT_EQ(disabled.prepare_literals_calls, 0);
         EXPECT_EQ(disabled.filtered_row_groups, 0);
         EXPECT_EQ(disabled.filtered_row_groups_by_min_max, 0);
@@ -7177,11 +7177,11 @@ TEST_F(NewOrcReaderTest, SargDirectInNullSafeOrFallsBackBeforeLiteralConversion)
                                       DirectInPredicateShape::OR_WITH_NULL_SAFE_EQUAL, &disabled)
                         .ok());
 
-    EXPECT_EQ(enabled.materialize_calls, 1);
+    EXPECT_EQ(enabled.begin_calls, 1);
     EXPECT_EQ(enabled.prepare_literals_calls, 0);
     EXPECT_EQ(enabled.filtered_row_groups, 0);
     EXPECT_EQ(enabled.filtered_row_groups_by_min_max, 0);
-    EXPECT_EQ(disabled.materialize_calls, 0);
+    EXPECT_EQ(disabled.begin_calls, 0);
     EXPECT_EQ(disabled.prepare_literals_calls, 0);
     EXPECT_EQ(disabled.filtered_row_groups, 0);
     EXPECT_EQ(disabled.filtered_row_groups_by_min_max, 0);
@@ -7209,11 +7209,11 @@ TEST_F(NewOrcReaderTest, SargDirectInOverLimitFallsBackBeforeMaterialization) {
                                       DirectInPredicateShape::ROOT, &disabled)
                         .ok());
 
-    EXPECT_EQ(enabled.materialize_calls, 0);
+    EXPECT_EQ(enabled.begin_calls, 0);
     EXPECT_EQ(enabled.prepare_literals_calls, 0);
     EXPECT_EQ(enabled.filtered_row_groups, 0);
     EXPECT_EQ(enabled.filtered_row_groups_by_min_max, 0);
-    EXPECT_EQ(disabled.materialize_calls, 0);
+    EXPECT_EQ(disabled.begin_calls, 0);
     EXPECT_EQ(disabled.prepare_literals_calls, 0);
     EXPECT_EQ(disabled.filtered_row_groups, 0);
     EXPECT_EQ(disabled.filtered_row_groups_by_min_max, 0);

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -42,8 +42,11 @@
 #include "core/data_type/data_type_time.h"
 #include "core/data_type/data_type_variant_v2.h"
 #include "core/field.h"
+#include "exprs/create_predicate_function.h"
 #include "exprs/expr_zonemap_filter.h"
 #include "exprs/function/functions_comparison.h"
+#include "exprs/hybrid_set.h"
+#include "exprs/hybrid_set_min_max.h"
 #include "exprs/vcompound_pred.h"
 #include "exprs/vexpr.h"
 #include "exprs/vexpr_context.h"
@@ -98,13 +101,57 @@ private:
     bool _fail_reads = false;
     int _read_count = 0;
 };
+
+std::shared_ptr<HybridSetBase> hybrid_set_from_fields(const DataTypePtr& data_type,
+                                                      const std::vector<Field>& values) {
+    const auto primitive_type = remove_nullable(data_type)->get_primitive_type();
+    std::shared_ptr<HybridSetBase> set(create_set(primitive_type, false));
+    for (const auto& field : values) {
+        if (field.is_null()) {
+            continue;
+        }
+        DORIS_CHECK(expr_zonemap::field_types_compatible(field.get_type(), primitive_type));
+        switch (primitive_type) {
+        case TYPE_BOOLEAN:
+            set->insert(&field.get<TYPE_BOOLEAN>());
+            break;
+        case TYPE_INT:
+            set->insert(&field.get<TYPE_INT>());
+            break;
+        case TYPE_BIGINT:
+            set->insert(&field.get<TYPE_BIGINT>());
+            break;
+        case TYPE_FLOAT:
+            set->insert(&field.get<TYPE_FLOAT>());
+            break;
+        case TYPE_DOUBLE:
+            set->insert(&field.get<TYPE_DOUBLE>());
+            break;
+        case TYPE_CHAR:
+        case TYPE_VARCHAR:
+        case TYPE_STRING: {
+            const auto value = field.as_string_view();
+            StringRef ref(value.data(), value.size());
+            set->insert(&ref);
+            break;
+        }
+        default:
+            DORIS_CHECK(false) << "Unsupported Bloom IN test type " << primitive_type;
+        }
+    }
+    return set;
+}
+
 class BloomInExpr final : public VExpr {
 public:
     BloomInExpr(int column_id, DataTypePtr data_type, std::vector<Field> values)
-            : BloomInExpr(VSlotRef::create_shared(0, column_id, -1, std::move(data_type), "c0"),
-                          std::move(values)) {}
+            : BloomInExpr(VSlotRef::create_shared(0, column_id, -1, data_type, "c0"),
+                          hybrid_set_from_fields(data_type, values)) {}
 
     BloomInExpr(VExprSPtr probe, std::vector<Field> values)
+            : BloomInExpr(probe, hybrid_set_from_fields(probe->data_type(), values)) {}
+
+    BloomInExpr(VExprSPtr probe, std::shared_ptr<HybridSetBase> values)
             : VExpr(std::make_shared<DataTypeUInt8>(), false), _values(std::move(values)) {
         add_child(std::move(probe));
     }
@@ -119,7 +166,7 @@ public:
     bool can_evaluate_bloom_filter() const override { return true; }
 
     ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const override {
-        return expr_zonemap::eval_in_bloom_filter(ctx, get_child(0), false, _values);
+        return expr_zonemap::eval_in_bloom_filter(ctx, get_child(0), false, *_values);
     }
 
     void collect_slot_column_ids(std::set<int>& column_ids) const override {
@@ -127,7 +174,7 @@ public:
     }
 
 private:
-    std::vector<Field> _values;
+    std::shared_ptr<HybridSetBase> _values;
     const std::string _expr_name = "BloomInExpr";
 };
 
@@ -188,6 +235,12 @@ public:
                     Field::create_field<TYPE_DOUBLE>(1.0), TYPE_DOUBLE, 0, 0));
             _not_in_values = {Field::create_field<TYPE_DOUBLE>(0.0)};
         }
+        _values_set = hybrid_set_from_fields(data_type, _values);
+        _not_in_values_set = hybrid_set_from_fields(data_type, _not_in_values);
+        expr_zonemap::get_hybrid_set_min_max_for_zonemap_filter(_values_set, data_type,
+                                                                _values_min_max);
+        expr_zonemap::get_hybrid_set_min_max_for_zonemap_filter(_not_in_values_set, data_type,
+                                                                _not_in_values_min_max);
     }
 
     const std::string& expr_name() const override { return _expr_name; }
@@ -202,8 +255,7 @@ public:
             return comparison_zonemap_detail::evaluate(ctx, {_slot, _nan_literal},
                                                        comparison_zonemap_detail::Op::EQ);
         case Mode::IN:
-            return expr_zonemap::eval_in_zonemap(ctx, _slot, false, _values, true, _values[0],
-                                                 _values[1]);
+            return expr_zonemap::eval_in_zonemap(ctx, _slot, false, _values_min_max, *_values_set);
         case Mode::NE:
             return comparison_zonemap_detail::evaluate(ctx, {_slot, _zero_literal},
                                                        comparison_zonemap_detail::Op::NE);
@@ -220,8 +272,8 @@ public:
             return comparison_zonemap_detail::evaluate(ctx, {_one_literal, _slot},
                                                        comparison_zonemap_detail::Op::LE);
         case Mode::NOT_IN:
-            return expr_zonemap::eval_in_zonemap(ctx, _slot, true, _not_in_values, false,
-                                                 _not_in_values[0], _not_in_values[0]);
+            return expr_zonemap::eval_in_zonemap(ctx, _slot, true, _not_in_values_min_max,
+                                                 *_not_in_values_set);
         }
         __builtin_unreachable();
     }
@@ -237,6 +289,10 @@ private:
     Mode _mode;
     std::vector<Field> _values;
     std::vector<Field> _not_in_values;
+    std::shared_ptr<HybridSetBase> _values_set;
+    std::shared_ptr<HybridSetBase> _not_in_values_set;
+    HybridSetMinMax _values_min_max;
+    HybridSetMinMax _not_in_values_min_max;
     const std::string _expr_name = "MetadataFloatingEqualityExpr";
 };
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

IN-filter metadata pruning previously converted `HybridSet` values through generic literal and `Field` materialization paths. This duplicated the IN set for zonemap pruning and made Bloom pruning allocate owning `Field` objects for every candidate.

This PR:

- exposes typed `HybridSet` operations for owning min/max bounds, exact range membership, and native-value callback traversal for Bloom probes;
- limits each zonemap snapshot to two owning non-NaN min/max `Field` bounds, tracks NaN presence separately, and performs exact checks against the source typed set;
- probes file Bloom filters directly from native `HybridSet` values with early exit, without building a `Field` vector;
- keeps dense tinyint/smallint bitset containers on conservative min/max-only zonemap pruning, avoiding full-domain scans on metadata hot paths;
- keeps dictionary, ORC, and Parquet pruning behavior conservative for unsupported or mismatched types.

Empty and NULL-only IN sets, embedded-NUL strings, borrowed string storage, prepared min/max reuse across expression clones, and native zonemap, dictionary, and Bloom pruning are covered by focused tests.

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test
        - `./run-regression-test.sh --conf output/local-regression/regression-conf-19700.groovy --run -d query_p0/expr_zonemap -s test_expr_zonemap_pruning` (1/1 suite passed on an earlier revision)
        - `./run-regression-test.sh --conf output/local-regression/regression-conf-19700.groovy --run -d query_p1/expr_zonemap -s test_expr_zonemap_pruning_p1` (1/1 suite passed on an earlier revision)
        - `./run-regression-test.sh --conf output/local-regression/regression-conf-19700.groovy --run -d query_p0/runtime_filter -s set_operator_in_filter` (1/1 suite passed on an earlier revision)
    - [x] Unit Test
        - `./run-be-ut.sh --run --filter='ExprZonemapFilterTest.*:HybridSetTest.IntegerMinMaxAndRangeLookup:HybridSetTest.SignedBitSetRangeLookup:HybridSetTest.StringRangeLookupPreservesEmbeddedNull:RuntimeFilterMergerTest.*:RuntimeFilterProducerTest.*:FileScannerV2Test.ConditionCacheDigestIncludesRuntimeFilterPayload:ParquetBloomFilterPruningTest.NativeUint32BloomUsesPhysicalInt32Hash:ParquetBloomFilterPruningTest.NativeRowGroupKeepsPresentUint32AboveInt32Max:NewOrcReaderTest.SargDirectIn*' -j 32` (67/67 tests passed on an earlier revision)
        - Current rebased revision: all touched unit-test translation units (`expr_zonemap_filter_test.cpp`, `hybrid_set_test.cpp`, and `parquet_statistics_test.cpp`) compiled under ASAN. Focused execution was not completed because the monolithic `doris_be_test` target still required rebuilding unrelated test objects.
    - [x] Manual test
        - `BUILD_TYPE=ASAN ./build.sh --be --fe --be-extension-ignore paimon-scanner,preload-extensions -j 32` (earlier revision)
        - `./build.sh --be -j 16` (current rebased revision, passed after locally omitting an unrelated stale upstream unity-skip entry for the absent `collection_statistics.cpp`)
        - `./build-support/clang-format.sh`
        - `./build-support/check-format.sh`
        - `git diff --check`
        - `./build-support/run-clang-tidy.sh --base origin/master --build-dir be/build_Release` (current revision; blocked by the local toolchain resource directory and pre-existing diagnostics)
        - Focused benchmark list/run for `(GetMinMax|LegacyMaterialize|AnyMatchRaw)` (32/32 cases completed on an earlier revision).
    - [ ] No need to test or manual test. Explain why:

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
