### PR TITLE
[feature](vault) Support keyless GCS vaults with GKE Workload Identity

### DIFF
--- a/be/src/cloud/cloud_storage_engine.cpp
+++ b/be/src/cloud/cloud_storage_engine.cpp
@@ -138,6 +138,24 @@ static Status vault_process_error(std::string_view id,
     return Status::IOError("Invalid vault, id {}, err {}, detail conf {}", id, err, ss.str());
 }
 
+static void check_keyless_storage_vault(const std::string& id, const S3Conf& s3_conf,
+                                        const std::shared_ptr<io::S3FileSystem>& fs,
+                                        bool check_fs) {
+    if (!check_fs ||
+        (s3_conf.client_conf.role_arn.empty() &&
+         s3_conf.client_conf.cred_provider_type != CredProviderType::GcpWorkloadIdentity)) {
+        return;
+    }
+
+    bool exists = false;
+    auto st = fs->exists("not_exist_object", &exists);
+    if (!st.ok()) {
+        LOG(FATAL) << "failed to check s3 fs, resource_id: " << id << " st: " << st
+                   << "s3_conf: " << s3_conf.to_string()
+                   << "add enable_check_storage_vault=false to be.conf to skip the check";
+    }
+}
+
 struct VaultCreateFSVisitor {
     VaultCreateFSVisitor(const std::string& id, const cloud::StorageVaultPB_PathFormat& path_format,
                          bool check_fs)
@@ -147,16 +165,7 @@ struct VaultCreateFSVisitor {
                   << " check_fs: " << check_fs;
 
         auto fs = DORIS_TRY(io::S3FileSystem::create(s3_conf, id));
-        if (check_fs && !s3_conf.client_conf.role_arn.empty()) {
-            bool res = false;
-            // just check connectivity, not care object if exist
-            auto st = fs->exists("not_exist_object", &res);
-            if (!st.ok()) {
-                LOG(FATAL) << "failed to check s3 fs, resource_id: " << id << " st: " << st
-                           << "s3_conf: " << s3_conf.to_string()
-                           << "add enable_check_storage_vault=false to be.conf to skip the check";
-            }
-        }
+        check_keyless_storage_vault(id, s3_conf, fs, check_fs);
 
         put_storage_resource(id, {std::move(fs), path_format}, 0);
         LOG_INFO("successfully create s3 vault, vault id {}", id);
@@ -180,8 +189,8 @@ struct VaultCreateFSVisitor {
 
 struct RefreshFSVaultVisitor {
     RefreshFSVaultVisitor(const std::string& id, io::FileSystemSPtr fs,
-                          const cloud::StorageVaultPB_PathFormat& path_format)
-            : id(id), fs(std::move(fs)), path_format(path_format) {}
+                          const cloud::StorageVaultPB_PathFormat& path_format, bool check_fs)
+            : id(id), fs(std::move(fs)), path_format(path_format), check_fs(check_fs) {}
 
     Status operator()(const S3Conf& s3_conf) const {
         DCHECK_EQ(fs->type(), io::FileSystemType::S3) << id;
@@ -190,8 +199,10 @@ struct RefreshFSVaultVisitor {
         auto st = client_holder->reset(s3_conf.client_conf);
         if (!st.ok()) {
             LOG(WARNING) << "failed to update s3 fs, resource_id=" << id << ": " << st;
+            return st;
         }
-        return st;
+        check_keyless_storage_vault(id, s3_conf, s3_fs, check_fs);
+        return Status::OK();
     }
 
     Status operator()(const cloud::HdfsVaultInfo& vault) const {
@@ -207,6 +218,7 @@ struct RefreshFSVaultVisitor {
     const std::string& id;
     io::FileSystemSPtr fs;
     const cloud::StorageVaultPB_PathFormat& path_format;
+    bool check_fs;
 };
 
 Status CloudStorageEngine::open() {
@@ -450,7 +462,18 @@ Status CloudStorageEngine::start_bg_threads(std::shared_ptr<WorkloadGroup> wg_sp
     return Status::OK();
 }
 
+bool CloudStorageEngine::_should_check_storage_vault(const S3ClientConf* current_conf,
+                                                     const S3ClientConf& new_conf) {
+    if (!config::enable_check_storage_vault ||
+        (new_conf.role_arn.empty() &&
+         new_conf.cred_provider_type != CredProviderType::GcpWorkloadIdentity)) {
+        return false;
+    }
+    return current_conf == nullptr || *current_conf != new_conf;
+}
+
 void CloudStorageEngine::sync_storage_vault() {
+    std::lock_guard sync_lock(_sync_storage_vault_mtx);
     cloud::StorageVaultInfos vault_infos;
     bool enable_storage_vault = false;
 
@@ -465,25 +488,32 @@ void CloudStorageEngine::sync_storage_vault() {
         return;
     }
 
-    bool check_storage_vault = false;
-    bool expected = false;
-    if (first_sync_storage_vault.compare_exchange_strong(expected, true)) {
-        check_storage_vault = config::enable_check_storage_vault;
-        LOG(INFO) << "first sync storage vault info, BE try to check iam role connectivity, "
-                     "check_storage_vault="
-                  << check_storage_vault;
-    }
-
     for (auto& [id, vault_info, path_format] : vault_infos) {
         auto fs = get_filesystem(id);
+        bool check_storage_vault = false;
+        if (auto* s3_conf = std::get_if<S3Conf>(&vault_info); s3_conf != nullptr) {
+            if (fs == nullptr) {
+                check_storage_vault = _should_check_storage_vault(nullptr, s3_conf->client_conf);
+            } else {
+                DCHECK_EQ(fs->type(), io::FileSystemType::S3) << id;
+                auto s3_fs = std::static_pointer_cast<io::S3FileSystem>(fs);
+                auto current_conf = s3_fs->client_holder()->s3_client_conf();
+                check_storage_vault =
+                        _should_check_storage_vault(&current_conf, s3_conf->client_conf);
+            }
+        }
+        if (check_storage_vault) {
+            LOG(INFO) << "check keyless storage vault connectivity, resource_id=" << id;
+        }
         auto status =
                 (fs == nullptr)
                         ? std::visit(VaultCreateFSVisitor {id, path_format, check_storage_vault},
                                      vault_info)
-                        : std::visit(RefreshFSVaultVisitor {id, std::move(fs), path_format},
+                        : std::visit(RefreshFSVaultVisitor {id, std::move(fs), path_format,
+                                                            check_storage_vault},
                                      vault_info);
         if (!status.ok()) [[unlikely]] {
-            LOG(WARNING) << vault_process_error(id, vault_info, std::move(st));
+            LOG(WARNING) << vault_process_error(id, vault_info, std::move(status));
         }
     }
 

--- a/be/src/cloud/cloud_storage_engine.h
+++ b/be/src/cloud/cloud_storage_engine.h
@@ -20,6 +20,9 @@
 #include <chrono>
 #include <memory>
 #include <mutex>
+#ifdef BE_TEST
+#include <gtest/gtest_prod.h>
+#endif
 
 //#include "cloud/cloud_cumulative_compaction.h"
 //#include "cloud/cloud_base_compaction.h"
@@ -36,6 +39,7 @@
 #include "util/threadpool.h"
 
 namespace doris {
+struct S3ClientConf;
 namespace cloud {
 class CloudMetaMgr;
 }
@@ -207,6 +211,11 @@ public:
 #endif
 
 private:
+#ifdef BE_TEST
+    FRIEND_TEST(CloudStorageEngineTest, CheckNewAndChangedKeylessStorageVault);
+#endif
+    static bool _should_check_storage_vault(const S3ClientConf* current_conf,
+                                            const S3ClientConf& new_conf);
     void _refresh_storage_vault_info_thread_callback();
     void _vacuum_stale_rowsets_thread_callback();
     void _sync_tablets_thread_callback();
@@ -287,7 +296,7 @@ private:
             std::unordered_map<std::string_view, std::shared_ptr<CloudCumulativeCompactionPolicy>>;
     CumuPolices _cumulative_compaction_policies;
 
-    std::atomic_bool first_sync_storage_vault {true};
+    std::mutex _sync_storage_vault_mtx;
 
     EngineOptions _options;
     std::mutex _store_lock;

--- a/be/src/io/fs/s3_file_system.cpp
+++ b/be/src/io/fs/s3_file_system.cpp
@@ -81,40 +81,21 @@ Status ObjClientHolder::init() {
 }
 
 Status ObjClientHolder::reset(const S3ClientConf& conf) {
-    S3ClientConf reset_conf;
     {
         std::shared_lock lock(_mtx);
-        reset_conf = _conf;
-        reset_conf.ak = conf.ak;
-        reset_conf.sk = conf.sk;
-        reset_conf.token = conf.token;
-        reset_conf.bucket = conf.bucket;
-        reset_conf.connect_timeout_ms = conf.connect_timeout_ms;
-        reset_conf.max_connections = conf.max_connections;
-        reset_conf.request_timeout_ms = conf.request_timeout_ms;
-        reset_conf.use_virtual_addressing = conf.use_virtual_addressing;
-        reset_conf.is_internal_bucket = conf.is_internal_bucket;
-
-        reset_conf.role_arn = conf.role_arn;
-        reset_conf.external_id = conf.external_id;
-        reset_conf.cred_provider_type = conf.cred_provider_type;
-
-        // Compare full-field equality of the merged conf, not get_hash(): the hash is
-        // an XOR of crc32s and distinct configurations can collide, which would skip a
-        // required client rebuild (e.g. a credential update).
-        if (reset_conf == _conf) {
+        if (conf == _conf) {
             return Status::OK(); // Same conf
         }
     }
 
-    auto client = DORIS_TRY(S3ClientFactory::instance().create(reset_conf));
+    auto client = DORIS_TRY(S3ClientFactory::instance().create(conf));
 
     LOG(WARNING) << "reset s3 client with new conf: " << conf.to_string();
 
     {
         std::lock_guard lock(_mtx);
         _client = std::move(client);
-        _conf = std::move(reset_conf);
+        _conf = conf;
     }
 
     return Status::OK();
@@ -142,6 +123,7 @@ Result<int64_t> ObjClientHolder::object_file_size(const std::string& bucket,
 }
 
 std::string ObjClientHolder::full_s3_path(std::string_view bucket, std::string_view key) const {
+    std::shared_lock lock(_mtx);
     return fmt::format("{}/{}/{}", _conf.endpoint, bucket, key);
 }
 
@@ -442,21 +424,25 @@ Status S3FileSystem::download_impl(const Path& remote_file, const Path& local_fi
 
 // oss has public endpoint and private endpoint, is_public_endpoint determines
 // whether to return a public endpoint.
-std::string S3FileSystem::generate_presigned_url(const Path& path, int64_t expiration_secs,
-                                                 bool is_public_endpoint) const {
+Result<std::string> S3FileSystem::generate_presigned_url(const Path& path, int64_t expiration_secs,
+                                                         bool is_public_endpoint) const {
+    auto current_conf = _client->s3_client_conf();
+    if (current_conf.cred_provider_type == CredProviderType::GcpWorkloadIdentity) {
+        return ResultError(Status::NotSupported(
+                "presigned URLs are not supported with GCP Workload Identity"));
+    }
+
     std::string key = fmt::format("{}/{}", _prefix, path.native());
     std::shared_ptr<ObjStorageClient> client;
-    if (is_public_endpoint &&
-        _client->s3_client_conf().endpoint.ends_with(OSS_PRIVATE_ENDPOINT_SUFFIX)) {
-        auto new_s3_conf = _client->s3_client_conf();
-        new_s3_conf.endpoint.erase(
-                _client->s3_client_conf().endpoint.size() - OSS_PRIVATE_ENDPOINT_SUFFIX.size(),
-                LEN_OF_OSS_PRIVATE_SUFFIX);
-        auto client_result = S3ClientFactory::instance().create(new_s3_conf);
+    if (is_public_endpoint && current_conf.endpoint.ends_with(OSS_PRIVATE_ENDPOINT_SUFFIX)) {
+        auto public_conf = std::move(current_conf);
+        public_conf.endpoint.erase(public_conf.endpoint.size() - OSS_PRIVATE_ENDPOINT_SUFFIX.size(),
+                                   LEN_OF_OSS_PRIVATE_SUFFIX);
+        auto client_result = S3ClientFactory::instance().create(public_conf);
         if (!client_result) {
             LOG(WARNING) << "failed to create S3 client for presigned URL: "
                          << client_result.error();
-            return {};
+            return ResultError(std::move(client_result).error());
         }
         client = std::move(client_result).value();
     } else {

--- a/be/src/io/fs/s3_file_system.h
+++ b/be/src/io/fs/s3_file_system.h
@@ -61,7 +61,10 @@ public:
     // For error msg
     std::string full_s3_path(std::string_view bucket, std::string_view key) const;
 
-    const S3ClientConf& s3_client_conf() { return _conf; }
+    S3ClientConf s3_client_conf() const {
+        std::shared_lock lock(_mtx);
+        return _conf;
+    }
 
 private:
     mutable std::shared_mutex _mtx;
@@ -89,8 +92,8 @@ public:
     const std::string& bucket() const { return _bucket; }
     const std::string& prefix() const { return _prefix; }
 
-    std::string generate_presigned_url(const Path& path, int64_t expiration_secs,
-                                       bool is_public_endpoint) const;
+    Result<std::string> generate_presigned_url(const Path& path, int64_t expiration_secs,
+                                               bool is_public_endpoint) const;
 
 protected:
     Status create_file_impl(const Path& file, FileWriterPtr* writer,

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -533,8 +533,12 @@ std::string RuntimeState::get_error_log_file_path() {
     auto presigned_url =
             s3_error_fs->generate_presigned_url(remote_error_log_file_path, EXPIRATION_SECONDS,
                                                 config::use_public_endpoint_for_error_log);
+    if (!presigned_url) {
+        LOG(WARNING) << "Failed to generate error log URL: " << presigned_url.error();
+        return local_error_log_file_path;
+    }
     std::lock_guard<std::mutex> load_lock(_load_error_log_lock);
-    _error_log_file_path = std::move(presigned_url);
+    _error_log_file_path = std::move(presigned_url).value();
     return _error_log_file_path;
 }
 

--- a/be/src/util/s3_util.cpp
+++ b/be/src/util/s3_util.cpp
@@ -45,6 +45,7 @@
 #include "common/logging.h"
 #include "common/status.h"
 #include "cpp/obj-client/auth/aws_credential_factory.h"
+#include "cpp/obj-client/auth/gcp_workload_identity_token_provider.h"
 #ifdef USE_AZURE
 #include "cpp/obj-client/auth/azure_auth_factory.h"
 #include "cpp/obj-client/azure_obj_storage_client.h"
@@ -70,6 +71,23 @@ doris::Status is_s3_conf_valid(const S3ClientConf& conf) {
     }
     if (conf.region.empty()) {
         return Status::InvalidArgument<false>("Invalid s3 conf, empty region");
+    }
+    if (conf.cred_provider_type == CredProviderType::GcpWorkloadIdentity) {
+        if (!conf.is_internal_bucket) {
+            return Status::InvalidArgument<false>(
+                    "GCP workload identity is only supported for storage vaults");
+        }
+        if (conf.provider != io::ObjStorageProvider::GCP) {
+            return Status::InvalidArgument<false>("GCP workload identity requires provider GCP");
+        }
+        if (!is_gcs_xml_endpoint(conf.endpoint)) {
+            return Status::InvalidArgument<false>("GCP workload identity requires endpoint {}",
+                                                  GCS_XML_ENDPOINT);
+        }
+        if (!conf.ak.empty() || !conf.sk.empty() || !conf.role_arn.empty()) {
+            return Status::InvalidArgument<false>(
+                    "GCP workload identity cannot be combined with other credentials");
+        }
     }
 
     if (conf.role_arn.empty()) {
@@ -380,6 +398,9 @@ Result<std::shared_ptr<io::ObjStorageClient>> S3ClientFactory::_create_s3_client
     }
 
     set_s3_client_default_http_scheme(aws_config, config::s3_client_http_scheme);
+    if (s3_conf.cred_provider_type == CredProviderType::GcpWorkloadIdentity) {
+        aws_config.scheme = Aws::Http::Scheme::HTTPS;
+    }
 
     aws_config.retryStrategy = std::make_shared<S3CustomRetryStrategy>(
             config::max_s3_client_retry /*scaleFactor = 25*/, /*retry_slow_down=*/true);
@@ -394,12 +415,18 @@ Result<std::shared_ptr<io::ObjStorageClient>> S3ClientFactory::_create_s3_client
             Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
             s3_conf.use_virtual_addressing);
 
+    std::shared_ptr<GcpWorkloadIdentityTokenProvider> token_provider;
+    if (s3_conf.cred_provider_type == CredProviderType::GcpWorkloadIdentity) {
+        token_provider = global_gcp_workload_identity_token_provider();
+    }
     auto provider_client = std::make_shared<io::S3ObjStorageClient>(
-            std::move(new_client), ObjStorageEndpointInfo {
-                                           .endpoint = s3_conf.endpoint,
-                                           .ak = s3_conf.ak,
-                                           .sk = s3_conf.sk,
-                                   });
+            std::move(new_client),
+            ObjStorageEndpointInfo {
+                    .endpoint = s3_conf.endpoint,
+                    .ak = s3_conf.ak,
+                    .sk = s3_conf.sk,
+            },
+            std::move(token_provider));
     LOG_INFO("create one s3 client with {}", s3_conf.to_string());
     return provider_client;
 }
@@ -537,6 +564,10 @@ S3Conf S3Conf::get_s3_conf(const cloud::ObjectStoreInfoPB& info) {
     if (info.has_cred_provider_type()) {
         ret.client_conf.cred_provider_type = cred_provider_type_from_pb(info.cred_provider_type());
     }
+    ret.client_conf.cred_provider_type =
+            resolve_cred_provider_type(ret.client_conf.cred_provider_type,
+                                       !ret.client_conf.ak.empty() && !ret.client_conf.sk.empty(),
+                                       !ret.client_conf.role_arn.empty());
 
     io::ObjStorageProvider type = io::ObjStorageProvider::AWS;
     switch (info.provider()) {

--- a/be/src/util/s3_util.h
+++ b/be/src/util/s3_util.h
@@ -36,10 +36,10 @@
 #include <unordered_map>
 
 #include "common/status.h"
-#include "core/string_ref.h"
 #include "cpp/aws_common.h"
 #include "cpp/obj-client/auth/aws_credential_factory.h"
 #include "cpp/obj-client/obj_storage_client.h"
+#include "util/hash_util.hpp"
 
 namespace Aws::S3 {
 class S3Client;
@@ -86,23 +86,23 @@ struct S3ClientConf {
     bool operator==(const S3ClientConf&) const = default;
 
     uint64_t get_hash() const {
-        uint64_t hash_code = 0;
-        // Use crc32_hash(ak + sk) hash to prevent swapped AK/SK order from producing same result.
-        hash_code ^= crc32_hash(ak + sk);
-        hash_code ^= crc32_hash(token);
-        hash_code ^= crc32_hash(endpoint);
-        hash_code ^= crc32_hash(region);
-        hash_code ^= crc32_hash(bucket);
-        hash_code ^= max_connections;
-        hash_code ^= request_timeout_ms;
-        hash_code ^= connect_timeout_ms;
-        hash_code ^= use_virtual_addressing;
-        hash_code ^= static_cast<int>(provider);
-
-        hash_code ^= static_cast<int>(cred_provider_type);
-        hash_code ^= crc32_hash(role_arn);
-        hash_code ^= crc32_hash(external_id);
-        hash_code ^= is_internal_bucket;
+        size_t hash_code = 0;
+        HashUtil::hash_combine(hash_code, endpoint);
+        HashUtil::hash_combine(hash_code, region);
+        HashUtil::hash_combine(hash_code, ak);
+        HashUtil::hash_combine(hash_code, sk);
+        HashUtil::hash_combine(hash_code, token);
+        HashUtil::hash_combine(hash_code, bucket);
+        HashUtil::hash_combine(hash_code, static_cast<int>(provider));
+        HashUtil::hash_combine(hash_code, max_connections);
+        HashUtil::hash_combine(hash_code, request_timeout_ms);
+        HashUtil::hash_combine(hash_code, connect_timeout_ms);
+        HashUtil::hash_combine(hash_code, use_virtual_addressing);
+        HashUtil::hash_combine(hash_code, need_override_endpoint);
+        HashUtil::hash_combine(hash_code, static_cast<int>(cred_provider_type));
+        HashUtil::hash_combine(hash_code, role_arn);
+        HashUtil::hash_combine(hash_code, external_id);
+        HashUtil::hash_combine(hash_code, is_internal_bucket);
         return hash_code;
     }
 

--- a/be/test/cloud/cloud_storage_engine_test.cpp
+++ b/be/test/cloud/cloud_storage_engine_test.cpp
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "cloud/cloud_storage_engine.h"
+
+#include <gtest/gtest.h>
+
+#include "util/s3_util.h"
+
+namespace doris {
+
+class CloudStorageEngineTest : public testing::Test {};
+
+TEST_F(CloudStorageEngineTest, CheckNewAndChangedKeylessStorageVault) {
+    bool previous_value = config::enable_check_storage_vault;
+    config::enable_check_storage_vault = true;
+
+    S3ClientConf hmac_conf {
+            .endpoint = std::string(GCS_XML_ENDPOINT),
+            .region = "us-central1",
+            .ak = "access-key",
+            .sk = "secret-key",
+            .bucket = "bucket",
+            .provider = io::ObjStorageProvider::GCP,
+            .is_internal_bucket = true,
+    };
+    S3ClientConf workload_identity_conf = hmac_conf;
+    workload_identity_conf.ak.clear();
+    workload_identity_conf.sk.clear();
+    workload_identity_conf.cred_provider_type = CredProviderType::GcpWorkloadIdentity;
+
+    EXPECT_TRUE(CloudStorageEngine::_should_check_storage_vault(nullptr, workload_identity_conf));
+    EXPECT_TRUE(
+            CloudStorageEngine::_should_check_storage_vault(&hmac_conf, workload_identity_conf));
+    EXPECT_FALSE(CloudStorageEngine::_should_check_storage_vault(&workload_identity_conf,
+                                                                 workload_identity_conf));
+    EXPECT_FALSE(CloudStorageEngine::_should_check_storage_vault(nullptr, hmac_conf));
+
+    S3ClientConf role_conf = hmac_conf;
+    role_conf.ak.clear();
+    role_conf.sk.clear();
+    role_conf.role_arn = "arn:aws:iam::123456789012:role/test-role";
+    EXPECT_TRUE(CloudStorageEngine::_should_check_storage_vault(nullptr, role_conf));
+
+    config::enable_check_storage_vault = false;
+    EXPECT_FALSE(CloudStorageEngine::_should_check_storage_vault(nullptr, workload_identity_conf));
+
+    config::enable_check_storage_vault = previous_value;
+}
+
+} // namespace doris

--- a/be/test/io/client/s3_file_system_test.cpp
+++ b/be/test/io/client/s3_file_system_test.cpp
@@ -616,7 +616,9 @@ TEST_F(S3FileSystemTest, GeneratePresignedUrlTest) {
 
     // Generate presigned URL
     int64_t expiration_secs = 3600; // 1 hour
-    std::string presigned_url = s3_fs_->generate_presigned_url(test_file, expiration_secs, false);
+    auto presigned_url_result = s3_fs_->generate_presigned_url(test_file, expiration_secs, false);
+    ASSERT_TRUE(presigned_url_result) << presigned_url_result.error();
+    const auto& presigned_url = presigned_url_result.value();
 
     std::cout << "Generated presigned URL: " << presigned_url << std::endl;
 
@@ -626,8 +628,10 @@ TEST_F(S3FileSystemTest, GeneratePresignedUrlTest) {
 
     // For public endpoint test (if using OSS)
     if (config_->get_provider() == "OSS") {
-        std::string presigned_url_public =
+        auto presigned_url_public_result =
                 s3_fs_->generate_presigned_url(test_file, expiration_secs, true);
+        ASSERT_TRUE(presigned_url_public_result) << presigned_url_public_result.error();
+        const auto& presigned_url_public = presigned_url_public_result.value();
         std::cout << "Generated presigned URL (public): " << presigned_url_public << std::endl;
         EXPECT_FALSE(presigned_url_public.empty()) << "Public presigned URL should not be empty";
     }

--- a/be/test/io/fs/s3_obj_stroage_client_mock_test.cpp
+++ b/be/test/io/fs/s3_obj_stroage_client_mock_test.cpp
@@ -17,10 +17,20 @@
 
 #include <aws/core/Aws.h>
 #include <aws/s3/S3Client.h>
+#include <aws/s3/model/DeleteObjectsRequest.h>
+#include <aws/s3/model/DeleteObjectsResult.h>
 #include <aws/s3/model/ListObjectsV2Request.h>
 #include <aws/s3/model/ListObjectsV2Result.h>
 #include <aws/s3/model/Object.h>
+#include <fmt/format.h>
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#include "cpp/obj-client/auth/gcp_workload_identity_token_provider.h"
 #include "cpp/obj-client/obj_storage_client.h"
 #include "cpp/obj-client/rate_limited_obj_storage_client.h"
 #include "cpp/obj-client/s3_obj_storage_client.h"
@@ -86,6 +96,317 @@ TEST_F(S3ObjStorageClientMockTest, list_objects_compatibility) {
 
     EXPECT_TRUE(objects.empty());
     EXPECT_EQ(response.status.code, ErrorCode::INTERNAL_ERROR);
+}
+
+TEST_F(S3ObjStorageClientMockTest, gcp_workload_identity_bearer_token_applied) {
+    auto mock_s3_client = std::make_shared<MockS3Client>();
+    std::atomic<int> fetch_count = 0;
+    auto token_provider = std::make_shared<GcpWorkloadIdentityTokenProvider>(
+            [&](std::string* token, std::chrono::seconds* expires_in) {
+                ++fetch_count;
+                *token = "test-token";
+                *expires_in = std::chrono::hours(1);
+                return true;
+            },
+            std::chrono::steady_clock::now);
+    S3ObjStorageClient s3_obj_storage_client(mock_s3_client, {}, token_provider);
+
+    std::vector<ObjectMeta> files;
+    ListObjectsV2Result result;
+    result.SetIsTruncated(false);
+    EXPECT_CALL(*mock_s3_client, ListObjectsV2(testing::_))
+            .Times(2)
+            .WillRepeatedly([&](const ListObjectsV2Request& request) {
+                const auto& headers = request.GetAdditionalCustomHeaders();
+                auto header = headers.find("authorization");
+                EXPECT_NE(header, headers.end());
+                if (header != headers.end()) {
+                    EXPECT_EQ(header->second, "Bearer test-token");
+                }
+                return ListObjectsV2Outcome(result);
+            });
+
+    auto response = s3_obj_storage_client.list_objects(
+            {.bucket = "dummy-bucket",
+             .prefix = "S3ObjStorageClientMockTest/gcp_workload_identity"},
+            &files);
+    EXPECT_EQ(response.status.code, ErrorCode::OK);
+
+    // The token is cached: a second request must not refresh it again.
+    response = s3_obj_storage_client.list_objects(
+            {.bucket = "dummy-bucket",
+             .prefix = "S3ObjStorageClientMockTest/gcp_workload_identity"},
+            &files);
+    EXPECT_EQ(response.status.code, ErrorCode::OK);
+    EXPECT_EQ(fetch_count.load(), 1);
+}
+
+TEST_F(S3ObjStorageClientMockTest, reset_uses_complete_client_configuration) {
+    auto mock_s3_client = std::make_shared<MockS3Client>();
+    std::vector<S3ClientConf> created_configs;
+    S3ClientFactory::instance().set_client_creator_for_test([&](const S3ClientConf& conf) {
+        created_configs.push_back(conf);
+        return std::make_shared<S3ObjStorageClient>(mock_s3_client);
+    });
+
+    S3ClientConf initial_conf {
+            .endpoint = "https://s3.us-east-1.amazonaws.com",
+            .region = "us-east-1",
+            .ak = "access-key",
+            .sk = "secret-key",
+            .bucket = "bucket",
+            .provider = io::ObjStorageProvider::AWS,
+    };
+    ObjClientHolder holder(initial_conf);
+    EXPECT_TRUE(holder.init().ok());
+
+    S3ClientConf workload_identity_conf {
+            .endpoint = std::string(GCS_XML_ENDPOINT),
+            .region = "us-central1",
+            .bucket = "bucket",
+            .provider = io::ObjStorageProvider::GCP,
+            .need_override_endpoint = false,
+            .cred_provider_type = CredProviderType::GcpWorkloadIdentity,
+            .is_internal_bucket = true,
+    };
+    EXPECT_TRUE(holder.reset(workload_identity_conf).ok());
+    S3ClientFactory::instance().clear_client_creator_for_test();
+
+    ASSERT_EQ(created_configs.size(), 2);
+    const auto& reset_conf = created_configs.back();
+    EXPECT_EQ(reset_conf.endpoint, workload_identity_conf.endpoint);
+    EXPECT_EQ(reset_conf.region, workload_identity_conf.region);
+    EXPECT_EQ(reset_conf.provider, workload_identity_conf.provider);
+    EXPECT_EQ(reset_conf.need_override_endpoint, workload_identity_conf.need_override_endpoint);
+    EXPECT_EQ(reset_conf.cred_provider_type, workload_identity_conf.cred_provider_type);
+    EXPECT_TRUE(reset_conf.ak.empty());
+    EXPECT_TRUE(reset_conf.sk.empty());
+}
+
+TEST_F(S3ObjStorageClientMockTest, reset_distinguishes_addressing_and_endpoint_override) {
+    auto mock_s3_client = std::make_shared<MockS3Client>();
+    int created_clients = 0;
+    S3ClientFactory::instance().set_client_creator_for_test([&](const S3ClientConf&) {
+        ++created_clients;
+        return std::make_shared<S3ObjStorageClient>(mock_s3_client);
+    });
+
+    S3ClientConf initial_conf {
+            .endpoint = "https://s3.us-east-1.amazonaws.com",
+            .region = "us-east-1",
+            .ak = "access-key",
+            .sk = "secret-key",
+            .use_virtual_addressing = false,
+            .need_override_endpoint = true,
+    };
+    ObjClientHolder holder(initial_conf);
+    EXPECT_TRUE(holder.init().ok());
+
+    S3ClientConf updated_conf = initial_conf;
+    updated_conf.use_virtual_addressing = true;
+    updated_conf.need_override_endpoint = false;
+    EXPECT_TRUE(holder.reset(updated_conf).ok());
+    S3ClientFactory::instance().clear_client_creator_for_test();
+
+    EXPECT_EQ(created_clients, 2);
+    EXPECT_EQ(holder.s3_client_conf(), updated_conf);
+}
+
+TEST_F(S3ObjStorageClientMockTest, explicit_credentials_override_stale_workload_identity) {
+    cloud::ObjectStoreInfoPB info;
+    info.set_endpoint("https://storage.googleapis.com");
+    info.set_region("us-central1");
+    info.set_bucket("bucket");
+    info.set_provider(cloud::ObjectStoreInfoPB::GCP);
+    info.set_cred_provider_type(cloud::CredProviderTypePB::GCP_WORKLOAD_IDENTITY);
+    info.set_ak("access-key");
+    info.set_sk("secret-key");
+
+    auto conf = S3Conf::get_s3_conf(info);
+    EXPECT_EQ(conf.client_conf.cred_provider_type, CredProviderType::Default);
+
+    info.clear_ak();
+    info.clear_sk();
+    info.set_role_arn("arn:aws:iam::123456789012:role/test-role");
+    conf = S3Conf::get_s3_conf(info);
+    EXPECT_EQ(conf.client_conf.cred_provider_type, CredProviderType::InstanceProfile);
+}
+
+TEST_F(S3ObjStorageClientMockTest, gcp_workload_identity_delete_bearer_token_applied) {
+    auto mock_s3_client = std::make_shared<MockS3Client>();
+    auto token_provider = std::make_shared<GcpWorkloadIdentityTokenProvider>(
+            [](std::string* token, std::chrono::seconds* expires_in) {
+                *token = "test-token";
+                *expires_in = std::chrono::hours(1);
+                return true;
+            },
+            std::chrono::steady_clock::now);
+    S3ObjStorageClient s3_obj_storage_client(mock_s3_client, {}, token_provider);
+
+    auto expect_bearer_token = [](const auto& request) {
+        const auto& headers = request.GetAdditionalCustomHeaders();
+        auto header = headers.find("authorization");
+        ASSERT_NE(header, headers.end());
+        EXPECT_EQ(header->second, "Bearer test-token");
+    };
+
+    DeleteObjectsResult delete_result;
+    EXPECT_CALL(*mock_s3_client, DeleteObjects(testing::_))
+            .WillOnce([&](const DeleteObjectsRequest& request) {
+                expect_bearer_token(request);
+                return DeleteObjectsOutcome(delete_result);
+            });
+
+    auto response = s3_obj_storage_client.delete_objects(
+            {.bucket = "dummy-bucket"}, {"S3ObjStorageClientMockTest/delete-object"});
+    EXPECT_EQ(response.status.code, ErrorCode::OK);
+}
+
+TEST_F(S3ObjStorageClientMockTest, gcp_workload_identity_token_refresh) {
+    auto now = std::chrono::steady_clock::now();
+    int fetch_count = 0;
+    bool fetch_succeeds = true;
+    GcpWorkloadIdentityTokenProvider token_provider(
+            [&](std::string* token, std::chrono::seconds* expires_in) {
+                ++fetch_count;
+                if (!fetch_succeeds) {
+                    return false;
+                }
+                *token = fmt::format("token-{}", fetch_count);
+                *expires_in = std::chrono::hours(1);
+                return true;
+            },
+            [&] { return now; });
+
+    EXPECT_EQ(token_provider.get_token(), "token-1");
+    EXPECT_EQ(token_provider.get_token(), "token-1");
+    EXPECT_EQ(fetch_count, 1);
+
+    now += std::chrono::minutes(56);
+    EXPECT_EQ(token_provider.get_token(), "token-2");
+
+    fetch_succeeds = false;
+    now += std::chrono::minutes(56);
+    EXPECT_EQ(token_provider.get_token(), "token-2");
+    EXPECT_EQ(token_provider.get_token(), "token-2");
+    EXPECT_EQ(fetch_count, 3);
+    now += std::chrono::seconds(5);
+    EXPECT_EQ(token_provider.get_token(), "token-2");
+    EXPECT_EQ(fetch_count, 3);
+    now += std::chrono::seconds(26);
+    EXPECT_EQ(token_provider.get_token(), "token-2");
+    EXPECT_EQ(fetch_count, 4);
+    now += std::chrono::minutes(4);
+    EXPECT_TRUE(token_provider.get_token().empty());
+    EXPECT_EQ(fetch_count, 5);
+}
+
+TEST_F(S3ObjStorageClientMockTest, gcp_workload_identity_refresh_uses_valid_cached_token) {
+    auto now = std::chrono::steady_clock::now();
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool refresh_started = false;
+    bool finish_refresh = false;
+    bool cached_read_finished = false;
+    int fetch_count = 0;
+
+    GcpWorkloadIdentityTokenProvider token_provider(
+            [&](std::string* token, std::chrono::seconds* expires_in) {
+                ++fetch_count;
+                if (fetch_count > 1) {
+                    std::unique_lock lock(mutex);
+                    refresh_started = true;
+                    condition.notify_all();
+                    condition.wait(lock, [&] { return finish_refresh; });
+                }
+                *token = fmt::format("token-{}", fetch_count);
+                *expires_in = std::chrono::hours(1);
+                return true;
+            },
+            [&] { return now; });
+
+    EXPECT_EQ(token_provider.get_token(), "token-1");
+    now += std::chrono::minutes(56);
+
+    std::string refreshed_token;
+    std::thread refresh_thread([&] { refreshed_token = token_provider.get_token(); });
+    {
+        std::unique_lock lock(mutex);
+        EXPECT_TRUE(
+                condition.wait_for(lock, std::chrono::seconds(1), [&] { return refresh_started; }));
+    }
+
+    std::string cached_token;
+    std::thread cached_read_thread([&] {
+        cached_token = token_provider.get_token();
+        std::lock_guard lock(mutex);
+        cached_read_finished = true;
+        condition.notify_all();
+    });
+    {
+        std::unique_lock lock(mutex);
+        EXPECT_TRUE(condition.wait_for(lock, std::chrono::seconds(1),
+                                       [&] { return cached_read_finished; }));
+        finish_refresh = true;
+        condition.notify_all();
+    }
+
+    cached_read_thread.join();
+    refresh_thread.join();
+    EXPECT_EQ(cached_token, "token-1");
+    EXPECT_EQ(refreshed_token, "token-2");
+    EXPECT_EQ(fetch_count, 2);
+}
+
+TEST_F(S3ObjStorageClientMockTest, gcp_workload_identity_refresh_is_serialized) {
+    std::atomic<int> fetch_count = 0;
+    GcpWorkloadIdentityTokenProvider token_provider(
+            [&](std::string* token, std::chrono::seconds* expires_in) {
+                ++fetch_count;
+                *token = "shared-token";
+                *expires_in = std::chrono::hours(1);
+                return true;
+            },
+            std::chrono::steady_clock::now);
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < 16; ++i) {
+        threads.emplace_back([&] { EXPECT_EQ(token_provider.get_token(), "shared-token"); });
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+    EXPECT_EQ(fetch_count.load(), 1);
+}
+
+TEST_F(S3ObjStorageClientMockTest, gcp_workload_identity_fails_closed_without_token) {
+    auto mock_s3_client = std::make_shared<MockS3Client>();
+    auto token_provider = std::make_shared<GcpWorkloadIdentityTokenProvider>(
+            [](std::string*, std::chrono::seconds*) { return false; },
+            std::chrono::steady_clock::now);
+    S3ObjStorageClient client(mock_s3_client, {}, token_provider);
+    EXPECT_CALL(*mock_s3_client, ListObjectsV2(testing::_)).Times(0);
+
+    std::vector<ObjectMeta> objects;
+    auto response = client.list_objects({.bucket = "dummy-bucket", .prefix = "prefix"}, &objects);
+    EXPECT_EQ(response.status.code, ObjStorageStatus::NETWORK_ERROR);
+    EXPECT_EQ(response.http_code, 0);
+}
+
+TEST_F(S3ObjStorageClientMockTest, gcp_workload_identity_presigned_url_unsupported) {
+    auto mock_s3_client = std::make_shared<MockS3Client>();
+    auto token_provider = std::make_shared<GcpWorkloadIdentityTokenProvider>(
+            [](std::string* token, std::chrono::seconds* expires_in) {
+                *token = "test-token";
+                *expires_in = std::chrono::hours(1);
+                return true;
+            },
+            std::chrono::steady_clock::now);
+    S3ObjStorageClient s3_obj_storage_client(mock_s3_client, {}, token_provider);
+
+    EXPECT_TRUE(s3_obj_storage_client
+                        .generate_presigned_url({.bucket = "dummy-bucket", .key = "object"}, 60)
+                        .empty());
 }
 
 ListObjectsV2Result CreatePageResult(const std::string& nextToken,

--- a/be/test/io/s3_client_factory_test.cpp
+++ b/be/test/io/s3_client_factory_test.cpp
@@ -136,7 +136,27 @@ private:
     bool _was_enabled;
 };
 
-} // namespace
+TEST_F(S3ClientFactoryTest, ClientIdentityDistinguishesAddressingAndEndpointOverride) {
+    S3ClientConf path_style_conf {
+            .endpoint = "https://config-identity-test.example.com",
+            .region = "us-east-1",
+            .ak = "access-key",
+            .sk = "secret-key",
+            .use_virtual_addressing = false,
+            .need_override_endpoint = true,
+    };
+    S3ClientConf virtual_hosted_conf = path_style_conf;
+    virtual_hosted_conf.use_virtual_addressing = true;
+    virtual_hosted_conf.need_override_endpoint = false;
+
+    EXPECT_NE(path_style_conf, virtual_hosted_conf);
+
+    auto path_style_client = S3ClientFactory::instance().create(path_style_conf);
+    auto virtual_hosted_client = S3ClientFactory::instance().create(virtual_hosted_conf);
+    ASSERT_NE(path_style_client, nullptr);
+    ASSERT_NE(virtual_hosted_client, nullptr);
+    EXPECT_NE(path_style_client, virtual_hosted_client);
+}
 
 TEST_F(S3ClientFactoryTest, DistinguishesHashCollisions) {
     auto external_conf =
@@ -163,12 +183,10 @@ TEST_F(S3ClientFactoryTest, DistinguishesHashCollisions) {
     EXPECT_EQ(cached_internal.value(), internal_client);
 }
 
-TEST_F(S3ClientFactoryTest, ObjClientHolderResetDistinguishesHashCollisions) {
-    auto external_conf =
-            make_hash_collision_conf("s3-client-holder-hash-collision.example.com", false);
-    auto internal_conf =
-            make_hash_collision_conf("s3-client-holder-hash-collision.example.com", true);
-    ASSERT_EQ(external_conf.get_hash(), internal_conf.get_hash());
+TEST_F(S3ClientFactoryTest, ObjClientHolderResetDistinguishesClientScope) {
+    auto external_conf = make_factory_conf("s3-client-holder-client-scope.example.com", false);
+    auto internal_conf = make_factory_conf("s3-client-holder-client-scope.example.com", true);
+    ASSERT_NE(external_conf, internal_conf);
 
     auto external_client =
             std::make_shared<io::S3ObjStorageClient>(std::shared_ptr<Aws::S3::S3Client> {});
@@ -295,6 +313,9 @@ TEST_F(S3ClientFactoryTest, AwsCredentialsProvider) {
     S3ClientConf web_identity_conf;
     web_identity_conf.cred_provider_type = CredProviderType::WebIdentity;
 
+    S3ClientConf gcp_workload_identity_conf;
+    gcp_workload_identity_conf.cred_provider_type = CredProviderType::GcpWorkloadIdentity;
+
     config::aws_credentials_provider_version = "v2";
     {
         auto provider_v2 = factory.create_aws_credentials_provider(anonymous_conf).provider;
@@ -331,6 +352,12 @@ TEST_F(S3ClientFactoryTest, AwsCredentialsProvider) {
                         provider_v2);
         ASSERT_NE(web_identity_v2, nullptr);
     }
+    {
+        auto provider =
+                factory.create_aws_credentials_provider(gcp_workload_identity_conf).provider;
+        ASSERT_NE(std::dynamic_pointer_cast<Aws::Auth::AnonymousAWSCredentialsProvider>(provider),
+                  nullptr);
+    }
 
     config::aws_credentials_provider_version = "v1";
     {
@@ -361,8 +388,28 @@ TEST_F(S3ClientFactoryTest, AwsCredentialsProvider) {
                 std::dynamic_pointer_cast<Aws::Auth::STSAssumeRoleCredentialsProvider>(provider_v1);
         ASSERT_NE(default_chain_v1, nullptr);
     }
+    {
+        auto provider =
+                factory.create_aws_credentials_provider(gcp_workload_identity_conf).provider;
+        ASSERT_NE(std::dynamic_pointer_cast<Aws::Auth::AnonymousAWSCredentialsProvider>(provider),
+                  nullptr);
+    }
 
     config::aws_credentials_provider_version = "v2";
+}
+
+TEST_F(S3ClientFactoryTest, WorkloadIdentityAlwaysUsesAnonymousAwsCredentials) {
+    for (auto version : {AwsCredentialProviderVersion::V1, AwsCredentialProviderVersion::V2}) {
+        auto result = AwsCredentialFactory::create({
+                .version = version,
+                .provider_type = CredProviderType::GcpWorkloadIdentity,
+                .empty_credentials = EmptyCredentialsBehavior::DEFAULT_CHAIN,
+        });
+        ASSERT_TRUE(result);
+        ASSERT_NE(std::dynamic_pointer_cast<Aws::Auth::AnonymousAWSCredentialsProvider>(
+                          result.provider),
+                  nullptr);
+    }
 }
 
 TEST_F(S3ClientFactoryTest, RefreshCaCertForCredentialsProvider) {
@@ -448,6 +495,21 @@ TEST_F(S3ClientFactoryTest, ConvertPropertiesToS3ConfRoleArnProviderType) {
     properties["AWS_CREDENTIALS_PROVIDER_TYPE"] = "WEB_IDENTITY";
     ASSERT_TRUE(S3ClientFactory::convert_properties_to_s3_conf(properties, s3_uri, &s3_conf).ok());
     ASSERT_EQ(s3_conf.client_conf.cred_provider_type, CredProviderType::WebIdentity);
+}
+
+TEST_F(S3ClientFactoryTest, ConvertPropertiesRejectsWorkloadIdentityOutsideStorageVaults) {
+    std::map<std::string, std::string> properties {
+            {"AWS_ENDPOINT", "https://storage.googleapis.com"},
+            {"AWS_REGION", "us-central1"},
+            {"AWS_CREDENTIALS_PROVIDER_TYPE", "GCP_WORKLOAD_IDENTITY"},
+    };
+    S3URI s3_uri("s3://test-bucket/test-prefix");
+    ASSERT_TRUE(s3_uri.parse().ok());
+
+    S3Conf s3_conf;
+    auto status = S3ClientFactory::convert_properties_to_s3_conf(properties, s3_uri, &s3_conf);
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("only supported for storage vaults"), std::string::npos);
 }
 
 TEST_F(S3ClientFactoryTest, ConvertPropertiesToS3ConfProviderTypeMatrix) {

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -38,6 +38,7 @@
 #include "common/network_util.h"
 #include "common/stats.h"
 #include "common/string_util.h"
+#include "cpp/aws_common.h"
 #include "cpp/sync_point.h"
 #include "meta-service/meta_service.h"
 #include "meta-service/meta_service_helper.h"
@@ -768,9 +769,69 @@ static bool use_credential_provider(const ObjectStoreInfoPB& obj) {
     return obj.has_cred_provider_type() || has_non_empty_role_arn(obj);
 }
 
+static bool is_gcp_workload_identity_cred_provider(const ObjectStoreInfoPB& obj) {
+    return obj.has_cred_provider_type() &&
+           obj.cred_provider_type() == CredProviderTypePB::GCP_WORKLOAD_IDENTITY;
+}
+
+static void resolve_stale_gcp_workload_identity(ObjectStoreInfoPB* obj) {
+    if (!is_gcp_workload_identity_cred_provider(*obj)) {
+        return;
+    }
+    if (obj->has_ak() && obj->has_sk() && !obj->ak().empty() && !obj->sk().empty()) {
+        obj->clear_cred_provider_type();
+    } else if (has_non_empty_role_arn(*obj)) {
+        obj->set_cred_provider_type(CredProviderTypePB::INSTANCE_PROFILE);
+    }
+}
+
+static bool normalize_gcs_xml_endpoint(std::string* endpoint, bool allow_legacy_http = false) {
+    trim(*endpoint);
+    std::string lowercase_endpoint = *endpoint;
+    std::transform(lowercase_endpoint.begin(), lowercase_endpoint.end(), lowercase_endpoint.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (lowercase_endpoint == "storage.googleapis.com" || lowercase_endpoint == GCS_XML_ENDPOINT ||
+        (allow_legacy_http && lowercase_endpoint == "http://storage.googleapis.com")) {
+        *endpoint = GCS_XML_ENDPOINT;
+        return true;
+    }
+    return false;
+}
+
+static bool validate_credential_provider(ObjectStoreInfoPB* obj, bool allow_legacy_gcs_http,
+                                         MetaServiceCode& code, std::string& msg) {
+    if (!use_credential_provider(*obj)) {
+        return true;
+    }
+
+    if (!is_gcp_workload_identity_cred_provider(*obj)) {
+        if (obj->has_provider() && obj->provider() == ObjectStoreInfoPB::S3) {
+            return true;
+        }
+        code = MetaServiceCode::INVALID_ARGUMENT;
+        msg = "s3 conf info err with credentials_provider_type, please check it";
+        return false;
+    }
+
+    if (!obj->has_provider() || obj->provider() != ObjectStoreInfoPB::GCP || obj->has_ak() ||
+        obj->has_sk() || has_non_empty_role_arn(*obj)) {
+        code = MetaServiceCode::INVALID_ARGUMENT;
+        msg = "GCP workload identity requires provider GCP and no ak/sk or role_arn";
+        return false;
+    }
+    auto endpoint = obj->endpoint();
+    if (!normalize_gcs_xml_endpoint(&endpoint, allow_legacy_gcs_http)) {
+        code = MetaServiceCode::INVALID_ARGUMENT;
+        msg = fmt::format("GCP workload identity requires endpoint {}", GCS_XML_ENDPOINT);
+        return false;
+    }
+    obj->set_endpoint(std::move(endpoint));
+    return true;
+}
+
 static void create_object_info_with_encrypt(const InstanceInfoPB& instance, ObjectStoreInfoPB* obj,
-                                            bool sse_enabled, MetaServiceCode& code,
-                                            std::string& msg) {
+                                            bool sse_enabled, bool storage_vault,
+                                            MetaServiceCode& code, std::string& msg) {
     std::string plain_ak = obj->has_ak() ? obj->ak() : "";
     std::string plain_sk = obj->has_sk() ? obj->sk() : "";
     std::string bucket = obj->has_bucket() ? obj->bucket() : "";
@@ -781,7 +842,17 @@ static void create_object_info_with_encrypt(const InstanceInfoPB& instance, Obje
     std::string external_endpoint = obj->has_external_endpoint() ? obj->external_endpoint() : "";
     std::string region = obj->has_region() ? obj->region() : "";
 
-    if (obj->has_role_arn()) {
+    if (storage_vault && is_gcp_workload_identity_cred_provider(*obj)) {
+        if (bucket.empty() || endpoint.empty() || region.empty() ||
+            !validate_credential_provider(obj, false, code, msg)) {
+            if (code == MetaServiceCode::OK) {
+                code = MetaServiceCode::INVALID_ARGUMENT;
+                msg = "s3 conf info err with credentials provider, please check it";
+            }
+            return;
+        }
+        endpoint = obj->endpoint();
+    } else if (obj->has_role_arn()) {
         if (obj->role_arn().empty() || !obj->has_cred_provider_type() || !obj->has_provider() ||
             obj->provider() != ObjectStoreInfoPB::S3 || bucket.empty() || endpoint.empty() ||
             region.empty()) {
@@ -840,7 +911,8 @@ static int add_vault_into_instance(InstanceInfoPB& instance, Transaction* txn,
         return add_hdfs_storage_vault(instance, txn, vault_param, code, msg);
     }
 
-    create_object_info_with_encrypt(instance, vault_param.mutable_obj_info(), true, code, msg);
+    create_object_info_with_encrypt(instance, vault_param.mutable_obj_info(), true, true, code,
+                                    msg);
     if (code != MetaServiceCode::OK) {
         return -1;
     }
@@ -968,7 +1040,6 @@ static int alter_hdfs_storage_vault_by_id(InstanceInfoPB& instance,
         msg = ss.str();
         return -1;
     }
-
     auto origin_vault_info = new_vault.DebugString();
     if (vault.has_alter_name()) {
         if (!is_valid_storage_vault_name(vault.alter_name())) {
@@ -1105,6 +1176,7 @@ static int alter_s3_storage_vault_by_id(InstanceInfoPB& instance, std::unique_pt
         msg = ss.str();
         return -1;
     }
+    resolve_stale_gcp_workload_identity(new_vault.mutable_obj_info());
 
     auto origin_vault_info = new_vault.DebugString();
 
@@ -1146,6 +1218,38 @@ static int alter_s3_storage_vault_by_id(InstanceInfoPB& instance, std::unique_pt
         return -1;
     }
 
+    if (is_gcp_workload_identity_cred_provider(obj_info)) {
+        if (obj_info.has_ak() || obj_info.has_role_arn()) {
+            code = MetaServiceCode::INVALID_ARGUMENT;
+            msg = "invalid argument, GCP workload identity can not be set together with ak/sk or "
+                  "role_arn";
+            LOG(WARNING) << msg;
+            return -1;
+        }
+        if (!new_vault.obj_info().has_provider() ||
+            new_vault.obj_info().provider() != ObjectStoreInfoPB::GCP) {
+            code = MetaServiceCode::INVALID_ARGUMENT;
+            msg = "GCP workload identity is only supported for provider GCP";
+            LOG(WARNING) << msg;
+            return -1;
+        }
+        auto endpoint = new_vault.obj_info().endpoint();
+        if (!normalize_gcs_xml_endpoint(&endpoint, true)) {
+            code = MetaServiceCode::INVALID_ARGUMENT;
+            msg = fmt::format("GCP workload identity requires endpoint {}", GCS_XML_ENDPOINT);
+            LOG(WARNING) << msg;
+            return -1;
+        }
+        new_vault.mutable_obj_info()->clear_ak();
+        new_vault.mutable_obj_info()->clear_sk();
+        new_vault.mutable_obj_info()->clear_encryption_info();
+        new_vault.mutable_obj_info()->clear_role_arn();
+        new_vault.mutable_obj_info()->clear_external_id();
+        new_vault.mutable_obj_info()->set_endpoint(std::move(endpoint));
+        new_vault.mutable_obj_info()->set_cred_provider_type(
+                CredProviderTypePB::GCP_WORKLOAD_IDENTITY);
+    }
+
     if (obj_info.has_ak()) {
         EncryptionInfoPB encryption_info = new_vault.obj_info().encryption_info();
         AkSkPair new_ak_sk_pair {new_vault.obj_info().ak(), new_vault.obj_info().sk()};
@@ -1178,6 +1282,11 @@ static int alter_s3_storage_vault_by_id(InstanceInfoPB& instance, std::unique_pt
         if (obj_info.has_external_id()) {
             new_vault.mutable_obj_info()->set_external_id(obj_info.external_id());
         }
+    }
+
+    if (!validate_credential_provider(new_vault.mutable_obj_info(), true, code, msg)) {
+        LOG(WARNING) << msg;
+        return -1;
     }
 
     if (obj_info.has_use_path_style()) {
@@ -1496,7 +1605,20 @@ void MetaServiceImpl::alter_storage_vault(google::protobuf::RpcController* contr
         }
 
         if (use_credential_provider(obj)) {
-            if (!obj.has_provider() || obj.provider() != ObjectStoreInfoPB::S3) {
+            if (is_gcp_workload_identity_cred_provider(obj)) {
+                if (!obj.has_provider() || obj.provider() != ObjectStoreInfoPB::GCP ||
+                    has_non_empty_role_arn(obj)) {
+                    code = MetaServiceCode::INVALID_ARGUMENT;
+                    msg = "GCP workload identity requires provider GCP and no role_arn";
+                    return;
+                }
+                if (!normalize_gcs_xml_endpoint(&endpoint)) {
+                    code = MetaServiceCode::INVALID_ARGUMENT;
+                    msg = fmt::format("GCP workload identity requires endpoint {}",
+                                      GCS_XML_ENDPOINT);
+                    return;
+                }
+            } else if (!obj.has_provider() || obj.provider() != ObjectStoreInfoPB::S3) {
                 code = MetaServiceCode::INVALID_ARGUMENT;
                 msg = "s3 conf info err with credentials_provider_type, please check it";
                 return;
@@ -1582,7 +1704,7 @@ void MetaServiceImpl::alter_storage_vault(google::protobuf::RpcController* contr
             ret != 0) {
             return;
         }
-        return;
+        break;
     }
     case AlterObjStoreInfoRequest::DROP_HDFS_INFO: {
         if (auto ret = remove_hdfs_storage_vault(instance, txn.get(), request->vault(), code, msg);
@@ -1620,11 +1742,15 @@ void MetaServiceImpl::alter_storage_vault(google::protobuf::RpcController* contr
         break;
     }
     case AlterObjStoreInfoRequest::ALTER_S3_VAULT: {
-        alter_s3_storage_vault(instance, txn, request->vault(), code, msg, response);
+        if (alter_s3_storage_vault(instance, txn, request->vault(), code, msg, response) != 0) {
+            return;
+        }
         break;
     }
     case AlterObjStoreInfoRequest::ALTER_HDFS_VAULT: {
-        alter_hdfs_storage_vault(instance, txn, request->vault(), code, msg, response);
+        if (alter_hdfs_storage_vault(instance, txn, request->vault(), code, msg, response) != 0) {
+            return;
+        }
         break;
     }
     case AlterObjStoreInfoRequest::DROP_S3_VAULT:
@@ -2272,7 +2398,7 @@ void MetaServiceImpl::create_instance(google::protobuf::RpcController* controlle
     if (request->has_obj_info()) {
         create_object_info_with_encrypt(instance,
                                         const_cast<ObjectStoreInfoPB*>(&request->obj_info()),
-                                        request->sse_enabled(), code, msg);
+                                        request->sse_enabled(), false, code, msg);
         if (code != MetaServiceCode::OK) {
             return;
         }

--- a/cloud/src/recycler/s3_accessor.cpp
+++ b/cloud/src/recycler/s3_accessor.cpp
@@ -43,6 +43,7 @@
 #include "common/string_util.h"
 #include "common/util.h"
 #include "cpp/obj-client/auth/aws_credential_factory.h"
+#include "cpp/obj-client/auth/gcp_workload_identity_token_provider.h"
 #ifdef USE_AZURE
 #include "cpp/obj-client/auth/azure_auth_factory.h"
 #include "cpp/obj-client/azure_obj_storage_client.h"
@@ -299,6 +300,10 @@ std::optional<S3Conf> S3Conf::from_obj_store_info(const ObjectStoreInfoPB& obj_i
                 s3_conf.cred_provider_type = CredProviderType::InstanceProfile;
             }
         }
+
+        s3_conf.cred_provider_type = resolve_cred_provider_type(
+                s3_conf.cred_provider_type, !s3_conf.ak.empty() && !s3_conf.sk.empty(),
+                !s3_conf.role_arn.empty());
     }
 
     s3_conf.endpoint = obj_info.endpoint();
@@ -325,6 +330,14 @@ std::string S3Accessor::to_uri(const std::string& relative_path) const {
 
 int S3Accessor::create(S3Conf conf, std::shared_ptr<S3Accessor>* accessor) {
     TEST_SYNC_POINT_RETURN_WITH_VALUE("S3Accessor::init.s3_init_failed", (int)-1);
+    if (conf.cred_provider_type == CredProviderType::GcpWorkloadIdentity &&
+        (conf.provider != S3Conf::GCS || !is_gcs_xml_endpoint(conf.endpoint) || !conf.ak.empty() ||
+         !conf.sk.empty() || !conf.role_arn.empty())) {
+        LOG_WARNING("invalid GCP workload identity configuration")
+                .tag("provider", static_cast<int>(conf.provider))
+                .tag("endpoint", conf.endpoint);
+        return -1;
+    }
     switch (conf.provider) {
     case S3Conf::GCS:
         *accessor = std::make_shared<GcsAccessor>(conf);
@@ -447,6 +460,9 @@ int S3Accessor::init() {
                                              (long)aws_config.maxConnections);
 
         set_s3_client_default_http_scheme(aws_config, config::s3_client_http_scheme);
+        if (conf_.cred_provider_type == CredProviderType::GcpWorkloadIdentity) {
+            aws_config.scheme = Aws::Http::Scheme::HTTPS;
+        }
         // Recycler should fail fast on S3 SlowDown instead of retrying and blocking worker threads.
         aws_config.retryStrategy = std::make_shared<S3CustomRetryStrategy>(
                 config::max_s3_client_retry, /*retry_slow_down=*/false);
@@ -472,12 +488,18 @@ int S3Accessor::init() {
                 std::move(credentials.provider), std::move(aws_config),
                 Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
                 conf_.use_virtual_addressing /* useVirtualAddressing */);
-        auto client = std::make_shared<S3ObjStorageClient>(std::move(s3_client),
-                                                           ObjStorageEndpointInfo {
-                                                                   .endpoint = conf_.endpoint,
-                                                                   .ak = conf_.ak,
-                                                                   .sk = conf_.sk,
-                                                           });
+        std::shared_ptr<GcpWorkloadIdentityTokenProvider> token_provider;
+        if (conf_.cred_provider_type == CredProviderType::GcpWorkloadIdentity) {
+            token_provider = global_gcp_workload_identity_token_provider();
+        }
+        auto client = std::make_shared<S3ObjStorageClient>(
+                std::move(s3_client),
+                ObjStorageEndpointInfo {
+                        .endpoint = conf_.endpoint,
+                        .ak = conf_.ak,
+                        .sk = conf_.sk,
+                },
+                std::move(token_provider));
         obj_client_ = std::make_shared<RateLimitedObjStorageClient>(
                 std::move(client), std::make_shared<RecyclerObjStorageRateLimitPolicy>());
         return 0;

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -32,11 +32,13 @@
 #include <memory>
 #include <random>
 #include <string>
+#include <string_view>
 #include <thread>
 
 #include "common/config.h"
 #include "common/logging.h"
 #include "common/util.h"
+#include "cpp/aws_common.h"
 #include "cpp/sync_point.h"
 #include "meta-service/meta_service_helper.h"
 #include "meta-store/blob_message.h"
@@ -561,6 +563,41 @@ TEST(MetaServiceTest, CreateInstanceTest) {
         sp->disable_processing();
     }
 
+    // case: normal create instance with a GCP Workload Identity vault
+    {
+        brpc::Controller cntl;
+        CreateInstanceRequest req;
+        req.set_instance_id("test_instance_with_gcp_workload_identity");
+        req.set_user_id("test_user");
+        req.set_name("test_name");
+        auto* obj = req.mutable_vault()->mutable_obj_info();
+        obj->set_bucket("test_bucket");
+        obj->set_prefix("test_prefix");
+        obj->set_endpoint("Storage.GoogleApis.Com");
+        obj->set_region("us-central1");
+        obj->set_provider(ObjectStoreInfoPB::GCP);
+        obj->set_cred_provider_type(CredProviderTypePB::GCP_WORKLOAD_IDENTITY);
+
+        CreateInstanceResponse res;
+        meta_service->create_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                      &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+        std::string val;
+        ASSERT_EQ(txn->get(storage_vault_key({"test_instance_with_gcp_workload_identity", "1"}),
+                           &val),
+                  TxnErrorCode::TXN_OK);
+        StorageVaultPB vault;
+        ASSERT_TRUE(vault.ParseFromString(val));
+        ASSERT_EQ(vault.obj_info().endpoint(), GCS_XML_ENDPOINT);
+        ASSERT_EQ(vault.obj_info().cred_provider_type(), CredProviderTypePB::GCP_WORKLOAD_IDENTITY);
+        ASSERT_FALSE(vault.obj_info().has_ak());
+        ASSERT_FALSE(vault.obj_info().has_sk());
+        ASSERT_FALSE(vault.obj_info().has_encryption_info());
+    }
+
     // case: request has invalid argument
     {
         brpc::Controller cntl;
@@ -740,6 +777,37 @@ TEST(MetaServiceTest, AlterS3StorageVaultTest) {
 
     {
         AlterObjStoreInfoRequest req;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_op(AlterObjStoreInfoRequest::ALTER_S3_VAULT);
+        req.mutable_vault()->set_name(vault_name);
+        req.mutable_vault()->set_alter_name("rejected_workload_identity_rename");
+        req.mutable_vault()->mutable_obj_info()->set_cred_provider_type(
+                CredProviderTypePB::GCP_WORKLOAD_IDENTITY);
+
+        brpc::Controller cntl;
+        AlterObjStoreInfoResponse res;
+        meta_service->alter_storage_vault(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT) << res.status().msg();
+
+        InstanceInfoPB stored_instance;
+        get_test_instance(stored_instance);
+        ASSERT_EQ(stored_instance.storage_vault_names_size(), 1);
+        ASSERT_EQ(stored_instance.storage_vault_names(0), vault_name);
+
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+        std::string val;
+        ASSERT_EQ(txn->get(storage_vault_key({stored_instance.instance_id(), "2"}), &val),
+                  TxnErrorCode::TXN_OK);
+        StorageVaultPB stored_vault;
+        ASSERT_TRUE(stored_vault.ParseFromString(val));
+        ASSERT_EQ(stored_vault.name(), vault_name);
+        ASSERT_FALSE(stored_vault.obj_info().has_cred_provider_type());
+    }
+
+    {
+        AlterObjStoreInfoRequest req;
         constexpr char new_vault_name[] = "@!#vault_name";
         req.set_cloud_unique_id("test_cloud_unique_id");
         req.set_op(AlterObjStoreInfoRequest::ALTER_S3_VAULT);
@@ -813,6 +881,58 @@ TEST(MetaServiceTest, AlterS3StorageVaultTest) {
 
     SyncPoint::get_instance()->disable_processing();
     SyncPoint::get_instance()->clear_all_call_backs();
+}
+
+TEST(MetaServiceTest, AddBuiltInGcpWorkloadIdentityVaultTest) {
+    auto meta_service = get_meta_service();
+
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+    InstanceInfoPB instance;
+    instance.set_instance_id(mock_instance);
+    std::string key;
+    instance_key({mock_instance}, &key);
+    txn->put(key, instance.SerializeAsString());
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+    AlterObjStoreInfoRequest req;
+    req.set_cloud_unique_id("test_cloud_unique_id");
+    req.set_op(AlterObjStoreInfoRequest::ADD_BUILT_IN_VAULT);
+    auto* request_vault = req.mutable_vault();
+    request_vault->set_name(BUILT_IN_STORAGE_VAULT_NAME.data());
+    auto* obj = request_vault->mutable_obj_info();
+    obj->set_bucket("test_bucket");
+    obj->set_prefix("test_prefix");
+    obj->set_endpoint("Storage.GoogleApis.Com");
+    obj->set_region("us-central1");
+    obj->set_provider(ObjectStoreInfoPB::GCP);
+    obj->set_cred_provider_type(CredProviderTypePB::GCP_WORKLOAD_IDENTITY);
+
+    brpc::Controller cntl;
+    AlterObjStoreInfoResponse res;
+    meta_service->alter_storage_vault(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                      &req, &res, nullptr);
+    ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+
+    std::unique_ptr<Transaction> read_txn;
+    ASSERT_EQ(meta_service->txn_kv()->create_txn(&read_txn), TxnErrorCode::TXN_OK);
+    std::string val;
+    ASSERT_EQ(read_txn->get(key, &val), TxnErrorCode::TXN_OK);
+    InstanceInfoPB stored_instance;
+    ASSERT_TRUE(stored_instance.ParseFromString(val));
+    ASSERT_EQ(stored_instance.resource_ids_size(), 1);
+    ASSERT_EQ(stored_instance.resource_ids(0), "1");
+    ASSERT_EQ(stored_instance.storage_vault_names(0), BUILT_IN_STORAGE_VAULT_NAME.data());
+
+    ASSERT_EQ(read_txn->get(storage_vault_key({mock_instance, "1"}), &val), TxnErrorCode::TXN_OK);
+    StorageVaultPB stored_vault;
+    ASSERT_TRUE(stored_vault.ParseFromString(val));
+    ASSERT_EQ(stored_vault.obj_info().endpoint(), GCS_XML_ENDPOINT);
+    ASSERT_EQ(stored_vault.obj_info().cred_provider_type(),
+              CredProviderTypePB::GCP_WORKLOAD_IDENTITY);
+    ASSERT_FALSE(stored_vault.obj_info().has_ak());
+    ASSERT_FALSE(stored_vault.obj_info().has_sk());
+    ASSERT_FALSE(stored_vault.obj_info().has_encryption_info());
 }
 
 TEST(MetaServiceTest, AlterHdfsStorageVaultTest) {
@@ -10692,6 +10812,272 @@ TEST(MetaServiceTest, CreateS3VaultWithIamRole) {
     }
 
     LOG(INFO) << "instance:" << instance.ShortDebugString();
+    SyncPoint::get_instance()->disable_processing();
+    SyncPoint::get_instance()->clear_all_call_backs();
+}
+
+TEST(MetaServiceTest, CreateAndAlterS3VaultWithGcpWorkloadIdentity) {
+    auto sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    sp->set_call_back("encrypt_ak_sk:get_encryption_key", [](auto&& args) {
+        auto* ret = try_any_cast<int*>(args[0]);
+        *ret = 0;
+        auto* key = try_any_cast<std::string*>(args[1]);
+        *key = "selectdbselectdbselectdbselectdb";
+        auto* key_id = try_any_cast<int64_t*>(args[2]);
+        *key_id = 1;
+    });
+
+    auto meta_service = get_meta_service();
+
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+    std::string key;
+    std::string val;
+    InstanceKeyInfo key_info {"test_instance"};
+    instance_key(key_info, &key);
+
+    InstanceInfoPB instance;
+    instance.set_instance_id("GetObjStoreInfoTestInstance");
+    instance.set_enable_storage_vault(true);
+    val = instance.SerializeAsString();
+    txn->put(key, val);
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+    txn = nullptr;
+
+    auto add_vault = [&](StorageVaultPB vault, AlterObjStoreInfoResponse* res) {
+        AlterObjStoreInfoRequest req;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_op(AlterObjStoreInfoRequest::ADD_S3_VAULT);
+        req.mutable_vault()->CopyFrom(vault);
+        brpc::Controller cntl;
+        meta_service->alter_storage_vault(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, res, nullptr);
+    };
+
+    auto get_vault = [&](const std::string& vault_id, StorageVaultPB* vault) {
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+        std::string val;
+        ASSERT_EQ(txn->get(storage_vault_key({"GetObjStoreInfoTestInstance", vault_id}), &val),
+                  TxnErrorCode::TXN_OK);
+        vault->ParseFromString(val);
+    };
+
+    auto make_workload_identity_vault = [](std::string name, std::string_view endpoint,
+                                           ObjectStoreInfoPB::Provider provider) {
+        StorageVaultPB vault;
+        vault.set_name(std::move(name));
+        auto* obj_info = vault.mutable_obj_info();
+        obj_info->set_endpoint(std::string(endpoint));
+        obj_info->set_region("us-central1");
+        obj_info->set_bucket("test_bucket");
+        obj_info->set_prefix("test_prefix");
+        obj_info->set_provider(provider);
+        obj_info->set_cred_provider_type(CredProviderTypePB::GCP_WORKLOAD_IDENTITY);
+        return vault;
+    };
+
+    std::string workload_identity_vault_id;
+    {
+        auto vault = make_workload_identity_vault("gcp_workload_identity_vault",
+                                                  "storage.googleapis.com", ObjectStoreInfoPB::GCP);
+
+        AlterObjStoreInfoResponse res;
+        add_vault(vault, &res);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+        workload_identity_vault_id = res.storage_vault_id();
+
+        StorageVaultPB get_obj;
+        get_vault(workload_identity_vault_id, &get_obj);
+        ASSERT_FALSE(get_obj.obj_info().has_ak());
+        ASSERT_FALSE(get_obj.obj_info().has_role_arn());
+        ASSERT_EQ(get_obj.obj_info().cred_provider_type(),
+                  CredProviderTypePB::GCP_WORKLOAD_IDENTITY)
+                << get_obj.obj_info().cred_provider_type();
+        ASSERT_EQ(get_obj.obj_info().endpoint(), GCS_XML_ENDPOINT);
+    }
+
+    int invalid_endpoint_index = 0;
+    for (const auto& endpoint : {"http://storage.googleapis.com", "https://example.com"}) {
+        auto vault = make_workload_identity_vault(
+                fmt::format("gcp_workload_identity_invalid_endpoint_{}", invalid_endpoint_index++),
+                endpoint, ObjectStoreInfoPB::GCP);
+
+        AlterObjStoreInfoResponse res;
+        add_vault(vault, &res);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT) << res.status().msg();
+    }
+
+    {
+        auto vault = make_workload_identity_vault("gcp_workload_identity_wrong_provider_vault",
+                                                  GCS_XML_ENDPOINT, ObjectStoreInfoPB::S3);
+
+        AlterObjStoreInfoResponse res;
+        add_vault(vault, &res);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT) << res.status().msg();
+    }
+
+    {
+        auto vault = make_workload_identity_vault("gcp_workload_identity_role_arn_vault",
+                                                  GCS_XML_ENDPOINT, ObjectStoreInfoPB::GCP);
+        vault.mutable_obj_info()->set_role_arn("arn:aws:iam::123456789012:role/test-role");
+
+        AlterObjStoreInfoResponse res;
+        add_vault(vault, &res);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT) << res.status().msg();
+    }
+
+    std::string hmac_vault_id;
+    {
+        // A GCP vault created with HMAC keys...
+        StorageVaultPB vault;
+        vault.mutable_obj_info()->set_endpoint("Storage.GoogleApis.Com");
+        vault.mutable_obj_info()->set_region("us-central1");
+        vault.mutable_obj_info()->set_bucket("test_bucket");
+        vault.mutable_obj_info()->set_prefix("test_prefix_hmac");
+        vault.mutable_obj_info()->set_ak("hmac_ak");
+        vault.mutable_obj_info()->set_sk("hmac_sk");
+        vault.mutable_obj_info()->set_provider(
+                ObjectStoreInfoPB::Provider::ObjectStoreInfoPB_Provider_GCP);
+        vault.set_name("gcp_hmac_vault");
+
+        AlterObjStoreInfoResponse res;
+        add_vault(vault, &res);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+        hmac_vault_id = res.storage_vault_id();
+    }
+
+    {
+        // ...can be altered to Workload Identity, which clears the stored keys.
+        AlterObjStoreInfoRequest req;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_op(AlterObjStoreInfoRequest::ALTER_S3_VAULT);
+        req.mutable_vault()->set_name("gcp_hmac_vault");
+        req.mutable_vault()->mutable_obj_info()->set_cred_provider_type(
+                CredProviderTypePB::GCP_WORKLOAD_IDENTITY);
+
+        brpc::Controller cntl;
+        AlterObjStoreInfoResponse res;
+        meta_service->alter_storage_vault(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+
+        StorageVaultPB get_obj;
+        get_vault(hmac_vault_id, &get_obj);
+        ASSERT_FALSE(get_obj.obj_info().has_ak());
+        ASSERT_FALSE(get_obj.obj_info().has_sk());
+        ASSERT_FALSE(get_obj.obj_info().has_encryption_info());
+        ASSERT_EQ(get_obj.obj_info().cred_provider_type(),
+                  CredProviderTypePB::GCP_WORKLOAD_IDENTITY)
+                << get_obj.obj_info().cred_provider_type();
+        ASSERT_EQ(get_obj.obj_info().endpoint(), GCS_XML_ENDPOINT);
+    }
+
+    {
+        // An AWS role cannot be persisted on a GCP Workload Identity vault.
+        AlterObjStoreInfoRequest req;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_op(AlterObjStoreInfoRequest::ALTER_S3_VAULT);
+        req.mutable_vault()->set_name("gcp_hmac_vault");
+        req.mutable_vault()->mutable_obj_info()->set_role_arn(
+                "arn:aws:iam::123456789012:role/test-role");
+        req.mutable_vault()->mutable_obj_info()->set_cred_provider_type(
+                CredProviderTypePB::INSTANCE_PROFILE);
+
+        brpc::Controller cntl;
+        AlterObjStoreInfoResponse res;
+        meta_service->alter_storage_vault(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT) << res.status().msg();
+
+        StorageVaultPB get_obj;
+        get_vault(hmac_vault_id, &get_obj);
+        ASSERT_EQ(get_obj.obj_info().cred_provider_type(),
+                  CredProviderTypePB::GCP_WORKLOAD_IDENTITY);
+        ASSERT_FALSE(get_obj.obj_info().has_role_arn());
+    }
+
+    {
+        // Workload Identity can be altered back to HMAC credentials.
+        AlterObjStoreInfoRequest req;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_op(AlterObjStoreInfoRequest::ALTER_S3_VAULT);
+        req.mutable_vault()->set_name("gcp_hmac_vault");
+        req.mutable_vault()->mutable_obj_info()->set_ak("new_hmac_ak");
+        req.mutable_vault()->mutable_obj_info()->set_sk("new_hmac_sk");
+
+        brpc::Controller cntl;
+        AlterObjStoreInfoResponse res;
+        meta_service->alter_storage_vault(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+
+        StorageVaultPB get_obj;
+        get_vault(hmac_vault_id, &get_obj);
+        ASSERT_TRUE(get_obj.obj_info().has_ak());
+        ASSERT_TRUE(get_obj.obj_info().has_sk());
+        ASSERT_EQ(get_obj.obj_info().ak(), "new_hmac_ak");
+        ASSERT_NE(get_obj.obj_info().sk(), "new_hmac_sk");
+        ASSERT_TRUE(get_obj.obj_info().has_encryption_info());
+        ASSERT_FALSE(get_obj.obj_info().has_cred_provider_type());
+        ASSERT_FALSE(get_obj.obj_info().has_role_arn());
+        ASSERT_EQ(get_obj.obj_info().endpoint(), GCS_XML_ENDPOINT);
+    }
+
+    {
+        // Older binaries preserve an unknown enum field. If it reappears after rollback, the
+        // explicit HMAC credentials still identify the active authentication mode.
+        std::unique_ptr<Transaction> write_txn;
+        ASSERT_EQ(meta_service->txn_kv()->create_txn(&write_txn), TxnErrorCode::TXN_OK);
+        auto vault_key = storage_vault_key({"GetObjStoreInfoTestInstance", hmac_vault_id});
+        std::string persisted;
+        ASSERT_EQ(write_txn->get(vault_key, &persisted), TxnErrorCode::TXN_OK);
+        StorageVaultPB stale_vault;
+        ASSERT_TRUE(stale_vault.ParseFromString(persisted));
+        stale_vault.mutable_obj_info()->set_cred_provider_type(
+                CredProviderTypePB::GCP_WORKLOAD_IDENTITY);
+        write_txn->put(vault_key, stale_vault.SerializeAsString());
+        ASSERT_EQ(write_txn->commit(), TxnErrorCode::TXN_OK);
+
+        AlterObjStoreInfoRequest req;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_op(AlterObjStoreInfoRequest::ALTER_S3_VAULT);
+        req.mutable_vault()->set_name("gcp_hmac_vault");
+        req.mutable_vault()->mutable_obj_info()->set_use_path_style(true);
+
+        brpc::Controller cntl;
+        AlterObjStoreInfoResponse res;
+        meta_service->alter_storage_vault(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+
+        StorageVaultPB get_obj;
+        get_vault(hmac_vault_id, &get_obj);
+        ASSERT_FALSE(get_obj.obj_info().has_cred_provider_type());
+        ASSERT_TRUE(get_obj.obj_info().has_ak());
+        ASSERT_TRUE(get_obj.obj_info().has_sk());
+        ASSERT_TRUE(get_obj.obj_info().use_path_style());
+    }
+
+    {
+        // Altering to Workload Identity together with ak/sk in one request is rejected.
+        AlterObjStoreInfoRequest req;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_op(AlterObjStoreInfoRequest::ALTER_S3_VAULT);
+        req.mutable_vault()->set_name("gcp_hmac_vault");
+        req.mutable_vault()->mutable_obj_info()->set_cred_provider_type(
+                CredProviderTypePB::GCP_WORKLOAD_IDENTITY);
+        req.mutable_vault()->mutable_obj_info()->set_ak("new_ak");
+        req.mutable_vault()->mutable_obj_info()->set_sk("new_sk");
+
+        brpc::Controller cntl;
+        AlterObjStoreInfoResponse res;
+        meta_service->alter_storage_vault(
+                reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), MetaServiceCode::INVALID_ARGUMENT) << res.status().msg();
+    }
+
     SyncPoint::get_instance()->disable_processing();
     SyncPoint::get_instance()->clear_all_call_backs();
 }

--- a/cloud/test/s3_accessor_test.cpp
+++ b/cloud/test/s3_accessor_test.cpp
@@ -62,6 +62,28 @@ class S3AccessorTest : public testing::Test {
     }
 };
 
+TEST(S3ConfTest, ExplicitCredentialsOverrideStaleWorkloadIdentity) {
+    ObjectStoreInfoPB obj_info;
+    obj_info.set_provider(ObjectStoreInfoPB::GCP);
+    obj_info.set_endpoint("https://storage.googleapis.com");
+    obj_info.set_region("us-central1");
+    obj_info.set_bucket("bucket");
+    obj_info.set_cred_provider_type(CredProviderTypePB::GCP_WORKLOAD_IDENTITY);
+    obj_info.set_ak("access-key");
+    obj_info.set_sk("secret-key");
+
+    auto conf = S3Conf::from_obj_store_info(obj_info);
+    ASSERT_TRUE(conf.has_value());
+    EXPECT_EQ(conf->cred_provider_type, CredProviderType::Default);
+
+    obj_info.clear_ak();
+    obj_info.clear_sk();
+    obj_info.set_role_arn("arn:aws:iam::123456789012:role/test-role");
+    conf = S3Conf::from_obj_store_info(obj_info);
+    ASSERT_TRUE(conf.has_value());
+    EXPECT_EQ(conf->cred_provider_type, CredProviderType::InstanceProfile);
+}
+
 void test_s3_accessor(S3Accessor& accessor) {
     std::string file1 = "data/10000/1_0.dat";
 

--- a/common/cpp/aws_common.cpp
+++ b/common/cpp/aws_common.cpp
@@ -40,6 +40,8 @@ CredProviderType cred_provider_type_from_pb(cloud::CredProviderTypePB cred_provi
         return CredProviderType::Container;
     case cloud::CredProviderTypePB::ANONYMOUS:
         return CredProviderType::Anonymous;
+    case cloud::CredProviderTypePB::GCP_WORKLOAD_IDENTITY:
+        return CredProviderType::GcpWorkloadIdentity;
     default:
         __builtin_unreachable();
         LOG(WARNING) << "Invalid CredProviderTypePB value: " << cred_provider_type
@@ -73,8 +75,31 @@ CredProviderType cred_provider_type_from_string(const std::string& type) {
     if (type == "ANONYMOUS") {
         return CredProviderType::Anonymous;
     }
+    if (type == "GCP_WORKLOAD_IDENTITY") {
+        return CredProviderType::GcpWorkloadIdentity;
+    }
     LOG(WARNING) << "Unknown credentials provider type: " << type << ", use default instead.";
     return CredProviderType::Default;
+}
+
+CredProviderType resolve_cred_provider_type(CredProviderType configured_type,
+                                            bool has_static_credentials, bool has_role_arn) {
+    if (configured_type != CredProviderType::GcpWorkloadIdentity) {
+        return configured_type;
+    }
+    // Old protobuf consumers preserve the Workload Identity enum as an unknown field. Explicit
+    // credentials must win if that stale value reappears after a downgrade and later upgrade.
+    if (has_static_credentials) {
+        return CredProviderType::Default;
+    }
+    if (has_role_arn) {
+        return CredProviderType::InstanceProfile;
+    }
+    return configured_type;
+}
+
+bool is_gcs_xml_endpoint(std::string_view endpoint) {
+    return endpoint == GCS_XML_ENDPOINT;
 }
 
 std::string get_valid_ca_cert_path(const std::vector<std::string>& ca_cert_file_paths) {

--- a/common/cpp/aws_common.h
+++ b/common/cpp/aws_common.h
@@ -20,6 +20,9 @@
 #include <gen_cpp/cloud.pb.h>
 
 #include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
 
 namespace Aws::Client {
 struct ClientConfiguration;
@@ -35,12 +38,21 @@ enum class CredProviderType {
     SystemProperties = 4,
     WebIdentity = 5,
     Container = 6,
-    Anonymous = 7
+    Anonymous = 7,
+    // GKE Workload Identity; only valid with provider GCP.
+    GcpWorkloadIdentity = 8
 };
+
+inline constexpr std::string_view GCS_XML_ENDPOINT = "https://storage.googleapis.com";
+
+bool is_gcs_xml_endpoint(std::string_view endpoint);
 
 CredProviderType cred_provider_type_from_pb(cloud::CredProviderTypePB cred_provider_type);
 
 CredProviderType cred_provider_type_from_string(const std::string& type);
+
+CredProviderType resolve_cred_provider_type(CredProviderType configured_type,
+                                            bool has_static_credentials, bool has_role_arn);
 
 std::string get_valid_ca_cert_path(const std::vector<std::string>& ca_cert_file_paths);
 

--- a/common/cpp/obj-client/auth/aws_credential_factory.cpp
+++ b/common/cpp/obj-client/auth/aws_credential_factory.cpp
@@ -44,6 +44,7 @@ std::shared_ptr<Provider> create_v2_base_provider(CredProviderType type) {
         return std::make_shared<Aws::Auth::TaskRoleCredentialsProvider>(
                 Aws::Environment::GetEnv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI").c_str());
     case CredProviderType::Anonymous:
+    case CredProviderType::GcpWorkloadIdentity:
         return std::make_shared<Aws::Auth::AnonymousAWSCredentialsProvider>();
     case CredProviderType::Default:
     case CredProviderType::Simple:
@@ -79,6 +80,12 @@ AwsCredentialResult AwsCredentialFactory::create(const AwsCredentialOptions& opt
         return {
                 .provider = std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(
                         std::move(credentials)),
+        };
+    }
+
+    if (options.provider_type == CredProviderType::GcpWorkloadIdentity) {
+        return {
+                .provider = std::make_shared<Aws::Auth::AnonymousAWSCredentialsProvider>(),
         };
     }
 

--- a/common/cpp/obj-client/auth/gcp_workload_identity_token_provider.cpp
+++ b/common/cpp/obj-client/auth/gcp_workload_identity_token_provider.cpp
@@ -1,0 +1,156 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "gcp_workload_identity_token_provider.h"
+
+#include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/http/HttpClient.h>
+#include <aws/core/http/HttpClientFactory.h>
+#include <aws/core/http/HttpResponse.h>
+#include <aws/core/utils/json/JsonSerializer.h>
+#include <aws/core/utils/stream/ResponseStream.h>
+#include <glog/logging.h>
+
+#include <sstream>
+#include <string_view>
+#include <utility>
+
+namespace doris {
+namespace {
+
+constexpr std::chrono::seconds REFRESH_MARGIN {300};
+constexpr std::chrono::seconds REFRESH_RETRY_DELAY {30};
+constexpr std::string_view METADATA_TOKEN_URL =
+        "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+
+Aws::Client::ClientConfiguration http_client_configuration() {
+    Aws::Client::ClientConfiguration config(false, "legacy", true);
+    config.connectTimeoutMs = 2000;
+    config.requestTimeoutMs = 5000;
+    config.followRedirects = Aws::Client::FollowRedirectsPolicy::NEVER;
+    config.allowSystemProxy = false;
+    config.proxyHost.clear();
+    config.proxyUserName.clear();
+    config.proxyPassword.clear();
+    config.proxyPort = 0;
+    return config;
+}
+
+bool fetch_from_metadata_server(std::string* token, std::chrono::seconds* expires_in) {
+    auto request =
+            Aws::Http::CreateHttpRequest(Aws::String(METADATA_TOKEN_URL.data()),
+                                         Aws::Http::HttpMethod::HTTP_GET,
+                                         Aws::Utils::Stream::DefaultResponseStreamFactoryMethod);
+    request->SetHeaderValue("Metadata-Flavor", "Google");
+
+    auto client = Aws::Http::CreateHttpClient(http_client_configuration());
+    auto response = client->MakeRequest(request);
+    if (response == nullptr || response->GetResponseCode() != Aws::Http::HttpResponseCode::OK) {
+        LOG(WARNING) << "GCP workload identity: metadata token request failed, http_code="
+                     << (response == nullptr ? -1 : static_cast<int>(response->GetResponseCode()));
+        return false;
+    }
+
+    std::stringstream body;
+    body << response->GetResponseBody().rdbuf();
+    Aws::Utils::Json::JsonValue json(Aws::String(body.str()));
+    if (!json.WasParseSuccessful()) {
+        LOG(WARNING) << "GCP workload identity: metadata server returned invalid JSON";
+        return false;
+    }
+
+    auto view = json.View();
+    if (!view.ValueExists("access_token") || !view.ValueExists("expires_in")) {
+        LOG(WARNING) << "GCP workload identity: metadata response is missing access_token or "
+                        "expires_in";
+        return false;
+    }
+
+    *token = view.GetString("access_token");
+    *expires_in = std::chrono::seconds(view.GetInteger("expires_in"));
+    if (token->empty() || *expires_in <= std::chrono::seconds::zero()) {
+        LOG(WARNING) << "GCP workload identity: metadata server returned an invalid token";
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+GcpWorkloadIdentityTokenProvider::GcpWorkloadIdentityTokenProvider()
+        : GcpWorkloadIdentityTokenProvider(fetch_from_metadata_server,
+                                           std::chrono::steady_clock::now) {}
+
+GcpWorkloadIdentityTokenProvider::GcpWorkloadIdentityTokenProvider(TokenFetcher fetcher,
+                                                                   Clock clock)
+        : _fetcher(std::move(fetcher)), _clock(std::move(clock)) {}
+
+std::string GcpWorkloadIdentityTokenProvider::get_token() {
+    std::unique_lock lock(_mutex);
+    while (true) {
+        auto now = _clock();
+        bool has_valid_token = !_cached_token.empty() && now < _expire_at;
+        if (has_valid_token && now + REFRESH_MARGIN < _expire_at) {
+            return _cached_token;
+        }
+        if (now < _next_refresh_attempt) {
+            return has_valid_token ? _cached_token : "";
+        }
+        if (!_refresh_in_progress) {
+            _refresh_in_progress = true;
+            break;
+        }
+        if (has_valid_token) {
+            return _cached_token;
+        }
+        _refresh_complete.wait(lock, [this] { return !_refresh_in_progress; });
+    }
+
+    std::string token;
+    std::chrono::seconds expires_in {0};
+    lock.unlock();
+    bool refreshed = _fetcher(&token, &expires_in) && !token.empty() &&
+                     expires_in > std::chrono::seconds::zero();
+    lock.lock();
+
+    auto now = _clock();
+    if (refreshed) {
+        _cached_token = std::move(token);
+        _expire_at = now + expires_in;
+        _next_refresh_attempt = {};
+    } else {
+        _next_refresh_attempt = now + REFRESH_RETRY_DELAY;
+    }
+    _refresh_in_progress = false;
+    _refresh_complete.notify_all();
+
+    if (!refreshed) {
+        if (!_cached_token.empty() && now < _expire_at) {
+            return _cached_token;
+        }
+        LOG(WARNING) << "GCP workload identity: no valid access token is available";
+        return "";
+    }
+    return _cached_token;
+}
+
+std::shared_ptr<GcpWorkloadIdentityTokenProvider> global_gcp_workload_identity_token_provider() {
+    static auto provider = std::make_shared<GcpWorkloadIdentityTokenProvider>();
+    return provider;
+}
+
+} // namespace doris

--- a/common/cpp/obj-client/auth/gcp_workload_identity_token_provider.h
+++ b/common/cpp/obj-client/auth/gcp_workload_identity_token_provider.h
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace doris {
+
+// Provides short-lived Google OAuth2 access tokens from the GCE/GKE metadata server.
+class GcpWorkloadIdentityTokenProvider {
+public:
+    using Clock = std::function<std::chrono::steady_clock::time_point()>;
+    using TokenFetcher = std::function<bool(std::string* token, std::chrono::seconds* expires_in)>;
+
+    GcpWorkloadIdentityTokenProvider();
+    GcpWorkloadIdentityTokenProvider(TokenFetcher fetcher, Clock clock);
+
+    GcpWorkloadIdentityTokenProvider(const GcpWorkloadIdentityTokenProvider&) = delete;
+    GcpWorkloadIdentityTokenProvider& operator=(const GcpWorkloadIdentityTokenProvider&) = delete;
+
+    // Returns a valid token, or an empty string if no valid token is available. A still-valid
+    // cached token is retained across transient refresh failures.
+    std::string get_token();
+
+private:
+    TokenFetcher _fetcher;
+    Clock _clock;
+    std::mutex _mutex;
+    std::condition_variable _refresh_complete;
+    bool _refresh_in_progress = false;
+    std::string _cached_token;
+    std::chrono::steady_clock::time_point _expire_at {};
+    std::chrono::steady_clock::time_point _next_refresh_attempt {};
+};
+
+// All vaults in a process use the same pod identity and can share one token cache.
+std::shared_ptr<GcpWorkloadIdentityTokenProvider> global_gcp_workload_identity_token_provider();
+
+} // namespace doris

--- a/common/cpp/obj-client/s3_obj_storage_client.cpp
+++ b/common/cpp/obj-client/s3_obj_storage_client.cpp
@@ -71,10 +71,21 @@ ObjStorageStatus s3fs_error(const Aws::S3::S3Error& err, std::string_view msg) {
                                              s3_error_message(err, msg));
 }
 
+ObjStorageResponse S3ObjStorageClient::_gcp_token_unavailable() {
+    return {
+            .status = {ObjStorageStatus::NETWORK_ERROR,
+                       "GCP workload identity token is unavailable"},
+            .http_code = 0,
+    };
+}
+
 ObjStorageUploadResult S3ObjStorageClient::create_multipart_upload(const ObjStoragePath& opts) {
     CreateMultipartUploadRequest request;
     request.WithBucket(opts.bucket).WithKey(opts.key);
     request.SetContentType("application/octet-stream");
+    if (!_set_gcp_authorization_header(request)) {
+        return {.resp = _gcp_token_unavailable()};
+    }
 
     const auto start = std::chrono::steady_clock::now();
     auto outcome = SYNC_POINT_HOOK_RETURN_VALUE(
@@ -120,6 +131,9 @@ ObjStorageResponse S3ObjStorageClient::put_object(const ObjStoragePath& opts,
     request.SetBody(string_view_stream);
     request.SetContentLength(stream.size());
     request.SetContentType("application/octet-stream");
+    if (!_set_gcp_authorization_header(request)) {
+        return _gcp_token_unavailable();
+    }
 
     const auto start = std::chrono::steady_clock::now();
     auto outcome = SYNC_POINT_HOOK_RETURN_VALUE(
@@ -167,6 +181,9 @@ ObjStorageUploadResult S3ObjStorageClient::upload_part(const ObjStoragePath& opt
 
     request.SetContentLength(stream.size());
     request.SetContentType("application/octet-stream");
+    if (!_set_gcp_authorization_header(request)) {
+        return {.resp = _gcp_token_unavailable()};
+    }
 
     const auto start = std::chrono::steady_clock::now();
     auto outcome = SYNC_POINT_HOOK_RETURN_VALUE(
@@ -220,6 +237,9 @@ ObjStorageResponse S3ObjStorageClient::complete_multipart_upload(
                            });
     completed_upload.SetParts(std::move(complete_parts));
     request.WithMultipartUpload(completed_upload);
+    if (!_set_gcp_authorization_header(request)) {
+        return _gcp_token_unavailable();
+    }
 
     TEST_SYNC_POINT_RETURN_WITH_VALUE("S3FileWriter::_complete:3", ObjStorageResponse(), this);
 
@@ -257,6 +277,9 @@ ObjStorageResponse S3ObjStorageClient::complete_multipart_upload(
 ObjStorageHeadResult S3ObjStorageClient::head_object(const ObjStoragePath& opts) {
     Aws::S3::Model::HeadObjectRequest request;
     request.WithBucket(opts.bucket).WithKey(opts.key);
+    if (!_set_gcp_authorization_header(request)) {
+        return {.resp = _gcp_token_unavailable()};
+    }
 
     auto outcome = SYNC_POINT_HOOK_RETURN_VALUE(
             [&]() {
@@ -292,6 +315,9 @@ ObjStorageResponse S3ObjStorageClient::get_object(const ObjStoragePath& opts, vo
     request.WithBucket(opts.bucket).WithKey(opts.key);
     request.SetRange(fmt::format("bytes={}-{}", offset, offset + bytes_read - 1));
     request.SetResponseStreamFactory(AwsWriteableStreamFactory(buffer, bytes_read));
+    if (!_set_gcp_authorization_header(request)) {
+        return _gcp_token_unavailable();
+    }
 
     auto outcome = [&]() {
         client_bvar::ScopedLatency scoped_latency(client_bvar::s3_get_latency);
@@ -329,6 +355,9 @@ ObjStorageListPageResult S3ObjStorageClient::list_objects_page(
             .WithMaxKeys(static_cast<int>(capabilities().max_list_page));
     if (!continuation_token.empty()) {
         request.SetContinuationToken(std::string(continuation_token));
+    }
+    if (!_set_gcp_authorization_header(request)) {
+        return {.resp = _gcp_token_unavailable()};
     }
     TEST_SYNC_POINT_CALLBACK("S3ObjStorageClient::list_objects", &request);
 
@@ -418,6 +447,9 @@ ObjStorageResponse S3ObjStorageClient::delete_objects(const ObjStoragePath& opts
         }
         del.WithObjects(std::move(objects)).SetQuiet(true);
         delete_request.SetDelete(std::move(del));
+        if (!_set_gcp_authorization_header(delete_request)) {
+            return _gcp_token_unavailable();
+        }
 
         auto delete_outcome = [&]() {
             client_bvar::ScopedLatency scoped_latency(client_bvar::s3_delete_objects_latency);
@@ -462,6 +494,9 @@ ObjStorageResponse S3ObjStorageClient::delete_objects(const ObjStoragePath& opts
 ObjStorageResponse S3ObjStorageClient::delete_object(const ObjStoragePath& opts) {
     Aws::S3::Model::DeleteObjectRequest request;
     request.WithBucket(opts.bucket).WithKey(opts.key);
+    if (!_set_gcp_authorization_header(request)) {
+        return _gcp_token_unavailable();
+    }
 
     auto outcome = [&]() {
         client_bvar::ScopedLatency scoped_latency(client_bvar::s3_delete_object_latency);
@@ -493,6 +528,9 @@ ObjStorageResponse S3ObjStorageClient::delete_object(const ObjStoragePath& opts)
 
 std::string S3ObjStorageClient::generate_presigned_url(const ObjStoragePath& opts,
                                                        int64_t expiration_secs) {
+    if (_token_provider != nullptr) {
+        return {};
+    }
     return _client->GeneratePresignedUrl(opts.bucket, opts.key, Aws::Http::HttpMethod::HTTP_GET,
                                          expiration_secs);
 }
@@ -500,6 +538,9 @@ std::string S3ObjStorageClient::generate_presigned_url(const ObjStoragePath& opt
 ObjStorageResponse S3ObjStorageClient::check_versioning(const std::string& bucket) {
     Aws::S3::Model::GetBucketVersioningRequest request;
     request.SetBucket(bucket);
+    if (!_set_gcp_authorization_header(request)) {
+        return _gcp_token_unavailable();
+    }
 
     auto outcome = _client->GetBucketVersioning(request);
 
@@ -532,6 +573,9 @@ ObjStorageResponse S3ObjStorageClient::abort_multipart_upload(const ObjStoragePa
                                                               const std::string& upload_id) {
     Aws::S3::Model::AbortMultipartUploadRequest request;
     request.WithBucket(opts.bucket).WithKey(opts.key).WithUploadId(upload_id);
+    if (!_set_gcp_authorization_header(request)) {
+        return _gcp_token_unavailable();
+    }
 
     auto outcome = _client->AbortMultipartUpload(request);
     if (!outcome.IsSuccess()) {
@@ -561,6 +605,9 @@ ObjStorageResponse S3ObjStorageClient::get_lifecycle(const std::string& bucket,
                                                      int64_t* expiration_days) {
     Aws::S3::Model::GetBucketLifecycleConfigurationRequest request;
     request.SetBucket(bucket);
+    if (!_set_gcp_authorization_header(request)) {
+        return _gcp_token_unavailable();
+    }
 
     auto outcome = _client->GetBucketLifecycleConfiguration(request);
     bool has_lifecycle = false;

--- a/common/cpp/obj-client/s3_obj_storage_client.h
+++ b/common/cpp/obj-client/s3_obj_storage_client.h
@@ -70,6 +70,7 @@
 #include <memory>
 #include <ranges>
 
+#include "auth/gcp_workload_identity_token_provider.h"
 #include "client_bvar.h"
 #include "cpp/obj_retry_strategy.h"
 #include "cpp/sync_point.h"
@@ -90,8 +91,11 @@ ObjStorageStatus s3fs_error(const Aws::S3::S3Error& err, std::string_view msg);
 class S3ObjStorageClient final : public ObjStorageClient {
 public:
     S3ObjStorageClient(std::shared_ptr<Aws::S3::S3Client> client,
-                       ObjStorageEndpointInfo config = {})
-            : _config(std::move(config)), _client(std::move(client)) {}
+                       ObjStorageEndpointInfo config = {},
+                       std::shared_ptr<GcpWorkloadIdentityTokenProvider> token_provider = nullptr)
+            : _config(std::move(config)),
+              _client(std::move(client)),
+              _token_provider(std::move(token_provider)) {}
     ~S3ObjStorageClient() override = default;
     ObjStorageUploadResult create_multipart_upload(const ObjStoragePath& opts) override;
     ObjStorageResponse put_object(const ObjStoragePath& opts, std::string_view stream) override;
@@ -123,8 +127,25 @@ protected:
                                                std::string_view continuation_token) override;
 
 private:
+    template <typename Request>
+    bool _set_gcp_authorization_header(Request& request) const {
+        if (_token_provider == nullptr) {
+            return true;
+        }
+        auto token = _token_provider->get_token();
+        if (token.empty()) {
+            return false;
+        }
+        request.SetAdditionalCustomHeaderValue("Authorization",
+                                               Aws::String("Bearer ") + token.c_str());
+        return true;
+    }
+
+    static ObjStorageResponse _gcp_token_unavailable();
+
     ObjStorageEndpointInfo _config;
     std::shared_ptr<Aws::S3::S3Client> _client;
+    std::shared_ptr<GcpWorkloadIdentityTokenProvider> _token_provider;
 };
 
 } // namespace doris

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/S3Resource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/S3Resource.java
@@ -28,6 +28,7 @@ import org.apache.doris.filesystem.spi.ObjFileSystem;
 import org.apache.doris.filesystem.spi.ObjStorage;
 import org.apache.doris.filesystem.spi.RequestBody;
 import org.apache.doris.fs.FileSystemFactory;
+import org.apache.doris.nereids.trees.plans.commands.CreateResourceCommand;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -86,14 +87,58 @@ public class S3Resource extends Resource {
         properties = Maps.newHashMap();
     }
 
+    static S3Resource fromStorageVaultCommand(CreateResourceCommand command) throws DdlException {
+        S3Resource resource = new S3Resource(command.getInfo().getResourceName());
+        resource.id = Env.getCurrentEnv().getNextId();
+        resource.version = 0;
+        resource.setStorageVaultProperties(command.getInfo().getProperties());
+        return resource;
+    }
+
     public String getProperty(String propertyKey) {
         return properties.get(propertyKey);
     }
 
     @Override
     protected void setProperties(ImmutableMap<String, String> newProperties) throws DdlException {
+        setProperties(newProperties, false);
+    }
+
+    void setStorageVaultProperties(ImmutableMap<String, String> newProperties) throws DdlException {
+        setProperties(newProperties, true);
+    }
+
+    private void setProperties(ImmutableMap<String, String> newProperties, boolean storageVault)
+            throws DdlException {
         Preconditions.checkState(newProperties != null);
         this.properties = Maps.newHashMap(newProperties);
+        S3ResourceCompat.convertToStdProperties(this.properties);
+
+        boolean useWorkloadIdentity =
+                S3ResourceCompat.isGcpWorkloadIdentityCredentialsProvider(properties);
+        if (useWorkloadIdentity) {
+            if (!storageVault) {
+                throw new DdlException("gcp_workload_identity is only supported for storage vaults");
+            }
+            if (!"GCP".equalsIgnoreCase(properties.get(S3ResourceCompat.FS_PROVIDER_KEY))) {
+                throw new DdlException("gcp_workload_identity requires provider GCP");
+            }
+            if (properties.containsKey(S3ResourceCompat.ACCESS_KEY)
+                    || properties.containsKey(S3ResourceCompat.SECRET_KEY)
+                    || properties.containsKey(S3ResourceCompat.SESSION_TOKEN)
+                    || !Strings.isNullOrEmpty(properties.get(S3ResourceCompat.ROLE_ARN))) {
+                throw new DdlException(
+                        "gcp_workload_identity cannot be combined with other credentials");
+            }
+            try {
+                String endpoint = S3ResourceCompat.normalizeGcpWorkloadIdentityEndpoint(
+                        properties.get(S3ResourceCompat.ENDPOINT));
+                properties.put(S3ResourceCompat.ENDPOINT, endpoint);
+                properties.put(S3ResourceCompat.Env.ENDPOINT, endpoint);
+            } catch (IllegalArgumentException e) {
+                throw new DdlException(e.getMessage());
+            }
+        }
 
         // check properties
         S3ResourceCompat.requiredS3PingProperties(properties);
@@ -108,6 +153,15 @@ public class S3Resource extends Resource {
         String region = S3ResourceCompat.getRegionOfEndpoint(endpoint);
         properties.putIfAbsent(S3ResourceCompat.REGION, region);
 
+        if (needCheck && useWorkloadIdentity) {
+            // The FE's S3 client signs with static credentials and cannot attach
+            // the metadata-server bearer token, so the connectivity probe would always fail;
+            // BE probes the vault with the real credentials at startup instead.
+            LOG.info("skip s3 connectivity check: {}={} authenticates on BE via Workload Identity",
+                    S3ResourceCompat.CREDENTIALS_PROVIDER_TYPE,
+                    S3ResourceCompat.GCP_WORKLOAD_IDENTITY_CREDENTIALS_PROVIDER);
+            needCheck = false;
+        }
         if (needCheck) {
             Map<String, String> pingProperties = new HashMap<>(properties);
             String pingEndpoint = S3Util.buildEndpointUrl(endpoint);
@@ -236,6 +290,9 @@ public class S3Resource extends Resource {
         if (!Strings.isNullOrEmpty(properties.get(S3ResourceCompat.ENDPOINT))) {
             properties.put(S3ResourceCompat.Env.ENDPOINT, properties.get(S3ResourceCompat.ENDPOINT));
         }
+        if (S3ResourceCompat.isGcpWorkloadIdentityCredentialsProvider(properties)) {
+            throw new DdlException("gcp_workload_identity is only supported for storage vaults");
+        }
         boolean needCheck = isNeedCheck(properties);
         if (LOG.isDebugEnabled()) {
             LOG.debug("s3 info need check validity : {}", needCheck);
@@ -338,4 +395,3 @@ public class S3Resource extends Resource {
         readUnlock();
     }
 }
-

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/S3StorageVault.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/S3StorageVault.java
@@ -90,12 +90,12 @@ public class S3StorageVault extends StorageVault {
     public S3StorageVault(String name, boolean ifNotExists,
             boolean setAsDefault, CreateResourceCommand command) throws DdlException {
         super(name, StorageVault.StorageVaultType.S3, ifNotExists, setAsDefault);
-        resource = Resource.fromCommand(command);
+        resource = S3Resource.fromStorageVaultCommand(command);
     }
 
     @Override
     public void modifyProperties(ImmutableMap<String, String> properties) throws DdlException {
-        resource.setProperties(properties);
+        resource.setStorageVaultProperties(properties);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/storage/CloudObjectStoreAdapter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/storage/CloudObjectStoreAdapter.java
@@ -62,7 +62,11 @@ public final class CloudObjectStoreAdapter {
     public static Cloud.ObjectStoreInfoPB.Builder getObjStoreInfoPB(Map<String, String> properties) {
         Cloud.ObjectStoreInfoPB.Builder builder = Cloud.ObjectStoreInfoPB.newBuilder();
         if (properties.containsKey(ENDPOINT)) {
-            builder.setEndpoint(properties.get(ENDPOINT));
+            String endpoint = properties.get(ENDPOINT);
+            if (S3ResourceCompat.isGcpWorkloadIdentityCredentialsProvider(properties)) {
+                endpoint = S3ResourceCompat.normalizeGcpWorkloadIdentityEndpoint(endpoint);
+            }
+            builder.setEndpoint(endpoint);
         }
         if (properties.containsKey(REGION)) {
             builder.setRegion(properties.get(REGION));
@@ -99,7 +103,24 @@ public final class CloudObjectStoreAdapter {
         }
 
         if (hasCredentialsProviderType(properties)) {
-            builder.setCredProviderType(getCredProviderTypePB(properties));
+            if (S3ResourceCompat.isGcpWorkloadIdentityCredentialsProvider(properties)) {
+                Preconditions.checkArgument(!builder.hasProvider() || builder.getProvider() == Provider.GCP,
+                        "%s=%s is only supported with provider GCP",
+                        CREDENTIALS_PROVIDER_TYPE,
+                        S3ResourceCompat.GCP_WORKLOAD_IDENTITY_CREDENTIALS_PROVIDER);
+                Preconditions.checkArgument(!builder.hasAk() && !builder.hasSk(),
+                        "%s=%s cannot be used together with %s/%s",
+                        CREDENTIALS_PROVIDER_TYPE,
+                        S3ResourceCompat.GCP_WORKLOAD_IDENTITY_CREDENTIALS_PROVIDER,
+                        ACCESS_KEY, SECRET_KEY);
+                Preconditions.checkArgument(Strings.isNullOrEmpty(properties.get(ROLE_ARN)),
+                        "%s=%s cannot be used together with %s",
+                        CREDENTIALS_PROVIDER_TYPE,
+                        S3ResourceCompat.GCP_WORKLOAD_IDENTITY_CREDENTIALS_PROVIDER, ROLE_ARN);
+                builder.setCredProviderType(CredProviderTypePB.GCP_WORKLOAD_IDENTITY);
+            } else {
+                builder.setCredProviderType(getCredProviderTypePB(properties));
+            }
         }
 
         if (properties.containsKey(ROLE_ARN)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/storage/S3ResourceCompat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/storage/S3ResourceCompat.java
@@ -51,6 +51,8 @@ public final class S3ResourceCompat {
     public static final String EXTERNAL_ID = S3CompatibleFileSystemProperties.PROP_EXTERNAL_ID;
     public static final String CREDENTIALS_PROVIDER_TYPE =
             S3CompatibleFileSystemProperties.PROP_CREDENTIALS_PROVIDER_TYPE;
+    public static final String GCP_WORKLOAD_IDENTITY_CREDENTIALS_PROVIDER = "gcp_workload_identity";
+    public static final String GCS_XML_ENDPOINT = "https://storage.googleapis.com";
     public static final String USE_PATH_STYLE = S3CompatibleFileSystemProperties.PROP_USE_PATH_STYLE;
     public static final String VALIDITY_CHECK = "s3_validity_check";
     public static final String FS_PROVIDER_KEY = S3CompatibleFileSystemProperties.PROP_PROVIDER;
@@ -184,6 +186,25 @@ public final class S3ResourceCompat {
         if (properties.containsKey(Env.CREDENTIALS_PROVIDER_TYPE)) {
             properties.putIfAbsent(CREDENTIALS_PROVIDER_TYPE, properties.get(Env.CREDENTIALS_PROVIDER_TYPE));
         }
+    }
+
+    public static boolean isGcpWorkloadIdentityCredentialsProvider(Map<String, String> properties) {
+        String mode = properties.get(CREDENTIALS_PROVIDER_TYPE);
+        if (StringUtils.isBlank(mode)) {
+            mode = properties.get(Env.CREDENTIALS_PROVIDER_TYPE);
+        }
+        return GCP_WORKLOAD_IDENTITY_CREDENTIALS_PROVIDER.equalsIgnoreCase(mode);
+    }
+
+    public static String normalizeGcpWorkloadIdentityEndpoint(String endpoint) {
+        String normalized = StringUtils.trimToEmpty(endpoint);
+        if (normalized.equalsIgnoreCase("storage.googleapis.com")
+                || normalized.equalsIgnoreCase(GCS_XML_ENDPOINT)) {
+            return GCS_XML_ENDPOINT;
+        }
+        throw new IllegalArgumentException(String.format(
+                "%s requires the HTTPS GCS XML endpoint %s",
+                GCP_WORKLOAD_IDENTITY_CREDENTIALS_PROVIDER, GCS_XML_ENDPOINT));
     }
 
     public static String getRegionOfEndpoint(String endpoint) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowCreateStorageVaultCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowCreateStorageVaultCommand.java
@@ -28,6 +28,7 @@ import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.util.DatasourcePrintableMap;
+import org.apache.doris.datasource.storage.S3ResourceCompat;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.PlanType;
@@ -118,7 +119,7 @@ public class ShowCreateStorageVaultCommand extends ShowCommand {
         }
     }
 
-    private String getObjectCreateStmt(Cloud.ObjectStoreInfoPB objectInfo) {
+    String getObjectCreateStmt(Cloud.ObjectStoreInfoPB objectInfo) {
         StringBuilder stmtBuilder = new StringBuilder();
         stmtBuilder.append("CREATE STORAGE VAULT ");
         stmtBuilder.append(storageVaultName);
@@ -130,8 +131,16 @@ public class ShowCreateStorageVaultCommand extends ShowCommand {
         properties.put("s3.region", objectInfo.getRegion());
         properties.put("s3.root.path", objectInfo.getPrefix());
         properties.put("s3.bucket", objectInfo.getBucket());
-        properties.put("s3.access_key", objectInfo.getAk());
-        properties.put("s3.secret_key", objectInfo.getSk());
+        if (objectInfo.hasCredProviderType()
+                && objectInfo.getCredProviderType() == Cloud.CredProviderTypePB.GCP_WORKLOAD_IDENTITY
+                && objectInfo.getAk().isEmpty() && objectInfo.getSk().isEmpty()
+                && objectInfo.getRoleArn().isEmpty()) {
+            properties.put(S3ResourceCompat.CREDENTIALS_PROVIDER_TYPE,
+                    S3ResourceCompat.GCP_WORKLOAD_IDENTITY_CREDENTIALS_PROVIDER);
+        } else {
+            properties.put("s3.access_key", objectInfo.getAk());
+            properties.put("s3.secret_key", objectInfo.getSk());
+        }
         properties.put("provider", objectInfo.getProvider().name());
         properties.put("use_path_style", String.valueOf(objectInfo.getUsePathStyle()));
         if (objectInfo.hasExternalEndpoint()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/S3ResourceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/S3ResourceTest.java
@@ -262,6 +262,75 @@ public class S3ResourceTest {
     }
 
     @Test
+    public void testWorkloadIdentityIsRejectedForS3Resource() {
+        ImmutableMap<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("s3.endpoint", "storage.googleapis.com")
+                .put("s3.region", "us-central1")
+                .put("s3.bucket", "test-bucket")
+                .put("s3.root.path", "root")
+                .put("provider", "GCP")
+                .put("s3.credentials_provider_type", "gcp_workload_identity")
+                .build();
+
+        S3Resource resource = new S3Resource("gcp_resource");
+        DdlException exception = Assert.assertThrows(
+                DdlException.class, () -> resource.setProperties(properties));
+        Assert.assertTrue(exception.getMessage().contains("only supported for storage vaults"));
+    }
+
+    @Test
+    public void testWorkloadIdentityAliasesAreRejectedForS3Resource() {
+        ImmutableMap<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("AWS_ENDPOINT", "storage.googleapis.com")
+                .put("AWS_REGION", "us-central1")
+                .put("AWS_BUCKET", "test-bucket")
+                .put("AWS_ROOT_PATH", "root")
+                .put("provider", "GCP")
+                .put("AWS_CREDENTIALS_PROVIDER_TYPE", "gcp_workload_identity")
+                .build();
+
+        S3Resource resource = new S3Resource("gcp_resource");
+        DdlException exception = Assert.assertThrows(
+                DdlException.class, () -> resource.setProperties(properties));
+        Assert.assertTrue(exception.getMessage().contains("only supported for storage vaults"));
+    }
+
+    @Test
+    public void testWorkloadIdentityIsRejectedWhenModifyingS3Resource() throws DdlException {
+        S3Resource resource = new S3Resource("gcp_resource");
+        resource.setProperties(ImmutableMap.copyOf(s3Properties));
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("AWS_CREDENTIALS_PROVIDER_TYPE", "gcp_workload_identity");
+        DdlException exception = Assert.assertThrows(
+                DdlException.class, () -> resource.modifyProperties(properties));
+        Assert.assertTrue(exception.getMessage().contains("only supported for storage vaults"));
+    }
+
+    @Test
+    public void testWorkloadIdentityStorageVaultUsesHttpsEndpoint() throws DdlException {
+        ImmutableMap<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("type", "s3")
+                .put("AWS_ENDPOINT", "storage.googleapis.com")
+                .put("AWS_REGION", "us-central1")
+                .put("AWS_BUCKET", "test-bucket")
+                .put("AWS_ROOT_PATH", "root")
+                .put("provider", "GCP")
+                .put("AWS_CREDENTIALS_PROVIDER_TYPE", "gcp_workload_identity")
+                .build();
+        CreateResourceCommand command = new CreateResourceCommand(
+                new CreateResourceInfo(false, false, "gcp_vault", properties));
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            S3Resource resource = S3Resource.fromStorageVaultCommand(command);
+            Assert.assertEquals(S3ResourceCompat.GCS_XML_ENDPOINT,
+                    resource.getProperty(S3ResourceCompat.ENDPOINT));
+        }
+    }
+
+    @Test
     public void testPingS3() {
         try {
             String accessKey = System.getenv("ACCESS_KEY");

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/storage/CloudObjectStoreAdapterParityTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/storage/CloudObjectStoreAdapterParityTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.datasource.storage;
 
+import org.apache.doris.catalog.S3StorageVault;
 import org.apache.doris.cloud.proto.Cloud;
 
 import org.junit.jupiter.api.Assertions;
@@ -126,5 +127,88 @@ public class CloudObjectStoreAdapterParityTest {
     public void testEmptyMap() {
         Assertions.assertEquals(Cloud.ObjectStoreInfoPB.newBuilder().build(),
                 CloudObjectStoreAdapter.getObjStoreInfoPB(new HashMap<>()).build());
+    }
+
+    @Test
+    public void testGcpWorkloadIdentityCredentialsProvider() {
+        Map<String, String> props = map(
+                "s3.endpoint", "storage.googleapis.com",
+                "s3.region", "us-central1",
+                "s3.bucket", "bucket",
+                "s3.root.path", "root",
+                "provider", "GCP",
+                "s3.credentials_provider_type", "gcp_workload_identity");
+
+        Cloud.ObjectStoreInfoPB pb = CloudObjectStoreAdapter.getObjStoreInfoPB(props).build();
+        Assertions.assertEquals(Cloud.CredProviderTypePB.GCP_WORKLOAD_IDENTITY,
+                pb.getCredProviderType());
+        Assertions.assertEquals(S3ResourceCompat.GCS_XML_ENDPOINT, pb.getEndpoint());
+        Assertions.assertFalse(pb.hasAk());
+        Assertions.assertFalse(pb.hasSk());
+        Assertions.assertFalse(pb.hasRoleArn());
+        Assertions.assertTrue(S3StorageVault.ALLOW_ALTER_PROPERTIES.contains(
+                S3ResourceCompat.CREDENTIALS_PROVIDER_TYPE));
+    }
+
+    @Test
+    public void testGcpWorkloadIdentityEndpointValidation() {
+        Map<String, String> props = map(
+                "s3.endpoint", "http://storage.googleapis.com",
+                "provider", "GCP",
+                "s3.credentials_provider_type", "gcp_workload_identity");
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> CloudObjectStoreAdapter.getObjStoreInfoPB(props));
+
+        props.put("s3.endpoint", "https://example.com");
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> CloudObjectStoreAdapter.getObjStoreInfoPB(props));
+    }
+
+    @Test
+    public void testGcpWorkloadIdentityPartialAlterProperties() {
+        Map<String, String> props = map(
+                "s3.credentials_provider_type", "gcp_workload_identity");
+
+        Cloud.ObjectStoreInfoPB pb = CloudObjectStoreAdapter.getObjStoreInfoPB(props).build();
+        Assertions.assertEquals(Cloud.CredProviderTypePB.GCP_WORKLOAD_IDENTITY,
+                pb.getCredProviderType());
+        Assertions.assertFalse(pb.hasProvider());
+        Assertions.assertFalse(pb.hasEndpoint());
+    }
+
+    @Test
+    public void testGcpWorkloadIdentityRequiresGcpProvider() {
+        Map<String, String> props = map(
+                "s3.endpoint", "s3.us-west-2.amazonaws.com",
+                "s3.region", "us-west-2",
+                "s3.bucket", "bucket",
+                "s3.root.path", "root",
+                "provider", "S3",
+                "s3.credentials_provider_type", "gcp_workload_identity");
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> CloudObjectStoreAdapter.getObjStoreInfoPB(props));
+    }
+
+    @Test
+    public void testGcpWorkloadIdentityRejectsStaticCredentialsAndRole() {
+        Map<String, String> props = map(
+                "s3.endpoint", "storage.googleapis.com",
+                "s3.region", "us-central1",
+                "s3.bucket", "bucket",
+                "s3.root.path", "root",
+                "provider", "GCP",
+                "s3.credentials_provider_type", "gcp_workload_identity",
+                "s3.access_key", "hmac_id",
+                "s3.secret_key", "hmac_secret");
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> CloudObjectStoreAdapter.getObjStoreInfoPB(props));
+
+        props.remove("s3.access_key");
+        props.remove("s3.secret_key");
+        props.put("s3.role_arn", "arn:aws:iam::123456789012:role/MyTestRole");
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> CloudObjectStoreAdapter.getObjStoreInfoPB(props));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowCreateStorageVaultCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/ShowCreateStorageVaultCommandTest.java
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands;
+
+import org.apache.doris.cloud.proto.Cloud.CredProviderTypePB;
+import org.apache.doris.cloud.proto.Cloud.ObjectStoreInfoPB;
+import org.apache.doris.cloud.proto.Cloud.ObjectStoreInfoPB.Provider;
+import org.apache.doris.datasource.storage.S3ResourceCompat;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ShowCreateStorageVaultCommandTest {
+
+    @Test
+    void testGcpWorkloadIdentityProperties() {
+        ObjectStoreInfoPB objectInfo = ObjectStoreInfoPB.newBuilder()
+                .setEndpoint(S3ResourceCompat.GCS_XML_ENDPOINT)
+                .setRegion("us-central1")
+                .setPrefix("test-prefix")
+                .setBucket("test-bucket")
+                .setProvider(Provider.GCP)
+                .setCredProviderType(CredProviderTypePB.GCP_WORKLOAD_IDENTITY)
+                .build();
+
+        String createStmt =
+                new ShowCreateStorageVaultCommand("test-vault").getObjectCreateStmt(objectInfo);
+
+        Assertions.assertTrue(createStmt.contains(S3ResourceCompat.CREDENTIALS_PROVIDER_TYPE));
+        Assertions.assertTrue(
+                createStmt.contains(S3ResourceCompat.GCP_WORKLOAD_IDENTITY_CREDENTIALS_PROVIDER));
+        Assertions.assertFalse(createStmt.contains("s3.access_key"));
+        Assertions.assertFalse(createStmt.contains("s3.secret_key"));
+    }
+
+    @Test
+    void testExplicitCredentialsOverrideStaleWorkloadIdentity() {
+        ObjectStoreInfoPB objectInfo = ObjectStoreInfoPB.newBuilder()
+                .setEndpoint(S3ResourceCompat.GCS_XML_ENDPOINT)
+                .setRegion("us-central1")
+                .setPrefix("test-prefix")
+                .setBucket("test-bucket")
+                .setProvider(Provider.GCP)
+                .setAk("access-key")
+                .setSk("secret-key")
+                .setCredProviderType(CredProviderTypePB.GCP_WORKLOAD_IDENTITY)
+                .build();
+
+        String createStmt =
+                new ShowCreateStorageVaultCommand("test-vault").getObjectCreateStmt(objectInfo);
+
+        Assertions.assertTrue(createStmt.contains("s3.access_key"));
+        Assertions.assertTrue(createStmt.contains("s3.secret_key"));
+        Assertions.assertFalse(
+                createStmt.contains(S3ResourceCompat.GCP_WORKLOAD_IDENTITY_CREDENTIALS_PROVIDER));
+    }
+}

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -285,6 +285,9 @@ enum CredProviderTypePB {
     WEB_IDENTITY = 6;  // STSAssumeRoleWebIdentityCredentialsProvider
     CONTAINER = 7;  // TaskRoleCredentialsProvider
     ANONYMOUS = 8;  // AnonymousAWSCredentialsProvider
+    // GKE Workload Identity. Requests to the GCS XML API are authenticated
+    // with a short-lived OAuth2 token from the GKE metadata server.
+    GCP_WORKLOAD_IDENTITY = 9;
 }
 
 message ObjectStoreInfoPB {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #65432

Problem:

GCP storage vaults require long-lived HMAC access keys. GKE deployments using Workload Identity Federation therefore cannot authenticate the vault data path with the pod identity and short-lived Google credentials.

Solution:

Add `gcp_workload_identity`, a GCP-only storage-vault credentials provider. The shared C++ object-storage client used by BE and recycler obtains OAuth2 access tokens from the GKE/GCE metadata server and applies `Authorization: Bearer ...` to every GCS XML API request while AWS SigV4 signing remains anonymous.

```sql
CREATE STORAGE VAULT gcs_vault PROPERTIES (
    "type" = "S3",
    "s3.endpoint" = "storage.googleapis.com",
    "s3.region" = "us-central1",
    "s3.bucket" = "my-bucket",
    "s3.root.path" = "doris",
    "provider" = "GCP",
    "s3.credentials_provider_type" = "gcp_workload_identity"
);
```

The implementation:

- validates the provider, endpoint, and credential combination at FE, Meta Service, BE, and recycler boundaries;
- canonicalizes the endpoint to `https://storage.googleapis.com` before bearer authentication;
- caches tokens process-wide, serializes refreshes, refreshes before expiry, and retains a still-valid token across transient refresh failures;
- fails locally when no valid token exists instead of issuing an anonymous storage request;
- supports HMAC-to-Workload-Identity and Workload-Identity-to-HMAC ALTER transitions, including stale-enum recovery after rollback;
- serializes storage-vault refreshes and rechecks connectivity when keyless credentials change; and
- returns an explicit `NotSupported` result for presigned URLs.

Upgrade compatibility:

The persisted credential-provider enum is new. Do not create or alter a Workload Identity vault during a mixed-version rollout; upgrade every BE and recycler consumer before enabling it. Explicit HMAC or role credentials take precedence if a stale unknown enum value survives a rollback transition.

Security Impact:

This removes the need to distribute long-lived HMAC secrets on GKE. Metadata acquisition uses a fixed metadata hostname with the required `Metadata-Flavor: Google` header, disables AWS IMDS discovery, redirects, and proxies, and uses bounded timeouts. Storage requests are restricted to the canonical GCS HTTPS endpoint, and missing tokens fail closed.

Testing:

- Added FE tests for storage-vault-only scope, aliases, credential/provider validation, endpoint canonicalization, partial ALTER mapping, and `SHOW CREATE` output.
- Added Meta Service tests for creation paths, invalid configurations, credential transitions, rollback recovery, and credential cleanup.
- Added BE/shared-client tests for token caching, refresh, transient failure, concurrent single-flight refresh, fail-closed behavior, bearer headers, client reset, and presigned-URL rejection.
- Added recycler configuration and stale-enum coverage.
- `git diff --check origin/master` passes.
- `protoc --proto_path=gensrc/proto --descriptor_set_out=/dev/null gensrc/proto/cloud.proto` passes.
- A focused syntax check of the metadata provider against Doris's pinned AWS SDK 1.11.219 passes.
- Full FE/BE/cloud unit execution and C++ formatting are pending PR CI because this checkout lacks the Doris third-party build bundle and LLVM 16.
- End-to-end validation on GKE with Workload Identity is required before merge.

### Release note

Support keyless GCS storage vault authentication on GKE with Workload Identity Federation using `"s3.credentials_provider_type" = "gcp_workload_identity"`.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit tests added; execution pending PR CI
    - [ ] Manual test
    - [ ] No need to test or manual test

- Behavior changed:
    - [x] Yes. Adds GKE Workload Identity authentication for GCP storage vaults.

- Does this need documentation?
    - [x] Yes. A doris-website follow-up is required.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
