### PR TITLE
[opt](nereids) simplify IF(cond, x, x) to x for side-effect-free conditions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyConditionalFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyConditionalFunction.java
@@ -21,11 +21,23 @@ import org.apache.doris.nereids.rules.expression.ExpressionMatchingContext;
 import org.apache.doris.nereids.rules.expression.ExpressionPatternMatcher;
 import org.apache.doris.nereids.rules.expression.ExpressionPatternRuleFactory;
 import org.apache.doris.nereids.rules.expression.ExpressionRuleType;
+import org.apache.doris.nereids.trees.expressions.CaseWhen;
+import org.apache.doris.nereids.trees.expressions.ComparisonPredicate;
+import org.apache.doris.nereids.trees.expressions.CompoundPredicate;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.InPredicate;
+import org.apache.doris.nereids.trees.expressions.IsNull;
+import org.apache.doris.nereids.trees.expressions.Not;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.functions.NoneMovableFunction;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Coalesce;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.If;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Lambda;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.NullIf;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Nullable;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Nvl;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Sleep;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.util.TypeCoercionUtils;
 
@@ -45,6 +57,8 @@ public class SimplifyConditionalFunction implements ExpressionPatternRuleFactory
                 matchesType(Nvl.class).thenApply(SimplifyConditionalFunction::rewriteNvl)
                         .toRule(ExpressionRuleType.SIMPLIFY_CONDITIONAL_FUNCTION),
                 matchesType(NullIf.class).thenApply(SimplifyConditionalFunction::rewriteNullIf)
+                        .toRule(ExpressionRuleType.SIMPLIFY_CONDITIONAL_FUNCTION),
+                matchesType(If.class).thenApply(SimplifyConditionalFunction::rewriteIf)
                         .toRule(ExpressionRuleType.SIMPLIFY_CONDITIONAL_FUNCTION)
         );
     }
@@ -122,5 +136,114 @@ public class SimplifyConditionalFunction implements ExpressionPatternRuleFactory
         } else {
             return nullIf;
         }
