### PR TITLE
[fix](be) Pin  be exec version in segment test

### DIFF
--- a/be/test/storage/rowset/segment_flusher_format_test.cpp
+++ b/be/test/storage/rowset/segment_flusher_format_test.cpp
@@ -44,7 +44,6 @@
 #include <utility>
 #include <vector>
 
-#include "agent/be_exec_version_manager.h"
 #include "common/config.h"
 #include "common/consts.h"
 #include "common/status.h"
@@ -105,6 +104,9 @@ namespace {
 constexpr std::string_view kTestDir = "./ut_dir/segment_flusher_format_test";
 constexpr std::string_view kGoldenDir = "./be/test/storage/test_data/segment_flusher_format";
 constexpr std::string_view kGoldenOutputDirEnv = "DORIS_SEGMENT_FLUSHER_GOLDEN_OUTPUT_DIR";
+// BE exec version is encoded in the checked-in golden Segments. Change it only when intentionally
+// regenerating all golden files.
+constexpr int32_t kGoldenBeExecVersion = 10;
 constexpr int32_t kRowBinlogSystemColumnCount = 3;
 constexpr size_t kExpectedGoldenCaseCount = 76;
 constexpr size_t kExpectedGoldenSegmentCount = 154;
@@ -766,7 +768,7 @@ TabletSchemaSPtr create_complex_value_schema(TabletStorageFormatPB storage_forma
         auto* column = add_column(&schema_pb, unique_id, name, agg_state_type, false, false,
                                   function_name);
         column->set_result_is_nullable(false);
-        column->set_be_exec_version(BeExecVersionManager::get_newest_version());
+        column->set_be_exec_version(kGoldenBeExecVersion);
         return column;
     };
     auto* count = add_agg_state_column(8, "v_agg_count", "count");


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #65977 ， #66112

`SegmentFlusherFormatTest` was added by #65977. Its BE UT pipeline ran before #66112 was merged and passed with BE exec version 10.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - `./run-be-ut.sh --run --filter=SegmentFlusherFormatTest.ComplexObjectAndVariantValuesKeepTheirSegmentBytes -j 128`
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

