### PR TITLE
[fix](be) Adapt nullable column unnesting to new interface

### DIFF
--- a/be/src/exprs/function/ai/ai_functions.h
+++ b/be/src/exprs/function/ai/ai_functions.h
@@ -309,7 +309,12 @@ protected:
                 VectorizedUtils::update_null_map(result_null_map->get_data(),
                                                  nullable.get_null_map_data(), is_const);
             }
-            prompt_columns.emplace_back(argument.unnest_nullable().column);
+            prompt_columns.emplace_back(
+                    argument.unnest_nullable(argument.type->is_nullable()
+                                                     ? argument.get_nullable_column_info()
+                                                     : NullableColumnInfo {},
+                                             false)
+                            .column);
         }
 
         if (result_null_map &&

--- a/be/src/exprs/function/ai/embed.h
+++ b/be/src/exprs/function/ai/embed.h
@@ -71,7 +71,11 @@ public:
             return Status::OK();
         }
 
-        ColumnPtr input_column = input.unnest_nullable().column;
+        ColumnPtr input_column =
+                input.unnest_nullable(input.type->is_nullable() ? input.get_nullable_column_info()
+                                                                : NullableColumnInfo {},
+                                      false)
+                        .column;
         PrimitiveType input_type = remove_nullable(input.type)->get_primitive_type();
         if (input_type == PrimitiveType::TYPE_JSONB) {
             return _execute_multimodal_embed(context, block, result, input_rows_count, config,

--- a/be/test/ai/ai_function_test.cpp
+++ b/be/test/ai/ai_function_test.cpp
@@ -218,7 +218,13 @@ Columns get_prompt_columns(const Block& block, const ColumnNumbers& arguments) {
     Columns prompt_columns;
     prompt_columns.reserve(arguments.size() - 1);
     for (size_t i = 1; i < arguments.size(); ++i) {
-        prompt_columns.emplace_back(block.get_by_position(arguments[i]).unnest_nullable().column);
+        const auto& argument = block.get_by_position(arguments[i]);
+        prompt_columns.emplace_back(
+                argument.unnest_nullable(argument.type->is_nullable()
+                                                 ? argument.get_nullable_column_info()
+                                                 : NullableColumnInfo {},
+                                         false)
+                        .column);
     }
     return prompt_columns;
 }


### PR DESCRIPTION
Related PR: conflict between https://github.com/apache/doris/pull/66242 and https://github.com/apache/doris/pull/66031

Problem Summary:

fix be compile:
```text
In file included from ../src/exprs/function/ai/ai_functions.cpp:19:
In file included from ../src/exprs/function/ai/ai_classify.h:20:
../src/exprs/function/ai/ai_functions.h:312:66: error: too few arguments to function call, expected 2, have 0
  312 |             prompt_columns.emplace_back(argument.unnest_nullable().column);
      |                                         ~~~~~~~~~~~~~~~~~~~~~~~~ ^
../src/core/block/column_with_type_and_name.h:86:27: note: 'unnest_nullable' declared here
   86 |     ColumnWithTypeAndName unnest_nullable(const NullableColumnInfo& info,
      |                           ^               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   87 |                                           bool replace_null_data_to_default) const;
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../src/exprs/function/ai/ai_functions.cpp:29:
../src/exprs/function/ai/embed.h:74:56: error: too few arguments to function call, expected 2, have 0
   74 |         ColumnPtr input_column = input.unnest_nullable().column;
      |                                  ~~~~~~~~~~~~~~~~~~~~~ ^
../src/core/block/column_with_type_and_name.h:86:27: note: 'unnest_nullable' declared here
   86 |     ColumnWithTypeAndName unnest_nullable(const NullableColumnInfo& info,
      |                           ^               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   87 |                                           bool replace_null_data_to_default) const;
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
```