+    }
+
+    /*
+     * if(cond, x, x) => x
+     * Both branches are structurally identical, so the branch value is returned regardless of
+     * the condition. Removing the condition is only sound when it cannot change observable
+     * behavior, so the rewrite fires only when:
+     *   1. then and else are structurally equal;
+     *   2. the condition is deterministic (no rand()/now()/unique functions) so dropping its
+     *      evaluation cannot remove an observable side effect;
+     *   3. neither the condition NOR the branch itself contains a function whose evaluation is
+     *      observable even when deterministic and error-free, i.e. NoneMovableFunction
+     *      (contractually "should not prune", e.g. assert_true) or sleep() (a deterministic
+     *      ScalarFunction whose whole point is the blocking side effect — the BE also refuses to
+     *      fold it, see FoldConstantRuleOnBE). The branch must be checked too: BE's
+     *      VectorizedFnCall::_do_execute evaluates the then- and else-argument columns
+     *      unconditionally before FunctionIf selects between them, so if(cond, sleep(1), sleep(1))
+     *      already runs sleep() twice per block; collapsing it to a single sleep(1) would halve
+     *      that observable side effect even though the two branches are structurally identical;
+     *   4. every subtree of the condition that may throw is also evaluated UNCONDITIONALLY by the
+     *      surviving branch, so removing the condition cannot suppress a runtime error the original
+     *      expression would have raised (e.g. Case3's ROUND(cost/denom,8) appears both in the
+     *      condition and unconditionally inside CEIL(...) in the branch).
+     * Nullability is preserved automatically: If.nullable() = then.nullable() || else.nullable(),
+     * which equals then.nullable() when the branches are identical.
+     */
+    private static Expression rewriteIf(ExpressionMatchingContext<If> ctx) {
+        If ifExpr = ctx.expr;
+        Expression condition = ifExpr.child(0);
+        Expression thenBranch = ifExpr.child(1);
+        Expression elseBranch = ifExpr.child(2);
+        if (!thenBranch.equals(elseBranch)) {
+            return ifExpr;
+        }
+        if (condition.containsNondeterministic()) {
+            return ifExpr;
+        }
+        // Functions that stay observable even when deterministic and error-free: dropping the
+        // condition's evaluation would still change behavior (an assert_true never checked, one
+        // fewer sleep). containsNondeterministic() does not cover them, so guard explicitly.
+        // The branch itself needs the same guard: BE evaluates then/else unconditionally before
+        // selecting, so collapsing if(cond, sleep(1), sleep(1)) to one sleep(1) would halve the
+        // number of times it actually runs.
+        if (condition.containsType(NoneMovableFunction.class, Sleep.class)
+                || thenBranch.containsType(NoneMovableFunction.class, Sleep.class)) {
+            return ifExpr;
+        }
+        ImmutableList.Builder<Expression> throwingSubtrees = ImmutableList.builder();
+        collectThrowingSubtrees(condition, throwingSubtrees);
+        for (Expression throwingSubtree : throwingSubtrees.build()) {
+            if (!occursUnconditionally(thenBranch, throwingSubtree)) {
+                return ifExpr;
+            }
+        }
+        return TypeCoercionUtils.ensureSameResultType(ifExpr, thenBranch, ctx.rewriteContext);
+    }
+
+    // A node whose OWN evaluation cannot throw. Anything not listed is conservatively treated as
+    // potentially throwing; this is a sound over-approximation (an unknown node is assumed unsafe),
+    // avoiding an unmaintainable blacklist of every throwing expression class.
+    private static boolean cannotThrowAtNode(Expression expr) {
+        return expr instanceof Literal
+                || expr instanceof Slot
+                || expr instanceof ComparisonPredicate
+                || expr instanceof CompoundPredicate
+                || expr instanceof Not
+                || expr instanceof IsNull
+                || expr instanceof InPredicate;
+    }
+
+    // Operators that evaluate some of their children conditionally (short-circuit / guarded).
+    // When scanning a branch for unconditionally-evaluated subtrees we must not descend past these.
+    private static boolean isLazyBoundary(Expression expr) {
+        return expr instanceof If
+                || expr instanceof CaseWhen
+                || expr instanceof Coalesce
+                || expr instanceof Nvl
+                || expr instanceof NullIf
+                || expr instanceof CompoundPredicate
+                || expr instanceof Lambda;
+    }
+
+    // Collect the maximal subtrees of the condition that may throw: descend through no-throw nodes,
+    // and when a node that may throw is reached, record that whole subtree (its children are subsumed).
+    private static void collectThrowingSubtrees(Expression expr, ImmutableList.Builder<Expression> out) {
+        if (!cannotThrowAtNode(expr)) {
+            out.add(expr);
+            return;
+        }
+        for (Expression child : expr.children()) {
+            collectThrowingSubtrees(child, out);
+        }
+    }
+
+    // True if target occurs as an unconditionally-evaluated subtree of branch, i.e. reachable from
+    // the branch root without crossing a lazy/guarded boundary.
+    private static boolean occursUnconditionally(Expression branch, Expression target) {
+        if (branch.equals(target)) {
+            return true;
+        }
+        if (isLazyBoundary(branch)) {
+            return false;
+        }
+        for (Expression child : branch.children()) {
+            if (occursUnconditionally(child, target)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyConditionalFunctionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyConditionalFunctionTest.java
@@ -20,16 +20,31 @@ package org.apache.doris.nereids.rules.expression.rules;
 import org.apache.doris.nereids.rules.expression.ExpressionRewriteTestHelper;
 import org.apache.doris.nereids.rules.expression.ExpressionRuleExecutor;
 import org.apache.doris.nereids.trees.expressions.Cast;
+import org.apache.doris.nereids.trees.expressions.Divide;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.GreaterThan;
+import org.apache.doris.nereids.trees.expressions.GreaterThanEqual;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.AssertTrue;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Ceil;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Coalesce;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.If;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.NullIf;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Nullable;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Nvl;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Random;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Round;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Sleep;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.types.DateTimeV2Type;
+import org.apache.doris.nereids.types.DoubleType;
+import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.types.StringType;
 
 import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class SimplifyConditionalFunctionTest extends ExpressionRewriteTestHelper {
@@ -178,6 +193,78 @@ public class SimplifyConditionalFunctionTest extends ExpressionRewriteTestHelper
                 ),
                 new NullLiteral(DateTimeV2Type.of(6))
         );
+    }
+
+    @Test
+    public void testIf() {
+        executor = new ExpressionRuleExecutor(ImmutableList.of(bottomUp((SimplifyConditionalFunction.INSTANCE))));
+        SlotReference b = new SlotReference("b", IntegerType.INSTANCE, true);
+        SlotReference c = new SlotReference("c", IntegerType.INSTANCE, true);
+        SlotReference flag = new SlotReference("flag", IntegerType.INSTANCE, true);
+        SlotReference cost = new SlotReference("cost", DoubleType.INSTANCE, true);
+        SlotReference denom = new SlotReference("denom", DoubleType.INSTANCE, true);
+        IntegerLiteral zero = new IntegerLiteral(0);
+        IntegerLiteral eight = new IntegerLiteral(8);
+        GreaterThan noThrowCond = new GreaterThan(flag, zero);
+
+        // 1. no-throw deterministic condition, identical branches -> rewrite to the branch
+        assertIf(new If(noThrowCond, b, b), b);
+
+        // 2. non-deterministic condition -> keep (dropping rand() would remove a side effect)
+        If randIf = new If(new GreaterThan(new Random(), zero), b, b);
+        assertIf(randIf, randIf);
+
+        // 3. then != else -> keep
+        If distinctIf = new If(noThrowCond, b, c);
+        assertIf(distinctIf, distinctIf);
+
+        // 4. throwing subtree in condition but absent from branch -> keep (would suppress an error)
+        If divOnlyInCond = new If(new GreaterThanEqual(new Divide(cost, denom), zero), b, b);
+        assertIf(divOnlyInCond, divOnlyInCond);
+
+        // 5. Case3 shape: throwing round(cost/denom, 8) also appears unconditionally in the
+        //    ceil(...) branch -> safe to rewrite
+        Expression round = new Round(new Divide(cost, denom), eight);
+        Expression ceil = new Ceil(round);
+        assertIf(new If(new GreaterThanEqual(round, zero), ceil, ceil), ceil);
+
+        // 6. throwing subtree present only under a guarded inner if in the branch -> keep
+        Expression guardedBranch =
+                new If(new GreaterThan(flag, zero), new Ceil(new Divide(cost, denom)), zero);
+        If guardedIf =
+                new If(new GreaterThanEqual(new Divide(cost, denom), zero), guardedBranch, guardedBranch);
+        assertIf(guardedIf, guardedIf);
+
+        // 7. sleep() in condition -> keep. sleep is deterministic and its self-identical value
+        //    also occurs in the branch, but collapsing IF(sleep, sleep, sleep) would drop one
+        //    observable blocking evaluation.
+        If sleepIf = new If(new Sleep(new IntegerLiteral(1)),
+                new Sleep(new IntegerLiteral(1)), new Sleep(new IntegerLiteral(1)));
+        assertIf(sleepIf, sleepIf);
+
+        // 8. NoneMovableFunction (assert_true) in condition -> keep. Contractually must not be
+        //    pruned; dropping the condition would skip the assertion.
+        If assertTrueIf = new If(new AssertTrue(new GreaterThan(flag, zero), new VarcharLiteral("bad")), b, b);
+        assertIf(assertTrueIf, assertTrueIf);
+
+        // 9. sleep() identical in both branches -> keep. BE evaluates the then/else argument
+        //    columns unconditionally before selecting between them, so if(cond, sleep(1), sleep(1))
+        //    already runs sleep() twice per block; collapsing to one sleep(1) would halve that
+        //    observable blocking time even though the branches are structurally identical.
+        If sleepBranchIf = new If(noThrowCond, new Sleep(new IntegerLiteral(1)), new Sleep(new IntegerLiteral(1)));
+        assertIf(sleepBranchIf, sleepBranchIf);
+
+        // 10. NoneMovableFunction (assert_true) identical in both branches -> keep. Same
+        //     eager-evaluation reasoning: dropping the if would still halve how many times
+        //     assert_true's check actually runs.
+        If assertTrueBranchIf = new If(noThrowCond,
+                new AssertTrue(new GreaterThan(flag, zero), new VarcharLiteral("bad")),
+                new AssertTrue(new GreaterThan(flag, zero), new VarcharLiteral("bad")));
+        assertIf(assertTrueBranchIf, assertTrueBranchIf);
+    }
+
+    private void assertIf(Expression input, Expression expected) {
+        Assertions.assertEquals(expected, executor.rewrite(input, context));
     }
 
 }


