### PR TITLE
branch-4.0: [fix](regression) isolate ann_index_p0 table names and select compaction profile BE by tablet replica #62178 #65552

### DIFF
--- a/regression-test/suites/ann_index_p0/ann_index_basic.groovy
+++ b/regression-test/suites/ann_index_p0/ann_index_basic.groovy
@@ -21,20 +21,10 @@
 suite ("ann_index_basic") {
 		sql "set enable_common_expr_pushdown=true;"
 
-		// After an INSERT the ANN index can become queryable slightly before the freshly written
-		// raw rows are visible to a plain (brute-force) scan. Queries that cannot be evaluated by the
-		// ANN index fall back to a brute-force scan (Asc inner_product / Desc l2 topn, small-predicate
-		// topn) and may then intermittently see an empty table right after the load. Gate on scan
-		// visibility (a real row read, not count(*) metadata) after each INSERT to keep the ordered
-		// queries deterministic.
-		def waitRowsVisible = { String tbl, int expected ->
-			awaitUntil(30) { sql("select id from ${tbl}").size() == expected }
-		}
-
 		// 1) Basic L2 ANN table: dim=3
-		sql "drop table if exists tbl_ann_l2"
+		sql "drop table if exists basic_tbl_ann_l2"
 		sql """
-		CREATE TABLE tbl_ann_l2 (
+		CREATE TABLE basic_tbl_ann_l2 (
 			id INT NOT NULL,
 			embedding ARRAY<FLOAT> NOT NULL,
 			INDEX idx_emb (`embedding`) USING ANN PROPERTIES(
@@ -49,21 +39,19 @@ suite ("ann_index_basic") {
 		"""
 
 		qt_sql_l2_insert """
-		INSERT INTO tbl_ann_l2 VALUES
+		INSERT INTO basic_tbl_ann_l2 VALUES
 		(1, [1.0, 2.0, 3.0]),
 		(2, [0.5, 2.1, 2.9]),
 		(3, [10.0, 10.0, 10.0]);
 		"""
 
-		waitRowsVisible("tbl_ann_l2", 3)
-
 		// Query: l2 distance ascending (closest first)
-		qt_sql_l2_query "select id, l2_distance_approximate(embedding, [1.0,2.0,3.0]) as dist from tbl_ann_l2 order by dist limit 3;"
+		qt_sql_l2_query "select id, l2_distance_approximate(embedding, [1.0,2.0,3.0]) as dist from basic_tbl_ann_l2 order by dist limit 3;"
 
 		// 2) Basic inner_product ANN table: dim=4
-		sql "drop table if exists tbl_ann_ip"
+		sql "drop table if exists basic_tbl_ann_ip"
 		sql """
-		CREATE TABLE tbl_ann_ip (
+		CREATE TABLE basic_tbl_ann_ip (
 			id INT NOT NULL,
 			embedding ARRAY<FLOAT> NOT NULL,
 			INDEX idx_emb (`embedding`) USING ANN PROPERTIES(
@@ -78,25 +66,23 @@ suite ("ann_index_basic") {
 		"""
 
 		qt_sql_ip_insert """
-		INSERT INTO tbl_ann_ip VALUES
+		INSERT INTO basic_tbl_ann_ip VALUES
 		(1, [0.1, 0.2, 0.3, 0.4]),
 		(2, [0.5, 0.6, 0.7, 0.8]),
 		(3, [1.0, 1.0, 1.0, 1.0]);
 		"""
 
-		waitRowsVisible("tbl_ann_ip", 3)
-
 		// Query: inner product descending (higher score first)
-		qt_sql_ip_query "select id from tbl_ann_ip order by inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) desc limit 3;"
+		qt_sql_ip_query "select id from basic_tbl_ann_ip order by inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) desc limit 3;"
 
 		// 3) Simple threshold filter using l2_distance_approximate
-		qt_sql_l2_threshold "select id from tbl_ann_l2 where l2_distance_approximate(embedding, [1.0,2.0,3.0]) < 5.0 order by id;"
+		qt_sql_l2_threshold "select id from basic_tbl_ann_l2 where l2_distance_approximate(embedding, [1.0,2.0,3.0]) < 5.0 order by id;"
 
         // 4) Descending l2 order (should exercise path where Desc topn for l2/cosine cannot be evaluated by ann index)
-        qt_sql_l2_desc "select id from tbl_ann_l2 order by l2_distance_approximate(embedding, [1.0,2.0,3.0]) desc limit 2;"
+        qt_sql_l2_desc "select id from basic_tbl_ann_l2 order by l2_distance_approximate(embedding, [1.0,2.0,3.0]) desc limit 2;"
 
         // 5) Ascending inner_product order (should exercise path where Asc topn for inner product cannot be evaluated by ann index)
-        qt_sql_ip_asc "select id from tbl_ann_ip order by inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) asc limit 2;"
+        qt_sql_ip_asc "select id from basic_tbl_ann_ip order by inner_product_approximate(embedding, [0.1,0.2,0.3,0.4]) asc limit 2;"
 
         // 6) Large table to exercise predicate-input-ratio check (create many rows and run topn with small-range predicate)
         sql "drop table if exists tbl_ann_l2_large"
@@ -126,8 +112,6 @@ suite ("ann_index_basic") {
         }
         sql "INSERT INTO tbl_ann_l2_large VALUES ${values.join(',')};"
 
-        waitRowsVisible("tbl_ann_l2_large", 50)
-
         // topn with small predicate (id < 5) -> selects 4/50 = 8% (<30%), should exercise "will not use ann index" path
         qt_sql_l2_small_pred "select id from tbl_ann_l2_large where id < 5 order by l2_distance_approximate(embedding, [1.0,2.0,3.0]) limit 5;"
 
@@ -153,8 +137,6 @@ suite ("ann_index_basic") {
         """
 
         sql "INSERT INTO ann_compound VALUES (1, [1.0,2.0,3.0], 'quick brown fox'), (2, [2.0,3.0,4.0], 'lazy dog fox'), (3, [10.0,10.0,10.0], 'unrelated text');"
-
-        waitRowsVisible("ann_compound", 3)
 
         qt_sql_compound "select id from ann_compound where txt match_any 'fox' order by l2_distance_approximate(embedding, [1.0,2.0,3.0]) limit 3;"
 }

--- a/regression-test/suites/ann_index_p0/ivf_index_test.groovy
+++ b/regression-test/suites/ann_index_p0/ivf_index_test.groovy
@@ -19,9 +19,9 @@ suite ("ivf_index_test") {
     sql "set enable_common_expr_pushdown=true;"
 
     // IVF index
-    sql "drop table if exists tbl_ann_l2"
+    sql "drop table if exists ivf_tbl_ann_l2"
     sql """
-    CREATE TABLE tbl_ann_l2 (
+    CREATE TABLE ivf_tbl_ann_l2 (
         id INT NOT NULL,
         embedding ARRAY<FLOAT> NOT NULL,
         INDEX idx_emb (`embedding`) USING ANN PROPERTIES(
@@ -37,7 +37,7 @@ suite ("ivf_index_test") {
     """
 
     sql """
-    INSERT INTO tbl_ann_l2 VALUES
+    INSERT INTO ivf_tbl_ann_l2 VALUES
     (1, [1.0, 2.0, 3.0]),
     (2, [0.5, 2.1, 2.9]),
     (3, [10.0, 10.0, 10.0]),
@@ -45,15 +45,15 @@ suite ("ivf_index_test") {
     (5, [50.0, 20.0, 20.0]),
     (6, [60.0, 20.0, 20.0]);
     """
-    qt_sql "select * from tbl_ann_l2;"
+    qt_sql "select * from ivf_tbl_ann_l2;"
     // just approximate search
-    sql "select id, l2_distance_approximate(embedding, [1.0,2.0,3.0]) as dist from tbl_ann_l2 order by dist limit 2;"
+    sql "select id, l2_distance_approximate(embedding, [1.0,2.0,3.0]) as dist from ivf_tbl_ann_l2 order by dist limit 2;"
 
-    sql """drop table if exists tbl_ann_l2"""
+    sql """drop table if exists ivf_tbl_ann_l2"""
     test {
         // missing nlist
         sql """
-        CREATE TABLE tbl_ann_l2 (
+        CREATE TABLE ivf_tbl_ann_l2 (
             id INT NOT NULL,
             embedding ARRAY<FLOAT> NOT NULL,
             INDEX idx_emb (`embedding`) USING ANN PROPERTIES(
@@ -70,7 +70,7 @@ suite ("ivf_index_test") {
     }
 
     sql """
-    CREATE TABLE tbl_ann_l2 (
+    CREATE TABLE ivf_tbl_ann_l2 (
         id INT NOT NULL,
         embedding ARRAY<FLOAT> NOT NULL,
         INDEX idx_emb (`embedding`) USING ANN PROPERTIES(
@@ -87,16 +87,16 @@ suite ("ivf_index_test") {
     test {
         // not enough training points
         sql """
-        INSERT INTO tbl_ann_l2 VALUES
+        INSERT INTO ivf_tbl_ann_l2 VALUES
         (1, [1.0, 2.0, 3.0]),
         (2, [0.5, 2.1, 2.9]);
         """
         exception """exception occurred during training"""
     }
 
-    sql "drop table if exists tbl_ann_ip"
+    sql "drop table if exists ivf_tbl_ann_ip"
     sql """
-    CREATE TABLE tbl_ann_ip (
+    CREATE TABLE ivf_tbl_ann_ip (
         id INT NOT NULL,
         embedding ARRAY<FLOAT> NOT NULL,
         INDEX idx_emb (`embedding`) USING ANN PROPERTIES(
@@ -112,7 +112,7 @@ suite ("ivf_index_test") {
     """
 
     sql """
-    INSERT INTO tbl_ann_ip VALUES
+    INSERT INTO ivf_tbl_ann_ip VALUES
     (1, [1.0, 2.0, 3.0]),
     (2, [0.5, 2.1, 2.9]),
     (3, [10.0, 10.0, 10.0]),
@@ -120,7 +120,7 @@ suite ("ivf_index_test") {
     (5, [50.0, 20.0, 20.0]),
     (6, [60.0, 20.0, 20.0]);
     """
-    qt_sql "select * from tbl_ann_ip;"
+    qt_sql "select * from ivf_tbl_ann_ip;"
     // just approximate search
-    sql "select id, inner_product_approximate(embedding, [1.0,2.0,3.0]) as dist from tbl_ann_ip order by dist desc limit 2;"
+    sql "select id, inner_product_approximate(embedding, [1.0,2.0,3.0]) as dist from ivf_tbl_ann_ip order by dist desc limit 2;"
 }

--- a/regression-test/suites/compaction/test_compaction_profile_action.groovy
+++ b/regression-test/suites/compaction/test_compaction_profile_action.groovy
@@ -25,11 +25,6 @@ suite("test_compaction_profile_action", "p0") {
     def backendId_to_backendHttpPort = [:]
     getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort)
 
-    String backend_id = backendId_to_backendIP.keySet()[0]
-    def beHost = backendId_to_backendIP[backend_id]
-    def beHttpPort = backendId_to_backendHttpPort[backend_id]
-    def baseUrl = "http://${beHost}:${beHttpPort}/api/compaction/profile"
-
     try {
         // Step 2: Create table, insert data, trigger compaction, wait for completion
         sql """ DROP TABLE IF EXISTS ${tableName} """
@@ -64,6 +59,10 @@ suite("test_compaction_profile_action", "p0") {
         assertTrue(tablets.size() > 0)
         def tablet = tablets[0]
         String tablet_id = tablet.TabletId
+        String backend_id = tablet.BackendId
+        def beHost = backendId_to_backendIP[backend_id]
+        def beHttpPort = backendId_to_backendHttpPort[backend_id]
+        def baseUrl = "http://${beHost}:${beHttpPort}/api/compaction/profile"
 
         // Trigger compaction and wait for completion
         trigger_and_wait_compaction(tableName, "cumulative")


### PR DESCRIPTION
### What problem does this PR solve?

Backport two upstream regression-test fixes that never reached branch-4.0. Both cause recurring failures in the daily branch-4.0 P0 pipeline (latest: internal build #358, where `ann_index_basic` was the only failing case, and `test_compaction_profile_action` is currently muted with 5 failures in the last 26 runs).

**1. `ann_index_basic` ↔ `ivf_index_test` table-name collision (backport of #62178)**

Both suites run in the same regression database (`ann_index_p0`) and both used `tbl_ann_l2` / `tbl_ann_ip`. With `suiteParallel=10` they can run concurrently. FE logs of the failing run show `ivf_index_test` dropping and recreating `tbl_ann_ip` **230ms** after `ann_index_basic` created it, then inserting 6 rows and leaving the table behind. `ann_index_basic` then resolves the neighbor's table by name: its `waitRowsVisible` gate polls `select id from tbl_ann_ip` for 30s, always sees 6 rows != 3, and times out.

This also explains the historical intermittent empty result of `sql_ip_asc` (query landing between the neighbor's create and publish). The insert itself publishes in ~80ms even under ASAN, so the visibility-window theory behind the `waitRowsVisible` gate (#65942) was wrong; the gate is removed together with the rename.

Fix: rename the shared tables with `basic_` / `ivf_` prefixes exactly as upstream did in 9c226f5bf0f (#62178). After this change `ann_index_basic.groovy` is byte-identical to the upstream post-#62178 file (blob `41ae9e5c309`). `ivf_index_test` takes only the renames, because the upstream file also carries the #60358 behavior change (insufficient train rows no longer throws) which branch-4.0 BE does not have. No `.out` changes needed (both files contain result rows only).

**2. `test_compaction_profile_action` queries an arbitrary BE (backport of #65552)**

The suite built the `/api/compaction/profile` URL from `backendId_to_backendIP.keySet()[0]`. On a multi-BE pipeline (4 BEs, replication forced to 3) the chosen BE has ~1/4 chance of not hosting the tablet replica, so the `tablet_id` filter returns an empty list. Observed failure rate 5/26 (~19%) matches; single-BE environments never hit it. Fix: derive the endpoint from the `BackendId` of the selected `SHOW TABLETS` row, exactly as upstream did in fd16ebdc331 (#65552); the file is byte-identical to the upstream post-fix version (blob `9eae22eac0d`). Once merged, the mute for this case (DORIS-26131) can be lifted.

Note: branch-4.1 already has #62178 but still lacks #65552; a separate pick can follow.

### Check List (For Author)

- Test
    - [x] Regression test (existing suites `ann_index_p0/ann_index_basic`, `ann_index_p0/ivf_index_test`, `compaction/test_compaction_profile_action` cover this; test-only change)
- Behavior changed:
    - [x] No.
- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label

🤖 Generated with [Claude Code](https://claude.com/claude-code)
