### PR TITLE
[opt](expr) use compiler builtin for int128 multiplication overflow checks

### DIFF
--- a/be/src/exec/common/arithmetic_overflow.h
+++ b/be/src/exec/common/arithmetic_overflow.h
@@ -115,9 +115,56 @@ inline bool mul_overflow(long long x, long long y, long long& res) {
     return __builtin_smulll_overflow(x, y, &res);
 }
 
+#if defined(__aarch64__)
+// Some AArch64 toolchains lower the builtin to a runtime symbol unavailable in libgcc.
+// Use the implementation from __muloXi4 in LLVM's compiler-rt instead.
+static inline __int128 int128_overflow_mul(__int128 a, __int128 b, int* overflow) {
+    const int N = (int)(sizeof(__int128) * CHAR_BIT);
+    const auto MIN = (__int128)((__uint128_t)1 << (N - 1));
+    const __int128 MAX = ~MIN;
+    *overflow = 0;
+    __int128 result = (__uint128_t)a * b;
+    if (a == MIN) {
+        if (b != 0 && b != 1) {
+            *overflow = 1;
+        }
+        return result;
+    }
+    if (b == MIN) {
+        if (a != 0 && a != 1) {
+            *overflow = 1;
+        }
+        return result;
+    }
+    __int128 sa = a >> (N - 1);
+    __int128 abs_a = (a ^ sa) - sa;
+    __int128 sb = b >> (N - 1);
+    __int128 abs_b = (b ^ sb) - sb;
+    if (abs_a < 2 || abs_b < 2) {
+        return result;
+    }
+    if (sa == sb) {
+        if (abs_a > MAX / abs_b) {
+            *overflow = 1;
+        }
+    } else {
+        if (abs_a > MIN / -abs_b) {
+            *overflow = 1;
+        }
+    }
+    return result;
+}
+#endif
+
 template <>
 inline bool mul_overflow(__int128 x, __int128 y, __int128& res) {
+#if defined(__aarch64__)
+    int overflow = 0;
+    res = int128_overflow_mul(x, y, &overflow);
+    return overflow != 0;
+#else
     return __builtin_mul_overflow(x, y, &res);
+#endif
 }
 
 static inline wide::Int256 int256_overflow_mul(const wide::Int256& a, const wide::Int256& b,

--- a/be/src/exec/common/arithmetic_overflow.h
+++ b/be/src/exec/common/arithmetic_overflow.h
@@ -115,49 +115,9 @@ inline bool mul_overflow(long long x, long long y, long long& res) {
     return __builtin_smulll_overflow(x, y, &res);
 }
 
-// from __muloXi4 in llvm's compiler-rt
-static inline __int128 int128_overflow_mul(__int128 a, __int128 b, int* overflow) {
-    const int N = (int)(sizeof(__int128) * CHAR_BIT);
-    const auto MIN = (__int128)((__uint128_t)1 << (N - 1));
-    const __int128 MAX = ~MIN;
-    *overflow = 0;
-    __int128 result = (__uint128_t)a * b;
-    if (a == MIN) {
-        if (b != 0 && b != 1) {
-            *overflow = 1;
-        }
-        return result;
-    }
-    if (b == MIN) {
-        if (a != 0 && a != 1) {
-            *overflow = 1;
-        }
-        return result;
-    }
-    __int128 sa = a >> (N - 1);
-    __int128 abs_a = (a ^ sa) - sa;
-    __int128 sb = b >> (N - 1);
-    __int128 abs_b = (b ^ sb) - sb;
-    if (abs_a < 2 || abs_b < 2) {
-        return result;
-    }
-    if (sa == sb) {
-        if (abs_a > MAX / abs_b) {
-            *overflow = 1;
-        }
-    } else {
-        if (abs_a > MIN / -abs_b) {
-            *overflow = 1;
-        }
-    }
-    return result;
-}
-
 template <>
 inline bool mul_overflow(__int128 x, __int128 y, __int128& res) {
-    int overflow = 0;
-    res = int128_overflow_mul(x, y, &overflow);
-    return overflow != 0;
+    return __builtin_mul_overflow(x, y, &res);
 }
 
 static inline wide::Int256 int256_overflow_mul(const wide::Int256& a, const wide::Int256& b,

--- a/be/test/common/check_overflow.cpp
+++ b/be/test/common/check_overflow.cpp
@@ -17,7 +17,10 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <bit>
 #include <limits>
+#include <random>
 
 #include "core/types.h"
 #include "exec/common/arithmetic_overflow.h"
@@ -43,6 +46,18 @@ struct CheckOverFlowTest : public testing::Test {
     };
 
     wide::Int256 to_i256(std::string str) { return wide::Int256::_impl::from_str(str.c_str()); };
+
+    void expect_int128_mul(Int128 left, Int128 right) {
+        const wide::Int256 exact = wide::Int256(left) * wide::Int256(right);
+        const wide::Int256 min_int128 = std::numeric_limits<Int128>::min();
+        const wide::Int256 max_int128 = std::numeric_limits<Int128>::max();
+        const bool expected_overflow = exact < min_int128 || exact > max_int128;
+        const auto expected_bits = static_cast<__uint128_t>(exact);
+
+        Int128 result;
+        EXPECT_EQ(common::mul_overflow(left, right, result), expected_overflow);
+        EXPECT_EQ(static_cast<__uint128_t>(result), expected_bits);
+    }
 };
 
 TEST_F(CheckOverFlowTest, test_overflow_int128) {
@@ -65,6 +80,41 @@ TEST_F(CheckOverFlowTest, test_overflow_int128) {
         Int128 b = to_i128("12000");
         Int128 c;
         EXPECT_FALSE(common::mul_overflow(a, b, c));
+    }
+}
+
+TEST_F(CheckOverFlowTest, test_overflow_int128_boundaries_and_random_values) {
+    constexpr Int128 min_int128 = std::numeric_limits<Int128>::min();
+    constexpr Int128 max_int128 = std::numeric_limits<Int128>::max();
+    constexpr Int128 two_to_64 = Int128 {1} << 64;
+    const std::array<Int128, 17> boundaries = {min_int128,
+                                               min_int128 + 1,
+                                               max_int128,
+                                               max_int128 - 1,
+                                               0,
+                                               1,
+                                               -1,
+                                               2,
+                                               -2,
+                                               two_to_64,
+                                               -two_to_64,
+                                               max_int128 / 2,
+                                               max_int128 / 2 + 1,
+                                               min_int128 / 2,
+                                               min_int128 / 2 - 1,
+                                               Int128 {1} << 63,
+                                               -(Int128 {1} << 63)};
+    for (const auto left : boundaries) {
+        for (const auto right : boundaries) {
+            expect_int128_mul(left, right);
+        }
+    }
+
+    std::mt19937_64 rng(0x21261DEC1A1ULL);
+    for (size_t i = 0; i < 10'000; ++i) {
+        const __uint128_t left_bits = (static_cast<__uint128_t>(rng()) << 64) | rng();
+        const __uint128_t right_bits = (static_cast<__uint128_t>(rng()) << 64) | rng();
+        expect_int128_mul(std::bit_cast<Int128>(left_bits), std::bit_cast<Int128>(right_bits));
     }
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Checked `int128` multiplication used a division-based software implementation. On x86-64, this
generated a call to the expensive `__udivti3` helper in the decimal multiplication path.

This change uses `__builtin_mul_overflow`, allowing the compiler to emit inline multiplication and
carry instructions without a runtime helper call. It also adds boundary coverage and 10,000
deterministic random input pairs that validate both the overflow flag and low 128 result bits against
an `Int256` oracle.

For the query-like `DECIMAL64(10,7) * DECIMAL128(38,2) -> DECIMAL128(38,9)` benchmark with 65,536
items per batch, using aggregate CPU mean from five repetitions:

| Path | Before | After | Improvement |
|---|---:|---:|---:|
| Production, including precision-38 check | 21.32 ns/item | 6.32 ns/item | **70.34%** |
| Native overflow check only | 21.06 ns/item | 4.13 ns/item | **80.37%** |

### Release note

None

### Check List (For Author)

- Test: Manual test
    - Release benchmark build: sh build.sh --benchmark -j48
    - Benchmark correctness validation against Int256 oracle
    - clang-format 16 check
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