### PR DESCRIPTION
## Proposed changes

Issue Number: no issue

Problem Summary:

Add a new rewrite to `SimplifyConditionalFunction` that collapses
`if(cond, x, x)` to `x` when the two branches are structurally identical and
dropping the condition cannot change observable behavior. The rewrite is
registered as an additional `matchesType(If.class)` rule alongside the existing
Coalesce/Nvl/NullIf rules and fires only when all of the following soundness
guards hold:

1. `then` and `else` are structurally equal (`then.equals(else)`).
2. The condition is deterministic (`!condition.containsNondeterministic()`), so
   dropping its evaluation cannot remove an observable side effect such as
   `rand()`/`now()`/unique functions.
3. Neither the condition NOR the surviving branch contains a function that stays
   observable even when deterministic and error-free, i.e. a
   `NoneMovableFunction` (contractually must-not-prune, e.g. `assert_true`) or
   `sleep()` (a deterministic function whose whole point is the blocking side
   effect, which BE also refuses to fold). The branch is guarded too because BE
   evaluates the then/else argument columns unconditionally before selecting
   between them, so `if(cond, sleep(1), sleep(1))` already runs `sleep()` twice
   per block; collapsing to a single `sleep(1)` would halve that side effect.
4. Every subtree of the condition that may throw is also evaluated
   unconditionally by the surviving branch, so removing the condition cannot
   suppress a runtime error the original expression would have raised. This is
   checked by `collectThrowingSubtrees` (maximal potentially-throwing subtrees of
   the condition, using a conservative `cannotThrowAtNode` over-approximation)
   plus `occursUnconditionally` (target reachable from the branch root without
   crossing a lazy/guarded boundary such as `If`/`CaseWhen`/`Coalesce`/`Nvl`/
   `NullIf`/`CompoundPredicate`/`Lambda`).

Nullability is preserved automatically: `If.nullable()` is
`then.nullable() || else.nullable()`, which equals `then.nullable()` when the
branches are identical, so the result type is stabilized via
`TypeCoercionUtils.ensureSameResultType`.

## Release note

None

## Check List (For Author)

- Test: Unit Test
    - Added `SimplifyConditionalFunctionTest#testIf` covering 10 cases: basic
      rewrite, non-deterministic condition, distinct branches, throwing subtree
      only in condition, the Case3 shape where the throwing subtree also occurs
      unconditionally in the branch, a throwing subtree hidden under a guarded
      inner `if`, and the `sleep()`/`assert_true` guards in both the condition
      and the branches. Ran
      `run-fe-ut.sh --run org.apache.doris.nereids.rules.expression.rules.SimplifyConditionalFunctionTest`
      => Tests run: 4, Failures: 0, Errors: 0, Skipped: 0 (testIf included).
      FE `build.sh --fe` succeeded with 0 Checkstyle violations.
- Behavior changed: No
- Does this need documentation: No

