### PR TITLE
[fix](catalog) apply the jdbc driver_url checks to iceberg/paimon and to ALTER CATALOG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,18 @@ This is the codebase for Apache Doris, an MPP OLAP database. It primarily consis
 
 For security scans, vulnerability triage, security reviews, and changes involving authentication, authorization, network boundaries, external catalogs, cloud tenancy, or other security-sensitive behavior, read `SECURITY.md` first, then follow it to `threat-model.md`. Use `threat-model.md` to determine in-scope components, trust boundaries, attacker roles, explicit non-goals, and triage classification. Findings that are out of model or by design under `threat-model.md` should be reported as such, not treated as Doris vulnerabilities. Such reviews will not be conducted unless explicitly requested by the user, and no conclusions regarding this matter need to be provided.
 
+## Remote Artifacts and Dynamic Code Loading
+
+Do not add any new code path that fetches an artifact from a user-supplied URL and loads it into a Doris process. This covers `driver_url`-style catalog/resource properties, plugin and UDF locations, and any other property whose value reaches a `URLClassLoader`, `Class.forName`, `System.load`/`dlopen`, or an equivalent BE-side loader. A user who can write such a property gets code execution inside the process that loads it, so the property's effective privilege is that process, not the DDL privilege it was gated on.
+
+The existing `driver_url` paths (jdbc / iceberg-jdbc / paimon-jdbc catalogs) remain for backward compatibility. They are grandfathered, not a precedent — do not copy the pattern into a new connector or feature.
+
+When a feature genuinely needs an operator-supplied artifact, read it from a local, operator-controlled directory (the `jdbc_drivers_dir` / plugin-directory pattern), not from a URL. The ADBC catalog's `AdbcDriverPathResolver` is the model: remote schemes rejected outright, a scheme-less value restricted to a bare file name so no path separator can escape the configured directory, and the check placed where the artifact is loaded rather than only at CREATE.
+
+Every consumer of the **jdbc-flavored** `driver_url` (the jdbc / iceberg-jdbc / paimon-jdbc catalogs, which do accept a URL) must route the raw value through `JdbcDriverUrlSecurity.check` (`fe-connector-spi`) before it reaches a class loader, on **both** the CREATE and the ALTER CATALOG path — in practice the connector provider's `validateProperties`, which fe-core runs on both and never on replay. That class is the single source of truth for the rule; do not fork or re-derive it per connector. Such a connector must also declare the value from `ConnectorProvider.driverUrlsToValidate`, which is how the operator's `jdbc_driver_secure_path` / `jdbc_driver_url_white_list` policy reaches the ALTER CATALOG path — ALTER never runs `Connector.preCreateValidation`, where CREATE applies that policy, so a connector that skips the declaration lets an ALTER repoint the jar past the operator's configuration.
+
+Separately, any new outbound HTTP request the FE or BE issues to a host named by a non-SUPER user is an SSRF surface. Call it out explicitly in the PR description together with the privilege required to reach it.
+
 ## When running in a WORKTREE directory
 
 To ensure smooth test execution without interference between worktrees, the first thing to do upon entering a worktree directory is to check if `.worktree_initialized` exists. If not, execute `hooks/setup_worktree.sh`, setting `$ROOT_WORKSPACE_PATH` to the base directory (typically `${DORIS_REPO}`) beforehand. After successful execution, verify that `.worktree_initialized` has been touched and that `thirdparty/installed` dependencies exist correctly. Also check if submodules have been properly initialized; if not, do so manually.

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnector.java
@@ -32,6 +32,7 @@ import org.apache.doris.connector.spi.ConnectorStorageContext;
 import org.apache.doris.connector.spi.ConnectorTestResult;
 import org.apache.doris.connector.spi.ConnectorValidationContext;
 import org.apache.doris.connector.spi.DorisConnectorException;
+import org.apache.doris.connector.spi.JdbcDriverUrlSecurity;
 import org.apache.doris.connector.spi.handle.ConnectorTableHandle;
 import org.apache.doris.connector.spi.mvcc.ConnectorMvccPartitionView;
 import org.apache.doris.connector.spi.procedure.ConnectorProcedureOps;
