### PR TITLE
[fix](ci) Discover AI review auth objects

### DIFF
--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -219,6 +219,10 @@ jobs:
           install -m 700 -d "$RUNNER_TEMP/codex-home"
           printf 'CODEX_HOME=%s\n' "$RUNNER_TEMP/codex-home" >> "$GITHUB_ENV"
 
+          auth_prefix='oss://doris-community-ci/codex/auth.json.'
+          auth_listing="$(mktemp "$RUNNER_TEMP/codex-auth-objects.XXXXXX")"
+          ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" ls "$auth_prefix" -s > "$auth_listing"
+
           auth_object=""
           earliest_retry_after_epoch=""
           now_epoch="$(date +%s)"
@@ -252,13 +256,9 @@ jobs:
 
             auth_object="$candidate"
             break
-          done < <(printf '%s\n' \
-            'oss://doris-community-ci/codex/auth.json.1' \
-            'oss://doris-community-ci/codex/auth.json.2' \
-            'oss://doris-community-ci/codex/auth.json.3' \
-            'oss://doris-community-ci/codex/auth.json.4' \
-            'oss://doris-community-ci/codex/auth.json.5' \
-            | shuf)
+          done < <(
+            awk '$0 ~ /^oss:\/\/doris-community-ci\/codex\/auth\.json\.[0-9]+$/ { print }' "$auth_listing" | shuf
+          )
 
           if [ -z "$auth_object" ]; then
             retry_at="$(date -u -d "@$earliest_retry_after_epoch" +%Y-%m-%dT%H:%M:%SZ)"

--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -221,7 +221,22 @@ jobs:
 
           auth_prefix='oss://doris-community-ci/codex/auth.json.'
           auth_listing="$(mktemp "$RUNNER_TEMP/codex-auth-objects.XXXXXX")"
-          ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" ls "$auth_prefix" -s > "$auth_listing"
+          if ! ossutil -i "$OSS_AK" -k "$OSS_SK" -e "$OSS_ENDPOINT" ls "$auth_prefix" -s > "$auth_listing"; then
+            auth_failure_reason="Failed to list Codex review auth objects from OSS."
+            echo "failure_reason=$auth_failure_reason" >> "$GITHUB_OUTPUT"
+            echo "::error::$auth_failure_reason"
+            exit 1
+          fi
+
+          auth_candidates="$(mktemp "$RUNNER_TEMP/codex-auth-candidates.XXXXXX")"
+          awk '$0 ~ /^oss:\/\/doris-community-ci\/codex\/auth\.json\.[0-9]+$/ { print }' \
+            "$auth_listing" > "$auth_candidates"
+          if [ ! -s "$auth_candidates" ]; then
+            auth_failure_reason="No numbered Codex review auth objects were found in OSS."
+            echo "failure_reason=$auth_failure_reason" >> "$GITHUB_OUTPUT"
+            echo "::error::$auth_failure_reason"
+            exit 1
+          fi
 
           auth_object=""
           earliest_retry_after_epoch=""
@@ -256,9 +271,7 @@ jobs:
 
             auth_object="$candidate"
             break
-          done < <(
-            awk '$0 ~ /^oss:\/\/doris-community-ci\/codex\/auth\.json\.[0-9]+$/ { print }' "$auth_listing" | shuf
-          )
+          done < <(shuf "$auth_candidates")
 
           if [ -z "$auth_object" ]; then
             retry_at="$(date -u -d "@$earliest_retry_after_epoch" +%Y-%m-%dT%H:%M:%SZ)"


### PR DESCRIPTION
## Summary

- Discover numbered AI review auth objects from OSS at runtime.
- Keep the existing random selection and usage-limit context handling while removing the fixed account list.

## Validation

- Ruby YAML parsing passed.
- `bash -n` passed for all 21 workflow run blocks.
- Auth discovery fixture accepted numbered objects and rejected context, backup, and status objects.
- [Production workflow run 30972681563](https://github.com/wzz6423/doris/actions/runs/30972681563) discovered `auth.json.1` through `auth.json.5` and followed their online usage-limit contexts.
- [Isolated auth validation run 30973370634](https://github.com/wzz6423/doris/actions/runs/30973370634) remotely validated all five discovered credentials: four reported no quota and one completed successfully.

### What problem does this PR solve?

Issue Number: None

Related PR: #66119

Problem Summary: The AI review workflow enumerated five OSS credential object suffixes, so adding or removing an account required a code change. This change lists the `auth.json.` prefix from OSS and retains only numbered credential objects before applying the existing shuffle and usage-limit handling.

### Release note

None

### Check List (For Author)

- Test: Manual test and GitHub Actions
    - YAML parsing, shell syntax validation, filter fixture, production workflow, and isolated remote auth validation
- Behavior changed: Yes (AI review credentials are discovered from OSS instead of a fixed account list)
- Does this need documentation: No
