### PR TITLE
[fix](catalog) Preserve schema case for partition scans

### DIFF
--- a/be/src/exec/sink/viceberg_delete_sink.cpp
+++ b/be/src/exec/sink/viceberg_delete_sink.cpp
@@ -681,8 +681,8 @@ Status VIcebergDeleteSink::_write_deletion_vector_files(
         commit_data.__set_content_offset(blob.content_offset);
         commit_data.__set_content_size_in_bytes(blob.content_size_in_bytes);
         commit_data.__set_referenced_data_file_path(blob.referenced_data_file);
-        if (blob.partition_spec_id != 0 || !blob.partition_data_json.empty()) {
-            commit_data.__set_partition_spec_id(blob.partition_spec_id);
+        commit_data.__set_partition_spec_id(blob.partition_spec_id);
+        if (!blob.partition_data_json.empty()) {
             commit_data.__set_partition_data_json(blob.partition_data_json);
         }
 

--- a/be/src/format/orc/vorc_reader.cpp
+++ b/be/src/format/orc/vorc_reader.cpp
@@ -509,6 +509,15 @@ Status OrcReader::_do_init_reader(ReaderInitContext* base_ctx) {
         _fill_missing_cols.clear();
         _fill_missing_defaults.clear();
         for (const auto& col_name : _table_column_names) {
+            // A projected column absent from the table-side schema tree is an FE/BE schema-contract
+            // violation, not a column missing from this data file. Return an error for this query instead
+            // of aborting the BE through children_column_exists (or children.at in a release build).
+            if (!_table_info_node_ptr->has_children_column(col_name)) {
+                return Status::InternalError(
+                        "schema mapping is missing projected column '{}'; the schema info from FE "
+                        "is inconsistent with the scan projection (file: {})",
+                        col_name, _scan_range.path);
+            }
             if (!_table_info_node_ptr->children_column_exists(col_name)) {
                 _fill_missing_cols.insert(col_name);
             }

--- a/be/src/format/table/iceberg_reader.cpp
+++ b/be/src/format/table/iceberg_reader.cpp
@@ -482,6 +482,12 @@ Status IcebergParquetReader::on_before_init_reader(ReaderInitContext* ctx) {
             }
         } else if (desc.category == ColumnCategory::PARTITION_KEY) {
             bool has_partition_value = partition_col_names.contains(desc.name);
+            if (!ctx->table_info_node->has_children_column(desc.name)) {
+                return Status::InternalError(
+                        "Iceberg schema mapping is missing partition column '{}'; the schema info "
+                        "from FE is inconsistent with the scan tuple (file: {})",
+                        desc.name, ctx->range->path);
+            }
             bool exists_in_file = ctx->table_info_node->children_column_exists(desc.name);
             if (!has_partition_value || exists_in_file) {
                 // Keep PARTITION_KEY category stable for scan planning, but still read
@@ -881,6 +887,12 @@ Status IcebergOrcReader::on_before_init_reader(ReaderInitContext* ctx) {
             }
         } else if (desc.category == ColumnCategory::PARTITION_KEY) {
             bool has_partition_value = partition_col_names.contains(desc.name);
+            if (!ctx->table_info_node->has_children_column(desc.name)) {
+                return Status::InternalError(
+                        "Iceberg schema mapping is missing partition column '{}'; the schema info "
+                        "from FE is inconsistent with the scan tuple (file: {})",
+                        desc.name, ctx->range->path);
+            }
             bool exists_in_file = ctx->table_info_node->children_column_exists(desc.name);
             if (!has_partition_value || exists_in_file) {
                 ctx->column_names.push_back(desc.name);

--- a/be/test/exec/sink/viceberg_delete_sink_test.cpp
+++ b/be/test/exec/sink/viceberg_delete_sink_test.cpp
@@ -607,4 +607,30 @@ TEST_F(VIcebergDeleteSinkTest, TestWriteDeletionVectorsToSingleSharedPuffin) {
     std::filesystem::remove_all(temp_dir);
 }
 
+TEST_F(VIcebergDeleteSinkTest, TestDeletionVectorPreservesUnpartitionedSpecZero) {
+    std::filesystem::path temp_dir = std::filesystem::temp_directory_path() /
+                                     ("iceberg_delete_sink_test_" + generate_uuid_string());
+    ASSERT_TRUE(std::filesystem::create_directories(temp_dir));
+
+    TDataSink t_data_sink = build_local_delete_sink(temp_dir.string(), 3);
+    VExprContextSPtrs output_exprs;
+    auto sink = std::make_shared<VIcebergDeleteSink>(t_data_sink, output_exprs, nullptr, nullptr);
+    ObjectPool pool;
+    ASSERT_TRUE(sink->init_properties(&pool).ok());
+
+    std::map<std::string, IcebergFileDeletion> file_deletions;
+    auto [file_it, inserted] = file_deletions.emplace("file.parquet", IcebergFileDeletion(0, ""));
+    ASSERT_TRUE(inserted);
+    file_it->second.rows_to_delete.add((uint32_t)10);
+
+    ASSERT_TRUE(sink->_write_deletion_vector_files(file_deletions).ok());
+    ASSERT_EQ(1, sink->_commit_data_list.size());
+    const auto& commit_data = sink->_commit_data_list.front();
+    ASSERT_TRUE(commit_data.__isset.partition_spec_id);
+    ASSERT_EQ(0, commit_data.partition_spec_id);
+    ASSERT_FALSE(commit_data.__isset.partition_data_json);
+
+    std::filesystem::remove_all(temp_dir);
+}
+
 } // namespace doris

--- a/be/test/format/table/iceberg/iceberg_reader_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_reader_test.cpp
@@ -1526,6 +1526,58 @@ TEST_F(IcebergReaderTest, mixed_case_partition_schema_mismatch_returns_error_for
     std::filesystem::remove_all(test_dir);
 }
 
+TEST_F(IcebergReaderTest, mixed_case_regular_schema_mismatch_returns_error_for_orc) {
+    const auto test_dir = std::filesystem::temp_directory_path() /
+                          "doris_iceberg_orc_mixed_case_regular_schema_mismatch_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+    const auto data_file = (test_dir / "data.orc").string();
+    write_iceberg_int_orc_file(data_file, "City", 2, {1});
+
+    TFileScanRangeParams scan_params;
+    scan_params.__set_file_type(TFileType::FILE_LOCAL);
+    scan_params.__set_format_type(TFileFormatType::FORMAT_ORC);
+    scan_params.__set_current_schema_id(-1);
+    scan_params.__set_history_schema_info({make_single_int_external_schema("city", 2)});
+    TFileRangeDesc scan_range;
+    scan_range.__set_path(data_file);
+    scan_range.__set_start_offset(0);
+    scan_range.__set_size(static_cast<int64_t>(std::filesystem::file_size(data_file)));
+    scan_range.__set_file_size(static_cast<int64_t>(std::filesystem::file_size(data_file)));
+
+    ObjectPool object_pool;
+    DescriptorTbl* descriptor_table = nullptr;
+    const TupleDescriptor* tuple_descriptor = nullptr;
+    ASSERT_TRUE(create_single_int_tuple_descriptor(&object_pool, "City", 2, &descriptor_table,
+                                                   &tuple_descriptor)
+                        .ok());
+
+    RuntimeProfile profile("test_profile");
+    RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
+    runtime_state.set_timezone("UTC");
+    io::IOContext io_ctx;
+    ShardedKVCache kv_cache(8);
+    IcebergOrcReader reader(&kv_cache, &profile, &runtime_state, scan_params, scan_range, 1024,
+                            "UTC", &io_ctx, cache.get());
+
+    std::vector<ColumnDescriptor> column_descriptors(1);
+    column_descriptors[0].name = "City";
+    column_descriptors[0].category = ColumnCategory::REGULAR;
+    std::unordered_map<std::string, uint32_t> block_positions = {{"City", 0}};
+    OrcInitContext context;
+    context.column_descs = &column_descriptors;
+    context.col_name_to_block_idx = &block_positions;
+    context.tuple_descriptor = tuple_descriptor;
+    context.params = &scan_params;
+    context.range = &scan_range;
+
+    const auto status = reader.init_reader(&context);
+    EXPECT_TRUE(status.is<ErrorCode::INTERNAL_ERROR>()) << status;
+    EXPECT_NE(status.to_string().find("missing projected column 'City'"), std::string::npos)
+            << status;
+    std::filesystem::remove_all(test_dir);
+}
+
 TEST_F(IcebergReaderTest, detects_fully_dictionary_encoded_parquet_column) {
     tparquet::ColumnMetaData column_metadata;
     column_metadata.type = tparquet::Type::BYTE_ARRAY;

--- a/be/test/format/table/iceberg/iceberg_reader_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_reader_test.cpp
@@ -935,6 +935,16 @@ schema::external::TFieldPtr make_external_struct_field(
     return field_ptr;
 }
 
+schema::external::TSchema make_single_int_external_schema(const std::string& name,
+                                                          int32_t field_id) {
+    schema::external::TStructField root_field;
+    root_field.__set_fields({make_external_int_field(name, field_id, std::nullopt)});
+    schema::external::TSchema schema;
+    schema.__set_schema_id(-1);
+    schema.__set_root_field(std::move(root_field));
+    return schema;
+}
+
 class IcebergReaderTestHelper : public IcebergTableReader {
 public:
     using IcebergTableReader::_is_fully_dictionary_encoded;
@@ -1401,6 +1411,120 @@ protected:
     std::unordered_map<std::string, uint32_t> delete_file_col_name_to_block_idx = {{"file_path", 0},
                                                                                    {"pos", 1}};
 };
+
+TEST_F(IcebergReaderTest, mixed_case_partition_schema_mismatch_returns_error_for_parquet) {
+    const auto test_dir = std::filesystem::temp_directory_path() /
+                          "doris_iceberg_parquet_mixed_case_partition_schema_mismatch_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+    const auto data_file = (test_dir / "data.parquet").string();
+    write_iceberg_int_equality_delete_parquet_file(data_file, "City", 2, 1);
+
+    TFileScanRangeParams scan_params;
+    scan_params.__set_file_type(TFileType::FILE_LOCAL);
+    scan_params.__set_format_type(TFileFormatType::FORMAT_PARQUET);
+    scan_params.__set_current_schema_id(-1);
+    // Models the bad SPI plan: the scan tuple/path key is "City", while the full-schema fallback
+    // registered only the lower-cased table-side key "city".
+    scan_params.__set_history_schema_info({make_single_int_external_schema("city", 2)});
+    TFileRangeDesc scan_range;
+    scan_range.__set_path(data_file);
+    scan_range.__set_start_offset(0);
+    scan_range.__set_size(static_cast<int64_t>(std::filesystem::file_size(data_file)));
+    scan_range.__set_file_size(static_cast<int64_t>(std::filesystem::file_size(data_file)));
+    scan_range.__set_columns_from_path_keys({"City"});
+    scan_range.__set_columns_from_path({"Beijing"});
+    scan_range.__set_columns_from_path_is_null({false});
+
+    ObjectPool object_pool;
+    DescriptorTbl* descriptor_table = nullptr;
+    const TupleDescriptor* tuple_descriptor = nullptr;
+    ASSERT_TRUE(create_single_int_tuple_descriptor(&object_pool, "City", 2, &descriptor_table,
+                                                   &tuple_descriptor)
+                        .ok());
+
+    RuntimeProfile profile("test_profile");
+    RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
+    io::IOContext io_ctx;
+    ShardedKVCache kv_cache(8);
+    IcebergParquetReader reader(&kv_cache, &profile, scan_params, scan_range, 1024, &timezone_obj,
+                                &io_ctx, &runtime_state, cache.get());
+    io::FileReaderSPtr file_reader;
+    ASSERT_TRUE(io::global_local_filesystem()->open_file(data_file, &file_reader).ok());
+    reader.set_file_reader(file_reader);
+
+    std::vector<ColumnDescriptor> column_descriptors(1);
+    column_descriptors[0].name = "City";
+    column_descriptors[0].category = ColumnCategory::PARTITION_KEY;
+    std::unordered_map<std::string, uint32_t> block_positions = {{"City", 0}};
+    ParquetInitContext context;
+    context.column_descs = &column_descriptors;
+    context.col_name_to_block_idx = &block_positions;
+    context.tuple_descriptor = tuple_descriptor;
+    context.params = &scan_params;
+    context.range = &scan_range;
+
+    const auto status = reader.init_reader(&context);
+    EXPECT_TRUE(status.is<ErrorCode::INTERNAL_ERROR>()) << status;
+    EXPECT_NE(status.to_string().find("missing partition column 'City'"), std::string::npos)
+            << status;
+    std::filesystem::remove_all(test_dir);
+}
+
+TEST_F(IcebergReaderTest, mixed_case_partition_schema_mismatch_returns_error_for_orc) {
+    const auto test_dir = std::filesystem::temp_directory_path() /
+                          "doris_iceberg_orc_mixed_case_partition_schema_mismatch_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+    const auto data_file = (test_dir / "data.orc").string();
+    write_iceberg_int_orc_file(data_file, "City", 2, {1});
+
+    TFileScanRangeParams scan_params;
+    scan_params.__set_file_type(TFileType::FILE_LOCAL);
+    scan_params.__set_format_type(TFileFormatType::FORMAT_ORC);
+    scan_params.__set_current_schema_id(-1);
+    scan_params.__set_history_schema_info({make_single_int_external_schema("city", 2)});
+    TFileRangeDesc scan_range;
+    scan_range.__set_path(data_file);
+    scan_range.__set_start_offset(0);
+    scan_range.__set_size(static_cast<int64_t>(std::filesystem::file_size(data_file)));
+    scan_range.__set_file_size(static_cast<int64_t>(std::filesystem::file_size(data_file)));
+    scan_range.__set_columns_from_path_keys({"City"});
+    scan_range.__set_columns_from_path({"Beijing"});
+    scan_range.__set_columns_from_path_is_null({false});
+
+    ObjectPool object_pool;
+    DescriptorTbl* descriptor_table = nullptr;
+    const TupleDescriptor* tuple_descriptor = nullptr;
+    ASSERT_TRUE(create_single_int_tuple_descriptor(&object_pool, "City", 2, &descriptor_table,
+                                                   &tuple_descriptor)
+                        .ok());
+
+    RuntimeProfile profile("test_profile");
+    RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
+    runtime_state.set_timezone("UTC");
+    io::IOContext io_ctx;
+    ShardedKVCache kv_cache(8);
+    IcebergOrcReader reader(&kv_cache, &profile, &runtime_state, scan_params, scan_range, 1024,
+                            "UTC", &io_ctx, cache.get());
+
+    std::vector<ColumnDescriptor> column_descriptors(1);
+    column_descriptors[0].name = "City";
+    column_descriptors[0].category = ColumnCategory::PARTITION_KEY;
+    std::unordered_map<std::string, uint32_t> block_positions = {{"City", 0}};
+    OrcInitContext context;
+    context.column_descs = &column_descriptors;
+    context.col_name_to_block_idx = &block_positions;
+    context.tuple_descriptor = tuple_descriptor;
+    context.params = &scan_params;
+    context.range = &scan_range;
+
+    const auto status = reader.init_reader(&context);
+    EXPECT_TRUE(status.is<ErrorCode::INTERNAL_ERROR>()) << status;
+    EXPECT_NE(status.to_string().find("missing partition column 'City'"), std::string::npos)
+            << status;
+    std::filesystem::remove_all(test_dir);
+}
 
 TEST_F(IcebergReaderTest, detects_fully_dictionary_encoded_parquet_column) {
     tparquet::ColumnMetaData column_metadata;

--- a/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/HmsPartitionInfo.java
+++ b/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/HmsPartitionInfo.java
@@ -17,7 +17,10 @@
 
 package org.apache.doris.connector.hms;
 
+import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -25,7 +28,9 @@ import java.util.Objects;
 /**
  * HMS partition metadata DTO using connector-SPI types.
  */
-public final class HmsPartitionInfo {
+public final class HmsPartitionInfo implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private final List<String> values;
     private final String location;
@@ -39,14 +44,14 @@ public final class HmsPartitionInfo {
             String serializationLib, Map<String, String> parameters) {
         this.values = values == null
                 ? Collections.emptyList()
-                : Collections.unmodifiableList(values);
+                : Collections.unmodifiableList(new ArrayList<>(values));
         this.location = location;
         this.inputFormat = inputFormat;
         this.outputFormat = outputFormat;
         this.serializationLib = serializationLib;
         this.parameters = parameters == null
                 ? Collections.emptyMap()
-                : Collections.unmodifiableMap(parameters);
+                : Collections.unmodifiableMap(new LinkedHashMap<>(parameters));
     }
 
     /** Partition column values in declaration order. */

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/COWIncrementalRelation.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/COWIncrementalRelation.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
@@ -51,7 +52,7 @@ import java.util.stream.Collectors;
  * here, see {@link IncrementalRelation}) and the split type re-homed from fe-core {@code HudiSplit} to
  * {@link HudiScanRange}. Everything from the archived-flag computation onward is byte-faithful to legacy.
  *
- * <p>{@link #collectSplits(List, boolean, UnaryOperator)} yields native ranges directly (COW has only base files);
+ * <p>{@link #collectSplits(Function, UnaryOperator)} yields native ranges directly (COW has only base files);
  * {@link #collectFileSlices()} is unsupported (the MOR shape).
  */
 final class COWIncrementalRelation implements IncrementalRelation {
@@ -181,7 +182,8 @@ final class COWIncrementalRelation implements IncrementalRelation {
     }
 
     @Override
-    public List<HudiScanRange> collectSplits(List<String> partitionFieldNames, boolean hiveStylePartitioning,
+    public List<HudiScanRange> collectSplits(
+            Function<String, Map<String, String>> partitionValueResolver,
             UnaryOperator<String> nativePathNormalizer) {
         IncrementalRelation.checkNotFullTableScan(fullTableScan);
         if (filteredRegularFullPaths.isEmpty() && filteredMetaBootstrapFullPaths.isEmpty()) {
@@ -200,8 +202,7 @@ final class COWIncrementalRelation implements IncrementalRelation {
                     .length(stat.getFileSizeInBytes())
                     .fileSize(stat.getFileSizeInBytes())
                     .fileFormat(HudiScanPlanProvider.detectFileFormat(baseFile))
-                    .partitionValues(HudiScanPlanProvider.parsePartitionValues(
-                            stat.getPartitionPath(), partitionFieldNames, hiveStylePartitioning))
+                    .partitionValues(partitionValueResolver.apply(stat.getPartitionPath()))
                     .build());
         };
 

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/COWIncrementalRelation.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/COWIncrementalRelation.java
@@ -31,12 +31,10 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.TimelineUtils;
 import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
-import org.apache.hudi.common.util.Option;
 import org.apache.hudi.storage.StoragePath;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -53,8 +51,8 @@ import java.util.stream.Collectors;
  * here, see {@link IncrementalRelation}) and the split type re-homed from fe-core {@code HudiSplit} to
  * {@link HudiScanRange}. Everything from the archived-flag computation onward is byte-faithful to legacy.
  *
- * <p>{@link #collectSplits()} yields native ranges directly (COW has only base files); {@link #collectFileSlices()}
- * is unsupported (the MOR shape).
+ * <p>{@link #collectSplits(List, boolean, UnaryOperator)} yields native ranges directly (COW has only base files);
+ * {@link #collectFileSlices()} is unsupported (the MOR shape).
  */
 final class COWIncrementalRelation implements IncrementalRelation {
 
@@ -183,17 +181,13 @@ final class COWIncrementalRelation implements IncrementalRelation {
     }
 
     @Override
-    public List<HudiScanRange> collectSplits(UnaryOperator<String> nativePathNormalizer) {
+    public List<HudiScanRange> collectSplits(List<String> partitionFieldNames, boolean hiveStylePartitioning,
+            UnaryOperator<String> nativePathNormalizer) {
         IncrementalRelation.checkNotFullTableScan(fullTableScan);
         if (filteredRegularFullPaths.isEmpty() && filteredMetaBootstrapFullPaths.isEmpty()) {
             return Collections.emptyList();
         }
         List<HudiScanRange> splits = new ArrayList<>();
-        // Partition-column NAMES come from the hudi table config (byte-faithful to legacy COW:212), NOT the
-        // HMS-sourced handle.partitionKeyNames the snapshot path uses; the two coincide for hive-synced tables.
-        Option<String[]> partitionColumns = metaClient.getTableConfig().getPartitionFields();
-        List<String> partitionNames = partitionColumns.isPresent() ? Arrays.asList(partitionColumns.get())
-                : Collections.emptyList();
 
         Consumer<String> generatorSplit = baseFile -> {
             HoodieWriteStat stat = fileToWriteStat.get(baseFile);
@@ -206,8 +200,8 @@ final class COWIncrementalRelation implements IncrementalRelation {
                     .length(stat.getFileSizeInBytes())
                     .fileSize(stat.getFileSizeInBytes())
                     .fileFormat(HudiScanPlanProvider.detectFileFormat(baseFile))
-                    .partitionValues(
-                            HudiScanPlanProvider.parsePartitionValues(stat.getPartitionPath(), partitionNames))
+                    .partitionValues(HudiScanPlanProvider.parsePartitionValues(
+                            stat.getPartitionPath(), partitionFieldNames, hiveStylePartitioning))
                     .build());
         };
 

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/EmptyIncrementalRelation.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/EmptyIncrementalRelation.java
@@ -21,6 +21,8 @@ import org.apache.hudi.common.model.FileSlice;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 /**
@@ -44,7 +46,8 @@ final class EmptyIncrementalRelation implements IncrementalRelation {
     }
 
     @Override
-    public List<HudiScanRange> collectSplits(List<String> partitionFieldNames, boolean hiveStylePartitioning,
+    public List<HudiScanRange> collectSplits(
+            Function<String, Map<String, String>> partitionValueResolver,
             UnaryOperator<String> nativePathNormalizer) {
         return Collections.emptyList();
     }

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/EmptyIncrementalRelation.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/EmptyIncrementalRelation.java
@@ -44,7 +44,8 @@ final class EmptyIncrementalRelation implements IncrementalRelation {
     }
 
     @Override
-    public List<HudiScanRange> collectSplits(UnaryOperator<String> nativePathNormalizer) {
+    public List<HudiScanRange> collectSplits(List<String> partitionFieldNames, boolean hiveStylePartitioning,
+            UnaryOperator<String> nativePathNormalizer) {
         return Collections.emptyList();
     }
 

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnector.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnector.java
@@ -140,7 +140,7 @@ public class HudiConnector implements Connector {
 
     @Override
     public ConnectorScanPlanProvider getScanPlanProvider() {
-        return new HudiScanPlanProvider(properties, context);
+        return new HudiScanPlanProvider(properties, context, this::getOrCreateClient);
     }
 
     /**

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnectorMetadata.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnectorMetadata.java
@@ -19,6 +19,7 @@ package org.apache.doris.connector.hudi;
 
 import org.apache.doris.connector.hms.HmsClient;
 import org.apache.doris.connector.hms.HmsClientException;
+import org.apache.doris.connector.hms.HmsPartitionInfo;
 import org.apache.doris.connector.hms.HmsTableInfo;
 import org.apache.doris.connector.spi.ConnectorColumn;
 import org.apache.doris.connector.spi.ConnectorMetadata;
@@ -264,19 +265,19 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
             return Optional.empty();
         }
 
-        // H3: candidate partition paths MUST be the SAME shape the scan feeds fsView (Hudi RELATIVE STORAGE
-        // paths), and use_hive_sync_partition-aware (mirroring collectPartitions). HMS always exposes hive-style
-        // names ("year=2024/month=01"), even when Hudi's physical layout is positional ("2024/01"). FileSystemView
-        // is keyed by the physical relative paths, so a filtered hive-sync scan must translate the HMS matches
-        // back to that shape before carrying them on the handle. Keep maxParts=-1 (unlimited): no silent partition
-        // truncation.
+        // H3: Hive Sync partition names carry LOGICAL values after the configured extractor has run, while their
+        // storage locations carry the exact PHYSICAL directories FileSystemView is keyed by. Preserve both by
+        // carrying the matched HmsPartitionInfo objects on the handle. Reconstructing the physical path from the
+        // logical name is invalid for extractors such as SinglePartPartitionValueExtractor (physical
+        // "2024/03/15", logical "2024-03-15"). Non-Hive-Sync pruning still carries Hudi-relative paths from the
+        // same metadata listing the scan uses. Keep maxParts=-1 (unlimited): no silent partition truncation.
         boolean hiveSync = useHiveSyncPartition();
         int allPartitionCount;
-        List<String> matchedPartPaths;
+        int matchedPartitionCount;
+        HudiTableHandle.Builder handleBuilder = hudiHandle.toBuilder();
         if (hiveSync) {
-            // Hive Sync is authoritative for predicate matching, but its names do not encode whether the Hudi
-            // storage layout is hive-style or positional. Prune those names first, then match their canonical
-            // value maps against a physical Hudi listing whose layout flag comes from the same metaClient.
+            // Hive Sync is authoritative for predicate matching and for mapping each match to its storage
+            // location. getPartitions also preserves the extractor-produced logical values in declaration order.
             List<String> allHmsPartitionNames = hmsClient.listPartitionNames(
                     hudiHandle.getDbName(), hudiHandle.getTableName(), -1);
             if (allHmsPartitionNames == null || allHmsPartitionNames.isEmpty()) {
@@ -288,14 +289,19 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
                 // No pruning effect
                 return Optional.empty();
             }
-            if (matchedHmsPartitionNames.isEmpty()) {
-                matchedPartPaths = Collections.emptyList();
-            } else {
-                Map.Entry<Boolean, List<String>> listing = listPhysicalPartitionPaths(hudiHandle);
-                matchedPartPaths = matchPhysicalPartitionPaths(
-                        matchedHmsPartitionNames, listing.getValue(), partKeyNames, listing.getKey());
+            List<HmsPartitionInfo> matchedPartitions = matchedHmsPartitionNames.isEmpty()
+                    ? Collections.emptyList()
+                    : hmsClient.getPartitions(hudiHandle.getDbName(), hudiHandle.getTableName(),
+                            matchedHmsPartitionNames);
+            if (matchedPartitions.size() != matchedHmsPartitionNames.size()) {
+                throw new DorisConnectorException(String.format(
+                        "HMS returned %d of %d matched partitions for Hudi table %s.%s",
+                        matchedPartitions.size(), matchedHmsPartitionNames.size(),
+                        hudiHandle.getDbName(), hudiHandle.getTableName()));
             }
+            handleBuilder.prunedPartitions(matchedPartitions).prunedPartitionPaths(null);
             allPartitionCount = allHmsPartitionNames.size();
+            matchedPartitionCount = matchedPartitions.size();
         } else {
             // non-hive-sync (Hudi default): list the RELATIVE storage paths from Hudi metadata -- the SAME source
             // the unpruned scan (resolvePartitions -> listAllPartitionPaths) uses -- under the plugin auth + TCCL
@@ -307,23 +313,22 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
             if (allPartPaths == null || allPartPaths.isEmpty()) {
                 return Optional.empty();
             }
-            matchedPartPaths = prunePartitionPaths(
+            List<String> matchedPartPaths = prunePartitionPaths(
                     allPartPaths, partKeyNames, partitionPredicates, listing.getKey());
             if (matchedPartPaths.size() == allPartPaths.size()) {
                 // No pruning effect
                 return Optional.empty();
             }
+            handleBuilder.prunedPartitionPaths(matchedPartPaths).prunedPartitions(null);
             allPartitionCount = allPartPaths.size();
+            matchedPartitionCount = matchedPartPaths.size();
         }
 
         LOG.info("Partition pruning: {}.{} hiveSync={} all={} pruned={}",
                 hudiHandle.getDbName(), hudiHandle.getTableName(),
-                hiveSync, allPartitionCount, matchedPartPaths.size());
+                hiveSync, allPartitionCount, matchedPartitionCount);
 
-        // Build updated handle carrying only the matched (relative-shape) partition paths for scan planning.
-        HudiTableHandle updatedHandle = hudiHandle.toBuilder()
-                .prunedPartitionPaths(matchedPartPaths)
-                .build();
+        HudiTableHandle updatedHandle = handleBuilder.build();
 
         return Optional.of(new FilterApplicationResult<>(updatedHandle, constraint.getExpression(), false));
     }
@@ -1220,28 +1225,6 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
             }
         }
         return matched;
-    }
-
-    /**
-     * Translates Hive Sync partition names to the relative physical paths accepted by Hudi's FileSystemView.
-     * HMS names are always hive-style, while the physical paths follow {@code hiveStylePartitioning}; matching
-     * their canonical unescaped value maps preserves the HMS-pruned set without passing HMS-only names into the
-     * scan. Static + package-private for the offline Hive Sync + positional-layout regression test.
-     */
-    static List<String> matchPhysicalPartitionPaths(List<String> matchedHmsPartitionNames,
-            List<String> physicalPartitionPaths, List<String> partKeyNames, boolean hiveStylePartitioning) {
-        Set<Map<String, String>> matchedValues = matchedHmsPartitionNames.stream()
-                .map(partitionName -> parsePartitionName(partitionName, partKeyNames))
-                .collect(Collectors.toSet());
-        List<String> matchedPaths = new ArrayList<>();
-        for (String physicalPath : physicalPartitionPaths) {
-            Map<String, String> physicalValues = HudiScanPlanProvider.parsePartitionValues(
-                    physicalPath, partKeyNames, hiveStylePartitioning);
-            if (matchedValues.contains(physicalValues)) {
-                matchedPaths.add(physicalPath);
-            }
-        }
-        return matchedPaths;
     }
 
     static Map<String, String> parsePartitionName(String partName,

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnectorMetadata.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnectorMetadata.java
@@ -265,50 +265,60 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
         }
 
         // H3: candidate partition paths MUST be the SAME shape the scan feeds fsView (Hudi RELATIVE STORAGE
-        // paths), and use_hive_sync_partition-aware (mirroring collectPartitions). The old code fed HMS hive-style
-        // names ("year=2024/month=01") unconditionally; for a non-hive-style table (Hudi default) the physical
-        // layout is positional ("2024/01"), so fsView (keyed by relative storage paths) matched nothing -> 0
-        // splits for any filtered query. Keep maxParts=-1 (unlimited): no silent partition truncation.
+        // paths), and use_hive_sync_partition-aware (mirroring collectPartitions). HMS always exposes hive-style
+        // names ("year=2024/month=01"), even when Hudi's physical layout is positional ("2024/01"). FileSystemView
+        // is keyed by the physical relative paths, so a filtered hive-sync scan must translate the HMS matches
+        // back to that shape before carrying them on the handle. Keep maxParts=-1 (unlimited): no silent partition
+        // truncation.
         boolean hiveSync = useHiveSyncPartition();
-        List<String> allPartPaths;
+        int allPartitionCount;
         List<String> matchedPartPaths;
         if (hiveSync) {
-            // hive-sync: HMS registers the hive-style names, which ARE the relative storage layout, so fsView
-            // accepts them directly (no relativization, matching legacy / collectPartitions). Prune the HMS names.
-            allPartPaths = hmsClient.listPartitionNames(
+            // Hive Sync is authoritative for predicate matching, but its names do not encode whether the Hudi
+            // storage layout is hive-style or positional. Prune those names first, then match their canonical
+            // value maps against a physical Hudi listing whose layout flag comes from the same metaClient.
+            List<String> allHmsPartitionNames = hmsClient.listPartitionNames(
                     hudiHandle.getDbName(), hudiHandle.getTableName(), -1);
-            if (allPartPaths == null || allPartPaths.isEmpty()) {
+            if (allHmsPartitionNames == null || allHmsPartitionNames.isEmpty()) {
                 return Optional.empty();
             }
-            matchedPartPaths = prunePartitionNames(allPartPaths, partKeyNames, partitionPredicates);
+            List<String> matchedHmsPartitionNames = prunePartitionNames(
+                    allHmsPartitionNames, partKeyNames, partitionPredicates);
+            if (matchedHmsPartitionNames.size() == allHmsPartitionNames.size()) {
+                // No pruning effect
+                return Optional.empty();
+            }
+            if (matchedHmsPartitionNames.isEmpty()) {
+                matchedPartPaths = Collections.emptyList();
+            } else {
+                Map.Entry<Boolean, List<String>> listing = listPhysicalPartitionPaths(hudiHandle);
+                matchedPartPaths = matchPhysicalPartitionPaths(
+                        matchedHmsPartitionNames, listing.getValue(), partKeyNames, listing.getKey());
+            }
+            allPartitionCount = allHmsPartitionNames.size();
         } else {
             // non-hive-sync (Hudi default): list the RELATIVE storage paths from Hudi metadata -- the SAME source
             // the unpruned scan (resolvePartitions -> listAllPartitionPaths) uses -- under the plugin auth + TCCL
             // pin. Carry the table-config layout from the SAME metaClient as the paths: a positional value may
             // legally contain '=', so inferring the layout from path text would corrupt pruning. Net-neutral:
             // resolvePartitions short-circuits once prunedPaths is set, so a filtered query lists exactly once.
-            Map.Entry<Boolean, List<String>> listing = metaClientExecutor.execute(() -> {
-                HoodieTableMetaClient metaClient = HudiScanPlanProvider.buildMetaClient(
-                        buildHadoopConf(), hudiHandle.getBasePath());
-                return new AbstractMap.SimpleImmutableEntry<>(
-                        HudiScanPlanProvider.hiveStylePartitioning(metaClient),
-                        HudiScanPlanProvider.listAllPartitionPaths(metaClient));
-            });
-            allPartPaths = listing.getValue();
+            Map.Entry<Boolean, List<String>> listing = listPhysicalPartitionPaths(hudiHandle);
+            List<String> allPartPaths = listing.getValue();
             if (allPartPaths == null || allPartPaths.isEmpty()) {
                 return Optional.empty();
             }
             matchedPartPaths = prunePartitionPaths(
                     allPartPaths, partKeyNames, partitionPredicates, listing.getKey());
-        }
-        if (matchedPartPaths.size() == allPartPaths.size()) {
-            // No pruning effect
-            return Optional.empty();
+            if (matchedPartPaths.size() == allPartPaths.size()) {
+                // No pruning effect
+                return Optional.empty();
+            }
+            allPartitionCount = allPartPaths.size();
         }
 
         LOG.info("Partition pruning: {}.{} hiveSync={} all={} pruned={}",
                 hudiHandle.getDbName(), hudiHandle.getTableName(),
-                hiveSync, allPartPaths.size(), matchedPartPaths.size());
+                hiveSync, allPartitionCount, matchedPartPaths.size());
 
         // Build updated handle carrying only the matched (relative-shape) partition paths for scan planning.
         HudiTableHandle updatedHandle = hudiHandle.toBuilder()
@@ -316,6 +326,16 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
                 .build();
 
         return Optional.of(new FilterApplicationResult<>(updatedHandle, constraint.getExpression(), false));
+    }
+
+    private Map.Entry<Boolean, List<String>> listPhysicalPartitionPaths(HudiTableHandle handle) {
+        return metaClientExecutor.execute(() -> {
+            HoodieTableMetaClient metaClient = HudiScanPlanProvider.buildMetaClient(
+                    buildHadoopConf(), handle.getBasePath());
+            return new AbstractMap.SimpleImmutableEntry<>(
+                    HudiScanPlanProvider.hiveStylePartitioning(metaClient),
+                    HudiScanPlanProvider.listAllPartitionPaths(metaClient));
+        });
     }
 
     @Override
@@ -1200,6 +1220,28 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
             }
         }
         return matched;
+    }
+
+    /**
+     * Translates Hive Sync partition names to the relative physical paths accepted by Hudi's FileSystemView.
+     * HMS names are always hive-style, while the physical paths follow {@code hiveStylePartitioning}; matching
+     * their canonical unescaped value maps preserves the HMS-pruned set without passing HMS-only names into the
+     * scan. Static + package-private for the offline Hive Sync + positional-layout regression test.
+     */
+    static List<String> matchPhysicalPartitionPaths(List<String> matchedHmsPartitionNames,
+            List<String> physicalPartitionPaths, List<String> partKeyNames, boolean hiveStylePartitioning) {
+        Set<Map<String, String>> matchedValues = matchedHmsPartitionNames.stream()
+                .map(partitionName -> parsePartitionName(partitionName, partKeyNames))
+                .collect(Collectors.toSet());
+        List<String> matchedPaths = new ArrayList<>();
+        for (String physicalPath : physicalPartitionPaths) {
+            Map<String, String> physicalValues = HudiScanPlanProvider.parsePartitionValues(
+                    physicalPath, partKeyNames, hiveStylePartitioning);
+            if (matchedValues.contains(physicalValues)) {
+                matchedPaths.add(physicalPath);
+            }
+        }
+        return matchedPaths;
     }
 
     static Map<String, String> parsePartitionName(String partName,

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnectorMetadata.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnectorMetadata.java
@@ -284,15 +284,22 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
         } else {
             // non-hive-sync (Hudi default): list the RELATIVE storage paths from Hudi metadata -- the SAME source
             // the unpruned scan (resolvePartitions -> listAllPartitionPaths) uses -- under the plugin auth + TCCL
-            // pin. Net-neutral: resolvePartitions short-circuits once prunedPaths is set, so a filtered query lists
-            // exactly once (here) instead of there. parsePartitionValues handles the positional layout ("2024/01").
-            allPartPaths = metaClientExecutor.execute(() ->
-                    HudiScanPlanProvider.listAllPartitionPaths(
-                            HudiScanPlanProvider.buildMetaClient(buildHadoopConf(), hudiHandle.getBasePath())));
+            // pin. Carry the table-config layout from the SAME metaClient as the paths: a positional value may
+            // legally contain '=', so inferring the layout from path text would corrupt pruning. Net-neutral:
+            // resolvePartitions short-circuits once prunedPaths is set, so a filtered query lists exactly once.
+            Map.Entry<Boolean, List<String>> listing = metaClientExecutor.execute(() -> {
+                HoodieTableMetaClient metaClient = HudiScanPlanProvider.buildMetaClient(
+                        buildHadoopConf(), hudiHandle.getBasePath());
+                return new AbstractMap.SimpleImmutableEntry<>(
+                        HudiScanPlanProvider.hiveStylePartitioning(metaClient),
+                        HudiScanPlanProvider.listAllPartitionPaths(metaClient));
+            });
+            allPartPaths = listing.getValue();
             if (allPartPaths == null || allPartPaths.isEmpty()) {
                 return Optional.empty();
             }
-            matchedPartPaths = prunePartitionPaths(allPartPaths, partKeyNames, partitionPredicates);
+            matchedPartPaths = prunePartitionPaths(
+                    allPartPaths, partKeyNames, partitionPredicates, listing.getKey());
         }
         if (matchedPartPaths.size() == allPartPaths.size()) {
             // No pruning effect
@@ -680,6 +687,18 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
         return names;
     }
 
+    static final class PartitionListing {
+        private final long lastModifiedMillis;
+        private final List<String> paths;
+        private final boolean hiveStylePartitioning;
+
+        PartitionListing(long lastModifiedMillis, List<String> paths, boolean hiveStylePartitioning) {
+            this.lastModifiedMillis = lastModifiedMillis;
+            this.paths = paths;
+            this.hiveStylePartitioning = hiveStylePartitioning;
+        }
+    }
+
     /**
      * Shared partition collector backing {@link #listPartitions} and {@link #listPartitionNames}. Lists the
      * raw partition identifiers from the
@@ -706,7 +725,7 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
                     ? hmsClient.listPartitionNamesFresh(handle.getDbName(), handle.getTableName(), -1)
                     : hmsClient.listPartitionNames(handle.getDbName(), handle.getTableName(), -1);
             if (hmsNames != null && !hmsNames.isEmpty()) {
-                return buildPartitionInfos(hmsNames, partKeyNames, latestInstantMillis(handle));
+                return buildPartitionInfos(hmsNames, partKeyNames, latestInstantMillis(handle), true);
             }
             LOG.warn("hive-sync hudi table {}.{} has no HMS partitions; "
                     + "falling back to hudi metadata partition listing",
@@ -715,19 +734,21 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
         // Non-hive-sync (or hive-sync HMS-empty fallback): the instant and the partition paths both come from
         // the metaClient, built ONCE under the plugin auth + TCCL pin. Byte-consistent with the scan's unpruned
         // partition source (resolvePartitions -> listAllPartitionPaths), which is the R2 prune-to-zero guard.
-        Map.Entry<Long, List<String>> listing = metaClientExecutor.execute(() -> {
+        PartitionListing listing = metaClientExecutor.execute(() -> {
             HoodieTableMetaClient metaClient =
                     HudiScanPlanProvider.buildMetaClient(buildHadoopConf(), handle.getBasePath());
             // Convert to epoch millis HERE, on the metaClient we already built: the partition info's
             // last-modified field is contractually epoch millis, and the timeline zone is only readable
             // from the table config. Doing it here costs no extra remote call.
-            return new AbstractMap.SimpleImmutableEntry<>(
+            return new PartitionListing(
                     HudiScanPlanProvider.instantToEpochMillis(
                             HudiScanPlanProvider.latestCompletedInstant(metaClient),
                             HudiScanPlanProvider.timelineZone(metaClient)),
-                    HudiScanPlanProvider.listAllPartitionPaths(metaClient));
+                    HudiScanPlanProvider.listAllPartitionPaths(metaClient),
+                    HudiScanPlanProvider.hiveStylePartitioning(metaClient));
         });
-        return buildPartitionInfos(listing.getValue(), partKeyNames, listing.getKey());
+        return buildPartitionInfos(
+                listing.paths, partKeyNames, listing.lastModifiedMillis, listing.hiveStylePartitioning);
     }
 
     /**
@@ -739,12 +760,14 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
      * this method only passes the value through. Static + package-private for offline unit testing.
      */
     static List<ConnectorPartitionInfo> buildPartitionInfos(
-            List<String> rawPaths, List<String> partKeyNames, long lastModifiedMillis) {
+            List<String> rawPaths, List<String> partKeyNames, long lastModifiedMillis,
+            boolean hiveStylePartitioning) {
         List<ConnectorPartitionInfo> result = new ArrayList<>(rawPaths.size());
         for (String rawPath : rawPaths) {
             // Parse the unescaped values ONCE; render the hive-style name from the SAME values so the name and
             // the values map agree by construction (the name re-parses back to these values in fe-core).
-            Map<String, String> values = HudiScanPlanProvider.parsePartitionValues(rawPath, partKeyNames);
+            Map<String, String> values = HudiScanPlanProvider.parsePartitionValues(
+                    rawPath, partKeyNames, hiveStylePartitioning);
             String name = HudiScanPlanProvider.renderHiveStylePartitionName(partKeyNames, values);
             // Ordered values in partKeyNames (render) order; render/parse are exact inverses, so this equals
             // fe-core's legacy parse of `name`. Supplied so fe-core skips the parse.
@@ -1162,17 +1185,16 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
     }
 
     /**
-     * Prunes Hudi RELATIVE partition paths (positional {@code "2024/01"} or hive-style {@code
-     * "year=2024/month=01"}) using {@link HudiScanPlanProvider#parsePartitionValues} (handles both layouts and
-     * unescapes) + {@link #matchesPredicates}. Used by the non-hive-sync {@link #applyFilter} branch, whose
-     * candidate source is the Hudi metadata listing — the same relative-path shape the scan feeds fsView. Static +
-     * package-private for offline unit testing.
+     * Prunes Hudi RELATIVE partition paths using the table-config layout carried alongside the Hudi metadata
+     * listing. Used by the non-hive-sync {@link #applyFilter} branch, whose candidate source is the same
+     * relative-path shape the scan feeds fsView. Static + package-private for offline unit testing.
      */
     static List<String> prunePartitionPaths(List<String> allPartPaths,
-            List<String> partKeyNames, Map<String, List<String>> predicates) {
+            List<String> partKeyNames, Map<String, List<String>> predicates, boolean hiveStylePartitioning) {
         List<String> matched = new ArrayList<>();
         for (String partPath : allPartPaths) {
-            Map<String, String> partValues = HudiScanPlanProvider.parsePartitionValues(partPath, partKeyNames);
+            Map<String, String> partValues = HudiScanPlanProvider.parsePartitionValues(
+                    partPath, partKeyNames, hiveStylePartitioning);
             if (matchesPredicates(partValues, predicates)) {
                 matched.add(partPath);
             }

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnectorMetadata.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnectorMetadata.java
@@ -206,11 +206,13 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
         String location = tableInfo.getLocation();
         String hudiTableType = detectHudiTableType(tableInfo);
 
-        // Extract partition key names
+        // Hudi's Doris columns and native schema dictionary are lower-cased end to end. Canonicalize the HMS
+        // partition names at the same boundary so path_partition_keys and columns_from_path byte-match those
+        // slots even when an external metastore client registered a mixed-case name.
         List<String> partKeyNames = Collections.emptyList();
         if (tableInfo.getPartitionKeys() != null && !tableInfo.getPartitionKeys().isEmpty()) {
             partKeyNames = tableInfo.getPartitionKeys().stream()
-                    .map(ConnectorColumn::getName)
+                    .map(column -> column.getName().toLowerCase(Locale.ROOT))
                     .collect(Collectors.toList());
         }
 
@@ -371,9 +373,9 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
      * Wraps the resolved columns in a {@link ConnectorTableSchema}, stamping the hudi table-type and the
      * partition-column marker fe-core needs to model the table as partitioned (parity with the OLD
      * HMSExternalTable/HudiDlaTable path, which read the HMS partition keys). The keys already live on the handle
-     * (getTableHandle -> tableInfo.getPartitionKeys()); emit them as the RAW-name CSV, matching the schema column
-     * names (the partition columns are appended to {@code columns} by both schema sources). Shared by the memoized
-     * latest path and the at-instant {@link #buildTableSchema} path.
+     * (getTableHandle -> tableInfo.getPartitionKeys()); emit their Hudi-canonical lower-case names, matching the
+     * schema column names and native schema dictionary. Shared by the memoized latest path and the at-instant
+     * {@link #buildTableSchema} path.
      */
     private ConnectorTableSchema assembleTableSchema(HudiTableHandle hudiHandle, List<ConnectorColumn> columns) {
         Map<String, String> tableProperties = new HashMap<>();
@@ -1189,8 +1191,9 @@ public class HudiConnectorMetadata implements ConnectorMetadata {
                 // The predicate literal side (extractLiteralValue) is unescaped, so matchesPredicates' string
                 // compare needs the value unescaped too — otherwise an escaped partition value silently drops
                 // rows. Mirrors the sibling scan-side parse (HudiScanPlanProvider.parsePartitionValues) and
-                // legacy FileUtils.unescapePathName. The key is a column name (never escaped), left as-is.
-                values.put(part.substring(0, eq),
+                // legacy FileUtils.unescapePathName. Hudi's Doris slots are lower-cased, so canonicalize the
+                // unescaped column key too; otherwise an HMS name such as "City" cannot match a "city" predicate.
+                values.put(part.substring(0, eq).toLowerCase(Locale.ROOT),
                         HudiScanPlanProvider.unescapePathName(part.substring(eq + 1)));
             }
         }

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiScanPlanProvider.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiScanPlanProvider.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.connector.hudi;
 
+import org.apache.doris.connector.hms.HmsClient;
+import org.apache.doris.connector.hms.HmsPartitionInfo;
 import org.apache.doris.connector.spi.ConnectorContext;
 import org.apache.doris.connector.spi.ConnectorSession;
 import org.apache.doris.connector.spi.ConnectorStorageContext;
@@ -35,6 +37,7 @@ import org.apache.avro.Schema;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hudi.common.config.HoodieMetadataConfig;
 import org.apache.hudi.common.engine.HoodieLocalEngineContext;
+import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.BaseFile;
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
@@ -72,6 +75,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -116,10 +120,19 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
 
     private final Map<String, String> properties;
     private final ConnectorContext context;
+    private final Supplier<HmsClient> hmsClientSupplier;
 
     public HudiScanPlanProvider(Map<String, String> properties, ConnectorContext context) {
+        this(properties, context, () -> {
+            throw new IllegalStateException("HMS client is required for Hive Sync partition planning");
+        });
+    }
+
+    HudiScanPlanProvider(Map<String, String> properties, ConnectorContext context,
+            Supplier<HmsClient> hmsClientSupplier) {
         this.properties = properties;
         this.context = context;
+        this.hmsClientSupplier = hmsClientSupplier;
     }
 
     @Override
@@ -278,8 +291,9 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
         if (hudiHandle.getBeginInstant() != null) {
             IncrementalRelation relation = buildIncrementalRelation(metaClient, conf, hudiHandle, isCow);
             Optional<List<ConnectorScanRange>> incrementalRanges = incrementalRanges(relation, isCow, forceJni,
-                    basePath, inputFormat, serdeLib, columnNames, columnTypes, partitionFieldNames(metaClient),
-                    hiveStylePartitioning, this::normalizeNativeUri);
+                    basePath, inputFormat, serdeLib, columnNames, columnTypes,
+                    () -> incrementalPartitionValueResolver(hudiHandle, metaClient, hiveStylePartitioning),
+                    this::normalizeNativeUri);
             if (incrementalRanges.isPresent()) {
                 LOG.info("Hudi incremental scan planning: {}.{} window=({}, {}] splits={}",
                         hudiHandle.getDbName(), hudiHandle.getTableName(),
@@ -299,26 +313,24 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
                 engineCtx, metaClient, metadataConfig);
 
         // Resolve partitions
-        List<String> partitionPaths = resolvePartitions(hudiHandle, metaClient);
+        List<PartitionScanInfo> partitions = resolvePartitions(
+                hudiHandle, metaClient, hiveStylePartitioning);
 
         List<ConnectorScanRange> ranges = new ArrayList<>();
-        for (String partitionPath : partitionPaths) {
-            Map<String, String> partValues = parsePartitionValues(
-                    partitionPath, hudiHandle.getPartitionKeyNames(), hiveStylePartitioning);
-
+        for (PartitionScanInfo partition : partitions) {
             if (useNativeCowPath) {
-                collectCowSplits(fsView, partitionPath, queryInstant,
-                        partValues, ranges, schemaIdResolver);
+                collectCowSplits(fsView, partition.partitionPath, queryInstant,
+                        partition.partitionValues, ranges, schemaIdResolver);
             } else {
-                collectMorSplits(fsView, partitionPath, queryInstant,
+                collectMorSplits(fsView, partition.partitionPath, queryInstant,
                         basePath, inputFormat, serdeLib,
-                        columnNames, columnTypes, partValues, forceJni, ranges, schemaIdResolver);
+                        columnNames, columnTypes, partition.partitionValues, forceJni, ranges, schemaIdResolver);
             }
         }
 
         LOG.info("Hudi scan planning: {}.{} type={} partitions={} splits={}",
                 hudiHandle.getDbName(), hudiHandle.getTableName(),
-                hudiHandle.getHudiTableType(), partitionPaths.size(), ranges.size());
+                hudiHandle.getHudiTableType(), partitions.size(), ranges.size());
 
         return ranges;
     }
@@ -614,7 +626,7 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
      * <ul>
      *   <li>{@code relation.fallbackFullTableScan()} (an archived instant / missing file) &rarr;
      *       {@link Optional#empty()} = degrade to the latest-snapshot scan (NOT an error), legacy {@code :470}.</li>
-     *   <li>COW &rarr; {@link IncrementalRelation#collectSplits(List, boolean, UnaryOperator)} yields native ranges
+     *   <li>COW &rarr; {@link IncrementalRelation#collectSplits(Function, UnaryOperator)} yields native ranges
      *       directly.
      *       <b>{@code force_jni} is intentionally IGNORED for a COW incremental read</b> (it always reads native)
      *       &mdash; a signed, deliberate deviation from legacy, which routes {@code force_jni}+COW to the MOR-style
@@ -622,32 +634,33 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
      *       (a latent legacy crash). Routing on the relation type never calls the unsupported shape.</li>
      *   <li>MOR &rarr; {@link IncrementalRelation#collectFileSlices()} (a FLAT cross-partition slice list) turned
      *       into JNI ranges at the resolved window END ({@code relation.getEndTs()}), with per-slice partition
-     *       values parsed from the slice's own partition path against the Hudi table-config partition fields
-     *       (the same non-handle source the COW relation uses). {@code force_jni} still keeps a no-log MOR slice
-     *       on JNI via {@link #buildMorRange}.</li>
+     *       values resolved from the slice's own partition path. For Hive Sync tables the resolver is built from
+     *       HMS locations and extractor-produced logical values; otherwise it parses the Hudi physical layout.
+     *       {@code force_jni} still keeps a no-log MOR slice on JNI via {@link #buildMorRange}.</li>
      * </ul>
      * Package-private static, pure over the {@link IncrementalRelation} contract, so file-selection routing +
      * the degrade decision are unit-testable with a fake relation (no live metaClient).
      */
     static Optional<List<ConnectorScanRange>> incrementalRanges(IncrementalRelation relation, boolean isCow,
             boolean forceJni, String basePath, String inputFormat, String serdeLib,
-            List<String> columnNames, List<String> columnTypes, List<String> partitionFieldNames,
-            boolean hiveStylePartitioning, UnaryOperator<String> nativePathNormalizer) {
+            List<String> columnNames, List<String> columnTypes,
+            Supplier<Function<String, Map<String, String>>> partitionValueResolverSupplier,
+            UnaryOperator<String> nativePathNormalizer) {
         if (relation.fallbackFullTableScan()) {
             return Optional.empty();
         }
+        Function<String, Map<String, String>> partitionValueResolver =
+                new LazyPartitionValueResolver(partitionValueResolverSupplier);
         List<ConnectorScanRange> ranges = new ArrayList<>();
         if (isCow) {
             // COW @incr yields native ranges directly; normalize their scheme (s3a->s3) for BE's native reader
             // (COWIncrementalRelation.collectSplits builds .path() from the raw HMS base path).
-            ranges.addAll(relation.collectSplits(
-                    partitionFieldNames, hiveStylePartitioning, nativePathNormalizer));
+            ranges.addAll(relation.collectSplits(partitionValueResolver, nativePathNormalizer));
             return Optional.of(ranges);
         }
         String endTs = relation.getEndTs();
         for (FileSlice fileSlice : relation.collectFileSlices()) {
-            Map<String, String> partValues = parsePartitionValues(
-                    fileSlice.getPartitionPath(), partitionFieldNames, hiveStylePartitioning);
+            Map<String, String> partValues = partitionValueResolver.apply(fileSlice.getPartitionPath());
             // @incr lists the LATEST schema (no per-file schema_id dict on the incremental path) -> null resolver.
             ranges.add(buildMorRange(fileSlice, partValues, endTs, forceJni,
                     basePath, inputFormat, serdeLib, columnNames, columnTypes, null, nativePathNormalizer));
@@ -655,10 +668,57 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
         return Optional.of(ranges);
     }
 
+    private Function<String, Map<String, String>> incrementalPartitionValueResolver(
+            HudiTableHandle handle, HoodieTableMetaClient metaClient, boolean hiveStylePartitioning) {
+        return incrementalPartitionValueResolver(
+                partitionFieldNames(metaClient), handle.getPartitionKeyNames(),
+                useHiveSyncPartition(), hiveStylePartitioning,
+                () -> listHiveSyncPartitions(handle));
+    }
+
+    static Function<String, Map<String, String>> incrementalPartitionValueResolver(
+            List<String> tableConfigPartitionFields, List<String> hmsPartitionFields,
+            boolean useHiveSyncPartition, boolean hiveStylePartitioning,
+            Supplier<Optional<List<PartitionScanInfo>>> hiveSyncPartitionsSupplier) {
+        List<String> fields = tableConfigPartitionFields.isEmpty()
+                ? hmsPartitionFields : tableConfigPartitionFields;
+        Function<String, Map<String, String>> physicalPathResolver =
+                path -> parsePartitionValues(path, fields, hiveStylePartitioning);
+        if (!useHiveSyncPartition || hmsPartitionFields.isEmpty()) {
+            return physicalPathResolver;
+        }
+        Optional<List<PartitionScanInfo>> hiveSyncPartitions = hiveSyncPartitionsSupplier.get();
+        return hiveSyncPartitions.isPresent()
+                ? exactPartitionValueResolver(hiveSyncPartitions.get())
+                : physicalPathResolver;
+    }
+
+    /** Builds a fail-loud physical-path to logical-value resolver for Hive Sync incremental scans. */
+    static Function<String, Map<String, String>> exactPartitionValueResolver(
+            List<PartitionScanInfo> partitions) {
+        Map<String, Map<String, String>> valuesByPath = new HashMap<>();
+        for (PartitionScanInfo partition : partitions) {
+            Map<String, String> old = valuesByPath.put(
+                    partition.partitionPath, partition.partitionValues);
+            if (old != null) {
+                throw new DorisConnectorException(
+                        "Multiple Hudi Hive Sync partitions point to " + partition.partitionPath);
+            }
+        }
+        return partitionPath -> {
+            Map<String, String> values = valuesByPath.get(partitionPath);
+            if (values == null) {
+                throw new DorisConnectorException(
+                        "Hudi partition path " + partitionPath + " is missing from Hive Sync metadata");
+            }
+            return values;
+        };
+    }
+
     /**
      * The Hudi table-config partition-field names, canonicalized to Hudi's lower-case Doris-column convention.
-     * This is the source the incremental MOR path parses per-slice partition values against &mdash; NOT the
-     * HMS-sourced handle partition keys the snapshot path uses (the two coincide only for hive-synced tables).
+     * Incremental scans prefer these names when present and fall back to the HMS-backed handle keys for legacy
+     * Hudi tables whose table config predates the partition-fields property.
      */
     private static List<String> partitionFieldNames(HoodieTableMetaClient metaClient) {
         Option<String[]> fields = metaClient.getTableConfig().getPartitionFields();
@@ -677,26 +737,210 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
     /**
      * Resolve partition paths from handle or by listing all partitions.
      */
-    private List<String> resolvePartitions(
-            HudiTableHandle handle, HoodieTableMetaClient metaClient) {
-        // Check if partitions were pruned via applyFilter
+    List<PartitionScanInfo> resolvePartitions(
+            HudiTableHandle handle, HoodieTableMetaClient metaClient, boolean hiveStylePartitioning) {
+        // Hive Sync pruning carries both the exact storage location and the extractor-produced logical values.
+        List<HmsPartitionInfo> prunedPartitions = handle.getPrunedPartitions();
+        if (prunedPartitions != null) {
+            return hmsPartitionScanInfos(
+                    handle.getBasePath(), handle.getPartitionKeyNames(), prunedPartitions);
+        }
+
+        // Non-Hive-Sync pruning carries physical relative paths from Hudi metadata.
         List<String> prunedPaths = handle.getPrunedPartitionPaths();
         if (prunedPaths != null) {
-            return prunedPaths;
+            return physicalPartitionScanInfos(
+                    prunedPaths, handle.getPartitionKeyNames(), hiveStylePartitioning);
         }
 
         // No pruning — list all partitions
         List<String> partKeyNames = handle.getPartitionKeyNames();
         if (partKeyNames == null || partKeyNames.isEmpty()) {
             // Unpartitioned table
-            return Collections.singletonList("");
+            return Collections.singletonList(new PartitionScanInfo("", Collections.emptyMap()));
+        }
+
+        Optional<List<PartitionScanInfo>> hiveSyncPartitions = listHiveSyncPartitions(handle);
+        if (hiveSyncPartitions.isPresent()) {
+            return hiveSyncPartitions.get();
         }
 
         try {
-            return listAllPartitionPaths(metaClient);
+            return physicalPartitionScanInfos(
+                    listAllPartitionPaths(metaClient), partKeyNames, hiveStylePartitioning);
         } catch (Exception e) {
             throw new DorisConnectorException(
                     "Failed to list partitions for " + handle.getBasePath(), e);
+        }
+    }
+
+    /**
+     * Returns every Hive Sync partition with its authoritative physical location and logical values. An empty
+     * HMS listing deliberately returns {@link Optional#empty()} so callers retain the legacy Hudi-metadata
+     * fallback for tables whose sync has not run yet.
+     */
+    private Optional<List<PartitionScanInfo>> listHiveSyncPartitions(HudiTableHandle handle) {
+        if (!useHiveSyncPartition()) {
+            return Optional.empty();
+        }
+        HmsClient hmsClient = hmsClientSupplier.get();
+        List<String> partitionNames = hmsClient.listPartitionNames(
+                handle.getDbName(), handle.getTableName(), -1);
+        if (partitionNames == null || partitionNames.isEmpty()) {
+            LOG.warn("hive-sync hudi table {}.{} has no HMS partitions; "
+                            + "falling back to hudi metadata partition listing",
+                    handle.getDbName(), handle.getTableName());
+            return Optional.empty();
+        }
+        List<HmsPartitionInfo> partitions = hmsClient.getPartitions(
+                handle.getDbName(), handle.getTableName(), partitionNames);
+        if (partitions.size() != partitionNames.size()) {
+            throw new DorisConnectorException(String.format(
+                    "HMS returned %d of %d partitions for Hudi table %s.%s",
+                    partitions.size(), partitionNames.size(),
+                    handle.getDbName(), handle.getTableName()));
+        }
+        return Optional.of(hmsPartitionScanInfos(
+                handle.getBasePath(), handle.getPartitionKeyNames(), partitions));
+    }
+
+    private boolean useHiveSyncPartition() {
+        return Boolean.parseBoolean(properties.get(HudiCatalogProperties.USE_HIVE_SYNC_PARTITION));
+    }
+
+    private static List<PartitionScanInfo> physicalPartitionScanInfos(
+            List<String> partitionPaths, List<String> partKeyNames, boolean hiveStylePartitioning) {
+        List<PartitionScanInfo> result = new ArrayList<>(partitionPaths.size());
+        for (String partitionPath : partitionPaths) {
+            result.add(new PartitionScanInfo(partitionPath,
+                    parsePartitionValues(partitionPath, partKeyNames, hiveStylePartitioning)));
+        }
+        return result;
+    }
+
+    /**
+     * Converts one Hive Sync partition into the two values the scan consumes: an exact Hudi-relative physical
+     * path for FileSystemView lookup, and the extractor-produced logical HMS values for columns-from-path. The
+     * HMS client returns values in partition-key declaration order. Package-private for the extractor regression.
+     */
+    static PartitionScanInfo hmsPartitionScanInfo(
+            String basePath, List<String> partKeyNames, HmsPartitionInfo partition) {
+        List<String> values = partition.getValues();
+        if (values.size() != partKeyNames.size()) {
+            throw new DorisConnectorException(String.format(
+                    "Hudi partition at %s has %d values for %d partition columns",
+                    partition.getLocation(), values.size(), partKeyNames.size()));
+        }
+        String location = partition.getLocation();
+        if (location == null || location.isEmpty()) {
+            throw new DorisConnectorException("Hudi Hive Sync partition has no storage location");
+        }
+        String partitionPath;
+        try {
+            StoragePath baseStoragePath = new StoragePath(basePath);
+            StoragePath partitionStoragePath = new StoragePath(location);
+            String baseScheme = canonicalStorageScheme(baseStoragePath);
+            String partitionScheme = canonicalStorageScheme(partitionStoragePath);
+            if (!baseScheme.equals(partitionScheme)) {
+                throw new IllegalArgumentException("partition scheme differs from the table base path");
+            }
+            String baseAuthority = baseStoragePath.toUri().getAuthority();
+            String partitionAuthority = partitionStoragePath.toUri().getAuthority();
+            String normalizedBaseAuthority = baseAuthority == null
+                    ? "" : baseAuthority.toLowerCase(Locale.ROOT);
+            String normalizedPartitionAuthority = partitionAuthority == null
+                    ? "" : partitionAuthority.toLowerCase(Locale.ROOT);
+            if (!normalizedBaseAuthority.equals(normalizedPartitionAuthority)) {
+                throw new IllegalArgumentException("partition authority differs from the table base path");
+            }
+            String basePathWithoutScheme = baseStoragePath.getPathWithoutSchemeAndAuthority().toString();
+            String locationWithoutScheme = partitionStoragePath.getPathWithoutSchemeAndAuthority().toString();
+            String descendantPrefix = basePathWithoutScheme.endsWith("/")
+                    ? basePathWithoutScheme : basePathWithoutScheme + "/";
+            if (!locationWithoutScheme.equals(basePathWithoutScheme)
+                    && !locationWithoutScheme.startsWith(descendantPrefix)) {
+                throw new IllegalArgumentException("partition path is outside the table base path");
+            }
+            partitionPath = FSUtils.getRelativePartitionPath(baseStoragePath, partitionStoragePath);
+        } catch (IllegalArgumentException e) {
+            throw new DorisConnectorException(String.format(
+                    "Hudi partition location %s does not belong to table base path %s", location, basePath), e);
+        }
+        Map<String, String> partitionValues = new LinkedHashMap<>();
+        for (int i = 0; i < partKeyNames.size(); i++) {
+            partitionValues.put(partKeyNames.get(i), values.get(i));
+        }
+        return new PartitionScanInfo(partitionPath, partitionValues);
+    }
+
+    private static List<PartitionScanInfo> hmsPartitionScanInfos(
+            String basePath, List<String> partKeyNames, List<HmsPartitionInfo> partitions) {
+        List<PartitionScanInfo> result = new ArrayList<>(partitions.size());
+        Map<String, HmsPartitionInfo> partitionByPhysicalPath = new HashMap<>();
+        for (HmsPartitionInfo partition : partitions) {
+            PartitionScanInfo scanInfo = hmsPartitionScanInfo(basePath, partKeyNames, partition);
+            HmsPartitionInfo old = partitionByPhysicalPath.put(scanInfo.partitionPath, partition);
+            if (old != null) {
+                throw new DorisConnectorException(
+                        "Multiple Hudi Hive Sync partitions point to " + scanInfo.partitionPath);
+            }
+            result.add(scanInfo);
+        }
+        return result;
+    }
+
+    /** Canonicalizes only URI schemes that select the same Hadoop filesystem implementation. */
+    private static String canonicalStorageScheme(StoragePath path) {
+        String scheme = path.toUri().getScheme();
+        if (scheme == null) {
+            return "";
+        }
+        switch (scheme.toLowerCase(Locale.ROOT)) {
+            case "s3a":
+            case "s3n":
+                return "s3";
+            case "cosn":
+                return "cos";
+            default:
+                return scheme.toLowerCase(Locale.ROOT);
+        }
+    }
+
+    /** Defers HMS-backed resolver construction until an incremental split actually consumes a partition path. */
+    private static final class LazyPartitionValueResolver
+            implements Function<String, Map<String, String>> {
+        private final Supplier<Function<String, Map<String, String>>> resolverSupplier;
+        private Function<String, Map<String, String>> resolver;
+
+        private LazyPartitionValueResolver(
+                Supplier<Function<String, Map<String, String>>> resolverSupplier) {
+            this.resolverSupplier = resolverSupplier;
+        }
+
+        @Override
+        public Map<String, String> apply(String partitionPath) {
+            if (resolver == null) {
+                resolver = resolverSupplier.get();
+            }
+            return resolver.apply(partitionPath);
+        }
+    }
+
+    static final class PartitionScanInfo {
+        private final String partitionPath;
+        private final Map<String, String> partitionValues;
+
+        private PartitionScanInfo(String partitionPath, Map<String, String> partitionValues) {
+            this.partitionPath = partitionPath;
+            this.partitionValues = Collections.unmodifiableMap(new LinkedHashMap<>(partitionValues));
+        }
+
+        String getPartitionPath() {
+            return partitionPath;
+        }
+
+        Map<String, String> getPartitionValues() {
+            return partitionValues;
         }
     }
 

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiScanPlanProvider.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiScanPlanProvider.java
@@ -260,6 +260,7 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
 
         String inputFormat = hudiHandle.getInputFormat();
         String serdeLib = hudiHandle.getSerdeLib();
+        boolean hiveStylePartitioning = hiveStylePartitioning(metaClient);
 
         // @incr incremental read: a non-null beginInstant is the marker (INC-1 stamped the resolved (begin, end]
         // window onto the handle). Select the files the window touches via the ported IncrementalRelation family
@@ -276,7 +277,7 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
             IncrementalRelation relation = buildIncrementalRelation(metaClient, conf, hudiHandle, isCow);
             Optional<List<ConnectorScanRange>> incrementalRanges = incrementalRanges(relation, isCow, forceJni,
                     basePath, inputFormat, serdeLib, columnNames, columnTypes, partitionFieldNames(metaClient),
-                    this::normalizeNativeUri);
+                    hiveStylePartitioning, this::normalizeNativeUri);
             if (incrementalRanges.isPresent()) {
                 LOG.info("Hudi incremental scan planning: {}.{} window=({}, {}] splits={}",
                         hudiHandle.getDbName(), hudiHandle.getTableName(),
@@ -301,7 +302,7 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
         List<ConnectorScanRange> ranges = new ArrayList<>();
         for (String partitionPath : partitionPaths) {
             Map<String, String> partValues = parsePartitionValues(
-                    partitionPath, hudiHandle.getPartitionKeyNames());
+                    partitionPath, hudiHandle.getPartitionKeyNames(), hiveStylePartitioning);
 
             if (useNativeCowPath) {
                 collectCowSplits(fsView, partitionPath, queryInstant,
@@ -597,7 +598,8 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
      * <ul>
      *   <li>{@code relation.fallbackFullTableScan()} (an archived instant / missing file) &rarr;
      *       {@link Optional#empty()} = degrade to the latest-snapshot scan (NOT an error), legacy {@code :470}.</li>
-     *   <li>COW &rarr; {@link IncrementalRelation#collectSplits()} yields native ranges directly.
+     *   <li>COW &rarr; {@link IncrementalRelation#collectSplits(List, boolean, UnaryOperator)} yields native ranges
+     *       directly.
      *       <b>{@code force_jni} is intentionally IGNORED for a COW incremental read</b> (it always reads native)
      *       &mdash; a signed, deliberate deviation from legacy, which routes {@code force_jni}+COW to the MOR-style
      *       branch and calls {@code collectFileSlices()} on a COW relation &rarr; {@code UnsupportedOperationException}
@@ -614,7 +616,7 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
     static Optional<List<ConnectorScanRange>> incrementalRanges(IncrementalRelation relation, boolean isCow,
             boolean forceJni, String basePath, String inputFormat, String serdeLib,
             List<String> columnNames, List<String> columnTypes, List<String> partitionFieldNames,
-            UnaryOperator<String> nativePathNormalizer) {
+            boolean hiveStylePartitioning, UnaryOperator<String> nativePathNormalizer) {
         if (relation.fallbackFullTableScan()) {
             return Optional.empty();
         }
@@ -622,12 +624,14 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
         if (isCow) {
             // COW @incr yields native ranges directly; normalize their scheme (s3a->s3) for BE's native reader
             // (COWIncrementalRelation.collectSplits builds .path() from the raw HMS base path).
-            ranges.addAll(relation.collectSplits(nativePathNormalizer));
+            ranges.addAll(relation.collectSplits(
+                    partitionFieldNames, hiveStylePartitioning, nativePathNormalizer));
             return Optional.of(ranges);
         }
         String endTs = relation.getEndTs();
         for (FileSlice fileSlice : relation.collectFileSlices()) {
-            Map<String, String> partValues = parsePartitionValues(fileSlice.getPartitionPath(), partitionFieldNames);
+            Map<String, String> partValues = parsePartitionValues(
+                    fileSlice.getPartitionPath(), partitionFieldNames, hiveStylePartitioning);
             // @incr lists the LATEST schema (no per-file schema_id dict on the incremental path) -> null resolver.
             ranges.add(buildMorRange(fileSlice, partValues, endTs, forceJni,
                     basePath, inputFormat, serdeLib, columnNames, columnTypes, null, nativePathNormalizer));
@@ -647,6 +651,11 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
                         .map(name -> name.toLowerCase(Locale.ROOT))
                         .collect(Collectors.toList())
                 : Collections.emptyList();
+    }
+
+    /** Whether Hudi storage paths use {@code column=value} rather than positional fragments. */
+    static boolean hiveStylePartitioning(HoodieTableMetaClient metaClient) {
+        return Boolean.parseBoolean(metaClient.getTableConfig().getHiveStylePartitioningEnable());
     }
 
     /**
@@ -810,16 +819,15 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
     }
 
     /**
-     * Parse a Hudi partition's relative path into a column&rarr;value map, byte-faithful to legacy
-     * {@code HudiPartitionUtils.parsePartitionValues}. Handles BOTH hive-style ("year=2024/month=01") and Hudi's
-     * DEFAULT non-hive-style POSITIONAL ("2024/01") layouts, and URL-unescapes every value:
+     * Parse a Hudi partition's relative path into a column&rarr;value map using the table's declared storage
+     * layout, and URL-unescape every value:
      * <ul>
-     *   <li>A fragment carrying the "col=" prefix contributes the suffix; a fragment WITHOUT it is mapped
-     *       POSITIONALLY to the i-th partition column. The old split-on-'=' logic silently DROPPED a
-     *       prefix-less fragment, so a non-hive-style partitioned table read NULL partition columns on a plain
-     *       snapshot read — this is the regression this fix closes.</li>
-     *   <li>Single partition column with a mismatched fragment count: the whole path (minus an optional "col="
-     *       prefix) is that column's value (legacy single-column-whole-path fallback).</li>
+     *   <li>Hive-style ({@code hiveStylePartitioning=true}): every fragment must carry its case-insensitive
+     *       {@code column=} prefix, which is stripped.</li>
+     *   <li>Positional ({@code false}): each fragment is the literal value. In particular, a value such as
+     *       {@code City=Beijing} retains the {@code =}; guessing the layout from that text would corrupt it.</li>
+     *   <li>Single positional partition column with a mismatched fragment count: the whole path is that column's
+     *       value. The equivalent hive-style path strips its one leading prefix.</li>
      *   <li>Fragment count != column count with &gt; 1 column: fail loud, exactly like legacy.</li>
      *   <li>Every value is unescaped via {@link #unescapePathName} (e.g. "%20" &rarr; space) — legacy delegated
      *       to Hive's {@code FileUtils.unescapePathName}; inlined here so the connector needs no hive-common
@@ -828,15 +836,11 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
      *
      * <p>Static + package-private for direct unit testing (no live HoodieTableMetaClient needed).
      *
-     * <p>NOTE: this derives values from the partition path fed to the FileSystemView. On the UNPRUNED path that
-     * path is Hudi's own relative path (getAllPartitionPaths) = the shape the FileSystemView uses, so values are
-     * consistent. The PRUNED path (applyFilter) currently feeds HMS hive-style partition NAMES, which match the
-     * FileSystemView only for hive-sync'd tables; making the pruned partition SOURCE useHiveSyncPartition-aware
-     * for non-hive-style tables belongs to the partition-listing step (which ports that source once), and is
-     * likewise closed before the catalog flip.
+     * <p>NOTE: this derives values from the partition path fed to the FileSystemView. Callers must carry the
+     * path layout from the same partition source instead of inferring it from fragment contents.
      */
     static Map<String, String> parsePartitionValues(
-            String partitionPath, List<String> partKeyNames) {
+            String partitionPath, List<String> partKeyNames, boolean hiveStylePartitioning) {
         if (partKeyNames == null || partKeyNames.isEmpty()) {
             // Non-partitioned table (legacy returns an empty value list). The unpartitioned scan path always
             // reaches here with an empty key list, so an empty partitionPath needs no separate guard.
@@ -846,7 +850,9 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
         String[] fragments = partitionPath.split("/");
         if (fragments.length != partKeyNames.size()) {
             if (partKeyNames.size() == 1) {
-                String value = stripPartitionColumnPrefix(partitionPath, partKeyNames.get(0));
+                String value = hiveStylePartitioning
+                        ? stripHiveStylePartitionColumnPrefix(partitionPath, partKeyNames.get(0))
+                        : partitionPath;
                 values.put(partKeyNames.get(0), unescapePathName(value));
                 return values;
             }
@@ -854,19 +860,23 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
                     "Failed to parse partition values of path: " + partitionPath);
         }
         for (int i = 0; i < fragments.length; i++) {
-            String raw = stripPartitionColumnPrefix(fragments[i], partKeyNames.get(i));
+            String raw = hiveStylePartitioning
+                    ? stripHiveStylePartitionColumnPrefix(fragments[i], partKeyNames.get(i))
+                    : fragments[i];
             values.put(partKeyNames.get(i), unescapePathName(raw));
         }
         return values;
     }
 
-    /** Strips an optional Hive-style {@code column=} prefix using Hive/Hudi's case-insensitive identifiers. */
-    private static String stripPartitionColumnPrefix(String fragment, String columnName) {
+    /** Strips a required Hive-style {@code column=} prefix using Hive/Hudi's case-insensitive identifiers. */
+    private static String stripHiveStylePartitionColumnPrefix(String fragment, String columnName) {
         int separator = fragment.indexOf('=');
-        if (separator > 0 && fragment.substring(0, separator).equalsIgnoreCase(columnName)) {
-            return fragment.substring(separator + 1);
+        if (separator <= 0 || !fragment.substring(0, separator).equalsIgnoreCase(columnName)) {
+            throw new DorisConnectorException(
+                    "Invalid hive-style Hudi partition fragment '" + fragment
+                            + "' for column '" + columnName + "'");
         }
-        return fragment;
+        return fragment.substring(separator + 1);
     }
 
     /**

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiScanPlanProvider.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiScanPlanProvider.java
@@ -70,9 +70,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Scan plan provider for Hudi tables.
@@ -306,7 +308,7 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
 
             if (useNativeCowPath) {
                 collectCowSplits(fsView, partitionPath, queryInstant,
-                        basePath, partValues, ranges, schemaIdResolver);
+                        partValues, ranges, schemaIdResolver);
             } else {
                 collectMorSplits(fsView, partitionPath, queryInstant,
                         basePath, inputFormat, serdeLib,
@@ -451,30 +453,44 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
     private void collectCowSplits(
             HoodieTableFileSystemView fsView,
             String partitionPath, String queryInstant,
-            String basePath,
             Map<String, String> partValues,
             List<ConnectorScanRange> ranges,
             Function<String, Long> schemaIdResolver) {
-        fsView.getLatestBaseFilesBeforeOrOn(partitionPath, queryInstant)
-                .forEach(baseFile -> {
-                    String filePath = baseFile.getPath();
-                    long fileSize = baseFile.getFileSize();
-                    String format = detectFileFormat(filePath);
+        ranges.addAll(buildCowSnapshotRanges(partitionPath, queryInstant, partValues, schemaIdResolver,
+                this::normalizeNativeUri, fsView::getLatestBaseFilesBeforeOrOn));
+    }
 
-                    HudiScanRange.Builder builder = new HudiScanRange.Builder()
-                            .path(normalizeNativeUri(filePath))
-                            .start(0)
-                            .length(fileSize)
-                            .fileSize(fileSize)
-                            .fileFormat(format)
-                            .partitionValues(partValues);
-                    // COW base files always read native -> stamp the per-file schema version for BE's field-id path.
-                    Long schemaId = schemaIdResolver == null ? null : schemaIdResolver.apply(filePath);
-                    if (schemaId != null) {
-                        builder.schemaId(schemaId);
-                    }
-                    ranges.add(builder.build());
-                });
+    /**
+     * Looks up and builds COW snapshot ranges for one physical relative partition path. Keeping the exact
+     * FileSystemView lookup in this package-private helper makes the Hive Sync + positional-layout contract
+     * offline-testable: an HMS name such as {@code city=Beijing} must already have been translated to the
+     * physical key {@code Beijing} before reaching {@code baseFileLookup}.
+     */
+    static List<ConnectorScanRange> buildCowSnapshotRanges(
+            String partitionPath, String queryInstant, Map<String, String> partValues,
+            Function<String, Long> schemaIdResolver, UnaryOperator<String> nativePathNormalizer,
+            BiFunction<String, String, Stream<HoodieBaseFile>> baseFileLookup) {
+        List<ConnectorScanRange> ranges = new ArrayList<>();
+        baseFileLookup.apply(partitionPath, queryInstant).forEach(baseFile -> {
+            String filePath = baseFile.getPath();
+            long fileSize = baseFile.getFileSize();
+            String format = detectFileFormat(filePath);
+
+            HudiScanRange.Builder builder = new HudiScanRange.Builder()
+                    .path(nativePathNormalizer.apply(filePath))
+                    .start(0)
+                    .length(fileSize)
+                    .fileSize(fileSize)
+                    .fileFormat(format)
+                    .partitionValues(partValues);
+            // COW base files always read native -> stamp the per-file schema version for BE's field-id path.
+            Long schemaId = schemaIdResolver == null ? null : schemaIdResolver.apply(filePath);
+            if (schemaId != null) {
+                builder.schemaId(schemaId);
+            }
+            ranges.add(builder.build());
+        });
+        return ranges;
     }
 
     /**

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiScanPlanProvider.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiScanPlanProvider.java
@@ -636,13 +636,17 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
     }
 
     /**
-     * The Hudi table-config partition-field names (byte-faithful to legacy {@code HudiScanNode:391-393}), the
-     * source the incremental MOR path parses per-slice partition values against &mdash; NOT the HMS-sourced
-     * handle partition keys the snapshot path uses (the two coincide only for hive-synced tables).
+     * The Hudi table-config partition-field names, canonicalized to Hudi's lower-case Doris-column convention.
+     * This is the source the incremental MOR path parses per-slice partition values against &mdash; NOT the
+     * HMS-sourced handle partition keys the snapshot path uses (the two coincide only for hive-synced tables).
      */
     private static List<String> partitionFieldNames(HoodieTableMetaClient metaClient) {
         Option<String[]> fields = metaClient.getTableConfig().getPartitionFields();
-        return fields.isPresent() ? Arrays.asList(fields.get()) : Collections.emptyList();
+        return fields.isPresent()
+                ? Arrays.stream(fields.get())
+                        .map(name -> name.toLowerCase(Locale.ROOT))
+                        .collect(Collectors.toList())
+                : Collections.emptyList();
     }
 
     /**
@@ -842,9 +846,7 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
         String[] fragments = partitionPath.split("/");
         if (fragments.length != partKeyNames.size()) {
             if (partKeyNames.size() == 1) {
-                String prefix = partKeyNames.get(0) + "=";
-                String value = partitionPath.startsWith(prefix)
-                        ? partitionPath.substring(prefix.length()) : partitionPath;
+                String value = stripPartitionColumnPrefix(partitionPath, partKeyNames.get(0));
                 values.put(partKeyNames.get(0), unescapePathName(value));
                 return values;
             }
@@ -852,12 +854,19 @@ public class HudiScanPlanProvider implements ConnectorScanPlanProvider {
                     "Failed to parse partition values of path: " + partitionPath);
         }
         for (int i = 0; i < fragments.length; i++) {
-            String prefix = partKeyNames.get(i) + "=";
-            String raw = fragments[i].startsWith(prefix)
-                    ? fragments[i].substring(prefix.length()) : fragments[i];
+            String raw = stripPartitionColumnPrefix(fragments[i], partKeyNames.get(i));
             values.put(partKeyNames.get(i), unescapePathName(raw));
         }
         return values;
+    }
+
+    /** Strips an optional Hive-style {@code column=} prefix using Hive/Hudi's case-insensitive identifiers. */
+    private static String stripPartitionColumnPrefix(String fragment, String columnName) {
+        int separator = fragment.indexOf('=');
+        if (separator > 0 && fragment.substring(0, separator).equalsIgnoreCase(columnName)) {
+            return fragment.substring(separator + 1);
+        }
+        return fragment;
     }
 
     /**

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiTableHandle.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiTableHandle.java
@@ -17,9 +17,12 @@
 
 package org.apache.doris.connector.hudi;
 
+import org.apache.doris.connector.hms.HmsPartitionInfo;
 import org.apache.doris.connector.spi.handle.ConnectorTableHandle;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -28,8 +31,9 @@ import java.util.Map;
  * base path for MetaClient, Hudi table type (COW/MOR), and scan-related
  * metadata populated by {@link HudiConnectorMetadata#getTableHandle}.
  *
- * <p>After {@code applyFilter}, a new handle may carry
- * {@link #getPrunedPartitionPaths()} for partition-pruned scans.</p>
+ * <p>After {@code applyFilter}, a new handle may carry physical
+ * {@link #getPrunedPartitionPaths()} for Hudi-metadata pruning, or
+ * {@link #getPrunedPartitions()} when Hive Sync supplies authoritative locations and logical values.</p>
  */
 public class HudiTableHandle implements ConnectorTableHandle {
 
@@ -48,6 +52,7 @@ public class HudiTableHandle implements ConnectorTableHandle {
 
     // Set after applyFilter for partition pruning
     private final List<String> prunedPartitionPaths;
+    private final List<HmsPartitionInfo> prunedPartitions;
 
     // Set after applySnapshot for FOR TIME AS OF time travel: the completed-timeline instant the scan reads
     // BEFORE-OR-ON (a String like "20240101120000", not a numeric snapshot id). Null = no time travel; the scan
@@ -78,17 +83,22 @@ public class HudiTableHandle implements ConnectorTableHandle {
         this.inputFormat = builder.inputFormat;
         this.serdeLib = builder.serdeLib;
         this.partitionKeyNames = builder.partitionKeyNames != null
-                ? Collections.unmodifiableList(builder.partitionKeyNames)
+                ? Collections.unmodifiableList(new ArrayList<>(builder.partitionKeyNames))
                 : Collections.emptyList();
         this.tableParameters = builder.tableParameters != null
-                ? Collections.unmodifiableMap(builder.tableParameters)
+                ? Collections.unmodifiableMap(new LinkedHashMap<>(builder.tableParameters))
                 : Collections.emptyMap();
-        this.prunedPartitionPaths = builder.prunedPartitionPaths;
+        this.prunedPartitionPaths = builder.prunedPartitionPaths != null
+                ? Collections.unmodifiableList(new ArrayList<>(builder.prunedPartitionPaths))
+                : null;
+        this.prunedPartitions = builder.prunedPartitions != null
+                ? Collections.unmodifiableList(new ArrayList<>(builder.prunedPartitions))
+                : null;
         this.queryInstant = builder.queryInstant;
         this.beginInstant = builder.beginInstant;
         this.endInstant = builder.endInstant;
         this.incrementalParams = builder.incrementalParams != null
-                ? Collections.unmodifiableMap(builder.incrementalParams)
+                ? Collections.unmodifiableMap(new LinkedHashMap<>(builder.incrementalParams))
                 : Collections.emptyMap();
     }
 
@@ -133,6 +143,10 @@ public class HudiTableHandle implements ConnectorTableHandle {
         return prunedPartitionPaths;
     }
 
+    public List<HmsPartitionInfo> getPrunedPartitions() {
+        return prunedPartitions;
+    }
+
     /** The FOR TIME AS OF instant the scan reads before-or-on, or {@code null} for a latest read. */
     public String getQueryInstant() {
         return queryInstant;
@@ -167,6 +181,7 @@ public class HudiTableHandle implements ConnectorTableHandle {
         b.partitionKeyNames = this.partitionKeyNames;
         b.tableParameters = this.tableParameters;
         b.prunedPartitionPaths = this.prunedPartitionPaths;
+        b.prunedPartitions = this.prunedPartitions;
         b.queryInstant = this.queryInstant;
         b.beginInstant = this.beginInstant;
         b.endInstant = this.endInstant;
@@ -193,6 +208,7 @@ public class HudiTableHandle implements ConnectorTableHandle {
         private List<String> partitionKeyNames;
         private Map<String, String> tableParameters;
         private List<String> prunedPartitionPaths;
+        private List<HmsPartitionInfo> prunedPartitions;
         private String queryInstant;
         private String beginInstant;
         private String endInstant;
@@ -227,6 +243,11 @@ public class HudiTableHandle implements ConnectorTableHandle {
 
         public Builder prunedPartitionPaths(List<String> val) {
             this.prunedPartitionPaths = val;
+            return this;
+        }
+
+        public Builder prunedPartitions(List<HmsPartitionInfo> val) {
+            this.prunedPartitions = val;
             return this;
         }
 

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/IncrementalRelation.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/IncrementalRelation.java
@@ -24,6 +24,7 @@ import org.apache.hudi.common.table.timeline.TimelineUtils.HollowCommitHandling;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 /**
@@ -41,7 +42,7 @@ import java.util.function.UnaryOperator;
  * end) vanishes by construction because no sentinel re-resolution survives in the relation.
  *
  * <p>Two shapes, mirroring legacy's own asymmetry: a COW relation yields native {@link HudiScanRange}s directly
- * ({@link #collectSplits(List, boolean, UnaryOperator)}); a MOR relation yields merged {@link FileSlice}s
+ * ({@link #collectSplits(Function, UnaryOperator)}); a MOR relation yields merged {@link FileSlice}s
  * ({@link #collectFileSlices()}) that
  * the scan planner later turns into JNI ranges at {@code endTs}. Each relation supports only its own shape and
  * throws {@link UnsupportedOperationException} for the other.
@@ -62,12 +63,12 @@ interface IncrementalRelation {
      * {@code nativePathNormalizer} rewrites each range's raw storage URI to BE's canonical scheme
      * (s3a-&gt;s3) for the native reader; implementations that emit no native ranges here ignore it.
      */
-    List<HudiScanRange> collectSplits(List<String> partitionFieldNames, boolean hiveStylePartitioning,
+    List<HudiScanRange> collectSplits(Function<String, Map<String, String>> partitionValueResolver,
             UnaryOperator<String> nativePathNormalizer);
 
     /**
      * Whether the window fell back to a full-table scan (archived instant / missing file). The scan planner
-     * checks this BEFORE calling {@link #collectSplits(List, boolean, UnaryOperator)}/{@link #collectFileSlices()}
+     * checks this BEFORE calling {@link #collectSplits(Function, UnaryOperator)}/{@link #collectFileSlices()}
      * and, when true, degrades
      * to the normal latest-snapshot partition scan instead of the incremental path (legacy
      * {@code HudiScanNode.getSplits:470}).
@@ -125,7 +126,7 @@ interface IncrementalRelation {
      * ({@code COWIncrementalRelation:206} / {@code MORIncrementalRelation:177}), re-typed to the connector's
      * {@link DorisConnectorException}. A DEFENSIVE invariant: the scan planner is contracted to check
      * {@link #fallbackFullTableScan()} and degrade to the snapshot path BEFORE calling
-     * {@link #collectSplits(List, boolean, UnaryOperator)} / {@link #collectFileSlices()}, so this normally never
+     * {@link #collectSplits(Function, UnaryOperator)} / {@link #collectFileSlices()}, so this normally never
      * fires. Extracted (like the other guards) so the message is byte-verifiable offline.
      */
     static void checkNotFullTableScan(boolean fullTableScan) {

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/IncrementalRelation.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/IncrementalRelation.java
@@ -41,7 +41,8 @@ import java.util.function.UnaryOperator;
  * end) vanishes by construction because no sentinel re-resolution survives in the relation.
  *
  * <p>Two shapes, mirroring legacy's own asymmetry: a COW relation yields native {@link HudiScanRange}s directly
- * ({@link #collectSplits()}); a MOR relation yields merged {@link FileSlice}s ({@link #collectFileSlices()}) that
+ * ({@link #collectSplits(List, boolean, UnaryOperator)}); a MOR relation yields merged {@link FileSlice}s
+ * ({@link #collectFileSlices()}) that
  * the scan planner later turns into JNI ranges at {@code endTs}. Each relation supports only its own shape and
  * throws {@link UnsupportedOperationException} for the other.
  *
@@ -61,11 +62,13 @@ interface IncrementalRelation {
      * {@code nativePathNormalizer} rewrites each range's raw storage URI to BE's canonical scheme
      * (s3a-&gt;s3) for the native reader; implementations that emit no native ranges here ignore it.
      */
-    List<HudiScanRange> collectSplits(UnaryOperator<String> nativePathNormalizer);
+    List<HudiScanRange> collectSplits(List<String> partitionFieldNames, boolean hiveStylePartitioning,
+            UnaryOperator<String> nativePathNormalizer);
 
     /**
      * Whether the window fell back to a full-table scan (archived instant / missing file). The scan planner
-     * checks this BEFORE calling {@link #collectSplits()}/{@link #collectFileSlices()} and, when true, degrades
+     * checks this BEFORE calling {@link #collectSplits(List, boolean, UnaryOperator)}/{@link #collectFileSlices()}
+     * and, when true, degrades
      * to the normal latest-snapshot partition scan instead of the incremental path (legacy
      * {@code HudiScanNode.getSplits:470}).
      */
@@ -121,9 +124,9 @@ interface IncrementalRelation {
      * Fail loud when a resolved window fell back to a full-table scan, byte-for-byte with legacy
      * ({@code COWIncrementalRelation:206} / {@code MORIncrementalRelation:177}), re-typed to the connector's
      * {@link DorisConnectorException}. A DEFENSIVE invariant: the scan planner is contracted to check
-     * {@link #fallbackFullTableScan()} and degrade to the snapshot path BEFORE calling {@link #collectSplits()}
-     * / {@link #collectFileSlices()}, so this normally never fires. Extracted (like the other guards) so the
-     * message is byte-verifiable offline.
+     * {@link #fallbackFullTableScan()} and degrade to the snapshot path BEFORE calling
+     * {@link #collectSplits(List, boolean, UnaryOperator)} / {@link #collectFileSlices()}, so this normally never
+     * fires. Extracted (like the other guards) so the message is byte-verifiable offline.
      */
     static void checkNotFullTableScan(boolean fullTableScan) {
         if (fullTableScan) {

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/MORIncrementalRelation.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/MORIncrementalRelation.java
@@ -50,7 +50,7 @@ import java.util.stream.Stream;
  * fired) is gone by construction — no sentinel re-resolution survives in the relation.
  *
  * <p>{@link #collectFileSlices()} yields the merged slices for the scan planner to turn into JNI ranges at
- * {@code endTs}; {@link #collectSplits()} is unsupported (the COW shape).
+ * {@code endTs}; {@link #collectSplits(List, boolean, UnaryOperator)} is unsupported (the COW shape).
  */
 final class MORIncrementalRelation implements IncrementalRelation {
 
@@ -172,7 +172,8 @@ final class MORIncrementalRelation implements IncrementalRelation {
     }
 
     @Override
-    public List<HudiScanRange> collectSplits(UnaryOperator<String> nativePathNormalizer) {
+    public List<HudiScanRange> collectSplits(List<String> partitionFieldNames, boolean hiveStylePartitioning,
+            UnaryOperator<String> nativePathNormalizer) {
         // MOR emits ranges via collectFileSlices()/buildMorRange, not here; the normalizer is irrelevant.
         throw new UnsupportedOperationException();
     }

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/MORIncrementalRelation.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/MORIncrementalRelation.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -50,7 +51,7 @@ import java.util.stream.Stream;
  * fired) is gone by construction — no sentinel re-resolution survives in the relation.
  *
  * <p>{@link #collectFileSlices()} yields the merged slices for the scan planner to turn into JNI ranges at
- * {@code endTs}; {@link #collectSplits(List, boolean, UnaryOperator)} is unsupported (the COW shape).
+ * {@code endTs}; {@link #collectSplits(Function, UnaryOperator)} is unsupported (the COW shape).
  */
 final class MORIncrementalRelation implements IncrementalRelation {
 
@@ -172,7 +173,8 @@ final class MORIncrementalRelation implements IncrementalRelation {
     }
 
     @Override
-    public List<HudiScanRange> collectSplits(List<String> partitionFieldNames, boolean hiveStylePartitioning,
+    public List<HudiScanRange> collectSplits(
+            Function<String, Map<String, String>> partitionValueResolver,
             UnaryOperator<String> nativePathNormalizer) {
         // MOR emits ranges via collectFileSlices()/buildMorRange, not here; the normalizer is irrelevant.
         throw new UnsupportedOperationException();

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiConnectorPartitionListingTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiConnectorPartitionListingTest.java
@@ -33,7 +33,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -144,7 +143,7 @@ public class HudiConnectorPartitionListingTest {
         // Hudi's DEFAULT layout is positional "2024/01" with NO "col=" prefix. Rendering MUST inject the keys
         // so the generic re-parse yields exactly partKeys.size() values (else checkState throws -> the
         // partition is dropped -> silent UNPARTITIONED degrade).
-        String name = render("2024/01", YEAR_MONTH);
+        String name = render("2024/01", YEAR_MONTH, false);
         Assertions.assertEquals("year=2024/month=01", name);
         assertRoundTrips(name, YEAR_MONTH, Arrays.asList("2024", "01"));
     }
@@ -152,14 +151,14 @@ public class HudiConnectorPartitionListingTest {
     @Test
     public void singleColumnPositionalPathRendersOneSegment() {
         // Single partition column with a bare value: size 1, not 0.
-        String name = render("2024", Collections.singletonList("dt"));
+        String name = render("2024", Collections.singletonList("dt"), false);
         Assertions.assertEquals("dt=2024", name);
         assertRoundTrips(name, Collections.singletonList("dt"), Collections.singletonList("2024"));
     }
 
     @Test
     public void hiveStylePathIsRenderedIdempotently() {
-        String name = render("year=2024/month=01", YEAR_MONTH);
+        String name = render("year=2024/month=01", YEAR_MONTH, true);
         Assertions.assertEquals("year=2024/month=01", name);
         assertRoundTrips(name, YEAR_MONTH, Arrays.asList("2024", "01"));
     }
@@ -170,8 +169,8 @@ public class HudiConnectorPartitionListingTest {
         // back to it. (Space is not in Hive's escape set, so the rendered value carries a literal space.)
         List<String> dt = Collections.singletonList("dt");
         Assertions.assertEquals("a b",
-                HudiScanPlanProvider.parsePartitionValues("dt=a%20b", dt).get("dt"));
-        String name = render("dt=a%20b", dt);
+                HudiScanPlanProvider.parsePartitionValues("dt=a%20b", dt, true).get("dt"));
+        String name = render("dt=a%20b", dt, true);
         Assertions.assertEquals("dt=a b", name);
         assertRoundTrips(name, dt, Collections.singletonList("a b"));
     }
@@ -183,8 +182,8 @@ public class HudiConnectorPartitionListingTest {
         // '/', HiveUtil.toPartitionValues would truncate it to "2024". Escaping to "%2F" makes it round-trip.
         List<String> dt = Collections.singletonList("dt");
         Assertions.assertEquals("2024/01/02",
-                HudiScanPlanProvider.parsePartitionValues("2024/01/02", dt).get("dt"));
-        String name = render("2024/01/02", dt);
+                HudiScanPlanProvider.parsePartitionValues("2024/01/02", dt, false).get("dt"));
+        String name = render("2024/01/02", dt, false);
         Assertions.assertEquals("dt=2024%2F01%2F02", name);
         assertRoundTrips(name, dt, Collections.singletonList("2024/01/02"));
     }
@@ -194,8 +193,8 @@ public class HudiConnectorPartitionListingTest {
         // Two distinct single-column slash paths must render distinct names AND re-parse to distinct values —
         // else the generic model collapses them onto one partition key, corrupting MTMV per-partition tracking.
         List<String> dt = Collections.singletonList("dt");
-        String a = render("2024/01/02", dt);
-        String b = render("2024/03/04", dt);
+        String a = render("2024/01/02", dt, false);
+        String b = render("2024/03/04", dt, false);
         Assertions.assertNotEquals(a, b);
         assertRoundTrips(a, dt, Collections.singletonList("2024/01/02"));
         assertRoundTrips(b, dt, Collections.singletonList("2024/03/04"));
@@ -207,7 +206,7 @@ public class HudiConnectorPartitionListingTest {
     public void buildPartitionInfosStampsLastModifiedAndValues() {
         // The caller converts the instant to epoch millis; this method only passes it through.
         List<ConnectorPartitionInfo> infos = HudiConnectorMetadata.buildPartitionInfos(
-                Arrays.asList("2024/01", "2024/02"), YEAR_MONTH, 1704110400000L);
+                Arrays.asList("2024/01", "2024/02"), YEAR_MONTH, 1704110400000L, false);
 
         Assertions.assertEquals(2, infos.size());
         ConnectorPartitionInfo first = infos.get(0);
@@ -227,8 +226,8 @@ public class HudiConnectorPartitionListingTest {
     @Test
     public void listPartitionNamesMatchesListPartitions() {
         HudiConnectorMetadata md = metadata(false,
-                new RecordingHmsClient(null), stub(new AbstractMap.SimpleImmutableEntry<>(
-                        99L, Arrays.asList("2024/01", "2024/02"))));
+                new RecordingHmsClient(null), stub(new HudiConnectorMetadata.PartitionListing(
+                        99L, Arrays.asList("2024/01", "2024/02"), false)));
         ConnectorTableHandle handle = partitioned();
 
         List<String> names = md.listPartitionNames(null, handle);
@@ -271,7 +270,8 @@ public class HudiConnectorPartitionListingTest {
         // (the prune-to-zero guard), stamped with the metaClient instant — NOT return zero partitions.
         RecordingHmsClient hms = new RecordingHmsClient(Collections.emptyList());
         HudiConnectorMetadata md = metadata(true, hms,
-                stub(new AbstractMap.SimpleImmutableEntry<>(5L, Collections.singletonList("2024/01"))));
+                stub(new HudiConnectorMetadata.PartitionListing(
+                        5L, Collections.singletonList("2024/01"), false)));
 
         List<ConnectorPartitionInfo> parts = md.listPartitions(null, partitioned(), Optional.empty());
 
@@ -285,7 +285,8 @@ public class HudiConnectorPartitionListingTest {
     public void nonHiveSyncTableNeverConsultsHms() {
         RecordingHmsClient hms = new RecordingHmsClient(null); // throws if listPartitionNames is called
         HudiConnectorMetadata md = metadata(false, hms,
-                stub(new AbstractMap.SimpleImmutableEntry<>(88L, Collections.singletonList("2024/01"))));
+                stub(new HudiConnectorMetadata.PartitionListing(
+                        88L, Collections.singletonList("2024/01"), false)));
 
         List<ConnectorPartitionInfo> parts = md.listPartitions(null, partitioned(), Optional.empty());
 
@@ -364,9 +365,10 @@ public class HudiConnectorPartitionListingTest {
     }
 
     /** Renders the hive-style name for a raw partition path the way buildPartitionInfos does (parse then render). */
-    private static String render(String rawPath, List<String> partKeys) {
+    private static String render(String rawPath, List<String> partKeys, boolean hiveStylePartitioning) {
         return HudiScanPlanProvider.renderHiveStylePartitionName(
-                partKeys, HudiScanPlanProvider.parsePartitionValues(rawPath, partKeys));
+                partKeys, HudiScanPlanProvider.parsePartitionValues(
+                        rawPath, partKeys, hiveStylePartitioning));
     }
 
     /** Asserts the rendered name re-parses (fe-core-style) to exactly the expected values, correct arity. */

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiIncrementalPlanScanTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiIncrementalPlanScanTest.java
@@ -18,6 +18,8 @@
 package org.apache.doris.connector.hudi;
 
 import org.apache.doris.connector.spi.scan.ConnectorScanRange;
+import org.apache.doris.thrift.TFileRangeDesc;
+import org.apache.doris.thrift.TTableFormatFileDesc;
 
 import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieBaseFile;
@@ -67,7 +69,7 @@ public class HudiIncrementalPlanScanTest {
         fallback.collectFileSlicesThrows = true;
         Optional<List<ConnectorScanRange>> result = HudiScanPlanProvider.incrementalRanges(
                 fallback, /*isCow*/ true, /*forceJni*/ false, BASE_PATH, INPUT_FORMAT, SERDE,
-                Collections.emptyList(), Collections.emptyList(), YEAR_MONTH, UnaryOperator.identity());
+                Collections.emptyList(), Collections.emptyList(), YEAR_MONTH, true, UnaryOperator.identity());
         Assertions.assertFalse(result.isPresent(),
                 "fallbackFullTableScan must signal degrade to the snapshot scan (Optional.empty)");
     }
@@ -85,10 +87,30 @@ public class HudiIncrementalPlanScanTest {
         cow.collectFileSlicesThrows = true;
         Optional<List<ConnectorScanRange>> result = HudiScanPlanProvider.incrementalRanges(
                 cow, /*isCow*/ true, /*forceJni*/ false, BASE_PATH, INPUT_FORMAT, SERDE,
-                Collections.emptyList(), Collections.emptyList(), YEAR_MONTH, UnaryOperator.identity());
+                Collections.emptyList(), Collections.emptyList(), YEAR_MONTH, true, UnaryOperator.identity());
         Assertions.assertTrue(result.isPresent());
         Assertions.assertEquals(1, result.get().size());
         Assertions.assertSame(native1, result.get().get(0), "COW ranges must be the relation's collectSplits output");
+    }
+
+    @Test
+    public void cowIncrementalCanonicalPartitionKeyReachesBeRangeCarrier() {
+        // The real COW relation receives the canonical table-config field list through this interface. Model its
+        // write-stat path parse here and continue through populateRangeParams: a raw on-disk "City=" prefix must
+        // still produce the Doris/Hudi canonical "city" key that BE exact-matches against the tuple slot.
+        FakeRelation cow = new FakeRelation();
+        cow.rawCowPath = "s3://b/t/City=Beijing/f1.parquet";
+        cow.rawCowPartitionPath = "City=Beijing";
+        Optional<List<ConnectorScanRange>> result = HudiScanPlanProvider.incrementalRanges(
+                cow, /*isCow*/ true, /*forceJni*/ false, BASE_PATH, INPUT_FORMAT, SERDE,
+                Collections.emptyList(), Collections.emptyList(), Collections.singletonList("city"), true,
+                UnaryOperator.identity());
+
+        HudiScanRange range = (HudiScanRange) result.orElseThrow(AssertionError::new).get(0);
+        TFileRangeDesc rangeDesc = new TFileRangeDesc();
+        range.populateRangeParams(new TTableFormatFileDesc(), rangeDesc);
+        Assertions.assertEquals(Collections.singletonList("city"), rangeDesc.getColumnsFromPathKeys());
+        Assertions.assertEquals(Collections.singletonList("Beijing"), rangeDesc.getColumnsFromPath());
     }
 
     @Test
@@ -102,7 +124,7 @@ public class HudiIncrementalPlanScanTest {
         cow.collectFileSlicesThrows = true;
         Optional<List<ConnectorScanRange>> result = HudiScanPlanProvider.incrementalRanges(
                 cow, /*isCow*/ true, /*forceJni*/ true, BASE_PATH, INPUT_FORMAT, SERDE,
-                Collections.emptyList(), Collections.emptyList(), YEAR_MONTH, UnaryOperator.identity());
+                Collections.emptyList(), Collections.emptyList(), YEAR_MONTH, true, UnaryOperator.identity());
         Assertions.assertTrue(result.isPresent());
         Assertions.assertSame(native1, result.get().get(0),
                 "COW incremental must stay native even under force_jni (never call collectFileSlices)");
@@ -123,7 +145,7 @@ public class HudiIncrementalPlanScanTest {
         mor.collectSplitsThrows = true;
         Optional<List<ConnectorScanRange>> result = HudiScanPlanProvider.incrementalRanges(
                 mor, /*isCow*/ false, /*forceJni*/ true, BASE_PATH, INPUT_FORMAT, SERDE,
-                Arrays.asList("c1"), Arrays.asList("int"), YEAR_MONTH, UnaryOperator.identity());
+                Arrays.asList("c1"), Arrays.asList("int"), YEAR_MONTH, true, UnaryOperator.identity());
         Assertions.assertTrue(result.isPresent());
         Assertions.assertEquals(1, result.get().size());
         HudiScanRange range = (HudiScanRange) result.get().get(0);
@@ -145,7 +167,7 @@ public class HudiIncrementalPlanScanTest {
         mor.collectSplitsThrows = true;
         Optional<List<ConnectorScanRange>> result = HudiScanPlanProvider.incrementalRanges(
                 mor, /*isCow*/ false, /*forceJni*/ false, BASE_PATH, INPUT_FORMAT, SERDE,
-                Collections.emptyList(), Collections.emptyList(), YEAR_MONTH, UnaryOperator.identity());
+                Collections.emptyList(), Collections.emptyList(), YEAR_MONTH, true, UnaryOperator.identity());
         Assertions.assertTrue(result.isPresent());
         Assertions.assertTrue(result.get().isEmpty());
     }
@@ -159,7 +181,7 @@ public class HudiIncrementalPlanScanTest {
         FileSlice slice = baseOnlySlice("year=2024/month=01",
                 "s3://b/t/year=2024/month=01/fileid-1_0_20240101000000.parquet");
         Map<String, String> partValues = HudiScanPlanProvider.parsePartitionValues(
-                slice.getPartitionPath(), YEAR_MONTH);
+                slice.getPartitionPath(), YEAR_MONTH, true);
         HudiScanRange range = HudiScanPlanProvider.buildMorRange(slice, partValues, END_TS, /*forceJni*/ true,
                 BASE_PATH, INPUT_FORMAT, SERDE, Arrays.asList("c1"), Arrays.asList("int"), p -> 7L,
                 UnaryOperator.identity());
@@ -198,7 +220,7 @@ public class HudiIncrementalPlanScanTest {
         cow.collectFileSlicesThrows = true;
         Optional<List<ConnectorScanRange>> result = HudiScanPlanProvider.incrementalRanges(
                 cow, /*isCow*/ true, /*forceJni*/ false, BASE_PATH, INPUT_FORMAT, SERDE,
-                Collections.emptyList(), Collections.emptyList(), YEAR_MONTH,
+                Collections.emptyList(), Collections.emptyList(), YEAR_MONTH, true,
                 s -> s.replace("s3a://", "s3://"));
         Assertions.assertTrue(result.isPresent());
         HudiScanRange range = (HudiScanRange) result.get().get(0);
@@ -242,6 +264,7 @@ public class HudiIncrementalPlanScanTest {
         // stands in for the real COWIncrementalRelation.collectSplits (which needs a live metaClient), letting the
         // test verify incrementalRanges THREADS its normalizer into the COW collectSplits call.
         private String rawCowPath;
+        private String rawCowPartitionPath;
 
         @Override
         public List<FileSlice> collectFileSlices() {
@@ -252,13 +275,19 @@ public class HudiIncrementalPlanScanTest {
         }
 
         @Override
-        public List<HudiScanRange> collectSplits(UnaryOperator<String> nativePathNormalizer) {
+        public List<HudiScanRange> collectSplits(List<String> partitionFieldNames, boolean hiveStylePartitioning,
+                UnaryOperator<String> nativePathNormalizer) {
             if (collectSplitsThrows) {
                 throw new UnsupportedOperationException("collectSplits must not be called on this route");
             }
             if (rawCowPath != null) {
-                return Collections.singletonList(new HudiScanRange.Builder()
-                        .path(nativePathNormalizer.apply(rawCowPath)).fileFormat("parquet").build());
+                HudiScanRange.Builder builder = new HudiScanRange.Builder()
+                        .path(nativePathNormalizer.apply(rawCowPath)).fileFormat("parquet");
+                if (rawCowPartitionPath != null) {
+                    builder.partitionValues(HudiScanPlanProvider.parsePartitionValues(
+                            rawCowPartitionPath, partitionFieldNames, hiveStylePartitioning));
+                }
+                return Collections.singletonList(builder.build());
             }
             return splits;
         }

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiIncrementalPlanScanTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiIncrementalPlanScanTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.connector.hudi;
 
+import org.apache.doris.connector.hms.HmsPartitionInfo;
+import org.apache.doris.connector.spi.DorisConnectorException;
 import org.apache.doris.connector.spi.scan.ConnectorScanRange;
 import org.apache.doris.thrift.TFileRangeDesc;
 import org.apache.doris.thrift.TTableFormatFileDesc;
@@ -32,6 +34,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 /**
@@ -69,7 +73,10 @@ public class HudiIncrementalPlanScanTest {
         fallback.collectFileSlicesThrows = true;
         Optional<List<ConnectorScanRange>> result = HudiScanPlanProvider.incrementalRanges(
                 fallback, /*isCow*/ true, /*forceJni*/ false, BASE_PATH, INPUT_FORMAT, SERDE,
-                Collections.emptyList(), Collections.emptyList(), YEAR_MONTH, true, UnaryOperator.identity());
+                Collections.emptyList(), Collections.emptyList(), () -> {
+                    throw new AssertionError("fallback must not resolve partition values");
+                },
+                UnaryOperator.identity());
         Assertions.assertFalse(result.isPresent(),
                 "fallbackFullTableScan must signal degrade to the snapshot scan (Optional.empty)");
     }
@@ -87,10 +94,25 @@ public class HudiIncrementalPlanScanTest {
         cow.collectFileSlicesThrows = true;
         Optional<List<ConnectorScanRange>> result = HudiScanPlanProvider.incrementalRanges(
                 cow, /*isCow*/ true, /*forceJni*/ false, BASE_PATH, INPUT_FORMAT, SERDE,
-                Collections.emptyList(), Collections.emptyList(), YEAR_MONTH, true, UnaryOperator.identity());
+                Collections.emptyList(), Collections.emptyList(), hiveStyleResolver(YEAR_MONTH),
+                UnaryOperator.identity());
         Assertions.assertTrue(result.isPresent());
         Assertions.assertEquals(1, result.get().size());
         Assertions.assertSame(native1, result.get().get(0), "COW ranges must be the relation's collectSplits output");
+    }
+
+    @Test
+    public void cowEmptySplitListDoesNotResolvePartitionValues() {
+        FakeRelation cow = new FakeRelation();
+        cow.collectFileSlicesThrows = true;
+        Optional<List<ConnectorScanRange>> result = HudiScanPlanProvider.incrementalRanges(
+                cow, true, false, BASE_PATH, INPUT_FORMAT, SERDE,
+                Collections.emptyList(), Collections.emptyList(), () -> {
+                    throw new AssertionError("an empty COW window must not resolve partition values");
+                }, UnaryOperator.identity());
+
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertTrue(result.get().isEmpty());
     }
 
     @Test
@@ -103,7 +125,8 @@ public class HudiIncrementalPlanScanTest {
         cow.rawCowPartitionPath = "City=Beijing";
         Optional<List<ConnectorScanRange>> result = HudiScanPlanProvider.incrementalRanges(
                 cow, /*isCow*/ true, /*forceJni*/ false, BASE_PATH, INPUT_FORMAT, SERDE,
-                Collections.emptyList(), Collections.emptyList(), Collections.singletonList("city"), true,
+                Collections.emptyList(), Collections.emptyList(),
+                hiveStyleResolver(Collections.singletonList("city")),
                 UnaryOperator.identity());
 
         HudiScanRange range = (HudiScanRange) result.orElseThrow(AssertionError::new).get(0);
@@ -111,6 +134,83 @@ public class HudiIncrementalPlanScanTest {
         range.populateRangeParams(new TTableFormatFileDesc(), rangeDesc);
         Assertions.assertEquals(Collections.singletonList("city"), rangeDesc.getColumnsFromPathKeys());
         Assertions.assertEquals(Collections.singletonList("Beijing"), rangeDesc.getColumnsFromPath());
+    }
+
+    @Test
+    public void legacyHiveSyncWithoutTableConfigPartitionFieldsUsesExtractorLogicalValueForCowAndMor() {
+        HmsPartitionInfo hmsPartition = new HmsPartitionInfo(
+                Collections.singletonList("2024-03-15"), "s3://b/t/2024/03/15",
+                null, null, null, Collections.emptyMap());
+        HudiScanPlanProvider.PartitionScanInfo partition = HudiScanPlanProvider.hmsPartitionScanInfo(
+                BASE_PATH, Collections.singletonList("event_date"), hmsPartition);
+        Supplier<Function<String, Map<String, String>>> resolver =
+                () -> HudiScanPlanProvider.incrementalPartitionValueResolver(
+                        Collections.emptyList(), Collections.singletonList("event_date"),
+                        true, false, () -> Optional.of(Collections.singletonList(partition)));
+
+        FakeRelation cow = new FakeRelation();
+        cow.rawCowPath = "s3://b/t/2024/03/15/f1.parquet";
+        cow.rawCowPartitionPath = "2024/03/15";
+        HudiScanRange cowRange = (HudiScanRange) HudiScanPlanProvider.incrementalRanges(
+                cow, true, false, BASE_PATH, INPUT_FORMAT, SERDE,
+                Collections.emptyList(), Collections.emptyList(), resolver, UnaryOperator.identity())
+                .orElseThrow(AssertionError::new).get(0);
+
+        FakeRelation mor = new FakeRelation();
+        mor.fileSlices = Collections.singletonList(baseOnlySlice(
+                "2024/03/15", "s3://b/t/2024/03/15/f1.parquet"));
+        HudiScanRange morRange = (HudiScanRange) HudiScanPlanProvider.incrementalRanges(
+                mor, false, true, BASE_PATH, INPUT_FORMAT, SERDE,
+                Collections.emptyList(), Collections.emptyList(), resolver, UnaryOperator.identity())
+                .orElseThrow(AssertionError::new).get(0);
+
+        Map<String, String> expected = Collections.singletonMap("event_date", "2024-03-15");
+        Assertions.assertEquals(expected, cowRange.getPartitionValues());
+        Assertions.assertEquals(expected, morRange.getPartitionValues());
+    }
+
+    @Test
+    public void legacyPhysicalLayoutWithoutTableConfigPartitionFieldsUsesHandleKeysForCowAndMor() {
+        Supplier<Function<String, Map<String, String>>> resolver =
+                () -> HudiScanPlanProvider.incrementalPartitionValueResolver(
+                        Collections.emptyList(), Collections.singletonList("event_date"),
+                        false, false, () -> {
+                            throw new AssertionError("non-Hive-Sync planning must not read HMS partitions");
+                        });
+
+        FakeRelation cow = new FakeRelation();
+        cow.rawCowPath = "s3://b/t/2024-03-15/f1.parquet";
+        cow.rawCowPartitionPath = "2024-03-15";
+        HudiScanRange cowRange = (HudiScanRange) HudiScanPlanProvider.incrementalRanges(
+                cow, true, false, BASE_PATH, INPUT_FORMAT, SERDE,
+                Collections.emptyList(), Collections.emptyList(), resolver, UnaryOperator.identity())
+                .orElseThrow(AssertionError::new).get(0);
+
+        FakeRelation mor = new FakeRelation();
+        mor.fileSlices = Collections.singletonList(baseOnlySlice(
+                "2024-03-15", "s3://b/t/2024-03-15/f1.parquet"));
+        HudiScanRange morRange = (HudiScanRange) HudiScanPlanProvider.incrementalRanges(
+                mor, false, true, BASE_PATH, INPUT_FORMAT, SERDE,
+                Collections.emptyList(), Collections.emptyList(), resolver, UnaryOperator.identity())
+                .orElseThrow(AssertionError::new).get(0);
+
+        Map<String, String> expected = Collections.singletonMap("event_date", "2024-03-15");
+        Assertions.assertEquals(expected, cowRange.getPartitionValues());
+        Assertions.assertEquals(expected, morRange.getPartitionValues());
+    }
+
+    @Test
+    public void hiveSyncIncrementalRejectsUnknownPhysicalPartition() {
+        HudiScanPlanProvider.PartitionScanInfo partition = HudiScanPlanProvider.hmsPartitionScanInfo(
+                BASE_PATH, Collections.singletonList("event_date"), new HmsPartitionInfo(
+                        Collections.singletonList("2024-03-15"), "s3://b/t/2024/03/15",
+                        null, null, null, Collections.emptyMap()));
+        Function<String, Map<String, String>> resolver = HudiScanPlanProvider.exactPartitionValueResolver(
+                Collections.singletonList(partition));
+
+        DorisConnectorException error = Assertions.assertThrows(DorisConnectorException.class,
+                () -> resolver.apply("2024/03/16"));
+        Assertions.assertTrue(error.getMessage().contains("missing from Hive Sync metadata"));
     }
 
     @Test
@@ -124,7 +224,8 @@ public class HudiIncrementalPlanScanTest {
         cow.collectFileSlicesThrows = true;
         Optional<List<ConnectorScanRange>> result = HudiScanPlanProvider.incrementalRanges(
                 cow, /*isCow*/ true, /*forceJni*/ true, BASE_PATH, INPUT_FORMAT, SERDE,
-                Collections.emptyList(), Collections.emptyList(), YEAR_MONTH, true, UnaryOperator.identity());
+                Collections.emptyList(), Collections.emptyList(), hiveStyleResolver(YEAR_MONTH),
+                UnaryOperator.identity());
         Assertions.assertTrue(result.isPresent());
         Assertions.assertSame(native1, result.get().get(0),
                 "COW incremental must stay native even under force_jni (never call collectFileSlices)");
@@ -145,7 +246,8 @@ public class HudiIncrementalPlanScanTest {
         mor.collectSplitsThrows = true;
         Optional<List<ConnectorScanRange>> result = HudiScanPlanProvider.incrementalRanges(
                 mor, /*isCow*/ false, /*forceJni*/ true, BASE_PATH, INPUT_FORMAT, SERDE,
-                Arrays.asList("c1"), Arrays.asList("int"), YEAR_MONTH, true, UnaryOperator.identity());
+                Arrays.asList("c1"), Arrays.asList("int"), hiveStyleResolver(YEAR_MONTH),
+                UnaryOperator.identity());
         Assertions.assertTrue(result.isPresent());
         Assertions.assertEquals(1, result.get().size());
         HudiScanRange range = (HudiScanRange) result.get().get(0);
@@ -167,7 +269,9 @@ public class HudiIncrementalPlanScanTest {
         mor.collectSplitsThrows = true;
         Optional<List<ConnectorScanRange>> result = HudiScanPlanProvider.incrementalRanges(
                 mor, /*isCow*/ false, /*forceJni*/ false, BASE_PATH, INPUT_FORMAT, SERDE,
-                Collections.emptyList(), Collections.emptyList(), YEAR_MONTH, true, UnaryOperator.identity());
+                Collections.emptyList(), Collections.emptyList(), () -> {
+                    throw new AssertionError("an empty MOR window must not resolve partition values");
+                }, UnaryOperator.identity());
         Assertions.assertTrue(result.isPresent());
         Assertions.assertTrue(result.get().isEmpty());
     }
@@ -220,7 +324,7 @@ public class HudiIncrementalPlanScanTest {
         cow.collectFileSlicesThrows = true;
         Optional<List<ConnectorScanRange>> result = HudiScanPlanProvider.incrementalRanges(
                 cow, /*isCow*/ true, /*forceJni*/ false, BASE_PATH, INPUT_FORMAT, SERDE,
-                Collections.emptyList(), Collections.emptyList(), YEAR_MONTH, true,
+                Collections.emptyList(), Collections.emptyList(), hiveStyleResolver(YEAR_MONTH),
                 s -> s.replace("s3a://", "s3://"));
         Assertions.assertTrue(result.isPresent());
         HudiScanRange range = (HudiScanRange) result.get().get(0);
@@ -252,6 +356,10 @@ public class HudiIncrementalPlanScanTest {
         return slice;
     }
 
+    private static Supplier<Function<String, Map<String, String>>> hiveStyleResolver(List<String> fields) {
+        return () -> path -> HudiScanPlanProvider.parsePartitionValues(path, fields, true);
+    }
+
     /** A recording fake {@link IncrementalRelation}: canned outputs, throws on the shape it should not serve. */
     private static final class FakeRelation implements IncrementalRelation {
         private List<HudiScanRange> splits = new ArrayList<>();
@@ -275,7 +383,8 @@ public class HudiIncrementalPlanScanTest {
         }
 
         @Override
-        public List<HudiScanRange> collectSplits(List<String> partitionFieldNames, boolean hiveStylePartitioning,
+        public List<HudiScanRange> collectSplits(
+                Function<String, Map<String, String>> partitionValueResolver,
                 UnaryOperator<String> nativePathNormalizer) {
             if (collectSplitsThrows) {
                 throw new UnsupportedOperationException("collectSplits must not be called on this route");
@@ -284,8 +393,7 @@ public class HudiIncrementalPlanScanTest {
                 HudiScanRange.Builder builder = new HudiScanRange.Builder()
                         .path(nativePathNormalizer.apply(rawCowPath)).fileFormat("parquet");
                 if (rawCowPartitionPath != null) {
-                    builder.partitionValues(HudiScanPlanProvider.parsePartitionValues(
-                            rawCowPartitionPath, partitionFieldNames, hiveStylePartitioning));
+                    builder.partitionValues(partitionValueResolver.apply(rawCowPartitionPath));
                 }
                 return Collections.singletonList(builder.build());
             }

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiIncrementalRelationTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiIncrementalRelationTest.java
@@ -195,7 +195,8 @@ public class HudiIncrementalRelationTest {
         // The empty-timeline relation selects no files on either shape and never falls back. Its end bound is the
         // legacy "000" sentinel. Guards against a mutation returning non-empty / a non-"000" bound.
         EmptyIncrementalRelation empty = new EmptyIncrementalRelation();
-        Assertions.assertTrue(empty.collectSplits(Collections.emptyList(), false, UnaryOperator.identity()).isEmpty(),
+        Assertions.assertTrue(empty.collectSplits(
+                path -> Collections.emptyMap(), UnaryOperator.identity()).isEmpty(),
                 "empty relation must select no splits");
         Assertions.assertTrue(empty.collectFileSlices().isEmpty(), "empty relation must select no file slices");
         Assertions.assertFalse(empty.fallbackFullTableScan(), "empty relation never falls back to a full scan");

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiIncrementalRelationTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiIncrementalRelationTest.java
@@ -195,7 +195,7 @@ public class HudiIncrementalRelationTest {
         // The empty-timeline relation selects no files on either shape and never falls back. Its end bound is the
         // legacy "000" sentinel. Guards against a mutation returning non-empty / a non-"000" bound.
         EmptyIncrementalRelation empty = new EmptyIncrementalRelation();
-        Assertions.assertTrue(empty.collectSplits(UnaryOperator.identity()).isEmpty(),
+        Assertions.assertTrue(empty.collectSplits(Collections.emptyList(), false, UnaryOperator.identity()).isEmpty(),
                 "empty relation must select no splits");
         Assertions.assertTrue(empty.collectFileSlices().isEmpty(), "empty relation must select no file slices");
         Assertions.assertFalse(empty.fallbackFullTableScan(), "empty relation never falls back to a full scan");

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiPartitionPruningTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiPartitionPruningTest.java
@@ -22,6 +22,7 @@ import org.apache.doris.connector.hms.HmsDatabaseInfo;
 import org.apache.doris.connector.hms.HmsPartitionInfo;
 import org.apache.doris.connector.hms.HmsTableInfo;
 import org.apache.doris.connector.spi.ConnectorType;
+import org.apache.doris.connector.spi.DorisConnectorException;
 import org.apache.doris.connector.spi.handle.ConnectorTableHandle;
 import org.apache.doris.connector.spi.pushdown.ConnectorAnd;
 import org.apache.doris.connector.spi.pushdown.ConnectorColumnRef;
@@ -39,16 +40,22 @@ import org.apache.hudi.common.model.HoodieBaseFile;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 /**
  * Tests {@link HudiConnectorMetadata#applyFilter} partition pruning (P3-T05).
@@ -62,7 +69,7 @@ import java.util.concurrent.Callable;
  *   <li>predicates on non-partition columns (or range predicates) never prune;</li>
  *   <li>when no partition predicate applies, the handle is left untouched
  *       ({@code Optional.empty()}) so scan planning falls back to Hudi's own listing;</li>
- *   <li>Hive Sync names are translated to physical Hudi paths before FileSystemView lookup;</li>
+ *   <li>Hive Sync keeps metastore locations and extractor-produced logical values separate;</li>
  *   <li>a predicate that matches every / no partition is handled correctly.</li>
  * </ul>
  * A test that passed against the old stub (which always returned all partitions)
@@ -186,7 +193,7 @@ public class HudiPartitionPruningTest {
 
     @Test
     public void testHiveSyncMapsHmsMatchesToHiveStylePhysicalPaths() {
-        // When the physical Hudi layout is also hive-style, translating an HMS match preserves the same path.
+        // When the physical Hudi layout is also hive-style, the HMS location preserves that same exact path.
         HudiConnectorMetadata metadata = new HudiConnectorMetadata(
                 new FakeHmsClient(PARTITIONS),
                 HudiTestProperties.with(HudiCatalogProperties.USE_HIVE_SYNC_PARTITION, "true"),
@@ -195,54 +202,214 @@ public class HudiPartitionPruningTest {
                 metadata.applyFilter(null, partitionedHandle(), new ConnectorFilterConstraint(eq("year", "2024")));
         Assertions.assertTrue(result.isPresent());
         Assertions.assertEquals(
-                Arrays.asList("year=2024/month=01", "year=2024/month=02"), prunedPaths(result));
+                Arrays.asList("s3://b/t/year=2024/month=01", "s3://b/t/year=2024/month=02"),
+                prunedPartitions(result).stream()
+                        .map(HmsPartitionInfo::getLocation)
+                        .collect(Collectors.toList()));
     }
 
     @Test
-    public void testHiveSyncPositionalLayoutReturnsPhysicalSplitAndValue() {
-        // HMS always returns a hive-style name, even though hoodie.datasource.write.hive_style_partitioning=false
-        // stores this table under the positional directory "Beijing". The handle must carry that physical key:
-        // FileSystemView exact lookup with "city=Beijing" returns no base file, while lookup with "Beijing"
-        // returns one split whose BE partition carrier contains the unprefixed value "Beijing".
-        List<String> hmsPartitionNames = Arrays.asList("city=Beijing", "city=Shanghai");
-        List<String> physicalPartitionPaths = Arrays.asList("Beijing", "Shanghai");
+    public void testHiveSyncFailsWhenMatchedPartitionMetadataIsMissing() {
         HudiConnectorMetadata metadata = new HudiConnectorMetadata(
-                new FakeHmsClient(hmsPartitionNames),
+                new FakeHmsClient(PARTITIONS, Collections.emptyMap()),
                 HudiTestProperties.with(HudiCatalogProperties.USE_HIVE_SYNC_PARTITION, "true"),
-                new StubMetaClientExecutor(new AbstractMap.SimpleImmutableEntry<>(
-                        false, physicalPartitionPaths)));
+                new StubMetaClientExecutor(null));
+
+        DorisConnectorException error = Assertions.assertThrows(DorisConnectorException.class,
+                () -> metadata.applyFilter(null, partitionedHandle(),
+                        new ConnectorFilterConstraint(and(eq("year", "2024"), eq("month", "01")))));
+        Assertions.assertTrue(error.getMessage().contains("returned 0 of 1 matched partitions"));
+    }
+
+    @Test
+    public void testHiveSyncExtractorKeepsPhysicalPathAndLogicalValue() {
+        // SinglePartPartitionValueExtractor can register physical "2024/03/15" as logical
+        // event_date=2024-03-15. Matching the logical HMS value back against a positional path is invalid: the
+        // slash and hyphen forms intentionally differ. The HMS location must drive FileSystemView, while its
+        // ordered value must drive columns_from_path.
+        List<String> hmsPartitionNames = Arrays.asList(
+                "event_date=2024-03-15", "event_date=2024-03-16");
+        Map<String, HmsPartitionInfo> partitionsByName = new HashMap<>();
+        partitionsByName.put("event_date=2024-03-15", hmsPartition(
+                Collections.singletonList("2024-03-15"), "s3://b/t/2024/03/15"));
+        partitionsByName.put("event_date=2024-03-16", hmsPartition(
+                Collections.singletonList("2024-03-16"), "s3://b/t/2024/03/16"));
+        HudiConnectorMetadata metadata = new HudiConnectorMetadata(
+                new FakeHmsClient(hmsPartitionNames, partitionsByName),
+                HudiTestProperties.with(HudiCatalogProperties.USE_HIVE_SYNC_PARTITION, "true"),
+                new FailingMetaClientExecutor());
         HudiTableHandle handle = new HudiTableHandle.Builder("db", "t", "s3://b/t", "COPY_ON_WRITE")
-                .partitionKeyNames(Collections.singletonList("city"))
+                .partitionKeyNames(Collections.singletonList("event_date"))
                 .build();
 
         Optional<FilterApplicationResult<ConnectorTableHandle>> result = metadata.applyFilter(
-                null, handle, new ConnectorFilterConstraint(eq("city", "Beijing")));
+                null, handle, new ConnectorFilterConstraint(eq("event_date", "2024-03-15")));
         Assertions.assertTrue(result.isPresent());
-        Assertions.assertEquals(Collections.singletonList("Beijing"), prunedPaths(result));
+        HudiTableHandle prunedHandle = (HudiTableHandle) result.get().getHandle();
+        Assertions.assertEquals(1, prunedHandle.getPrunedPartitions().size());
+        HudiScanPlanProvider.PartitionScanInfo partition = HudiScanPlanProvider.hmsPartitionScanInfo(
+                prunedHandle.getBasePath(), prunedHandle.getPartitionKeyNames(),
+                prunedHandle.getPrunedPartitions().get(0));
+        Assertions.assertEquals("2024/03/15", partition.getPartitionPath());
+        Assertions.assertEquals(Collections.singletonMap("event_date", "2024-03-15"),
+                partition.getPartitionValues());
 
         List<String> lookupPaths = new ArrayList<>();
-        List<ConnectorScanRange> ranges = new ArrayList<>();
-        for (String partitionPath : prunedPaths(result)) {
-            Map<String, String> partitionValues = HudiScanPlanProvider.parsePartitionValues(
-                    partitionPath, Collections.singletonList("city"), false);
-            ranges.addAll(HudiScanPlanProvider.buildCowSnapshotRanges(
-                    partitionPath, "20240101120000", partitionValues, null, path -> path,
-                    (lookupPath, instant) -> {
-                        lookupPaths.add(lookupPath);
-                        return "Beijing".equals(lookupPath)
-                                ? Collections.singletonList(new HoodieBaseFile(
-                                        "s3://b/t/Beijing/fileid-1_0_20240101000000.parquet")).stream()
-                                : Collections.<HoodieBaseFile>emptyList().stream();
-                    }));
-        }
+        List<ConnectorScanRange> ranges = HudiScanPlanProvider.buildCowSnapshotRanges(
+                partition.getPartitionPath(), "20240101120000", partition.getPartitionValues(), null,
+                path -> path, (lookupPath, instant) -> {
+                    lookupPaths.add(lookupPath);
+                    return "2024/03/15".equals(lookupPath)
+                            ? Collections.singletonList(new HoodieBaseFile(
+                                    "s3://b/t/2024/03/15/fileid-1_0_20240101000000.parquet")).stream()
+                            : Collections.<HoodieBaseFile>emptyList().stream();
+                });
 
-        Assertions.assertEquals(Collections.singletonList("Beijing"), lookupPaths);
+        Assertions.assertEquals(Collections.singletonList("2024/03/15"), lookupPaths);
         Assertions.assertEquals(1, ranges.size());
         HudiScanRange range = (HudiScanRange) ranges.get(0);
         TFileRangeDesc rangeDesc = new TFileRangeDesc();
         range.populateRangeParams(new TTableFormatFileDesc(), rangeDesc);
-        Assertions.assertEquals(Collections.singletonList("city"), rangeDesc.getColumnsFromPathKeys());
-        Assertions.assertEquals(Collections.singletonList("Beijing"), rangeDesc.getColumnsFromPath());
+        Assertions.assertEquals(Collections.singletonList("event_date"), rangeDesc.getColumnsFromPathKeys());
+        Assertions.assertEquals(Collections.singletonList("2024-03-15"), rangeDesc.getColumnsFromPath());
+    }
+
+    @Test
+    public void testUnprunedHiveSyncScanUsesExtractorLocationsAndValues() {
+        List<String> names = Arrays.asList("event_date=2024-03-15", "event_date=2024-03-16");
+        Map<String, HmsPartitionInfo> partitionsByName = new HashMap<>();
+        partitionsByName.put(names.get(0), hmsPartition(
+                Collections.singletonList("2024-03-15"), "s3://b/t/2024/03/15"));
+        partitionsByName.put(names.get(1), hmsPartition(
+                Collections.singletonList("2024-03-16"), "s3://b/t/2024/03/16"));
+        FakeHmsClient hmsClient = new FakeHmsClient(names, partitionsByName);
+        Map<String, String> properties = HudiTestProperties.minimalMap();
+        properties.put(HudiCatalogProperties.USE_HIVE_SYNC_PARTITION, "true");
+        HudiScanPlanProvider provider = new HudiScanPlanProvider(properties, null, () -> hmsClient);
+        HudiTableHandle handle = new HudiTableHandle.Builder("db", "t", "s3://b/t", "COPY_ON_WRITE")
+                .partitionKeyNames(Collections.singletonList("event_date"))
+                .build();
+
+        List<HudiScanPlanProvider.PartitionScanInfo> partitions =
+                provider.resolvePartitions(handle, null, false);
+
+        Assertions.assertEquals(Arrays.asList("2024/03/15", "2024/03/16"), partitions.stream()
+                .map(HudiScanPlanProvider.PartitionScanInfo::getPartitionPath)
+                .collect(Collectors.toList()));
+        Assertions.assertEquals(Arrays.asList("2024-03-15", "2024-03-16"), partitions.stream()
+                .map(partition -> partition.getPartitionValues().get("event_date"))
+                .collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testUnprunedHiveSyncRejectsDuplicatePhysicalLocation() {
+        List<String> names = Arrays.asList("event_date=2024-03-15", "event_date=2024-03-16");
+        Map<String, HmsPartitionInfo> partitionsByName = new HashMap<>();
+        partitionsByName.put(names.get(0), hmsPartition(
+                Collections.singletonList("2024-03-15"), "s3://b/t/2024/03"));
+        partitionsByName.put(names.get(1), hmsPartition(
+                Collections.singletonList("2024-03-16"), "s3://b/t/2024/03"));
+        Map<String, String> properties = HudiTestProperties.minimalMap();
+        properties.put(HudiCatalogProperties.USE_HIVE_SYNC_PARTITION, "true");
+        HudiScanPlanProvider provider = new HudiScanPlanProvider(
+                properties, null, () -> new FakeHmsClient(names, partitionsByName));
+        HudiTableHandle handle = new HudiTableHandle.Builder("db", "t", "s3://b/t", "COPY_ON_WRITE")
+                .partitionKeyNames(Collections.singletonList("event_date"))
+                .build();
+
+        DorisConnectorException error = Assertions.assertThrows(DorisConnectorException.class,
+                () -> provider.resolvePartitions(handle, null, false));
+        Assertions.assertTrue(error.getMessage().contains(
+                "Multiple Hudi Hive Sync partitions point to 2024/03"));
+    }
+
+    @Test
+    public void testPrunedHiveSyncRejectsDuplicatePhysicalLocation() {
+        HudiTableHandle handle = new HudiTableHandle.Builder("db", "t", "s3://b/t", "COPY_ON_WRITE")
+                .partitionKeyNames(Collections.singletonList("event_date"))
+                .prunedPartitions(Arrays.asList(
+                        hmsPartition(Collections.singletonList("2024-03-15"), "s3://b/t/2024/03"),
+                        hmsPartition(Collections.singletonList("2024-03-16"), "s3://b/t/2024/03")))
+                .build();
+        HudiScanPlanProvider provider = new HudiScanPlanProvider(
+                HudiTestProperties.minimalMap(), null,
+                () -> {
+                    throw new AssertionError("pruned partitions must not access HMS");
+                });
+
+        DorisConnectorException error = Assertions.assertThrows(DorisConnectorException.class,
+                () -> provider.resolvePartitions(handle, null, false));
+        Assertions.assertTrue(error.getMessage().contains(
+                "Multiple Hudi Hive Sync partitions point to 2024/03"));
+    }
+
+    @Test
+    public void testHandleWithHiveSyncPartitionsIsSerializable() throws Exception {
+        HudiTableHandle handle = new HudiTableHandle.Builder("db", "t", "s3://b/t", "COPY_ON_WRITE")
+                .partitionKeyNames(Collections.singletonList("event_date"))
+                .prunedPartitions(Collections.singletonList(hmsPartition(
+                        Collections.singletonList("2024-03-15"), "s3://b/t/2024/03/15")))
+                .build();
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(handle);
+        }
+
+        HudiTableHandle restored;
+        try (ObjectInputStream input = new ObjectInputStream(
+                new ByteArrayInputStream(bytes.toByteArray()))) {
+            restored = (HudiTableHandle) input.readObject();
+        }
+        Assertions.assertEquals(handle.getPrunedPartitions(), restored.getPrunedPartitions());
+    }
+
+    @Test
+    public void testHiveSyncRejectsSiblingPartitionLocation() {
+        DorisConnectorException error = Assertions.assertThrows(DorisConnectorException.class,
+                () -> HudiScanPlanProvider.hmsPartitionScanInfo(
+                        "s3://b/table", Collections.singletonList("dt"),
+                        hmsPartition(Collections.singletonList("2024-03-15"),
+                                "s3://b/table_backup/dt=2024-03-15")));
+        Assertions.assertTrue(error.getMessage().contains("does not belong to table base path"));
+    }
+
+    @Test
+    public void testHiveSyncRejectsDifferentStorageAuthority() {
+        DorisConnectorException error = Assertions.assertThrows(DorisConnectorException.class,
+                () -> HudiScanPlanProvider.hmsPartitionScanInfo(
+                        "s3://bucket-a/table", Collections.singletonList("dt"),
+                        hmsPartition(Collections.singletonList("2024-03-15"),
+                                "s3://bucket-b/table/dt=2024-03-15")));
+        Assertions.assertTrue(error.getMessage().contains("does not belong to table base path"));
+    }
+
+    @Test
+    public void testHiveSyncRejectsIncompatibleStorageSchemeWithSameAuthority() {
+        DorisConnectorException error = Assertions.assertThrows(DorisConnectorException.class,
+                () -> HudiScanPlanProvider.hmsPartitionScanInfo(
+                        "s3://bucket/table", Collections.singletonList("dt"),
+                        hmsPartition(Collections.singletonList("2024-03-15"),
+                                "hdfs://bucket/table/dt=2024-03-15")));
+        Assertions.assertTrue(error.getMessage().contains("does not belong to table base path"));
+    }
+
+    @Test
+    public void testHiveSyncRejectsIncompatibleStorageSchemeWithoutAuthority() {
+        DorisConnectorException error = Assertions.assertThrows(DorisConnectorException.class,
+                () -> HudiScanPlanProvider.hmsPartitionScanInfo(
+                        "file:///warehouse/table", Collections.singletonList("dt"),
+                        hmsPartition(Collections.singletonList("2024-03-15"),
+                                "hdfs:///warehouse/table/dt=2024-03-15")));
+        Assertions.assertTrue(error.getMessage().contains("does not belong to table base path"));
+    }
+
+    @Test
+    public void testHiveSyncAcceptsS3SchemeAliases() {
+        HudiScanPlanProvider.PartitionScanInfo partition = HudiScanPlanProvider.hmsPartitionScanInfo(
+                "s3a://bucket/table", Collections.singletonList("dt"),
+                hmsPartition(Collections.singletonList("2024-03-15"),
+                        "s3://bucket/table/dt=2024-03-15"));
+        Assertions.assertEquals("dt=2024-03-15", partition.getPartitionPath());
     }
 
     @Test
@@ -328,6 +495,15 @@ public class HudiPartitionPruningTest {
         return ((HudiTableHandle) result.get().getHandle()).getPrunedPartitionPaths();
     }
 
+    private List<HmsPartitionInfo> prunedPartitions(
+            Optional<FilterApplicationResult<ConnectorTableHandle>> result) {
+        return ((HudiTableHandle) result.get().getHandle()).getPrunedPartitions();
+    }
+
+    private static HmsPartitionInfo hmsPartition(List<String> values, String location) {
+        return new HmsPartitionInfo(values, location, null, null, null, Collections.emptyMap());
+    }
+
     private static ConnectorColumnRef colRef(String name) {
         return new ConnectorColumnRef(name, ConnectorType.of("STRING"));
     }
@@ -358,9 +534,28 @@ public class HudiPartitionPruningTest {
      */
     private static final class FakeHmsClient implements HmsClient {
         private final List<String> partitionNames;
+        private final Map<String, HmsPartitionInfo> partitionsByName;
 
         FakeHmsClient(List<String> partitionNames) {
+            this(partitionNames, defaultPartitions(partitionNames));
+        }
+
+        FakeHmsClient(List<String> partitionNames, Map<String, HmsPartitionInfo> partitionsByName) {
             this.partitionNames = partitionNames;
+            this.partitionsByName = partitionsByName;
+        }
+
+        private static Map<String, HmsPartitionInfo> defaultPartitions(List<String> partitionNames) {
+            Map<String, HmsPartitionInfo> partitions = new HashMap<>();
+            for (String partitionName : partitionNames) {
+                List<String> values = new ArrayList<>();
+                for (String fragment : partitionName.split("/")) {
+                    values.add(HudiScanPlanProvider.unescapePathName(
+                            fragment.substring(fragment.indexOf('=') + 1)));
+                }
+                partitions.put(partitionName, hmsPartition(values, "s3://b/t/" + partitionName));
+            }
+            return partitions;
         }
 
         @Override
@@ -401,7 +596,14 @@ public class HudiPartitionPruningTest {
         @Override
         public List<HmsPartitionInfo> getPartitions(String dbName, String tableName,
                 List<String> partNames) {
-            throw new UnsupportedOperationException();
+            List<HmsPartitionInfo> result = new ArrayList<>(partNames.size());
+            for (String partName : partNames) {
+                HmsPartitionInfo partition = partitionsByName.get(partName);
+                if (partition != null) {
+                    result.add(partition);
+                }
+            }
+            return result;
         }
 
         @Override
@@ -430,6 +632,13 @@ public class HudiPartitionPruningTest {
         @Override
         public <T> T execute(Callable<T> action) {
             return (T) canned;
+        }
+    }
+
+    private static final class FailingMetaClientExecutor implements HudiMetaClientExecutor {
+        @Override
+        public <T> T execute(Callable<T> action) {
+            throw new AssertionError("Hive Sync must not list Hudi partition paths");
         }
     }
 }

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiPartitionPruningTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiPartitionPruningTest.java
@@ -31,7 +31,11 @@ import org.apache.doris.connector.spi.pushdown.ConnectorFilterConstraint;
 import org.apache.doris.connector.spi.pushdown.ConnectorIn;
 import org.apache.doris.connector.spi.pushdown.ConnectorLiteral;
 import org.apache.doris.connector.spi.pushdown.FilterApplicationResult;
+import org.apache.doris.connector.spi.scan.ConnectorScanRange;
+import org.apache.doris.thrift.TFileRangeDesc;
+import org.apache.doris.thrift.TTableFormatFileDesc;
 
+import org.apache.hudi.common.model.HoodieBaseFile;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -58,6 +62,7 @@ import java.util.concurrent.Callable;
  *   <li>predicates on non-partition columns (or range predicates) never prune;</li>
  *   <li>when no partition predicate applies, the handle is left untouched
  *       ({@code Optional.empty()}) so scan planning falls back to Hudi's own listing;</li>
+ *   <li>Hive Sync names are translated to physical Hudi paths before FileSystemView lookup;</li>
  *   <li>a predicate that matches every / no partition is handled correctly.</li>
  * </ul>
  * A test that passed against the old stub (which always returned all partitions)
@@ -180,18 +185,64 @@ public class HudiPartitionPruningTest {
     }
 
     @Test
-    public void testHiveSyncBranchPrunesHmsNames() {
-        // use_hive_sync_partition=true: partitions are registered in HMS and the hive-style name IS the relative
-        // storage layout, so applyFilter prunes the HMS names directly (no Hudi metadata listing / stub unused).
+    public void testHiveSyncMapsHmsMatchesToHiveStylePhysicalPaths() {
+        // When the physical Hudi layout is also hive-style, translating an HMS match preserves the same path.
         HudiConnectorMetadata metadata = new HudiConnectorMetadata(
                 new FakeHmsClient(PARTITIONS),
                 HudiTestProperties.with(HudiCatalogProperties.USE_HIVE_SYNC_PARTITION, "true"),
-                new StubMetaClientExecutor(Collections.emptyList()));
+                new StubMetaClientExecutor(new AbstractMap.SimpleImmutableEntry<>(true, PARTITIONS)));
         Optional<FilterApplicationResult<ConnectorTableHandle>> result =
                 metadata.applyFilter(null, partitionedHandle(), new ConnectorFilterConstraint(eq("year", "2024")));
         Assertions.assertTrue(result.isPresent());
         Assertions.assertEquals(
                 Arrays.asList("year=2024/month=01", "year=2024/month=02"), prunedPaths(result));
+    }
+
+    @Test
+    public void testHiveSyncPositionalLayoutReturnsPhysicalSplitAndValue() {
+        // HMS always returns a hive-style name, even though hoodie.datasource.write.hive_style_partitioning=false
+        // stores this table under the positional directory "Beijing". The handle must carry that physical key:
+        // FileSystemView exact lookup with "city=Beijing" returns no base file, while lookup with "Beijing"
+        // returns one split whose BE partition carrier contains the unprefixed value "Beijing".
+        List<String> hmsPartitionNames = Arrays.asList("city=Beijing", "city=Shanghai");
+        List<String> physicalPartitionPaths = Arrays.asList("Beijing", "Shanghai");
+        HudiConnectorMetadata metadata = new HudiConnectorMetadata(
+                new FakeHmsClient(hmsPartitionNames),
+                HudiTestProperties.with(HudiCatalogProperties.USE_HIVE_SYNC_PARTITION, "true"),
+                new StubMetaClientExecutor(new AbstractMap.SimpleImmutableEntry<>(
+                        false, physicalPartitionPaths)));
+        HudiTableHandle handle = new HudiTableHandle.Builder("db", "t", "s3://b/t", "COPY_ON_WRITE")
+                .partitionKeyNames(Collections.singletonList("city"))
+                .build();
+
+        Optional<FilterApplicationResult<ConnectorTableHandle>> result = metadata.applyFilter(
+                null, handle, new ConnectorFilterConstraint(eq("city", "Beijing")));
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertEquals(Collections.singletonList("Beijing"), prunedPaths(result));
+
+        List<String> lookupPaths = new ArrayList<>();
+        List<ConnectorScanRange> ranges = new ArrayList<>();
+        for (String partitionPath : prunedPaths(result)) {
+            Map<String, String> partitionValues = HudiScanPlanProvider.parsePartitionValues(
+                    partitionPath, Collections.singletonList("city"), false);
+            ranges.addAll(HudiScanPlanProvider.buildCowSnapshotRanges(
+                    partitionPath, "20240101120000", partitionValues, null, path -> path,
+                    (lookupPath, instant) -> {
+                        lookupPaths.add(lookupPath);
+                        return "Beijing".equals(lookupPath)
+                                ? Collections.singletonList(new HoodieBaseFile(
+                                        "s3://b/t/Beijing/fileid-1_0_20240101000000.parquet")).stream()
+                                : Collections.<HoodieBaseFile>emptyList().stream();
+                    }));
+        }
+
+        Assertions.assertEquals(Collections.singletonList("Beijing"), lookupPaths);
+        Assertions.assertEquals(1, ranges.size());
+        HudiScanRange range = (HudiScanRange) ranges.get(0);
+        TFileRangeDesc rangeDesc = new TFileRangeDesc();
+        range.populateRangeParams(new TTableFormatFileDesc(), rangeDesc);
+        Assertions.assertEquals(Collections.singletonList("city"), rangeDesc.getColumnsFromPathKeys());
+        Assertions.assertEquals(Collections.singletonList("Beijing"), rangeDesc.getColumnsFromPath());
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiPartitionPruningTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiPartitionPruningTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -170,7 +171,8 @@ public class HudiPartitionPruningTest {
         HudiConnectorMetadata metadata = new HudiConnectorMetadata(
                 new FakeHmsClient(PARTITIONS),                 // HMS hive-style names -- must NOT be used here
                 HudiTestProperties.minimal(),                  // use_hive_sync_partition=false -> non-hive-sync
-                new StubMetaClientExecutor(Arrays.asList("2024/01", "2024/02", "2023/12")));
+                new StubMetaClientExecutor(new AbstractMap.SimpleImmutableEntry<>(
+                        false, Arrays.asList("2024/01", "2024/02", "2023/12"))));
         Optional<FilterApplicationResult<ConnectorTableHandle>> result =
                 metadata.applyFilter(null, partitionedHandle(), new ConnectorFilterConstraint(eq("year", "2024")));
         Assertions.assertTrue(result.isPresent());
@@ -201,7 +203,7 @@ public class HudiPartitionPruningTest {
                 HudiConnectorMetadata.prunePartitionPaths(
                         Arrays.asList("2024/01", "2024/02", "2023/12"),
                         PART_KEYS,
-                        Collections.singletonMap("year", Collections.singletonList("2024"))));
+                        Collections.singletonMap("year", Collections.singletonList("2024")), false));
     }
 
     @Test
@@ -210,7 +212,8 @@ public class HudiPartitionPruningTest {
         // hiveDateTimeString -- String.valueOf(LocalDate) = "2024-01-01" already matches the stored DATE value.
         HudiConnectorMetadata metadata = new HudiConnectorMetadata(
                 new FakeHmsClient(PARTITIONS), HudiTestProperties.minimal(),
-                new StubMetaClientExecutor(Arrays.asList("2024-01-01", "2024-01-02")));
+                new StubMetaClientExecutor(new AbstractMap.SimpleImmutableEntry<>(
+                        false, Arrays.asList("2024-01-01", "2024-01-02"))));
         HudiTableHandle handle = new HudiTableHandle.Builder("db", "t", "s3://b/t", "COPY_ON_WRITE")
                 .partitionKeyNames(Collections.singletonList("dt"))
                 .build();
@@ -236,7 +239,8 @@ public class HudiPartitionPruningTest {
         // empty -> red.
         HudiConnectorMetadata metadata = new HudiConnectorMetadata(
                 new FakeHmsClient(PARTITIONS), HudiTestProperties.minimal(),
-                new StubMetaClientExecutor(Arrays.asList("1", "2")));
+                new StubMetaClientExecutor(new AbstractMap.SimpleImmutableEntry<>(
+                        false, Arrays.asList("1", "2"))));
         HudiTableHandle handle = new HudiTableHandle.Builder("db", "t", "s3://b/t", "COPY_ON_WRITE")
                 .partitionKeyNames(Collections.singletonList("d"))
                 .build();
@@ -258,7 +262,7 @@ public class HudiPartitionPruningTest {
         // hive-style names here parse the same via parsePartitionValues, so the pruning assertions are unchanged.
         HudiConnectorMetadata metadata = new HudiConnectorMetadata(
                 new FakeHmsClient(PARTITIONS), HudiTestProperties.minimal(),
-                new StubMetaClientExecutor(PARTITIONS));
+                new StubMetaClientExecutor(new AbstractMap.SimpleImmutableEntry<>(true, PARTITIONS)));
         return metadata.applyFilter(null, handle, new ConnectorFilterConstraint(expr));
     }
 

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiPartitionValuesTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiPartitionValuesTest.java
@@ -40,7 +40,7 @@ public class HudiPartitionValuesTest {
         // paths like "2024/01" with NO "col=" prefix. The old split-on-'=' logic dropped every prefix-less
         // fragment, so the value map was EMPTY -> BE returned NULL partition columns on a plain snapshot read.
         Map<String, String> values = HudiScanPlanProvider.parsePartitionValues(
-                "2024/01", Arrays.asList("year", "month"));
+                "2024/01", Arrays.asList("year", "month"), false);
 
         Assertions.assertEquals(2, values.size(), "both positional fragments must map to their columns");
         Assertions.assertEquals("2024", values.get("year"));
@@ -50,7 +50,7 @@ public class HudiPartitionValuesTest {
     @Test
     public void hiveStylePathStripsColumnPrefix() {
         Map<String, String> values = HudiScanPlanProvider.parsePartitionValues(
-                "year=2024/month=01", Arrays.asList("year", "month"));
+                "year=2024/month=01", Arrays.asList("year", "month"), true);
 
         Assertions.assertEquals("2024", values.get("year"));
         Assertions.assertEquals("01", values.get("month"));
@@ -62,20 +62,21 @@ public class HudiPartitionValuesTest {
         // may still carry the original mixed-case key. Strip that prefix case-insensitively and keep the map key
         // canonical so columns_from_path byte-matches the Doris slot/schema dictionary.
         Map<String, String> values = HudiScanPlanProvider.parsePartitionValues(
-                "City=Beijing/DT=2026-08-03", Arrays.asList("city", "dt"));
+                "City=Beijing/DT=2026-08-03", Arrays.asList("city", "dt"), true);
 
         Assertions.assertEquals("Beijing", values.get("city"));
         Assertions.assertEquals("2026-08-03", values.get("dt"));
     }
 
     @Test
-    public void mixedPrefixedAndPositionalFragments() {
-        // Legacy decides per fragment (startsWith "col=" or not), so a mixed path must resolve each side.
+    public void positionalValueContainingEqualsIsPreserved() {
+        // The default positional layout permits '=' as literal data when URL encoding is disabled. Layout must
+        // come from table config; a case-insensitive prefix guess would corrupt City=Beijing into Beijing.
         Map<String, String> values = HudiScanPlanProvider.parsePartitionValues(
-                "year=2024/01", Arrays.asList("year", "month"));
+                "City=Beijing/2026-08-03", Arrays.asList("city", "dt"), false);
 
-        Assertions.assertEquals("2024", values.get("year"), "prefixed fragment strips the col= prefix");
-        Assertions.assertEquals("01", values.get("month"), "prefix-less fragment maps positionally");
+        Assertions.assertEquals("City=Beijing", values.get("city"));
+        Assertions.assertEquals("2026-08-03", values.get("dt"));
     }
 
     @Test
@@ -83,7 +84,7 @@ public class HudiPartitionValuesTest {
         // Legacy unescaped every value via Hive's FileUtils.unescapePathName; %20 -> space, %2F -> slash. A
         // partition value with an escaped char would otherwise reach BE literally (wrong value).
         Map<String, String> values = HudiScanPlanProvider.parsePartitionValues(
-                "dt=2024-01-01%2012%3A00%3A00", Collections.singletonList("dt"));
+                "dt=2024-01-01%2012%3A00%3A00", Collections.singletonList("dt"), true);
 
         Assertions.assertEquals("2024-01-01 12:00:00", values.get("dt"), "escaped chars must be decoded");
     }
@@ -93,7 +94,7 @@ public class HudiPartitionValuesTest {
         // Single partition column, path has more '/' fragments than columns: legacy maps the WHOLE path to the
         // single column (after stripping an optional "col=" prefix), not throw.
         Map<String, String> values = HudiScanPlanProvider.parsePartitionValues(
-                "2024/01/01", Collections.singletonList("dt"));
+                "2024/01/01", Collections.singletonList("dt"), false);
 
         Assertions.assertEquals(1, values.size());
         Assertions.assertEquals("2024/01/01", values.get("dt"), "whole path maps to the single column");
@@ -102,7 +103,7 @@ public class HudiPartitionValuesTest {
     @Test
     public void singleColumnStripsPrefixInWholePathFallback() {
         Map<String, String> values = HudiScanPlanProvider.parsePartitionValues(
-                "dt=2024/01/01", Collections.singletonList("dt"));
+                "dt=2024/01/01", Collections.singletonList("dt"), true);
 
         Assertions.assertEquals("2024/01/01", values.get("dt"),
                 "the leading col= prefix is stripped before the whole-path fallback");
@@ -114,7 +115,7 @@ public class HudiPartitionValuesTest {
         // producing a partial/wrong value map. Fail loud, matching legacy.
         DorisConnectorException ex = Assertions.assertThrows(DorisConnectorException.class,
                 () -> HudiScanPlanProvider.parsePartitionValues(
-                        "2024/01/extra", Arrays.asList("year", "month")));
+                        "2024/01/extra", Arrays.asList("year", "month"), false));
         Assertions.assertTrue(ex.getMessage().contains("2024/01/extra"),
                 "the failure must name the offending partition path");
     }
@@ -168,8 +169,8 @@ public class HudiPartitionValuesTest {
         // Unpartitioned tables reach here with an empty key list and an empty path; the result must be empty
         // (no spurious partition column).
         Assertions.assertTrue(
-                HudiScanPlanProvider.parsePartitionValues("", Collections.emptyList()).isEmpty());
+                HudiScanPlanProvider.parsePartitionValues("", Collections.emptyList(), false).isEmpty());
         Assertions.assertTrue(
-                HudiScanPlanProvider.parsePartitionValues("", null).isEmpty());
+                HudiScanPlanProvider.parsePartitionValues("", null, false).isEmpty());
     }
 }

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiPartitionValuesTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiPartitionValuesTest.java
@@ -57,6 +57,18 @@ public class HudiPartitionValuesTest {
     }
 
     @Test
+    public void hiveStylePrefixMatchesCanonicalPartitionNameCaseInsensitively() {
+        // The handle canonicalizes Hudi partition slots to lower-case, but an existing hive-style storage path
+        // may still carry the original mixed-case key. Strip that prefix case-insensitively and keep the map key
+        // canonical so columns_from_path byte-matches the Doris slot/schema dictionary.
+        Map<String, String> values = HudiScanPlanProvider.parsePartitionValues(
+                "City=Beijing/DT=2026-08-03", Arrays.asList("city", "dt"));
+
+        Assertions.assertEquals("Beijing", values.get("city"));
+        Assertions.assertEquals("2026-08-03", values.get("dt"));
+    }
+
+    @Test
     public void mixedPrefixedAndPositionalFragments() {
         // Legacy decides per fragment (startsWith "col=" or not), so a mixed path must resolve each side.
         Map<String, String> values = HudiScanPlanProvider.parsePartitionValues(
@@ -119,6 +131,15 @@ public class HudiPartitionValuesTest {
 
         Assertions.assertEquals("US:CA", values.get("code"), "colon-escaped value must be decoded");
         Assertions.assertEquals("a/b", values.get("kind"), "slash-escaped value must be decoded");
+    }
+
+    @Test
+    public void parsePartitionNameCanonicalizesMixedCaseHmsKey() {
+        Map<String, String> values = HudiConnectorMetadata.parsePartitionName(
+                "City=BeiJing", Collections.singletonList("city"));
+
+        Assertions.assertEquals("BeiJing", values.get("city"));
+        Assertions.assertFalse(values.containsKey("City"));
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiTableTypeTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiTableTypeTest.java
@@ -21,6 +21,8 @@ import org.apache.doris.connector.hms.HmsClient;
 import org.apache.doris.connector.hms.HmsDatabaseInfo;
 import org.apache.doris.connector.hms.HmsPartitionInfo;
 import org.apache.doris.connector.hms.HmsTableInfo;
+import org.apache.doris.connector.spi.ConnectorColumn;
+import org.apache.doris.connector.spi.ConnectorType;
 import org.apache.doris.connector.spi.handle.ConnectorTableHandle;
 
 import org.junit.jupiter.api.Assertions;
@@ -83,6 +85,25 @@ public class HudiTableTypeTest {
     public void testUnknownWhenNoHudiSignal() {
         Assertions.assertEquals("UNKNOWN",
                 detect("org.apache.hadoop.mapred.TextInputFormat", Collections.emptyMap()));
+    }
+
+    @Test
+    public void mixedCaseHmsPartitionNameUsesHudiLowerCaseConvention() {
+        HmsTableInfo info = HmsTableInfo.builder()
+                .dbName("db").tableName("t")
+                .location("s3://b/t")
+                .inputFormat("org.apache.hudi.hadoop.HoodieParquetInputFormat")
+                .partitionKeys(Collections.singletonList(
+                        new ConnectorColumn("City", ConnectorType.of("STRING"), "", true, null)))
+                .build();
+        HudiConnectorMetadata metadata = new HudiConnectorMetadata(
+                new FakeHmsClient(info), HudiTestProperties.minimal(), new DirectHudiMetaClientExecutor());
+
+        HudiTableHandle handle = (HudiTableHandle) metadata.getTableHandle(null, "db", "t").orElseThrow();
+
+        // Avro-derived slots and history_schema_info are both lower-case. The handle drives
+        // path_partition_keys, column classification, and columns_from_path, so it must use the same key.
+        Assertions.assertEquals(Collections.singletonList("city"), handle.getPartitionKeyNames());
     }
 
     /**

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergColumnHandle.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergColumnHandle.java
@@ -26,13 +26,13 @@ import java.util.Set;
 
 /**
  * Iceberg {@link ConnectorColumnHandle}, mirroring the paimon connector's {@code PaimonColumnHandle}. Carries
- * the (lowercased) column name and the iceberg field id. {@code IcebergConnectorMetadata.getColumnHandles}
+ * the case-preserved column name and the iceberg field id. {@code IcebergConnectorMetadata.getColumnHandles}
  * produces these so {@code PluginDrivenScanNode.buildColumnHandles} can hand the provider the pruned set of
  * requested columns — which the field-id schema dictionary (T06) keys the {@code current_schema_id = -1}
  * entry off (the CI #969249 fix: the dict's top-level names == the BE scan-slot names BY CONSTRUCTION).
  *
  * <p>Equality/hashCode are by name only (mirrors {@code PaimonColumnHandle}): a handle identifies a column
- * by its (lowercased) name, the same key {@code allHandles.get(slot.getColumn().getName())} looks it up by.
+ * by its case-preserved name, the same key {@code allHandles.get(slot.getColumn().getName())} looks it up by.
  */
 public class IcebergColumnHandle implements ConnectorColumnHandle {
 

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergPartitionUtils.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergPartitionUtils.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.PartitionData;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
@@ -119,14 +120,14 @@ final class IcebergPartitionUtils {
      * excluded from the file-decode set (the CI #968880 double-fill guard). Non-identity transforms
      * (bucket/truncate/year/month/...) are excluded.
      */
-    static List<String> getIdentityPartitionColumns(Table table) {
+    static List<String> getIdentityPartitionColumns(Table table, Schema scanSchema) {
         LinkedHashSet<String> partitionColumns = new LinkedHashSet<>();
         for (PartitionSpec spec : table.specs().values()) {
             for (PartitionField partitionField : spec.fields()) {
                 if (!partitionField.transform().isIdentity()) {
                     continue;
                 }
-                String columnName = table.schema().findColumnName(partitionField.sourceId());
+                String columnName = scanSchema.findColumnName(partitionField.sourceId());
                 if (columnName != null) {
                     partitionColumns.add(columnName);
                 }
@@ -141,7 +142,7 @@ final class IcebergPartitionUtils {
      * (LinkedHashMap, spec field order). Mirrors legacy {@code IcebergUtils.getIdentityPartitionInfoMap}.
      */
     static Map<String, String> getIdentityPartitionInfoMap(PartitionData partitionData,
-            PartitionSpec partitionSpec, Table table, ZoneId zone) {
+            PartitionSpec partitionSpec, Schema scanSchema, ZoneId zone) {
         Map<String, String> partitionInfoMap = new LinkedHashMap<>();
         List<NestedField> fields = partitionData.getPartitionType().asNestedType().fields();
         List<PartitionField> partitionFields = partitionSpec.fields();
@@ -159,7 +160,7 @@ final class IcebergPartitionUtils {
                 continue;
             }
 
-            String columnName = table.schema().findColumnName(partitionField.sourceId());
+            String columnName = scanSchema.findColumnName(partitionField.sourceId());
             if (columnName == null) {
                 continue;
             }

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergScanPlanProvider.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergScanPlanProvider.java
@@ -504,9 +504,10 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
         Table table = resolveTable(session, iceHandle);
         TableScan scan = buildScan(table, iceHandle, filter, session);
         int formatVersion = getFormatVersion(table);
-        List<String> orderedPartitionKeys = IcebergPartitionUtils.getIdentityPartitionColumns(table);
+        Schema scanSchema = pinnedSchema(table, iceHandle);
+        List<String> orderedPartitionKeys =
+                IcebergPartitionUtils.getIdentityPartitionColumns(table, scanSchema);
         ZoneId zone = resolveSessionZone(session);
-        boolean partitioned = table.spec().isPartitioned();
         Map<String, String> vendedToken = context != null
                 ? extractVendedToken(table, restVendedCredentialsEnabled()) : Collections.emptyMap();
         UnaryOperator<String> uriNormalizer = newUriNormalizer(vendedToken);
@@ -516,7 +517,7 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
         try {
             CloseableIterable<FileScanTask> tasks = streamingFileScanTasks(
                     scan, session, table, filter, sliceSize);
-            return new IcebergStreamingSplitSource(tasks, table, formatVersion, partitioned,
+            return new IcebergStreamingSplitSource(tasks, table, scanSchema, formatVersion,
                     orderedPartitionKeys, zone, uriNormalizer, sliceSize,
                     iceHandle.getRewriteFileScope(), iceHandle);
         } catch (RuntimeException e) {
@@ -575,8 +576,8 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
     private final class IcebergStreamingSplitSource implements ConnectorSplitSource {
         private final CloseableIterable<FileScanTask> tasks;
         private final Table table;
+        private final Schema scanSchema;
         private final int formatVersion;
-        private final boolean partitioned;
         private final List<String> orderedPartitionKeys;
         private final ZoneId zone;
         private final UnaryOperator<String> uriNormalizer;
@@ -595,14 +596,14 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
         // 1-entry cache stays O(1) memory (never accumulates), preserving the streaming path's OOM safety.
         private final PerFileScratch scratch = new PerFileScratch();
 
-        IcebergStreamingSplitSource(CloseableIterable<FileScanTask> tasks, Table table, int formatVersion,
-                boolean partitioned, List<String> orderedPartitionKeys, ZoneId zone,
+        IcebergStreamingSplitSource(CloseableIterable<FileScanTask> tasks, Table table, Schema scanSchema,
+                int formatVersion, List<String> orderedPartitionKeys, ZoneId zone,
                 UnaryOperator<String> uriNormalizer, long sliceSize, Set<String> rewriteScope,
                 IcebergTableHandle handle) {
             this.tasks = tasks;
             this.table = table;
+            this.scanSchema = scanSchema;
             this.formatVersion = formatVersion;
-            this.partitioned = partitioned;
             this.orderedPartitionKeys = orderedPartitionKeys;
             this.zone = zone;
             this.uriNormalizer = uriNormalizer;
@@ -621,7 +622,7 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
                     iterator = tasks.iterator();
                 }
                 while (iterator.hasNext()) {
-                    IcebergScanRange range = buildRangeForTask(iterator.next(), table, formatVersion, partitioned,
+                    IcebergScanRange range = buildRangeForTask(iterator.next(), table, scanSchema, formatVersion,
                             orderedPartitionKeys, zone, uriNormalizer, sliceSize, rewriteScope, null, scratch);
                     if (range != null) {
                         buffered = range;
@@ -691,7 +692,9 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
         }
 
         int formatVersion = getFormatVersion(table);
-        List<String> orderedPartitionKeys = IcebergPartitionUtils.getIdentityPartitionColumns(table);
+        Schema scanSchema = pinnedSchema(table, iceHandle);
+        List<String> orderedPartitionKeys =
+                IcebergPartitionUtils.getIdentityPartitionColumns(table, scanSchema);
         ZoneId zone = resolveSessionZone(session);
         boolean partitioned = table.spec().isPartitioned();
 
@@ -715,7 +718,7 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
         if (countPushdown) {
             long realCount = getCountFromSnapshot(scan, session);
             if (realCount >= 0) {
-                return planCountPushdown(table, scan, realCount, formatVersion, partitioned,
+                return planCountPushdown(table, scan, scanSchema, realCount, formatVersion, partitioned,
                         orderedPartitionKeys, zone, uriNormalizer, session, filter);
             }
         }
@@ -753,9 +756,9 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
             for (FileScanTask task : plan.tasks) {
                 // Shared per-task mapping (rewrite-scope skip + M-2 weight denominator + v3 stash side-effect),
                 // identical to the streaming path's IcebergStreamingSplitSource so both produce the same ranges.
-                IcebergScanRange range = buildRangeForTask(task, table, formatVersion, partitioned,
-                        orderedPartitionKeys, zone, uriNormalizer, plan.targetSplitSize, rewriteScope,
-                        rewritableDeleteSupply, scratch);
+                IcebergScanRange range = buildRangeForTask(task, table, scanSchema, formatVersion,
+                        partitioned, orderedPartitionKeys, zone, uriNormalizer, plan.targetSplitSize,
+                        rewriteScope, rewritableDeleteSupply, scratch);
                 if (range != null) {
                     ranges.add(range);
                 }
@@ -811,8 +814,8 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
      * side-effect. The streaming path passes {@code rewritableDeleteSupply=null} (v3 is gated onto the eager
      * path — see {@link #streamingSplitEstimate}), so the accumulation is inert there.
      */
-    private IcebergScanRange buildRangeForTask(FileScanTask task, Table table, int formatVersion,
-            boolean partitioned, List<String> orderedPartitionKeys, ZoneId zone,
+    private IcebergScanRange buildRangeForTask(FileScanTask task, Table table, Schema scanSchema,
+            int formatVersion, boolean partitioned, List<String> orderedPartitionKeys, ZoneId zone,
             UnaryOperator<String> uriNormalizer, long targetSplitSize, Set<String> rewriteScope,
             Map<String, List<TIcebergDeleteFileDesc>> rewritableDeleteSupply, PerFileScratch scratch) {
         DataFile dataFile = task.file();
@@ -826,7 +829,7 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
         boolean firstSliceOfFile = scratch.file != dataFile;
         // targetSplitSize is the scan-level weight denominator (M-2): each data-file range carries a
         // size-proportional BE scheduling weight (selfSplitWeight computed inside buildRange).
-        IcebergScanRange range = buildRange(table, dataFile, task, formatVersion, partitioned,
+        IcebergScanRange range = buildRange(table, scanSchema, dataFile, task, formatVersion, partitioned,
                 orderedPartitionKeys, zone, uriNormalizer, -1, targetSplitSize, scratch);
         if (rewritableDeleteSupply != null && firstSliceOfFile) {
             // Record this data file's non-equality delete supply keyed on its RAW path (the exact string the BE
@@ -1250,14 +1253,14 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
      * legacy's {@code >10000} parallel multi-split trim is the perf-only divergence we drop). An empty table
      * (no files) yields no range, so BE gets 0 ranges and COUNT returns 0 (legacy returns empty splits too).
      */
-    private List<ConnectorScanRange> planCountPushdown(Table table, TableScan scan, long realCount,
-            int formatVersion, boolean partitioned, List<String> orderedPartitionKeys, ZoneId zone,
+    private List<ConnectorScanRange> planCountPushdown(Table table, TableScan scan, Schema scanSchema,
+            long realCount, int formatVersion, boolean partitioned, List<String> orderedPartitionKeys, ZoneId zone,
             UnaryOperator<String> uriNormalizer, ConnectorSession session, Optional<ConnectorExpression> filter) {
         try (CloseableIterable<FileScanTask> tasks = countPushdownFileScanTasks(scan, session, table, filter)) {
             for (FileScanTask task : tasks) {
                 // targetSplitSize = -1: the count-pushdown collapse emits a single range, so its scheduling
                 // weight is irrelevant → PluginDrivenSplit keeps SplitWeight.standard().
-                return Collections.singletonList(buildRange(table, task.file(), task, formatVersion,
+                return Collections.singletonList(buildRange(table, scanSchema, task.file(), task, formatVersion,
                         partitioned, orderedPartitionKeys, zone, uriNormalizer, realCount, -1, null));
             }
         } catch (IOException e) {
@@ -1326,13 +1329,13 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
      * size-proportional {@code selfSplitWeight} are per-slice. A {@code null} scratch (the single
      * count-pushdown range) computes without caching. Byte-identical to the former per-slice recompute.</p>
      */
-    private IcebergScanRange buildRange(Table table, DataFile dataFile, FileScanTask task, int formatVersion,
-            boolean partitioned, List<String> orderedPartitionKeys, ZoneId zone,
+    private IcebergScanRange buildRange(Table table, Schema scanSchema, DataFile dataFile, FileScanTask task,
+            int formatVersion, boolean partitioned, List<String> orderedPartitionKeys, ZoneId zone,
             UnaryOperator<String> uriNormalizer, long pushDownRowCount, long targetSplitSize,
             PerFileScratch scratch) {
         PerFileScratch file = (scratch != null && scratch.file == dataFile)
                 ? scratch
-                : computePerFileInvariants(table, dataFile, task, formatVersion, partitioned,
+                : computePerFileInvariants(table, scanSchema, dataFile, task, formatVersion, partitioned,
                         orderedPartitionKeys, zone, uriNormalizer, scratch);
         // M-2 size-proportional weight numerator = this split's byte length + the byte size of every
         // merge-on-read delete file applying to it, mirroring legacy IcebergSplit.selfSplitWeight (ctor sets
@@ -1374,8 +1377,8 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
      * so the memoized range is byte-identical to the per-slice recompute. The scratch fields are assigned only
      * after the fail-loud check, so a rejected file never leaves a half-populated scratch.
      */
-    private PerFileScratch computePerFileInvariants(Table table, DataFile dataFile, FileScanTask task,
-            int formatVersion, boolean partitioned, List<String> orderedPartitionKeys, ZoneId zone,
+    private PerFileScratch computePerFileInvariants(Table table, Schema scanSchema, DataFile dataFile,
+            FileScanTask task, int formatVersion, boolean partitioned, List<String> orderedPartitionKeys, ZoneId zone,
             UnaryOperator<String> uriNormalizer, PerFileScratch scratch) {
         perFileInvariantComputeCount++;
         Integer partitionSpecId = null;
@@ -1390,7 +1393,7 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
             // Order the identity values as the path_partition_keys list (legacy getOrderedPathPartitionKeys),
             // filtered to keys this file carries — so columns-from-path matches legacy ordering exactly.
             Map<String, String> identityMap =
-                    IcebergPartitionUtils.getIdentityPartitionInfoMap(partitionData, spec, table, zone);
+                    IcebergPartitionUtils.getIdentityPartitionInfoMap(partitionData, spec, scanSchema, zone);
             Map<String, String> ordered = new LinkedHashMap<>();
             for (String key : orderedPartitionKeys) {
                 if (identityMap.containsKey(key)) {
@@ -1677,7 +1680,7 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
         // (empty partitionKeys + null schema-dict table). resolveTable still loads the base table here for
         // the credential overlay below (the metadata table shares the base table's FileIO).
         if (!systemTable) {
-            List<String> partitionKeys = IcebergPartitionUtils.getIdentityPartitionColumns(table);
+            List<String> partitionKeys = IcebergPartitionUtils.getIdentityPartitionColumns(table, scanSchema);
             if (!partitionKeys.isEmpty()) {
                 props.put(ScanNodePropertyKeys.PATH_PARTITION_KEYS, String.join(",", partitionKeys));
             }

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergScanPlanProvider.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergScanPlanProvider.java
@@ -696,7 +696,6 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
         List<String> orderedPartitionKeys =
                 IcebergPartitionUtils.getIdentityPartitionColumns(table, scanSchema);
         ZoneId zone = resolveSessionZone(session);
-        boolean partitioned = table.spec().isPartitioned();
 
         // Vended credentials (T09): extract the per-table REST vended token ONCE per scan (gated on the catalog
         // flag iceberg.rest.vended-credentials-enabled, mirroring legacy IcebergVendedCredentialsProvider), then
@@ -718,7 +717,7 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
         if (countPushdown) {
             long realCount = getCountFromSnapshot(scan, session);
             if (realCount >= 0) {
-                return planCountPushdown(table, scan, scanSchema, realCount, formatVersion, partitioned,
+                return planCountPushdown(table, scan, scanSchema, realCount, formatVersion,
                         orderedPartitionKeys, zone, uriNormalizer, session, filter);
             }
         }
@@ -757,7 +756,7 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
                 // Shared per-task mapping (rewrite-scope skip + M-2 weight denominator + v3 stash side-effect),
                 // identical to the streaming path's IcebergStreamingSplitSource so both produce the same ranges.
                 IcebergScanRange range = buildRangeForTask(task, table, scanSchema, formatVersion,
-                        partitioned, orderedPartitionKeys, zone, uriNormalizer, plan.targetSplitSize,
+                        orderedPartitionKeys, zone, uriNormalizer, plan.targetSplitSize,
                         rewriteScope, rewritableDeleteSupply, scratch);
                 if (range != null) {
                     ranges.add(range);
@@ -815,7 +814,7 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
      * path — see {@link #streamingSplitEstimate}), so the accumulation is inert there.
      */
     private IcebergScanRange buildRangeForTask(FileScanTask task, Table table, Schema scanSchema,
-            int formatVersion, boolean partitioned, List<String> orderedPartitionKeys, ZoneId zone,
+            int formatVersion, List<String> orderedPartitionKeys, ZoneId zone,
             UnaryOperator<String> uriNormalizer, long targetSplitSize, Set<String> rewriteScope,
             Map<String, List<TIcebergDeleteFileDesc>> rewritableDeleteSupply, PerFileScratch scratch) {
         DataFile dataFile = task.file();
@@ -829,7 +828,7 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
         boolean firstSliceOfFile = scratch.file != dataFile;
         // targetSplitSize is the scan-level weight denominator (M-2): each data-file range carries a
         // size-proportional BE scheduling weight (selfSplitWeight computed inside buildRange).
-        IcebergScanRange range = buildRange(table, scanSchema, dataFile, task, formatVersion, partitioned,
+        IcebergScanRange range = buildRange(table, scanSchema, dataFile, task, formatVersion,
                 orderedPartitionKeys, zone, uriNormalizer, -1, targetSplitSize, scratch);
         if (rewritableDeleteSupply != null && firstSliceOfFile) {
             // Record this data file's non-equality delete supply keyed on its RAW path (the exact string the BE
@@ -1254,14 +1253,14 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
      * (no files) yields no range, so BE gets 0 ranges and COUNT returns 0 (legacy returns empty splits too).
      */
     private List<ConnectorScanRange> planCountPushdown(Table table, TableScan scan, Schema scanSchema,
-            long realCount, int formatVersion, boolean partitioned, List<String> orderedPartitionKeys, ZoneId zone,
+            long realCount, int formatVersion, List<String> orderedPartitionKeys, ZoneId zone,
             UnaryOperator<String> uriNormalizer, ConnectorSession session, Optional<ConnectorExpression> filter) {
         try (CloseableIterable<FileScanTask> tasks = countPushdownFileScanTasks(scan, session, table, filter)) {
             for (FileScanTask task : tasks) {
                 // targetSplitSize = -1: the count-pushdown collapse emits a single range, so its scheduling
                 // weight is irrelevant → PluginDrivenSplit keeps SplitWeight.standard().
                 return Collections.singletonList(buildRange(table, scanSchema, task.file(), task, formatVersion,
-                        partitioned, orderedPartitionKeys, zone, uriNormalizer, realCount, -1, null));
+                        orderedPartitionKeys, zone, uriNormalizer, realCount, -1, null));
             }
         } catch (IOException e) {
             throw new RuntimeException("Failed to plan iceberg count-pushdown file, error message is:"
@@ -1320,9 +1319,9 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
     /**
      * Build the BE-ready {@link IcebergScanRange} for one {@link FileScanTask}, mirroring legacy
      * {@code IcebergScanNode.createIcebergSplit} + {@code setIcebergParams}: the file path/offset/size, the
-     * per-file format (native parquet/orc), the table format version, the v3 row-lineage fields, and — for a
-     * partitioned table — the partition spec-id, the all-fields {@code partition_data_json}, and the ordered
-     * identity {@code partitionValues} that become columns-from-path.
+     * per-file format (native parquet/orc), the table format version, the v3 row-lineage fields, the file's
+     * partition spec-id, and — when the file carries partition data — the all-fields
+     * {@code partition_data_json} plus ordered identity {@code partitionValues} that become columns-from-path.
      *
      * <p>The per-file-invariant work is memoized through {@code scratch} (keyed by the shared {@code DataFile}
      * instance) and reused across the file's byte-slices; only {@code start} / {@code length} / the
@@ -1330,12 +1329,12 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
      * count-pushdown range) computes without caching. Byte-identical to the former per-slice recompute.</p>
      */
     private IcebergScanRange buildRange(Table table, Schema scanSchema, DataFile dataFile, FileScanTask task,
-            int formatVersion, boolean partitioned, List<String> orderedPartitionKeys, ZoneId zone,
+            int formatVersion, List<String> orderedPartitionKeys, ZoneId zone,
             UnaryOperator<String> uriNormalizer, long pushDownRowCount, long targetSplitSize,
             PerFileScratch scratch) {
         PerFileScratch file = (scratch != null && scratch.file == dataFile)
                 ? scratch
-                : computePerFileInvariants(table, scanSchema, dataFile, task, formatVersion, partitioned,
+                : computePerFileInvariants(table, scanSchema, dataFile, task, formatVersion,
                         orderedPartitionKeys, zone, uriNormalizer, scratch);
         // M-2 size-proportional weight numerator = this split's byte length + the byte size of every
         // merge-on-read delete file applying to it, mirroring legacy IcebergSplit.selfSplitWeight (ctor sets
@@ -1372,23 +1371,25 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
     /**
      * Compute {@link #buildRange}'s per-file invariants and, when {@code scratch} is non-null, store them into
      * it so the file's remaining byte-slices reuse them. Uses {@code task.deletes()} (identical across a
-     * file's slices) for the delete carriers. Mirrors the former inline per-slice computation exactly — same
-     * partition-JSON / identity-map ordering, same fail-loud on a non-parquet/orc file, same v3 row-lineage —
-     * so the memoized range is byte-identical to the per-slice recompute. The scratch fields are assigned only
-     * after the fail-loud check, so a rejected file never leaves a half-populated scratch.
+     * file's slices) for the delete carriers. Partition JSON / identity-map ordering, format validation, and v3
+     * row-lineage are identical for every slice, while the spec id is always the data file's true spec (including
+     * evolved unpartitioned specs). The scratch fields are assigned only after the fail-loud check, so a rejected
+     * file never leaves a half-populated scratch.
      */
     private PerFileScratch computePerFileInvariants(Table table, Schema scanSchema, DataFile dataFile,
-            FileScanTask task, int formatVersion, boolean partitioned, List<String> orderedPartitionKeys, ZoneId zone,
+            FileScanTask task, int formatVersion, List<String> orderedPartitionKeys, ZoneId zone,
             UnaryOperator<String> uriNormalizer, PerFileScratch scratch) {
         perFileInvariantComputeCount++;
-        Integer partitionSpecId = null;
+        // Carry the file's real spec id even when that spec is unpartitioned. BE embeds this id in Iceberg
+        // $row_id for row-level delete/update/merge; omitting it makes an evolved unpartitioned file fall back
+        // to spec 0 (which may be an old partitioned spec). Partition JSON and identity values remain gated on
+        // actual partition data below.
+        Integer partitionSpecId = dataFile.specId();
         String partitionDataJson = null;
         Map<String, String> partitionValues = Collections.emptyMap();
-        if (partitioned && dataFile.partition() instanceof PartitionData) {
+        PartitionSpec spec = table.specs().get(dataFile.specId());
+        if (spec.isPartitioned() && dataFile.partition() instanceof PartitionData) {
             PartitionData partitionData = (PartitionData) dataFile.partition();
-            int specId = dataFile.specId();
-            PartitionSpec spec = table.specs().get(specId);
-            partitionSpecId = specId;
             partitionDataJson = IcebergPartitionUtils.getPartitionDataJson(partitionData, spec, zone);
             // Order the identity values as the path_partition_keys list (legacy getOrderedPathPartitionKeys),
             // filtered to keys this file carries — so columns-from-path matches legacy ordering exactly.

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergScanPlanProvider.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergScanPlanProvider.java
@@ -895,7 +895,7 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
         //      the ids through a Set and re-emit them in TABLE-schema order (TypeUtil.project), breaking that
         //      contract; scan.project(orderedSchema) preserves the requested order, so we build the schema by
         //      hand from the requested columns.
-        List<String> projectedColumns = requestedLowerNames(columns);
+        List<String> projectedColumns = requestedColumnNames(columns);
         if (!projectedColumns.isEmpty()) {
             Schema metadataSchema = metadataTable.schema();
             List<NestedField> projectedFields = new ArrayList<>(projectedColumns.size());
@@ -1143,7 +1143,7 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
 
     /** Whether the query projects the {@code partition} column (legacy read the tuple's slots). */
     private static boolean isPositionDeletesPartitionColumnRequested(List<ConnectorColumnHandle> columns) {
-        return requestedLowerNames(columns).stream().anyMatch("partition"::equalsIgnoreCase);
+        return requestedColumnNames(columns).stream().anyMatch("partition"::equalsIgnoreCase);
     }
 
     /**
@@ -1600,7 +1600,7 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
      * <ul>
      *   <li>{@code file_format_type=jni} — makes the parent default the per-range format to {@code FORMAT_JNI},
      *       which each native range overrides to parquet/orc in {@code populateRangeParams} (mirrors paimon).</li>
-     *   <li>{@code path_partition_keys} — the lowercased, comma-joined identity partition columns, so FE marks
+     *   <li>{@code path_partition_keys} — the case-preserved, comma-joined identity partition columns, so FE marks
      *       those slots as partition columns and excludes them from the file-decode set; without it BE
      *       double-fills the partition columns (decode-from-file AND append-from-path) and DCHECKs (CI #968880).
      *       Emitted only when the table is partitioned (an empty value would split into a single "" key).</li>
@@ -1718,17 +1718,17 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
         // pruned-by-requested-columns dict (CI #969249).
         //
         // Row-lineage (format-version >= 3): _row_id / _last_updated_sequence_number are GENERATED BE scan slots
-        // (they reach BE column_names) but are NOT in schema.columns(), so requestedLowerNames — keyed off the
+        // (they reach BE column_names) but are NOT in schema.columns(), so requestedColumnNames — keyed off the
         // iceberg column handles — never carries them. encodeSchemaEvolutionProp(appendRowLineage=true) appends
         // them to the dict root so BE's StructNode children map contains them; else the ParquetReader's
         // unconditional children.at("_row_id") std::out_of_range-SIGABRTs the whole BE.
         //
         // Partition evolution (#65870) needs NO further widening here: a column that a newer spec turns into an
-        // identity partition column — and that older files may still store physically — is declared in
-        // path_partition_keys (unioned over ALL specs, see IcebergPartitionUtils.getIdentityPartitionColumns), so
-        // FileQueryScanNode.classifyColumn categorizes it PARTITION_KEY, i.e. a NON-file slot filled from
-        // columns_from_path. BE resolves through this dict only the slots it decodes FROM the file, so such a
-        // column is never looked up in it whether or not the query projects it.
+        // identity partition column is declared in path_partition_keys (unioned over ALL specs, see
+        // IcebergPartitionUtils.getIdentityPartitionColumns). BE still resolves that slot through this dict to
+        // decide whether an older file stores it physically or columns_from_path should fill it, so the dict name
+        // must byte-match the case-preserved slot. Both the requested-column path and the full-schema paths below
+        // now preserve that top-level case.
         boolean enableVarbinary = catalogProps.isEnableMappingVarbinary();
         boolean enableTimestampTz = catalogProps.isEnableMappingTimestampTz();
         if (!systemTable) {
@@ -1759,7 +1759,7 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
                         enableVarbinary, enableTimestampTz);
             } else {
                 dict = IcebergSchemaUtils.encodeSchemaEvolutionProp(
-                        table, table.schema(), requestedLowerNames(columns),
+                        table, table.schema(), requestedColumnNames(columns),
                         appendRowLineage, enableVarbinary, enableTimestampTz);
             }
             props.put(SCHEMA_EVOLUTION_PROP, dict);
@@ -1797,7 +1797,7 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
             Table metadataTable = MetadataTableUtils.createMetadataTableInstance(
                     table, MetadataTableType.POSITION_DELETES);
             props.put(SCHEMA_EVOLUTION_PROP, IcebergSchemaUtils.encodeSchemaEvolutionProp(
-                    metadataTable, metadataTable.schema(), requestedLowerNames(columns), false,
+                    metadataTable, metadataTable.schema(), requestedColumnNames(columns), false,
                     enableVarbinary, enableTimestampTz));
         }
         // Pushed-predicate EXPLAIN prop (explain gap): serialize the iceberg Expression form of each pushed
@@ -1831,13 +1831,13 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
     }
 
     /**
-     * The lowercased names of the requested (pruned) columns — the authoritative Doris scan slots the field-id
+     * The case-preserved names of the requested (pruned) columns — the authoritative Doris scan slots the field-id
      * dictionary keys its {@code -1} entry off (so its top-level names == the BE scan-slot names BY
      * CONSTRUCTION; CI #969249). The names come straight from the {@link IcebergColumnHandle}s
-     * {@code IcebergConnectorMetadata.getColumnHandles} produced (already lowercased). An empty list (count-only
+     * {@code IcebergConnectorMetadata.getColumnHandles} produced. An empty list (count-only
      * scan / no column handles) makes the dictionary fall back to all top-level columns.
      */
-    private static List<String> requestedLowerNames(List<ConnectorColumnHandle> columns) {
+    private static List<String> requestedColumnNames(List<ConnectorColumnHandle> columns) {
         if (columns == null || columns.isEmpty()) {
             return Collections.emptyList();
         }

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergScanRange.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergScanRange.java
@@ -64,7 +64,7 @@ public class IcebergScanRange implements ConnectorScanRange {
     private final String partitionDataJson;
     private final Long firstRowId;
     private final Long lastUpdatedSequenceNumber;
-    // Identity partition column (lowercased) -> serialized value, already ordered as the path_partition_keys
+    // Identity partition column (case-preserved) -> serialized value, already ordered as the path_partition_keys
     // list, filtered to keys this file carries. Drives columns-from-path. Never null (empty when unpartitioned).
     private final Map<String, String> partitionValues;
     // Merge-on-read delete files applying to this data file (T04). Never null (empty when none / v1).

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergSchemaUtils.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergSchemaUtils.java
@@ -109,19 +109,19 @@ public final class IcebergSchemaUtils {
     }
 
     /**
-     * Orchestrator: build the schema dictionary for {@code table} keyed off the requested (lowercased) column
-     * names and serialize it for transport via the scan-node props. {@code requestedLowerNames} is the pruned
+     * Orchestrator: build the schema dictionary for {@code table} keyed off the requested, case-preserved column
+     * names and serialize it for transport via the scan-node props. {@code requestedNames} is the pruned
      * scan-slot list ({@code PluginDrivenScanNode} hands the provider the requested columns); an empty list
      * (count-only scan / no column handles) falls back to all top-level schema columns.
      */
-    static String encodeSchemaEvolutionProp(Table table, List<String> requestedLowerNames) {
-        return encodeSchemaEvolutionProp(table, table.schema(), requestedLowerNames, false, false, false);
+    static String encodeSchemaEvolutionProp(Table table, List<String> requestedNames) {
+        return encodeSchemaEvolutionProp(table, table.schema(), requestedNames, false, false, false);
     }
 
     /**
      * Like {@link #encodeSchemaEvolutionProp(Table, List)} but builds the dictionary from an explicit
      * {@code dictSchema} (the latest schema for a normal read, or a historical schema for a time-travel read —
-     * T07 Option A passes the PINNED schema with an empty {@code requestedLowerNames} so the dict covers every
+     * T07 Option A passes the PINNED schema with an empty {@code requestedNames} so the dict covers every
      * BE scan slot). The name mapping is still read from {@code table} (it is table-level, not schema-versioned).
      *
      * <p>{@code appendRowLineage} (set by the caller when the table format-version &gt;= 3) appends the iceberg
@@ -131,12 +131,12 @@ public final class IcebergSchemaUtils {
      * {@code children.at("_row_id")} {@code std::out_of_range}-SIGABRTs the whole BE. See
      * {@link #appendRowLineageFields}.</p>
      */
-    static String encodeSchemaEvolutionProp(Table table, Schema dictSchema, List<String> requestedLowerNames,
+    static String encodeSchemaEvolutionProp(Table table, Schema dictSchema, List<String> requestedNames,
             boolean appendRowLineage) {
         // Thin overload: keep both optional type mappings disabled for callers that do not thread catalog
         // properties.
         return encodeSchemaEvolutionProp(
-                table, dictSchema, requestedLowerNames, appendRowLineage, false, false);
+                table, dictSchema, requestedNames, appendRowLineage, false, false);
     }
 
     /**
@@ -145,19 +145,19 @@ public final class IcebergSchemaUtils {
      * TIMESTAMPTZ column's iceberg initial default is serialized consistently with how BE will read the
      * column (keep the trailing offset when tz-mapping is on, drop it — DATETIMEV2 UTC wall time — when off).
      */
-    static String encodeSchemaEvolutionProp(Table table, Schema dictSchema, List<String> requestedLowerNames,
+    static String encodeSchemaEvolutionProp(Table table, Schema dictSchema, List<String> requestedNames,
             boolean appendRowLineage, boolean enableTimestampTz) {
         return encodeSchemaEvolutionProp(
-                table, dictSchema, requestedLowerNames, appendRowLineage, false, enableTimestampTz);
+                table, dictSchema, requestedNames, appendRowLineage, false, enableTimestampTz);
     }
 
     /** Build and encode a schema dictionary with the catalog's Doris type-mapping options. */
-    static String encodeSchemaEvolutionProp(Table table, Schema dictSchema, List<String> requestedLowerNames,
+    static String encodeSchemaEvolutionProp(Table table, Schema dictSchema, List<String> requestedNames,
             boolean appendRowLineage, boolean enableVarbinary, boolean enableTimestampTz) {
         Optional<Map<Integer, List<String>>> nameMapping = extractNameMapping(table);
         // #65784: it is the PRESENCE of the table-level mapping (not its non-emptiness) that makes it
         // authoritative for BE, so thread isPresent() through as hasNameMapping.
-        TSchema current = buildCurrentSchema(dictSchema, requestedLowerNames,
+        TSchema current = buildCurrentSchema(dictSchema, requestedNames,
                 nameMapping.orElse(Collections.emptyMap()), nameMapping.isPresent(), enableVarbinary,
                 enableTimestampTz);
         if (appendRowLineage) {
@@ -255,16 +255,17 @@ public final class IcebergSchemaUtils {
      * fix: the top-level names == the BE scan slots so the {@code StructNode} DCHECK can never miss). Each
      * requested name is matched case-insensitively to the iceberg schema; its top-level {@code TField} name is
      * the requested name VERBATIM (byte-matching the Doris slot name; case-preserved post-#65094). An
-     * empty/{@code null} {@code requestedLowerNames} falls back to all top-level columns (lowercased). Fail
+     * empty/{@code null} {@code requestedNames} falls back to all top-level columns with their Iceberg case
+     * preserved. Fail
      * loud if a requested column is absent from the schema (a genuine FE/connector inconsistency — not a
      * silent drop).
      */
-    static TSchema buildCurrentSchema(Schema schema, List<String> requestedLowerNames,
+    static TSchema buildCurrentSchema(Schema schema, List<String> requestedNames,
             Map<Integer, List<String>> nameMapping) {
         // Thin overload: default enableTimestampTz=false (pre-#65502 timestamp-default behaviour) and derive
         // hasNameMapping from the map (a non-empty map ⇒ the table carried a mapping — the #65784 default;
         // the production path threads the precise isPresent() instead).
-        return buildCurrentSchema(schema, requestedLowerNames, nameMapping,
+        return buildCurrentSchema(schema, requestedNames, nameMapping,
                 nameMapping != null && !nameMapping.isEmpty(), false, false);
     }
 
@@ -275,26 +276,26 @@ public final class IcebergSchemaUtils {
      * AUTHORITATIVE, so every field carries an explicit (possibly empty) per-field mapping (see
      * {@link #buildField}).
      */
-    static TSchema buildCurrentSchema(Schema schema, List<String> requestedLowerNames,
+    static TSchema buildCurrentSchema(Schema schema, List<String> requestedNames,
             Map<Integer, List<String>> nameMapping, boolean hasNameMapping, boolean enableTimestampTz) {
-        return buildCurrentSchema(schema, requestedLowerNames, nameMapping, hasNameMapping, false,
+        return buildCurrentSchema(schema, requestedNames, nameMapping, hasNameMapping, false,
                 enableTimestampTz);
     }
 
     /** Build the dictionary using the same Doris scalar mappings as the connector's catalog columns. */
-    static TSchema buildCurrentSchema(Schema schema, List<String> requestedLowerNames,
+    static TSchema buildCurrentSchema(Schema schema, List<String> requestedNames,
             Map<Integer, List<String>> nameMapping, boolean hasNameMapping, boolean enableVarbinary,
             boolean enableTimestampTz) {
         TSchema tSchema = new TSchema();
         tSchema.setSchemaId(CURRENT_SCHEMA_ID);
         TStructField root = new TStructField();
-        if (requestedLowerNames == null || requestedLowerNames.isEmpty()) {
+        if (requestedNames == null || requestedNames.isEmpty()) {
             for (Types.NestedField field : schema.columns()) {
-                addField(root, buildField(field, field.name().toLowerCase(Locale.ROOT), nameMapping,
+                addField(root, buildField(field, field.name(), nameMapping,
                         hasNameMapping, enableVarbinary, enableTimestampTz));
             }
         } else {
-            for (String name : requestedLowerNames) {
+            for (String name : requestedNames) {
                 Types.NestedField field = schema.caseInsensitiveFindField(name);
                 if (field == null) {
                     throw new RuntimeException("iceberg schema-evolution: requested column '" + name
@@ -308,6 +309,12 @@ public final class IcebergSchemaUtils {
         return tSchema;
     }
 
+    /**
+     * Builds the equality-delete carrier without an Iceberg {@link Schema}, which would reject historical
+     * drop/re-add fields that share a name. Preserve top-level case because the list starts with the selected
+     * schema's current fields and those names still key BE's table-side {@code StructNode}; historical-only
+     * equality fields are resolved by their stable IDs.
+     */
     private static TSchema buildCurrentSchema(List<Types.NestedField> fields,
             Map<Integer, List<String>> nameMapping, boolean hasNameMapping, boolean enableVarbinary,
             boolean enableTimestampTz) {
@@ -315,7 +322,7 @@ public final class IcebergSchemaUtils {
         tSchema.setSchemaId(CURRENT_SCHEMA_ID);
         TStructField root = new TStructField();
         for (Types.NestedField field : fields) {
-            addField(root, buildField(field, field.name().toLowerCase(Locale.ROOT), nameMapping,
+            addField(root, buildField(field, field.name(), nameMapping,
                     hasNameMapping, enableVarbinary, enableTimestampTz));
         }
         tSchema.setRootField(root);

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergPartitionUtilsTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergPartitionUtilsTest.java
@@ -165,7 +165,7 @@ public class IcebergPartitionUtilsTest {
                 .build();
         Table table = tableWith(schema, spec);
 
-        List<String> cols = IcebergPartitionUtils.getIdentityPartitionColumns(table);
+        List<String> cols = IcebergPartitionUtils.getIdentityPartitionColumns(table, schema);
 
         // Only the two identity columns, CASE-PRESERVED (#65094 read-path alignment), in spec order; the
         // bucket(id) transform is excluded. MUTATION: including non-identity transforms -> "id_bucket"/"id"
@@ -191,7 +191,7 @@ public class IcebergPartitionUtilsTest {
         table.updateSpec().removeField("payload").addField("int_col").commit();
         Assertions.assertEquals(2, table.specs().size());
 
-        List<String> cols = IcebergPartitionUtils.getIdentityPartitionColumns(table);
+        List<String> cols = IcebergPartitionUtils.getIdentityPartitionColumns(table, table.schema());
 
         // Both specs contribute, in first-seen (spec id) order. MUTATION: iterating table.spec() instead of
         // table.specs() -> ["int_col"] -> red. MUTATION: dropping the LinkedHashSet dedup -> duplicates -> red.
@@ -209,13 +209,12 @@ public class IcebergPartitionUtilsTest {
                 .identity("P")
                 .bucket("id", 4)
                 .build();
-        Table table = tableWith(schema, spec);
         PartitionData pd = new PartitionData(spec.partitionType());
         pd.set(0, 7);          // P = 7  (identity)
         pd.set(1, 2);          // id_bucket = 2 (non-identity -> skipped)
 
         Map<String, String> info =
-                IcebergPartitionUtils.getIdentityPartitionInfoMap(pd, spec, table, ZoneOffset.UTC);
+                IcebergPartitionUtils.getIdentityPartitionInfoMap(pd, spec, schema, ZoneOffset.UTC);
 
         // Only the identity column survives, key CASE-PRESERVED (#65094 read-path alignment). MUTATION:
         // emitting id_bucket -> size 2 -> red. MUTATION: re-lowercasing the key -> "p" != "P" -> red.
@@ -228,12 +227,11 @@ public class IcebergPartitionUtilsTest {
                 Types.NestedField.required(1, "id", Types.IntegerType.get()),
                 Types.NestedField.optional(2, "p", Types.IntegerType.get()));
         PartitionSpec spec = PartitionSpec.builderFor(schema).identity("p").build();
-        Table table = tableWith(schema, spec);
         PartitionData pd = new PartitionData(spec.partitionType());
         pd.set(0, null);       // genuine null partition value
 
         Map<String, String> info =
-                IcebergPartitionUtils.getIdentityPartitionInfoMap(pd, spec, table, ZoneOffset.UTC);
+                IcebergPartitionUtils.getIdentityPartitionInfoMap(pd, spec, schema, ZoneOffset.UTC);
 
         Assertions.assertTrue(info.containsKey("p"));
         Assertions.assertNull(info.get("p"));

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanPlanProviderTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanPlanProviderTest.java
@@ -1230,6 +1230,42 @@ public class IcebergScanPlanProviderTest {
         Assertions.assertEquals("p", props.get("path_partition_keys"));
     }
 
+    @Test
+    public void getScanNodePropertiesUnderPinAlignsMixedCasePartitionWithFullSchemaDict() throws Exception {
+        // Every ordinary Iceberg scan is snapshot-pinned by the generic MVCC node. The pinned path builds a FULL
+        // dictionary by passing an empty requested-column list, while partition planning emits the Iceberg source
+        // name verbatim. Both carriers must therefore contain "City", not path_partition_keys="City" paired with
+        // a dictionary key "city" (the mismatch that made BE abort while checking partition fallback).
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "K1", Types.IntegerType.get()),
+                Types.NestedField.required(2, "City", Types.StringType.get()));
+        PartitionSpec spec = PartitionSpec.builderFor(schema).identity("City").build();
+        Table table = createTable("mixed_case_partition", schema, spec);
+        table.newAppend()
+                .appendFile(dataFile(spec,
+                        "s3://b/db/mixed_case_partition/City=Beijing/data.parquet",
+                        1024, null, "City=Beijing"))
+                .commit();
+        IcebergScanPlanProvider provider = providerOver(table);
+        IcebergTableHandle pinned = new IcebergTableHandle("db1", "mixed_case_partition")
+                .withSnapshot(table.currentSnapshot().snapshotId(), null,
+                        table.currentSnapshot().schemaId());
+
+        Map<String, String> props = provider.getScanNodeProperties(
+                null, pinned, Collections.emptyList(), Optional.empty());
+        TFileScanRangeParams params = new TFileScanRangeParams();
+        provider.populateScanLevelParams(params, props);
+        List<String> fieldNames = new ArrayList<>();
+        for (TFieldPtr ptr : params.getHistorySchemaInfo().get(0).getRootField().getFields()) {
+            fieldNames.add(ptr.getFieldPtr().getName());
+        }
+
+        Assertions.assertEquals("City", props.get("path_partition_keys"));
+        Assertions.assertTrue(fieldNames.contains("K1"));
+        Assertions.assertTrue(fieldNames.contains("City"));
+        Assertions.assertFalse(fieldNames.contains("city"));
+    }
+
     // --- T06 [D-065]: getScanNodeProperties sys-handle guard (skip dict + path_partition_keys) ---
 
     @Test

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanPlanProviderTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanPlanProviderTest.java
@@ -143,6 +143,32 @@ public class IcebergScanPlanProviderTest {
         return builder.build();
     }
 
+    private static Table retainedIdentityFileAfterCurrentSpecBecomesUnpartitioned(String name) {
+        PartitionSpec oldSpec = PartitionSpec.builderFor(PART_SCHEMA).identity("p").build();
+        Table table = createTable(name, PART_SCHEMA, oldSpec,
+                Collections.singletonMap("format-version", "2"));
+        table.newAppend()
+                .appendFile(dataFile(oldSpec, "s3://b/db/" + name + "/p=7/f.parquet", 512, null, "p=7"))
+                .commit();
+        table.updateSpec().removeField("p").commit();
+        Assertions.assertFalse(table.spec().isPartitioned(), "the current spec must be unpartitioned");
+        return table;
+    }
+
+    private static Table currentUnpartitionedFileAfterSpecEvolution(String name) {
+        PartitionSpec oldSpec = PartitionSpec.builderFor(PART_SCHEMA).identity("p").build();
+        Table table = createTable(name, PART_SCHEMA, oldSpec,
+                Collections.singletonMap("format-version", "2"));
+        table.updateSpec().removeField("p").commit();
+        PartitionSpec currentSpec = table.spec();
+        Assertions.assertFalse(currentSpec.isPartitioned(), "the current spec must be unpartitioned");
+        Assertions.assertNotEquals(oldSpec.specId(), currentSpec.specId(), "spec evolution must allocate a new id");
+        table.newAppend()
+                .appendFile(dataFile(currentSpec, "s3://b/db/" + name + "/f.parquet", 512, null, null))
+                .commit();
+        return table;
+    }
+
     /** Run a range's BE-param population end-to-end (the generic node pre-sets table_format_type). */
     private static TFileRangeDesc populate(ConnectorScanRange range) {
         TTableFormatFileDesc formatDesc = new TTableFormatFileDesc();
@@ -3318,6 +3344,84 @@ public class IcebergScanPlanProviderTest {
         Assertions.assertEquals(1, capped.size(), "max_file_split_num=1 must collapse to one whole-file range");
         Assertions.assertEquals(0L, capped.get(0).getStart());
         Assertions.assertEquals(96 * mb, capped.get(0).getLength());
+    }
+
+    @Test
+    public void planScanUsesRetainedDataFilesPartitionSpec() {
+        // A current unpartitioned spec does not erase partition data from retained files written by an old
+        // identity spec. The eager path must classify partition presence from dataFile.specId(), otherwise p is
+        // still advertised as a path partition key but this range omits columns_from_path and BE materializes
+        // NULL/default instead of the manifest value.
+        Table table = retainedIdentityFileAfterCurrentSpecBecomesUnpartitioned("old_spec_eager");
+        IcebergScanPlanProvider provider = new IcebergScanPlanProvider(
+                IcebergCatalogProperties.of(Collections.emptyMap()), opsReturning(table));
+
+        List<ConnectorScanRange> ranges = provider.planScan(null,
+                ConnectorScanRequest.builder(
+                        new IcebergTableHandle("db1", "old_spec_eager"), Collections.emptyList())
+                .build());
+
+        Assertions.assertEquals(1, ranges.size());
+        ConnectorScanRange range = ranges.get(0);
+        Assertions.assertEquals(Collections.singletonMap("p", "7"), range.getPartitionValues());
+        Assertions.assertTrue(range.isPartitionBearing());
+        Assertions.assertTrue(populate(range).getTableFormatParams().getIcebergParams().isSetPartitionSpecId());
+    }
+
+    @Test
+    public void streamSplitsUsesRetainedDataFilesPartitionSpec() throws IOException {
+        // The lazy streaming source shares buildRangeForTask with eager planning and must make the same per-file
+        // spec decision; a scan-level current-spec flag would drop p only on this path as well.
+        Table table = retainedIdentityFileAfterCurrentSpecBecomesUnpartitioned("old_spec_streaming");
+        IcebergScanPlanProvider provider = new IcebergScanPlanProvider(
+                IcebergCatalogProperties.of(Collections.emptyMap()), opsReturning(table));
+
+        List<ConnectorScanRange> ranges = drain(provider.streamSplits(emptySession(),
+                new IcebergTableHandle("db1", "old_spec_streaming"),
+                Collections.emptyList(), Optional.empty(), -1L));
+
+        Assertions.assertEquals(1, ranges.size());
+        ConnectorScanRange range = ranges.get(0);
+        Assertions.assertEquals(Collections.singletonMap("p", "7"), range.getPartitionValues());
+        Assertions.assertTrue(range.isPartitionBearing());
+        Assertions.assertTrue(populate(range).getTableFormatParams().getIcebergParams().isSetPartitionSpecId());
+    }
+
+    @Test
+    public void planScanCarriesCurrentUnpartitionedFileSpecIdForRowId() {
+        Table table = currentUnpartitionedFileAfterSpecEvolution("new_unpartitioned_eager");
+        IcebergScanPlanProvider provider = new IcebergScanPlanProvider(
+                IcebergCatalogProperties.of(Collections.emptyMap()), opsReturning(table));
+
+        List<ConnectorScanRange> ranges = provider.planScan(null,
+                ConnectorScanRequest.builder(
+                        new IcebergTableHandle("db1", "new_unpartitioned_eager"), Collections.emptyList())
+                        .build());
+
+        Assertions.assertEquals(1, ranges.size());
+        ConnectorScanRange range = ranges.get(0);
+        Assertions.assertTrue(range.getPartitionValues().isEmpty());
+        TIcebergFileDesc params = populate(range).getTableFormatParams().getIcebergParams();
+        Assertions.assertEquals(table.spec().specId(), params.getPartitionSpecId());
+        Assertions.assertFalse(params.isSetPartitionDataJson());
+    }
+
+    @Test
+    public void streamSplitsCarriesCurrentUnpartitionedFileSpecIdForRowId() throws IOException {
+        Table table = currentUnpartitionedFileAfterSpecEvolution("new_unpartitioned_streaming");
+        IcebergScanPlanProvider provider = new IcebergScanPlanProvider(
+                IcebergCatalogProperties.of(Collections.emptyMap()), opsReturning(table));
+
+        List<ConnectorScanRange> ranges = drain(provider.streamSplits(emptySession(),
+                new IcebergTableHandle("db1", "new_unpartitioned_streaming"),
+                Collections.emptyList(), Optional.empty(), -1L));
+
+        Assertions.assertEquals(1, ranges.size());
+        ConnectorScanRange range = ranges.get(0);
+        Assertions.assertTrue(range.getPartitionValues().isEmpty());
+        TIcebergFileDesc params = populate(range).getTableFormatParams().getIcebergParams();
+        Assertions.assertEquals(table.spec().specId(), params.getPartitionSpecId());
+        Assertions.assertFalse(params.isSetPartitionDataJson());
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanPlanProviderTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanPlanProviderTest.java
@@ -1232,10 +1232,10 @@ public class IcebergScanPlanProviderTest {
 
     @Test
     public void getScanNodePropertiesUnderPinAlignsMixedCasePartitionWithFullSchemaDict() throws Exception {
-        // Every ordinary Iceberg scan is snapshot-pinned by the generic MVCC node. The pinned path builds a FULL
-        // dictionary by passing an empty requested-column list, while partition planning emits the Iceberg source
-        // name verbatim. Both carriers must therefore contain "City", not path_partition_keys="City" paired with
-        // a dictionary key "city" (the mismatch that made BE abort while checking partition fallback).
+        // S1 uses "City". The current schema later renames that SAME field id to "CITY". A scan pinned to S1
+        // must resolve every carrier from S1: full dictionary, path_partition_keys, and the eager/streaming
+        // per-file columns_from_path key. Otherwise BE exact-matches a "City" slot against a latest "CITY" key
+        // and drops the manifest value; an imported file without the physical partition column then yields NULL.
         Schema schema = new Schema(
                 Types.NestedField.required(1, "K1", Types.IntegerType.get()),
                 Types.NestedField.required(2, "City", Types.StringType.get()));
@@ -1246,10 +1246,13 @@ public class IcebergScanPlanProviderTest {
                         "s3://b/db/mixed_case_partition/City=Beijing/data.parquet",
                         1024, null, "City=Beijing"))
                 .commit();
+        long snapshotId = table.currentSnapshot().snapshotId();
+        long schemaId = table.currentSnapshot().schemaId();
+        table.updateSchema().renameColumn("City", "CITY").commit();
+        Assertions.assertNotNull(table.schema().findField("CITY"));
         IcebergScanPlanProvider provider = providerOver(table);
         IcebergTableHandle pinned = new IcebergTableHandle("db1", "mixed_case_partition")
-                .withSnapshot(table.currentSnapshot().snapshotId(), null,
-                        table.currentSnapshot().schemaId());
+                .withSnapshot(snapshotId, null, schemaId);
 
         Map<String, String> props = provider.getScanNodeProperties(
                 null, pinned, Collections.emptyList(), Optional.empty());
@@ -1264,6 +1267,19 @@ public class IcebergScanPlanProviderTest {
         Assertions.assertTrue(fieldNames.contains("K1"));
         Assertions.assertTrue(fieldNames.contains("City"));
         Assertions.assertFalse(fieldNames.contains("city"));
+        Assertions.assertFalse(fieldNames.contains("CITY"));
+
+        List<ConnectorScanRange> eager = provider.planScan(emptySession(),
+                ConnectorScanRequest.builder(pinned, Collections.emptyList()).build());
+        TFileRangeDesc eagerDesc = populate(eager.get(0));
+        Assertions.assertEquals(Collections.singletonList("City"), eagerDesc.getColumnsFromPathKeys());
+        Assertions.assertEquals(Collections.singletonList("Beijing"), eagerDesc.getColumnsFromPath());
+
+        List<ConnectorScanRange> streaming = drain(provider.streamSplits(
+                emptySession(), pinned, Collections.emptyList(), Optional.empty(), -1L));
+        TFileRangeDesc streamingDesc = populate(streaming.get(0));
+        Assertions.assertEquals(Collections.singletonList("City"), streamingDesc.getColumnsFromPathKeys());
+        Assertions.assertEquals(Collections.singletonList("Beijing"), streamingDesc.getColumnsFromPath());
     }
 
     // --- T06 [D-065]: getScanNodeProperties sys-handle guard (skip dict + path_partition_keys) ---

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergSchemaUtilsTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergSchemaUtilsTest.java
@@ -78,11 +78,11 @@ public class IcebergSchemaUtilsTest {
     }
 
     /** Build the dictionary for the given requested column names and return the single (-1) entry. */
-    private static TSchema dict(Table table, String... requestedLowerNames) {
+    private static TSchema dict(Table table, String... requestedNames) {
         // Mirror the production path (encodeSchemaEvolutionProp): thread the PRECISE isPresent() as
         // hasNameMapping (#65784), so a present-but-empty mapping is still authoritative.
         Optional<Map<Integer, List<String>>> nameMapping = IcebergSchemaUtils.extractNameMapping(table);
-        return IcebergSchemaUtils.buildCurrentSchema(table.schema(), Arrays.asList(requestedLowerNames),
+        return IcebergSchemaUtils.buildCurrentSchema(table.schema(), Arrays.asList(requestedNames),
                 nameMapping.orElse(Collections.emptyMap()), nameMapping.isPresent(), false);
     }
 
@@ -129,7 +129,7 @@ public class IcebergSchemaUtilsTest {
         Assertions.assertEquals(-1L, params.getHistorySchemaInfo().get(0).getSchemaId());
     }
 
-    // --- top-level: iceberg field ids + lowercased names keyed off the requested columns ---
+    // --- top-level: iceberg field ids + names keyed off the requested columns ---
 
     @Test
     public void topLevelFieldsCarryIcebergFieldIdsAndLowercasedNames() {
@@ -255,7 +255,7 @@ public class IcebergSchemaUtilsTest {
     @Test
     public void emptyRequestedFallsBackToAllColumns() {
         // A count-only scan (no projected slots) / a table with no column handles yields an empty requested list;
-        // the dictionary then carries all top-level columns (lowercased) so it is still a valid superset. MUTATION:
+        // the dictionary then carries all top-level columns so it is still a valid superset. MUTATION:
         // return an empty root struct -> BE has no table entry -> red.
         Table table = createTable("t1", SCHEMA);
         Map<String, TField> fields = topFields(dict(table /* no requested names */));
@@ -264,6 +264,26 @@ public class IcebergSchemaUtilsTest {
         Assertions.assertEquals(1, fields.get("id").getId());
         Assertions.assertEquals(2, fields.get("name").getId());
         Assertions.assertEquals(3, fields.get("extra").getId());
+    }
+
+    @Test
+    public void emptyRequestedPreservesMixedCaseTopLevelNames() {
+        // Snapshot-pinned and Top-N lazy scans request the full schema by passing an empty list. Their Doris slots
+        // and path_partition_keys keep the Iceberg top-level case, so this fallback must do the same. Lowercasing
+        // only this branch makes a mixed-case partition slot ("City") miss the dictionary key ("city") and used
+        // to abort BE in StructNode::children_column_exists.
+        Schema mixed = new Schema(
+                Types.NestedField.required(7, "ID", Types.IntegerType.get()),
+                Types.NestedField.optional(9, "City", Types.StringType.get()));
+        Table table = createTable("mixed_full_schema", mixed);
+
+        Map<String, TField> fields = topFields(dict(table /* no requested names */));
+
+        Assertions.assertEquals(2, fields.size());
+        Assertions.assertEquals(table.schema().findField("ID").fieldId(), fields.get("ID").getId());
+        Assertions.assertEquals(table.schema().findField("City").fieldId(), fields.get("City").getId());
+        Assertions.assertFalse(fields.containsKey("id"));
+        Assertions.assertFalse(fields.containsKey("city"));
     }
 
     @Test
@@ -395,6 +415,18 @@ public class IcebergSchemaUtilsTest {
         Assertions.assertEquals(32, nested.get(1).getFieldPtr().getId());
         Assertions.assertEquals("key", nested.get(0).getFieldPtr().getName());
         Assertions.assertEquals("key", nested.get(1).getFieldPtr().getName());
+    }
+
+    @Test
+    public void equalityCarrierPreservesMixedCaseTopLevelNames() throws Exception {
+        Table table = createTable("mixed_equality_carrier", SCHEMA);
+        List<Types.NestedField> fields = Collections.singletonList(
+                Types.NestedField.optional(10, "City", Types.StringType.get()));
+
+        TStructField root = decode(IcebergSchemaUtils.encodeEqualitySchemaEvolutionProp(
+                table, fields, false, false, false)).getHistorySchemaInfo().get(0).getRootField();
+
+        Assertions.assertEquals("City", root.getFields().get(0).getFieldPtr().getName());
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #64304

Problem Summary: 
Snapshot-pinned Iceberg scans built the full field-id schema dictionary with lower-cased top-level names while scan slots and identity partition keys retained the source names. Mixed-case partition columns therefore missed the BE schema mapping and could abort the backend. Preserve Iceberg top-level names in full-schema dictionaries, return query errors for malformed mappings instead of aborting, and align Hudi partition carriers with the Hudi lower-case schema convention.


### Release note

Fix mixed-case partition reads for Iceberg and Hudi external tables.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

