### PR TITLE
[fix](be) fail the query instead of crashing BE on iceberg schema-mapping mismatch

### DIFF
--- a/be/src/format/orc/vorc_reader.cpp
+++ b/be/src/format/orc/vorc_reader.cpp
@@ -509,6 +509,17 @@ Status OrcReader::_do_init_reader(ReaderInitContext* base_ctx) {
         _fill_missing_cols.clear();
         _fill_missing_defaults.clear();
         for (const auto& col_name : _table_column_names) {
+            // A projected column that is not present at all in the table-side schema tree means
+            // the schema info from FE is inconsistent with the scan projection. Fail this query
+            // loudly instead of aborting the whole BE process via children_column_exists's
+            // std::out_of_range (release) or DCHECK (debug). A column that IS known but missing
+            // from the data file is correctly classified as fill-missing below. See #61225.
+            if (!_table_info_node_ptr->has_children_column(col_name)) {
+                return Status::InternalError(
+                        "schema mapping is missing projected column '{}'; the schema info from FE "
+                        "is inconsistent with the scan projection (file: {})",
+                        col_name, _scan_range.path);
+            }
             if (!_table_info_node_ptr->children_column_exists(col_name)) {
                 _fill_missing_cols.insert(col_name);
             }
@@ -868,7 +879,12 @@ std::tuple<bool, orc::Literal> convert_to_orc_literal(const orc::Type* type,
 
 std::pair<bool, orc::PredicateDataType> OrcReader::_get_orc_predicate_type(
         const VSlotRef* slot_ref) {
-    DCHECK(_table_info_node_ptr->children_column_exists(slot_ref->expr_name()));
+    // Refuse pushdown for columns the table-side schema tree does not know instead of crashing
+    // on children.at() (release) / DCHECK (debug). See #61225.
+    if (!_table_info_node_ptr->has_children_column(slot_ref->expr_name()) ||
+        !_table_info_node_ptr->children_column_exists(slot_ref->expr_name())) {
+        return {false, orc::PredicateDataType::LONG};
+    }
     auto file_col_name = _table_info_node_ptr->children_file_column_name(slot_ref->expr_name());
     if (!_type_map.contains(file_col_name)) {
         LOG(WARNING) << "Column " << slot_ref->expr_name() << "in file name" << file_col_name
@@ -958,7 +974,8 @@ bool OrcReader::_check_slot_can_push_down(const VExprSPtr& expr) {
     const auto* slot_ref = static_cast<const VSlotRef*>(expr->children()[0].get());
     // check if the slot exists in orc file and not partition column
     if (_lazy_read_ctx.predicate_partition_columns.contains(slot_ref->expr_name()) ||
-        (!_table_info_node_ptr->children_column_exists(slot_ref->expr_name()))) {
+        !_table_info_node_ptr->has_children_column(slot_ref->expr_name()) ||
+        !_table_info_node_ptr->children_column_exists(slot_ref->expr_name())) {
         return false;
     }
 
@@ -2123,6 +2140,16 @@ Status OrcReader::_fill_doris_data_column(const std::string& col_name,
 
         for (int i = 0; i < doris_struct.tuple_size(); ++i) {
             const auto& table_column_name = doris_struct_type->get_name_by_position(i);
+            // A projected nested field absent from the table-side schema tree means the schema
+            // info from FE is inconsistent with the table column type. Fail the query instead
+            // of aborting the whole BE process via children.at()'s std::out_of_range (release)
+            // or DCHECK (debug). See #61225.
+            if (!root_node->has_children_column(table_column_name)) {
+                return Status::InternalError(
+                        "schema mapping is missing projected nested field '{}' of column '{}'; "
+                        "the schema info from FE is inconsistent with the scan projection",
+                        table_column_name, col_name);
+            }
             if (!root_node->children_column_exists(table_column_name)) {
                 schema_missing_fields.insert(i);
                 continue;

--- a/be/src/format/parquet/byte_array_dict_decoder.cpp
+++ b/be/src/format/parquet/byte_array_dict_decoder.cpp
@@ -128,6 +128,13 @@ Status ByteArrayDictDecoder::_decode_values(MutableColumnPtr& doris_column, Data
                                             ColumnSelectVector& select_vector,
                                             bool is_dict_filter) {
     size_t non_null_size = select_vector.num_values() - select_vector.num_nulls();
+    if (_dict_items.empty() && non_null_size > 0) [[unlikely]] {
+        // Data pages reference a dictionary that was never decoded (missing or corrupt
+        // dictionary page); indexing into an empty _dict_items dereferences a null StringRef
+        // and SIGSEGVs the whole BE process (#61225, pattern A). Report corruption instead.
+        return Status::Corruption(
+                "parquet byte-array dictionary is empty but {} values reference it", non_null_size);
+    }
     if (doris_column->is_column_dictionary()) {
         ColumnDictI32& dict_column = assert_cast<ColumnDictI32&>(*doris_column);
         if (dict_column.dict_size() == 0 && !_dict_items.empty()) {

--- a/be/src/format/parquet/byte_array_dict_decoder.cpp
+++ b/be/src/format/parquet/byte_array_dict_decoder.cpp
@@ -128,13 +128,6 @@ Status ByteArrayDictDecoder::_decode_values(MutableColumnPtr& doris_column, Data
                                             ColumnSelectVector& select_vector,
                                             bool is_dict_filter) {
     size_t non_null_size = select_vector.num_values() - select_vector.num_nulls();
-    if (_dict_items.empty() && non_null_size > 0) [[unlikely]] {
-        // Data pages reference a dictionary that was never decoded (missing or corrupt
-        // dictionary page); indexing into an empty _dict_items dereferences a null StringRef
-        // and SIGSEGVs the whole BE process (#61225, pattern A). Report corruption instead.
-        return Status::Corruption(
-                "parquet byte-array dictionary is empty but {} values reference it", non_null_size);
-    }
     if (doris_column->is_column_dictionary()) {
         ColumnDictI32& dict_column = assert_cast<ColumnDictI32&>(*doris_column);
         if (dict_column.dict_size() == 0 && !_dict_items.empty()) {
@@ -145,7 +138,27 @@ Status ByteArrayDictDecoder::_decode_values(MutableColumnPtr& doris_column, Data
         }
     }
     _indexes.resize(non_null_size);
-    _index_batch_decoder->GetBatch(_indexes.data(), cast_set<uint32_t>(non_null_size));
+    // Data pages can reference a dictionary that was never decoded, or carry indices past the
+    // end of the dictionary (corrupt or mismatched files, #61225 pattern A). Indexing
+    // _dict_items with such indices dereferences a wild/null StringRef and SIGSEGVs the whole
+    // BE process — either on the plain decoding path below, or later in
+    // convert_dict_column_to_string_column for the dictionary-column path. Validate the whole
+    // decoded index stream before entering either branch and report corruption instead
+    // (mirrors decode_dictionary_indices in format_v2/parquet/reader/native/decoder.h).
+    const uint32_t decoded =
+            _index_batch_decoder->GetBatch(_indexes.data(), cast_set<uint32_t>(non_null_size));
+    if (decoded != non_null_size) [[unlikely]] {
+        return Status::Corruption(
+                "parquet dictionary index stream is truncated: expected {} indices, decoded {}",
+                non_null_size, decoded);
+    }
+    for (size_t row = 0; row < non_null_size; ++row) {
+        if (_indexes[row] >= _dict_items.size()) [[unlikely]] {
+            return Status::Corruption(
+                    "parquet dictionary index {} at row {} exceeds dictionary size {}",
+                    _indexes[row], row, _dict_items.size());
+        }
+    }
 
     if (doris_column->is_column_dictionary() || is_dict_filter) {
         return _decode_dict_values<has_filter>(doris_column, select_vector, is_dict_filter);

--- a/be/src/format/parquet/vparquet_column_reader.cpp
+++ b/be/src/format/parquet/vparquet_column_reader.cpp
@@ -831,6 +831,16 @@ Status StructColumnReader::read_column_data(
         ColumnPtr& doris_field = doris_struct.get_column_ptr(i);
         auto& doris_type = doris_struct_type->get_element(i);
         auto& doris_name = doris_struct_type->get_element_name(i);
+        // A projected nested field absent from the table-side schema tree means the schema info
+        // from FE is inconsistent with the table column type. Fail the query instead of aborting
+        // the whole BE process via children.at()'s std::out_of_range (release) or DCHECK
+        // (debug). See #61225.
+        if (!root_node->has_children_column(doris_name)) {
+            return Status::InternalError(
+                    "schema mapping is missing projected nested field '{}' of column '{}'; the "
+                    "schema info from FE is inconsistent with the scan projection",
+                    doris_name, _field_schema->name);
+        }
         if (!root_node->children_column_exists(doris_name)) {
             missing_column_idxs.push_back(i);
             VLOG_DEBUG << "[ParquetReader] Missing column in schema: column_idx[" << i

--- a/be/src/format/parquet/vparquet_group_reader.cpp
+++ b/be/src/format/parquet/vparquet_group_reader.cpp
@@ -175,6 +175,19 @@ Status RowGroupReader::init(
                 continue;
             }
 
+            // A predicate column the schema tree does not know (FE/BE contract mismatch)
+            // cannot be dict-filtered; fall back to plain conjunct filtering instead of
+            // crashing on children.at(). See #61225.
+            if (!_table_info_node_ptr->has_children_column(predicate_col_name)) {
+                if (_slot_id_to_filter_conjuncts->find(slot_id) !=
+                    _slot_id_to_filter_conjuncts->end()) {
+                    for (auto& ctx : _slot_id_to_filter_conjuncts->at(slot_id)) {
+                        _filter_conjuncts.push_back(ctx);
+                    }
+                }
+                continue;
+            }
+
             auto predicate_file_col_name =
                     _table_info_node_ptr->children_file_column_name(predicate_col_name);
             auto field = schema.get_column(predicate_file_col_name);

--- a/be/src/format/parquet/vparquet_reader.cpp
+++ b/be/src/format/parquet/vparquet_reader.cpp
@@ -599,7 +599,8 @@ bool ParquetReader::_exists_in_file(const std::string& expr_name) const {
     // in `_table_info_node_ptr` is that Iceberg、Hudi has inconsistent requirements for this node;
     // Iceberg partition evolution need read partition columns from a file.
     // hudi set `hoodie.datasource.write.drop.partition.columns=false` not need read partition columns from a file.
-    return _table_info_node_ptr->children_column_exists(expr_name) &&
+    return _table_info_node_ptr->has_children_column(expr_name) &&
+           _table_info_node_ptr->children_column_exists(expr_name) &&
            _read_table_columns_set.contains(expr_name);
 }
 
@@ -1271,8 +1272,11 @@ Status ParquetReader::_process_page_index_filter(
         auto& sig_stat = cached_page_index.stats[cid];
 
         auto* slot = _tuple_descriptor->slots()[cid];
-        if (!_table_info_node_ptr->children_column_exists(slot->col_name())) {
-            // table column not exist in file, may be schema change.
+        if (!_table_info_node_ptr->has_children_column(slot->col_name()) ||
+            !_table_info_node_ptr->children_column_exists(slot->col_name())) {
+            // table column not exist in file, may be schema change; a slot the schema tree
+            // does not know at all is an FE/BE contract mismatch — skip page-index filtering
+            // instead of crashing on children.at(). See #61225.
             return false;
         }
 
@@ -1522,7 +1526,10 @@ Status ParquetReader::_process_column_stat_filter(
                         return false;
                     }
                     auto* slot = _tuple_descriptor->slots()[cid];
-                    if (!_table_info_node_ptr->children_column_exists(slot->col_name())) {
+                    if (!_table_info_node_ptr->has_children_column(slot->col_name()) ||
+                        !_table_info_node_ptr->children_column_exists(slot->col_name())) {
+                        // Unknown (contract mismatch) or file-missing column: skip this
+                        // filter instead of crashing on children.at(). See #61225.
                         return false;
                     }
                     const auto& file_col_name =
@@ -1540,7 +1547,10 @@ Status ParquetReader::_process_column_stat_filter(
         std::function<bool(ParquetPredicate::ColumnStat*, int)> get_bloom_filter_func =
                 [&](ParquetPredicate::ColumnStat* stat, const int cid) {
                     auto* slot = _tuple_descriptor->slots()[cid];
-                    if (!_table_info_node_ptr->children_column_exists(slot->col_name())) {
+                    if (!_table_info_node_ptr->has_children_column(slot->col_name()) ||
+                        !_table_info_node_ptr->children_column_exists(slot->col_name())) {
+                        // Unknown (contract mismatch) or file-missing column: skip this
+                        // filter instead of crashing on children.at(). See #61225.
                         return false;
                     }
                     const auto& file_col_name =
@@ -1618,7 +1628,8 @@ Status ParquetReader::_process_column_stat_filter(
             }
             // Find the column id for caching
             for (auto* slot : _tuple_descriptor->slots()) {
-                if (_table_info_node_ptr->children_column_exists(slot->col_name())) {
+                if (_table_info_node_ptr->has_children_column(slot->col_name()) &&
+                    _table_info_node_ptr->children_column_exists(slot->col_name())) {
                     const auto& file_col_name =
                             _table_info_node_ptr->children_file_column_name(slot->col_name());
                     const FieldSchema* col_schema =

--- a/be/src/format/table/iceberg_position_delete_sys_table_reader.cpp
+++ b/be/src/format/table/iceberg_position_delete_sys_table_reader.cpp
@@ -248,6 +248,14 @@ Status IcebergPositionDeleteSysTableReader::_init_position_delete_reader() {
                                             table_schema->root_field, *schema, mapped_file_schema,
                                             supports_iceberg_scan_semantics_v1(_range_params)));
         }
+        if (row_requested && !mapped_file_schema->has_children_column(kRowColumn)) {
+            // The delete-file schema tree does not know the row column at all (FE/BE contract
+            // mismatch); fail the query instead of crashing on children.at(). See #61225.
+            return Status::InternalError(
+                    "Iceberg position delete system table schema is missing the '{}' column; the "
+                    "schema info from FE is inconsistent with the delete file schema",
+                    kRowColumn);
+        }
         const bool read_row =
                 row_requested && mapped_file_schema->children_column_exists(kRowColumn);
         _init_read_columns(read_row);
@@ -297,6 +305,14 @@ Status IcebergPositionDeleteSysTableReader::_init_position_delete_reader() {
                     TableSchemaChangeHelper::BuildTableInfoUtil::by_orc_field_id_with_name_mapping(
                             table_schema->root_field, root_type, kIcebergOrcAttribute,
                             mapped_file_schema, supports_iceberg_scan_semantics_v1(_range_params)));
+        }
+        if (row_requested && !mapped_file_schema->has_children_column(kRowColumn)) {
+            // The delete-file schema tree does not know the row column at all (FE/BE contract
+            // mismatch); fail the query instead of crashing on children.at(). See #61225.
+            return Status::InternalError(
+                    "Iceberg position delete system table schema is missing the '{}' column; the "
+                    "schema info from FE is inconsistent with the delete file schema",
+                    kRowColumn);
         }
         const bool read_row =
                 row_requested && mapped_file_schema->children_column_exists(kRowColumn);

--- a/be/src/format/table/iceberg_reader.cpp
+++ b/be/src/format/table/iceberg_reader.cpp
@@ -482,6 +482,16 @@ Status IcebergParquetReader::on_before_init_reader(ReaderInitContext* ctx) {
             }
         } else if (desc.category == ColumnCategory::PARTITION_KEY) {
             bool has_partition_value = partition_col_names.contains(desc.name);
+            // A projected column absent from the table-side schema tree means the schema info
+            // from FE is inconsistent with the scan projection. Fail this query loudly instead
+            // of aborting the whole BE process via children_column_exists's std::out_of_range
+            // (release) or DCHECK (debug). See #61225.
+            if (!ctx->table_info_node->has_children_column(desc.name)) {
+                return Status::InternalError(
+                        "schema mapping is missing projected column '{}'; the schema info from FE "
+                        "is inconsistent with the scan projection (file: {})",
+                        desc.name, ctx->range->path);
+            }
             bool exists_in_file = ctx->table_info_node->children_column_exists(desc.name);
             if (!has_partition_value || exists_in_file) {
                 // Keep PARTITION_KEY category stable for scan planning, but still read
@@ -491,6 +501,12 @@ Status IcebergParquetReader::on_before_init_reader(ReaderInitContext* ctx) {
             }
             has_partition_from_path = true;
         } else if (desc.category == ColumnCategory::REGULAR) {
+            if (!ctx->table_info_node->has_children_column(desc.name)) {
+                return Status::InternalError(
+                        "schema mapping is missing projected column '{}'; the schema info from FE "
+                        "is inconsistent with the scan projection (file: {})",
+                        desc.name, ctx->range->path);
+            }
             ctx->column_names.push_back(desc.name);
         } else if (desc.category == ColumnCategory::GENERATED) {
             _init_row_lineage_columns();
@@ -881,6 +897,16 @@ Status IcebergOrcReader::on_before_init_reader(ReaderInitContext* ctx) {
             }
         } else if (desc.category == ColumnCategory::PARTITION_KEY) {
             bool has_partition_value = partition_col_names.contains(desc.name);
+            // A projected column absent from the table-side schema tree means the schema info
+            // from FE is inconsistent with the scan projection. Fail this query loudly instead
+            // of aborting the whole BE process via children_column_exists's std::out_of_range
+            // (release) or DCHECK (debug). See #61225.
+            if (!ctx->table_info_node->has_children_column(desc.name)) {
+                return Status::InternalError(
+                        "schema mapping is missing projected column '{}'; the schema info from FE "
+                        "is inconsistent with the scan projection (file: {})",
+                        desc.name, ctx->range->path);
+            }
             bool exists_in_file = ctx->table_info_node->children_column_exists(desc.name);
             if (!has_partition_value || exists_in_file) {
                 ctx->column_names.push_back(desc.name);
@@ -888,6 +914,12 @@ Status IcebergOrcReader::on_before_init_reader(ReaderInitContext* ctx) {
             }
             has_partition_from_path = true;
         } else if (desc.category == ColumnCategory::REGULAR) {
+            if (!ctx->table_info_node->has_children_column(desc.name)) {
+                return Status::InternalError(
+                        "schema mapping is missing projected column '{}'; the schema info from FE "
+                        "is inconsistent with the scan projection (file: {})",
+                        desc.name, ctx->range->path);
+            }
             ctx->column_names.push_back(desc.name);
         } else if (desc.category == ColumnCategory::GENERATED) {
             _init_row_lineage_columns();

--- a/be/test/format/orc/orc_reader_fill_data_test.cpp
+++ b/be/test/format/orc/orc_reader_fill_data_test.cpp
@@ -552,4 +552,47 @@ TEST_F(OrcReaderFillDataTest, ComplexTypeConversionTest) {
                   "+-------------------+\n");
     }
 }
+
+TEST_F(OrcReaderFillDataTest, FillStructFailsLoudlyWhenSchemaMappingMissesNestedField) {
+    // Covers the #61225 guard in OrcReader::_fill_doris_data_column (TYPE_STRUCT branch):
+    // the projected nested field "ghost_field" is absent from the table-side schema tree
+    // (FE/BE schema contract mismatch), so the fill must fail with InternalError instead of
+    // aborting the whole BE process via children.at() (release) / DCHECK (debug).
+    using namespace orc;
+    std::unique_ptr<orc::Type> type(orc::Type::buildTypeFromString("struct<col1:int,col2:int>"));
+
+    const size_t row_count = 10;
+    MemoryOutputStream memStream(100 * 1024 * 1024);
+    WriterOptions options;
+    options.setMemoryPool(getDefaultPool());
+    auto writer = createWriter(*type, &memStream, options);
+    auto batch = writer->createRowBatch(row_count);
+    auto& struct_batch = dynamic_cast<StructVectorBatch&>(*batch);
+
+    TFileScanRangeParams params;
+    TFileRangeDesc range;
+    auto reader = OrcReader::create_unique(params, range, 4064, "", nullptr, nullptr, true);
+
+    auto doris_struct_type = std::make_shared<DataTypeStruct>(
+            std::vector<DataTypePtr> {std::make_shared<DataTypeInt32>(),
+                                      std::make_shared<DataTypeInt32>()},
+            std::vector<std::string> {"col1", "ghost_field"});
+    MutableColumnPtr doris_column = doris_struct_type->create_column()->assert_mutable();
+
+    // The table-side schema tree only knows "col1"; "ghost_field" is the projected nested
+    // field that the FE schema info does not know about.
+    auto table_info_node = std::make_shared<TableSchemaChangeHelper::StructNode>();
+    table_info_node->add_children("col1", "col1",
+                                  TableSchemaChangeHelper::ConstNode::get_instance());
+
+    Status status = reader->_fill_doris_data_column<false>("test_struct", doris_column,
+                                                           doris_struct_type, table_info_node,
+                                                           type.get(), &struct_batch, row_count);
+
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("schema mapping is missing projected nested field "
+                                      "'ghost_field' of column 'test_struct'"),
+              std::string::npos)
+            << status;
+}
 } // namespace doris

--- a/be/test/format/orc/orc_reader_test.cpp
+++ b/be/test/format/orc/orc_reader_test.cpp
@@ -37,6 +37,7 @@
 #include "exprs/vliteral.h"
 #include "exprs/vslot_ref.h"
 #include "format/orc/orc_memory_pool.h"
+#include "format/orc/orc_memory_stream_test.h"
 #include "format/orc/vorc_reader.h"
 #include "io/fs/file_meta_cache.h"
 #include "orc/sargs/SearchArgument.hh"
@@ -435,6 +436,121 @@ TEST_F(OrcReaderTest, deletion_vector_filters_rows_without_query_conjuncts) {
     auto expected = all_order_keys;
     expected.erase(expected.begin());
     EXPECT_EQ(filtered_order_keys, expected);
+}
+
+TEST_F(OrcReaderTest, orc_init_fails_loudly_when_schema_mapping_misses_projected_column) {
+    // Covers the #61225 guard in OrcReader::_do_init_reader: the projected column is absent
+    // from the table-side schema tree (FE/BE schema contract mismatch), so init_reader must
+    // fail with InternalError instead of aborting the whole BE process via
+    // children_column_exists's children.at() (release) / DCHECK (debug).
+    using namespace orc;
+    size_t rowCount = 10;
+    MemoryOutputStream memStream(100 * 1024 * 1024);
+    MemoryPool* pool = getDefaultPool();
+    auto type = std::unique_ptr<Type>(Type::buildTypeFromString("struct<id:int>"));
+    WriterOptions options;
+    options.setMemoryPool(pool);
+    auto writer = createWriter(*type, &memStream, options);
+    auto batch = writer->createRowBatch(rowCount);
+    writer->add(*batch);
+    writer->close();
+
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
+    ReaderOptions readerOptions;
+    readerOptions.setMemoryPool(*pool);
+    auto orc_reader = createReader(std::move(inStream), readerOptions);
+
+    TFileScanRangeParams params;
+    TFileRangeDesc range;
+    range.path = "in_memory_schema_guard.orc";
+    auto reader = OrcReader::create_unique(params, range, 4064, "UTC", nullptr, nullptr, true);
+    reader->_reader = std::move(orc_reader);
+
+    // The table-side schema tree only knows "id". tuple_descriptor stays null so that
+    // on_before_init_reader keeps this injected tree instead of rebuilding one by name.
+    auto table_info_node = std::make_shared<TableSchemaChangeHelper::StructNode>();
+    table_info_node->add_children("id", "id", TableSchemaChangeHelper::ConstNode::get_instance());
+
+    // "ghost_col" is the projected column the FE schema info does not know about.
+    std::vector<ColumnDescriptor> column_descs;
+    ColumnDescriptor ghost_desc;
+    ghost_desc.name = "ghost_col";
+    column_descs.push_back(ghost_desc);
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"ghost_col", 0}};
+
+    OrcInitContext orc_ctx;
+    orc_ctx.column_descs = &column_descs;
+    orc_ctx.col_name_to_block_idx = &col_name_to_block_idx;
+    orc_ctx.params = &params;
+    orc_ctx.range = &range;
+    orc_ctx.table_info_node = table_info_node;
+
+    auto status = reader->init_reader(&orc_ctx);
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("schema mapping is missing projected column 'ghost_col'"),
+              std::string::npos)
+            << status;
+}
+
+TEST_F(OrcReaderTest, predicate_pushdown_refused_for_column_unknown_to_schema_mapping) {
+    // Covers the #61225 guards in OrcReader::_get_orc_predicate_type and
+    // OrcReader::_check_slot_can_push_down: a slot whose column is absent from the table-side
+    // schema tree must silently refuse pushdown (return false / {false, LONG}) instead of
+    // aborting the BE process via children.at() (release) / DCHECK (debug).
+    TFileScanRangeParams params;
+    TFileRangeDesc range;
+    auto reader = OrcReader::create_unique(params, range, 4064, "UTC", nullptr, nullptr, true);
+
+    auto string_type = DataTypeFactory::instance().create_data_type(TYPE_STRING, false);
+
+    // Branch 1 of the guard in _get_orc_predicate_type: has_children_column is false.
+    auto table_info_node = std::make_shared<TableSchemaChangeHelper::StructNode>();
+    table_info_node->add_children("id", "id", TableSchemaChangeHelper::ConstNode::get_instance());
+    reader->_table_info_node_ptr = table_info_node;
+
+    auto ghost_slot = VSlotRef::create_shared(0, 0, -1, string_type, "ghost_col");
+    auto [ghost_valid, ghost_predicate_type] = reader->_get_orc_predicate_type(ghost_slot.get());
+    EXPECT_FALSE(ghost_valid);
+    EXPECT_EQ(ghost_predicate_type, orc::PredicateDataType::LONG);
+
+    // Branch 2 of the guard in _get_orc_predicate_type: the column is known to the schema
+    // tree but marked not present in the file, so children_column_exists is false.
+    auto missing_node = std::make_shared<TableSchemaChangeHelper::StructNode>();
+    missing_node->add_not_exist_children("missing_col");
+    reader->_table_info_node_ptr = missing_node;
+
+    auto missing_slot = VSlotRef::create_shared(0, 0, -1, string_type, "missing_col");
+    auto [missing_valid, missing_predicate_type] =
+            reader->_get_orc_predicate_type(missing_slot.get());
+    EXPECT_FALSE(missing_valid);
+    EXPECT_EQ(missing_predicate_type, orc::PredicateDataType::LONG);
+
+    // Same unknown-column guard in _check_slot_can_push_down, reached through the expr path.
+    reader->_table_info_node_ptr = table_info_node;
+
+    TFunction fn;
+    TFunctionName fn_name;
+    fn_name.__set_db_name("");
+    fn_name.__set_function_name("eq");
+    fn.__set_name(fn_name);
+    fn.__set_binary_type(TFunctionBinaryType::BUILTIN);
+    fn.__set_arg_types({create_type_desc(TYPE_STRING), create_type_desc(TYPE_STRING)});
+    fn.__set_ret_type(create_type_desc(TYPE_BOOLEAN));
+    fn.__set_has_var_args(false);
+
+    TExprNode eq_node;
+    eq_node.__set_type(create_type_desc(TYPE_BOOLEAN));
+    eq_node.__set_node_type(TExprNodeType::BINARY_PRED);
+    eq_node.__set_opcode(TExprOpcode::EQ);
+    eq_node.__set_fn(fn);
+    eq_node.__set_num_children(2);
+    eq_node.__set_is_nullable(true);
+    auto eq_expr = VectorizedFnCall::create_shared(eq_node);
+    eq_expr->add_child(ghost_slot);
+    eq_expr->add_child(create_string_literal("x"));
+    // The expr is deliberately left unprepared: the guard only inspects children()[0]
+    // before consulting the schema tree.
+    EXPECT_FALSE(reader->_check_slot_can_push_down(eq_expr));
 }
 
 } // namespace doris

--- a/be/test/format/parquet/byte_array_dict_decoder_test.cpp
+++ b/be/test/format/parquet/byte_array_dict_decoder_test.cpp
@@ -528,4 +528,103 @@ TEST_F(ByteArrayDictDecoderTest, test_set_dict_rejects_truncated_payload_after_p
     ASSERT_FALSE(decoder.set_dict(dict_data, 4, 1).ok());
 }
 
+// #61225 pattern A: data pages reference a dictionary that was never decoded, leaving
+// _dict_items empty. decode_values must report Corruption instead of indexing the empty
+// dictionary and dereferencing a null StringRef (SIGSEGV before the guard).
+TEST_F(ByteArrayDictDecoderTest, test_decode_values_empty_dict_returns_corruption) {
+    ByteArrayDictDecoder empty_decoder;
+    auto dict_data = make_unique_buffer<uint8_t>(0);
+    ASSERT_TRUE(empty_decoder.set_dict(dict_data, 0, 0).ok());
+
+    MutableColumnPtr column = ColumnString::create();
+    DataTypePtr data_type = std::make_shared<DataTypeString>();
+
+    // Well-formed RLE index stream: 4 zeros followed by 1, 2, 1 — 7 indices into an EMPTY
+    // dictionary.
+    std::vector<uint8_t> rle_data = {2, 8, 0, 3, 0b00011001, 0};
+    Slice data_slice(reinterpret_cast<char*>(rle_data.data()), rle_data.size());
+    ASSERT_TRUE(empty_decoder.set_data(&data_slice).ok());
+
+    const size_t num_values = 7;
+    std::vector<uint16_t> run_length_null_map(1, num_values); // All non-null
+    std::vector<uint8_t> filter_data(num_values, 1);
+    FilterMap filter_map;
+    ASSERT_TRUE(filter_map.init(filter_data.data(), filter_data.size(), false).ok());
+    ColumnSelectVector select_vector;
+    ASSERT_TRUE(select_vector.init(run_length_null_map, num_values, nullptr, &filter_map, 0).ok());
+
+    auto status = empty_decoder.decode_values(column, data_type, select_vector, false);
+    EXPECT_TRUE(status.is<ErrorCode::CORRUPTION>()) << status;
+}
+
+// A data page carrying an index past the end of the dictionary must report Corruption instead
+// of reading past _dict_items and dereferencing a wild StringRef (#61225 pattern A hardening).
+TEST_F(ByteArrayDictDecoderTest, test_decode_values_out_of_range_index_returns_corruption) {
+    MutableColumnPtr column = ColumnString::create();
+    DataTypePtr data_type = std::make_shared<DataTypeString>();
+
+    // RLE run: 4 repeats of index 3, but the dictionary only holds 3 entries (indices 0..2).
+    std::vector<uint8_t> rle_data = {2, 8, 3};
+    Slice data_slice(reinterpret_cast<char*>(rle_data.data()), rle_data.size());
+    ASSERT_TRUE(_decoder.set_data(&data_slice).ok());
+
+    const size_t num_values = 4;
+    std::vector<uint16_t> run_length_null_map(1, num_values); // All non-null
+    std::vector<uint8_t> filter_data(num_values, 1);
+    FilterMap filter_map;
+    ASSERT_TRUE(filter_map.init(filter_data.data(), filter_data.size(), false).ok());
+    ColumnSelectVector select_vector;
+    ASSERT_TRUE(select_vector.init(run_length_null_map, num_values, nullptr, &filter_map, 0).ok());
+
+    auto status = _decoder.decode_values(column, data_type, select_vector, false);
+    EXPECT_TRUE(status.is<ErrorCode::CORRUPTION>()) << status;
+}
+
+// Same out-of-range index on the dictionary-column path: the raw indices would previously be
+// stored unvalidated and only crash later in convert_dict_column_to_string_column.
+TEST_F(ByteArrayDictDecoderTest,
+       test_decode_values_out_of_range_index_dict_column_returns_corruption) {
+    MutableColumnPtr column = ColumnDictI32::create();
+    DataTypePtr data_type = std::make_shared<DataTypeInt32>();
+
+    // RLE run: 4 repeats of index 3, but the dictionary only holds 3 entries (indices 0..2).
+    std::vector<uint8_t> rle_data = {2, 8, 3};
+    Slice data_slice(reinterpret_cast<char*>(rle_data.data()), rle_data.size());
+    ASSERT_TRUE(_decoder.set_data(&data_slice).ok());
+
+    const size_t num_values = 4;
+    std::vector<uint16_t> run_length_null_map(1, num_values); // All non-null
+    std::vector<uint8_t> filter_data(num_values, 1);
+    FilterMap filter_map;
+    ASSERT_TRUE(filter_map.init(filter_data.data(), filter_data.size(), false).ok());
+    ColumnSelectVector select_vector;
+    ASSERT_TRUE(select_vector.init(run_length_null_map, num_values, nullptr, &filter_map, 0).ok());
+
+    auto status = _decoder.decode_values(column, data_type, select_vector, false);
+    EXPECT_TRUE(status.is<ErrorCode::CORRUPTION>()) << status;
+}
+
+// A truncated index stream yields fewer indices than the non-null value count; previously the
+// short count from GetBatch went unchecked and garbage indices were used to index _dict_items.
+TEST_F(ByteArrayDictDecoderTest, test_decode_values_truncated_index_stream_returns_corruption) {
+    MutableColumnPtr column = ColumnString::create();
+    DataTypePtr data_type = std::make_shared<DataTypeString>();
+
+    // RLE run: only 4 repeats of index 0, but 7 non-null values are requested below.
+    std::vector<uint8_t> rle_data = {2, 8, 0};
+    Slice data_slice(reinterpret_cast<char*>(rle_data.data()), rle_data.size());
+    ASSERT_TRUE(_decoder.set_data(&data_slice).ok());
+
+    const size_t num_values = 7;
+    std::vector<uint16_t> run_length_null_map(1, num_values); // All non-null
+    std::vector<uint8_t> filter_data(num_values, 1);
+    FilterMap filter_map;
+    ASSERT_TRUE(filter_map.init(filter_data.data(), filter_data.size(), false).ok());
+    ColumnSelectVector select_vector;
+    ASSERT_TRUE(select_vector.init(run_length_null_map, num_values, nullptr, &filter_map, 0).ok());
+
+    auto status = _decoder.decode_values(column, data_type, select_vector, false);
+    EXPECT_TRUE(status.is<ErrorCode::CORRUPTION>()) << status;
+}
+
 } // namespace doris

--- a/be/test/format/parquet/parquet_expr_test.cpp
+++ b/be/test/format/parquet/parquet_expr_test.cpp
@@ -2480,4 +2480,175 @@ TEST_F(ParquetExprTest, test_bloom_filter_reused_after_first_load) {
     EXPECT_EQ(2, loader_calls);
 }
 
+TEST_F(ParquetExprTest, struct_column_reader_fails_query_when_projected_nested_field_unknown) {
+    // #61225: StructColumnReader::read_column_data must fail the query with InternalError when a
+    // projected nested field is absent from the table-side schema tree (FE/BE contract mismatch),
+    // instead of aborting the BE via StructNode::children.at() (std::out_of_range in release,
+    // DCHECK in debug). The guard runs before any child reader is consulted, so the unknown
+    // field is placed first and no child readers are needed.
+    auto element_type = std::make_shared<DataTypeInt64>();
+    auto struct_type = std::make_shared<DataTypeStruct>(
+            std::vector<DataTypePtr> {element_type, element_type},
+            std::vector<std::string> {"ghost_field", "known_field"});
+    ColumnPtr column = struct_type->create_column();
+
+    FieldSchema field;
+    field.name = "struct_col";
+    field.data_type = struct_type;
+
+    RowRanges row_ranges = RowRanges::create_single(1);
+    StructColumnReader reader(row_ranges, 1, nullptr, nullptr);
+    std::unordered_map<std::string, std::unique_ptr<ParquetColumnReader>> child_readers;
+    ASSERT_TRUE(reader.init(std::move(child_readers), &field).ok());
+
+    // The table-side schema tree only knows "known_field"; "ghost_field" is the projected
+    // nested field the schema info from FE never registered.
+    auto root_node = std::make_shared<TableSchemaChangeHelper::StructNode>();
+    root_node->add_children("known_field", "known_field",
+                            TableSchemaChangeHelper::ConstNode::get_instance());
+
+    FilterMap filter_map;
+    size_t read_rows = 0;
+    bool eof = false;
+    Status status = reader.read_column_data(column, struct_type, root_node, filter_map, 1,
+                                            &read_rows, &eof, false);
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.is<ErrorCode::INTERNAL_ERROR>()) << status;
+    EXPECT_NE(std::string::npos,
+              status.to_string().find("missing projected nested field 'ghost_field'"))
+            << status;
+}
+
+TEST_F(ParquetExprTest, dict_filter_falls_back_to_plain_conjunct_when_predicate_column_unknown) {
+    // #61225: RowGroupReader::init collects dict-filter candidates from the predicate columns.
+    // A predicate column the table-side schema tree does not know (FE/BE contract mismatch)
+    // cannot be dict-filtered; its conjuncts must fall back to plain filtering instead of
+    // crashing on StructNode::children.at().
+    TDescriptorTable local_desc_table;
+    TTableDescriptor local_table_desc;
+    create_table_desc(local_desc_table, local_table_desc, {"string_col", "ghost_predicate_col"},
+                      {TPrimitiveType::STRING, TPrimitiveType::STRING});
+    DescriptorTbl* local_desc_tbl = nullptr;
+    ObjectPool local_obj_pool;
+    ASSERT_TRUE(DescriptorTbl::create(&local_obj_pool, local_desc_table, &local_desc_tbl).ok());
+    auto* tuple_desc = local_desc_tbl->get_tuple_descriptor(0);
+    RowDescriptor row_desc(tuple_desc);
+
+    RuntimeState state = RuntimeState(TQueryOptions(), TQueryGlobals());
+    state.set_desc_tbl(local_desc_tbl);
+    const int ghost_slot_id = tuple_desc->slots()[1]->id();
+    auto ghost_conjunct =
+            create_string_equal(&state, row_desc, VSlotRef::create_shared(tuple_desc->slots()[1]),
+                                create_string_literal("keep"));
+
+    io::FileReaderSPtr file_reader;
+    ASSERT_TRUE(io::global_local_filesystem()->open_file(file_path, &file_reader).ok());
+    const auto& row_group = doris_metadata.row_groups[0];
+
+    // The table-side schema tree knows only the read column; the predicate column is absent.
+    auto table_info_node = std::make_shared<TableSchemaChangeHelper::StructNode>();
+    table_info_node->add_children("string_col", "string_col",
+                                  TableSchemaChangeHelper::ConstNode::get_instance());
+
+    RowGroupReader::PositionDeleteContext position_delete_ctx(row_group.num_rows, 0);
+    RowGroupReader::LazyReadContext lazy_read_ctx;
+    lazy_read_ctx.predicate_columns.first = {"ghost_predicate_col"};
+    lazy_read_ctx.predicate_columns.second = {ghost_slot_id};
+    std::set<uint64_t> column_ids;
+    std::set<uint64_t> filter_column_ids;
+    RowGroupReader group_reader(file_reader, {"string_col"}, 0, row_group, &ctz, nullptr,
+                                position_delete_ctx, lazy_read_ctx, &state, column_ids,
+                                filter_column_ids);
+    group_reader._table_info_node_ptr = table_info_node;
+    group_reader.set_table_format_reader(p_reader.get());
+
+    std::unordered_map<int, VExprContextSPtrs> slot_id_to_filter_conjuncts = {
+            {ghost_slot_id, {ghost_conjunct}}};
+    RowRanges row_ranges = RowRanges::create_single(row_group.num_rows);
+    std::unordered_map<int, tparquet::OffsetIndex> col_offsets;
+    std::unordered_map<std::string, int> col_name_to_slot_id = {
+            {"string_col", tuple_desc->slots()[0]->id()}};
+    ASSERT_TRUE(group_reader
+                        .init(doris_file_metadata->schema(), row_ranges, col_offsets, tuple_desc,
+                              &row_desc, &col_name_to_slot_id, nullptr,
+                              &slot_id_to_filter_conjuncts)
+                        .ok());
+
+    // Fallback happened: the conjunct moved to plain filtering and no dict filter registered.
+    EXPECT_TRUE(group_reader._dict_filter_cols.empty());
+    ASSERT_EQ(1, group_reader._filter_conjuncts.size());
+    EXPECT_EQ(ghost_conjunct, group_reader._filter_conjuncts.front());
+}
+
+TEST_F(ParquetExprTest, test_column_stat_filter_skips_slot_absent_from_schema_mapping) {
+    // #61225: the min-max and bloom-filter stat lambdas of _process_column_stat_filter must skip
+    // a slot the table-side schema tree does not know (FE/BE contract mismatch) instead of
+    // crashing on StructNode::children.at().
+    // Control: with the intact schema tree, an EQ predicate outside the file min/max range
+    // (int64_col holds 10000000000..10000000005 in row group 0) filters the row group out.
+    std::unique_ptr<MutilColumnBlockPredicate> control_pred =
+            AndBlockColumnPredicate::create_unique();
+    control_pred->add_column_predicate(SingleColumnBlockPredicate::create_unique(
+            ComparisonPredicateBase<TYPE_BIGINT, PredicateType::EQ>::create_shared(
+                    2, "", Field::create_field<TYPE_BIGINT>(-1))));
+    p_reader->_push_down_predicates.push_back(std::move(control_pred));
+
+    bool filter_group = false;
+    bool filtered_by_min_max = false;
+    bool filtered_by_bloom_filter = false;
+    ASSERT_TRUE(p_reader
+                        ->_process_column_stat_filter(doris_metadata.row_groups[0],
+                                                      p_reader->_push_down_predicates,
+                                                      &filter_group, &filtered_by_min_max,
+                                                      &filtered_by_bloom_filter)
+                        .ok());
+    EXPECT_TRUE(filter_group);
+    EXPECT_TRUE(filtered_by_min_max);
+
+    // Contract mismatch: the schema tree no longer knows int64_col (cid 2). The same predicate
+    // must be skipped (both stat and bloom lambdas return false), keeping the row group,
+    // instead of throwing std::out_of_range / hitting the DCHECK.
+    auto table_info_node = std::make_shared<TableSchemaChangeHelper::StructNode>();
+    table_info_node->add_children("int32_partial_null_col", "int32_partial_null_col",
+                                  TableSchemaChangeHelper::ConstNode::get_instance());
+    p_reader->_table_info_node_ptr = table_info_node;
+
+    p_reader->_push_down_predicates.clear();
+    std::unique_ptr<MutilColumnBlockPredicate> mismatch_pred =
+            AndBlockColumnPredicate::create_unique();
+    mismatch_pred->add_column_predicate(SingleColumnBlockPredicate::create_unique(
+            ComparisonPredicateBase<TYPE_BIGINT, PredicateType::EQ>::create_shared(
+                    2, "", Field::create_field<TYPE_BIGINT>(-1))));
+    p_reader->_push_down_predicates.push_back(std::move(mismatch_pred));
+
+    filter_group = false;
+    filtered_by_min_max = false;
+    filtered_by_bloom_filter = false;
+    ASSERT_TRUE(p_reader
+                        ->_process_column_stat_filter(doris_metadata.row_groups[0],
+                                                      p_reader->_push_down_predicates,
+                                                      &filter_group, &filtered_by_min_max,
+                                                      &filtered_by_bloom_filter)
+                        .ok());
+    EXPECT_FALSE(filter_group);
+    EXPECT_FALSE(filtered_by_min_max);
+    EXPECT_FALSE(filtered_by_bloom_filter);
+}
+
+TEST_F(ParquetExprTest, test_exists_in_file_false_for_column_absent_from_schema_mapping) {
+    // #61225: _exists_in_file must report a column the table-side schema tree never registered
+    // (FE/BE contract mismatch) as absent without touching StructNode::children.at().
+    // Baseline: the fixture hive-style name mapping knows every column of the file.
+    EXPECT_TRUE(p_reader->_exists_in_file("int64_col"));
+
+    // Swap in a table-side schema tree that registered only int32_partial_null_col.
+    auto table_info_node = std::make_shared<TableSchemaChangeHelper::StructNode>();
+    table_info_node->add_children("int32_partial_null_col", "int32_partial_null_col",
+                                  TableSchemaChangeHelper::ConstNode::get_instance());
+    p_reader->_table_info_node_ptr = table_info_node;
+
+    EXPECT_FALSE(p_reader->_exists_in_file("int64_col"));
+    EXPECT_TRUE(p_reader->_exists_in_file("int32_partial_null_col"));
+}
+
 } // namespace doris

--- a/be/test/format/parquet/parquet_expr_test.cpp
+++ b/be/test/format/parquet/parquet_expr_test.cpp
@@ -50,6 +50,7 @@
 #include <vector>
 
 #include "common/config.h"
+#include "common/consts.h"
 #include "common/object_pool.h"
 #include "common/status.h"
 #include "core/column/column.h"
@@ -71,10 +72,12 @@
 #include "format/parquet/vparquet_file_metadata.h"
 #include "format/parquet/vparquet_page_index.h"
 #include "format/parquet/vparquet_reader.h"
+#include "format/table/iceberg_reader.h"
 #include "gtest/gtest_pred_impl.h"
 #include "information_schema/schema_scanner.h"
 #include "io/fs/local_file_system.h"
 #include "runtime/descriptors.h"
+#include "runtime/runtime_profile.h"
 #include "runtime/runtime_state.h"
 #include "storage/index/zone_map/zonemap_eval_context.h"
 #include "storage/predicate/comparison_predicate.h"
@@ -1267,6 +1270,95 @@ TEST_F(ParquetExprTest, test_page_index_filter_skips_column_index_for_unsupporte
     assert_single_range(&candidate_row_ranges, 0, row_group.num_rows);
     EXPECT_EQ(read_calls_before + 1, p_reader->_column_statistics.page_index_read_calls);
     EXPECT_EQ(0, p_reader->_reader_statistics.filtered_row_groups_by_expr_zonemap);
+}
+
+TEST_F(ParquetExprTest, test_page_index_filter_skips_synthetic_slot_absent_from_schema_mapping) {
+    // #61225: TopN appends a synthetic GLOBAL_ROWID_COL slot to the scan tuple. The Iceberg
+    // scan builds the table-side schema tree from the FE schema info (history_schema_info),
+    // which never registers synthetic slots. The page-index path must skip such a slot instead
+    // of crashing on StructNode::children.at() (std::out_of_range / DCHECK abort).
+    ScopedBoolConfig enable_page_index_guard(config::enable_parquet_page_index, true);
+
+    // Tuple: one real column (int64_col, cid 0) + one synthetic slot (cid 1).
+    TDescriptorTable local_desc_table;
+    TTableDescriptor local_table_desc;
+    create_table_desc(local_desc_table, local_table_desc, {"int64_col", BeConsts::GLOBAL_ROWID_COL},
+                      {TPrimitiveType::BIGINT, TPrimitiveType::BIGINT});
+    DescriptorTbl* local_desc_tbl = nullptr;
+    ObjectPool local_obj_pool;
+    ASSERT_TRUE(DescriptorTbl::create(&local_obj_pool, local_desc_table, &local_desc_tbl).ok());
+    const auto* local_tuple_desc = local_desc_tbl->get_tuple_descriptor(0);
+    ASSERT_EQ(2, local_tuple_desc->slots().size());
+
+    // The FE schema info registers ONLY int64_col — synthetic slots are never registered.
+    schema::external::TSchema fe_schema;
+    {
+        TColumnType bigint_type;
+        bigint_type.__set_type(TPrimitiveType::BIGINT);
+        auto field = std::make_shared<schema::external::TField>();
+        field->__set_name("int64_col");
+        field->__set_id(2);
+        field->__set_is_optional(true);
+        field->__set_type(bigint_type);
+        schema::external::TFieldPtr field_ptr;
+        field_ptr.__set_field_ptr(std::move(field));
+        schema::external::TStructField root_field;
+        root_field.__set_fields({std::move(field_ptr)});
+        fe_schema.__set_schema_id(-1);
+        fe_schema.__set_root_field(root_field);
+    }
+
+    io::FileReaderSPtr local_file_reader;
+    ASSERT_TRUE(io::global_local_filesystem()->open_file(file_path, &local_file_reader).ok());
+
+    TFileScanRangeParams scan_params;
+    scan_params.format_type = TFileFormatType::FORMAT_PARQUET;
+    scan_params.__set_history_schema_info({std::move(fe_schema)});
+    TFileRangeDesc scan_range;
+    scan_range.start_offset = 0;
+    scan_range.size = local_file_reader->size();
+    scan_range.path = file_path;
+
+    RuntimeProfile profile("test_profile");
+    auto iceberg_reader = std::make_unique<IcebergParquetReader>(
+            nullptr /* kv_cache */, &profile, scan_params, scan_range, 1024, &ctz,
+            nullptr /* io_ctx */, runtime_state.get(), nullptr /* meta_cache */);
+    iceberg_reader->set_file_reader(local_file_reader);
+
+    std::vector<ColumnDescriptor> column_descs;
+    ColumnDescriptor desc;
+    desc.name = "int64_col";
+    column_descs.push_back(desc);
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"int64_col", 0}};
+    std::unordered_map<std::string, int> local_colname_to_slot_id = {{"int64_col", 0}};
+
+    ParquetInitContext pq_ctx;
+    pq_ctx.column_descs = &column_descs;
+    pq_ctx.col_name_to_block_idx = &col_name_to_block_idx;
+    pq_ctx.tuple_descriptor = local_tuple_desc;
+    pq_ctx.colname_to_slot_id = &local_colname_to_slot_id;
+    pq_ctx.params = &scan_params;
+    pq_ctx.range = &scan_range;
+    ASSERT_TRUE(iceberg_reader->init_reader(&pq_ctx).ok());
+
+    // A zonemap conjunct on the synthetic slot (cid 1): the slot is in the tuple but not in
+    // the FE-built schema tree, so page-index filtering must skip it gracefully.
+    VExprContextSPtrs conjuncts {make_page_zonemap_context(std::make_shared<TestPageZonemapExpr>(
+            std::vector<int> {1}, TestPageZonemapExpr::Mode::BIGINT_MAX_AT_LEAST, 10))};
+    iceberg_reader->set_conjuncts_for_test(conjuncts);
+
+    RowRanges candidate_row_ranges;
+    std::vector<std::unique_ptr<MutilColumnBlockPredicate>> push_down_pred;
+    const auto& row_group = doris_metadata.row_groups[0];
+    RowGroupReader::RowGroupIndex row_group_index(0, 0, row_group.num_rows);
+    ASSERT_TRUE(iceberg_reader
+                        ->_process_page_index_filter(row_group, row_group_index, push_down_pred,
+                                                     &candidate_row_ranges)
+                        .ok());
+
+    // Optimization skipped: the full row group range is kept and nothing was filtered.
+    assert_single_range(&candidate_row_ranges, 0, row_group.num_rows);
+    EXPECT_EQ(0, iceberg_reader->_reader_statistics.filtered_row_groups_by_expr_zonemap);
 }
 
 TEST_F(ParquetExprTest, test_expr_zonemap_page_filter_handles_all_null_pages) {

--- a/be/test/format/table/iceberg/iceberg_reader_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_reader_test.cpp
@@ -1652,6 +1652,95 @@ TEST_F(IcebergReaderTest, read_iceberg_parquet_file) {
     verify_test_results(block, read_rows);
 }
 
+TEST_F(IcebergReaderTest, parquet_init_fails_loudly_when_schema_mapping_misses_projected_column) {
+    // #61225 pattern B, reader level: the schema info from FE (history_schema_info) does not
+    // contain the projected columns, so the table-side schema tree has no key for them.
+    // init_reader must fail with InternalError instead of letting children_column_exists's bare
+    // map::at throw std::out_of_range, which kills the whole BE process.
+    auto local_fs = io::global_local_filesystem();
+    io::FileReaderSPtr file_reader;
+    std::string test_file =
+            "./be/test/exec/test_data/complex_user_profiles_iceberg_parquet/data/"
+            "00000-0-a0022aad-d3b6-4e73-b181-f0a09aac7034-0-00001.parquet";
+    auto st = local_fs->open_file(test_file, &file_reader);
+    if (!st.ok()) {
+        GTEST_SKIP() << "Test file not found: " << test_file;
+        return;
+    }
+
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
+
+    TFileScanRangeParams scan_params;
+    scan_params.format_type = TFileFormatType::FORMAT_PARQUET;
+    // The FE schema info only knows "id"; the projected "name"/"profile" below are absent —
+    // an FE/BE contract violation.
+    {
+        TColumnType bigint_type;
+        bigint_type.__set_type(TPrimitiveType::BIGINT);
+        auto id_field = std::make_shared<schema::external::TField>();
+        id_field->__set_name("id");
+        id_field->__set_id(1);
+        id_field->__set_is_optional(false);
+        id_field->__set_type(bigint_type);
+        schema::external::TFieldPtr id_field_ptr;
+        id_field_ptr.__set_field_ptr(std::move(id_field));
+        schema::external::TStructField root_field;
+        root_field.__set_fields({std::move(id_field_ptr)});
+        schema::external::TSchema fe_schema;
+        fe_schema.__set_schema_id(-1);
+        fe_schema.__set_root_field(root_field);
+        scan_params.__set_history_schema_info({std::move(fe_schema)});
+    }
+
+    TFileRangeDesc scan_range;
+    scan_range.start_offset = 0;
+    scan_range.size = file_reader->size();
+    scan_range.path = test_file;
+
+    RuntimeProfile profile("test_profile");
+    cctz::time_zone ctz;
+    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+
+    auto iceberg_reader = std::make_unique<IcebergParquetReader>(
+            nullptr /* kv_cache */, &profile, scan_params, scan_range, 1024, &ctz,
+            nullptr /* io_ctx */, &runtime_state, cache.get());
+    iceberg_reader->set_file_reader(file_reader);
+
+    DataTypePtr coordinates_struct_type, address_struct_type, phone_struct_type;
+    DataTypePtr contact_struct_type, hobby_element_struct_type, hobbies_array_type;
+    DataTypePtr profile_struct_type, name_type;
+    create_complex_struct_types(coordinates_struct_type, address_struct_type, phone_struct_type,
+                                contact_struct_type, hobby_element_struct_type, hobbies_array_type,
+                                profile_struct_type, name_type);
+
+    DescriptorTbl* desc_tbl;
+    ObjectPool obj_pool;
+    TDescriptorTable t_desc_table;
+    TTableDescriptor t_table_desc;
+    const TupleDescriptor* tuple_descriptor =
+            create_tuple_descriptor(&desc_tbl, obj_pool, t_desc_table, t_table_desc);
+
+    std::unordered_map<std::string, uint32_t> col_name_to_block_idx = {{"name", 0}, {"profile", 1}};
+    std::vector<ColumnDescriptor> column_descs;
+    for (const auto& name : {"name", "profile"}) {
+        ColumnDescriptor desc;
+        desc.name = name;
+        column_descs.push_back(desc);
+    }
+
+    ParquetInitContext pq_ctx;
+    pq_ctx.column_descs = &column_descs;
+    pq_ctx.col_name_to_block_idx = &col_name_to_block_idx;
+    pq_ctx.tuple_descriptor = tuple_descriptor;
+    pq_ctx.params = &scan_params;
+    pq_ctx.range = &scan_range;
+    st = iceberg_reader->init_reader(&pq_ctx);
+    ASSERT_FALSE(st.ok());
+    EXPECT_NE(st.to_string().find("schema mapping is missing projected column 'name'"),
+              std::string::npos)
+            << st;
+}
+
 TEST_F(IcebergReaderTest, v1_deletion_vector_read_error_releases_cache_entry) {
     RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     TFileScanRangeParams scan_params;

--- a/be/test/format/table/iceberg/iceberg_reader_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_reader_test.cpp
@@ -63,6 +63,7 @@
 #include "format/parquet/vparquet_column_chunk_reader.h"
 #include "format/parquet/vparquet_reader.h"
 #include "format/table/iceberg_default_value.h"
+#include "format/table/iceberg_position_delete_sys_table_reader.h"
 #include "format/table/iceberg_scan_semantics.h"
 #include "io/fs/file_meta_cache.h"
 #include "io/fs/file_reader_writer_fwd.h"
@@ -935,6 +936,35 @@ schema::external::TFieldPtr make_external_struct_field(
     return field_ptr;
 }
 
+schema::external::TFieldPtr make_external_scalar_field(const std::string& name, int32_t field_id,
+                                                       TPrimitiveType::type primitive_type) {
+    auto field = std::make_shared<schema::external::TField>();
+    field->__set_name(name);
+    field->__set_id(field_id);
+    TColumnType type;
+    type.__set_type(primitive_type);
+    field->__set_type(type);
+    schema::external::TFieldPtr field_ptr;
+    field_ptr.__set_field_ptr(std::move(field));
+    return field_ptr;
+}
+
+SlotDescriptor* make_position_delete_sys_table_slot(ObjectPool* pool, int32_t id,
+                                                    const std::string& name, DataTypePtr type) {
+    TSlotDescriptor slot_desc;
+    slot_desc.__set_id(id);
+    slot_desc.__set_parent(0);
+    slot_desc.__set_slotType(type->to_thrift());
+    slot_desc.__set_columnPos(id);
+    slot_desc.__set_byteOffset(0);
+    slot_desc.__set_nullIndicatorByte(id / 8);
+    slot_desc.__set_nullIndicatorBit(id % 8);
+    slot_desc.__set_slotIdx(id);
+    slot_desc.__set_isMaterialized(true);
+    slot_desc.__set_colName(name);
+    return pool->add(new SlotDescriptor(slot_desc));
+}
+
 class IcebergReaderTestHelper : public IcebergTableReader {
 public:
     using IcebergTableReader::_is_fully_dictionary_encoded;
@@ -1739,6 +1769,369 @@ TEST_F(IcebergReaderTest, parquet_init_fails_loudly_when_schema_mapping_misses_p
     EXPECT_NE(st.to_string().find("schema mapping is missing projected column 'name'"),
               std::string::npos)
             << st;
+}
+
+TEST_F(IcebergReaderTest, parquet_init_fails_loudly_when_partition_key_missing_from_schema_mapping) {
+    // #61225 pattern B, IcebergParquetReader PARTITION_KEY branch: the schema info from FE
+    // (history_schema_info) does not contain the projected partition column, so the table-side
+    // schema tree has no key for it. init_reader must fail with InternalError instead of letting
+    // children_column_exists's bare map::at throw std::out_of_range, which kills the BE process.
+    const auto test_dir = std::filesystem::temp_directory_path() /
+                          "doris_iceberg_parquet_partition_key_schema_mismatch_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+    const auto data_file = (test_dir / "data.parquet").string();
+    write_iceberg_three_int_parquet_file(data_file, "id", 0, {1, 2, 3}, "part_col", 1, {4, 5, 6},
+                                         "value", 2, {7, 8, 9});
+
+    // The FE schema info only knows "id"; the projected partition column "part_col" is absent —
+    // an FE/BE contract violation.
+    schema::external::TStructField root_field;
+    root_field.__set_fields({make_external_int_field("id", 0, std::nullopt)});
+    schema::external::TSchema current_schema;
+    current_schema.__set_schema_id(-1);
+    current_schema.__set_root_field(root_field);
+
+    TFileScanRangeParams scan_params;
+    scan_params.__set_iceberg_scan_semantics_version(ICEBERG_SCAN_SEMANTICS_VERSION_1);
+    scan_params.__set_file_type(TFileType::FILE_LOCAL);
+    scan_params.__set_format_type(TFileFormatType::FORMAT_PARQUET);
+    scan_params.__set_current_schema_id(-1);
+    scan_params.__set_history_schema_info({std::move(current_schema)});
+
+    TFileRangeDesc scan_range;
+    scan_range.__set_fs_name("");
+    scan_range.__set_path(data_file);
+    scan_range.__set_start_offset(0);
+    scan_range.__set_size(static_cast<int64_t>(std::filesystem::file_size(data_file)));
+    scan_range.__set_file_size(static_cast<int64_t>(std::filesystem::file_size(data_file)));
+    // A partition column would normally carry its value from the file path.
+    scan_range.__set_columns_from_path({"2024-01-01"});
+    scan_range.__set_columns_from_path_keys({"part_col"});
+
+    ObjectPool object_pool;
+    DescriptorTbl* descriptor_table = nullptr;
+    const TupleDescriptor* tuple_descriptor = nullptr;
+    ASSERT_TRUE(create_single_int_tuple_descriptor(&object_pool, "part_col", 1, &descriptor_table,
+                                                   &tuple_descriptor)
+                        .ok());
+    ASSERT_NE(tuple_descriptor, nullptr);
+
+    RuntimeProfile profile("test_profile");
+    RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
+    cctz::time_zone ctz;
+    TimezoneUtils::find_cctz_time_zone("UTC", ctz);
+    io::IOContext io_ctx;
+    ShardedKVCache kv_cache(8);
+    IcebergParquetReader reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz, &io_ctx,
+                                &runtime_state, cache.get());
+    io::FileReaderSPtr file_reader;
+    ASSERT_TRUE(io::global_local_filesystem()->open_file(data_file, &file_reader).ok());
+    reader.set_file_reader(file_reader);
+
+    std::vector<ColumnDescriptor> column_descriptors(1);
+    column_descriptors[0].name = "part_col";
+    column_descriptors[0].category = ColumnCategory::PARTITION_KEY;
+    std::unordered_map<std::string, uint32_t> block_positions = {{"part_col", 0}};
+    ParquetInitContext context;
+    context.column_descs = &column_descriptors;
+    context.col_name_to_block_idx = &block_positions;
+    context.tuple_descriptor = tuple_descriptor;
+    context.params = &scan_params;
+    context.range = &scan_range;
+    const auto status = reader.init_reader(&context);
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.is<ErrorCode::INTERNAL_ERROR>()) << status;
+    EXPECT_NE(status.to_string().find("schema mapping is missing projected column 'part_col'"),
+              std::string::npos)
+            << status;
+
+    std::filesystem::remove_all(test_dir);
+}
+
+TEST_F(IcebergReaderTest, orc_init_fails_loudly_when_schema_mapping_misses_projected_column) {
+    // #61225 pattern B, IcebergOrcReader REGULAR branch: same contract violation as the parquet
+    // case — the FE schema info lacks the projected column, so the table-side schema tree has no
+    // key for it and init_reader must return InternalError instead of crashing the BE process.
+    const auto test_dir = std::filesystem::temp_directory_path() /
+                          "doris_iceberg_orc_regular_schema_mismatch_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+    const auto data_file = (test_dir / "data.orc").string();
+    write_iceberg_three_int_orc_file(data_file, "id", 0, {1, 2, 3}, "value", 1, {4, 5, 6}, "extra",
+                                     2, {7, 8, 9});
+
+    // The FE schema info only knows "id"; the projected "value" below is absent — an FE/BE
+    // contract violation.
+    schema::external::TStructField root_field;
+    root_field.__set_fields({make_external_int_field("id", 0, std::nullopt)});
+    schema::external::TSchema current_schema;
+    current_schema.__set_schema_id(-1);
+    current_schema.__set_root_field(root_field);
+
+    TFileScanRangeParams scan_params;
+    scan_params.__set_iceberg_scan_semantics_version(ICEBERG_SCAN_SEMANTICS_VERSION_1);
+    scan_params.__set_file_type(TFileType::FILE_LOCAL);
+    scan_params.__set_format_type(TFileFormatType::FORMAT_ORC);
+    scan_params.__set_current_schema_id(-1);
+    scan_params.__set_history_schema_info({std::move(current_schema)});
+
+    TFileRangeDesc scan_range;
+    scan_range.__set_fs_name("");
+    scan_range.__set_path(data_file);
+    scan_range.__set_start_offset(0);
+    scan_range.__set_size(static_cast<int64_t>(std::filesystem::file_size(data_file)));
+    scan_range.__set_file_size(static_cast<int64_t>(std::filesystem::file_size(data_file)));
+
+    ObjectPool object_pool;
+    DescriptorTbl* descriptor_table = nullptr;
+    const TupleDescriptor* tuple_descriptor = nullptr;
+    ASSERT_TRUE(create_single_int_tuple_descriptor(&object_pool, "value", 1, &descriptor_table,
+                                                   &tuple_descriptor)
+                        .ok());
+    ASSERT_NE(tuple_descriptor, nullptr);
+
+    RuntimeProfile profile("test_profile");
+    RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
+    runtime_state.set_timezone("UTC");
+    io::IOContext io_ctx;
+    ShardedKVCache kv_cache(8);
+    IcebergOrcReader reader(&kv_cache, &profile, &runtime_state, scan_params, scan_range, 1024,
+                            "UTC", &io_ctx, cache.get());
+
+    std::vector<ColumnDescriptor> column_descriptors(1);
+    column_descriptors[0].name = "value";
+    std::unordered_map<std::string, uint32_t> block_positions = {{"value", 0}};
+    OrcInitContext context;
+    context.column_descs = &column_descriptors;
+    context.col_name_to_block_idx = &block_positions;
+    context.tuple_descriptor = tuple_descriptor;
+    context.params = &scan_params;
+    context.range = &scan_range;
+    const auto status = reader.init_reader(&context);
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.is<ErrorCode::INTERNAL_ERROR>()) << status;
+    EXPECT_NE(status.to_string().find("schema mapping is missing projected column 'value'"),
+              std::string::npos)
+            << status;
+
+    std::filesystem::remove_all(test_dir);
+}
+
+TEST_F(IcebergReaderTest, orc_init_fails_loudly_when_partition_key_missing_from_schema_mapping) {
+    // #61225 pattern B, IcebergOrcReader PARTITION_KEY branch: the FE schema info does not know
+    // the projected partition column, so the guard must turn the would-be children.at() crash
+    // into a per-query InternalError.
+    const auto test_dir = std::filesystem::temp_directory_path() /
+                          "doris_iceberg_orc_partition_key_schema_mismatch_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+    const auto data_file = (test_dir / "data.orc").string();
+    write_iceberg_three_int_orc_file(data_file, "id", 0, {1, 2, 3}, "part_col", 1, {4, 5, 6},
+                                     "value", 2, {7, 8, 9});
+
+    // The FE schema info only knows "id"; the projected partition column "part_col" is absent —
+    // an FE/BE contract violation.
+    schema::external::TStructField root_field;
+    root_field.__set_fields({make_external_int_field("id", 0, std::nullopt)});
+    schema::external::TSchema current_schema;
+    current_schema.__set_schema_id(-1);
+    current_schema.__set_root_field(root_field);
+
+    TFileScanRangeParams scan_params;
+    scan_params.__set_iceberg_scan_semantics_version(ICEBERG_SCAN_SEMANTICS_VERSION_1);
+    scan_params.__set_file_type(TFileType::FILE_LOCAL);
+    scan_params.__set_format_type(TFileFormatType::FORMAT_ORC);
+    scan_params.__set_current_schema_id(-1);
+    scan_params.__set_history_schema_info({std::move(current_schema)});
+
+    TFileRangeDesc scan_range;
+    scan_range.__set_fs_name("");
+    scan_range.__set_path(data_file);
+    scan_range.__set_start_offset(0);
+    scan_range.__set_size(static_cast<int64_t>(std::filesystem::file_size(data_file)));
+    scan_range.__set_file_size(static_cast<int64_t>(std::filesystem::file_size(data_file)));
+    // A partition column would normally carry its value from the file path.
+    scan_range.__set_columns_from_path({"2024-01-01"});
+    scan_range.__set_columns_from_path_keys({"part_col"});
+
+    ObjectPool object_pool;
+    DescriptorTbl* descriptor_table = nullptr;
+    const TupleDescriptor* tuple_descriptor = nullptr;
+    ASSERT_TRUE(create_single_int_tuple_descriptor(&object_pool, "part_col", 1, &descriptor_table,
+                                                   &tuple_descriptor)
+                        .ok());
+    ASSERT_NE(tuple_descriptor, nullptr);
+
+    RuntimeProfile profile("test_profile");
+    RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
+    runtime_state.set_timezone("UTC");
+    io::IOContext io_ctx;
+    ShardedKVCache kv_cache(8);
+    IcebergOrcReader reader(&kv_cache, &profile, &runtime_state, scan_params, scan_range, 1024,
+                            "UTC", &io_ctx, cache.get());
+
+    std::vector<ColumnDescriptor> column_descriptors(1);
+    column_descriptors[0].name = "part_col";
+    column_descriptors[0].category = ColumnCategory::PARTITION_KEY;
+    std::unordered_map<std::string, uint32_t> block_positions = {{"part_col", 0}};
+    OrcInitContext context;
+    context.column_descs = &column_descriptors;
+    context.col_name_to_block_idx = &block_positions;
+    context.tuple_descriptor = tuple_descriptor;
+    context.params = &scan_params;
+    context.range = &scan_range;
+    const auto status = reader.init_reader(&context);
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.is<ErrorCode::INTERNAL_ERROR>()) << status;
+    EXPECT_NE(status.to_string().find("schema mapping is missing projected column 'part_col'"),
+              std::string::npos)
+            << status;
+
+    std::filesystem::remove_all(test_dir);
+}
+
+TEST_F(IcebergReaderTest,
+       position_delete_sys_table_parquet_init_fails_loudly_when_row_missing_from_schema_mapping) {
+    // #61225, IcebergPositionDeleteSysTableReader parquet branch: the query projects the "row"
+    // column but the FE schema info for the delete file has no "row" field, so the mapped
+    // delete-file schema tree has no key for it. init_reader must fail with InternalError instead
+    // of crashing the BE process on children.at().
+    const auto test_dir = std::filesystem::temp_directory_path() /
+                          "doris_iceberg_position_delete_row_schema_mismatch_parquet_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+    const auto delete_path = (test_dir / "delete.parquet").string();
+    // The delete file physically stores file_path/pos/row (ids follow the Iceberg spec), but the
+    // FE schema info below only knows file_path/pos — an FE/BE contract violation.
+    write_iceberg_three_int_parquet_file(delete_path, "file_path", 2147483546, {1}, "pos",
+                                         2147483545, {5}, "row", 2147483544, {42});
+
+    ObjectPool object_pool;
+    const auto row_type = make_nullable(std::make_shared<DataTypeInt32>());
+    std::vector<SlotDescriptor*> slots {
+            make_position_delete_sys_table_slot(&object_pool, 0, "row", row_type)};
+
+    RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
+    runtime_state.set_timezone("UTC");
+    RuntimeProfile profile("test_profile");
+
+    TFileScanRangeParams scan_params;
+    scan_params.__set_iceberg_scan_semantics_version(ICEBERG_SCAN_SEMANTICS_VERSION_1);
+    scan_params.__set_file_type(TFileType::FILE_LOCAL);
+    scan_params.__set_format_type(TFileFormatType::FORMAT_PARQUET);
+    scan_params.__set_current_schema_id(-1);
+    schema::external::TStructField root_field;
+    root_field.__set_fields(
+            {make_external_scalar_field("file_path", 2147483546, TPrimitiveType::STRING),
+             make_external_scalar_field("pos", 2147483545, TPrimitiveType::BIGINT)});
+    schema::external::TSchema current_schema;
+    current_schema.__set_schema_id(-1);
+    current_schema.__set_root_field(root_field);
+    scan_params.__set_history_schema_info({std::move(current_schema)});
+
+    auto io_ctx = std::make_shared<io::IOContext>();
+    io::FileReaderStats file_reader_stats;
+    io_ctx->file_reader_stats = &file_reader_stats;
+
+    TIcebergDeleteFileDesc delete_file;
+    delete_file.__set_content(1); // position delete content
+    delete_file.__set_path(delete_path);
+    delete_file.__set_file_format(TFileFormatType::FORMAT_PARQUET);
+    TIcebergFileDesc iceberg_descriptor;
+    iceberg_descriptor.__set_delete_files({delete_file});
+    TTableFormatFileDesc table_format_descriptor;
+    table_format_descriptor.__set_iceberg_params(iceberg_descriptor);
+    TFileRangeDesc scan_range;
+    scan_range.__set_fs_name("");
+    scan_range.__set_path(delete_path);
+    scan_range.__set_start_offset(0);
+    scan_range.__set_size(static_cast<int64_t>(std::filesystem::file_size(delete_path)));
+    scan_range.__set_file_size(static_cast<int64_t>(std::filesystem::file_size(delete_path)));
+    scan_range.__set_table_format_params(table_format_descriptor);
+
+    IcebergPositionDeleteSysTableReader reader(slots, &runtime_state, &profile, scan_range,
+                                               &scan_params, io_ctx, nullptr);
+    ReaderInitContext context;
+    const auto status = reader.init_reader(&context);
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.is<ErrorCode::INTERNAL_ERROR>()) << status;
+    EXPECT_NE(status.to_string().find("position delete system table schema is missing"),
+              std::string::npos)
+            << status;
+
+    std::filesystem::remove_all(test_dir);
+}
+
+TEST_F(IcebergReaderTest,
+       position_delete_sys_table_orc_init_fails_loudly_when_row_missing_from_schema_mapping) {
+    // #61225, IcebergPositionDeleteSysTableReader orc branch: same contract violation as the
+    // parquet branch — "row" is projected but absent from the FE schema info, so init_reader must
+    // return InternalError instead of crashing the BE process on children.at().
+    const auto test_dir = std::filesystem::temp_directory_path() /
+                          "doris_iceberg_position_delete_row_schema_mismatch_orc_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+    const auto delete_path = (test_dir / "delete.orc").string();
+    // The delete file physically stores file_path/pos/row (ids follow the Iceberg spec), but the
+    // FE schema info below only knows file_path/pos — an FE/BE contract violation.
+    write_iceberg_three_int_orc_file(delete_path, "file_path", 2147483546, {1}, "pos", 2147483545,
+                                     {5}, "row", 2147483544, {42});
+
+    ObjectPool object_pool;
+    const auto row_type = make_nullable(std::make_shared<DataTypeInt32>());
+    std::vector<SlotDescriptor*> slots {
+            make_position_delete_sys_table_slot(&object_pool, 0, "row", row_type)};
+
+    RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
+    runtime_state.set_timezone("UTC");
+    RuntimeProfile profile("test_profile");
+
+    TFileScanRangeParams scan_params;
+    scan_params.__set_iceberg_scan_semantics_version(ICEBERG_SCAN_SEMANTICS_VERSION_1);
+    scan_params.__set_file_type(TFileType::FILE_LOCAL);
+    scan_params.__set_format_type(TFileFormatType::FORMAT_ORC);
+    scan_params.__set_current_schema_id(-1);
+    schema::external::TStructField root_field;
+    root_field.__set_fields(
+            {make_external_scalar_field("file_path", 2147483546, TPrimitiveType::STRING),
+             make_external_scalar_field("pos", 2147483545, TPrimitiveType::BIGINT)});
+    schema::external::TSchema current_schema;
+    current_schema.__set_schema_id(-1);
+    current_schema.__set_root_field(root_field);
+    scan_params.__set_history_schema_info({std::move(current_schema)});
+
+    auto io_ctx = std::make_shared<io::IOContext>();
+    io::FileReaderStats file_reader_stats;
+    io_ctx->file_reader_stats = &file_reader_stats;
+
+    TIcebergDeleteFileDesc delete_file;
+    delete_file.__set_content(1); // position delete content
+    delete_file.__set_path(delete_path);
+    delete_file.__set_file_format(TFileFormatType::FORMAT_ORC);
+    TIcebergFileDesc iceberg_descriptor;
+    iceberg_descriptor.__set_delete_files({delete_file});
+    TTableFormatFileDesc table_format_descriptor;
+    table_format_descriptor.__set_iceberg_params(iceberg_descriptor);
+    TFileRangeDesc scan_range;
+    scan_range.__set_fs_name("");
+    scan_range.__set_path(delete_path);
+    scan_range.__set_start_offset(0);
+    scan_range.__set_size(static_cast<int64_t>(std::filesystem::file_size(delete_path)));
+    scan_range.__set_file_size(static_cast<int64_t>(std::filesystem::file_size(delete_path)));
+    scan_range.__set_table_format_params(table_format_descriptor);
+
+    IcebergPositionDeleteSysTableReader reader(slots, &runtime_state, &profile, scan_range,
+                                               &scan_params, io_ctx, nullptr);
+    ReaderInitContext context;
+    const auto status = reader.init_reader(&context);
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.is<ErrorCode::INTERNAL_ERROR>()) << status;
+    EXPECT_NE(status.to_string().find("position delete system table schema is missing"),
+              std::string::npos)
+            << status;
+
+    std::filesystem::remove_all(test_dir);
 }
 
 TEST_F(IcebergReaderTest, v1_deletion_vector_read_error_releases_cache_entry) {

--- a/be/test/format/table/table_schema_change_helper_test.cpp
+++ b/be/test/format/table/table_schema_change_helper_test.cpp
@@ -215,6 +215,75 @@ TEST(MockTableSchemaChangeHelper, HasChildrenColumnGuardsAbsentProjectedColumn) 
             TableSchemaChangeHelper::ConstNode::get_instance()->has_children_column("anything"));
 }
 
+TEST(MockTableSchemaChangeHelper, HasChildrenColumnGuardsNestedStructField) {
+    // Nested analog of HasChildrenColumnGuardsAbsentProjectedColumn (#61225): the struct-field
+    // readers resolve each projected nested field through the column's child StructNode, so a
+    // nested field that is absent from that tree must be detectable via has_children_column
+    // BEFORE children_column_exists / children_file_column_name, whose children.at() throws
+    // std::out_of_range (release) / DCHECK-aborts (debug).
+    SlotDescriptor slot1;
+    slot1._type = std::make_shared<DataTypeStruct>(
+            std::vector<DataTypePtr> {
+                    DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_BIGINT, true),
+                    DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_BIGINT, true)},
+            Strings {"a", "b"});
+    slot1._col_name = "struct_col";
+
+    TupleDescriptor tuple_desc;
+    tuple_desc.add_slot(&slot1);
+
+    std::unique_ptr<orc::Type> orc_type(
+            orc::Type::buildTypeFromString("struct<struct_col:struct<a:int,b:int>>"));
+    std::shared_ptr<TableSchemaChangeHelper::Node> node = nullptr;
+    ASSERT_TRUE(TableSchemaChangeHelper::BuildTableInfoUtil::by_orc_name(&tuple_desc,
+                                                                         orc_type.get(), node)
+                        .ok());
+
+    ASSERT_TRUE(node->has_children_column("struct_col"));
+    const auto& struct_child = node->get_children_node("struct_col");
+
+    // Nested fields that ARE in the table-side tree -> present.
+    EXPECT_TRUE(struct_child->has_children_column("a"));
+    EXPECT_TRUE(struct_child->has_children_column("b"));
+    // A nested field the tree does not know (FE/BE contract mismatch, e.g. the table column
+    // type carries a field the schema info from FE never registered) must be reported absent
+    // WITHOUT triggering children.at(). MUTATION: dropping the has_children_column guard at the
+    // nested struct readers -> std::out_of_range/DCHECK instead of a per-query error.
+    EXPECT_FALSE(struct_child->has_children_column("renamed_away_field"));
+}
+
+TEST(MockTableSchemaChangeHelper, NestedStructFieldMissingInFileKeepsKey) {
+    // The legitimate schema-evolution counterpart of the guard (#61225): a nested field added
+    // after the data file was written IS registered in the table-side tree (key present,
+    // exists=false), so the readers classify it as fill-missing (initial default / NULL) rather
+    // than failing the query. The has_children_column guard must NOT swallow this case.
+    SlotDescriptor slot1;
+    slot1._type = std::make_shared<DataTypeStruct>(
+            std::vector<DataTypePtr> {
+                    DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_BIGINT, true),
+                    DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_BIGINT, true)},
+            Strings {"a", "b"});
+    slot1._col_name = "struct_col";
+
+    TupleDescriptor tuple_desc;
+    tuple_desc.add_slot(&slot1);
+
+    // The file only stores field 'a'; table field 'b' was added later.
+    std::unique_ptr<orc::Type> orc_type(
+            orc::Type::buildTypeFromString("struct<struct_col:struct<a:int>>"));
+    std::shared_ptr<TableSchemaChangeHelper::Node> node = nullptr;
+    ASSERT_TRUE(TableSchemaChangeHelper::BuildTableInfoUtil::by_orc_name(&tuple_desc,
+                                                                         orc_type.get(), node)
+                        .ok());
+
+    const auto& struct_child = node->get_children_node("struct_col");
+    EXPECT_TRUE(struct_child->has_children_column("a"));
+    EXPECT_TRUE(struct_child->children_column_exists("a"));
+    // 'b' is known to the table schema but absent from the file: key stays, exists=false.
+    EXPECT_TRUE(struct_child->has_children_column("b"));
+    EXPECT_FALSE(struct_child->children_column_exists("b"));
+}
+
 TEST(MockTableSchemaChangeHelper, OrcNameSchemaChange1) {
     std::vector<DataTypePtr> data_types;
     std::vector<std::string> column_names;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #61225 — intentionally NOT auto-closing. Pattern B is root-caused at the crash mechanism level, and Pattern A is now fully guarded at the crash site (any truncated or out-of-bounds dictionary index stream returns `Status::Corruption`), but the upstream reason a data page can reference a missing/corrupt dictionary remains unproven because the issue has no reproducer. The issue should stay open until that is confirmed.

Related PR: cbfe3096dff (precedent: `has_children_column` guard for the top-level parquet path), #65784

Problem Summary:

BE crashes while scanning Iceberg tables in the two modes reported by #61225:

1. **Pattern B – std::out_of_range / DCHECK abort.** `StructNode::children_column_exists` does a bare `children.at()`. If the schema info from FE is inconsistent with the scan projection, the whole BE process dies (release: uncaught exception; debug: DCHECK abort). The top-level parquet entry was fixed by cbfe3096dff, but sibling call sites were not:
   - `OrcReader::_do_init_reader` top-level missing-column loop (the ORC twin of cbfe3096dff)
   - `IcebergParquetReader`/`IcebergOrcReader::on_before_init_reader` classification loops (PARTITION_KEY + REGULAR branches)
   - Nested struct field resolution: `StructColumnReader::read_column_data` (parquet) and `OrcReader::_fill_doris_data_column` (orc)
   - `IcebergPositionDeleteSysTableReader` (`$position_deletes` system table)
   - Filter/optimization paths that iterate **all** tuple slots: page-index stat func, min-max/bloom lambdas, bloom cache backfill, dict-filter fallback in group reader, ORC pushdown type checks. These touch every slot in the tuple — including synthetic slots such as TopN's GLOBAL_ROWID_COL that are never registered in the schema tree — so they can crash even without any FE misbehavior.

2. **Pattern A – SIGSEGV.** `ByteArrayDictDecoder::_decode_values` indexes an empty `_dict_items` when data pages reference a dictionary that was never decoded, dereferencing a null StringRef.

This PR applies defense-in-depth using the `has_children_column` API from cbfe3096dff:

- **Query contract paths fail loudly** with `Status::InternalError` — a contract violation is a bug and must not produce silent wrong results.
- **Optimization/filter paths silently skip the optimization** (return false / fall back to plain conjunct filtering) — no result correctness impact.
- **Pattern A is guarded at the crash site, not root-caused**: the decoded dictionary index stream is now fully validated before use — `GetBatch` must return exactly the requested count (truncated stream → `Status::Corruption`) and every index must be smaller than the dictionary size (out-of-range index, including the empty-dictionary case → `Status::Corruption`). This also covers the dictionary-column path, whose raw indices previously crashed later in `convert_dict_column_to_string_column`. The issue provides no reproducer, so the exact reason a dictionary page can go missing remains unproven; this converts every SIGSEGV mode at that stack frame into a query error.

The schema mapping built by FE is designed as a superset of the BE scan slots (top-level names = requested columns, row-lineage fields appended explicitly, time-travel/TopN use the full schema, partition-evolution PARTITION_KEY columns are present), so the new guards only fire on a genuine contract violation and never change legitimate query behavior.

### Release note

Fix BE process crash (std::out_of_range / SIGSEGV) when scanning Iceberg tables with inconsistent schema mapping - the query now fails with an error instead.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Unit Test — (a) decoder level: empty dictionary with non-null data, out-of-range dictionary index (plain and dictionary-column paths), and truncated index stream all return `Status::Corruption` (`byte_array_dict_decoder_test.cpp`); (b) reader level: `IcebergParquetReader` init fails with `InternalError` when the FE schema info misses a projected column (`iceberg_reader_test.cpp`), and page-index filtering skips a synthetic TopN `GLOBAL_ROWID_COL` slot that the FE-built schema tree never registers (`parquet_expr_test.cpp`); (c) helper level: `HasChildrenColumnGuardsNestedStructField` / `NestedStructFieldMissingInFileKeepsKey`. Reader-level coverage for a known nested field absent from the file already exists (`v2_parquet_materializes_nested_initial_default_without_reviving_parent`, `v1_top_level_missing_binary_prefers_iceberg_initial_default`). All 130 tests in the touched suites pass locally; the external_table_p0/p2 Iceberg regression suites cover behavior invariance.

- Behavior changed:
    - [x] No. (Legitimate query behavior is unchanged. On a schema-mapping contract violation, the query now fails with InternalError instead of crashing the BE process.)

- Does this need documentation?
    - [x] No.

