### PR TITLE
[fix](be) Safely prune nested Parquet columns with Bloom filters

### DIFF
--- a/be/src/exprs/expr_zonemap_filter.cpp
+++ b/be/src/exprs/expr_zonemap_filter.cpp
@@ -112,6 +112,24 @@ bool bloom_filter_probes_equal(const BloomFilterProbe& lhs, const BloomFilterPro
            data_types_compatible(lhs.value_type, rhs.value_type);
 }
 
+template <typename T>
+bool floating_point_bloom_filter_may_contain(const segment_v2::BloomFilter& bloom_filter, T value) {
+    static_assert(std::is_floating_point_v<T>);
+    // Doris equality collapses NaN payloads and signed zeros, while Parquet Bloom hashes physical
+    // bytes. A negative probe is safe only after covering the entire Doris-equivalent class.
+    if (std::isnan(value)) {
+        return true;
+    }
+    const auto test_value = [&](T candidate) {
+        return bloom_filter.test_bytes(reinterpret_cast<const char*>(&candidate),
+                                       sizeof(candidate));
+    };
+    if (test_value(value)) {
+        return true;
+    }
+    return value == T {0} && test_value(-value);
+}
+
 bool bloom_filter_may_contain(const BloomFilterEvalContext::SlotBloomFilter& slot_filter,
                               const Field& value) {
     DORIS_CHECK(slot_filter.data_type != nullptr);
@@ -321,27 +339,37 @@ std::optional<BloomFilterProbe> extract_bloom_filter_probe(const VExprSPtr& expr
     return probe;
 }
 
-std::optional<BloomFilterProbe> extract_bloom_filter_predicate_probe(const VExprSPtr& expr) {
+bool collect_unique_bloom_filter_probe(const VExprSPtr& expr,
+                                       std::optional<BloomFilterProbe>* result) {
+    DORIS_CHECK(result != nullptr);
     if (auto probe = extract_bloom_filter_probe(expr); probe.has_value()) {
-        return probe;
+        if (result->has_value() && !bloom_filter_probes_equal(**result, *probe)) {
+            return false;
+        }
+        *result = std::move(probe);
+        return true;
     }
     if (expr == nullptr) {
-        return std::nullopt;
+        return true;
     }
-    std::optional<BloomFilterProbe> result;
     for (uint16_t child_idx = 0; child_idx < expr->get_num_children(); ++child_idx) {
         const auto& child = expr->get_child(child_idx);
         if (child == nullptr || child->is_literal()) {
             continue;
         }
-        auto child_probe = extract_bloom_filter_predicate_probe(child);
-        if (!child_probe.has_value()) {
-            continue;
+        // Every Bloom-capable branch must bind to the same leaf; a conflicting subtree cannot be
+        // treated like a branch without a probe because the compound evaluator would use it.
+        if (!collect_unique_bloom_filter_probe(child, result)) {
+            return false;
         }
-        if (result.has_value() && !bloom_filter_probes_equal(*result, *child_probe)) {
-            return std::nullopt;
-        }
-        result = std::move(child_probe);
+    }
+    return true;
+}
+
+std::optional<BloomFilterProbe> extract_bloom_filter_predicate_probe(const VExprSPtr& expr) {
+    std::optional<BloomFilterProbe> result;
+    if (!collect_unique_bloom_filter_probe(expr, &result)) {
+        return std::nullopt;
     }
     return result;
 }

--- a/be/src/exprs/expr_zonemap_filter.cpp
+++ b/be/src/exprs/expr_zonemap_filter.cpp
@@ -112,24 +112,6 @@ bool bloom_filter_probes_equal(const BloomFilterProbe& lhs, const BloomFilterPro
            data_types_compatible(lhs.value_type, rhs.value_type);
 }
 
-template <typename T>
-bool floating_point_bloom_filter_may_contain(const segment_v2::BloomFilter& bloom_filter, T value) {
-    static_assert(std::is_floating_point_v<T>);
-    // Doris equality collapses NaN payloads and signed zeros, while Parquet Bloom hashes physical
-    // bytes. A negative probe is safe only after covering the entire Doris-equivalent class.
-    if (std::isnan(value)) {
-        return true;
-    }
-    const auto test_value = [&](T candidate) {
-        return bloom_filter.test_bytes(reinterpret_cast<const char*>(&candidate),
-                                       sizeof(candidate));
-    };
-    if (test_value(value)) {
-        return true;
-    }
-    return value == T {0} && test_value(-value);
-}
-
 bool bloom_filter_may_contain(const BloomFilterEvalContext::SlotBloomFilter& slot_filter,
                               const Field& value) {
     DORIS_CHECK(slot_filter.data_type != nullptr);
@@ -396,7 +378,10 @@ std::optional<SlotLiteral> extract_bloom_filter_slot_and_literal(const VExprSPtr
 
 bool can_evaluate_bloom_filter_equality(const VExprSPtrs& args) {
     auto slot_literal = extract_bloom_filter_slot_and_literal(args);
+    // Parquet Bloom hashes physical bytes, so it cannot disprove Doris NaN equality across
+    // different NaN payloads even when the probe targets a nested leaf.
     return slot_literal.has_value() && !slot_literal->literal.is_null() &&
+           !slot_literal->literal.is_nan() &&
            data_types_compatible(slot_literal->slot_type, slot_literal->literal_type);
 }
 

--- a/be/src/exprs/expr_zonemap_filter.cpp
+++ b/be/src/exprs/expr_zonemap_filter.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <set>
 #include <type_traits>
 #include <utility>
@@ -50,6 +51,33 @@ std::optional<std::pair<Field, DataTypePtr>> field_from_literal_expr(const VExpr
     return std::make_pair(std::move(field), literal->get_data_type());
 }
 
+std::optional<int32_t> struct_field_ordinal(const Field& field) {
+    int64_t ordinal = -1;
+    switch (field.get_type()) {
+    case TYPE_BOOLEAN:
+        ordinal = field.get<TYPE_BOOLEAN>();
+        break;
+    case TYPE_TINYINT:
+        ordinal = field.get<TYPE_TINYINT>();
+        break;
+    case TYPE_SMALLINT:
+        ordinal = field.get<TYPE_SMALLINT>();
+        break;
+    case TYPE_INT:
+        ordinal = field.get<TYPE_INT>();
+        break;
+    case TYPE_BIGINT:
+        ordinal = field.get<TYPE_BIGINT>();
+        break;
+    default:
+        return std::nullopt;
+    }
+    if (ordinal <= 0 || ordinal > std::numeric_limits<int32_t>::max()) {
+        return std::nullopt;
+    }
+    return static_cast<int32_t>(ordinal - 1);
+}
+
 bool value_in_range(const Field& value, const Field& min_value, const Field& max_value) {
     return value >= min_value && value <= max_value;
 }
@@ -77,6 +105,11 @@ bool floating_point_bloom_filter_may_contain(const segment_v2::BloomFilter& bloo
         return true;
     }
     return value == T {0} && test_value(-value);
+}
+
+bool bloom_filter_probes_equal(const BloomFilterProbe& lhs, const BloomFilterProbe& rhs) {
+    return lhs.slot_index == rhs.slot_index && lhs.path == rhs.path &&
+           data_types_compatible(lhs.value_type, rhs.value_type);
 }
 
 bool bloom_filter_may_contain(const BloomFilterEvalContext::SlotBloomFilter& slot_filter,
@@ -230,6 +263,113 @@ std::optional<SlotLiteral> extract_slot_and_literal(const VExprSPtrs& args) {
     }
 
     return std::nullopt;
+}
+
+std::optional<BloomFilterProbe> extract_bloom_filter_probe(const VExprSPtr& expr) {
+    if (expr == nullptr || expr->data_type() == nullptr) {
+        return std::nullopt;
+    }
+    if (auto slot = std::dynamic_pointer_cast<VSlotRef>(expr); slot) {
+        return BloomFilterProbe {
+                .slot_index = slot->column_id(), .value_type = slot->data_type(), .path = {}};
+    }
+    if ((expr->fn().name.function_name != "element_at" &&
+         expr->fn().name.function_name != "struct_element") ||
+        expr->get_num_children() != 2) {
+        return std::nullopt;
+    }
+
+    auto probe = extract_bloom_filter_probe(expr->get_child(0));
+    auto selector = field_from_literal_expr(expr->get_child(1));
+    if (!probe.has_value() || !selector.has_value() || selector->first.is_null()) {
+        return std::nullopt;
+    }
+    const auto parent_type = remove_nullable(expr->get_child(0)->data_type());
+    if (parent_type == nullptr) {
+        return std::nullopt;
+    }
+
+    BloomFilterPathElement path_element;
+    switch (parent_type->get_primitive_type()) {
+    case TYPE_STRUCT: {
+        path_element.kind = BloomFilterPathKind::STRUCT_FIELD;
+        const auto selector_type = remove_nullable(selector->second);
+        if (selector_type == nullptr) {
+            return std::nullopt;
+        }
+        if (is_string_type(selector_type->get_primitive_type())) {
+            path_element.field_name = selector->first.get<TYPE_STRING>();
+        } else {
+            auto ordinal = struct_field_ordinal(selector->first);
+            if (!ordinal.has_value()) {
+                return std::nullopt;
+            }
+            path_element.field_ordinal = *ordinal;
+        }
+        break;
+    }
+    case TYPE_ARRAY:
+        // Array element positions share one repeated Parquet leaf; membership in that leaf is a
+        // necessary condition for any element_at(array, constant) equality to match.
+        path_element.kind = BloomFilterPathKind::LIST_ELEMENT;
+        break;
+    default:
+        return std::nullopt;
+    }
+    probe->value_type = expr->data_type();
+    probe->path.push_back(std::move(path_element));
+    return probe;
+}
+
+std::optional<BloomFilterProbe> extract_bloom_filter_predicate_probe(const VExprSPtr& expr) {
+    if (auto probe = extract_bloom_filter_probe(expr); probe.has_value()) {
+        return probe;
+    }
+    if (expr == nullptr) {
+        return std::nullopt;
+    }
+    std::optional<BloomFilterProbe> result;
+    for (uint16_t child_idx = 0; child_idx < expr->get_num_children(); ++child_idx) {
+        const auto& child = expr->get_child(child_idx);
+        if (child == nullptr || child->is_literal()) {
+            continue;
+        }
+        auto child_probe = extract_bloom_filter_predicate_probe(child);
+        if (!child_probe.has_value()) {
+            continue;
+        }
+        if (result.has_value() && !bloom_filter_probes_equal(*result, *child_probe)) {
+            return std::nullopt;
+        }
+        result = std::move(child_probe);
+    }
+    return result;
+}
+
+std::optional<SlotLiteral> extract_bloom_filter_slot_and_literal(const VExprSPtrs& args) {
+    if (args.size() != 2) {
+        return std::nullopt;
+    }
+    for (size_t probe_idx = 0; probe_idx < args.size(); ++probe_idx) {
+        auto probe = extract_bloom_filter_probe(args[probe_idx]);
+        auto literal = field_from_literal_expr(args[1 - probe_idx]);
+        if (!probe.has_value() || !literal.has_value()) {
+            continue;
+        }
+        auto [literal_value, literal_type] = std::move(*literal);
+        return SlotLiteral {.slot_index = probe->slot_index,
+                            .slot_type = probe->value_type,
+                            .literal = std::move(literal_value),
+                            .literal_type = std::move(literal_type),
+                            .literal_on_left = probe_idx == 1};
+    }
+    return std::nullopt;
+}
+
+bool can_evaluate_bloom_filter_equality(const VExprSPtrs& args) {
+    auto slot_literal = extract_bloom_filter_slot_and_literal(args);
+    return slot_literal.has_value() && !slot_literal->literal.is_null() &&
+           data_types_compatible(slot_literal->slot_type, slot_literal->literal_type);
 }
 
 bool range_stats_usable_for_zonemap(const segment_v2::ZoneMap& zone_map,
@@ -400,14 +540,14 @@ ZoneMapFilterResult eval_in_bloom_filter(const BloomFilterEvalContext& ctx,
     if (is_not_in) {
         return ZoneMapFilterResult::kUnsupported;
     }
-    auto slot = std::dynamic_pointer_cast<VSlotRef>(slot_expr);
-    DORIS_CHECK(slot != nullptr);
-    auto slot_filter = ctx.slot(slot->column_id());
+    auto probe = extract_bloom_filter_probe(slot_expr);
+    DORIS_CHECK(probe.has_value());
+    auto slot_filter = ctx.slot(probe->slot_index);
     if (slot_filter == nullptr || slot_filter->data_type == nullptr ||
         slot_filter->bloom_filter == nullptr) {
         return ZoneMapFilterResult::kUnsupported;
     }
-    DORIS_CHECK(data_types_compatible(slot_filter->data_type, slot->data_type()));
+    DORIS_CHECK(data_types_compatible(slot_filter->data_type, probe->value_type));
     if (values.empty()) {
         return ZoneMapFilterResult::kNoMatch;
     }

--- a/be/src/exprs/expr_zonemap_filter.h
+++ b/be/src/exprs/expr_zonemap_filter.h
@@ -20,6 +20,7 @@
 #include <compare>
 #include <map>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "common/status.h"
@@ -99,7 +100,36 @@ struct SlotLiteral {
     bool literal_on_left;
 };
 
+enum class BloomFilterPathKind {
+    STRUCT_FIELD,
+    LIST_ELEMENT,
+};
+
+struct BloomFilterPathElement {
+    BloomFilterPathKind kind;
+    std::string field_name;
+    int32_t field_ordinal = -1;
+
+    bool operator==(const BloomFilterPathElement&) const = default;
+};
+
+struct BloomFilterProbe {
+    int slot_index;
+    DataTypePtr value_type;
+    std::vector<BloomFilterPathElement> path;
+
+    bool operator==(const BloomFilterProbe&) const = default;
+};
+
 std::optional<SlotLiteral> extract_slot_and_literal(const VExprSPtrs& args);
+
+std::optional<BloomFilterProbe> extract_bloom_filter_probe(const VExprSPtr& expr);
+
+std::optional<BloomFilterProbe> extract_bloom_filter_predicate_probe(const VExprSPtr& expr);
+
+std::optional<SlotLiteral> extract_bloom_filter_slot_and_literal(const VExprSPtrs& args);
+
+bool can_evaluate_bloom_filter_equality(const VExprSPtrs& args);
 
 TExprNode create_texpr_node_from_hybrid_set_value(const void* data, const PrimitiveType& type,
                                                   int precision, int scale);

--- a/be/src/exprs/function/comparison_equal_for_null.cpp
+++ b/be/src/exprs/function/comparison_equal_for_null.cpp
@@ -37,6 +37,7 @@
 #include "core/data_type/data_type_number.h"
 #include "core/types.h"
 #include "exprs/aggregate/aggregate_function.h"
+#include "exprs/expr_zonemap_filter.h"
 #include "exprs/function/function.h"
 #include "exprs/function/function_helpers.h"
 #include "exprs/function/simple_function_factory.h"
@@ -63,6 +64,19 @@ public:
     }
 
     bool use_default_implementation_for_nulls() const override { return false; }
+
+    ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx,
+                                              const VExprSPtrs& arguments) const override {
+        auto slot_literal = expr_zonemap::extract_bloom_filter_slot_and_literal(arguments);
+        DORIS_CHECK(slot_literal.has_value());
+        return expr_zonemap::eval_eq_bloom_filter(ctx, *slot_literal);
+    }
+
+    bool can_evaluate_bloom_filter(const VExprSPtrs& arguments) const override {
+        // Parquet Bloom filters do not encode null membership, so null-safe equality can only use
+        // them when its literal is non-null and ordinary equality semantics apply.
+        return expr_zonemap::can_evaluate_bloom_filter_equality(arguments);
+    }
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {

--- a/be/src/exprs/function/functions_comparison.h
+++ b/be/src/exprs/function/functions_comparison.h
@@ -439,7 +439,7 @@ inline ZoneMapFilterResult evaluate_dictionary(const DictionaryEvalContext& ctx,
 inline ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx,
                                                  const VExprSPtrs& arguments, Op op) {
     DORIS_CHECK(op == Op::EQ);
-    auto slot_literal = expr_zonemap::extract_slot_and_literal(arguments);
+    auto slot_literal = expr_zonemap::extract_bloom_filter_slot_and_literal(arguments);
     DORIS_CHECK(slot_literal.has_value());
     return expr_zonemap::eval_eq_bloom_filter(ctx, *slot_literal);
 }
@@ -680,7 +680,8 @@ public:
 
     bool can_evaluate_bloom_filter(const VExprSPtrs& arguments) const override {
         auto op = comparison_zonemap_detail::op_from_name(name);
-        return op.has_value() && comparison_zonemap_detail::can_evaluate_equality(arguments, *op);
+        return op == comparison_zonemap_detail::Op::EQ &&
+               expr_zonemap::can_evaluate_bloom_filter_equality(arguments);
     }
 
     /// Get result types by argument types. If the function does not apply to these arguments, throw an exception.

--- a/be/src/exprs/vectorized_fn_call.cpp
+++ b/be/src/exprs/vectorized_fn_call.cpp
@@ -668,11 +668,24 @@ bool VectorizedFnCall::is_deterministic() const {
 }
 
 bool VectorizedFnCall::is_safe_to_execute_on_selected_rows() const {
-    static const std::set<std::string> TOTAL_PREDICATE_FUNCTIONS = {
-            "eq", "ne", "lt", "le", "gt", "ge", "in", "not_in", "is_null_pred", "is_not_null_pred"};
+    static const std::set<std::string> TOTAL_PREDICATE_FUNCTIONS = {"eq",
+                                                                    "eq_for_null",
+                                                                    "ne",
+                                                                    "lt",
+                                                                    "le",
+                                                                    "gt",
+                                                                    "ge",
+                                                                    "in",
+                                                                    "not_in",
+                                                                    "is_null_pred",
+                                                                    "is_not_null_pred",
+                                                                    "element_at",
+                                                                    "struct_element"};
     // Selected-row execution may hide data-dependent errors in rows rejected by an earlier
     // predicate. Keep function calls unsafe by default and opt in only operations that are total
-    // for their input domain; child checks then reject expressions such as gt(mod(x, -1), 0).
+    // for their input domain. Accessors return NULL for absent elements, so admitting them keeps
+    // nested metadata predicates reachable without crossing an error-producing child such as
+    // gt(mod(x, -1), 0).
     return TOTAL_PREDICATE_FUNCTIONS.contains(_function_name) &&
            VExpr::is_safe_to_execute_on_selected_rows();
 }

--- a/be/src/exprs/vin_predicate.cpp
+++ b/be/src/exprs/vin_predicate.cpp
@@ -161,11 +161,17 @@ Status VInPredicate::_materialize_for_zonemap_filter(VExprContext* context) {
     _seg_filter_contains_nan = false;
     _zonemap_materialized = false;
     _direct_filter_set.reset();
-    if (_children.size() < 2 || !_children[0]->is_slot_ref()) {
+    if (_children.size() < 2) {
         return Status::OK();
     }
 
-    const auto data_type = remove_nullable(_children[0]->data_type());
+    auto bloom_probe = expr_zonemap::extract_bloom_filter_probe(_children[0]);
+    if (!bloom_probe.has_value()) {
+        return Status::OK();
+    }
+    // Materialization is shared by all pruning paths. Their capability checks keep ZoneMap,
+    // dictionary, and raw evaluation direct-slot-only while Bloom may consume a nested leaf.
+    const auto data_type = remove_nullable(bloom_probe->value_type);
     DORIS_CHECK(data_type != nullptr);
     if (is_complex_type(data_type->get_primitive_type())) {
         return Status::OK();

--- a/be/src/exprs/vin_predicate.cpp
+++ b/be/src/exprs/vin_predicate.cpp
@@ -223,7 +223,7 @@ ZoneMapFilterResult VInPredicate::evaluate_bloom_filter(const BloomFilterEvalCon
 bool VInPredicate::can_evaluate_bloom_filter() const {
     // A NaN member forces conservative retention regardless of the remaining finite probes.
     return _zonemap_materialized && !_is_not_in && !_seg_filter_contains_nan &&
-           std::dynamic_pointer_cast<VSlotRef>(get_child(0)) != nullptr;
+           expr_zonemap::extract_bloom_filter_probe(get_child(0)).has_value();
 }
 
 bool VInPredicate::can_execute_on_raw_fixed_values(const DataTypePtr& data_type,

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -335,6 +335,8 @@ struct FileSlotRewriteInfo {
     DataTypePtr file_type;
     DataTypePtr table_type;
     std::string file_column_name;
+    const ColumnMapping* root_mapping = nullptr;
+    LocalColumnIndex scan_projection;
 };
 
 struct RewriteContext {
@@ -522,6 +524,17 @@ static bool table_filter_has_only_local_entries(
         }
     }
     return true;
+}
+
+static bool table_filter_has_only_constant_entries(
+        const TableFilter& table_filter, const std::map<GlobalIndex, FilterEntry>& filter_entries) {
+    for (const auto global_index : table_filter.global_indices) {
+        const auto entry_it = filter_entries.find(global_index);
+        if (entry_it == filter_entries.end() || !entry_it->second.is_constant()) {
+            return false;
+        }
+    }
+    return !table_filter.global_indices.empty();
 }
 
 static VExprSPtr unwrap_literal_for_file_cast(const VExprSPtr& expr,
@@ -890,6 +903,39 @@ static bool can_filter_before_table_nullability_alignment(const DataTypePtr& fil
     return !file_type->is_nullable() || table_type->is_nullable();
 }
 
+static const ColumnMapping* find_projected_child_mapping(const ColumnMapping& mapping,
+                                                         int32_t file_local_id) {
+    const auto child_it = std::ranges::find_if(
+            mapping.child_mappings, [file_local_id](const ColumnMapping& child) {
+                return child.file_local_id.has_value() && *child.file_local_id == file_local_id;
+            });
+    return child_it == mapping.child_mappings.end() ? nullptr : &*child_it;
+}
+
+static bool projected_mapping_preserves_table_nullability(const ColumnMapping& mapping,
+                                                          const LocalColumnIndex* projection) {
+    if (!can_filter_before_table_nullability_alignment(mapping.file_type, mapping.table_type)) {
+        return false;
+    }
+    if (is_full_projection(projection)) {
+        for (const auto& child : mapping.child_mappings) {
+            if (child.file_local_id.has_value() &&
+                !projected_mapping_preserves_table_nullability(child, nullptr)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    for (const auto& child_projection : projection->children) {
+        const auto* child = find_projected_child_mapping(mapping, child_projection.local_id());
+        if (child == nullptr ||
+            !projected_mapping_preserves_table_nullability(*child, &child_projection)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 static bool rewrite_struct_element_path_to_file_expr(
         const VExprSPtr& expr, const std::vector<ColumnMapping>& mappings,
         const std::map<GlobalIndex, FileSlotRewriteInfo>& global_to_file_slot,
@@ -918,13 +964,12 @@ static bool rewrite_struct_element_path_to_file_expr(
         return false;
     }
 
-    // Check every value-producing level, including the root struct. A nullable parent also makes
-    // a child access nullable even when the child type itself is required, so checking only the
-    // final leaf is insufficient. If any file level is more nullable than its table counterpart,
-    // keep the complete predicate above TableReader so schema validation observes all NULLs before
-    // row filtering.
-    if (!can_filter_before_table_nullability_alignment(rewrite_it->second.file_type,
-                                                       rewrite_it->second.table_type)) {
+    DORIS_CHECK(rewrite_it->second.root_mapping != nullptr);
+    // File-local filtering cannot discard rows before every physically projected mapped child has
+    // reached TableReader's nullability validation. ARRAY access uses a full element projection on
+    // this branch, so validating only the selected STRUCT chain can miss a required sibling.
+    if (!projected_mapping_preserves_table_nullability(*rewrite_it->second.root_mapping,
+                                                       &rewrite_it->second.scan_projection)) {
         return false;
     }
     for (size_t idx = 0; idx < struct_element_chain.size(); ++idx) {
@@ -1025,6 +1070,8 @@ static bool rewrite_binary_struct_literal_predicate(
             .file_type = file_leaf_type,
             .table_type = table_leaf_type,
             .file_column_name = {},
+            .root_mapping = nullptr,
+            .scan_projection = {},
     };
     auto file_literal =
             rewrite_literal_to_file_type(table_literal, leaf_rewrite_info, rewrite_context);
@@ -1083,6 +1130,8 @@ static bool rewrite_in_struct_literal_predicate(
             .file_type = file_leaf_type,
             .table_type = table_leaf_type,
             .file_column_name = {},
+            .root_mapping = nullptr,
+            .scan_projection = {},
     };
     VExprSPtrs file_literals;
     file_literals.reserve(table_literals.size());
@@ -1997,7 +2046,9 @@ static void rebuild_projection(ColumnMapping* mapping, LocalIndex block_position
 // file-reader expressions; constant and unset targets stay above the file reader.
 static std::map<GlobalIndex, FileSlotRewriteInfo> build_file_slot_rewrite_map(
         const std::vector<ColumnMapping>& mappings,
-        const std::map<GlobalIndex, FilterEntry>& filter_entries) {
+        const std::vector<ColumnMapping>& output_mappings,
+        const std::map<GlobalIndex, FilterEntry>& filter_entries,
+        const FileScanRequest& file_request) {
     std::map<GlobalIndex, FileSlotRewriteInfo> global_to_file_slot;
     for (const auto& mapping : mappings) {
         const auto entry_it = filter_entries.find(mapping.global_index);
@@ -2005,12 +2056,28 @@ static std::map<GlobalIndex, FileSlotRewriteInfo> build_file_slot_rewrite_map(
             continue;
         }
         DORIS_CHECK(mapping.file_local_id.has_value());
+        const auto file_column_id = LocalColumnId(*mapping.file_local_id);
+        const auto* scan_projection =
+                find_scan_projection(file_request.predicate_columns, file_column_id);
+        if (scan_projection == nullptr) {
+            scan_projection =
+                    find_scan_projection(file_request.non_predicate_columns, file_column_id);
+        }
+        DORIS_CHECK(scan_projection != nullptr);
+        const auto output_mapping_it =
+                std::ranges::find_if(output_mappings, [&](const ColumnMapping& output_mapping) {
+                    return output_mapping.global_index == mapping.global_index;
+                });
+        const auto* physical_mapping =
+                output_mapping_it == output_mappings.end() ? &mapping : &*output_mapping_it;
         global_to_file_slot.emplace(
                 mapping.global_index,
                 FileSlotRewriteInfo {.block_position = entry_it->second.local_index().value(),
                                      .file_type = mapping.file_type,
                                      .table_type = mapping.table_type,
-                                     .file_column_name = mapping.file_column_name});
+                                     .file_column_name = mapping.file_column_name,
+                                     .root_mapping = physical_mapping,
+                                     .scan_projection = *scan_projection});
     }
     return global_to_file_slot;
 }
@@ -2263,6 +2330,7 @@ Status TableColumnMapper::create_scan_request(
     file_request->non_predicate_positions.clear();
     file_request->conjuncts.clear();
     file_request->metadata_pruning_safe_conjunct_count = 0;
+    file_request->constant_pruning_safe_table_filter_count = 0;
     file_request->delete_conjuncts.clear();
     _filter_entries.clear();
     // 1. Build referenced non-predicate columns
@@ -2430,8 +2498,11 @@ Status TableColumnMapper::localize_filters(const std::vector<TableFilter>& table
     // Build the complete table-slot rewrite map after all predicate columns have been assigned.
     // This keeps expression localization independent from filter iteration order.
     filter_mappings = _filter_visible_mappings();
-    const auto global_to_file_slot = build_file_slot_rewrite_map(filter_mappings, _filter_entries);
-    for (const auto& table_filter : table_filters) {
+    const auto global_to_file_slot =
+            build_file_slot_rewrite_map(filter_mappings, _mappings, _filter_entries, *file_request);
+    std::vector<bool> localized_table_filters(table_filters.size(), false);
+    for (size_t table_filter_idx = 0; table_filter_idx < table_filters.size(); ++table_filter_idx) {
+        const auto& table_filter = table_filters[table_filter_idx];
         if (table_filter.conjunct != nullptr && table_filter.conjunct->root() != nullptr) {
             const auto root = table_filter.conjunct->root();
             const auto impl = root->get_impl();
@@ -2489,9 +2560,7 @@ Status TableColumnMapper::localize_filters(const std::vector<TableFilter>& table
             auto localized_conjunct = VExprContext::create_shared(std::move(localized_root));
             RETURN_IF_ERROR(rewrite_context.prepare_created_exprs(localized_conjunct.get()));
             file_request->conjuncts.push_back(std::move(localized_conjunct));
-            if (table_filter.metadata_pruning_safe) {
-                ++file_request->metadata_pruning_safe_conjunct_count;
-            }
+            localized_table_filters[table_filter_idx] = true;
             for (const auto global_index : table_filter.global_indices) {
                 const auto* mapping = _find_filter_mapping(global_index);
                 if (mapping != nullptr && mapping->file_local_id.has_value() &&
@@ -2502,17 +2571,44 @@ Status TableColumnMapper::localize_filters(const std::vector<TableFilter>& table
         }
     }
 
+    bool in_metadata_pruning_safe_prefix = true;
+    bool in_constant_pruning_safe_prefix = true;
+    for (size_t table_filter_idx = 0; table_filter_idx < table_filters.size(); ++table_filter_idx) {
+        const auto& table_filter = table_filters[table_filter_idx];
+        const bool constant_filter =
+                table_filter_has_only_constant_entries(table_filter, _filter_entries);
+        if (!table_filter.metadata_pruning_safe) {
+            in_metadata_pruning_safe_prefix = false;
+        }
+        if (constant_filter) {
+            // Safe constant filters are evaluated before opening the file and do not occupy a
+            // file-local conjunct position.
+        } else if (!localized_table_filters[table_filter_idx]) {
+            in_metadata_pruning_safe_prefix = false;
+        } else if (in_metadata_pruning_safe_prefix) {
+            ++file_request->metadata_pruning_safe_conjunct_count;
+        }
+
+        if (in_constant_pruning_safe_prefix &&
+            (constant_filter || localized_table_filters[table_filter_idx])) {
+            ++file_request->constant_pruning_safe_table_filter_count;
+        } else {
+            // A rejected localization must preserve all later filters for post-materialization
+            // evaluation, even if a later constant would otherwise prune the complete split.
+            in_constant_pruning_safe_prefix = false;
+        }
+    }
+
     // Candidate columns are added before expression rewriting because their file-block positions
     // are needed to localize slot refs. If rewriting rejects every filter that references a visible
-    // column, move its all-access-path projection to the lazy non-predicate set instead of forcing
-    // it through the eager predicate path.
+    // column, merge any independent output/filter subtrees and move the result to the lazy
+    // non-predicate set instead of forcing it through the eager predicate path.
     for (auto& mapping : _mappings) {
         if (!mapping.file_local_id.has_value()) {
             continue;
         }
         const auto local_id = LocalColumnId(*mapping.file_local_id);
-        if (localized_predicate_columns.contains(local_id) ||
-            file_request->has_deferred_non_predicate_column(local_id)) {
+        if (localized_predicate_columns.contains(local_id)) {
             continue;
         }
         const auto predicate_it = std::ranges::find_if(
@@ -2522,8 +2618,23 @@ Status TableColumnMapper::localize_filters(const std::vector<TableFilter>& table
         if (predicate_it == file_request->predicate_columns.end()) {
             continue;
         }
-        file_request->non_predicate_columns.push_back(std::move(*predicate_it));
+        LocalColumnIndex demoted_projection = std::move(*predicate_it);
         file_request->predicate_columns.erase(predicate_it);
+        const auto output_it = std::ranges::find_if(file_request->non_predicate_columns,
+                                                    [local_id](const LocalColumnIndex& projection) {
+                                                        return projection.column_id() == local_id;
+                                                    });
+        if (output_it != file_request->non_predicate_columns.end()) {
+            // A rejected complex predicate still needs its filter-only subtree on Scanner's
+            // table-level path. Merge it with the deferred output before collapsing the two block
+            // positions, or branch-4.1 can silently drop the child used by the residual filter.
+            RETURN_IF_ERROR(merge_local_column_index(&demoted_projection, *output_it));
+            file_request->non_predicate_columns.erase(output_it);
+            file_request->non_predicate_positions.erase(local_id);
+            std::erase(file_request->predicate_only_columns, local_id);
+        }
+        FileScanRequestBuilder builder(file_request);
+        RETURN_IF_ERROR(builder.add_non_predicate_column(std::move(demoted_projection)));
     }
     return Status::OK();
 }

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -917,6 +917,11 @@ static bool projected_mapping_preserves_table_nullability(const ColumnMapping& m
     if (!can_filter_before_table_nullability_alignment(mapping.file_type, mapping.table_type)) {
         return false;
     }
+    if (remove_nullable(mapping.table_type)->get_primitive_type() == TYPE_VARIANT) {
+        // Shredded Variant children describe physical encoding, not table-schema nullability
+        // contracts. The Variant root is therefore the only mapped level that can be validated.
+        return true;
+    }
     if (is_full_projection(projection)) {
         for (const auto& child : mapping.child_mappings) {
             if (child.file_local_id.has_value() &&

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -912,20 +912,40 @@ static const ColumnMapping* find_projected_child_mapping(const ColumnMapping& ma
     return child_it == mapping.child_mappings.end() ? nullptr : &*child_it;
 }
 
-static bool projected_mapping_preserves_table_nullability(const ColumnMapping& mapping,
-                                                          const LocalColumnIndex* projection) {
+static bool projected_mapping_allows_file_filtering(const ColumnMapping& mapping,
+                                                    const LocalColumnIndex* projection) {
     if (!can_filter_before_table_nullability_alignment(mapping.file_type, mapping.table_type)) {
         return false;
     }
-    if (remove_nullable(mapping.table_type)->get_primitive_type() == TYPE_VARIANT) {
+    const auto file_type = remove_nullable(mapping.file_type);
+    const auto table_type = remove_nullable(mapping.table_type);
+    if (table_type->get_primitive_type() == TYPE_VARIANT) {
         // Shredded Variant children describe physical encoding, not table-schema nullability
         // contracts. The Variant root is therefore the only mapped level that can be validated.
         return true;
     }
+
+    const auto file_primitive_type = file_type->get_primitive_type();
+    const auto table_primitive_type = table_type->get_primitive_type();
+    if (is_complex_type(file_primitive_type) || is_complex_type(table_primitive_type)) {
+        if (file_primitive_type != table_primitive_type) {
+            return false;
+        }
+        if (mapping.child_mappings.empty()) {
+            return file_type->equals(*table_type);
+        }
+    } else if (!file_type->equals(*table_type) &&
+               !is_lossless_file_to_table_numeric_cast(mapping.file_type, mapping.table_type)) {
+        // A file-local filter can discard a row before TableReader casts a projected sibling.
+        // Require every projected scalar cast to preserve all source values so filtering cannot
+        // hide overflow or other materialization errors in that sibling.
+        return false;
+    }
+
     if (is_full_projection(projection)) {
         for (const auto& child : mapping.child_mappings) {
             if (child.file_local_id.has_value() &&
-                !projected_mapping_preserves_table_nullability(child, nullptr)) {
+                !projected_mapping_allows_file_filtering(child, nullptr)) {
                 return false;
             }
         }
@@ -934,7 +954,7 @@ static bool projected_mapping_preserves_table_nullability(const ColumnMapping& m
     for (const auto& child_projection : projection->children) {
         const auto* child = find_projected_child_mapping(mapping, child_projection.local_id());
         if (child == nullptr ||
-            !projected_mapping_preserves_table_nullability(*child, &child_projection)) {
+            !projected_mapping_allows_file_filtering(*child, &child_projection)) {
             return false;
         }
     }
@@ -971,10 +991,11 @@ static bool rewrite_struct_element_path_to_file_expr(
 
     DORIS_CHECK(rewrite_it->second.root_mapping != nullptr);
     // File-local filtering cannot discard rows before every physically projected mapped child has
-    // reached TableReader's nullability validation. ARRAY access uses a full element projection on
-    // this branch, so validating only the selected STRUCT chain can miss a required sibling.
-    if (!projected_mapping_preserves_table_nullability(*rewrite_it->second.root_mapping,
-                                                       &rewrite_it->second.scan_projection)) {
+    // reached TableReader's schema validation and casts. ARRAY access uses a full element
+    // projection on this branch, so validating only the selected STRUCT chain can miss an invalid
+    // required or narrowing sibling.
+    if (!projected_mapping_allows_file_filtering(*rewrite_it->second.root_mapping,
+                                                 &rewrite_it->second.scan_projection)) {
         return false;
     }
     for (size_t idx = 0; idx < struct_element_chain.size(); ++idx) {

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -843,11 +843,21 @@ static bool needs_complex_file_slot_cast(const DataTypePtr& file_type,
 
 static bool collect_struct_element_chain(const VExprSPtr& expr, std::vector<VExprSPtr>* chain) {
     DORIS_CHECK(chain != nullptr);
-    if (!is_struct_element_expr(expr)) {
+    const auto is_supported_element = [](const VExprSPtr& candidate) {
+        if (is_struct_element_expr(candidate)) {
+            return true;
+        }
+        return candidate != nullptr && candidate->get_num_children() == 2 &&
+               candidate->fn().name.function_name == "element_at" &&
+               candidate->children()[0]->data_type() != nullptr &&
+               remove_nullable(candidate->children()[0]->data_type())->get_primitive_type() ==
+                       TYPE_ARRAY;
+    };
+    if (!is_supported_element(expr)) {
         return false;
     }
     const auto& parent = expr->children()[0];
-    if (is_struct_element_expr(parent)) {
+    if (is_supported_element(parent)) {
         if (!collect_struct_element_chain(parent, chain)) {
             return false;
         }
@@ -892,7 +902,8 @@ static bool rewrite_struct_element_path_to_file_expr(
     std::vector<VExprSPtr> struct_element_chain;
     if (!collect_struct_element_chain(expr, &struct_element_chain) ||
         struct_element_chain.size() != resolved.file_child_names.size() ||
-        struct_element_chain.size() != resolved.file_child_types.size()) {
+        struct_element_chain.size() != resolved.file_child_types.size() ||
+        struct_element_chain.size() != resolved.file_array_elements.size()) {
         return false;
     }
 
@@ -934,8 +945,10 @@ static bool rewrite_struct_element_path_to_file_expr(
     struct_element_chain.front()->set_children(std::move(root_children));
     for (size_t idx = 0; idx < struct_element_chain.size(); ++idx) {
         auto children = struct_element_chain[idx]->children();
-        children[1] = create_file_struct_child_name_literal(resolved.file_child_names[idx],
-                                                            rewrite_context);
+        if (!resolved.file_array_elements[idx]) {
+            children[1] = create_file_struct_child_name_literal(resolved.file_child_names[idx],
+                                                                rewrite_context);
+        }
         struct_element_chain[idx]->set_children(std::move(children));
         // The selector name and the expression return type must be moved to file schema together.
         // Example:
@@ -2245,6 +2258,7 @@ Status TableColumnMapper::create_scan_request(
     }
     file_request->non_predicate_positions.clear();
     file_request->conjuncts.clear();
+    file_request->metadata_pruning_safe_conjunct_count = 0;
     file_request->delete_conjuncts.clear();
     _filter_entries.clear();
     // 1. Build referenced non-predicate columns
@@ -2471,6 +2485,9 @@ Status TableColumnMapper::localize_filters(const std::vector<TableFilter>& table
             auto localized_conjunct = VExprContext::create_shared(std::move(localized_root));
             RETURN_IF_ERROR(rewrite_context.prepare_created_exprs(localized_conjunct.get()));
             file_request->conjuncts.push_back(std::move(localized_conjunct));
+            if (table_filter.metadata_pruning_safe) {
+                ++file_request->metadata_pruning_safe_conjunct_count;
+            }
             for (const auto global_index : table_filter.global_indices) {
                 const auto* mapping = _find_filter_mapping(global_index);
                 if (mapping != nullptr && mapping->file_local_id.has_value() &&

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -903,6 +903,7 @@ static bool rewrite_struct_element_path_to_file_expr(
     if (!collect_struct_element_chain(expr, &struct_element_chain) ||
         struct_element_chain.size() != resolved.file_child_names.size() ||
         struct_element_chain.size() != resolved.file_child_types.size() ||
+        struct_element_chain.size() != resolved.table_child_types.size() ||
         struct_element_chain.size() != resolved.file_array_elements.size()) {
         return false;
     }
@@ -927,8 +928,11 @@ static bool rewrite_struct_element_path_to_file_expr(
         return false;
     }
     for (size_t idx = 0; idx < struct_element_chain.size(); ++idx) {
-        if (!can_filter_before_table_nullability_alignment(
-                    resolved.file_child_types[idx], struct_element_chain[idx]->data_type())) {
+        // Accessor results become nullable for missing ARRAY indices and NULL parents. Compare the
+        // file child with the declared table child instead, or that execution-only wrapper can
+        // hide a nullable-file-to-required-table contract violation before alignment reports it.
+        if (!can_filter_before_table_nullability_alignment(resolved.file_child_types[idx],
+                                                           resolved.table_child_types[idx])) {
             return false;
         }
     }

--- a/be/src/format_v2/column_mapper_nested.cpp
+++ b/be/src/format_v2/column_mapper_nested.cpp
@@ -88,7 +88,13 @@ static bool parse_struct_child_selector(const VExprSPtr& expr, StructChildSelect
 
 static bool extract_nested_struct_path(const VExprSPtr& expr, NestedStructPath* path) {
     DORIS_CHECK(path != nullptr);
-    if (!is_struct_element_expr(expr)) {
+    const bool is_struct_element = is_struct_element_expr(expr);
+    const bool is_array_element =
+            expr != nullptr && expr->get_num_children() == 2 &&
+            expr->fn().name.function_name == "element_at" &&
+            expr->children()[0]->data_type() != nullptr &&
+            remove_nullable(expr->children()[0]->data_type())->get_primitive_type() == TYPE_ARRAY;
+    if (!is_struct_element && !is_array_element) {
         return false;
     }
 
@@ -96,6 +102,13 @@ static bool extract_nested_struct_path(const VExprSPtr& expr, NestedStructPath* 
     StructChildSelector selector;
     if (!parse_struct_child_selector(expr->children()[1], &selector)) {
         return false;
+    }
+    if (is_array_element) {
+        if (selector.by_name) {
+            return false;
+        }
+        // Every array ordinal is represented by the same repeated Parquet element projection.
+        selector.is_array_element = true;
     }
 
     const auto& parent = expr->children()[0];
@@ -118,6 +131,9 @@ static bool extract_nested_struct_path(const VExprSPtr& expr, NestedStructPath* 
 
 static const ColumnDefinition* resolve_file_child(const std::vector<ColumnDefinition>& children,
                                                   const StructChildSelector& selector) {
+    if (selector.is_array_element) {
+        return children.size() == 1 ? &children[0] : nullptr;
+    }
     if (selector.by_name) {
         const auto child_it = std::ranges::find_if(children, [&](const ColumnDefinition& child) {
             return child.name == selector.name;
@@ -143,6 +159,14 @@ static const DataTypeStruct* struct_type_or_null(const DataTypePtr& type) {
 
 static std::optional<int32_t> struct_child_index(const ColumnMapping& mapping,
                                                  const StructChildSelector& selector) {
+    if (selector.is_array_element) {
+        const auto nested_type = remove_nullable(mapping.table_type);
+        if (nested_type == nullptr || nested_type->get_primitive_type() != TYPE_ARRAY ||
+            mapping.child_mappings.size() != 1) {
+            return std::nullopt;
+        }
+        return 0;
+    }
     const auto* struct_type = struct_type_or_null(mapping.table_type);
     if (struct_type == nullptr) {
         return std::nullopt;
@@ -249,8 +273,10 @@ static NestedProjectionResolveResult resolve_nested_projection_with_mapping(
     return NestedProjectionResolveResult::RESOLVED;
 }
 
-static bool table_root_is_struct(const ColumnMapping& mapping) {
-    return struct_type_or_null(mapping.table_type) != nullptr;
+static bool table_root_is_nested_container(const ColumnMapping& mapping) {
+    const auto nested_type = remove_nullable(mapping.table_type);
+    return nested_type != nullptr && (nested_type->get_primitive_type() == TYPE_STRUCT ||
+                                      nested_type->get_primitive_type() == TYPE_ARRAY);
 }
 
 static const std::vector<ColumnDefinition>& scan_file_children(const ColumnMapping& mapping) {
@@ -344,7 +370,7 @@ bool resolve_nested_struct_path_for_file(const NestedStructPath& path,
         return false;
     }
     if (mapping_result == NestedProjectionResolveResult::NOT_REPRESENTED) {
-        if (!table_root_is_struct(*mapping_it)) {
+        if (!table_root_is_nested_container(*mapping_it)) {
             return false;
         }
         LocalColumnIndex child_projection;
@@ -381,6 +407,10 @@ bool resolve_nested_struct_path_for_file(const NestedStructPath& path,
         resolved->file_child_types.size() != path.selectors.size()) {
         *resolved = {};
         return false;
+    }
+    resolved->file_array_elements.reserve(path.selectors.size());
+    for (const auto& selector : path.selectors) {
+        resolved->file_array_elements.push_back(selector.is_array_element);
     }
     return true;
 }

--- a/be/src/format_v2/column_mapper_nested.cpp
+++ b/be/src/format_v2/column_mapper_nested.cpp
@@ -26,6 +26,7 @@
 #include "common/cast_set.h"
 #include "common/exception.h"
 #include "core/assert_cast.h"
+#include "core/data_type/data_type_array.h"
 #include "core/data_type/data_type_nullable.h"
 #include "core/data_type/data_type_struct.h"
 #include "core/data_type/primitive_type.h"
@@ -115,6 +116,7 @@ static bool extract_nested_struct_path(const VExprSPtr& expr, NestedStructPath* 
     if (parent->is_slot_ref()) {
         const auto* slot_ref = assert_cast<const VSlotRef*>(parent.get());
         path->root_global_index = slot_ref_global_index(*slot_ref);
+        path->root_table_type = slot_ref->data_type();
         path->selectors.clear();
         path->selectors.push_back(std::move(selector));
         return true;
@@ -155,6 +157,32 @@ static const DataTypeStruct* struct_type_or_null(const DataTypePtr& type) {
         return nullptr;
     }
     return assert_cast<const DataTypeStruct*>(nested_type.get());
+}
+
+static DataTypePtr resolve_table_child_type(const DataTypePtr& parent_type,
+                                            const StructChildSelector& selector) {
+    if (parent_type == nullptr) {
+        return nullptr;
+    }
+    const auto nested_type = remove_nullable(parent_type);
+    if (selector.is_array_element) {
+        if (nested_type->get_primitive_type() != TYPE_ARRAY) {
+            return nullptr;
+        }
+        return assert_cast<const DataTypeArray*>(nested_type.get())->get_nested_type();
+    }
+    const auto* struct_type = struct_type_or_null(nested_type);
+    if (struct_type == nullptr) {
+        return nullptr;
+    }
+    if (selector.by_name) {
+        const auto position = struct_type->try_get_position_by_name(selector.name);
+        return position.has_value() ? struct_type->get_element(*position) : nullptr;
+    }
+    if (selector.ordinal == 0 || selector.ordinal > struct_type->get_elements().size()) {
+        return nullptr;
+    }
+    return struct_type->get_element(selector.ordinal - 1);
 }
 
 static std::optional<int32_t> struct_child_index(const ColumnMapping& mapping,
@@ -409,8 +437,18 @@ bool resolve_nested_struct_path_for_file(const NestedStructPath& path,
         return false;
     }
     resolved->file_array_elements.reserve(path.selectors.size());
+    resolved->table_child_types.reserve(path.selectors.size());
+    auto table_child_type = path.root_table_type;
     for (const auto& selector : path.selectors) {
         resolved->file_array_elements.push_back(selector.is_array_element);
+        if (path.root_table_type != nullptr) {
+            table_child_type = resolve_table_child_type(table_child_type, selector);
+            if (table_child_type == nullptr) {
+                *resolved = {};
+                return false;
+            }
+            resolved->table_child_types.push_back(table_child_type);
+        }
     }
     return true;
 }

--- a/be/src/format_v2/column_mapper_nested.h
+++ b/be/src/format_v2/column_mapper_nested.h
@@ -42,6 +42,7 @@ struct StructChildSelector {
 
 struct NestedStructPath {
     GlobalIndex root_global_index;
+    DataTypePtr root_table_type;
     std::vector<StructChildSelector> selectors;
 };
 
@@ -49,6 +50,7 @@ struct ResolvedNestedStructPath {
     LocalColumnIndex file_projection;
     std::vector<std::string> file_child_names;
     std::vector<DataTypePtr> file_child_types;
+    std::vector<DataTypePtr> table_child_types;
     std::vector<bool> file_array_elements;
 };
 

--- a/be/src/format_v2/column_mapper_nested.h
+++ b/be/src/format_v2/column_mapper_nested.h
@@ -34,6 +34,7 @@
 namespace doris::format {
 
 struct StructChildSelector {
+    bool is_array_element = false;
     bool by_name = true;
     std::string name;
     size_t ordinal = 0;
@@ -48,6 +49,7 @@ struct ResolvedNestedStructPath {
     LocalColumnIndex file_projection;
     std::vector<std::string> file_child_names;
     std::vector<DataTypePtr> file_child_types;
+    std::vector<bool> file_array_elements;
 };
 
 // A split-local literal produced by slot-literal predicate localization. This wrapper keeps the

--- a/be/src/format_v2/file_reader.cpp
+++ b/be/src/format_v2/file_reader.cpp
@@ -74,6 +74,8 @@ std::string FileScanRequest::debug_string() const {
         out << column_id << ":" << block_position;
     }
     out << "}, conjunct_count=" << conjuncts.size()
+        << ", metadata_pruning_safe_conjunct_count=" << metadata_pruning_safe_conjunct_count
+        << ", constant_pruning_safe_table_filter_count=" << constant_pruning_safe_table_filter_count
         << ", delete_conjunct_count=" << delete_conjuncts.size() << ", variant_schema_overrides="
         << join_debug_strings(
                    variant_schema_overrides,

--- a/be/src/format_v2/file_reader.h
+++ b/be/src/format_v2/file_reader.h
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
@@ -84,6 +85,9 @@ struct FileScanRequest {
     std::map<LocalColumnId, LocalIndex> non_predicate_positions;
     // Row-level filters converted to file-local expressions from table-level predicates.
     VExprContextSPtrs conjuncts;
+    // Metadata pruning may use only this prefix. A later predicate must not jump over an earlier
+    // non-deterministic or error-preserving conjunct in the original row-level order.
+    size_t metadata_pruning_safe_conjunct_count = std::numeric_limits<size_t>::max();
     // Delete predicates converted to file-local expressions. A TRUE result means that the row is
     // deleted, so readers must invert each result when building their keep filter.
     VExprContextSPtrs delete_conjuncts;

--- a/be/src/format_v2/file_reader.h
+++ b/be/src/format_v2/file_reader.h
@@ -88,6 +88,9 @@ struct FileScanRequest {
     // Metadata pruning may use only this prefix. A later predicate must not jump over an earlier
     // non-deterministic or error-preserving conjunct in the original row-level order.
     size_t metadata_pruning_safe_conjunct_count = std::numeric_limits<size_t>::max();
+    // Constant split pruning may use only this table-filter prefix after mapping. A rejected
+    // file-local rewrite is a materialization barrier even when a later filter is constant.
+    size_t constant_pruning_safe_table_filter_count = std::numeric_limits<size_t>::max();
     // Delete predicates converted to file-local expressions. A TRUE result means that the row is
     // deleted, so readers must invert each result when building their keep filter.
     VExprContextSPtrs delete_conjuncts;

--- a/be/src/format_v2/orc/orc_reader.cpp
+++ b/be/src/format_v2/orc/orc_reader.cpp
@@ -1380,7 +1380,9 @@ Status OrcReader::_configure_row_reader_projection() {
 }
 
 Status OrcReader::_init_search_argument_from_local_filters() {
-    if (!_state->enable_filter_by_min_max || _request->conjuncts.empty()) {
+    const size_t safe_count =
+            std::min(_request->metadata_pruning_safe_conjunct_count, _request->conjuncts.size());
+    if (!_state->enable_filter_by_min_max || safe_count == 0) {
         return Status::OK();
     }
 
@@ -1388,7 +1390,10 @@ Status OrcReader::_init_search_argument_from_local_filters() {
         auto builder = ::orc::SearchArgumentFactory::newBuilder();
         bool has_pushdown = false;
         builder->startAnd();
-        for (const auto& conjunct : _request->conjuncts) {
+        // ORC may omit unsupported expressions from a SARG, so a later predicate must not cross
+        // an earlier error-preserving barrier.
+        for (size_t i = 0; i < safe_count; ++i) {
+            const auto& conjunct = _request->conjuncts[i];
             if (conjunct == nullptr) {
                 continue;
             }

--- a/be/src/format_v2/parquet/parquet_profile.cpp
+++ b/be/src/format_v2/parquet/parquet_profile.cpp
@@ -250,6 +250,14 @@ void ParquetProfile::init(RuntimeProfile* profile) {
                                                              TUnit::UNIT, parquet_profile, 1);
     rows_filtered_by_dict_filter = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "RowsFilteredByDictFilter",
                                                                 TUnit::UNIT, parquet_profile, 1);
+    bloom_filter_probe_attempts = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "BloomFilterProbeAttempts",
+                                                               TUnit::UNIT, parquet_profile, 1);
+    bloom_filter_probe_successes = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "BloomFilterProbeSuccesses", TUnit::UNIT, parquet_profile, 1);
+    bloom_filter_conservative_fallbacks = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "BloomFilterConservativeFallbacks", TUnit::UNIT, parquet_profile, 1);
+    bloom_filter_corrupt_rejections = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "BloomFilterCorruptRejections", TUnit::UNIT, parquet_profile, 1);
     bloom_filter_read_time =
             ADD_CHILD_TIMER_WITH_LEVEL(profile, "BloomFilterReadTime", parquet_profile, 1);
 }
@@ -271,6 +279,11 @@ void ParquetProfile::update_pruning_stats(const ParquetPruningStats& pruning_sta
     COUNTER_UPDATE(filtered_bytes, pruning_stats.filtered_bytes);
     COUNTER_UPDATE(filtered_page_rows, pruning_stats.filtered_page_rows);
     COUNTER_UPDATE(page_index_read_calls, pruning_stats.page_index_read_calls);
+    COUNTER_UPDATE(bloom_filter_probe_attempts, pruning_stats.bloom_filter_probe_attempts);
+    COUNTER_UPDATE(bloom_filter_probe_successes, pruning_stats.bloom_filter_probe_successes);
+    COUNTER_UPDATE(bloom_filter_conservative_fallbacks,
+                   pruning_stats.bloom_filter_conservative_fallbacks);
+    COUNTER_UPDATE(bloom_filter_corrupt_rejections, pruning_stats.bloom_filter_corrupt_rejections);
     COUNTER_UPDATE(bloom_filter_read_time, pruning_stats.bloom_filter_read_time);
     COUNTER_UPDATE(row_group_filter_time, pruning_stats.row_group_filter_time);
     COUNTER_UPDATE(page_index_filter_time, pruning_stats.page_index_filter_time);
@@ -300,6 +313,11 @@ void ParquetProfile::update_deferred_pruning_stats(const ParquetPruningStats& pr
     COUNTER_UPDATE(filtered_bytes, pruning_stats.filtered_bytes);
     COUNTER_UPDATE(filtered_page_rows, pruning_stats.filtered_page_rows);
     COUNTER_UPDATE(page_index_read_calls, pruning_stats.page_index_read_calls);
+    COUNTER_UPDATE(bloom_filter_probe_attempts, pruning_stats.bloom_filter_probe_attempts);
+    COUNTER_UPDATE(bloom_filter_probe_successes, pruning_stats.bloom_filter_probe_successes);
+    COUNTER_UPDATE(bloom_filter_conservative_fallbacks,
+                   pruning_stats.bloom_filter_conservative_fallbacks);
+    COUNTER_UPDATE(bloom_filter_corrupt_rejections, pruning_stats.bloom_filter_corrupt_rejections);
     COUNTER_UPDATE(bloom_filter_read_time, pruning_stats.bloom_filter_read_time);
     COUNTER_UPDATE(row_group_filter_time, pruning_stats.row_group_filter_time);
     COUNTER_UPDATE(page_index_filter_time, pruning_stats.page_index_filter_time);

--- a/be/src/format_v2/parquet/parquet_profile.h
+++ b/be/src/format_v2/parquet/parquet_profile.h
@@ -258,6 +258,10 @@ struct ParquetProfile {
     RuntimeProfile::Counter* dict_filter_unsupported_columns = nullptr;
     RuntimeProfile::Counter* dict_filter_read_failures = nullptr;
     RuntimeProfile::Counter* rows_filtered_by_dict_filter = nullptr;
+    RuntimeProfile::Counter* bloom_filter_probe_attempts = nullptr;
+    RuntimeProfile::Counter* bloom_filter_probe_successes = nullptr;
+    RuntimeProfile::Counter* bloom_filter_conservative_fallbacks = nullptr;
+    RuntimeProfile::Counter* bloom_filter_corrupt_rejections = nullptr;
     RuntimeProfile::Counter* bloom_filter_read_time = nullptr;
 };
 

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -1286,27 +1286,15 @@ ParquetRowGroupPruneReason native_bloom_filter_prune_reason(
             std::min(request.metadata_pruning_safe_conjunct_count, request.conjuncts.size());
     const VExprContextSPtrs safe_conjuncts(request.conjuncts.begin(),
                                            request.conjuncts.begin() + safe_count);
-    const auto conjuncts_by_slot = collect_conjuncts_by_single_slot(
-            safe_conjuncts, expr_zonemap::single_slot_bloom_filter_index);
-    for (const auto& [slot_index, conjuncts] : conjuncts_by_slot) {
-        const auto file_column_id = file_column_id_by_block_position(request, slot_index);
-        if (!file_column_id.has_value()) {
-            continue;
-        }
-        const auto* column_schema = resolve_local_leaf_schema(file_schema, *file_column_id);
-        if (column_schema == nullptr) {
-            continue;
-        }
-        add_probe(*column_schema, slot_index, conjuncts);
-    }
-
+    // Resolve direct and nested probes in one conjunct-order pass. Deduplication happens only
+    // after first use so a later Bloom payload cannot be read before an earlier pruning probe.
     for (const auto& conjunct : safe_conjuncts) {
         if (conjunct == nullptr || conjunct->root() == nullptr ||
             !conjunct->root()->can_evaluate_bloom_filter()) {
             continue;
         }
         auto probe = expr_zonemap::extract_bloom_filter_predicate_probe(conjunct->root());
-        if (!probe.has_value() || probe->path.empty()) {
+        if (!probe.has_value()) {
             continue;
         }
         const auto file_column_id = file_column_id_by_block_position(request, probe->slot_index);
@@ -1314,7 +1302,9 @@ ParquetRowGroupPruneReason native_bloom_filter_prune_reason(
             continue;
         }
         const auto* column_schema =
-                resolve_bloom_filter_leaf_schema(file_schema, *file_column_id, *probe);
+                probe->path.empty()
+                        ? resolve_local_leaf_schema(file_schema, *file_column_id)
+                        : resolve_bloom_filter_leaf_schema(file_schema, *file_column_id, *probe);
         if (column_schema == nullptr ||
             !expr_zonemap::data_types_compatible(column_schema->type, probe->value_type)) {
             continue;

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -24,6 +24,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <string>
 #include <type_traits>
@@ -823,9 +824,9 @@ bool variant_statistics_exclude(const VariantShreddedPredicate& predicate,
 bool has_expr_zonemap_filter(const format::FileScanRequest& request, const RuntimeState*) {
     // FileScannerV2 metadata pruning is a fixed part of its scan pipeline and must not inherit
     // the legacy scanner's expression ZoneMap session gate.
-    // TODO: Fence metadata pruning at the first unsafe/error-preserving conjunct so a later
-    // ZoneMap predicate cannot bypass its row-level evaluation.
-    for (const auto& conjunct : request.conjuncts) {
+    const size_t safe_count =
+            std::min(request.metadata_pruning_safe_conjunct_count, request.conjuncts.size());
+    for (const auto& conjunct : request.conjuncts | std::views::take(safe_count)) {
         if (conjunct != nullptr && conjunct->root() != nullptr &&
             conjunct->root()->can_evaluate_zonemap_filter()) {
             return true;
@@ -1022,7 +1023,11 @@ bool check_native_statistics(const tparquet::FileMetaData& metadata,
                              const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
                              const format::FileScanRequest& request,
                              ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone) {
-    const auto slot_indexes = collect_expr_zonemap_slot_indexes(request.conjuncts);
+    const size_t safe_count =
+            std::min(request.metadata_pruning_safe_conjunct_count, request.conjuncts.size());
+    const VExprContextSPtrs safe_conjuncts(request.conjuncts.begin(),
+                                           request.conjuncts.begin() + safe_count);
+    const auto slot_indexes = collect_expr_zonemap_slot_indexes(safe_conjuncts);
     if (slot_indexes.empty()) {
         return false;
     }
@@ -1057,7 +1062,7 @@ bool check_native_statistics(const tparquet::FileMetaData& metadata,
         }
         add_slot_zonemap(&ctx, slot_index, column_schema->type, std::move(zone_map));
     }
-    const auto result = VExprContext::evaluate_zonemap_filter(request.conjuncts, ctx);
+    const auto result = VExprContext::evaluate_zonemap_filter(safe_conjuncts, ctx);
     accumulate_zonemap_stats(ctx, pruning_stats);
     return result == ZoneMapFilterResult::kNoMatch;
 }
@@ -1167,8 +1172,12 @@ ParquetRowGroupPruneReason native_dictionary_prune_reason(
     if (file_context == nullptr || file_context->native_metadata == nullptr) {
         return ParquetRowGroupPruneReason::NONE;
     }
+    const size_t safe_count =
+            std::min(request.metadata_pruning_safe_conjunct_count, request.conjuncts.size());
+    const VExprContextSPtrs safe_conjuncts(request.conjuncts.begin(),
+                                           request.conjuncts.begin() + safe_count);
     const auto conjuncts_by_slot = collect_conjuncts_by_single_slot(
-            request.conjuncts, expr_zonemap::single_slot_dictionary_index);
+            safe_conjuncts, expr_zonemap::single_slot_dictionary_index);
     for (const auto& [slot_index, conjuncts] : conjuncts_by_slot) {
         const auto file_column_id = file_column_id_by_block_position(request, slot_index);
         if (!file_column_id.has_value()) {
@@ -1236,41 +1245,35 @@ ParquetRowGroupPruneReason native_bloom_filter_prune_reason(
     if (file_context == nullptr || file_context->native_file == nullptr) {
         return ParquetRowGroupPruneReason::NONE;
     }
-    std::map<int, std::unique_ptr<native::BlockSplitBloomFilter>> bloom_filters_by_leaf;
-    const auto bloom_filter_excludes = [&](const ParquetColumnSchema& column_schema, int slot_index,
-                                           const VExprContextSPtrs& conjuncts) {
+    struct BloomProbeGroup {
+        const ParquetColumnSchema* column_schema = nullptr;
+        int slot_index = -1;
+        VExprContextSPtrs conjuncts;
+    };
+    std::map<int, std::vector<BloomProbeGroup>> probes_by_leaf;
+    const auto add_probe = [&](const ParquetColumnSchema& column_schema, int slot_index,
+                               VExprContextSPtrs conjuncts) {
         if (column_schema.type == nullptr ||
             !native_metadata_predicate_is_type_safe(column_schema) ||
             !bloom_filter_supported(column_schema) || column_schema.leaf_column_id < 0 ||
             column_schema.leaf_column_id >= static_cast<int>(row_group.columns.size())) {
-            return false;
+            return;
         }
         const auto& chunk = row_group.columns[column_schema.leaf_column_id];
         if (!chunk.__isset.meta_data) {
-            return false;
+            return;
         }
-        // A physical leaf can back multiple retained predicates. Cache failed reads as null too so
-        // unreadable remote Bloom metadata is not fetched repeatedly for the same row group.
-        auto [bloom_filter_it, inserted] =
-                bloom_filters_by_leaf.try_emplace(column_schema.leaf_column_id);
-        if (inserted) {
-            int64_t timer_sink = 0;
-            SCOPED_RAW_TIMER(pruning_stats == nullptr ? &timer_sink
-                                                      : &pruning_stats->bloom_filter_read_time);
-            const auto status =
-                    read_native_bloom_filter(chunk.meta_data, file_context->native_file,
-                                             file_context->native_io_ctx, &bloom_filter_it->second);
-            if (!status.ok()) {
-                bloom_filter_it->second.reset();
-            }
-        }
-        return bloom_filter_it->second != nullptr &&
-               ParquetStatisticsUtils::NativeBloomFilterExcludes(
-                       column_schema, slot_index, conjuncts, *bloom_filter_it->second);
+        probes_by_leaf[column_schema.leaf_column_id].push_back({.column_schema = &column_schema,
+                                                                .slot_index = slot_index,
+                                                                .conjuncts = std::move(conjuncts)});
     };
 
+    const size_t safe_count =
+            std::min(request.metadata_pruning_safe_conjunct_count, request.conjuncts.size());
+    const VExprContextSPtrs safe_conjuncts(request.conjuncts.begin(),
+                                           request.conjuncts.begin() + safe_count);
     const auto conjuncts_by_slot = collect_conjuncts_by_single_slot(
-            request.conjuncts, expr_zonemap::single_slot_bloom_filter_index);
+            safe_conjuncts, expr_zonemap::single_slot_bloom_filter_index);
     for (const auto& [slot_index, conjuncts] : conjuncts_by_slot) {
         const auto file_column_id = file_column_id_by_block_position(request, slot_index);
         if (!file_column_id.has_value()) {
@@ -1280,12 +1283,10 @@ ParquetRowGroupPruneReason native_bloom_filter_prune_reason(
         if (column_schema == nullptr) {
             continue;
         }
-        if (bloom_filter_excludes(*column_schema, slot_index, conjuncts)) {
-            return ParquetRowGroupPruneReason::BLOOM_FILTER;
-        }
+        add_probe(*column_schema, slot_index, conjuncts);
     }
 
-    for (const auto& conjunct : request.conjuncts) {
+    for (const auto& conjunct : safe_conjuncts) {
         if (conjunct == nullptr || conjunct->root() == nullptr ||
             !conjunct->root()->can_evaluate_bloom_filter()) {
             continue;
@@ -1304,8 +1305,31 @@ ParquetRowGroupPruneReason native_bloom_filter_prune_reason(
             !expr_zonemap::data_types_compatible(column_schema->type, probe->value_type)) {
             continue;
         }
-        if (bloom_filter_excludes(*column_schema, probe->slot_index, {conjunct})) {
-            return ParquetRowGroupPruneReason::BLOOM_FILTER;
+        add_probe(*column_schema, probe->slot_index, {conjunct});
+    }
+
+    for (const auto& [leaf_column_id, probes] : probes_by_leaf) {
+        std::unique_ptr<native::BlockSplitBloomFilter> bloom_filter;
+        int64_t timer_sink = 0;
+        {
+            SCOPED_RAW_TIMER(pruning_stats == nullptr ? &timer_sink
+                                                      : &pruning_stats->bloom_filter_read_time);
+            const auto status = read_native_bloom_filter(
+                    row_group.columns[leaf_column_id].meta_data, file_context->native_file,
+                    file_context->native_io_ctx, &bloom_filter);
+            if (!status.ok()) {
+                bloom_filter.reset();
+            }
+        }
+        if (bloom_filter == nullptr) {
+            continue;
+        }
+        // Keep at most one decoded payload live while reusing it for every predicate on this leaf.
+        for (const auto& probe : probes) {
+            if (ParquetStatisticsUtils::NativeBloomFilterExcludes(
+                        *probe.column_schema, probe.slot_index, probe.conjuncts, *bloom_filter)) {
+                return ParquetRowGroupPruneReason::BLOOM_FILTER;
+            }
         }
     }
     return ParquetRowGroupPruneReason::NONE;
@@ -1924,7 +1948,9 @@ Status select_row_group_ranges_by_native_page_index(
 
     std::map<int, VExprContextSPtrs> conjuncts_by_slot;
     VExprContextSPtrs multi_slot_conjuncts;
-    for (const auto& conjunct : request.conjuncts) {
+    const size_t safe_count =
+            std::min(request.metadata_pruning_safe_conjunct_count, request.conjuncts.size());
+    for (const auto& conjunct : request.conjuncts | std::views::take(safe_count)) {
         const auto slot_index = expr_zonemap::single_slot_zonemap_index(conjunct);
         if (slot_index >= 0) {
             conjuncts_by_slot[slot_index].push_back(conjunct);

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -1236,6 +1236,7 @@ ParquetRowGroupPruneReason native_bloom_filter_prune_reason(
     if (file_context == nullptr || file_context->native_file == nullptr) {
         return ParquetRowGroupPruneReason::NONE;
     }
+    std::map<int, std::unique_ptr<native::BlockSplitBloomFilter>> bloom_filters_by_leaf;
     const auto bloom_filter_excludes = [&](const ParquetColumnSchema& column_schema, int slot_index,
                                            const VExprContextSPtrs& conjuncts) {
         if (column_schema.type == nullptr ||
@@ -1248,18 +1249,24 @@ ParquetRowGroupPruneReason native_bloom_filter_prune_reason(
         if (!chunk.__isset.meta_data) {
             return false;
         }
-        std::unique_ptr<native::BlockSplitBloomFilter> bloom_filter;
-        Status status;
-        {
+        // A physical leaf can back multiple retained predicates. Cache failed reads as null too so
+        // unreadable remote Bloom metadata is not fetched repeatedly for the same row group.
+        auto [bloom_filter_it, inserted] =
+                bloom_filters_by_leaf.try_emplace(column_schema.leaf_column_id);
+        if (inserted) {
             int64_t timer_sink = 0;
             SCOPED_RAW_TIMER(pruning_stats == nullptr ? &timer_sink
                                                       : &pruning_stats->bloom_filter_read_time);
-            status = read_native_bloom_filter(chunk.meta_data, file_context->native_file,
-                                              file_context->native_io_ctx, &bloom_filter);
+            const auto status =
+                    read_native_bloom_filter(chunk.meta_data, file_context->native_file,
+                                             file_context->native_io_ctx, &bloom_filter_it->second);
+            if (!status.ok()) {
+                bloom_filter_it->second.reset();
+            }
         }
-        return status.ok() && bloom_filter != nullptr &&
-               ParquetStatisticsUtils::NativeBloomFilterExcludes(column_schema, slot_index,
-                                                                 conjuncts, *bloom_filter);
+        return bloom_filter_it->second != nullptr &&
+               ParquetStatisticsUtils::NativeBloomFilterExcludes(
+                       column_schema, slot_index, conjuncts, *bloom_filter_it->second);
     };
 
     const auto conjuncts_by_slot = collect_conjuncts_by_single_slot(

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -445,6 +445,55 @@ const ParquetColumnSchema* resolve_local_leaf_schema(
     return column_schema;
 }
 
+const ParquetColumnSchema* resolve_bloom_filter_leaf_schema(
+        const std::vector<std::unique_ptr<ParquetColumnSchema>>& schema,
+        const format::LocalColumnId file_column_id, const expr_zonemap::BloomFilterProbe& probe) {
+    if (probe.path.empty()) {
+        return resolve_local_leaf_schema(schema, file_column_id);
+    }
+    if (!file_column_id.is_valid() || file_column_id.value() >= static_cast<int>(schema.size())) {
+        return nullptr;
+    }
+    const ParquetColumnSchema* column_schema = schema[file_column_id.value()].get();
+    // A nested predicate must bind to its exact localized primitive path. Falling back to a
+    // sibling leaf's Bloom filter could turn absence in that sibling into an invalid row-group skip.
+    for (const auto& path_element : probe.path) {
+        if (column_schema == nullptr) {
+            return nullptr;
+        }
+        if (path_element.kind == expr_zonemap::BloomFilterPathKind::STRUCT_FIELD) {
+            if (column_schema->kind != ParquetColumnSchemaKind::STRUCT) {
+                return nullptr;
+            }
+            const ParquetColumnSchema* field_schema = nullptr;
+            if (!path_element.field_name.empty()) {
+                auto field = std::ranges::find_if(column_schema->children, [&](const auto& child) {
+                    return child != nullptr && child->name == path_element.field_name;
+                });
+                if (field != column_schema->children.end()) {
+                    field_schema = field->get();
+                }
+            } else if (path_element.field_ordinal >= 0 &&
+                       path_element.field_ordinal <
+                               static_cast<int32_t>(column_schema->children.size())) {
+                field_schema = column_schema->children[path_element.field_ordinal].get();
+            }
+            column_schema = field_schema;
+        } else {
+            if (column_schema->kind != ParquetColumnSchemaKind::LIST ||
+                column_schema->children.size() != 1) {
+                return nullptr;
+            }
+            column_schema = column_schema->children[0].get();
+        }
+    }
+    if (column_schema == nullptr || column_schema->kind != ParquetColumnSchemaKind::PRIMITIVE ||
+        column_schema->leaf_column_id < 0) {
+        return nullptr;
+    }
+    return column_schema;
+}
+
 std::optional<format::LocalColumnId> file_column_id_by_block_position(
         const format::FileScanRequest& request, int block_position) {
     for (const auto& [file_column_id, local_index] : request.local_positions) {
@@ -1187,23 +1236,17 @@ ParquetRowGroupPruneReason native_bloom_filter_prune_reason(
     if (file_context == nullptr || file_context->native_file == nullptr) {
         return ParquetRowGroupPruneReason::NONE;
     }
-    const auto conjuncts_by_slot = collect_conjuncts_by_single_slot(
-            request.conjuncts, expr_zonemap::single_slot_bloom_filter_index);
-    for (const auto& [slot_index, conjuncts] : conjuncts_by_slot) {
-        const auto file_column_id = file_column_id_by_block_position(request, slot_index);
-        if (!file_column_id.has_value()) {
-            continue;
+    const auto bloom_filter_excludes = [&](const ParquetColumnSchema& column_schema, int slot_index,
+                                           const VExprContextSPtrs& conjuncts) {
+        if (column_schema.type == nullptr ||
+            !native_metadata_predicate_is_type_safe(column_schema) ||
+            !bloom_filter_supported(column_schema) || column_schema.leaf_column_id < 0 ||
+            column_schema.leaf_column_id >= static_cast<int>(row_group.columns.size())) {
+            return false;
         }
-        const auto* column_schema = resolve_local_leaf_schema(file_schema, *file_column_id);
-        if (column_schema == nullptr || column_schema->type == nullptr ||
-            !native_metadata_predicate_is_type_safe(*column_schema) ||
-            !bloom_filter_supported(*column_schema) ||
-            column_schema->leaf_column_id >= static_cast<int>(row_group.columns.size())) {
-            continue;
-        }
-        const auto& chunk = row_group.columns[column_schema->leaf_column_id];
+        const auto& chunk = row_group.columns[column_schema.leaf_column_id];
         if (!chunk.__isset.meta_data) {
-            continue;
+            return false;
         }
         std::unique_ptr<native::BlockSplitBloomFilter> bloom_filter;
         Status status;
@@ -1214,11 +1257,47 @@ ParquetRowGroupPruneReason native_bloom_filter_prune_reason(
             status = read_native_bloom_filter(chunk.meta_data, file_context->native_file,
                                               file_context->native_io_ctx, &bloom_filter);
         }
-        if (!status.ok() || bloom_filter == nullptr) {
+        return status.ok() && bloom_filter != nullptr &&
+               ParquetStatisticsUtils::NativeBloomFilterExcludes(column_schema, slot_index,
+                                                                 conjuncts, *bloom_filter);
+    };
+
+    const auto conjuncts_by_slot = collect_conjuncts_by_single_slot(
+            request.conjuncts, expr_zonemap::single_slot_bloom_filter_index);
+    for (const auto& [slot_index, conjuncts] : conjuncts_by_slot) {
+        const auto file_column_id = file_column_id_by_block_position(request, slot_index);
+        if (!file_column_id.has_value()) {
             continue;
         }
-        if (ParquetStatisticsUtils::NativeBloomFilterExcludes(*column_schema, slot_index, conjuncts,
-                                                              *bloom_filter)) {
+        const auto* column_schema = resolve_local_leaf_schema(file_schema, *file_column_id);
+        if (column_schema == nullptr) {
+            continue;
+        }
+        if (bloom_filter_excludes(*column_schema, slot_index, conjuncts)) {
+            return ParquetRowGroupPruneReason::BLOOM_FILTER;
+        }
+    }
+
+    for (const auto& conjunct : request.conjuncts) {
+        if (conjunct == nullptr || conjunct->root() == nullptr ||
+            !conjunct->root()->can_evaluate_bloom_filter()) {
+            continue;
+        }
+        auto probe = expr_zonemap::extract_bloom_filter_predicate_probe(conjunct->root());
+        if (!probe.has_value() || probe->path.empty()) {
+            continue;
+        }
+        const auto file_column_id = file_column_id_by_block_position(request, probe->slot_index);
+        if (!file_column_id.has_value()) {
+            continue;
+        }
+        const auto* column_schema =
+                resolve_bloom_filter_leaf_schema(file_schema, *file_column_id, *probe);
+        if (column_schema == nullptr ||
+            !expr_zonemap::data_types_compatible(column_schema->type, probe->value_type)) {
+            continue;
+        }
+        if (bloom_filter_excludes(*column_schema, probe->slot_index, {conjunct})) {
             return ParquetRowGroupPruneReason::BLOOM_FILTER;
         }
     }

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -171,7 +171,12 @@ Status read_native_bloom_filter(const tparquet::ColumnMetaData& metadata,
                                   io_ctx));
     tparquet::BloomFilterHeader header;
     uint32_t header_size = cast_set<uint32_t>(bytes_read);
-    RETURN_IF_ERROR(deserialize_thrift_msg(header_buffer.data(), &header_size, true, &header));
+    const auto deserialize_status =
+            deserialize_thrift_msg(header_buffer.data(), &header_size, true, &header);
+    if (!deserialize_status.ok()) {
+        // Keep invalid on-disk metadata distinguishable from transient read failures in profiles.
+        return Status::Corruption("Malformed Parquet Bloom filter header");
+    }
     if (!header.algorithm.__isset.BLOCK || !header.compression.__isset.UNCOMPRESSED ||
         !header.hash.__isset.XXHASH || header.numBytes <= 0) {
         return Status::NotSupported("Unsupported Parquet Bloom filter encoding");
@@ -1250,7 +1255,14 @@ ParquetRowGroupPruneReason native_bloom_filter_prune_reason(
         int slot_index = -1;
         VExprContextSPtrs conjuncts;
     };
-    std::map<int, std::vector<BloomProbeGroup>> probes_by_leaf;
+    struct LeafBloomProbeGroup {
+        int leaf_column_id = -1;
+        std::vector<BloomProbeGroup> probes;
+    };
+    // The vector preserves first-probe order, while the map only deduplicates repeated leaves.
+    // This avoids reading a potentially large later payload before an earlier probe can prune.
+    std::vector<LeafBloomProbeGroup> probes_by_first_use;
+    std::map<int, size_t> group_index_by_leaf;
     const auto add_probe = [&](const ParquetColumnSchema& column_schema, int slot_index,
                                VExprContextSPtrs conjuncts) {
         if (column_schema.type == nullptr ||
@@ -1259,11 +1271,13 @@ ParquetRowGroupPruneReason native_bloom_filter_prune_reason(
             column_schema.leaf_column_id >= static_cast<int>(row_group.columns.size())) {
             return;
         }
-        const auto& chunk = row_group.columns[column_schema.leaf_column_id];
-        if (!chunk.__isset.meta_data) {
-            return;
+        const auto [group_it, inserted] = group_index_by_leaf.try_emplace(
+                column_schema.leaf_column_id, probes_by_first_use.size());
+        if (inserted) {
+            probes_by_first_use.push_back(
+                    {.leaf_column_id = column_schema.leaf_column_id, .probes = {}});
         }
-        probes_by_leaf[column_schema.leaf_column_id].push_back({.column_schema = &column_schema,
+        probes_by_first_use[group_it->second].probes.push_back({.column_schema = &column_schema,
                                                                 .slot_index = slot_index,
                                                                 .conjuncts = std::move(conjuncts)});
     };
@@ -1308,24 +1322,45 @@ ParquetRowGroupPruneReason native_bloom_filter_prune_reason(
         add_probe(*column_schema, probe->slot_index, {conjunct});
     }
 
-    for (const auto& [leaf_column_id, probes] : probes_by_leaf) {
+    for (const auto& leaf_group : probes_by_first_use) {
+        const int leaf_column_id = leaf_group.leaf_column_id;
+        if (pruning_stats != nullptr) {
+            ++pruning_stats->bloom_filter_probe_attempts;
+        }
+        const auto& chunk = row_group.columns[leaf_column_id];
+        if (!chunk.__isset.meta_data) {
+            if (pruning_stats != nullptr) {
+                ++pruning_stats->bloom_filter_conservative_fallbacks;
+            }
+            continue;
+        }
         std::unique_ptr<native::BlockSplitBloomFilter> bloom_filter;
+        Status bloom_status;
         int64_t timer_sink = 0;
         {
             SCOPED_RAW_TIMER(pruning_stats == nullptr ? &timer_sink
                                                       : &pruning_stats->bloom_filter_read_time);
-            const auto status = read_native_bloom_filter(
-                    row_group.columns[leaf_column_id].meta_data, file_context->native_file,
-                    file_context->native_io_ctx, &bloom_filter);
-            if (!status.ok()) {
+            bloom_status = read_native_bloom_filter(row_group.columns[leaf_column_id].meta_data,
+                                                    file_context->native_file,
+                                                    file_context->native_io_ctx, &bloom_filter);
+            if (!bloom_status.ok()) {
                 bloom_filter.reset();
             }
         }
         if (bloom_filter == nullptr) {
+            if (pruning_stats != nullptr) {
+                ++pruning_stats->bloom_filter_conservative_fallbacks;
+                if (bloom_status.is<ErrorCode::CORRUPTION>()) {
+                    ++pruning_stats->bloom_filter_corrupt_rejections;
+                }
+            }
             continue;
         }
+        if (pruning_stats != nullptr) {
+            ++pruning_stats->bloom_filter_probe_successes;
+        }
         // Keep at most one decoded payload live while reusing it for every predicate on this leaf.
-        for (const auto& probe : probes) {
+        for (const auto& probe : leaf_group.probes) {
             if (ParquetStatisticsUtils::NativeBloomFilterExcludes(
                         *probe.column_schema, probe.slot_index, probe.conjuncts, *bloom_filter)) {
                 return ParquetRowGroupPruneReason::BLOOM_FILTER;

--- a/be/src/format_v2/parquet/parquet_statistics.h
+++ b/be/src/format_v2/parquet/parquet_statistics.h
@@ -80,6 +80,10 @@ struct ParquetPruningStats {
     int64_t selected_row_ranges = 0;                 // selected row range count
     int64_t page_index_read_calls = 0;               // Page Index read count
     int64_t bloom_filter_read_time = 0;              // Bloom filter read time (ns)
+    int64_t bloom_filter_probe_attempts = 0;         // unique leaf Bloom probes attempted
+    int64_t bloom_filter_probe_successes = 0;        // usable Bloom payloads decoded
+    int64_t bloom_filter_conservative_fallbacks = 0; // unavailable/unreadable Blooms retained
+    int64_t bloom_filter_corrupt_rejections = 0;     // malformed Blooms rejected conservatively
     int64_t row_group_filter_time = 0;               // row-group pruning time (ns)
     int64_t page_index_filter_time = 0;              // page-index pruning time (ns)
     int64_t read_page_index_time = 0;                // page-index read time (ns)

--- a/be/src/format_v2/table_reader.cpp
+++ b/be/src/format_v2/table_reader.cpp
@@ -822,8 +822,13 @@ Status TableReader::_build_table_filters_from_conjuncts() {
         if (in_safe_prefix && !_is_safe_to_pre_execute(conjunct)) {
             in_safe_prefix = false;
         }
+        const size_t first_new_filter = _table_filters.size();
         RETURN_IF_ERROR(
                 build_table_filters_from_conjunct(conjunct, _runtime_state, &_table_filters));
+        for (size_t filter_idx = first_new_filter; filter_idx < _table_filters.size();
+             ++filter_idx) {
+            _table_filters[filter_idx].metadata_pruning_safe = in_safe_prefix;
+        }
         if (in_safe_prefix) {
             _constant_pruning_safe_filter_count = _table_filters.size();
         }

--- a/be/src/format_v2/table_reader.h
+++ b/be/src/format_v2/table_reader.h
@@ -452,6 +452,9 @@ protected:
         auto file_request = std::make_shared<FileScanRequest>();
         RETURN_IF_ERROR(_data_reader.column_mapper->create_scan_request(
                 _table_filters, _projected_columns, file_request.get(), _runtime_state));
+        _constant_pruning_safe_filter_count =
+                std::min(_constant_pruning_safe_filter_count,
+                         file_request->constant_pruning_safe_table_filter_count);
         bool constant_filter_pruned_split = false;
         RETURN_IF_ERROR(_evaluate_constant_filters(&constant_filter_pruned_split));
         if (constant_filter_pruned_split) {

--- a/be/src/format_v2/table_reader.h
+++ b/be/src/format_v2/table_reader.h
@@ -82,6 +82,7 @@ using DeleteRows = std::vector<int64_t>;
 struct TableFilter {
     VExprContextSPtr conjunct;
     std::vector<GlobalIndex> global_indices;
+    bool metadata_pruning_safe = true;
 };
 
 struct ScanTask {

--- a/be/test/exprs/expr_zonemap_filter_test.cpp
+++ b/be/test/exprs/expr_zonemap_filter_test.cpp
@@ -267,6 +267,27 @@ private:
     std::string _expr_name;
 };
 
+class MetadataBloomPredicateExpr final : public VExpr {
+public:
+    explicit MetadataBloomPredicateExpr(VExprSPtr probe)
+            : VExpr(std::make_shared<DataTypeUInt8>(), false) {
+        add_child(std::move(probe));
+    }
+
+    const std::string& expr_name() const override { return _expr_name; }
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
+                               ColumnPtr&) const override {
+        return Status::InternalError("MetadataBloomPredicateExpr is metadata-only");
+    }
+    bool can_evaluate_bloom_filter() const override { return true; }
+    ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext&) const override {
+        return ZoneMapFilterResult::kMayMatch;
+    }
+
+private:
+    const std::string _expr_name = "MetadataBloomPredicateExpr";
+};
+
 class UnsupportedSingleSlotExpr final : public VExpr {
 public:
     explicit UnsupportedSingleSlotExpr(const VExprSPtr& slot) {
@@ -719,6 +740,51 @@ TEST(ExprZonemapFilterTest, EqualityBloomAcceptsStructAndListLeafAccessors) {
               equals.evaluate_bloom_filter(bloom_ctx, {nested_leaf, make_int_literal(2)}));
 }
 
+TEST(ExprZonemapFilterTest, CompoundBloomProbeRequiresOneUniqueNestedLeaf) {
+    const auto make_accessor = [](const DataTypePtr& struct_type, const DataTypePtr& leaf_type,
+                                  std::string field_name) {
+        return std::make_shared<MetadataAccessorExpr>("element_at", leaf_type,
+                                                      make_slot(0, struct_type),
+                                                      make_string_literal(std::move(field_name)));
+    };
+    const auto compound_probe = [](const VExprSPtr& first, const VExprSPtr& second,
+                                   const VExprSPtr& outer) {
+        auto inner =
+                std::make_shared<VCompoundPred>(make_compound_node(TExprOpcode::COMPOUND_AND, 2));
+        inner->add_child(std::make_shared<MetadataBloomPredicateExpr>(first));
+        inner->add_child(std::make_shared<MetadataBloomPredicateExpr>(second));
+        auto root =
+                std::make_shared<VCompoundPred>(make_compound_node(TExprOpcode::COMPOUND_OR, 2));
+        root->add_child(std::move(inner));
+        root->add_child(std::make_shared<MetadataBloomPredicateExpr>(outer));
+        EXPECT_TRUE(root->can_evaluate_bloom_filter());
+        return expr_zonemap::extract_bloom_filter_predicate_probe(root);
+    };
+
+    auto int_leaf = int_type();
+    auto same_type_struct =
+            std::make_shared<DataTypeStruct>(DataTypes {int_leaf, int_leaf}, Strings {"a", "b"});
+    EXPECT_FALSE(compound_probe(make_accessor(same_type_struct, int_leaf, "a"),
+                                make_accessor(same_type_struct, int_leaf, "b"),
+                                make_accessor(same_type_struct, int_leaf, "a"))
+                         .has_value());
+
+    auto string_leaf = std::make_shared<DataTypeString>();
+    auto mixed_type_struct =
+            std::make_shared<DataTypeStruct>(DataTypes {int_leaf, string_leaf}, Strings {"a", "b"});
+    EXPECT_FALSE(compound_probe(make_accessor(mixed_type_struct, int_leaf, "a"),
+                                make_accessor(mixed_type_struct, string_leaf, "b"),
+                                make_accessor(mixed_type_struct, int_leaf, "a"))
+                         .has_value());
+
+    auto same_leaf_probe = compound_probe(make_accessor(same_type_struct, int_leaf, "a"),
+                                          make_accessor(same_type_struct, int_leaf, "a"),
+                                          make_accessor(same_type_struct, int_leaf, "a"));
+    ASSERT_TRUE(same_leaf_probe.has_value());
+    ASSERT_EQ(same_leaf_probe->path.size(), 1);
+    EXPECT_EQ(same_leaf_probe->path[0].field_name, "a");
+}
+
 TEST(ExprZonemapFilterTest, MissingSlotTypeCountsUnsupportedZonemapEvalOnce) {
     auto type = int_type();
     auto slot = make_slot(0, type);
@@ -1065,6 +1131,44 @@ TEST(ExprZonemapFilterTest, VInPredicateDictionaryAndBloomUseMaterializedValues)
     auto matching_bloom_ctx = make_bloom_filter_context(matching_bloom_filter.get(), type);
     EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
               in_predicate->evaluate_bloom_filter(matching_bloom_ctx));
+}
+
+TEST(ExprZonemapFilterTest, VInPredicateMaterializesNestedBloomValuesDuringOpen) {
+    auto leaf_type = int_type();
+    auto struct_type = std::make_shared<DataTypeStruct>(DataTypes {leaf_type}, Strings {"value"});
+    auto slot = VSlotRef::create_shared(0, 0, -1, struct_type, "root");
+    auto accessor = std::make_shared<MetadataAccessorExpr>("element_at", leaf_type, std::move(slot),
+                                                           make_string_literal("value"));
+    auto in_predicate = std::make_shared<VInPredicate>(make_in_predicate_node(false, 3));
+    in_predicate->add_child(std::move(accessor));
+    in_predicate->add_child(make_int_literal(2));
+    in_predicate->add_child(make_int_literal(4));
+
+    ObjectPool obj_pool;
+    DescriptorTbl* desc_tbl = nullptr;
+    auto thrift_desc_tbl = make_k2_scan_desc_tbl();
+    ASSERT_TRUE(DescriptorTbl::create(&obj_pool, thrift_desc_tbl, &desc_tbl).ok());
+    RuntimeState runtime_state;
+    runtime_state.set_desc_tbl(desc_tbl);
+    RowDescriptor row_desc(runtime_state.desc_tbl(), {0});
+    VExprContext in_context(in_predicate);
+    ASSERT_TRUE(in_context.prepare(&runtime_state, row_desc).ok());
+    ASSERT_TRUE(in_context.open(&runtime_state).ok());
+
+    EXPECT_TRUE(in_predicate->_zonemap_materialized);
+    EXPECT_TRUE(in_predicate->can_evaluate_bloom_filter());
+    EXPECT_FALSE(in_predicate->can_evaluate_zonemap_filter());
+    EXPECT_FALSE(in_predicate->can_evaluate_dictionary_filter());
+    EXPECT_FALSE(in_predicate->can_execute_on_raw_fixed_values(leaf_type, 0));
+
+    auto missing_bloom_filter = make_int_bloom_filter({1, 3});
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              in_predicate->evaluate_bloom_filter(
+                      make_bloom_filter_context(missing_bloom_filter.get(), leaf_type)));
+    auto matching_bloom_filter = make_int_bloom_filter({4});
+    EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+              in_predicate->evaluate_bloom_filter(
+                      make_bloom_filter_context(matching_bloom_filter.get(), leaf_type)));
 }
 
 TEST(ExprZonemapFilterTest, DirectInPredicateMaterializesStringSetForZonemap) {

--- a/be/test/exprs/expr_zonemap_filter_test.cpp
+++ b/be/test/exprs/expr_zonemap_filter_test.cpp
@@ -32,11 +32,13 @@
 
 #include "common/object_pool.h"
 #include "core/column/column_vector.h"
+#include "core/data_type/data_type_array.h"
 #include "core/data_type/data_type_date_or_datetime_v2.h"
 #include "core/data_type/data_type_decimal.h"
 #include "core/data_type/data_type_nullable.h"
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
+#include "core/data_type/data_type_struct.h"
 #include "core/field.h"
 #include "core/string_ref.h"
 #include "core/value/vdatetime_value.h"
@@ -242,6 +244,27 @@ public:
 private:
     ZoneMapFilterResult _result;
     std::string _expr_name = "fixed_zonemap_expr";
+};
+
+class MetadataAccessorExpr final : public VExpr {
+public:
+    MetadataAccessorExpr(std::string function_name, DataTypePtr result_type, VExprSPtr parent,
+                         VExprSPtr selector)
+            : VExpr(std::move(result_type), false), _expr_name(std::move(function_name)) {
+        _fn.name.function_name = _expr_name;
+        add_child(std::move(parent));
+        add_child(std::move(selector));
+    }
+
+    const std::string& expr_name() const override { return _expr_name; }
+
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
+                               ColumnPtr&) const override {
+        return Status::InternalError("MetadataAccessorExpr is metadata-only");
+    }
+
+private:
+    std::string _expr_name;
 };
 
 class UnsupportedSingleSlotExpr final : public VExpr {
@@ -640,6 +663,60 @@ TEST(ExprZonemapFilterTest, DefaultFunctionForwardsDictionaryAndBloomEvaluation)
               equals->evaluate_bloom_filter(bloom_ctx, {slot, make_int_literal(2)}));
     EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
               equals->evaluate_bloom_filter(bloom_ctx, {slot, make_int_literal(3)}));
+}
+
+TEST(ExprZonemapFilterTest, NullSafeEqualityUsesBloomOnlyForNonNullLiteral) {
+    auto type = int_type();
+    auto slot = make_slot(0, type);
+    auto equals_for_null = SimpleFunctionFactory::instance().get_function(
+            "eq_for_null",
+            ColumnsWithTypeAndName {{nullptr, type, "slot"}, {nullptr, type, "literal"}},
+            std::make_shared<DataTypeUInt8>());
+    ASSERT_NE(equals_for_null, nullptr);
+
+    auto bloom_filter = make_int_bloom_filter({1, 3});
+    auto bloom_ctx = make_bloom_filter_context(bloom_filter.get(), type);
+    EXPECT_TRUE(equals_for_null->can_evaluate_bloom_filter({slot, make_int_literal(2)}));
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              equals_for_null->evaluate_bloom_filter(bloom_ctx, {slot, make_int_literal(2)}));
+    EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+              equals_for_null->evaluate_bloom_filter(bloom_ctx, {slot, make_int_literal(3)}));
+
+    EXPECT_FALSE(equals_for_null->can_evaluate_bloom_filter({slot, make_null_int_literal()}));
+}
+
+TEST(ExprZonemapFilterTest, EqualityBloomAcceptsStructAndListLeafAccessors) {
+    auto leaf_type = int_type();
+    auto bloom_filter = make_int_bloom_filter({1, 3});
+    auto bloom_ctx = make_bloom_filter_context(bloom_filter.get(), leaf_type);
+    FunctionComparison<EqualsOp, NameEquals> equals;
+
+    auto struct_type = std::make_shared<DataTypeStruct>(DataTypes {leaf_type}, Strings {"value"});
+    auto struct_accessor = std::make_shared<MetadataAccessorExpr>(
+            "element_at", leaf_type, make_slot(0, struct_type), make_string_literal("value"));
+    EXPECT_TRUE(equals.can_evaluate_bloom_filter({struct_accessor, make_int_literal(2)}));
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              equals.evaluate_bloom_filter(bloom_ctx, {struct_accessor, make_int_literal(2)}));
+
+    auto list_type = std::make_shared<DataTypeArray>(leaf_type);
+    auto list_accessor = std::make_shared<MetadataAccessorExpr>(
+            "element_at", leaf_type, make_slot(0, list_type), make_int_literal(1));
+    EXPECT_TRUE(equals.can_evaluate_bloom_filter({list_accessor, make_int_literal(3)}));
+    EXPECT_EQ(ZoneMapFilterResult::kMayMatch,
+              equals.evaluate_bloom_filter(bloom_ctx, {list_accessor, make_int_literal(3)}));
+
+    auto nested_type = std::make_shared<DataTypeStruct>(DataTypes {list_type}, Strings {"items"});
+    auto nested_list = std::make_shared<MetadataAccessorExpr>(
+            "element_at", list_type, make_slot(0, nested_type), make_string_literal("items"));
+    auto nested_leaf = std::make_shared<MetadataAccessorExpr>(
+            "element_at", leaf_type, std::move(nested_list), make_int_literal(1));
+    auto nested_probe = expr_zonemap::extract_bloom_filter_probe(nested_leaf);
+    ASSERT_TRUE(nested_probe.has_value());
+    ASSERT_EQ(nested_probe->path.size(), 2);
+    EXPECT_EQ(nested_probe->path[0].kind, expr_zonemap::BloomFilterPathKind::STRUCT_FIELD);
+    EXPECT_EQ(nested_probe->path[1].kind, expr_zonemap::BloomFilterPathKind::LIST_ELEMENT);
+    EXPECT_EQ(ZoneMapFilterResult::kNoMatch,
+              equals.evaluate_bloom_filter(bloom_ctx, {nested_leaf, make_int_literal(2)}));
 }
 
 TEST(ExprZonemapFilterTest, MissingSlotTypeCountsUnsupportedZonemapEvalOnce) {

--- a/be/test/exprs/expr_zonemap_filter_test.cpp
+++ b/be/test/exprs/expr_zonemap_filter_test.cpp
@@ -1150,7 +1150,7 @@ TEST(ExprZonemapFilterTest, VInPredicateMaterializesNestedBloomValuesDuringOpen)
     ASSERT_TRUE(DescriptorTbl::create(&obj_pool, thrift_desc_tbl, &desc_tbl).ok());
     RuntimeState runtime_state;
     runtime_state.set_desc_tbl(desc_tbl);
-    RowDescriptor row_desc(runtime_state.desc_tbl(), {0});
+    RowDescriptor row_desc(runtime_state.desc_tbl(), {0}, {false});
     VExprContext in_context(in_predicate);
     ASSERT_TRUE(in_context.prepare(&runtime_state, row_desc).ok());
     ASSERT_TRUE(in_context.open(&runtime_state).ok());

--- a/be/test/format_v2/column_mapper_test.cpp
+++ b/be/test/format_v2/column_mapper_test.cpp
@@ -2448,6 +2448,39 @@ TEST(ColumnMapperScanRequestTest, ArrayStructPathKeepsNullableFileLeafAboveRequi
     EXPECT_TRUE(request.conjuncts.empty());
 }
 
+// ARRAY access projects every element child, so an unrelated narrowing sibling conversion must
+// remain visible to TableReader before any file-local predicate can discard its source row.
+TEST(ColumnMapperScanRequestTest, ArrayStructPathKeepsLossyProjectedSiblingAtTableLevel) {
+    const auto int_type = i32();
+    const auto bigint_type = i64();
+
+    auto table_a = name_col("a", int_type, 0);
+    auto table_b = name_col("b", int_type, 1);
+    auto table_element = struct_name_col("element", {table_a, table_b}, 0);
+    auto table_array = array_col("items", -1, table_element, 0);
+    set_name_identifiers(&table_array, 0);
+
+    auto file_a = name_col("a", int_type, 0);
+    auto file_b = name_col("b", bigint_type, 1);
+    auto file_element = struct_name_col("element", {file_a, file_b}, 0);
+    auto file_array = array_col("items", -1, file_element, 0);
+    set_name_identifiers(&file_array, 0);
+
+    auto item_expr = array_element_at(table_slot(0, 0, table_array.type, "items"),
+                                      make_nullable(table_element.type), 1);
+    auto leaf_expr = struct_element(item_expr, make_nullable(int_type), "a");
+    auto filter_expr = int_gt(leaf_expr, 5);
+    TableFilter filter {.conjunct = VExprContext::create_shared(filter_expr),
+                        .global_indices = {GlobalIndex(0)}};
+
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_NAME});
+    ASSERT_TRUE(mapper.create_mapping({table_array}, {}, {file_array}).ok());
+
+    FileScanRequest request;
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_array}, &request).ok());
+    EXPECT_TRUE(request.conjuncts.empty());
+}
+
 // Scenario: a map value struct projects child `b`, while a row filter reads value child `a`.
 // The filter is too complex to become a file-local nested predicate. Lazy demotion must move the
 // merged projection to the non-predicate set without dropping either physical value child.

--- a/be/test/format_v2/column_mapper_test.cpp
+++ b/be/test/format_v2/column_mapper_test.cpp
@@ -2459,6 +2459,10 @@ TEST(ColumnMapperScanRequestTest, MapFilterOnlyValueChildMergesWithOutputProject
     auto table_value_b = name_col("b", string_type);
     auto table_value = struct_name_col("value", {table_value_b});
     auto table_map = map_col("m", -1, {table_value}, key_type, table_value.type);
+    auto predicate_value_a = name_col("a", int_type);
+    auto predicate_value = struct_name_col("value", {predicate_value_a});
+    table_map.has_predicate_access_paths = true;
+    table_map.predicate_children = {std::move(predicate_value)};
     set_name_identifiers(&table_map, 0);
 
     auto file_key = name_col("key", key_type, 0);
@@ -2477,7 +2481,7 @@ TEST(ColumnMapperScanRequestTest, MapFilterOnlyValueChildMergesWithOutputProject
     TableFilter filter {.conjunct = VExprContext::create_shared(filter_expr),
                         .global_indices = {GlobalIndex(0)}};
 
-    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_NAME});
+    ParquetColumnMapper mapper({.mode = TableColumnMappingMode::BY_NAME});
     ASSERT_TRUE(mapper.create_mapping({table_map}, {}, {file_map}).ok());
 
     FileScanRequest request;

--- a/be/test/format_v2/column_mapper_test.cpp
+++ b/be/test/format_v2/column_mapper_test.cpp
@@ -2379,10 +2379,9 @@ TEST(ColumnMapperScanRequestTest, StructProjectionPrunesChildrenByName) {
     EXPECT_EQ(projected_type->get_element_name(0), "b");
 }
 
-// Scenario: a row filter reaches a struct child through an array wrapper
-// (`items.item.a > 5`). The mapper cannot localize the filter, so it keeps the full array root in
-// the lazy non-predicate set for table-level evaluation.
-TEST(ColumnMapperScanRequestTest, ArrayWrapperDoesNotBuildNestedPredicateFilter) {
+// Scenario: a row filter reaches a struct child through an array element
+// (`items[1].a > 5`). Identical table/file schemas can safely localize the complete accessor path.
+TEST(ColumnMapperScanRequestTest, ArrayStructPathBuildsNestedPredicateFilter) {
     const auto int_type = i32();
     const auto string_type = str();
 
@@ -2395,7 +2394,7 @@ TEST(ColumnMapperScanRequestTest, ArrayWrapperDoesNotBuildNestedPredicateFilter)
     auto table_array = file_array;
 
     const auto item_type = file_element.type;
-    auto item_expr = struct_element(table_slot(0, 0, table_array.type, "items"), item_type, "item");
+    auto item_expr = array_element_at(table_slot(0, 0, table_array.type, "items"), item_type, 1);
     auto filter_expr = int_gt(struct_element(item_expr, int_type, "a"), 5);
     TableFilter filter {.conjunct = VExprContext::create_shared(filter_expr),
                         .global_indices = {GlobalIndex(0)}};
@@ -2404,14 +2403,17 @@ TEST(ColumnMapperScanRequestTest, ArrayWrapperDoesNotBuildNestedPredicateFilter)
     ASSERT_TRUE(mapper.create_mapping({table_array}, {}, {file_array}).ok());
 
     FileScanRequest request;
-    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_array}, &request).ok());
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {}, &request).ok());
 
-    EXPECT_TRUE(request.conjuncts.empty());
-    EXPECT_TRUE(request.predicate_columns.empty());
-    ASSERT_EQ(request.non_predicate_columns.size(), 1);
-    EXPECT_EQ(request.non_predicate_columns[0].column_id(), LocalColumnId(0));
-    EXPECT_TRUE(request.non_predicate_columns[0].project_all_children);
-    EXPECT_TRUE(request.non_predicate_columns[0].children.empty());
+    ASSERT_EQ(request.conjuncts.size(), 1);
+    ASSERT_EQ(request.predicate_columns.size(), 1);
+    EXPECT_TRUE(request.non_predicate_columns.empty());
+    const auto& projection = request.predicate_columns[0];
+    EXPECT_EQ(projection.column_id(), LocalColumnId(0));
+    // Array indexing still needs the complete repeated sequence, while the localized accessor lets
+    // Parquet metadata pruning resolve the selected struct leaf.
+    EXPECT_TRUE(projection.project_all_children);
+    EXPECT_TRUE(projection.children.empty());
 }
 
 // Scenario: when projected struct children are an in-order prefix of the file struct, the mapper can

--- a/be/test/format_v2/column_mapper_test.cpp
+++ b/be/test/format_v2/column_mapper_test.cpp
@@ -2416,6 +2416,83 @@ TEST(ColumnMapperScanRequestTest, ArrayStructPathBuildsNestedPredicateFilter) {
     EXPECT_TRUE(projection.children.empty());
 }
 
+// Production ARRAY and STRUCT accessors make their result nullable for missing indices and NULL
+// parents. That execution nullability must not hide a required table child when deciding whether
+// the file predicate may run before TableReader's schema validation.
+TEST(ColumnMapperScanRequestTest, ArrayStructPathKeepsNullableFileLeafAboveRequiredTableLeaf) {
+    const auto required_int_type = i32();
+    const auto nullable_int_type = make_nullable(required_int_type);
+
+    auto table_a = name_col("a", required_int_type);
+    auto table_element = struct_name_col("element", {table_a}, 0);
+    auto table_array = array_col("items", -1, table_element, 0);
+    set_name_identifiers(&table_array, 0);
+
+    auto file_a = name_col("a", nullable_int_type, 0);
+    auto file_element = struct_name_col("element", {file_a}, 0);
+    auto file_array = array_col("items", -1, file_element, 0);
+    set_name_identifiers(&file_array, 0);
+
+    auto item_expr = array_element_at(table_slot(0, 0, table_array.type, "items"),
+                                      make_nullable(table_element.type), 1);
+    auto leaf_expr = struct_element(item_expr, nullable_int_type, "a");
+    auto filter_expr = int_gt(leaf_expr, 10);
+    TableFilter filter {.conjunct = VExprContext::create_shared(filter_expr),
+                        .global_indices = {GlobalIndex(0)}};
+
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_NAME});
+    ASSERT_TRUE(mapper.create_mapping({table_array}, {}, {file_array}).ok());
+
+    FileScanRequest request;
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_array}, &request).ok());
+    EXPECT_TRUE(request.conjuncts.empty());
+}
+
+// Scenario: a map value struct projects child `b`, while a row filter reads value child `a`.
+// The filter is too complex to become a file-local nested predicate. Lazy demotion must move the
+// merged projection to the non-predicate set without dropping either physical value child.
+TEST(ColumnMapperScanRequestTest, MapFilterOnlyValueChildMergesWithOutputProjection) {
+    const auto key_type = i32();
+    const auto int_type = i32();
+    const auto string_type = str();
+
+    auto table_value_b = name_col("b", string_type);
+    auto table_value = struct_name_col("value", {table_value_b});
+    auto table_map = map_col("m", -1, {table_value}, key_type, table_value.type);
+    set_name_identifiers(&table_map, 0);
+
+    auto file_key = name_col("key", key_type, 0);
+    auto file_value_a = name_col("a", int_type, 0);
+    auto file_value_b = name_col("b", string_type, 1);
+    auto file_value = struct_name_col("value", {file_value_a, file_value_b}, 1);
+    auto file_map = map_col("m", -1, {file_key, file_value}, key_type, file_value.type, 0);
+    set_name_identifiers(&file_map, 0);
+
+    auto full_value_type =
+            std::make_shared<DataTypeStruct>(DataTypes {int_type, string_type}, Strings {"a", "b"});
+    auto full_map_type = std::make_shared<DataTypeMap>(key_type, full_value_type);
+    auto value_expr =
+            struct_element(table_slot(0, 0, full_map_type, "m"), full_value_type, "value");
+    auto filter_expr = int_gt(struct_element(value_expr, int_type, "a"), 5);
+    TableFilter filter {.conjunct = VExprContext::create_shared(filter_expr),
+                        .global_indices = {GlobalIndex(0)}};
+
+    TableColumnMapper mapper({.mode = TableColumnMappingMode::BY_NAME});
+    ASSERT_TRUE(mapper.create_mapping({table_map}, {}, {file_map}).ok());
+
+    FileScanRequest request;
+    ASSERT_TRUE(mapper.create_scan_request({filter}, {table_map}, &request).ok());
+
+    EXPECT_TRUE(request.predicate_columns.empty());
+    ASSERT_EQ(request.non_predicate_columns.size(), 1);
+    const auto& projection = request.non_predicate_columns[0];
+    EXPECT_EQ(projection.column_id(), LocalColumnId(0));
+    ASSERT_FALSE(projection.project_all_children);
+    ASSERT_EQ(projection.children.size(), 1);
+    EXPECT_EQ(projection.children[0].local_id(), 1);
+    EXPECT_EQ(projection_ids(projection.children[0].children), std::vector<int32_t>({0, 1}));
+}
+
 // Scenario: when projected struct children are an in-order prefix of the file struct, the mapper can
 // read those physical children directly without rebuilding the file-side complex type.
 TEST(ColumnMapperScanRequestTest, MatchingProjectedStructDoesNotNeedComplexRematerialize) {

--- a/be/test/format_v2/orc/orc_reader_test.cpp
+++ b/be/test/format_v2/orc/orc_reader_test.cpp
@@ -9864,6 +9864,36 @@ TEST_F(NewOrcReaderTest, SargConjunctReturnsEofWhenAllStripesArePruned) {
     EXPECT_EQ(reader->reader_statistics().filtered_group_rows, 400);
 }
 
+TEST_F(NewOrcReaderTest, SargSafePrefixPreservesEarlierRowFilterError) {
+    const auto multi_stripe_file_path = (_test_dir / "sarg_safe_prefix.orc").string();
+    write_multi_stripe_orc_int_file(multi_stripe_file_path);
+    ASSERT_EQ(get_orc_stripe_count(multi_stripe_file_path), 2);
+
+    auto reader = create_reader_for_path(multi_stripe_file_path);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    ASSERT_TRUE(reader->init(&state).ok());
+
+    std::vector<format::ColumnDefinition> schema;
+    ASSERT_TRUE(reader->get_schema(&schema).ok());
+    ASSERT_EQ(schema.size(), 2);
+
+    auto request = std::make_shared<format::FileScanRequest>();
+    request->predicate_columns = {field_projection(0)};
+    request->conjuncts.push_back(
+            VExprContext::create_shared(std::make_shared<FailingRowFilterExpr>()));
+    request->conjuncts.push_back(
+            VExprContext::create_shared(std::make_shared<NullableInt32GreaterThanExpr>(0, 5000)));
+    request->metadata_pruning_safe_conjunct_count = 0;
+    ASSERT_TRUE(reader->open(request).ok());
+
+    Block block = build_file_block(schema);
+    size_t rows = 0;
+    bool eof = false;
+    const Status status = reader->get_block(&block, &rows, &eof);
+    EXPECT_NE(status.to_string().find("synthetic row filter failure"), std::string::npos) << status;
+    EXPECT_EQ(reader->reader_statistics().filtered_row_groups, 0);
+}
+
 TEST_F(NewOrcReaderTest, CloseClearsFileLocalState) {
     auto reader = create_reader();
     RuntimeState state {TQueryOptions(), TQueryGlobals()};

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -2094,6 +2094,48 @@ TEST(ParquetScanAdaptivePredicateTest, ThrowingNestedFunctionDisablesSelectedRow
     EXPECT_FALSE(throwing_comparison->root()->is_safe_to_execute_on_selected_rows());
 }
 
+TEST(ParquetScanAdaptivePredicateTest, TotalNestedAccessorsAndNullSafeEqualityAreSafe) {
+    const auto int_type = std::make_shared<DataTypeInt32>();
+    const auto nullable_int_type = make_nullable(int_type);
+    const auto struct_type = make_nullable(
+            std::make_shared<DataTypeStruct>(DataTypes {nullable_int_type}, Strings {"value"}));
+    const auto array_type = std::make_shared<DataTypeArray>(struct_type);
+
+    const auto function_call = [](const std::string& name, const DataTypePtr& result_type,
+                                  VExprSPtrs children) {
+        TFunctionName function_name;
+        function_name.__set_function_name(name);
+        TFunction function;
+        function.__set_name(function_name);
+        TExprNode node;
+        node.__set_node_type(TExprNodeType::FUNCTION_CALL);
+        node.__set_type(result_type->to_thrift());
+        node.__set_fn(function);
+        node.__set_num_children(cast_set<int16_t>(children.size()));
+        node.__set_is_nullable(result_type->is_nullable());
+        auto expr = VectorizedFnCall::create_shared(node);
+        expr->set_children(std::move(children));
+        return expr;
+    };
+
+    auto array_element =
+            function_call("element_at", struct_type,
+                          {VSlotRef::create_shared(0, 0, -1, array_type, "items"),
+                           VLiteral::create_shared(int_type, Field::create_field<TYPE_INT>(1))});
+    auto struct_element = function_call(
+            "struct_element", nullable_int_type,
+            {array_element, VLiteral::create_shared(std::make_shared<DataTypeString>(),
+                                                    Field::create_field<TYPE_STRING>("value"))});
+    auto null_safe_eq = function_call(
+            "eq_for_null", std::make_shared<DataTypeUInt8>(),
+            {struct_element,
+             VLiteral::create_shared(nullable_int_type, Field::create_field<TYPE_INT>(7))});
+
+    EXPECT_TRUE(array_element->is_safe_to_execute_on_selected_rows());
+    EXPECT_TRUE(struct_element->is_safe_to_execute_on_selected_rows());
+    EXPECT_TRUE(null_safe_eq->is_safe_to_execute_on_selected_rows());
+}
+
 TEST(ParquetScanSmallFileTest, StagesOnlyBoundedHttpObjects) {
     using format::parquet::detail::should_stage_small_http_file;
     EXPECT_TRUE(should_stage_small_http_file("http://host/tiny.parquet", 512, 1024));

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -182,37 +182,6 @@ private:
     const std::string _expr_name = "MetadataAccessorExpr";
 };
 
-class BloomEqExpr final : public VExpr {
-public:
-    BloomEqExpr(int column_id, DataTypePtr data_type, Field value)
-            : VExpr(std::make_shared<DataTypeUInt8>(), false),
-              _slot(VSlotRef::create_shared(0, column_id, -1, std::move(data_type), "c0")),
-              _value(std::move(value)) {}
-
-    const std::string& expr_name() const override { return _expr_name; }
-    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
-                               ColumnPtr&) const override {
-        return Status::InternalError("BloomEqExpr is only used by parquet statistics tests");
-    }
-    bool can_evaluate_bloom_filter() const override { return true; }
-    ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const override {
-        return expr_zonemap::eval_eq_bloom_filter(
-                ctx, expr_zonemap::SlotLiteral {.slot_index = _slot->column_id(),
-                                                .slot_type = _slot->data_type(),
-                                                .literal = _value,
-                                                .literal_type = _slot->data_type(),
-                                                .literal_on_left = false});
-    }
-    void collect_slot_column_ids(std::set<int>& column_ids) const override {
-        _slot->collect_slot_column_ids(column_ids);
-    }
-
-private:
-    std::shared_ptr<VSlotRef> _slot;
-    Field _value;
-    const std::string _expr_name = "BloomEqExpr";
-};
-
 class MetadataFloatingEqualityExpr final : public VExpr {
 public:
     enum class Mode { EQ, IN, NE, GT, GE, REVERSED_LT, REVERSED_LE, NOT_IN };
@@ -1259,9 +1228,9 @@ TEST(ParquetBloomFilterPruningTest, NativeBloomPreservesFirstLogicalProbeOrder) 
     request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
     request.local_positions.emplace(format::LocalColumnId(1), format::LocalIndex(1));
     request.conjuncts = {VExprContext::create_shared(std::make_shared<BloomInExpr>(
-                                 0, type, std::vector<Field> {Field::create_field<TYPE_INT>(2)})),
+                                 1, type, std::vector<Field> {Field::create_field<TYPE_INT>(2)})),
                          VExprContext::create_shared(std::make_shared<BloomInExpr>(
-                                 1, type, std::vector<Field> {Field::create_field<TYPE_INT>(1)}))};
+                                 0, type, std::vector<Field> {Field::create_field<TYPE_INT>(1)}))};
 
     format::parquet::ParquetFileContext file_context;
     auto file_reader = std::make_shared<StatisticsMemoryFileReader>(std::move(file_bytes));
@@ -1278,42 +1247,115 @@ TEST(ParquetBloomFilterPruningTest, NativeBloomPreservesFirstLogicalProbeOrder) 
     EXPECT_EQ(pruning_stats.bloom_filter_probe_successes, 1);
 }
 
-TEST(ParquetBloomFilterPruningTest, NativeFloatingBloomPreservesDorisEquality) {
-    const auto check_type = []<PrimitiveType Type, typename DataType>(
-                                    tparquet::Type::type physical_type,
-                                    typename PrimitiveTypeTraits<Type>::CppType stored_value,
-                                    typename PrimitiveTypeTraits<Type>::CppType predicate_value) {
-        format::parquet::ParquetColumnSchema column_schema;
-        column_schema.type = std::make_shared<DataType>();
-        column_schema.type_descriptor.doris_type = column_schema.type;
-        column_schema.type_descriptor.physical_type = physical_type;
-
+TEST(ParquetBloomFilterPruningTest, NativeBloomPreservesOrderAcrossNestedAndDirectProbes) {
+    const auto make_bloom = [] {
         format::parquet::native::BlockSplitBloomFilter bloom_filter;
-        ASSERT_TRUE(bloom_filter
+        EXPECT_TRUE(bloom_filter
                             .init(segment_v2::BloomFilter::MINIMUM_BYTES,
                                   segment_v2::HashStrategyPB::XX_HASH_64)
                             .ok());
-        bloom_filter.add_bytes(reinterpret_cast<const char*>(&stored_value), sizeof(stored_value));
-        ASSERT_FALSE(bloom_filter.test_bytes(reinterpret_cast<const char*>(&predicate_value),
-                                             sizeof(predicate_value)));
-        const auto field = Field::create_field<Type>(predicate_value);
-
-        EXPECT_FALSE(format::parquet::ParquetStatisticsUtils::NativeBloomFilterExcludes(
-                column_schema, 0, bloom_eq_conjunct(column_schema.type, field), bloom_filter));
-        EXPECT_FALSE(format::parquet::ParquetStatisticsUtils::NativeBloomFilterExcludes(
-                column_schema, 0, bloom_conjuncts(column_schema.type, {field}), bloom_filter));
+        const int32_t present_value = 1;
+        bloom_filter.add_bytes(reinterpret_cast<const char*>(&present_value),
+                               sizeof(present_value));
+        tparquet::BloomFilterAlgorithm algorithm;
+        algorithm.__set_BLOCK(tparquet::SplitBlockAlgorithm());
+        tparquet::BloomFilterHash hash;
+        hash.__set_XXHASH(tparquet::XxHash());
+        tparquet::BloomFilterCompression compression;
+        compression.__set_UNCOMPRESSED(tparquet::Uncompressed());
+        tparquet::BloomFilterHeader header;
+        header.__set_numBytes(static_cast<int32_t>(bloom_filter.size()));
+        header.__set_algorithm(algorithm);
+        header.__set_hash(hash);
+        header.__set_compression(compression);
+        std::vector<uint8_t> bytes;
+        ThriftSerializer serializer(/*compact=*/true, 64);
+        EXPECT_TRUE(serializer.serialize(&header, &bytes).ok());
+        bytes.insert(bytes.end(), bloom_filter.data(), bloom_filter.data() + bloom_filter.size());
+        return bytes;
     };
+    const auto bloom = make_bloom();
+    std::vector<uint8_t> file_bytes = bloom;
+    file_bytes.insert(file_bytes.end(), bloom.begin(), bloom.end());
 
-    check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(tparquet::Type::FLOAT, -0.0F, 0.0F);
-    check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(tparquet::Type::FLOAT, 0.0F, -0.0F);
-    check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(tparquet::Type::DOUBLE, -0.0, 0.0);
-    check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(tparquet::Type::DOUBLE, 0.0, -0.0);
-    check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(
-            tparquet::Type::FLOAT, std::bit_cast<float>(uint32_t {0x7fc00001U}),
-            std::bit_cast<float>(uint32_t {0x7fc00002U}));
-    check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(
-            tparquet::Type::DOUBLE, std::bit_cast<double>(uint64_t {0x7ff8000000000001ULL}),
-            std::bit_cast<double>(uint64_t {0x7ff8000000000002ULL}));
+    const auto int_type = std::make_shared<DataTypeInt32>();
+    const auto struct_type =
+            std::make_shared<DataTypeStruct>(DataTypes {int_type}, Strings {"value"});
+    auto direct_schema = std::make_unique<format::parquet::ParquetColumnSchema>();
+    direct_schema->kind = format::parquet::ParquetColumnSchemaKind::PRIMITIVE;
+    direct_schema->local_id = 0;
+    direct_schema->leaf_column_id = 1;
+    direct_schema->type = int_type;
+    direct_schema->type_descriptor.doris_type = int_type;
+    direct_schema->type_descriptor.physical_type = tparquet::Type::INT32;
+
+    auto struct_schema = std::make_unique<format::parquet::ParquetColumnSchema>();
+    struct_schema->kind = format::parquet::ParquetColumnSchemaKind::STRUCT;
+    struct_schema->local_id = 1;
+    struct_schema->name = "nested";
+    struct_schema->type = struct_type;
+    auto nested_leaf_schema = std::make_unique<format::parquet::ParquetColumnSchema>();
+    nested_leaf_schema->kind = format::parquet::ParquetColumnSchemaKind::PRIMITIVE;
+    nested_leaf_schema->local_id = 0;
+    nested_leaf_schema->name = "value";
+    nested_leaf_schema->leaf_column_id = 0;
+    nested_leaf_schema->type = int_type;
+    nested_leaf_schema->type_descriptor.doris_type = int_type;
+    nested_leaf_schema->type_descriptor.physical_type = tparquet::Type::INT32;
+    struct_schema->children.push_back(std::move(nested_leaf_schema));
+
+    std::vector<tparquet::ColumnChunk> chunks;
+    for (int leaf_id = 0; leaf_id < 2; ++leaf_id) {
+        tparquet::ColumnMetaData column_metadata;
+        column_metadata.__set_type(tparquet::Type::INT32);
+        column_metadata.__set_codec(tparquet::CompressionCodec::UNCOMPRESSED);
+        column_metadata.__set_num_values(1);
+        column_metadata.__set_total_compressed_size(0);
+        column_metadata.__set_data_page_offset(0);
+        column_metadata.__set_bloom_filter_offset(leaf_id * bloom.size());
+        column_metadata.__set_bloom_filter_length(static_cast<int32_t>(bloom.size()));
+        tparquet::ColumnChunk chunk;
+        chunk.__set_meta_data(column_metadata);
+        chunks.push_back(std::move(chunk));
+    }
+    tparquet::RowGroup row_group;
+    row_group.__set_columns(std::move(chunks));
+    row_group.__set_total_byte_size(0);
+    row_group.__set_num_rows(1);
+    tparquet::FileMetaData metadata;
+    metadata.__set_version(1);
+    metadata.__set_num_rows(1);
+    metadata.__set_row_groups({row_group});
+
+    format::FileScanRequest request;
+    request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    request.local_positions.emplace(format::LocalColumnId(1), format::LocalIndex(1));
+    auto nested_slot = VSlotRef::create_shared(0, 1, -1, struct_type, "nested");
+    auto selector = VLiteral::create_shared(std::make_shared<DataTypeString>(),
+                                            Field::create_field<TYPE_STRING>("value"));
+    auto nested_accessor =
+            std::make_shared<MetadataAccessorExpr>(int_type, std::move(nested_slot), selector);
+    request.conjuncts = {
+            VExprContext::create_shared(std::make_shared<BloomInExpr>(
+                    std::move(nested_accessor),
+                    std::vector<Field> {Field::create_field<TYPE_INT>(2)})),
+            VExprContext::create_shared(std::make_shared<BloomInExpr>(
+                    0, int_type, std::vector<Field> {Field::create_field<TYPE_INT>(1)}))};
+
+    std::vector<std::unique_ptr<format::parquet::ParquetColumnSchema>> schema;
+    schema.push_back(std::move(direct_schema));
+    schema.push_back(std::move(struct_schema));
+    format::parquet::ParquetFileContext file_context;
+    auto file_reader = std::make_shared<StatisticsMemoryFileReader>(std::move(file_bytes));
+    file_context.native_file = file_reader;
+    std::vector<int> selected_row_groups;
+    format::parquet::ParquetPruningStats pruning_stats;
+    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
+                        metadata, schema, request, nullptr, &selected_row_groups, true,
+                        &pruning_stats, nullptr, nullptr, &file_context)
+                        .ok());
+    EXPECT_TRUE(selected_row_groups.empty());
+    EXPECT_EQ(file_reader->read_count(), 2);
 }
 
 TEST(ParquetBloomFilterPruningTest, NativeRowGroupKeepsDorisEqualFloatingValues) {

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -505,6 +505,20 @@ VExprContextSPtr variant_path_string_gt_conjunct(std::string literal_value) {
     return VExprContext::create_shared(std::move(gt));
 }
 
+class UnsafeMetadataExpr final : public VExpr {
+public:
+    UnsafeMetadataExpr() : VExpr(std::make_shared<DataTypeUInt8>(), false) {}
+
+    const std::string& expr_name() const override { return _expr_name; }
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
+                               ColumnPtr&) const override {
+        return Status::InternalError("UnsafeMetadataExpr is metadata-only");
+    }
+    bool is_safe_to_execute_on_selected_rows() const override { return false; }
+
+private:
+    const std::string _expr_name = "UnsafeMetadataExpr";
+};
 VExprContextSPtrs bloom_conjuncts(DataTypePtr data_type, std::vector<Field> values) {
     return {VExprContext::create_shared(
             std::make_shared<BloomInExpr>(0, std::move(data_type), std::move(values)))};
@@ -958,7 +972,8 @@ TEST(ParquetBloomFilterPruningTest, NativeFloatingBloomPreservesDorisEquality) {
 TEST(ParquetBloomFilterPruningTest, NativeBloomResolvesStructAndListLeaves) {
     const auto run_case = [](format::parquet::ParquetColumnSchemaKind root_kind,
                              int32_t predicate_value, bool path_exists, int conjunct_count,
-                             bool expected_pruned, int expected_reads) {
+                             bool expected_pruned, int expected_reads,
+                             bool add_unsafe_barrier = false) {
         auto leaf_type = std::make_shared<DataTypeInt32>();
         DataTypePtr root_type;
         VExprSPtr selector;
@@ -1038,6 +1053,11 @@ TEST(ParquetBloomFilterPruningTest, NativeBloomResolvesStructAndListLeaves) {
 
         format::FileScanRequest request;
         request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+        if (add_unsafe_barrier) {
+            request.conjuncts.push_back(
+                    VExprContext::create_shared(std::make_shared<UnsafeMetadataExpr>()));
+            request.metadata_pruning_safe_conjunct_count = 0;
+        }
         for (int conjunct_idx = 0; conjunct_idx < conjunct_count; ++conjunct_idx) {
             auto slot = VSlotRef::create_shared(0, 0, -1, root_type, "root");
             auto accessor =
@@ -1068,6 +1088,7 @@ TEST(ParquetBloomFilterPruningTest, NativeBloomResolvesStructAndListLeaves) {
     run_case(format::parquet::ParquetColumnSchemaKind::LIST, 2, true, 1, true, 2);
     run_case(format::parquet::ParquetColumnSchemaKind::LIST, 1, true, 1, false, 2);
     run_case(format::parquet::ParquetColumnSchemaKind::STRUCT, 1, true, 2, false, 2);
+    run_case(format::parquet::ParquetColumnSchemaKind::STRUCT, 2, true, 1, false, 0, true);
 }
 
 TEST(ParquetBloomFilterPruningTest, NativeFloatingBloomPreservesDorisEquality) {

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -32,11 +32,13 @@
 #include <utility>
 #include <vector>
 
+#include "core/data_type/data_type_array.h"
 #include "core/data_type/data_type_date.h"
 #include "core/data_type/data_type_decimal.h"
 #include "core/data_type/data_type_nullable.h"
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
+#include "core/data_type/data_type_struct.h"
 #include "core/data_type/data_type_time.h"
 #include "core/data_type/data_type_variant_v2.h"
 #include "core/field.h"
@@ -90,9 +92,13 @@ private:
 class BloomInExpr final : public VExpr {
 public:
     BloomInExpr(int column_id, DataTypePtr data_type, std::vector<Field> values)
-            : VExpr(std::make_shared<DataTypeUInt8>(), false),
-              _slot(VSlotRef::create_shared(0, column_id, -1, std::move(data_type), "c0")),
-              _values(std::move(values)) {}
+            : BloomInExpr(VSlotRef::create_shared(0, column_id, -1, std::move(data_type), "c0"),
+                          std::move(values)) {}
+
+    BloomInExpr(VExprSPtr probe, std::vector<Field> values)
+            : VExpr(std::make_shared<DataTypeUInt8>(), false), _values(std::move(values)) {
+        add_child(std::move(probe));
+    }
 
     const std::string& expr_name() const override { return _expr_name; }
 
@@ -104,17 +110,36 @@ public:
     bool can_evaluate_bloom_filter() const override { return true; }
 
     ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const override {
-        return expr_zonemap::eval_in_bloom_filter(ctx, _slot, false, _values);
+        return expr_zonemap::eval_in_bloom_filter(ctx, get_child(0), false, _values);
     }
 
     void collect_slot_column_ids(std::set<int>& column_ids) const override {
-        _slot->collect_slot_column_ids(column_ids);
+        get_child(0)->collect_slot_column_ids(column_ids);
     }
 
 private:
-    VExprSPtr _slot;
     std::vector<Field> _values;
     const std::string _expr_name = "BloomInExpr";
+};
+
+class MetadataAccessorExpr final : public VExpr {
+public:
+    MetadataAccessorExpr(DataTypePtr result_type, VExprSPtr parent, VExprSPtr selector)
+            : VExpr(std::move(result_type), false) {
+        _fn.name.function_name = "element_at";
+        add_child(std::move(parent));
+        add_child(std::move(selector));
+    }
+
+    const std::string& expr_name() const override { return _expr_name; }
+
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
+                               ColumnPtr&) const override {
+        return Status::InternalError("MetadataAccessorExpr is metadata-only");
+    }
+
+private:
+    const std::string _expr_name = "MetadataAccessorExpr";
 };
 
 class BloomEqExpr final : public VExpr {
@@ -854,6 +879,116 @@ TEST(ParquetBloomFilterPruningTest, NativeUint32BloomUsesPhysicalInt32Hash) {
             column_schema, 0,
             bloom_conjuncts(column_schema.type, {Field::create_field<TYPE_BIGINT>(-1)}),
             bloom_filter));
+}
+
+TEST(ParquetBloomFilterPruningTest, NativeBloomResolvesStructAndListLeaves) {
+    const auto run_case = [](format::parquet::ParquetColumnSchemaKind root_kind,
+                             int32_t predicate_value, bool path_exists, bool expected_pruned) {
+        auto leaf_type = std::make_shared<DataTypeInt32>();
+        DataTypePtr root_type;
+        VExprSPtr selector;
+        if (root_kind == format::parquet::ParquetColumnSchemaKind::STRUCT) {
+            root_type = std::make_shared<DataTypeStruct>(DataTypes {leaf_type}, Strings {"value"});
+            selector = VLiteral::create_shared(std::make_shared<DataTypeString>(),
+                                               Field::create_field<TYPE_STRING>("value"));
+        } else {
+            root_type = std::make_shared<DataTypeArray>(leaf_type);
+            selector = VLiteral::create_shared(leaf_type, Field::create_field<TYPE_INT>(1));
+        }
+
+        auto root_schema = std::make_unique<format::parquet::ParquetColumnSchema>();
+        root_schema->kind = root_kind;
+        root_schema->local_id = 0;
+        root_schema->name = "root";
+        root_schema->type = root_type;
+        auto leaf_schema = std::make_unique<format::parquet::ParquetColumnSchema>();
+        leaf_schema->kind = format::parquet::ParquetColumnSchemaKind::PRIMITIVE;
+        leaf_schema->local_id = 0;
+        leaf_schema->name = root_kind == format::parquet::ParquetColumnSchemaKind::STRUCT
+                                    ? (path_exists ? "value" : "renamed_value")
+                                    : "element";
+        leaf_schema->leaf_column_id = 0;
+        leaf_schema->type = leaf_type;
+        leaf_schema->type_descriptor.doris_type = leaf_type;
+        leaf_schema->type_descriptor.physical_type = tparquet::Type::INT32;
+        if (root_kind == format::parquet::ParquetColumnSchemaKind::LIST) {
+            root_schema->max_repetition_level = 1;
+            leaf_schema->max_repetition_level = 1;
+        }
+        root_schema->children.push_back(std::move(leaf_schema));
+
+        format::parquet::native::BlockSplitBloomFilter bloom_filter;
+        ASSERT_TRUE(bloom_filter
+                            .init(segment_v2::BloomFilter::MINIMUM_BYTES,
+                                  segment_v2::HashStrategyPB::XX_HASH_64)
+                            .ok());
+        const int32_t present_value = 1;
+        bloom_filter.add_bytes(reinterpret_cast<const char*>(&present_value),
+                               sizeof(present_value));
+        tparquet::BloomFilterAlgorithm algorithm;
+        algorithm.__set_BLOCK(tparquet::SplitBlockAlgorithm());
+        tparquet::BloomFilterHash hash;
+        hash.__set_XXHASH(tparquet::XxHash());
+        tparquet::BloomFilterCompression compression;
+        compression.__set_UNCOMPRESSED(tparquet::Uncompressed());
+        tparquet::BloomFilterHeader bloom_header;
+        bloom_header.__set_numBytes(static_cast<int32_t>(bloom_filter.size()));
+        bloom_header.__set_algorithm(algorithm);
+        bloom_header.__set_hash(hash);
+        bloom_header.__set_compression(compression);
+        std::vector<uint8_t> bloom_bytes;
+        ThriftSerializer serializer(/*compact=*/true, 64);
+        ASSERT_TRUE(serializer.serialize(&bloom_header, &bloom_bytes).ok());
+        bloom_bytes.insert(bloom_bytes.end(), bloom_filter.data(),
+                           bloom_filter.data() + bloom_filter.size());
+
+        tparquet::ColumnMetaData column_metadata;
+        column_metadata.__set_type(tparquet::Type::INT32);
+        column_metadata.__set_codec(tparquet::CompressionCodec::UNCOMPRESSED);
+        column_metadata.__set_num_values(1);
+        column_metadata.__set_total_compressed_size(0);
+        column_metadata.__set_data_page_offset(0);
+        column_metadata.__set_bloom_filter_offset(0);
+        column_metadata.__set_bloom_filter_length(static_cast<int32_t>(bloom_bytes.size()));
+        tparquet::ColumnChunk chunk;
+        chunk.__set_meta_data(column_metadata);
+        tparquet::RowGroup row_group;
+        row_group.__set_columns({chunk});
+        row_group.__set_total_byte_size(0);
+        row_group.__set_num_rows(1);
+        tparquet::FileMetaData metadata;
+        metadata.__set_version(1);
+        metadata.__set_num_rows(1);
+        metadata.__set_row_groups({row_group});
+
+        auto slot = VSlotRef::create_shared(0, 0, -1, root_type, "root");
+        auto accessor =
+                std::make_shared<MetadataAccessorExpr>(leaf_type, std::move(slot), selector);
+        format::FileScanRequest request;
+        request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+        request.conjuncts = {VExprContext::create_shared(std::make_shared<BloomInExpr>(
+                std::move(accessor),
+                std::vector<Field> {Field::create_field<TYPE_INT>(predicate_value)}))};
+        std::vector<std::unique_ptr<format::parquet::ParquetColumnSchema>> schema;
+        schema.push_back(std::move(root_schema));
+        format::parquet::ParquetFileContext file_context;
+        file_context.native_file =
+                std::make_shared<StatisticsMemoryFileReader>(std::move(bloom_bytes));
+        std::vector<int> selected_row_groups;
+        format::parquet::ParquetPruningStats pruning_stats;
+        ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
+                            metadata, schema, request, nullptr, &selected_row_groups, true,
+                            &pruning_stats, nullptr, nullptr, &file_context)
+                            .ok());
+        EXPECT_EQ(selected_row_groups.empty(), expected_pruned);
+        EXPECT_EQ(pruning_stats.filtered_row_groups_by_bloom_filter, expected_pruned ? 1 : 0);
+    };
+
+    run_case(format::parquet::ParquetColumnSchemaKind::STRUCT, 2, true, true);
+    run_case(format::parquet::ParquetColumnSchemaKind::STRUCT, 1, true, false);
+    run_case(format::parquet::ParquetColumnSchemaKind::STRUCT, 2, false, false);
+    run_case(format::parquet::ParquetColumnSchemaKind::LIST, 2, true, true);
+    run_case(format::parquet::ParquetColumnSchemaKind::LIST, 1, true, false);
 }
 
 TEST(ParquetBloomFilterPruningTest, NativeFloatingBloomPreservesDorisEquality) {

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -72,10 +72,12 @@ public:
     size_t size() const override { return _bytes.size(); }
     bool closed() const override { return _closed; }
     int64_t mtime() const override { return 1; }
+    int read_count() const { return _read_count; }
 
 protected:
     Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                         const io::IOContext*) override {
+        ++_read_count;
         if (offset > _bytes.size() || result.size > _bytes.size() - offset) {
             return Status::IOError("native Bloom test read exceeds memory file");
         }
@@ -88,6 +90,7 @@ private:
     std::vector<uint8_t> _bytes;
     io::Path _path;
     bool _closed = false;
+    int _read_count = 0;
 };
 class BloomInExpr final : public VExpr {
 public:
@@ -120,6 +123,37 @@ public:
 private:
     std::vector<Field> _values;
     const std::string _expr_name = "BloomInExpr";
+};
+
+class BloomEqExpr final : public VExpr {
+public:
+    BloomEqExpr(int column_id, DataTypePtr data_type, Field value)
+            : VExpr(std::make_shared<DataTypeUInt8>(), false),
+              _slot(VSlotRef::create_shared(0, column_id, -1, std::move(data_type), "c0")),
+              _value(std::move(value)) {}
+
+    const std::string& expr_name() const override { return _expr_name; }
+    Status execute_column_impl(VExprContext*, const Block*, const Selector*, size_t,
+                               ColumnPtr&) const override {
+        return Status::InternalError("BloomEqExpr is only used by parquet statistics tests");
+    }
+    bool can_evaluate_bloom_filter() const override { return true; }
+    ZoneMapFilterResult evaluate_bloom_filter(const BloomFilterEvalContext& ctx) const override {
+        return expr_zonemap::eval_eq_bloom_filter(
+                ctx, expr_zonemap::SlotLiteral {.slot_index = _slot->column_id(),
+                                                .slot_type = _slot->data_type(),
+                                                .literal = _value,
+                                                .literal_type = _slot->data_type(),
+                                                .literal_on_left = false});
+    }
+    void collect_slot_column_ids(std::set<int>& column_ids) const override {
+        _slot->collect_slot_column_ids(column_ids);
+    }
+
+private:
+    std::shared_ptr<VSlotRef> _slot;
+    Field _value;
+    const std::string _expr_name = "BloomEqExpr";
 };
 
 class MetadataAccessorExpr final : public VExpr {
@@ -881,9 +915,50 @@ TEST(ParquetBloomFilterPruningTest, NativeUint32BloomUsesPhysicalInt32Hash) {
             bloom_filter));
 }
 
+TEST(ParquetBloomFilterPruningTest, NativeFloatingBloomPreservesDorisEquality) {
+    const auto check_type = []<PrimitiveType Type, typename DataType>(
+                                    tparquet::Type::type physical_type,
+                                    typename PrimitiveTypeTraits<Type>::CppType stored_value,
+                                    typename PrimitiveTypeTraits<Type>::CppType predicate_value) {
+        format::parquet::ParquetColumnSchema column_schema;
+        column_schema.type = std::make_shared<DataType>();
+        column_schema.type_descriptor.doris_type = column_schema.type;
+        column_schema.type_descriptor.physical_type = physical_type;
+
+        format::parquet::native::BlockSplitBloomFilter bloom_filter;
+        ASSERT_TRUE(bloom_filter
+                            .init(segment_v2::BloomFilter::MINIMUM_BYTES,
+                                  segment_v2::HashStrategyPB::XX_HASH_64)
+                            .ok());
+        // These raw PLAIN bytes model an external writer; the predicate uses a different physical
+        // representation from the same Doris equality class.
+        bloom_filter.add_bytes(reinterpret_cast<const char*>(&stored_value), sizeof(stored_value));
+        ASSERT_FALSE(bloom_filter.test_bytes(reinterpret_cast<const char*>(&predicate_value),
+                                             sizeof(predicate_value)));
+        const auto field = Field::create_field<Type>(predicate_value);
+
+        EXPECT_FALSE(format::parquet::ParquetStatisticsUtils::NativeBloomFilterExcludes(
+                column_schema, 0, bloom_eq_conjunct(column_schema.type, field), bloom_filter));
+        EXPECT_FALSE(format::parquet::ParquetStatisticsUtils::NativeBloomFilterExcludes(
+                column_schema, 0, bloom_conjuncts(column_schema.type, {field}), bloom_filter));
+    };
+
+    check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(tparquet::Type::FLOAT, -0.0F, 0.0F);
+    check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(tparquet::Type::FLOAT, 0.0F, -0.0F);
+    check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(tparquet::Type::DOUBLE, -0.0, 0.0);
+    check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(tparquet::Type::DOUBLE, 0.0, -0.0);
+    check_type.template operator()<TYPE_FLOAT, DataTypeFloat32>(
+            tparquet::Type::FLOAT, std::bit_cast<float>(uint32_t {0x7fc00001U}),
+            std::bit_cast<float>(uint32_t {0x7fc00002U}));
+    check_type.template operator()<TYPE_DOUBLE, DataTypeFloat64>(
+            tparquet::Type::DOUBLE, std::bit_cast<double>(uint64_t {0x7ff8000000000001ULL}),
+            std::bit_cast<double>(uint64_t {0x7ff8000000000002ULL}));
+}
+
 TEST(ParquetBloomFilterPruningTest, NativeBloomResolvesStructAndListLeaves) {
     const auto run_case = [](format::parquet::ParquetColumnSchemaKind root_kind,
-                             int32_t predicate_value, bool path_exists, bool expected_pruned) {
+                             int32_t predicate_value, bool path_exists, int conjunct_count,
+                             bool expected_pruned, int expected_reads) {
         auto leaf_type = std::make_shared<DataTypeInt32>();
         DataTypePtr root_type;
         VExprSPtr selector;
@@ -961,19 +1036,21 @@ TEST(ParquetBloomFilterPruningTest, NativeBloomResolvesStructAndListLeaves) {
         metadata.__set_num_rows(1);
         metadata.__set_row_groups({row_group});
 
-        auto slot = VSlotRef::create_shared(0, 0, -1, root_type, "root");
-        auto accessor =
-                std::make_shared<MetadataAccessorExpr>(leaf_type, std::move(slot), selector);
         format::FileScanRequest request;
         request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
-        request.conjuncts = {VExprContext::create_shared(std::make_shared<BloomInExpr>(
-                std::move(accessor),
-                std::vector<Field> {Field::create_field<TYPE_INT>(predicate_value)}))};
+        for (int conjunct_idx = 0; conjunct_idx < conjunct_count; ++conjunct_idx) {
+            auto slot = VSlotRef::create_shared(0, 0, -1, root_type, "root");
+            auto accessor =
+                    std::make_shared<MetadataAccessorExpr>(leaf_type, std::move(slot), selector);
+            request.conjuncts.push_back(VExprContext::create_shared(std::make_shared<BloomInExpr>(
+                    std::move(accessor),
+                    std::vector<Field> {Field::create_field<TYPE_INT>(predicate_value)})));
+        }
         std::vector<std::unique_ptr<format::parquet::ParquetColumnSchema>> schema;
         schema.push_back(std::move(root_schema));
         format::parquet::ParquetFileContext file_context;
-        file_context.native_file =
-                std::make_shared<StatisticsMemoryFileReader>(std::move(bloom_bytes));
+        auto file_reader = std::make_shared<StatisticsMemoryFileReader>(std::move(bloom_bytes));
+        file_context.native_file = file_reader;
         std::vector<int> selected_row_groups;
         format::parquet::ParquetPruningStats pruning_stats;
         ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
@@ -982,13 +1059,15 @@ TEST(ParquetBloomFilterPruningTest, NativeBloomResolvesStructAndListLeaves) {
                             .ok());
         EXPECT_EQ(selected_row_groups.empty(), expected_pruned);
         EXPECT_EQ(pruning_stats.filtered_row_groups_by_bloom_filter, expected_pruned ? 1 : 0);
+        EXPECT_EQ(file_reader->read_count(), expected_reads);
     };
 
-    run_case(format::parquet::ParquetColumnSchemaKind::STRUCT, 2, true, true);
-    run_case(format::parquet::ParquetColumnSchemaKind::STRUCT, 1, true, false);
-    run_case(format::parquet::ParquetColumnSchemaKind::STRUCT, 2, false, false);
-    run_case(format::parquet::ParquetColumnSchemaKind::LIST, 2, true, true);
-    run_case(format::parquet::ParquetColumnSchemaKind::LIST, 1, true, false);
+    run_case(format::parquet::ParquetColumnSchemaKind::STRUCT, 2, true, 1, true, 2);
+    run_case(format::parquet::ParquetColumnSchemaKind::STRUCT, 1, true, 1, false, 2);
+    run_case(format::parquet::ParquetColumnSchemaKind::STRUCT, 2, false, 1, false, 0);
+    run_case(format::parquet::ParquetColumnSchemaKind::LIST, 2, true, 1, true, 2);
+    run_case(format::parquet::ParquetColumnSchemaKind::LIST, 1, true, 1, false, 2);
+    run_case(format::parquet::ParquetColumnSchemaKind::STRUCT, 1, true, 2, false, 2);
 }
 
 TEST(ParquetBloomFilterPruningTest, NativeFloatingBloomPreservesDorisEquality) {

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -61,8 +61,10 @@ namespace {
 
 class StatisticsMemoryFileReader final : public io::FileReader {
 public:
-    explicit StatisticsMemoryFileReader(std::vector<uint8_t> bytes)
-            : _bytes(std::move(bytes)), _path("native-bloom-filter.parquet") {}
+    explicit StatisticsMemoryFileReader(std::vector<uint8_t> bytes, bool fail_reads = false)
+            : _bytes(std::move(bytes)),
+              _path("native-bloom-filter.parquet"),
+              _fail_reads(fail_reads) {}
 
     Status close() override {
         _closed = true;
@@ -78,6 +80,9 @@ protected:
     Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                         const io::IOContext*) override {
         ++_read_count;
+        if (_fail_reads) {
+            return Status::IOError("injected native Bloom read failure");
+        }
         if (offset > _bytes.size() || result.size > _bytes.size() - offset) {
             return Status::IOError("native Bloom test read exceeds memory file");
         }
@@ -90,6 +95,7 @@ private:
     std::vector<uint8_t> _bytes;
     io::Path _path;
     bool _closed = false;
+    bool _fail_reads = false;
     int _read_count = 0;
 };
 class BloomInExpr final : public VExpr {
@@ -1080,6 +1086,10 @@ TEST(ParquetBloomFilterPruningTest, NativeBloomResolvesStructAndListLeaves) {
         EXPECT_EQ(selected_row_groups.empty(), expected_pruned);
         EXPECT_EQ(pruning_stats.filtered_row_groups_by_bloom_filter, expected_pruned ? 1 : 0);
         EXPECT_EQ(file_reader->read_count(), expected_reads);
+        EXPECT_EQ(pruning_stats.bloom_filter_probe_attempts, expected_reads == 0 ? 0 : 1);
+        EXPECT_EQ(pruning_stats.bloom_filter_probe_successes, expected_reads == 0 ? 0 : 1);
+        EXPECT_EQ(pruning_stats.bloom_filter_conservative_fallbacks, 0);
+        EXPECT_EQ(pruning_stats.bloom_filter_corrupt_rejections, 0);
     };
 
     run_case(format::parquet::ParquetColumnSchemaKind::STRUCT, 2, true, 1, true, 2);
@@ -1089,6 +1099,183 @@ TEST(ParquetBloomFilterPruningTest, NativeBloomResolvesStructAndListLeaves) {
     run_case(format::parquet::ParquetColumnSchemaKind::LIST, 1, true, 1, false, 2);
     run_case(format::parquet::ParquetColumnSchemaKind::STRUCT, 1, true, 2, false, 2);
     run_case(format::parquet::ParquetColumnSchemaKind::STRUCT, 2, true, 1, false, 0, true);
+}
+
+TEST(ParquetBloomFilterPruningTest, NativeBloomReportsConservativeReadOutcomes) {
+    const auto make_valid_bloom = [] {
+        format::parquet::native::BlockSplitBloomFilter bloom_filter;
+        EXPECT_TRUE(bloom_filter
+                            .init(segment_v2::BloomFilter::MINIMUM_BYTES,
+                                  segment_v2::HashStrategyPB::XX_HASH_64)
+                            .ok());
+        const int32_t present_value = 1;
+        bloom_filter.add_bytes(reinterpret_cast<const char*>(&present_value),
+                               sizeof(present_value));
+        tparquet::BloomFilterAlgorithm algorithm;
+        algorithm.__set_BLOCK(tparquet::SplitBlockAlgorithm());
+        tparquet::BloomFilterHash hash;
+        hash.__set_XXHASH(tparquet::XxHash());
+        tparquet::BloomFilterCompression compression;
+        compression.__set_UNCOMPRESSED(tparquet::Uncompressed());
+        tparquet::BloomFilterHeader header;
+        header.__set_numBytes(static_cast<int32_t>(bloom_filter.size()));
+        header.__set_algorithm(algorithm);
+        header.__set_hash(hash);
+        header.__set_compression(compression);
+        std::vector<uint8_t> bytes;
+        ThriftSerializer serializer(/*compact=*/true, 64);
+        EXPECT_TRUE(serializer.serialize(&header, &bytes).ok());
+        bytes.insert(bytes.end(), bloom_filter.data(), bloom_filter.data() + bloom_filter.size());
+        return bytes;
+    };
+
+    const auto run_case = [&](std::vector<uint8_t> bytes, bool has_offset, bool fail_reads,
+                              int64_t expected_corrupt_rejections) {
+        auto type = std::make_shared<DataTypeInt32>();
+        auto column_schema = std::make_unique<format::parquet::ParquetColumnSchema>();
+        column_schema->kind = format::parquet::ParquetColumnSchemaKind::PRIMITIVE;
+        column_schema->local_id = 0;
+        column_schema->leaf_column_id = 0;
+        column_schema->type = type;
+        column_schema->type_descriptor.doris_type = type;
+        column_schema->type_descriptor.physical_type = tparquet::Type::INT32;
+
+        tparquet::ColumnMetaData column_metadata;
+        column_metadata.__set_type(tparquet::Type::INT32);
+        column_metadata.__set_codec(tparquet::CompressionCodec::UNCOMPRESSED);
+        column_metadata.__set_num_values(1);
+        column_metadata.__set_total_compressed_size(0);
+        column_metadata.__set_data_page_offset(0);
+        if (has_offset) {
+            column_metadata.__set_bloom_filter_offset(0);
+            column_metadata.__set_bloom_filter_length(static_cast<int32_t>(bytes.size()));
+        }
+        tparquet::ColumnChunk chunk;
+        chunk.__set_meta_data(column_metadata);
+        tparquet::RowGroup row_group;
+        row_group.__set_columns({chunk});
+        row_group.__set_total_byte_size(0);
+        row_group.__set_num_rows(1);
+        tparquet::FileMetaData metadata;
+        metadata.__set_version(1);
+        metadata.__set_num_rows(1);
+        metadata.__set_row_groups({row_group});
+
+        auto request = request_with_bloom_conjunct(type, {Field::create_field<TYPE_INT>(2)});
+        std::vector<std::unique_ptr<format::parquet::ParquetColumnSchema>> schema;
+        schema.push_back(std::move(column_schema));
+        format::parquet::ParquetFileContext file_context;
+        file_context.native_file =
+                std::make_shared<StatisticsMemoryFileReader>(std::move(bytes), fail_reads);
+        std::vector<int> selected_row_groups;
+        format::parquet::ParquetPruningStats pruning_stats;
+        ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
+                            metadata, schema, request, nullptr, &selected_row_groups, true,
+                            &pruning_stats, nullptr, nullptr, &file_context)
+                            .ok());
+        EXPECT_EQ(selected_row_groups, std::vector<int>({0}));
+        EXPECT_EQ(pruning_stats.bloom_filter_probe_attempts, 1);
+        EXPECT_EQ(pruning_stats.bloom_filter_probe_successes, 0);
+        EXPECT_EQ(pruning_stats.bloom_filter_conservative_fallbacks, 1);
+        EXPECT_EQ(pruning_stats.bloom_filter_corrupt_rejections, expected_corrupt_rejections);
+    };
+
+    run_case({}, false, false, 0);                // missing metadata offset
+    run_case({0xff, 0xff, 0xff}, true, false, 1); // malformed header
+    auto truncated = make_valid_bloom();
+    truncated.resize(truncated.size() - 16);
+    run_case(std::move(truncated), true, false, 1); // truncated payload
+    run_case(make_valid_bloom(), true, true, 0);    // I/O failure
+}
+
+TEST(ParquetBloomFilterPruningTest, NativeBloomPreservesFirstLogicalProbeOrder) {
+    const auto make_bloom = [] {
+        format::parquet::native::BlockSplitBloomFilter bloom_filter;
+        EXPECT_TRUE(bloom_filter
+                            .init(segment_v2::BloomFilter::MINIMUM_BYTES,
+                                  segment_v2::HashStrategyPB::XX_HASH_64)
+                            .ok());
+        const int32_t present_value = 1;
+        bloom_filter.add_bytes(reinterpret_cast<const char*>(&present_value),
+                               sizeof(present_value));
+        tparquet::BloomFilterAlgorithm algorithm;
+        algorithm.__set_BLOCK(tparquet::SplitBlockAlgorithm());
+        tparquet::BloomFilterHash hash;
+        hash.__set_XXHASH(tparquet::XxHash());
+        tparquet::BloomFilterCompression compression;
+        compression.__set_UNCOMPRESSED(tparquet::Uncompressed());
+        tparquet::BloomFilterHeader header;
+        header.__set_numBytes(static_cast<int32_t>(bloom_filter.size()));
+        header.__set_algorithm(algorithm);
+        header.__set_hash(hash);
+        header.__set_compression(compression);
+        std::vector<uint8_t> bytes;
+        ThriftSerializer serializer(/*compact=*/true, 64);
+        EXPECT_TRUE(serializer.serialize(&header, &bytes).ok());
+        bytes.insert(bytes.end(), bloom_filter.data(), bloom_filter.data() + bloom_filter.size());
+        return bytes;
+    };
+    const auto bloom = make_bloom();
+    std::vector<uint8_t> file_bytes = bloom;
+    file_bytes.insert(file_bytes.end(), bloom.begin(), bloom.end());
+
+    const auto type = std::make_shared<DataTypeInt32>();
+    std::vector<std::unique_ptr<format::parquet::ParquetColumnSchema>> schema;
+    for (int local_id = 0; local_id < 2; ++local_id) {
+        auto column = std::make_unique<format::parquet::ParquetColumnSchema>();
+        column->kind = format::parquet::ParquetColumnSchemaKind::PRIMITIVE;
+        column->local_id = local_id;
+        column->leaf_column_id = 1 - local_id;
+        column->type = type;
+        column->type_descriptor.doris_type = type;
+        column->type_descriptor.physical_type = tparquet::Type::INT32;
+        schema.push_back(std::move(column));
+    }
+
+    std::vector<tparquet::ColumnChunk> chunks;
+    for (int leaf_id = 0; leaf_id < 2; ++leaf_id) {
+        tparquet::ColumnMetaData column_metadata;
+        column_metadata.__set_type(tparquet::Type::INT32);
+        column_metadata.__set_codec(tparquet::CompressionCodec::UNCOMPRESSED);
+        column_metadata.__set_num_values(1);
+        column_metadata.__set_total_compressed_size(0);
+        column_metadata.__set_data_page_offset(0);
+        column_metadata.__set_bloom_filter_offset(leaf_id * bloom.size());
+        column_metadata.__set_bloom_filter_length(static_cast<int32_t>(bloom.size()));
+        tparquet::ColumnChunk chunk;
+        chunk.__set_meta_data(column_metadata);
+        chunks.push_back(std::move(chunk));
+    }
+    tparquet::RowGroup row_group;
+    row_group.__set_columns(std::move(chunks));
+    row_group.__set_total_byte_size(0);
+    row_group.__set_num_rows(1);
+    tparquet::FileMetaData metadata;
+    metadata.__set_version(1);
+    metadata.__set_num_rows(1);
+    metadata.__set_row_groups({row_group});
+
+    format::FileScanRequest request;
+    request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    request.local_positions.emplace(format::LocalColumnId(1), format::LocalIndex(1));
+    request.conjuncts = {VExprContext::create_shared(std::make_shared<BloomInExpr>(
+                                 0, type, std::vector<Field> {Field::create_field<TYPE_INT>(2)})),
+                         VExprContext::create_shared(std::make_shared<BloomInExpr>(
+                                 1, type, std::vector<Field> {Field::create_field<TYPE_INT>(1)}))};
+
+    format::parquet::ParquetFileContext file_context;
+    auto file_reader = std::make_shared<StatisticsMemoryFileReader>(std::move(file_bytes));
+    file_context.native_file = file_reader;
+    std::vector<int> selected_row_groups;
+    format::parquet::ParquetPruningStats pruning_stats;
+    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
+                        metadata, schema, request, nullptr, &selected_row_groups, true,
+                        &pruning_stats, nullptr, nullptr, &file_context)
+                        .ok());
+    EXPECT_TRUE(selected_row_groups.empty());
+    EXPECT_EQ(file_reader->read_count(), 2);
+    EXPECT_EQ(pruning_stats.bloom_filter_probe_attempts, 1);
+    EXPECT_EQ(pruning_stats.bloom_filter_probe_successes, 1);
 }
 
 TEST(ParquetBloomFilterPruningTest, NativeFloatingBloomPreservesDorisEquality) {

--- a/be/test/format_v2/table_reader_test.cpp
+++ b/be/test/format_v2/table_reader_test.cpp
@@ -784,6 +784,43 @@ void write_nullable_list_struct_parquet_file(const std::string& file_path, bool 
                                                       writer_builder.build()));
 }
 
+void write_narrowing_list_struct_parquet_file(const std::string& file_path) {
+    auto struct_type = arrow::struct_(
+            {arrow::field("a", arrow::int32(), false), arrow::field("b", arrow::int64(), false)});
+    std::vector<std::shared_ptr<arrow::ArrayBuilder>> field_builders;
+    field_builders.push_back(std::make_shared<arrow::Int32Builder>());
+    field_builders.push_back(std::make_shared<arrow::Int64Builder>());
+    auto struct_builder = std::make_shared<arrow::StructBuilder>(
+            struct_type, arrow::default_memory_pool(), std::move(field_builders));
+    auto list_type = arrow::list(arrow::field("element", struct_type, true));
+    arrow::ListBuilder builder(arrow::default_memory_pool(), struct_builder, list_type);
+    auto* a_builder = assert_cast<arrow::Int32Builder*>(struct_builder->field_builder(0));
+    auto* b_builder = assert_cast<arrow::Int64Builder*>(struct_builder->field_builder(1));
+
+    EXPECT_TRUE(builder.Append().ok());
+    EXPECT_TRUE(struct_builder->Append().ok());
+    EXPECT_TRUE(a_builder->Append(0).ok());
+    EXPECT_TRUE(b_builder->Append(2147483648LL).ok());
+
+    EXPECT_TRUE(builder.Append().ok());
+    EXPECT_TRUE(struct_builder->Append().ok());
+    EXPECT_TRUE(a_builder->Append(20).ok());
+    EXPECT_TRUE(b_builder->Append(1).ok());
+
+    auto schema = arrow::schema({arrow::field("items", list_type, false)});
+    auto table = arrow::Table::Make(schema, {finish_array(&builder)});
+    auto file_result = arrow::io::FileOutputStream::Open(file_path);
+    ASSERT_TRUE(file_result.ok()) << file_result.status();
+    std::shared_ptr<arrow::io::FileOutputStream> out = *file_result;
+
+    ::parquet::WriterProperties::Builder writer_builder;
+    writer_builder.version(::parquet::ParquetVersion::PARQUET_2_6);
+    writer_builder.data_page_version(::parquet::ParquetDataPageVersion::V2);
+    writer_builder.compression(::parquet::Compression::UNCOMPRESSED);
+    PARQUET_THROW_NOT_OK(::parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), out, 2,
+                                                      writer_builder.build()));
+}
+
 void write_map_struct_parquet_file(const std::string& file_path) {
     auto key_builder = std::make_shared<arrow::Int32Builder>();
     auto struct_type = arrow::struct_(
@@ -4401,6 +4438,57 @@ TEST(TableReaderTest, ArrayAccessorDoesNotHideRequiredUnreferencedSibling) {
     bool eos = false;
     const auto status = reader.get_block(&block, &eos);
     EXPECT_FALSE(status.ok()) << "A file-local filter must not hide a required sibling NULL";
+
+    ASSERT_TRUE(reader.close().ok());
+    std::filesystem::remove_all(test_dir);
+}
+
+TEST(TableReaderTest, ArrayAccessorDoesNotHideLossyUnreferencedSiblingConversion) {
+    const auto test_dir = std::filesystem::temp_directory_path() /
+                          "doris_table_reader_array_sibling_conversion_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+    const auto file_path = (test_dir / "split.parquet").string();
+    write_narrowing_list_struct_parquet_file(file_path);
+
+    const auto int_type = std::make_shared<DataTypeInt32>();
+    const auto table_element = make_nullable(
+            std::make_shared<DataTypeStruct>(DataTypes {int_type, int_type}, Strings {"a", "b"}));
+    const auto table_array = std::make_shared<DataTypeArray>(table_element);
+    auto a_child = make_table_column(0, "a", int_type);
+    auto b_child = make_table_column(1, "b", int_type);
+    ColumnDefinition element_child;
+    element_child.name = "element";
+    element_child.type = table_element;
+    element_child.children = {std::move(a_child), std::move(b_child)};
+    ColumnDefinition list_column;
+    list_column.name = "items";
+    list_column.type = make_nullable(table_array);
+    list_column.children = {std::move(element_child)};
+    std::vector<ColumnDefinition> projected_columns = {std::move(list_column)};
+    set_name_identifiers(&projected_columns);
+
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    const auto root_type = projected_columns[0].type;
+    auto predicate = table_array_struct_int_greater_than_expr(0, "items", root_type, table_element,
+                                                              make_nullable(int_type), "a", 5);
+    TableReader reader;
+    ASSERT_TRUE(reader.init({
+                                    .projected_columns = projected_columns,
+                                    .conjuncts = {prepared_conjunct(&state, predicate)},
+                                    .format = FileFormat::PARQUET,
+                                    .scan_params = nullptr,
+                                    .io_ctx = nullptr,
+                                    .runtime_state = &state,
+                                    .scanner_profile = nullptr,
+                            })
+                        .ok());
+    ASSERT_TRUE(reader.prepare_split(build_split_options(file_path)).ok());
+
+    Block block = build_table_block(projected_columns);
+    bool eos = false;
+    const auto status = reader.get_block(&block, &eos);
+    EXPECT_FALSE(status.ok()) << "A file-local filter must not hide a lossy sibling conversion";
 
     ASSERT_TRUE(reader.close().ok());
     std::filesystem::remove_all(test_dir);

--- a/be/test/format_v2/table_reader_test.cpp
+++ b/be/test/format_v2/table_reader_test.cpp
@@ -1496,7 +1496,13 @@ TEST(TableReaderTest, UnsafePredicateStaysOnScannerPath) {
     FakeTableReader reader(file_schema, fake_state);
     ASSERT_TRUE(reader.init({
                                     .projected_columns = projected_columns,
-                                    .conjuncts = {prepared_conjunct(&state, unsafe_predicate)},
+                                    .conjuncts =
+                                            {
+                                                    prepared_conjunct(&state, unsafe_predicate),
+                                                    prepared_conjunct(&state,
+                                                                      table_int32_greater_than_expr(
+                                                                              0, 0, 10)),
+                                            },
                                     .format = FileFormat::PARQUET,
                                     .scan_params = nullptr,
                                     .io_ctx = nullptr,
@@ -1512,7 +1518,8 @@ TEST(TableReaderTest, UnsafePredicateStaysOnScannerPath) {
     bool eos = false;
     ASSERT_TRUE(reader.get_block(&block, &eos).ok());
     ASSERT_NE(fake_state->last_request, nullptr);
-    EXPECT_TRUE(fake_state->last_request->conjuncts.empty());
+    ASSERT_EQ(fake_state->last_request->conjuncts.size(), 1);
+    EXPECT_EQ(fake_state->last_request->metadata_pruning_safe_conjunct_count, 0);
     EXPECT_FALSE(predicate_executed);
     ASSERT_TRUE(reader.close().ok());
 }

--- a/be/test/format_v2/table_reader_test.cpp
+++ b/be/test/format_v2/table_reader_test.cpp
@@ -300,6 +300,28 @@ VExprSPtr table_int32_greater_than_expr(int slot_id, int column_id, int32_t valu
     return expr;
 }
 
+VExprSPtr table_array_struct_int_greater_than_expr(int column_id, const std::string& column_name,
+                                                   const DataTypePtr& array_type,
+                                                   const DataTypePtr& element_type,
+                                                   const DataTypePtr& accessor_type,
+                                                   const std::string& child_name, int32_t value) {
+    const auto int_type = std::make_shared<DataTypeInt32>();
+    auto array_element = table_function_expr("element_at", element_type, {array_type, int_type});
+    array_element->add_child(VSlotRef::create_shared(0, column_id, -1, array_type, column_name));
+    array_element->add_child(table_int32_literal(1));
+    auto struct_element = table_function_expr("element_at", accessor_type,
+                                              {element_type, std::make_shared<DataTypeString>()});
+    struct_element->add_child(std::move(array_element));
+    struct_element->add_child(VLiteral::create_shared(
+            std::make_shared<DataTypeString>(), Field::create_field<TYPE_STRING>(child_name)));
+    auto greater_than = table_function_expr("gt", make_nullable(std::make_shared<DataTypeUInt8>()),
+                                            {accessor_type, int_type}, TExprNodeType::BINARY_PRED,
+                                            TExprOpcode::GT);
+    greater_than->add_child(std::move(struct_element));
+    greater_than->add_child(table_int32_literal(value));
+    return greater_than;
+}
+
 VExprSPtr runtime_filter_wrapper_expr(VExprSPtr impl) {
     TExprNode node;
     node.__set_node_type(TExprNodeType::SLOT_REF);
@@ -718,6 +740,47 @@ void write_list_struct_parquet_file(const std::string& file_path) {
     writer_builder.data_page_version(::parquet::ParquetDataPageVersion::V2);
     writer_builder.compression(::parquet::Compression::UNCOMPRESSED);
     PARQUET_THROW_NOT_OK(::parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), out, 3,
+                                                      writer_builder.build()));
+}
+
+void write_nullable_list_struct_parquet_file(const std::string& file_path, bool first_a_is_null) {
+    auto struct_type = arrow::struct_(
+            {arrow::field("a", arrow::int32(), true), arrow::field("b", arrow::int32(), true)});
+    std::vector<std::shared_ptr<arrow::ArrayBuilder>> field_builders;
+    field_builders.push_back(std::make_shared<arrow::Int32Builder>());
+    field_builders.push_back(std::make_shared<arrow::Int32Builder>());
+    auto struct_builder = std::make_shared<arrow::StructBuilder>(
+            struct_type, arrow::default_memory_pool(), std::move(field_builders));
+    auto list_type = arrow::list(arrow::field("element", struct_type, true));
+    arrow::ListBuilder builder(arrow::default_memory_pool(), struct_builder, list_type);
+    auto* a_builder = assert_cast<arrow::Int32Builder*>(struct_builder->field_builder(0));
+    auto* b_builder = assert_cast<arrow::Int32Builder*>(struct_builder->field_builder(1));
+
+    EXPECT_TRUE(builder.Append().ok());
+    EXPECT_TRUE(struct_builder->Append().ok());
+    if (first_a_is_null) {
+        EXPECT_TRUE(a_builder->AppendNull().ok());
+    } else {
+        EXPECT_TRUE(a_builder->Append(0).ok());
+    }
+    EXPECT_TRUE(b_builder->AppendNull().ok());
+
+    EXPECT_TRUE(builder.Append().ok());
+    EXPECT_TRUE(struct_builder->Append().ok());
+    EXPECT_TRUE(a_builder->Append(20).ok());
+    EXPECT_TRUE(b_builder->Append(1).ok());
+
+    auto schema = arrow::schema({arrow::field("items", list_type, false)});
+    auto table = arrow::Table::Make(schema, {finish_array(&builder)});
+    auto file_result = arrow::io::FileOutputStream::Open(file_path);
+    ASSERT_TRUE(file_result.ok()) << file_result.status();
+    std::shared_ptr<arrow::io::FileOutputStream> out = *file_result;
+
+    ::parquet::WriterProperties::Builder writer_builder;
+    writer_builder.version(::parquet::ParquetVersion::PARQUET_2_6);
+    writer_builder.data_page_version(::parquet::ParquetDataPageVersion::V2);
+    writer_builder.compression(::parquet::Compression::UNCOMPRESSED);
+    PARQUET_THROW_NOT_OK(::parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), out, 2,
                                                       writer_builder.build()));
 }
 
@@ -4284,6 +4347,126 @@ TEST(TableReaderTest, NestedEqualityReachesParquetBloomProbe) {
     ASSERT_NE(fallbacks, nullptr);
     EXPECT_EQ(attempts->value(), 1);
     EXPECT_EQ(fallbacks->value(), 1);
+
+    ASSERT_TRUE(reader.close().ok());
+    std::filesystem::remove_all(test_dir);
+}
+
+TEST(TableReaderTest, ArrayAccessorDoesNotHideRequiredUnreferencedSibling) {
+    const auto test_dir = std::filesystem::temp_directory_path() /
+                          "doris_table_reader_array_sibling_nullability_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+    const auto file_path = (test_dir / "split.parquet").string();
+    write_nullable_list_struct_parquet_file(file_path, false);
+
+    const auto int_type = std::make_shared<DataTypeInt32>();
+    const auto nullable_int_type = make_nullable(int_type);
+    const auto table_element = make_nullable(std::make_shared<DataTypeStruct>(
+            DataTypes {nullable_int_type, int_type}, Strings {"a", "b"}));
+    const auto table_array = std::make_shared<DataTypeArray>(table_element);
+    auto a_child = make_table_column(0, "a", nullable_int_type);
+    ColumnDefinition b_child;
+    b_child.name = "b";
+    b_child.type = int_type;
+    ColumnDefinition element_child;
+    element_child.name = "element";
+    element_child.type = table_element;
+    element_child.children = {std::move(a_child), std::move(b_child)};
+    ColumnDefinition list_column;
+    list_column.name = "items";
+    list_column.type = make_nullable(table_array);
+    list_column.children = {std::move(element_child)};
+    std::vector<ColumnDefinition> projected_columns = {std::move(list_column)};
+    set_name_identifiers(&projected_columns);
+
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    const auto root_type = projected_columns[0].type;
+    auto predicate = table_array_struct_int_greater_than_expr(0, "items", root_type, table_element,
+                                                              nullable_int_type, "a", 5);
+    TableReader reader;
+    ASSERT_TRUE(reader.init({
+                                    .projected_columns = projected_columns,
+                                    .conjuncts = {prepared_conjunct(&state, predicate)},
+                                    .format = FileFormat::PARQUET,
+                                    .scan_params = nullptr,
+                                    .io_ctx = nullptr,
+                                    .runtime_state = &state,
+                                    .scanner_profile = nullptr,
+                            })
+                        .ok());
+    ASSERT_TRUE(reader.prepare_split(build_split_options(file_path)).ok());
+
+    Block block = build_table_block(projected_columns);
+    bool eos = false;
+    const auto status = reader.get_block(&block, &eos);
+    EXPECT_FALSE(status.ok()) << "A file-local filter must not hide a required sibling NULL";
+
+    ASSERT_TRUE(reader.close().ok());
+    std::filesystem::remove_all(test_dir);
+}
+
+TEST(TableReaderTest, RejectedArrayAccessorFencesLaterDefaultConstantPruning) {
+    const auto test_dir = std::filesystem::temp_directory_path() /
+                          "doris_table_reader_array_constant_pruning_barrier_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+    const auto file_path = (test_dir / "split.parquet").string();
+    write_nullable_list_struct_parquet_file(file_path, true);
+
+    const auto int_type = std::make_shared<DataTypeInt32>();
+    const auto nullable_int_type = make_nullable(int_type);
+    const auto table_element = make_nullable(std::make_shared<DataTypeStruct>(
+            DataTypes {int_type, nullable_int_type}, Strings {"a", "b"}));
+    const auto table_array = std::make_shared<DataTypeArray>(table_element);
+    ColumnDefinition a_child;
+    a_child.name = "a";
+    a_child.type = int_type;
+    auto b_child = make_table_column(1, "b", nullable_int_type);
+    ColumnDefinition element_child;
+    element_child.name = "element";
+    element_child.type = table_element;
+    element_child.children = {std::move(a_child), std::move(b_child)};
+    ColumnDefinition list_column;
+    list_column.name = "items";
+    list_column.type = make_nullable(table_array);
+    list_column.children = {std::move(element_child)};
+    auto missing_default = make_table_column(101, "z", nullable_int_type);
+    missing_default.default_expr = VExprContext::create_shared(
+            VLiteral::create_shared(nullable_int_type, Field::create_field<TYPE_INT>(0)));
+    std::vector<ColumnDefinition> projected_columns = {std::move(list_column),
+                                                       std::move(missing_default)};
+    set_name_identifiers(&projected_columns);
+
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    const auto root_type = projected_columns[0].type;
+    auto accessor_predicate = table_array_struct_int_greater_than_expr(
+            0, "items", root_type, table_element, nullable_int_type, "a", 10);
+    auto default_predicate = table_function_expr(
+            "eq", make_nullable(std::make_shared<DataTypeUInt8>()), {nullable_int_type, int_type},
+            TExprNodeType::BINARY_PRED, TExprOpcode::EQ);
+    default_predicate->add_child(VSlotRef::create_shared(1, 1, -1, nullable_int_type, "z"));
+    default_predicate->add_child(table_int32_literal(7));
+
+    TableReader reader;
+    ASSERT_TRUE(reader.init({
+                                    .projected_columns = projected_columns,
+                                    .conjuncts = {prepared_conjunct(&state, accessor_predicate),
+                                                  prepared_conjunct(&state, default_predicate)},
+                                    .format = FileFormat::PARQUET,
+                                    .scan_params = nullptr,
+                                    .io_ctx = nullptr,
+                                    .runtime_state = &state,
+                                    .scanner_profile = nullptr,
+                            })
+                        .ok());
+    ASSERT_TRUE(reader.prepare_split(build_split_options(file_path)).ok());
+
+    Block block = build_table_block(projected_columns);
+    bool eos = false;
+    const auto status = reader.get_block(&block, &eos);
+    EXPECT_FALSE(status.ok())
+            << "A later false default predicate must not bypass required-child validation";
 
     ASSERT_TRUE(reader.close().ok());
     std::filesystem::remove_all(test_dir);

--- a/be/test/format_v2/table_reader_test.cpp
+++ b/be/test/format_v2/table_reader_test.cpp
@@ -4228,6 +4228,67 @@ TEST(TableReaderTest, ProjectedListStructReadsSelectedElementChild) {
     std::filesystem::remove_all(test_dir);
 }
 
+TEST(TableReaderTest, NestedEqualityReachesParquetBloomProbe) {
+    const auto test_dir =
+            std::filesystem::temp_directory_path() / "doris_table_reader_nested_bloom_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+    const auto file_path = (test_dir / "split.parquet").string();
+    write_list_struct_parquet_file(file_path);
+
+    const auto int_type = std::make_shared<DataTypeInt32>();
+    const auto nullable_int_type = make_nullable(int_type);
+    auto element_type = make_nullable(std::make_shared<DataTypeStruct>(
+            DataTypes {nullable_int_type, nullable_int_type}, Strings {"a", "b"}));
+    auto list_column = make_table_column(100, "xs", std::make_shared<DataTypeArray>(element_type));
+    std::vector<ColumnDefinition> projected_columns = {list_column};
+    set_name_identifiers(&projected_columns);
+
+    const auto root_type = projected_columns[0].type;
+    auto array_element = table_function_expr("element_at", element_type, {root_type, int_type});
+    array_element->add_child(VSlotRef::create_shared(0, 0, -1, root_type, "xs"));
+    array_element->add_child(table_int32_literal(1));
+    auto struct_element = table_function_expr("element_at", nullable_int_type,
+                                              {element_type, std::make_shared<DataTypeString>()});
+    struct_element->add_child(std::move(array_element));
+    struct_element->add_child(VLiteral::create_shared(std::make_shared<DataTypeString>(),
+                                                      Field::create_field<TYPE_STRING>("a")));
+    auto equality = table_function_expr("eq", make_nullable(std::make_shared<DataTypeUInt8>()),
+                                        {nullable_int_type, int_type}, TExprNodeType::BINARY_PRED,
+                                        TExprOpcode::EQ);
+    equality->add_child(std::move(struct_element));
+    equality->add_child(table_int32_literal(10));
+
+    RuntimeProfile profile("profile");
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    TableReader reader;
+    ASSERT_TRUE(reader.init({
+                                    .projected_columns = projected_columns,
+                                    .conjuncts = {prepared_conjunct(&state, equality)},
+                                    .format = FileFormat::PARQUET,
+                                    .scan_params = nullptr,
+                                    .io_ctx = nullptr,
+                                    .runtime_state = &state,
+                                    .scanner_profile = &profile,
+                            })
+                        .ok());
+    ASSERT_TRUE(reader.prepare_split(build_split_options(file_path)).ok());
+
+    Block block = build_table_block(projected_columns);
+    bool eos = false;
+    const auto status = reader.get_block(&block, &eos);
+    ASSERT_TRUE(status.ok()) << status;
+    auto* attempts = profile.get_counter("BloomFilterProbeAttempts");
+    auto* fallbacks = profile.get_counter("BloomFilterConservativeFallbacks");
+    ASSERT_NE(attempts, nullptr);
+    ASSERT_NE(fallbacks, nullptr);
+    EXPECT_EQ(attempts->value(), 1);
+    EXPECT_EQ(fallbacks->value(), 1);
+
+    ASSERT_TRUE(reader.close().ok());
+    std::filesystem::remove_all(test_dir);
+}
+
 TEST(TableReaderTest, ProjectedListStructReordersRenamedAndMissingElementChildren) {
     const auto test_dir = std::filesystem::temp_directory_path() /
                           "doris_table_reader_list_schema_evolution_test";


### PR DESCRIPTION
## Summary

- backport nested Parquet Bloom-filter pruning support to branch-4.1
- resolve struct and list leaf predicates for equality, null-safe equality, and IN probes
- retain table-level evaluation when schema mapping, nullability, or expression localization makes early filtering unsafe
- preserve filter order and merge deferred complex projections so rejected localization cannot bypass validation or drop residual-filter children
- keep nested Variant leaf predicates eager while validating nullability only at mapped table-schema levels
- add pruning diagnostics and focused coverage for Parquet, ORC, column mapping, and TableReader paths

## Testing

- clang-format 16 check on all affected C/C++ files
- 162 focused BE unit tests across ExprZonemapFilterTest, ColumnMapperScanRequestTest, ParquetBloomFilterPruningTest, and TableReaderTest
- 38 focused mapper tests, including ColumnMapperTest.NestedVariantAllAccessPathKeepsPhysicalTypedLeaf from BE UT build 1016464