### PR TITLE
[fix](memory) track realloc net delta to avoid spurious MEM_LIMIT_EXCEEDED

### DIFF
--- a/be/src/core/allocator.cpp
+++ b/be/src/core/allocator.cpp
@@ -395,22 +395,30 @@ void* Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
         /// BTW, it's not possible to change alignment while doing realloc.
         return buf;
     }
-    memory_check(new_size);
-    // Realloc can do 2 possible things:
-    // - expand existing memory region
-    // - allocate new memory block and free the old one
-    // Because we don't know which option will be picked we need to make sure there is enough
-    // memory for all options.
-    consume_memory(new_size);
-
     if (!use_mmap ||
         (old_size < doris::config::mmap_threshold && new_size < doris::config::mmap_threshold &&
          alignment <= MALLOC_MIN_ALIGNMENT)) {
+        // Malloc/mmap realloc paths overwhelmingly resolve in-place (tcmalloc/jemalloc
+        // grow the existing region without copying physical pages). Tracking the
+        // net delta avoids a transient double-count of old_size, which would trip
+        // mem_limit checks on the boundary in queries without spill fallback and
+        // surface as a spurious MEM_LIMIT_EXCEEDED. If realloc internally falls
+        // back to alloc+copy+free, the tracker is briefly under-counted by
+        // old_size for the duration of the copy; that window is bounded by a
+        // single memcpy and self-corrects immediately after.
+        const bool grow = new_size > old_size;
+        const size_t delta = grow ? (new_size - old_size) : (old_size - new_size);
+        if (grow) {
+            memory_check(delta);
+            consume_memory(delta);
+        }
         remove_address_sanitizers(buf, old_size);
         /// Resize malloc'd memory region with no special alignment requirement.
         void* new_buf = MemoryAllocator::realloc(buf, new_size);
         if (nullptr == new_buf) {
-            release_memory(new_size);
+            if (grow) {
+                release_memory(delta);
+            }
             throw_bad_alloc(
                     fmt::format("Allocator: Cannot realloc from {} to {}.", old_size, new_size));
         }
@@ -418,7 +426,9 @@ void* Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
         add_address_sanitizers(new_buf, new_size);
 
         buf = new_buf;
-        release_memory(old_size);
+        if (!grow) {
+            release_memory(delta);
+        }
         if constexpr (clear_memory) {
             if (new_size > old_size) {
                 memset(reinterpret_cast<char*>(buf) + old_size, 0, new_size - old_size);
@@ -427,15 +437,30 @@ void* Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
     } else if (old_size >= doris::config::mmap_threshold &&
                new_size >= doris::config::mmap_threshold) {
         /// Resize mmap'd memory region.
-        // On apple and freebsd self-implemented mremap used (common/mremap.h)
+        // Native Linux mremap (MREMAP_MAYMOVE) rewires page tables in place
+        // without duplicating physical pages, so the peak equals new_size and
+        // tracking the net delta is exact. On apple/freebsd there is no native
+        // mremap: common/mremap.h falls back to mmap(new)+memcpy+munmap(old),
+        // whose copy window peaks at old+new and is briefly under-counted by
+        // old_size here. Production is Linux-only, so we track the net delta.
+        const bool grow = new_size > old_size;
+        const size_t delta = grow ? (new_size - old_size) : (old_size - new_size);
+        if (grow) {
+            memory_check(delta);
+            consume_memory(delta);
+        }
         buf = clickhouse_mremap(buf, old_size, new_size, MREMAP_MAYMOVE, PROT_READ | PROT_WRITE,
                                 mmap_flags, -1, 0);
         if (MAP_FAILED == buf) {
-            release_memory(new_size);
+            if (grow) {
+                release_memory(delta);
+            }
             throw_bad_alloc(fmt::format("Allocator: Cannot mremap memory chunk from {} to {}.",
                                         old_size, new_size));
         }
-        release_memory(old_size);
+        if (!grow) {
+            release_memory(delta);
+        }
 
         /// No need for zero-fill, because mmap guarantees it.
 
@@ -447,14 +472,15 @@ void* Allocator<clear_memory_, mmap_populate, use_mmap, MemoryAllocator,
             }
         }
     } else {
-        // Big allocs that requires a copy.
+        // Big allocs that requires a copy. Inner alloc()/free() already track
+        // new_size and old_size respectively; the peak here is genuinely double
+        // for the copy window, and consumers of this path must tolerate it.
         void* new_buf = alloc(new_size, alignment);
         memcpy(new_buf, buf, std::min(old_size, new_size));
         add_address_sanitizers(new_buf, new_size);
         remove_address_sanitizers(buf, old_size);
         free(buf, old_size);
         buf = new_buf;
-        release_memory(old_size);
     }
 
     return buf;