@@ -1374,11 +1375,15 @@ public class IcebergConnector implements Connector {
 
     /**
      * Enforces JDBC driver-url security at CREATE CATALOG (mirrors {@code PaimonConnector.preCreateValidation}):
-     * for the jdbc flavor a configured {@code iceberg.jdbc.driver_url} is routed through the engine's
-     * {@link ConnectorValidationContext#validateAndResolveDriverPath} hook (the FE format /
-     * {@code jdbc_driver_url_white_list} / {@code jdbc_driver_secure_path} gates), so a rejected url fails
-     * CREATE CATALOG before the jar is ever loaded by {@link #maybeRegisterJdbcDriver}. Non-jdbc flavors are
-     * a no-op.
+     * for the jdbc flavor a configured {@code iceberg.jdbc.driver_url} is first put through the mandatory,
+     * non-configurable {@link JdbcDriverUrlSecurity} rule shared with the jdbc / paimon-jdbc catalogs, then
+     * routed through the engine's {@link ConnectorValidationContext#validateAndResolveDriverPath} hook (the FE
+     * format / {@code jdbc_driver_url_white_list} / {@code jdbc_driver_secure_path} gates), so a rejected url
+     * fails CREATE CATALOG before the jar is ever loaded by {@link #maybeRegisterJdbcDriver}. Same order as
+     * {@code JdbcDorisConnector.preCreateValidation}. Non-jdbc flavors are a no-op.
+     *
+     * <p>ALTER CATALOG does not reach this hook; {@code IcebergConnectorProvider.validateProperties} applies
+     * the same rule on that path.
      */
     @Override
     public void preCreateValidation(ConnectorValidationContext validationContext) throws Exception {
@@ -1387,6 +1392,7 @@ public class IcebergConnector implements Connector {
         }
         String driverUrl = IcebergCatalogFactory.firstNonBlank(properties, IcebergConnectorProperties.JDBC_DRIVER_URL);
         if (StringUtils.isNotBlank(driverUrl)) {
+            JdbcDriverUrlSecurity.check(driverUrl);
             validationContext.validateAndResolveDriverPath(driverUrl);
         }
     }

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnectorProvider.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnectorProvider.java
@@ -22,8 +22,12 @@ import org.apache.doris.connector.metastore.spi.MetaStoreProviders;
 import org.apache.doris.connector.spi.Connector;
 import org.apache.doris.connector.spi.ConnectorContext;
 import org.apache.doris.connector.spi.ConnectorProvider;
+import org.apache.doris.connector.spi.JdbcDriverUrlSecurity;
+
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -77,7 +81,30 @@ public class IcebergConnectorProvider implements ConnectorProvider {
     public void validateProperties(Map<String, String> properties) {
         checkMetaCacheProperties(properties);
         String flavor = IcebergCatalogFactory.resolveFlavor(properties);
+        // The mandatory, non-configurable driver_url rule shared with the jdbc and paimon-jdbc catalogs
+        // (all three reach the same URLClassLoader + Class.forName sink from a catalog property). This
+        // hook is what the engine runs on CREATE *and* ALTER CATALOG, so it is the one that keeps a
+        // traversal / non-bare-name driver jar out of IcebergConnector's class loader;
+        // preCreateValidation covers CREATE only. Never runs on replay.
+        driverUrlsToValidate(properties).forEach(JdbcDriverUrlSecurity::check);
         MetaStoreProviders.bindForType(flavor, properties, Collections.emptyMap()).validate();
+    }
+
+    /**
+     * Only the jdbc flavor loads a driver jar; on every other flavor {@code iceberg.jdbc.driver_url} is
+     * dead config that never reaches a class loader, so declaring it would turn a previously-accepted
+     * catalog into a CREATE/ALTER failure for no security gain. See
+     * {@link ConnectorProvider#driverUrlsToValidate}.
+     */
+    @Override
+    public List<String> driverUrlsToValidate(Map<String, String> properties) {
+        if (!IcebergConnectorProperties.TYPE_JDBC.equals(IcebergCatalogFactory.resolveFlavor(properties))) {
+            return Collections.emptyList();
+        }
+        String driverUrl = IcebergCatalogFactory.firstNonBlank(
+                properties, IcebergConnectorProperties.JDBC_DRIVER_URL);
+        return StringUtils.isBlank(driverUrl)
+                ? Collections.emptyList() : Collections.singletonList(driverUrl);
     }
 
     /**

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergJdbcDriverUrlSecurityTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergJdbcDriverUrlSecurityTest.java
@@ -1,0 +1,153 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.iceberg;
+
+import org.apache.doris.connector.spi.ConnectorValidationContext;
+import org.apache.doris.connector.spi.JdbcDriverUrlSecurity;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The Iceberg JDBC catalog loads {@code iceberg.jdbc.driver_url} into the FE JVM through a
+ * {@code URLClassLoader} + {@code Class.forName(name, true, loader)}, exactly like the jdbc catalog does.
+ * These tests pin that it reaches the SAME mandatory rule ({@link JdbcDriverUrlSecurity}) on BOTH
+ * user-facing paths — the provider hook that fe-core runs on CREATE and ALTER, and the connector's
+ * CREATE-only pre-create hook.
+ *
+ * <p>The rule's own semantics live in {@code JdbcDriverUrlSecurityTest}; here one rejected shape is enough
+ * to prove the call is wired.
+ */
+public class IcebergJdbcDriverUrlSecurityTest {
+
+    private static final IcebergConnectorProvider PROVIDER = new IcebergConnectorProvider();
+
+    private static Map<String, String> jdbcProps(String driverUrl) {
+        Map<String, String> props = new HashMap<>();
+        props.put("iceberg.catalog.type", "jdbc");
+        props.put("uri", "jdbc:mysql://127.0.0.1:3306/iceberg");
+        props.put("iceberg.jdbc.catalog_name", "c");
+        props.put("warehouse", "s3://bucket/wh");
+        props.put("iceberg.jdbc.driver_url", driverUrl);
+        props.put("iceberg.jdbc.driver_class", "com.mysql.cj.jdbc.Driver");
+        return props;
+    }
+
+    // ---------------------------------------------------------------------
+    // provider hook — the only one fe-core runs on ALTER CATALOG
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void providerRejectsTraversalDriverUrl() {
+        // MUTATION: drop the JdbcDriverUrlSecurity.check call from IcebergConnectorProvider
+        // -> the props are otherwise valid, so validateProperties returns -> red.
+        IllegalArgumentException e = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> PROVIDER.validateProperties(jdbcProps("file:///opt/drivers/../../etc/evil.jar")));
+        Assertions.assertTrue(e.getMessage().contains("path traversal"), e.getMessage());
+    }
+
+    @Test
+    public void providerRejectsSchemelessPathDriverUrl() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> PROVIDER.validateProperties(jdbcProps("sub/dir/evil.jar")));
+    }
+
+    @Test
+    public void providerAcceptsBareJarName() {
+        PROVIDER.validateProperties(jdbcProps("mysql-connector-j-8.4.0.jar"));
+    }
+
+    @Test
+    public void providerSkipsRuleForNonJdbcFlavor() {
+        // A driver_url is dead config on a non-jdbc flavor: it never reaches a class loader, so the rule
+        // must not turn a previously-accepted REST catalog into a CREATE/ALTER failure.
+        Map<String, String> props = new HashMap<>();
+        props.put("iceberg.catalog.type", "hms");
+        props.put("hive.metastore.uris", "thrift://h");
+        props.put("iceberg.jdbc.driver_url", "../evil.jar");
+        PROVIDER.validateProperties(props);
+    }
+
+    // ---------------------------------------------------------------------
+    // connector pre-create hook — must reject BEFORE the configurable secure-path gate
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void preCreateValidationRejectsTraversalBeforeEngineGate() {
+        RecordingValidationContext ctx = new RecordingValidationContext();
+        IcebergConnector connector = new IcebergConnector(
+                jdbcProps("file:///opt/drivers/../../etc/evil.jar"), new RecordingConnectorContext());
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> connector.preCreateValidation(ctx));
+        // WHY: the mandatory rule cannot be turned off, so it must fire even when the operator left
+        // jdbc_driver_secure_path at its allow-all default (which is what the engine gate applies).
+        // MUTATION: run the check after validateAndResolveDriverPath -> the url reaches the gate -> red.
+        Assertions.assertTrue(ctx.validatedDriverUrls.isEmpty(),
+                "the mandatory rule must reject before the configurable engine gate is consulted");
+    }
+
+    @Test
+    public void preCreateValidationPassesCleanDriverUrlToEngineGate() throws Exception {
+        RecordingValidationContext ctx = new RecordingValidationContext();
+        new IcebergConnector(jdbcProps("mysql-connector-j-8.4.0.jar"), new RecordingConnectorContext())
+                .preCreateValidation(ctx);
+
+        Assertions.assertEquals(List.of("mysql-connector-j-8.4.0.jar"), ctx.validatedDriverUrls);
+    }
+
+    /** Hand-written {@link ConnectorValidationContext} test double (no Mockito), as in the paimon tests. */
+    private static final class RecordingValidationContext implements ConnectorValidationContext {
+        final List<String> validatedDriverUrls = new ArrayList<>();
+
+        @Override
+        public long getCatalogId() {
+            return 0;
+        }
+
+        @Override
+        public String getProperty(String key) {
+            return null;
+        }
+
+        @Override
+        public void storeProperty(String key, String value) {
+        }
+
+        @Override
+        public String validateAndResolveDriverPath(String driverUrl) {
+            validatedDriverUrls.add(driverUrl);
+            return "file:///resolved/" + driverUrl;
+        }
+
+        @Override
+        public String computeDriverChecksum(String driverUrl) {
+            return "deadbeef";
+        }
+
+        @Override
+        public void requestBeConnectivityTest(byte[] serializedDescriptor, int connectionTypeValue,
+                String testQuery) {
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcConnectorProvider.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcConnectorProvider.java
@@ -21,8 +21,10 @@ import org.apache.doris.connector.spi.Connector;
 import org.apache.doris.connector.spi.ConnectorContext;
 import org.apache.doris.connector.spi.ConnectorProvider;
 import org.apache.doris.connector.spi.DorisConnectorException;
+import org.apache.doris.connector.spi.JdbcDriverUrlSecurity;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -58,10 +60,10 @@ public class JdbcConnectorProvider implements ConnectorProvider {
             }
         }
 
-        // 1b. Mandatory, non-configurable driver_url security rule. checkProperties() runs this on
-        // both CREATE and ALTER CATALOG (both !isReplay), so a malicious driver_url cannot be
-        // introduced by either; metadata replay of existing catalogs is never affected.
-        JdbcDorisConnector.checkDriverUrlSecurityRule(resolve(properties, JdbcConnectorProperties.DRIVER_URL));
+        // 1b. Mandatory, non-configurable driver_url security rule, shared with the Iceberg/Paimon JDBC
+        // catalogs. checkProperties() runs this on both CREATE and ALTER CATALOG (both !isReplay), so a
+        // malicious driver_url cannot be introduced by either; metadata replay is never affected.
+        JdbcDriverUrlSecurity.check(resolve(properties, JdbcConnectorProperties.DRIVER_URL));
 
         // 2. Reject deprecated lower_case_table_names
         if (properties.containsKey(JdbcConnectorProperties.LOWER_CASE_TABLE_NAMES)
@@ -114,6 +116,18 @@ public class JdbcConnectorProvider implements ConnectorProvider {
                 throw new IllegalArgumentException(e.getMessage(), e);
             }
         }
+    }
+
+    /**
+     * A jdbc catalog always loads {@code driver_url} into the FE JVM, so it is always declared. See
+     * {@link ConnectorProvider#driverUrlsToValidate} for why the engine needs it (ALTER CATALOG does not
+     * reach {@code preCreateValidation}, where the operator's driver gate is applied on CREATE).
+     */
+    @Override
+    public List<String> driverUrlsToValidate(Map<String, String> properties) {
+        String driverUrl = resolve(properties, JdbcConnectorProperties.DRIVER_URL);
+        return driverUrl == null || driverUrl.isEmpty()
+                ? Collections.emptyList() : Collections.singletonList(driverUrl);
     }
 
     private static void checkBooleanProperty(Map<String, String> properties, String key) {

--- a/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcDorisConnector.java
+++ b/fe/fe-connector/fe-connector-jdbc/src/main/java/org/apache/doris/connector/jdbc/JdbcDorisConnector.java
@@ -27,6 +27,7 @@ import org.apache.doris.connector.spi.ConnectorSession;
 import org.apache.doris.connector.spi.ConnectorTestResult;
 import org.apache.doris.connector.spi.ConnectorValidationContext;
 import org.apache.doris.connector.spi.DorisConnectorException;
+import org.apache.doris.connector.spi.JdbcDriverUrlSecurity;
 import org.apache.doris.connector.spi.scan.ConnectorScanPlanProvider;
 import org.apache.doris.connector.spi.write.ConnectorWritePlanProvider;
 import org.apache.doris.thrift.TJdbcTable;
@@ -40,15 +41,12 @@ import org.apache.thrift.TSerializer;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 /**
  * JDBC connector implementation. Manages the lifecycle of
@@ -138,64 +136,6 @@ public class JdbcDorisConnector implements Connector {
         return scanPlanProvider;
     }
 
-    // A scheme-less driver_url must be a plain jar file name: letters, digits, dot, underscore, hyphen.
-    // This intentionally forbids any path separator, so it can never escape jdbc_drivers_dir.
-    private static final Pattern SAFE_DRIVER_FILE_NAME = Pattern.compile("^[A-Za-z0-9._-]+\\.jar$");
-
-    /**
-     * Mandatory, non-configurable driver_url security rule. It is invoked from
-     * {@link JdbcConnectorProvider#validateProperties} (and from {@link #preCreateValidation}),
-     * i.e. from the engine's {@code checkProperties()} hook, which runs only on the user-facing
-     * CREATE / ALTER CATALOG paths (both guarded by {@code !isReplay}). Therefore the rule never
-     * runs during metadata/edit-log replay nor at query time, so existing catalogs are unaffected
-     * and FE startup / follower replay can never be blocked by it.
-     *
-     * <p>The rule cannot be turned off:
-     * <ul>
-     *   <li>any {@code ..} path-traversal segment is rejected, for {@code file://} and {@code http(s)} alike;</li>
-     *   <li>a scheme-less driver_url must be a bare jar file name matching {@code [A-Za-z0-9._-]+.jar}
-     *       (no directories, no special characters), which is then resolved under {@code jdbc_drivers_dir}.</li>
-     * </ul>
-     * Whether a remote/absolute URL is allowed at all remains governed by the fe.conf-only
-     * {@code jdbc_driver_secure_path} / {@code jdbc_driver_url_white_list} configs; this rule only
-     * forbids traversal and enforces the bare-name charset.
-     *
-     * <p>Throws {@link IllegalArgumentException} so the engine wraps it into a {@code DdlException}
-     * (and, on ALTER, triggers the property rollback).
-     */
-    public static void checkDriverUrlSecurityRule(String driverUrl) {
-        if (driverUrl == null || driverUrl.isEmpty()) {
-            return;
-        }
-        // Check traversal on the decoded path so percent-encoded segments (e.g. %2e%2e) — which the
-        // driver-loading consumers decode — cannot slip a ".." past this rule.
-        String pathToCheck = driverUrl;
-        if (driverUrl.contains("://")) {
-            try {
-                String decoded = new URI(driverUrl).getPath();
-                if (decoded != null) {
-                    pathToCheck = decoded;
-                }
-            } catch (URISyntaxException e) {
-                throw new IllegalArgumentException("Invalid driver_url: " + driverUrl);
-            }
-        }
-        String probe = pathToCheck.replace('\\', '/');
-        for (String segment : probe.split("/")) {
-            if ("..".equals(segment)) {
-                throw new IllegalArgumentException(
-                        "Invalid driver_url: path traversal ('..') is not allowed: " + driverUrl);
-            }
-        }
-        if (!driverUrl.contains("://")) {
-            if (!SAFE_DRIVER_FILE_NAME.matcher(driverUrl).matches()) {
-                throw new IllegalArgumentException(
-                        "Invalid driver_url: a driver file name must match [A-Za-z0-9._-]+.jar (got: "
-                                + driverUrl + ")");
-            }
-        }
-    }
-
     @Override
     public ConnectorWritePlanProvider getWritePlanProvider() {
         // Returning a non-null provider routes jdbc writes through the unified plan-provider sink
@@ -210,7 +150,7 @@ public class JdbcDorisConnector implements Connector {
         String driverUrl = properties.get(JdbcConnectorProperties.DRIVER_URL);
         if (driverUrl != null && !driverUrl.isEmpty()) {
             // Mandatory, non-configurable security rule, enforced on catalog creation only.
-            checkDriverUrlSecurityRule(driverUrl);
+            JdbcDriverUrlSecurity.check(driverUrl);
             context.validateAndResolveDriverPath(driverUrl);
 
             // 2. Compute and verify checksum.

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnector.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnector.java
@@ -30,6 +30,7 @@ import org.apache.doris.connector.spi.ConnectorPartitionInfo;
 import org.apache.doris.connector.spi.ConnectorSession;
 import org.apache.doris.connector.spi.ConnectorStorageContext;
 import org.apache.doris.connector.spi.ConnectorValidationContext;
+import org.apache.doris.connector.spi.JdbcDriverUrlSecurity;
 import org.apache.doris.connector.spi.handle.ConnectorTableHandle;
 import org.apache.doris.connector.spi.scan.ConnectorScanPlanProvider;
 import org.apache.doris.filesystem.properties.StorageProperties;
@@ -497,12 +498,16 @@ public class PaimonConnector implements Connector {
     /**
      * Enforces JDBC driver-url security at CREATE CATALOG (rereview2 B-8b). For the JDBC flavor a
      * configured {@code driver_url} — read from either the {@code jdbc.driver_url} or the
-     * {@code paimon.jdbc.driver_url} alias — is routed through the engine's
-     * {@link ConnectorValidationContext#validateAndResolveDriverPath} hook, which applies the FE
+     * {@code paimon.jdbc.driver_url} alias — first goes through the mandatory, non-configurable
+     * {@link JdbcDriverUrlSecurity} rule shared with the jdbc / iceberg-jdbc catalogs, then through the
+     * engine's {@link ConnectorValidationContext#validateAndResolveDriverPath} hook, which applies the FE
      * format / {@code jdbc_driver_url_white_list} / {@code jdbc_driver_secure_path} gates (legacy
      * {@code JdbcResource.getFullDriverUrl}). A rejected url throws here, so CREATE CATALOG fails
-     * before the jar is ever loaded into the FE JVM by {@link #maybeRegisterJdbcDriver}. Mirrors
+     * before the jar is ever loaded into the FE JVM by {@link #maybeRegisterJdbcDriver}. Same order as
      * {@code JdbcDorisConnector.preCreateValidation}; non-JDBC flavors are a no-op.
+     *
+     * <p>ALTER CATALOG does not reach this hook; {@code PaimonConnectorProvider.validateProperties} applies
+     * the same rule on that path.
      */
     @Override
     public void preCreateValidation(ConnectorValidationContext validationContext) throws Exception {
@@ -512,6 +517,7 @@ public class PaimonConnector implements Connector {
         String driverUrl = PaimonCatalogFactory.firstNonBlank(
                 properties, PaimonConnectorProperties.JDBC_DRIVER_URL);
         if (StringUtils.isNotBlank(driverUrl)) {
+            JdbcDriverUrlSecurity.check(driverUrl);
             validationContext.validateAndResolveDriverPath(driverUrl);
         }
     }

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnectorProvider.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnectorProvider.java
@@ -22,7 +22,9 @@ import org.apache.doris.connector.metastore.spi.MetaStoreProviders;
 import org.apache.doris.connector.spi.Connector;
 import org.apache.doris.connector.spi.ConnectorContext;
 import org.apache.doris.connector.spi.ConnectorProvider;
+import org.apache.doris.connector.spi.JdbcDriverUrlSecurity;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -90,6 +92,12 @@ public class PaimonConnectorProvider implements ConnectorProvider {
     public void validateProperties(Map<String, String> properties) {
         checkMetaCacheProperties(properties);
         warnIgnoredDeadTableCacheKeys(properties);
+        // The mandatory, non-configurable driver_url rule shared with the jdbc and iceberg-jdbc catalogs
+        // (all three reach the same URLClassLoader + Class.forName sink from a catalog property). This
+        // hook is what the engine runs on CREATE *and* ALTER CATALOG, so it is the one that keeps a
+        // traversal / non-bare-name driver jar out of PaimonConnector's class loader;
+        // preCreateValidation covers CREATE only. Never runs on replay.
+        driverUrlsToValidate(properties).forEach(JdbcDriverUrlSecurity::check);
         // #65955: an unknown or unparseable paimon.table-option.* must fail the CREATE/ALTER CATALOG.
         // Upstream got this from AbstractPaimonProperties.initNormalizeAndCheckProps(), which the SPI
         // path no longer runs; validateProperties is this path's fail-fast hook.
@@ -117,6 +125,22 @@ public class PaimonConnectorProvider implements ConnectorProvider {
             }
         });
         validateProperties(candidate);
+    }
+
+    /**
+     * Only the jdbc flavor loads a driver jar; on every other flavor {@code jdbc.driver_url} is dead config
+     * that never reaches a class loader, so declaring it would turn a previously-accepted catalog into a
+     * CREATE/ALTER failure for no security gain. See {@link ConnectorProvider#driverUrlsToValidate}.
+     */
+    @Override
+    public List<String> driverUrlsToValidate(Map<String, String> properties) {
+        if (!PaimonConnectorProperties.JDBC.equals(PaimonCatalogFactory.resolveFlavor(properties))) {
+            return Collections.emptyList();
+        }
+        String driverUrl = PaimonCatalogFactory.firstNonBlank(
+                properties, PaimonConnectorProperties.JDBC_DRIVER_URL);
+        return StringUtils.isBlank(driverUrl)
+                ? Collections.emptyList() : Collections.singletonList(driverUrl);
     }
 
     /**

--- a/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonJdbcDriverUrlSecurityTest.java
+++ b/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonJdbcDriverUrlSecurityTest.java
@@ -1,0 +1,161 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.paimon;
+
+import org.apache.doris.connector.spi.ConnectorValidationContext;
+import org.apache.doris.connector.spi.JdbcDriverUrlSecurity;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The Paimon JDBC catalog loads {@code paimon.jdbc.driver_url} / {@code jdbc.driver_url} into the FE JVM
+ * through a {@code URLClassLoader} + {@code Class.forName(name, true, loader)}, exactly like the jdbc
+ * catalog does. These tests pin that it reaches the SAME mandatory rule ({@link JdbcDriverUrlSecurity}) on
+ * BOTH user-facing paths — the provider hook that fe-core runs on CREATE and ALTER, and the connector's
+ * CREATE-only pre-create hook.
+ *
+ * <p>The rule's own semantics live in {@code JdbcDriverUrlSecurityTest}; here one rejected shape is enough
+ * to prove the call is wired.
+ */
+public class PaimonJdbcDriverUrlSecurityTest {
+
+    private static final PaimonConnectorProvider PROVIDER = new PaimonConnectorProvider();
+
+    private static Map<String, String> jdbcProps(String driverUrlKey, String driverUrl) {
+        Map<String, String> props = new HashMap<>();
+        props.put("paimon.catalog.type", "jdbc");
+        props.put("uri", "jdbc:mysql://127.0.0.1:3306/paimon");
+        props.put("warehouse", "s3://bucket/wh");
+        props.put(driverUrlKey, driverUrl);
+        props.put("jdbc.driver_class", "com.mysql.cj.jdbc.Driver");
+        return props;
+    }
+
+    // ---------------------------------------------------------------------
+    // provider hook — the only one fe-core runs on ALTER CATALOG
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void providerRejectsTraversalDriverUrl() {
+        // MUTATION: drop the JdbcDriverUrlSecurity.check call from PaimonConnectorProvider
+        // -> the props are otherwise valid, so validateProperties returns -> red.
+        IllegalArgumentException e = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> PROVIDER.validateProperties(
+                        jdbcProps("jdbc.driver_url", "file:///opt/drivers/../../etc/evil.jar")));
+        Assertions.assertTrue(e.getMessage().contains("path traversal"), e.getMessage());
+    }
+
+    @Test
+    public void providerRejectsTraversalOnPaimonPrefixedAlias() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> PROVIDER.validateProperties(
+                        jdbcProps("paimon.jdbc.driver_url", "file:///opt/drivers/../../etc/evil.jar")));
+    }
+
+    @Test
+    public void providerRejectsSchemelessPathDriverUrl() {
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> PROVIDER.validateProperties(jdbcProps("jdbc.driver_url", "sub/dir/evil.jar")));
+    }
+
+    @Test
+    public void providerAcceptsBareJarName() {
+        PROVIDER.validateProperties(jdbcProps("jdbc.driver_url", "mysql-connector-j-8.4.0.jar"));
+    }
+
+    @Test
+    public void providerSkipsRuleForNonJdbcFlavor() {
+        // A driver_url is dead config on a non-jdbc flavor: it never reaches a class loader, so the rule
+        // must not turn a previously-accepted filesystem catalog into a CREATE/ALTER failure.
+        Map<String, String> props = new HashMap<>();
+        props.put("paimon.catalog.type", "filesystem");
+        props.put("warehouse", "s3://bucket/wh");
+        props.put("jdbc.driver_url", "../evil.jar");
+        PROVIDER.validateProperties(props);
+    }
+
+    // ---------------------------------------------------------------------
+    // connector pre-create hook — must reject BEFORE the configurable secure-path gate
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void preCreateValidationRejectsTraversalBeforeEngineGate() {
+        RecordingValidationContext ctx = new RecordingValidationContext();
+        PaimonConnector connector = new PaimonConnector(
+                jdbcProps("jdbc.driver_url", "file:///opt/drivers/../../etc/evil.jar"),
+                new RecordingConnectorContext());
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> connector.preCreateValidation(ctx));
+        // WHY: the mandatory rule cannot be turned off, so it must fire even when the operator left
+        // jdbc_driver_secure_path at its allow-all default (which is what the engine gate applies).
+        // MUTATION: run the check after validateAndResolveDriverPath -> the url reaches the gate -> red.
+        Assertions.assertTrue(ctx.validatedDriverUrls.isEmpty(),
+                "the mandatory rule must reject before the configurable engine gate is consulted");
+    }
+
+    @Test
+    public void preCreateValidationPassesCleanDriverUrlToEngineGate() throws Exception {
+        RecordingValidationContext ctx = new RecordingValidationContext();
+        new PaimonConnector(jdbcProps("jdbc.driver_url", "mysql-connector-j-8.4.0.jar"),
+                new RecordingConnectorContext()).preCreateValidation(ctx);
+
+        Assertions.assertEquals(List.of("mysql-connector-j-8.4.0.jar"), ctx.validatedDriverUrls);
+    }
+
+    /** Hand-written {@link ConnectorValidationContext} test double (no Mockito). */
+    private static final class RecordingValidationContext implements ConnectorValidationContext {
+        final List<String> validatedDriverUrls = new ArrayList<>();
+
+        @Override
+        public long getCatalogId() {
+            return 0;
+        }
+
+        @Override
+        public String getProperty(String key) {
+            return null;
+        }
+
+        @Override
+        public void storeProperty(String key, String value) {
+        }
+
+        @Override
+        public String validateAndResolveDriverPath(String driverUrl) {
+            validatedDriverUrls.add(driverUrl);
+            return "file:///resolved/" + driverUrl;
+        }
+
+        @Override
+        public String computeDriverChecksum(String driverUrl) {
+            return "deadbeef";
+        }
+
+        @Override
+        public void requestBeConnectivityTest(byte[] serializedDescriptor, int connectionTypeValue,
+                String testQuery) {
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorProvider.java
+++ b/fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorProvider.java
@@ -22,6 +22,7 @@ import org.apache.doris.extension.spi.PluginFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -115,6 +116,28 @@ public interface ConnectorProvider extends PluginFactory {
                 ? new HashMap<>() : new HashMap<>(currentProperties);
         candidate.putAll(updatedProperties);
         validateProperties(candidate);
+    }
+
+    /**
+     * The JDBC driver jar URLs that the given catalog properties would make this connector load into the
+     * FE JVM — raw (not resolved to a full URL), alias-resolved, and flavor-aware, so a property that is
+     * dead config for the resolved flavor must not be reported. Default: none.
+     *
+     * <p><b>Why the engine asks.</b> Whether a driver jar location is allowed at all is an operator
+     * decision expressed in fe.conf ({@code jdbc_driver_secure_path}, {@code jdbc_driver_url_white_list}),
+     * so only the engine can apply it. On CREATE the engine applies it through
+     * {@link Connector#preCreateValidation}. ALTER CATALOG never reaches that hook — it validates through
+     * {@link #validatePropertiesForUpdate} alone — so without this declaration an operator's allow-list
+     * would be enforced at CREATE and then silently bypassable by a follow-up ALTER that repoints
+     * {@code driver_url} at any URL. Any connector that hands a property value to a class loader MUST
+     * declare it here.
+     *
+     * <p>This is only the operator-configurable gate. The mandatory, non-configurable rule
+     * ({@link JdbcDriverUrlSecurity}) is the connector's own responsibility and belongs in
+     * {@link #validateProperties}, which the engine runs on both CREATE and ALTER.
+     */
+    default List<String> driverUrlsToValidate(Map<String, String> properties) {
+        return Collections.emptyList();
     }
 
     /**

--- a/fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/JdbcDriverUrlSecurity.java
+++ b/fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/JdbcDriverUrlSecurity.java
@@ -1,0 +1,102 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.spi;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Pattern;
+
+/**
+ * The mandatory, non-configurable {@code driver_url} security rule, shared by every connector that
+ * loads a JDBC driver jar into the FE JVM.
+ *
+ * <p>Three catalog types reach the same {@code URLClassLoader} + {@code Class.forName(name, true, loader)}
+ * sink from a user-supplied catalog property, so they must share one rule rather than each re-deriving it:
+ * the {@code jdbc} catalog ({@code driver_url}), the Iceberg JDBC catalog
+ * ({@code iceberg.jdbc.driver_url}) and the Paimon JDBC catalog
+ * ({@code paimon.jdbc.driver_url} / {@code jdbc.driver_url}). This class is that single source of truth;
+ * it lives in the SPI module because it is the only module all three connectors depend on.
+ *
+ * <p>The rule cannot be turned off:
+ * <ul>
+ *   <li>any {@code ..} path-traversal segment is rejected, for {@code file://} and {@code http(s)} alike,
+ *       checked on the percent-decoded path so {@code %2e%2e} cannot slip past;</li>
+ *   <li>a scheme-less driver_url must be a bare jar file name matching {@code [A-Za-z0-9._-]+.jar}
+ *       (no directories, no special characters), which is then resolved under the connector's drivers
+ *       directory.</li>
+ * </ul>
+ * Whether a remote/absolute URL is allowed <em>at all</em> remains governed by the fe.conf-only
+ * {@code jdbc_driver_secure_path} / {@code jdbc_driver_url_white_list} configs, applied separately through
+ * {@code ConnectorValidationContext.validateAndResolveDriverPath}; this rule only forbids traversal and
+ * enforces the bare-name charset.
+ *
+ * <p><b>Where callers must invoke it.</b> From the provider's {@code validateProperties} — the engine's
+ * {@code checkProperties()} hook, which runs on the user-facing CREATE <em>and</em> ALTER CATALOG paths
+ * (both guarded by {@code !isReplay}) — so a malicious driver_url cannot be introduced by either. It must
+ * never be run during metadata/edit-log replay or at query time, so existing catalogs are unaffected and
+ * FE startup / follower replay can never be blocked by it.
+ *
+ * <p>Throws {@link IllegalArgumentException} so the engine wraps it into a {@code DdlException}
+ * (and, on ALTER, triggers the property rollback).
+ */
+public final class JdbcDriverUrlSecurity {
+
+    // A scheme-less driver_url must be a plain jar file name: letters, digits, dot, underscore, hyphen.
+    // This intentionally forbids any path separator, so it can never escape the drivers directory.
+    private static final Pattern SAFE_DRIVER_FILE_NAME = Pattern.compile("^[A-Za-z0-9._-]+\\.jar$");
+
+    private JdbcDriverUrlSecurity() {
+    }
+
+    /**
+     * Applies the rule to a raw, alias-resolved {@code driver_url}. A null/empty value means "use the
+     * engine-provided driver" and is accepted; every other value must satisfy the rule above.
+     */
+    public static void check(String driverUrl) {
+        if (driverUrl == null || driverUrl.isEmpty()) {
+            return;
+        }
+        // Check traversal on the decoded path so percent-encoded segments (e.g. %2e%2e) — which the
+        // driver-loading consumers decode — cannot slip a ".." past this rule.
+        String pathToCheck = driverUrl;
+        if (driverUrl.contains("://")) {
+            try {
+                String decoded = new URI(driverUrl).getPath();
+                if (decoded != null) {
+                    pathToCheck = decoded;
+                }
+            } catch (URISyntaxException e) {
+                throw new IllegalArgumentException("Invalid driver_url: " + driverUrl);
+            }
+        }
+        String probe = pathToCheck.replace('\\', '/');
+        for (String segment : probe.split("/")) {
+            if ("..".equals(segment)) {
+                throw new IllegalArgumentException(
+                        "Invalid driver_url: path traversal ('..') is not allowed: " + driverUrl);
+            }
+        }
+        if (!driverUrl.contains("://")) {
+            if (!SAFE_DRIVER_FILE_NAME.matcher(driverUrl).matches()) {
+                throw new IllegalArgumentException(
+                        "Invalid driver_url: a driver file name must match [A-Za-z0-9._-]+.jar (got: "
+                                + driverUrl + ")");
+            }
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-spi/src/test/java/org/apache/doris/connector/spi/ConnectorPluginSurfaceTest.java
+++ b/fe/fe-connector/fe-connector-spi/src/test/java/org/apache/doris/connector/spi/ConnectorPluginSurfaceTest.java
@@ -71,10 +71,14 @@ public class ConnectorPluginSurfaceTest {
             Assertions.assertNotNull(in, "missing connector plugin API version resource");
             version.load(in);
         }
-        // ConnectorWritePlanProvider and ConnectorColumnHandle gained public default methods in this
-        // surface revision. A plugin built against major 3 must be refused rather than silently run
-        // against an expanded contract it did not compile against.
-        Assertions.assertEquals("4.0", version.getProperty("api.version"));
+        // Major 4: ConnectorWritePlanProvider and ConnectorColumnHandle gained public default methods.
+        // Major 5 adds ConnectorProvider#driverUrlsToValidate: the FE asks the provider which properties
+        // name a jar it will load into the FE JVM, and applies the operator's jdbc_driver_secure_path /
+        // jdbc_driver_url_white_list policy to them on ALTER CATALOG (which never reaches
+        // Connector#preCreateValidation). A 4.x plugin answers "no jars" by inheriting the default, so a
+        // repointed driver_url on such a plugin would skip the operator's policy silently - the FE must
+        // refuse it at load time instead.
+        Assertions.assertEquals("5.0", version.getProperty("api.version"));
     }
 
     /** Root entry points plus provider/handle types returned to connector plugins. */

--- a/fe/fe-connector/fe-connector-spi/src/test/java/org/apache/doris/connector/spi/JdbcDriverUrlSecurityTest.java
+++ b/fe/fe-connector/fe-connector-spi/src/test/java/org/apache/doris/connector/spi/JdbcDriverUrlSecurityTest.java
@@ -15,56 +15,58 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.connector.jdbc;
+package org.apache.doris.connector.spi;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for the mandatory, non-configurable create-time driver_url security rule
- * in {@link JdbcDorisConnector#checkDriverUrlSecurityRule(String)}.
+ * Tests for the mandatory, non-configurable driver_url security rule in
+ * {@link JdbcDriverUrlSecurity#check(String)}, shared by the jdbc, iceberg-jdbc and paimon-jdbc catalogs.
+ * The per-connector tests assert only that each catalog type reaches this rule; the rule's own semantics
+ * are pinned here, once.
  */
-public class JdbcDriverUrlSecurityRuleTest {
+public class JdbcDriverUrlSecurityTest {
 
     // ---- rejected ----
 
     @Test
     public void testBareNameTraversalRejected() {
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> JdbcDorisConnector.checkDriverUrlSecurityRule("../evil.jar"));
+                () -> JdbcDriverUrlSecurity.check("../evil.jar"));
     }
 
     @Test
     public void testBareNameWithDirectoryRejected() {
         // A scheme-less driver_url must be a plain file name; any '/' fails the charset check.
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> JdbcDorisConnector.checkDriverUrlSecurityRule("sub/dir/driver.jar"));
+                () -> JdbcDriverUrlSecurity.check("sub/dir/driver.jar"));
     }
 
     @Test
     public void testBareNameSpecialCharsRejected() {
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> JdbcDorisConnector.checkDriverUrlSecurityRule("driver.jar; rm -rf /"));
+                () -> JdbcDriverUrlSecurity.check("driver.jar; rm -rf /"));
     }
 
     @Test
     public void testFileUrlTraversalRejected() {
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> JdbcDorisConnector.checkDriverUrlSecurityRule(
+                () -> JdbcDriverUrlSecurity.check(
                         "file:///opt/doris/plugins/jdbc_drivers/../../etc/evil.jar"));
     }
 
     @Test
     public void testHttpUrlTraversalRejected() {
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> JdbcDorisConnector.checkDriverUrlSecurityRule("http://host/a/../b.jar"));
+                () -> JdbcDriverUrlSecurity.check("http://host/a/../b.jar"));
     }
 
     @Test
     public void testEncodedTraversalRejected() {
         // %2e%2e decodes to "..", which must be caught on the decoded path.
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> JdbcDorisConnector.checkDriverUrlSecurityRule(
+                () -> JdbcDriverUrlSecurity.check(
                         "file:///opt/doris/plugins/jdbc_drivers/%2e%2e/%2e%2e/etc/evil.jar"));
     }
 
@@ -73,20 +75,20 @@ public class JdbcDriverUrlSecurityRuleTest {
     @Test
     public void testPlainJarNameAllowed() {
         Assertions.assertDoesNotThrow(
-                () -> JdbcDorisConnector.checkDriverUrlSecurityRule("mysql-connector-j-8.4.0.jar"));
+                () -> JdbcDriverUrlSecurity.check("mysql-connector-j-8.4.0.jar"));
         Assertions.assertDoesNotThrow(
-                () -> JdbcDorisConnector.checkDriverUrlSecurityRule("postgresql-42.5.0.jar"));
+                () -> JdbcDriverUrlSecurity.check("postgresql-42.5.0.jar"));
     }
 
     @Test
     public void testNormalHttpsUrlAllowed() {
-        Assertions.assertDoesNotThrow(() -> JdbcDorisConnector.checkDriverUrlSecurityRule(
+        Assertions.assertDoesNotThrow(() -> JdbcDriverUrlSecurity.check(
                 "https://bucket.s3.amazonaws.com/regression/jdbc_driver/mysql-connector-j-8.4.0.jar"));
     }
 
     @Test
     public void testNormalFileUrlAllowed() {
-        Assertions.assertDoesNotThrow(() -> JdbcDorisConnector.checkDriverUrlSecurityRule(
+        Assertions.assertDoesNotThrow(() -> JdbcDriverUrlSecurity.check(
                 "file:///opt/doris/plugins/jdbc_drivers/mysql-connector-j-8.4.0.jar"));
     }
 }

--- a/fe/fe-connector/fe-connector-spi/src/test/resources/connector-plugin-surface.txt
+++ b/fe/fe-connector/fe-connector-spi/src/test/resources/connector-plugin-surface.txt
@@ -35,6 +35,7 @@ org.apache.doris.connector.spi.ConnectorProvider#create(org.apache.doris.extensi
 org.apache.doris.connector.spi.ConnectorProvider#defaultDatabaseOnUse():java.util.Optional
 org.apache.doris.connector.spi.ConnectorProvider#description():java.lang.String
 org.apache.doris.connector.spi.ConnectorProvider#displayEngineName():java.lang.String
+org.apache.doris.connector.spi.ConnectorProvider#driverUrlsToValidate(java.util.Map):java.util.List
 org.apache.doris.connector.spi.ConnectorProvider#getType():java.lang.String
 org.apache.doris.connector.spi.ConnectorProvider#isStandaloneCatalogType():boolean
 org.apache.doris.connector.spi.ConnectorProvider#name():java.lang.String

--- a/fe/fe-connector/pom.xml
+++ b/fe/fe-connector/pom.xml
@@ -55,7 +55,7 @@ under the License.
           of the latter two means bumping this property as well (and fe-extension-spi means bumping
           all four families).
         -->
-        <connector.plugin.api.version>4.0</connector.plugin.api.version>
+        <connector.plugin.api.version>5.0</connector.plugin.api.version>
     </properties>
 
     <modules>

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/JdbcResource.java
@@ -325,7 +325,7 @@ public class JdbcResource extends Resource {
             // legacy JDBC consumers call it directly, with no create/alter or replay context), so it
             // deliberately applies no new restriction here: an unmodified historical catalog must keep
             // resolving exactly as before. The mandatory bare-name grammar is enforced only when a
-            // catalog is created or altered, in JdbcDorisConnector.checkDriverUrlSecurityRule.
+            // catalog is created or altered, in JdbcDriverUrlSecurity.check.
             return checkAndReturnDefaultDriverUrl(driverUrl);
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/connector/ConnectorFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/connector/ConnectorFactory.java
@@ -24,6 +24,8 @@ import org.apache.doris.connector.spi.ConnectorProvider;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -153,6 +155,17 @@ public final class ConnectorFactory {
         if (mgr != null) {
             mgr.validatePropertiesForUpdate(catalogType, currentProperties, updatedProperties);
         }
+    }
+
+    /**
+     * The driver jar URLs the matching connector would load into the FE JVM for these properties, so the
+     * caller can apply the operator's {@code jdbc_driver_secure_path} / {@code jdbc_driver_url_white_list}
+     * gate to them. Empty when no provider matches or the connector loads no driver jar.
+     */
+    public static List<String> driverUrlsToValidate(String catalogType, Map<String, String> properties) {
+        ConnectorPluginManager mgr = pluginManager;
+        return mgr == null ? Collections.emptyList()
+                : mgr.driverUrlsToValidate(catalogType, properties);
     }
 
     /** For testing only. */

--- a/fe/fe-core/src/main/java/org/apache/doris/connector/ConnectorPluginManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/connector/ConnectorPluginManager.java
@@ -481,6 +481,19 @@ public class ConnectorPluginManager {
     }
 
     /**
+     * The driver jar URLs the matching provider would load for {@code properties}. Empty when no provider
+     * matches or the connector loads no driver jar.
+     */
+    public List<String> driverUrlsToValidate(String catalogType, Map<String, String> properties) {
+        for (ConnectorProvider provider : providers) {
+            if (provider.supports(catalogType, properties)) {
+                return provider.driverUrlsToValidate(properties);
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    /**
      * Registers a provider at highest priority (index 0). For testing overrides.
      *
      * <p>Deliberately bypasses {@link #registerDiscovered}'s uniqueness check: shadowing an already-registered

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalog.java
@@ -20,6 +20,7 @@ package org.apache.doris.datasource.plugin;
 import org.apache.doris.analysis.ColumnPath;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.JdbcResource;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.info.ColumnPosition;
 import org.apache.doris.catalog.info.CreateOrReplaceBranchInfo;
@@ -243,8 +244,36 @@ public class PluginDrivenExternalCatalog extends ExternalCatalog {
         } catch (IllegalArgumentException e) {
             throw new DdlException(e.getMessage(), e);
         }
+        checkDriverUrlsAgainstOperatorGate(candidate);
         ExternalFunctionRules.check(candidateProperty.getOrDefault("function_rules", null));
         return true;
+    }
+
+    /**
+     * Applies the operator's driver-jar gate ({@code jdbc_driver_secure_path} /
+     * {@code jdbc_driver_url_white_list}) to every driver_url the connector says these properties would
+     * make it load into the FE JVM.
+     *
+     * <p>On CREATE the same gate is applied by the connector's {@code preCreateValidation} (through
+     * {@link org.apache.doris.connector.DefaultConnectorValidationContext#validateAndResolveDriverPath}),
+     * which ALTER CATALOG never reaches — it validates through {@code validatePropertiesBeforeUpdate}
+     * alone. Without this call an operator who restricts {@code jdbc_driver_secure_path} would have that
+     * restriction enforced at CREATE and then bypassed by a follow-up
+     * {@code ALTER CATALOG ... SET PROPERTIES("driver_url" = "http://attacker/evil.jar")}, which
+     * {@code resetToUninitialized} makes effective on the next metadata access.
+     *
+     * <p>Deliberately NOT applied on replay: this runs from the {@code !isReplay} ALTER path only, so an
+     * existing catalog whose driver_url predates a since-tightened allow-list keeps loading and FE
+     * startup / follower replay can never be blocked by it.
+     */
+    private void checkDriverUrlsAgainstOperatorGate(Map<String, String> candidate) throws DdlException {
+        for (String driverUrl : ConnectorFactory.driverUrlsToValidate(getType(), candidate)) {
+            try {
+                JdbcResource.getFullDriverUrl(driverUrl);
+            } catch (IllegalArgumentException e) {
+                throw new DdlException(e.getMessage(), e);
+            }
+        }
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalogDriverUrlGateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalogDriverUrlGateTest.java
@@ -1,0 +1,159 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.plugin;
+
+import org.apache.doris.common.Config;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.connector.ConnectorFactory;
+import org.apache.doris.connector.ConnectorPluginManager;
+import org.apache.doris.connector.spi.Connector;
+import org.apache.doris.connector.spi.ConnectorContext;
+import org.apache.doris.connector.spi.ConnectorProvider;
+import org.apache.doris.connector.spi.ConnectorSession;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * ALTER CATALOG must apply the operator's driver-jar gate ({@code jdbc_driver_secure_path} /
+ * {@code jdbc_driver_url_white_list}) to a repointed {@code driver_url}.
+ *
+ * <p>WHY this exists: CREATE applies that gate inside {@code Connector.preCreateValidation}, but ALTER
+ * CATALOG never reaches that hook — it validates through {@code validatePropertiesBeforeUpdate} alone, and
+ * {@code resetToUninitialized} then makes the new driver_url effective on the next metadata access. So
+ * without this gate an operator who restricts {@code jdbc_driver_secure_path} gets the restriction enforced
+ * at CREATE and silently bypassed by a follow-up ALTER — i.e. the config would not actually protect
+ * anything. The connector names the property (via {@code ConnectorProvider.driverUrlsToValidate}); only the
+ * engine knows the fe.conf policy.
+ */
+public class PluginDrivenExternalCatalogDriverUrlGateTest {
+
+    private static final String ALLOWED_DIR = "/opt/doris/plugins/jdbc_drivers";
+
+    private String savedSecurePath;
+
+    @BeforeEach
+    public void setUp() {
+        savedSecurePath = Config.jdbc_driver_secure_path;
+        // The operator has locked driver jars down to one directory — the posture this gate exists to keep.
+        Config.jdbc_driver_secure_path = ALLOWED_DIR;
+        ConnectorPluginManager mgr = new ConnectorPluginManager();
+        mgr.registerProvider(new DriverLoadingProvider());
+        ConnectorFactory.initPluginManager(mgr);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Config.jdbc_driver_secure_path = savedSecurePath;
+        ConnectorFactory.initPluginManager(null);
+    }
+
+    @Test
+    public void alterRejectsDriverUrlOutsideOperatorAllowList() {
+        TestCatalog catalog = new TestCatalog(props("driver_url", ALLOWED_DIR + "/mysql.jar"));
+
+        // MUTATION: drop checkDriverUrlsAgainstOperatorGate from validatePropertiesBeforeUpdate
+        // -> the ALTER is accepted and the remote jar is loaded on the next metadata access -> red.
+        DdlException e = Assertions.assertThrows(DdlException.class,
+                () -> catalog.validatePropertiesBeforeUpdate(
+                        props("driver_url", ALLOWED_DIR + "/mysql.jar"),
+                        Collections.singletonMap("driver_url", "http://attacker.test/evil.jar")));
+        Assertions.assertTrue(e.getMessage().contains("does not match any allowed paths"), e.getMessage());
+    }
+
+    @Test
+    public void alterAcceptsDriverUrlInsideOperatorAllowList() throws Exception {
+        TestCatalog catalog = new TestCatalog(props("driver_url", ALLOWED_DIR + "/mysql.jar"));
+
+        catalog.validatePropertiesBeforeUpdate(
+                props("driver_url", ALLOWED_DIR + "/mysql.jar"),
+                Collections.singletonMap("driver_url", "file://" + ALLOWED_DIR + "/postgresql.jar"));
+    }
+
+    @Test
+    public void alterUntouchedByGateWhenConnectorLoadsNoDriver() throws Exception {
+        // A connector that declares no driver_url must not be affected by the operator's jdbc policy —
+        // the gate is driven by the connector's declaration, not by the property name existing in the map.
+        TestCatalog catalog = new TestCatalog(props("some.other.url", "http://elsewhere.test/x"));
+
+        catalog.validatePropertiesBeforeUpdate(
+                props("some.other.url", "http://elsewhere.test/x"),
+                Collections.singletonMap("some.other.url", "http://another.test/y"));
+    }
+
+    private static Map<String, String> props(String key, String value) {
+        Map<String, String> props = new HashMap<>();
+        props.put("type", DriverLoadingProvider.TYPE);
+        props.put(key, value);
+        return props;
+    }
+
+    /**
+     * Stands in for the jdbc / iceberg-jdbc / paimon-jdbc providers: it declares that {@code driver_url}
+     * is a jar it will load into the FE JVM, which is all the engine needs to know to apply the policy.
+     */
+    private static final class DriverLoadingProvider implements ConnectorProvider {
+        static final String TYPE = "driver-loading-test";
+
+        @Override
+        public String getType() {
+            return TYPE;
+        }
+
+        @Override
+        public Connector create(Map<String, String> properties, ConnectorContext context) {
+            return Mockito.mock(Connector.class);
+        }
+
+        @Override
+        public List<String> driverUrlsToValidate(Map<String, String> properties) {
+            String driverUrl = properties.get("driver_url");
+            return driverUrl == null ? Collections.emptyList() : Collections.singletonList(driverUrl);
+        }
+    }
+
+    /** Keeps the real {@code validatePropertiesBeforeUpdate}; stubs out what needs a full FE environment. */
+    private static final class TestCatalog extends PluginDrivenExternalCatalog {
+        TestCatalog(Map<String, String> props) {
+            super(1L, "driver-gate-catalog", null, props, "", Mockito.mock(Connector.class));
+            this.initialized = true;
+        }
+
+        @Override
+        protected Connector createConnectorFromProperties() {
+            return null;
+        }
+
+        @Override
+        protected void initLocalObjectsImpl() {
+        }
+
+        @Override
+        public ConnectorSession buildConnectorSession() {
+            return Mockito.mock(ConnectorSession.class);
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

`driver_url` on a jdbc-flavored catalog names a jar that the FE loads into its own JVM
(`URLClassLoader` + `Class.forName(name, true, loader)`). Doris guards it in two layers:

1. a mandatory, non-configurable rule — no `..` path segment, and a bare file name must match
   `[A-Za-z0-9._-]+\.jar`;
2. an operator-configurable gate from fe.conf — `jdbc_driver_secure_path` / `jdbc_driver_url_white_list`.

Two gaps:

**The iceberg-jdbc and paimon-jdbc catalogs never ran the mandatory rule.** `iceberg.catalog.type=jdbc`
and `paimon.catalog.type=jdbc` reach the same class-loading sink through `iceberg.jdbc.driver_url` /
`jdbc.driver_url`. Their `preCreateValidation` routes the value through the fe.conf gate at CREATE, but
with the default `jdbc_driver_secure_path=*` that gate accepts everything — nothing forbids a `..`
traversal segment, and the connector-side resolver (`JdbcDriverSupport.resolveDriverUrl`) happily
resolves `../` against the drivers directory.

**None of the three ran either check on `ALTER CATALOG`.** ALTER validates through
`PluginDrivenExternalCatalog.validatePropertiesBeforeUpdate` and never reaches
`Connector.preCreateValidation`, which is where CREATE applies both layers; `resetToUninitialized`
then makes the new value effective on the next metadata access. So an operator who narrowed
`jdbc_driver_secure_path` got the restriction enforced at `CREATE CATALOG` and silently bypassed by
a follow-up `ALTER CATALOG ... SET ("driver_url" = ...)` — the configuration did not actually
protect the catalogs it was meant to protect. (The paimon connector's own javadoc records this as a
known gap "shared by all plugin connectors".)

What this PR does:

- Extracts the mandatory rule into `JdbcDriverUrlSecurity` (fe-connector-spi — the one module all
  three connectors depend on), deleting the jdbc-local copy
  (`JdbcDorisConnector.checkDriverUrlSecurityRule`), and calls it from each provider's
  `validateProperties`. fe-core runs that hook on CREATE **and** on ALTER, and never on replay, so
  existing catalogs and follower startup are unaffected. The iceberg and paimon providers override
  `validatePropertiesForUpdate` without funneling back to `validateProperties`, so the rule is wired
  into those overrides as well, each pinned by a dedicated `alterOverrideRejectsRepointedDriverUrl`
  test.
- Adds `ConnectorProvider.driverUrlsToValidate(properties)`: the connector names the values it would
  hand to a class loader, and `PluginDrivenExternalCatalog` applies the fe.conf gate to them on
  ALTER. Only the connector knows which property is a jar; only the engine knows the fe.conf policy.
  The declaration is flavor-gated, so a stray `driver_url` left on a REST/HMS/filesystem catalog
  does not turn a previously-accepted catalog into a CREATE/ALTER failure.
- Bumps `<connector.plugin.api.version>` `9.0` -> `10.0` together with the refreshed
  `connector-plugin-surface.txt`, per the rule recorded in `ConnectorPluginSurfaceTest`: an older
  plugin inherits the empty default of the new method, so its `driver_url` would skip the operator's
  policy without any error — it has to be refused at load time rather than silently under-enforced.
- `AGENTS.md`: no new code path may fetch an artifact from a user-supplied URL and load it into a
  Doris process; the existing `driver_url` paths are grandfathered, not a precedent. The
  ADBC catalog's local-only `AdbcDriverPathResolver` (#66331) is cited there as the model to follow.

### Release note

Fixed `driver_url` validation for jdbc-flavored catalogs: the Iceberg and Paimon JDBC catalogs now
apply the same mandatory driver-jar rules as the JDBC catalog, and `ALTER CATALOG` now applies
`jdbc_driver_secure_path` / `jdbc_driver_url_white_list` instead of only `CREATE CATALOG` doing so.

### Check List (For Author)

- Test
    - [x] Unit Test

  New: `JdbcDriverUrlSecurityTest` (rule semantics, moved with the class),
  `IcebergJdbcDriverUrlSecurityTest`, `PaimonJdbcDriverUrlSecurityTest` (rule reachable on both the
  provider and the `preCreateValidation` path; skipped on non-jdbc flavors),
  `PluginDrivenExternalCatalogDriverUrlGateTest` (ALTER honours the operator allow-list; a connector
  that declares no jar is untouched).

  Each new test was mutation-checked: removing the corresponding production line turns it red.
  Full runs (rebased onto master): fe-connector spi/jdbc/paimon suites all green; fe-connector-iceberg
  green except `IcebergWritePlanProviderTest#planMergePreservesExplicitlyEmptyReadAcrossConcurrentFirstAppend`,
  which fails identically on unmodified master in the same environment (pre-existing, unrelated to
  this change). fe-core plugin/API-version/gate tests `Tests run: 33, Failures: 0, Errors: 0`;
  0 Checkstyle violations.

- Behavior changed:
    - [x] Yes.

  A `driver_url` containing a `..` segment, or a bare file name outside `[A-Za-z0-9._-]+\.jar`, is
  now rejected on the Iceberg/Paimon JDBC catalogs as it already was on the JDBC catalog, and on
  ALTER as well as CREATE. `jdbc_driver_secure_path` / `jdbc_driver_url_white_list` now also apply
  on ALTER. The default posture is unchanged: `jdbc_driver_secure_path` still defaults to `*`, so a
  remote driver jar is still accepted unless the operator narrows the config — what changes is that
  narrowing it now holds on every DDL path. Validation never runs on replay, so no existing catalog
  and no follower startup can be broken by this.

  Note that ALTER validates the **merged** property candidate, not only the keys being changed: once
  an operator narrows `jdbc_driver_secure_path`, any ALTER on a catalog whose stored `driver_url`
  falls outside the new allow-list is rejected (fail-closed) until the `driver_url` itself is fixed
  in the same statement. The catalog keeps working for queries and across restarts either way.

- Does this need documentation?
    - [ ] No.

