### PR TITLE
[Bug](iceberg) fix BE core when reading MOR table with rowid + lazy read

### DIFF
--- a/be/src/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/format/parquet/vparquet_group_reader.cpp
@@ -645,7 +645,7 @@ Status RowGroupReader::_do_lazy_read(Block* block, size_t batch_size, size_t* re
                                                                 &result_filter, &can_filter_all));
             }
 
-            if (_lazy_read_ctx.resize_first_column) {
+            if (resize_first_column) {
                 // We have to clean the first column to insert right data.
                 block->clear_column_data(std::vector<uint32_t> {0});
             }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

coredump:

```
*** Query id: 8bxxx-xxx ***
*** is nereids: 1 ***
*** tablet id: 0 ***
*** Aborted at 1785897717 (unix time) try "date -d @1785897717" if you are using GNU date ***
*** Current BE git commitID: 2607291 ***
*** SIGSEGV address not mapped to object (@0x0) received by PID 1002 (TID 3954234 OR 0x7f42d110e6c0) from PID 0; stack trace: ***
0# doris::signal::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*) in /usr/local/service/doris/lib/be/doris_be
 1# PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.10] in /usr/local/jdk/lib/server/libjvm.so
 2# JVM_handle_linux_signal in /usr/local/jdk/lib/server/libjvm.so
 3# 0x00007F8C17A4ABB0 in /lib64/libc.so.6
 4# doris::Block::filter_block_internal(doris::Block*, std::vector<unsigned int, std::allocator<unsigned int> > const&, doris::PODArray<unsigned char, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, true>, 16ul, 15ul> const&) in /usr/local/service/doris/lib/be/doris_be
 5# doris::Block::filter_block_internal(doris::Block*, doris::PODArray<unsigned char, 4096ul, doris::Allocator<false, false, false, doris::DefaultMemoryAllocator, true>, 16ul, 15ul> const&, unsigned int) in /usr/local/service/doris/lib/be/doris_be
 6# doris::IcebergTableReader::get_next_block_inner(doris::Block*, unsigned long*, bool*) in /usr/local/service/doris/lib/be/doris_be
 7# doris::TableFormatReader::get_next_block(doris::Block*, unsigned long*, bool*) in /usr/local/service/doris/lib/be/doris_be
 8# doris::FileScanner::_get_block_wrapped(doris::RuntimeState*, doris::Block*, bool*) in /usr/local/service/doris/lib/be/doris_be
 9# doris::FileScanner::_get_block_impl(doris::RuntimeState*, doris::Block*, bool*) in /usr/local/service/doris/lib/be/doris_be
10# doris::Scanner::get_block(doris::RuntimeState*, doris::Block*, bool*) in /usr/local/service/doris/lib/be/doris_be
11# doris::Scanner::get_block_after_projects(doris::RuntimeState*, doris::Block*, bool*) in /usr/local/service/doris/lib/be/doris_be
12# doris::ScannerScheduler::_scanner_scan(std::shared_ptr<doris::ScannerContext>, std::shared_ptr<doris::ScanTask>) in /usr/local/service/doris/lib/be/doris_be
13# std::_Function_handler<bool (), doris::ScannerScheduler::submit(std::shared_ptr<doris::ScannerContext>, std::shared_ptr<doris::ScanTask>)::$_0::operator()() const::{lambda()#1}>::_M_invoke(std::_Any_data const&) in /usr/local/service/doris/lib/be/doris_be
14# doris::ScannerSplitRunner::process_for(std::chrono::duration<long, std::ratio<1l, 1000000000l> >) in /usr/local/service/doris/lib/be/doris_be
15# doris::PrioritizedSplitRunner::process() in /usr/local/service/doris/lib/be/doris_be
16# doris::TimeSharingTaskExecutor::_dispatch_thread() in /usr/local/service/doris/lib/be/doris_be
17# doris::Thread::supervise_thread(void*) in /usr/local/service/doris/lib/be/doris_be
18# start_thread in /lib64/libc.so.6
19# __GI___clone3 in /lib64/libc.so.6
```

The master branch is fine.
This bug only exists in 4.1 branch and introduce by: #61818 

This commit only pick this line from the pr in master: #60482

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