--- a/be/test/runtime/memory/allocator_test.cpp
+++ b/be/test/runtime/memory/allocator_test.cpp
@@ -22,8 +22,13 @@
 
 #include <memory>
 
+#include "common/exception.h"
 #include "core/allocator_fwd.h"
 #include "gtest/gtest_pred_impl.h"
+#include "runtime/memory/mem_tracker_limiter.h"
+#include "runtime/memory/thread_mem_tracker_mgr.h"
+#include "runtime/thread_context.h"
+#include "runtime/workload_management/resource_context.h"
 
 namespace doris {
 
@@ -57,6 +62,216 @@ void test_normal() {
 
 TEST(AllocatorTest, TestNormal) {
     test_normal();
+}
+
+// Guards realloc's tracker accounting: growing a buffer must charge only the
+// delta (new-old) to the current MemTracker, never new+old with a transient
+// double-count of the old region. A regression here surfaces as spurious
+// MEM_LIMIT_EXCEEDED when a hash table doubles at the memory-limit boundary
+// in queries without spill fallback.
+//
+// Coverage note: these cases exercise the malloc realloc path (use_mmap=false)
+// and the big-alloc copy path (old<threshold<new). The mremap path
+// (old_size and new_size both >= mmap_threshold, default 128 MiB) is not
+// covered on purpose: forcing it needs a >=128 MiB allocation per case, which
+// is uneconomical on CI. Its accounting is byte-for-byte identical to the
+// malloc grow/shrink branch already tested here (grow ? consume(delta) :
+// release(delta)); the only branch-specific difference is whether the kernel
+// resizes via mremap or realloc, which is libc/kernel behavior, not this fix's
+// accounting logic.
+class AllocatorTrackerTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        _tracker = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::OTHER,
+                                                    "UT-AllocatorTrackerTest");
+        _rc = ResourceContext::create_shared();
+        _rc->memory_context()->set_mem_tracker(_tracker);
+    }
+
+    // ThreadMemTrackerMgr batches small allocations in `_untracked_mem` and
+    // only flushes to the tracker at `mem_tracker_consume_min_size_bytes`.
+    // Force a flush so single-alloc tests see deterministic `consumption()`.
+    static void flush_thread_tracker() {
+        thread_context()->thread_mem_tracker_mgr->flush_untracked_mem();
+    }
+
+    std::shared_ptr<MemTrackerLimiter> _tracker;
+    std::shared_ptr<ResourceContext> _rc;
+};
+
+TEST_F(AllocatorTrackerTest, GrowChargesDeltaOnly) {
+    SCOPED_ATTACH_TASK(_rc);
+    flush_thread_tracker();
+    const int64_t base = _tracker->consumption();
+
+    Allocator<false, false, false> allocator;
+    // Both sizes are >= mem_tracker_consume_min_size_bytes (default 1 MiB)
+    // to guarantee the thread-local batch flushes on each call.
+    constexpr size_t kOld = 4 * 1024 * 1024;  // 4 MiB
+    constexpr size_t kNew = 16 * 1024 * 1024; // 16 MiB
+
+    void* buf = allocator.alloc(kOld);
+    ASSERT_NE(nullptr, buf);
+    flush_thread_tracker();
+    const int64_t after_alloc = _tracker->consumption();
+    EXPECT_EQ(after_alloc, base + static_cast<int64_t>(kOld));
+
+    buf = allocator.realloc(buf, kOld, kNew);
+    ASSERT_NE(nullptr, buf);
+    flush_thread_tracker();
+    const int64_t after_grow = _tracker->consumption();
+    // Net delta must equal (kNew - kOld); the old_size must NOT be
+    // transiently added on top of new_size before being released.
+    EXPECT_EQ(after_grow, base + static_cast<int64_t>(kNew));
+    EXPECT_LT(after_grow, base + static_cast<int64_t>(kOld + kNew));
+
+    allocator.free(buf, kNew);
+    flush_thread_tracker();
+    EXPECT_EQ(_tracker->consumption(), base);
+}
+
+TEST_F(AllocatorTrackerTest, ShrinkReleasesDeltaOnly) {
+    SCOPED_ATTACH_TASK(_rc);
+    flush_thread_tracker();
+    const int64_t base = _tracker->consumption();
+
+    Allocator<false, false, false> allocator;
+    constexpr size_t kOld = 16 * 1024 * 1024;
+    constexpr size_t kNew = 4 * 1024 * 1024;
+
+    void* buf = allocator.alloc(kOld);
+    ASSERT_NE(nullptr, buf);
+    flush_thread_tracker();
+    EXPECT_EQ(_tracker->consumption(), base + static_cast<int64_t>(kOld));
+
+    buf = allocator.realloc(buf, kOld, kNew);
+    ASSERT_NE(nullptr, buf);
+    flush_thread_tracker();
+    EXPECT_EQ(_tracker->consumption(), base + static_cast<int64_t>(kNew));
+
+    allocator.free(buf, kNew);
+    flush_thread_tracker();
+    EXPECT_EQ(_tracker->consumption(), base);
+}
+
+TEST_F(AllocatorTrackerTest, GrowDoesNotTripLimitOnBoundary) {
+    // Simulates the OOM boundary observed in production: tracker consumption
+    // is close to the query mem_limit and a hash table doubles. Under delta
+    // accounting the check charges only (new-old), so realloc succeeds; a
+    // regression to `charge new_size` would fail the check.
+    SCOPED_ATTACH_TASK(_rc);
+    flush_thread_tracker();
+
+    Allocator<false, false, false> allocator;
+    constexpr size_t kOld = 4 * 1024 * 1024;    // 4 MiB
+    constexpr size_t kNew = 6 * 1024 * 1024;    // 6 MiB
+    constexpr int64_t kLimit = 9 * 1024 * 1024; // 9 MiB
+
+    void* buf = allocator.alloc(kOld);
+    ASSERT_NE(nullptr, buf);
+    flush_thread_tracker();
+
+    // Set limit AFTER the initial alloc so consumption() sits at 4 MiB with
+    // 5 MiB headroom. A regression that charges new_size=6MiB during realloc
+    // would exceed 9 MiB (4 + 6 > 9). Delta accounting charges only 2 MiB
+    // (4 + 2 <= 9), which passes.
+    _tracker->set_limit(kLimit);
+    ASSERT_TRUE(_tracker->check_limit(static_cast<int64_t>(kNew - kOld)).ok());
+
+    void* new_buf = nullptr;
+    try {
+        new_buf = allocator.realloc(buf, kOld, kNew);
+    } catch (const Exception& e) {
+        _tracker->set_limit(-1);
+        allocator.free(buf, kOld);
+        FAIL() << "realloc must not double-count old_size against mem_limit; got: " << e.what();
+    }
+    _tracker->set_limit(-1);
+    ASSERT_NE(nullptr, new_buf);
+    flush_thread_tracker();
+    EXPECT_EQ(_tracker->consumption(), static_cast<int64_t>(kNew));
+
+    allocator.free(new_buf, kNew);
+    flush_thread_tracker();
+    EXPECT_EQ(_tracker->consumption(), 0);
+}
+
+TEST_F(AllocatorTrackerTest, SameSizeReallocIsNoOp) {
+    SCOPED_ATTACH_TASK(_rc);
+    flush_thread_tracker();
+    const int64_t base = _tracker->consumption();
+
+    Allocator<false, false, false> allocator;
+    constexpr size_t kSize = 4 * 1024 * 1024;
+
+    void* buf = allocator.alloc(kSize);
+    ASSERT_NE(nullptr, buf);
+    flush_thread_tracker();
+    const int64_t after_alloc = _tracker->consumption();
+
+    void* same = allocator.realloc(buf, kSize, kSize);
+    EXPECT_EQ(same, buf);
+    flush_thread_tracker();
+    EXPECT_EQ(_tracker->consumption(), after_alloc);
+
+    allocator.free(same, kSize);
+    flush_thread_tracker();
+    EXPECT_EQ(_tracker->consumption(), base);
+}
+
+TEST_F(AllocatorTrackerTest, GrowThenShrinkReturnsToBase) {
+    // Chained realloc must keep the tracker balanced end-to-end regardless of
+    // which realloc path each hop takes.
+    SCOPED_ATTACH_TASK(_rc);
+    flush_thread_tracker();
+    const int64_t base = _tracker->consumption();
+
+    Allocator<false, false, false> allocator;
+    constexpr size_t kA = 4 * 1024 * 1024;
+    constexpr size_t kB = 32 * 1024 * 1024;
+    constexpr size_t kC = 8 * 1024 * 1024;
+
+    void* buf = allocator.alloc(kA);
+    ASSERT_NE(nullptr, buf);
+    buf = allocator.realloc(buf, kA, kB);
+    ASSERT_NE(nullptr, buf);
+    flush_thread_tracker();
+    EXPECT_EQ(_tracker->consumption(), base + static_cast<int64_t>(kB));
+
+    buf = allocator.realloc(buf, kB, kC);
+    ASSERT_NE(nullptr, buf);
+    flush_thread_tracker();
+    EXPECT_EQ(_tracker->consumption(), base + static_cast<int64_t>(kC));
+
+    allocator.free(buf, kC);
+    flush_thread_tracker();
+    EXPECT_EQ(_tracker->consumption(), base);
+}
+
+TEST_F(AllocatorTrackerTest, GrowAcrossMmapThresholdChargesDeltaOnly) {
+    // old_size below the mmap threshold and new_size above it forces the
+    // copy path (`alloc(new)+memcpy+free(old)`). Inner alloc/free self-track;
+    // the outer realloc must not add a second layer of consume/release.
+    SCOPED_ATTACH_TASK(_rc);
+    flush_thread_tracker();
+    const int64_t base = _tracker->consumption();
+
+    Allocator<false, false, true> allocator; // use_mmap = true
+    const size_t threshold = static_cast<size_t>(doris::config::mmap_threshold);
+    const size_t kOld = 4 * 1024 * 1024;
+    const size_t kNew = threshold + 16 * 1024 * 1024; // comfortably above threshold
+
+    void* buf = allocator.alloc(kOld);
+    ASSERT_NE(nullptr, buf);
+
+    buf = allocator.realloc(buf, kOld, kNew);
+    ASSERT_NE(nullptr, buf);
+    flush_thread_tracker();
+    EXPECT_EQ(_tracker->consumption(), base + static_cast<int64_t>(kNew));
+
+    allocator.free(buf, kNew);
+    flush_thread_tracker();
+    EXPECT_EQ(_tracker->consumption(), base);
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: no issue

Problem Summary:

`Allocator::realloc` previously charged the full `new_size` to the memory
tracker up front (`memory_check(new_size); consume_memory(new_size);`) and only
released `old_size` after the underlying resize completed. This transiently
double-counts the old region: for the window between `consume_memory(new_size)`
and `release_memory(old_size)` the tracker reflects `old_size + new_size`. When
a query sits near its `mem_limit` and a container (e.g. a hash table) doubles at
the boundary, that transient peak trips the limit check and surfaces as a
spurious `MEM_LIMIT_EXCEEDED` for queries that have no spill fallback, even
though the steady-state footprint after the resize is only `new_size`.

The fix tracks the net delta instead of the gross size:

- Malloc / small-mmap `realloc` path: compute `grow = new_size > old_size` and
  `delta = |new_size - old_size|`. On grow, `memory_check(delta)` +
  `consume_memory(delta)` before the resize and `release_memory(delta)` on the
  failure path; on shrink, `release_memory(delta)` after success. These paths
  overwhelmingly resolve in place (tcmalloc/jemalloc grow the region without
  copying), so the net delta matches the real peak. If the allocator internally
  falls back to alloc+copy+free, the tracker is briefly under-counted by
  `old_size` for the duration of a single `memcpy`, then self-corrects.
- mremap path: same net-delta pattern. Native Linux `mremap(MREMAP_MAYMOVE)`
  rewires page tables in place without duplicating physical pages, so the peak
  equals `new_size` and net-delta accounting is exact. The apple/freebsd
  `common/mremap.h` fallback (mmap+memcpy+munmap) peaks at `old+new` and is
  briefly under-counted here; production is Linux-only.
- Big-alloc copy branch (`old < threshold < new`): drop the outer
  `release_memory(old_size)`. The inner `alloc(new_size)` and `free(buf,
  old_size)` already self-track new_size and old_size respectively, so the outer
  release would double-release. The peak here is genuinely `old+new` for the
  copy window, which consumers of this path already tolerate.

Net effect: growing a buffer charges only `(new_size - old_size)` to the current
tracker, eliminating the false positive at the limit boundary while keeping the
tracker balanced end-to-end.

### Release note

Fix spurious `MEM_LIMIT_EXCEEDED` errors that could occur when a buffer is
reallocated (e.g. a hash table grows) while a query's memory usage is near its
limit and no spill fallback is available.

### Check List (For Author)

- Test: Unit Test
    - Added `AllocatorTrackerTest` (6 cases) in
      `be/test/runtime/memory/allocator_test.cpp` covering grow-charges-delta,
      shrink-releases-delta, no-trip-at-limit-boundary, same-size no-op,
      grow-then-shrink balance, and the big-alloc copy path. Ran
      `run-be-ut.sh --filter='*Allocator*'`: 10/10 tests PASSED, including the
      pre-existing `AllocatorTest.TestNormal`.
- Behavior changed: Yes. `realloc` now charges the net size delta to the memory
  tracker instead of the gross `new_size`, so it no longer transiently
  double-counts `old_size` against `mem_limit`.
- Does this need documentation: No

