### PR TITLE
[fix](cloud) Track deleted instance recycle status

### DIFF
--- a/cloud/src/common/http_helper.cpp
+++ b/cloud/src/common/http_helper.cpp
@@ -576,23 +576,10 @@ HttpResponse process_skip_instance_data_cleanup(RecyclerServiceImpl* service,
                                                 brpc::Controller* ctrl) {
     auto& uri = ctrl->http_request().uri();
     std::string instance_id(http_query(uri, "instance_id"));
-    std::string recycled_state_str(http_query(uri, "recycled_state"));
     if (instance_id.empty()) {
         return http_json_reply(MetaServiceCode::INVALID_ARGUMENT, "instance_id is empty");
     }
-    if (recycled_state_str.empty()) {
-        return http_json_reply(MetaServiceCode::INVALID_ARGUMENT, "recycled_state is empty");
-    }
-
-    InstanceRecycleState recycled_state;
-    if (!InstanceRecycleState_Parse(recycled_state_str, &recycled_state) ||
-        (recycled_state != InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED)) {
-        return http_json_reply(MetaServiceCode::INVALID_ARGUMENT,
-                               "invalid recycled_state, supported values: "
-                               "INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED");
-    }
-
-    auto [code, msg] = service->skip_instance_data_cleanup(instance_id, recycled_state);
+    auto [code, msg] = service->skip_instance_data_cleanup(instance_id);
     return http_json_reply(code, msg);
 }
 

--- a/cloud/src/common/http_helper.cpp
+++ b/cloud/src/common/http_helper.cpp
@@ -370,7 +370,12 @@ const std::unordered_map<std::string_view, HttpHandlerInfo>& get_http_handlers()
                               return process_query_rate_limit((MS*)s, c);
                           },
                   .role = HttpRole::META_SERVICE}},
-
+                {"check_instance_recycle_completed",
+                 {.handler =
+                          [](void* s, brpc::Controller* c) {
+                              return process_check_instance_recycle_completed((MS*)s, c);
+                          },
+                  .role = HttpRole::META_SERVICE}},
                 // Recycler APIs
                 {"recycle_instance",
                  {.handler =
@@ -399,6 +404,12 @@ const std::unordered_map<std::string_view, HttpHandlerInfo>& get_http_handlers()
                 {"check_instance",
                  {.handler = [](void* s,
                                 brpc::Controller* c) { return process_check_instance((RS*)s, c); },
+                  .role = HttpRole::RECYCLER}},
+                {"skip_instance_data_cleanup",
+                 {.handler =
+                          [](void* s, brpc::Controller* c) {
+                              return process_skip_instance_data_cleanup((RS*)s, c);
+                          },
                   .role = HttpRole::RECYCLER}},
                 {"check_job_info",
                  {.handler = [](void* s,
@@ -561,6 +572,30 @@ HttpResponse process_alter_instance(MetaServiceImpl* service, brpc::Controller* 
     return http_json_reply(resp.status());
 }
 
+HttpResponse process_skip_instance_data_cleanup(RecyclerServiceImpl* service,
+                                                brpc::Controller* ctrl) {
+    auto& uri = ctrl->http_request().uri();
+    std::string instance_id(http_query(uri, "instance_id"));
+    std::string recycled_state_str(http_query(uri, "recycled_state"));
+    if (instance_id.empty()) {
+        return http_json_reply(MetaServiceCode::INVALID_ARGUMENT, "instance_id is empty");
+    }
+    if (recycled_state_str.empty()) {
+        return http_json_reply(MetaServiceCode::INVALID_ARGUMENT, "recycled_state is empty");
+    }
+
+    InstanceRecycleState recycled_state;
+    if (!InstanceRecycleState_Parse(recycled_state_str, &recycled_state) ||
+        (recycled_state != InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED)) {
+        return http_json_reply(MetaServiceCode::INVALID_ARGUMENT,
+                               "invalid recycled_state, supported values: "
+                               "INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED");
+    }
+
+    auto [code, msg] = service->skip_instance_data_cleanup(instance_id, recycled_state);
+    return http_json_reply(code, msg);
+}
+
 HttpResponse process_abort_txn(MetaServiceImpl* service, brpc::Controller* ctrl) {
     AbortTxnRequest req;
     PARSE_MESSAGE_OR_RETURN(ctrl, req);
@@ -699,6 +734,32 @@ HttpResponse process_query_rate_limit(MetaServiceImpl* service, brpc::Controller
     rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(sb);
     d.Accept(writer);
     return http_json_reply(MetaServiceCode::OK, "", sb.GetString());
+}
+
+HttpResponse process_check_instance_recycle_completed(MetaServiceImpl* service,
+                                                      brpc::Controller* cntl) {
+    const auto* instance_id = cntl->http_request().uri().GetQuery("instance_id");
+    if (!instance_id || instance_id->empty()) {
+        return http_json_reply(MetaServiceCode::INVALID_ARGUMENT, "no instance id");
+    }
+
+    bool finished = false;
+    std::string reason;
+    auto [code, msg] = service->check_instance_recycle_completed(*instance_id, finished, reason);
+    if (code != MetaServiceCode::OK) {
+        return http_json_reply(code, msg);
+    }
+
+    rapidjson::Document result;
+    result.SetObject();
+    result.AddMember("finished", finished, result.GetAllocator());
+    result.AddMember("reason",
+                     rapidjson::Value(reason.data(), reason.size(), result.GetAllocator()),
+                     result.GetAllocator());
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    result.Accept(writer);
+    return http_json_reply(code, msg, buffer.GetString());
 }
 
 // Recycler HTTP handlers

--- a/cloud/src/common/http_helper.h
+++ b/cloud/src/common/http_helper.h
@@ -124,6 +124,9 @@ const std::unordered_map<std::string_view, HttpHandlerInfo>& get_http_handlers()
 [[maybe_unused]] HttpResponse process_query_rate_limit(MetaServiceImpl* service,
                                                        brpc::Controller* cntl);
 
+[[maybe_unused]] HttpResponse process_check_instance_recycle_completed(MetaServiceImpl* service,
+                                                                       brpc::Controller* cntl);
+
 [[maybe_unused]] HttpResponse process_decode_key(MetaServiceImpl*, brpc::Controller* ctrl);
 
 [[maybe_unused]] HttpResponse process_encode_key(MetaServiceImpl*, brpc::Controller* ctrl);
@@ -199,6 +202,9 @@ const std::unordered_map<std::string_view, HttpHandlerInfo>& get_http_handlers()
                                                        brpc::Controller* cntl);
 [[maybe_unused]] HttpResponse process_check_instance(RecyclerServiceImpl* service,
                                                      brpc::Controller* cntl);
+
+[[maybe_unused]] HttpResponse process_skip_instance_data_cleanup(RecyclerServiceImpl* service,
+                                                                 brpc::Controller* ctrl);
 
 [[maybe_unused]] HttpResponse process_check_job_info(RecyclerServiceImpl* service,
                                                      brpc::Controller* cntl);

--- a/cloud/src/meta-service/meta_service.h
+++ b/cloud/src/meta-service/meta_service.h
@@ -430,6 +430,9 @@ public:
                           const CompactSnapshotRequest* request, CompactSnapshotResponse* response,
                           ::google::protobuf::Closure* done) override;
 
+    std::pair<MetaServiceCode, std::string> check_instance_recycle_completed(
+            const std::string& instance_id, bool& finished, std::string& reason);
+
 private:
     std::pair<MetaServiceCode, std::string> alter_instance(
             const AlterInstanceRequest* request,

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -2562,9 +2562,11 @@ static std::pair<MetaServiceCode, std::string> drop_single_instance(const std::s
 
     instance->set_status(InstanceInfoPB::DELETED);
     instance->set_mtime(duration_cast<seconds>(system_clock::now().time_since_epoch()).count());
-    instance->set_recycle_state(INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING);
-    instance->set_recycle_state_update_time_ms(
-            duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
+    if (!instance->has_recycle_state()) {
+        instance->set_recycle_state(INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING);
+        instance->set_recycle_state_update_time_ms(
+                duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
+    }
 
     std::string serialized = instance->SerializeAsString();
     if (serialized.empty()) {

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -2562,6 +2562,9 @@ static std::pair<MetaServiceCode, std::string> drop_single_instance(const std::s
 
     instance->set_status(InstanceInfoPB::DELETED);
     instance->set_mtime(duration_cast<seconds>(system_clock::now().time_since_epoch()).count());
+    instance->set_recycled_state(INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
+    instance->set_recycled_state_update_time_ms(
+            duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
 
     std::string serialized = instance->SerializeAsString();
     if (serialized.empty()) {
@@ -2658,6 +2661,55 @@ static std::pair<MetaServiceCode, std::string> drop_instance_chain(
     return {MetaServiceCode::OK, std::move(serialized)};
 }
 
+std::pair<MetaServiceCode, std::string> MetaServiceImpl::check_instance_recycle_completed(
+        const std::string& instance_id, bool& finished, std::string& reason) {
+    reason.clear();
+    std::unique_ptr<Transaction> txn;
+    TxnErrorCode err = txn_kv_->create_txn(&txn);
+    if (err != TxnErrorCode::TXN_OK) {
+        std::string msg = fmt::format("failed to create txn, err={}", err);
+        LOG(WARNING) << msg << " instance_id=" << instance_id;
+        return {MetaServiceCode::KV_TXN_CREATE_ERR, std::move(msg)};
+    }
+
+    std::string key = instance_key({instance_id});
+    std::string value;
+    err = txn->get(key, &value);
+    if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) {
+        // The recycler only removes keys after cleanup is complete, so do not treat this as an
+        // incomplete or unknown state.
+        finished = true;
+        reason = fmt::format(
+                "instance recycling is considered completed because the instance key does not "
+                "exist, instance_id={}",
+                instance_id);
+        return {MetaServiceCode::OK, "OK"};
+    }
+    if (err != TxnErrorCode::TXN_OK) {
+        std::string msg =
+                fmt::format("failed to get instance, instance_id={}, err={}", instance_id, err);
+        LOG(WARNING) << msg;
+        return {MetaServiceCode::KV_TXN_GET_ERR, std::move(msg)};
+    }
+
+    InstanceInfoPB instance;
+    if (!instance.ParseFromString(value)) {
+        std::string msg = fmt::format("malformed instance info, key={}", hex(key));
+        LOG(WARNING) << msg;
+        return {MetaServiceCode::PROTOBUF_PARSE_ERR, std::move(msg)};
+    }
+
+    finished = instance.recycled_state() ==
+               InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED;
+    if (!finished) {
+        reason = fmt::format(
+                "instance has not completed recycling, instance_id={}, recycled_state={}",
+                instance_id, InstanceRecycleState_Name(instance.recycled_state()));
+        return {MetaServiceCode::OK, "OK"};
+    }
+    return {MetaServiceCode::OK, "OK"};
+}
+
 void MetaServiceImpl::alter_instance(google::protobuf::RpcController* controller,
                                      const AlterInstanceRequest* request,
                                      AlterInstanceResponse* response,
@@ -2686,6 +2738,12 @@ void MetaServiceImpl::alter_instance(google::protobuf::RpcController* controller
     switch (request->op()) {
     case AlterInstanceRequest::DROP: {
         ret = alter_instance(request, [&instance_id](Transaction* txn, InstanceInfoPB* instance) {
+            if (instance->status() == InstanceInfoPB::DELETED) {
+                std::string msg = "failed to drop instance, instance has already been recycled";
+                LOG(WARNING) << msg << " instance_id=" << instance_id;
+                return std::make_pair(MetaServiceCode::INVALID_ARGUMENT, std::move(msg));
+            }
+
             // check instance doesn't have any cluster.
             if (instance->clusters_size() != 0) {
                 std::string msg = "failed to drop instance, instance has clusters";

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -2562,8 +2562,8 @@ static std::pair<MetaServiceCode, std::string> drop_single_instance(const std::s
 
     instance->set_status(InstanceInfoPB::DELETED);
     instance->set_mtime(duration_cast<seconds>(system_clock::now().time_since_epoch()).count());
-    instance->set_recycled_state(INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
-    instance->set_recycled_state_update_time_ms(
+    instance->set_recycle_state(INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING);
+    instance->set_recycle_state_update_time_ms(
             duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
 
     std::string serialized = instance->SerializeAsString();
@@ -2637,6 +2637,11 @@ static std::pair<MetaServiceCode, std::string> drop_instance_chain(
     for (auto& instance : predecessors) {
         instance.set_status(InstanceInfoPB::DELETED);
         instance.set_mtime(now);
+        if (!instance.has_recycle_state()) {
+            instance.set_recycle_state(INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING);
+            instance.set_recycle_state_update_time_ms(
+                    duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
+        }
         std::string serialized;
         if (!instance.SerializeToString(&serialized)) {
             std::string msg =
@@ -2650,6 +2655,11 @@ static std::pair<MetaServiceCode, std::string> drop_instance_chain(
 
     tail_instance->set_status(InstanceInfoPB::DELETED);
     tail_instance->set_mtime(now);
+    if (!tail_instance->has_recycle_state()) {
+        tail_instance->set_recycle_state(INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING);
+        tail_instance->set_recycle_state_update_time_ms(
+                duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
+    }
     std::string serialized = tail_instance->SerializeAsString();
     if (serialized.empty()) {
         std::string msg = "failed to serialize";
@@ -2699,12 +2709,12 @@ std::pair<MetaServiceCode, std::string> MetaServiceImpl::check_instance_recycle_
         return {MetaServiceCode::PROTOBUF_PARSE_ERR, std::move(msg)};
     }
 
-    finished = instance.recycled_state() ==
+    finished = instance.recycle_state() ==
                InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED;
     if (!finished) {
         reason = fmt::format(
-                "instance has not completed recycling, instance_id={}, recycled_state={}",
-                instance_id, InstanceRecycleState_Name(instance.recycled_state()));
+                "instance has not completed recycling, instance_id={}, recycle_state={}",
+                instance_id, InstanceRecycleState_Name(instance.recycle_state()));
         return {MetaServiceCode::OK, "OK"};
     }
     return {MetaServiceCode::OK, "OK"};
@@ -2739,9 +2749,9 @@ void MetaServiceImpl::alter_instance(google::protobuf::RpcController* controller
     case AlterInstanceRequest::DROP: {
         ret = alter_instance(request, [&instance_id](Transaction* txn, InstanceInfoPB* instance) {
             if (instance->status() == InstanceInfoPB::DELETED) {
-                std::string msg = "failed to drop instance, instance has already been recycled";
+                std::string msg = "instance has already been recycled";
                 LOG(WARNING) << msg << " instance_id=" << instance_id;
-                return std::make_pair(MetaServiceCode::INVALID_ARGUMENT, std::move(msg));
+                return std::make_pair(MetaServiceCode::OK, instance->SerializeAsString());
             }
 
             // check instance doesn't have any cluster.

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -757,8 +757,8 @@ int InstanceRecycler::init_storage_vault_accessors() {
 
 int InstanceRecycler::init() {
     if (instance_info_.status() == InstanceInfoPB::DELETED &&
-        (instance_info_.recycled_state() == INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED ||
-         instance_info_.recycled_state() == INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED)) {
+        (instance_info_.recycle_state() == INSTANCE_RECYCLE_STATE_METADATA_CLEANUP_PENDING ||
+         instance_info_.recycle_state() == INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED)) {
         return 0;
     }
 
@@ -852,19 +852,30 @@ int InstanceRecycler::recycle_deleted_instance() {
 
     int ret = 0;
     auto start_time = steady_clock::now();
+    const auto recycle_state = instance_info_.recycle_state();
 
     DORIS_CLOUD_DEFER {
         auto cost = duration<float>(steady_clock::now() - start_time).count();
-        LOG(WARNING) << (ret == 0 ? "successfully" : "failed to")
-                     << " recycle deleted instance, cost=" << cost
-                     << "s, instance_id=" << instance_id_;
+        if (ret != 0) {
+            LOG(WARNING) << "failed to recycle deleted instance, recycle_state="
+                         << InstanceRecycleState_Name(recycle_state) << ", cost=" << cost
+                         << "s, instance_id=" << instance_id_;
+        } else if (recycle_state ==
+                   InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED) {
+            LOG(INFO) << "successfully removed recycled instance key, cost=" << cost
+                      << "s, instance_id=" << instance_id_;
+        } else {
+            LOG(INFO) << "finished recycle deleted instance step, recycle_state="
+                      << InstanceRecycleState_Name(recycle_state) << ", cost=" << cost
+                      << "s, instance_id=" << instance_id_;
+        }
     };
 
-    switch (instance_info_.recycled_state()) {
-    case InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING:
+    switch (recycle_state) {
+    case InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING:
         ret = recycle_deleted_instance_data();
         break;
-    case InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED:
+    case InstanceRecycleState::INSTANCE_RECYCLE_STATE_METADATA_CLEANUP_PENDING:
         ret = recycle_deleted_instance_metadata();
         break;
     case InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED:
@@ -873,7 +884,7 @@ int InstanceRecycler::recycle_deleted_instance() {
     default:
         LOG_WARNING("invalid instance recycle state")
                 .tag("instance_id", instance_id_)
-                .tag("recycled_state", instance_info_.recycled_state());
+                .tag("recycle_state", instance_info_.recycle_state());
         ret = -1;
         break;
     }
@@ -935,12 +946,12 @@ int InstanceRecycler::recycle_deleted_instance_data() {
         } else if (has_unrecycled_rowsets) {
             LOG_INFO("instance has referenced rowsets, skip recycling")
                     .tag("instance_id", instance_id_);
-            return 0;
+            return ret;
         }
     } else { // delete all remote data if snapshot is disabled
         for (auto& [_, accessor] : accessor_map_) {
             if (stopped()) {
-                return 0;
+                return ret;
             }
 
             LOG(INFO) << "begin to delete all objects in " << accessor->uri();
@@ -960,9 +971,9 @@ int InstanceRecycler::recycle_deleted_instance_data() {
         }
     }
 
-    if (update_instance_recycled_state(
-                InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING,
-                InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED) != 0) {
+    if (update_instance_recycle_state(
+                InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING,
+                InstanceRecycleState::INSTANCE_RECYCLE_STATE_METADATA_CLEANUP_PENDING) != 0) {
         return -1;
     }
 
@@ -970,7 +981,7 @@ int InstanceRecycler::recycle_deleted_instance_data() {
 }
 
 int InstanceRecycler::recycle_deleted_instance_metadata() {
-    // Keep metadata until the successor instance finishes cleanup because it may still reference it.
+    // Check successor instance, if exists, skip deleting kv because successor instance may still need the data in kv
     if (instance_info_.has_successor_instance_id() &&
         !instance_info_.successor_instance_id().empty()) {
         std::string key = instance_key(instance_info_.successor_instance_id());
@@ -1056,8 +1067,8 @@ int InstanceRecycler::recycle_deleted_instance_metadata() {
 
     // Updating the recycle state also commits this transaction, making the metadata deletions
     // and state transition atomic.
-    if (update_instance_recycled_state(
-                InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED,
+    if (update_instance_recycle_state(
+                InstanceRecycleState::INSTANCE_RECYCLE_STATE_METADATA_CLEANUP_PENDING,
                 InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED, txn.get()) != 0) {
         return -1;
     }
@@ -1067,13 +1078,44 @@ int InstanceRecycler::recycle_deleted_instance_metadata() {
 
 int InstanceRecycler::remove_instance_key() {
     std::unique_ptr<Transaction> txn;
+    std::string key = instance_key(instance_info_.instance_id());
+    std::string value;
     TxnErrorCode err = txn_kv_->create_txn(&txn);
     if (err != TxnErrorCode::TXN_OK) {
         LOG(WARNING) << "failed to create txn";
         return -1;
     }
+
+    err = txn->get(key, &value);
+    if (err != TxnErrorCode::TXN_OK) {
+        LOG(WARNING) << "failed to get instance, instance_id=" << instance_info_.instance_id()
+                     << ", err=" << err;
+        return -1;
+    }
+
+    InstanceInfoPB instance;
+    if (!instance.ParseFromString(value)) {
+        LOG(WARNING) << "malformed instance info, key=" << key;
+        return -1;
+    }
+
+    if (instance.status() != InstanceInfoPB::DELETED) {
+        LOG(WARNING) << "failed to remove instance key, instance is not deleted, instance_id="
+                     << instance_id_ << ", status=" << instance.status();
+        return -1;
+    }
+
+    if (instance.recycle_state() != INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED) {
+        LOG(WARNING) << "failed to remove instance key, invalid recycle state, instance_id="
+                     << instance_id_
+                     << ", current_state=" << InstanceRecycleState_Name(instance.recycle_state())
+                     << ", expected_state="
+                     << InstanceRecycleState_Name(INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+        return -1;
+    }
+
     txn->atomic_add(system_meta_service_instance_update_key(), 1);
-    txn->remove(instance_key({instance_id_}));
+    txn->remove(key);
     err = txn->commit();
     if (err != TxnErrorCode::TXN_OK) {
         LOG(WARNING) << "failed to delete instance kv, instance_id=" << instance_id_
@@ -1083,24 +1125,25 @@ int InstanceRecycler::remove_instance_key() {
     return 0;
 }
 
-int InstanceRecycler::update_instance_recycled_state(InstanceRecycleState expected_state,
-                                                     InstanceRecycleState target_state) {
+int InstanceRecycler::update_instance_recycle_state(InstanceRecycleState expected_state,
+                                                    InstanceRecycleState target_state) {
     std::unique_ptr<Transaction> txn;
     TxnErrorCode err = txn_kv_->create_txn(&txn);
     if (err != TxnErrorCode::TXN_OK) {
         LOG(WARNING) << "failed to create txn";
         return -1;
     }
-    return update_instance_recycled_state(expected_state, target_state, txn.get());
+    return update_instance_recycle_state(expected_state, target_state, txn.get());
 }
 
-int InstanceRecycler::update_instance_recycled_state(InstanceRecycleState current_state,
-                                                     InstanceRecycleState target_state,
-                                                     Transaction* txn) {
-    const bool valid_transition = (current_state == INSTANCE_RECYCLE_STATE_CLEANUP_PENDING &&
-                                   target_state == INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED) ||
-                                  (current_state == INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED &&
-                                   target_state == INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+int InstanceRecycler::update_instance_recycle_state(InstanceRecycleState current_state,
+                                                    InstanceRecycleState target_state,
+                                                    Transaction* txn) {
+    const bool valid_transition =
+            (current_state == INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING &&
+             target_state == INSTANCE_RECYCLE_STATE_METADATA_CLEANUP_PENDING) ||
+            (current_state == INSTANCE_RECYCLE_STATE_METADATA_CLEANUP_PENDING &&
+             target_state == INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
 
     if (!valid_transition) {
         LOG_WARNING("invalid instance recycled state transition")
@@ -1138,17 +1181,17 @@ int InstanceRecycler::update_instance_recycled_state(InstanceRecycleState curren
                 .tag("target_state", InstanceRecycleState_Name(target_state));
         return -1;
     }
-    if (instance.recycled_state() != current_state) {
+    if (instance.recycle_state() != current_state) {
         LOG_WARNING("instance recycled state changed before update")
                 .tag("instance_id", instance_id_)
-                .tag("current_state", InstanceRecycleState_Name(instance.recycled_state()))
+                .tag("current_state", InstanceRecycleState_Name(instance.recycle_state()))
                 .tag("expected_state", InstanceRecycleState_Name(current_state))
                 .tag("target_state", InstanceRecycleState_Name(target_state));
         return -1;
     }
 
-    instance.set_recycled_state(target_state);
-    instance.set_recycled_state_update_time_ms(
+    instance.set_recycle_state(target_state);
+    instance.set_recycle_state_update_time_ms(
             duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
     if (!instance.SerializeToString(&value)) {
         LOG_WARNING("failed to serialize InstanceInfoPB when updating instance recycled state")
@@ -1170,7 +1213,7 @@ int InstanceRecycler::update_instance_recycled_state(InstanceRecycleState curren
     instance_info_.Swap(&instance);
     LOG_INFO("updated instance recycled state")
             .tag("instance_id", instance_id_)
-            .tag("recycled_state", InstanceRecycleState_Name(target_state));
+            .tag("recycle_state", InstanceRecycleState_Name(target_state));
     return 0;
 }
 

--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -756,6 +756,12 @@ int InstanceRecycler::init_storage_vault_accessors() {
 }
 
 int InstanceRecycler::init() {
+    if (instance_info_.status() == InstanceInfoPB::DELETED &&
+        (instance_info_.recycled_state() == INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED ||
+         instance_info_.recycled_state() == INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED)) {
+        return 0;
+    }
+
     int ret = init_obj_store_accessors();
     if (ret != 0) {
         return ret;
@@ -854,6 +860,30 @@ int InstanceRecycler::recycle_deleted_instance() {
                      << "s, instance_id=" << instance_id_;
     };
 
+    switch (instance_info_.recycled_state()) {
+    case InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING:
+        ret = recycle_deleted_instance_data();
+        break;
+    case InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED:
+        ret = recycle_deleted_instance_metadata();
+        break;
+    case InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED:
+        ret = remove_instance_key();
+        break;
+    default:
+        LOG_WARNING("invalid instance recycle state")
+                .tag("instance_id", instance_id_)
+                .tag("recycled_state", instance_info_.recycled_state());
+        ret = -1;
+        break;
+    }
+
+    return ret;
+}
+
+int InstanceRecycler::recycle_deleted_instance_data() {
+    int ret = 0;
+
     // Step 1: Recycle tmp rowsets (contains ref count but txn is not committed)
     auto recycle_tmp_rowsets_with_mark_delete_enabled = [&]() -> int {
         int res = recycle_tmp_rowsets();
@@ -866,23 +896,21 @@ int InstanceRecycler::recycle_deleted_instance() {
         }
         return res;
     };
+
     if (recycle_tmp_rowsets_with_mark_delete_enabled() != 0) {
         LOG_WARNING("failed to recycle tmp rowsets").tag("instance_id", instance_id_);
-        ret = -1;
         return -1;
     }
 
     // Step 2: Recycle versioned rowsets in recycle space (already marked for deletion)
     if (recycle_versioned_rowsets() != 0) {
         LOG_WARNING("failed to recycle versioned rowsets").tag("instance_id", instance_id_);
-        ret = -1;
         return -1;
     }
 
     // Step 3: Recycle operation logs (can recycle logs not referenced by snapshots)
     if (recycle_operation_logs() != 0) {
         LOG_WARNING("failed to recycle operation logs").tag("instance_id", instance_id_);
-        ret = -1;
         return -1;
     }
 
@@ -890,7 +918,6 @@ int InstanceRecycler::recycle_deleted_instance() {
     bool has_snapshots = false;
     if (has_cluster_snapshots(&has_snapshots) != 0) {
         LOG(WARNING) << "check instance cluster snapshots failed, instance_id=" << instance_id_;
-        ret = -1;
         return -1;
     } else if (has_snapshots) {
         LOG(INFO) << "instance has cluster snapshots, skip recycling, instance_id=" << instance_id_;
@@ -904,17 +931,16 @@ int InstanceRecycler::recycle_deleted_instance() {
         bool has_unrecycled_rowsets = false;
         if (recycle_ref_rowsets(&has_unrecycled_rowsets) != 0) {
             LOG_WARNING("failed to recycle ref rowsets").tag("instance_id", instance_id_);
-            ret = -1;
             return -1;
         } else if (has_unrecycled_rowsets) {
             LOG_INFO("instance has referenced rowsets, skip recycling")
                     .tag("instance_id", instance_id_);
-            return ret;
+            return 0;
         }
     } else { // delete all remote data if snapshot is disabled
         for (auto& [_, accessor] : accessor_map_) {
             if (stopped()) {
-                return ret;
+                return 0;
             }
 
             LOG(INFO) << "begin to delete all objects in " << accessor->uri();
@@ -934,7 +960,17 @@ int InstanceRecycler::recycle_deleted_instance() {
         }
     }
 
-    // Check successor instance, if exists, skip deleting kv because successor instance may still need the data in kv
+    if (update_instance_recycled_state(
+                InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING,
+                InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED) != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int InstanceRecycler::recycle_deleted_instance_metadata() {
+    // Keep metadata until the successor instance finishes cleanup because it may still reference it.
     if (instance_info_.has_successor_instance_id() &&
         !instance_info_.successor_instance_id().empty()) {
         std::string key = instance_key(instance_info_.successor_instance_id());
@@ -944,7 +980,6 @@ int InstanceRecycler::recycle_deleted_instance() {
             LOG(WARNING) << "failed to create txn, instance_id=" << instance_id_
                          << " successor_instance_id=" << instance_info_.successor_instance_id()
                          << " err=" << err;
-            ret = -1;
             return -1;
         }
 
@@ -959,7 +994,6 @@ int InstanceRecycler::recycle_deleted_instance() {
             LOG(WARNING) << "failed to get successor instance, instance_id=" << instance_id_
                          << " successor_instance_id=" << instance_info_.successor_instance_id()
                          << " err=" << err;
-            ret = -1;
             return -1;
         }
     }
@@ -969,7 +1003,6 @@ int InstanceRecycler::recycle_deleted_instance() {
     TxnErrorCode err = txn_kv_->create_txn(&txn);
     if (err != TxnErrorCode::TXN_OK) {
         LOG(WARNING) << "failed to create txn";
-        ret = -1;
         return -1;
     }
     LOG(INFO) << "begin to delete all kv, instance_id=" << instance_id_;
@@ -1020,33 +1053,125 @@ int InstanceRecycler::recycle_deleted_instance() {
     std::string versioned_log_key_start = versioned::log_key_prefix(instance_id_);
     std::string versioned_log_key_end = versioned::log_key_prefix(instance_id_ + '\x00');
     txn->remove(versioned_log_key_start, versioned_log_key_end);
-    err = txn->commit();
-    if (err != TxnErrorCode::TXN_OK) {
-        LOG(WARNING) << "failed to delete all kv, instance_id=" << instance_id_ << ", err=" << err;
-        ret = -1;
+
+    // Updating the recycle state also commits this transaction, making the metadata deletions
+    // and state transition atomic.
+    if (update_instance_recycled_state(
+                InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED,
+                InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED, txn.get()) != 0) {
+        return -1;
     }
 
-    if (ret == 0) {
-        // remove instance kv
-        // ATTN: MUST ensure that cloud platform won't regenerate the same instance id
-        err = txn_kv_->create_txn(&txn);
-        if (err != TxnErrorCode::TXN_OK) {
-            LOG(WARNING) << "failed to create txn";
-            ret = -1;
-            return ret;
-        }
-        std::string key;
-        instance_key({instance_id_}, &key);
-        txn->atomic_add(system_meta_service_instance_update_key(), 1);
-        txn->remove(key);
-        err = txn->commit();
-        if (err != TxnErrorCode::TXN_OK) {
-            LOG(WARNING) << "failed to delete instance kv, instance_id=" << instance_id_
-                         << " err=" << err;
-            ret = -1;
-        }
+    return 0;
+}
+
+int InstanceRecycler::remove_instance_key() {
+    std::unique_ptr<Transaction> txn;
+    TxnErrorCode err = txn_kv_->create_txn(&txn);
+    if (err != TxnErrorCode::TXN_OK) {
+        LOG(WARNING) << "failed to create txn";
+        return -1;
     }
-    return ret;
+    txn->atomic_add(system_meta_service_instance_update_key(), 1);
+    txn->remove(instance_key({instance_id_}));
+    err = txn->commit();
+    if (err != TxnErrorCode::TXN_OK) {
+        LOG(WARNING) << "failed to delete instance kv, instance_id=" << instance_id_
+                     << " err=" << err;
+        return -1;
+    }
+    return 0;
+}
+
+int InstanceRecycler::update_instance_recycled_state(InstanceRecycleState expected_state,
+                                                     InstanceRecycleState target_state) {
+    std::unique_ptr<Transaction> txn;
+    TxnErrorCode err = txn_kv_->create_txn(&txn);
+    if (err != TxnErrorCode::TXN_OK) {
+        LOG(WARNING) << "failed to create txn";
+        return -1;
+    }
+    return update_instance_recycled_state(expected_state, target_state, txn.get());
+}
+
+int InstanceRecycler::update_instance_recycled_state(InstanceRecycleState current_state,
+                                                     InstanceRecycleState target_state,
+                                                     Transaction* txn) {
+    const bool valid_transition = (current_state == INSTANCE_RECYCLE_STATE_CLEANUP_PENDING &&
+                                   target_state == INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED) ||
+                                  (current_state == INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED &&
+                                   target_state == INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+
+    if (!valid_transition) {
+        LOG_WARNING("invalid instance recycled state transition")
+                .tag("instance_id", instance_id_)
+                .tag("current_state", InstanceRecycleState_Name(current_state))
+                .tag("target_state", InstanceRecycleState_Name(target_state));
+        return -1;
+    }
+
+    std::string key = instance_key({instance_id_});
+    std::string value;
+    TxnErrorCode err = txn->get(key, &value);
+    if (err != TxnErrorCode::TXN_OK) {
+        LOG_WARNING("failed to get instance when updating instance recycled state")
+                .tag("instance_id", instance_id_)
+                .tag("current_state", InstanceRecycleState_Name(current_state))
+                .tag("target_state", InstanceRecycleState_Name(target_state))
+                .tag("err", err);
+        return -1;
+    }
+
+    InstanceInfoPB instance;
+    if (!instance.ParseFromString(value)) {
+        LOG_WARNING("failed to parse InstanceInfoPB when updating instance recycled state")
+                .tag("instance_id", instance_id_)
+                .tag("current_state", InstanceRecycleState_Name(current_state))
+                .tag("target_state", InstanceRecycleState_Name(target_state));
+        return -1;
+    }
+    if (instance.status() != InstanceInfoPB::DELETED) {
+        LOG_WARNING("instance is not deleted when updating instance recycled state")
+                .tag("instance_id", instance_id_)
+                .tag("status", instance.status())
+                .tag("current_state", InstanceRecycleState_Name(current_state))
+                .tag("target_state", InstanceRecycleState_Name(target_state));
+        return -1;
+    }
+    if (instance.recycled_state() != current_state) {
+        LOG_WARNING("instance recycled state changed before update")
+                .tag("instance_id", instance_id_)
+                .tag("current_state", InstanceRecycleState_Name(instance.recycled_state()))
+                .tag("expected_state", InstanceRecycleState_Name(current_state))
+                .tag("target_state", InstanceRecycleState_Name(target_state));
+        return -1;
+    }
+
+    instance.set_recycled_state(target_state);
+    instance.set_recycled_state_update_time_ms(
+            duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count());
+    if (!instance.SerializeToString(&value)) {
+        LOG_WARNING("failed to serialize InstanceInfoPB when updating instance recycled state")
+                .tag("instance_id", instance_id_)
+                .tag("expected_state", InstanceRecycleState_Name(current_state))
+                .tag("target_state", InstanceRecycleState_Name(target_state));
+        return -1;
+    }
+
+    txn->atomic_add(system_meta_service_instance_update_key(), 1);
+    txn->put(key, value);
+    err = txn->commit();
+    if (err != TxnErrorCode::TXN_OK) {
+        LOG(WARNING) << "failed to commit fdb txn when updating instance recycled state, "
+                     << "instance_id=" << instance_id_ << ", err=" << err;
+        return -1;
+    }
+
+    instance_info_.Swap(&instance);
+    LOG_INFO("updated instance recycled state")
+            .tag("instance_id", instance_id_)
+            .tag("recycled_state", InstanceRecycleState_Name(target_state));
+    return 0;
 }
 
 int InstanceRecycler::check_rowset_exists(int64_t tablet_id, const std::string& rowset_id,

--- a/cloud/src/recycler/recycler.h
+++ b/cloud/src/recycler/recycler.h
@@ -288,6 +288,16 @@ public:
     // returns 0 for success otherwise error
     int recycle_deleted_instance();
 
+    int recycle_deleted_instance_data();
+
+    int recycle_deleted_instance_metadata();
+
+    int update_instance_recycled_state(InstanceRecycleState expected_state,
+                                       InstanceRecycleState target_state);
+
+    int update_instance_recycled_state(InstanceRecycleState expected_state,
+                                       InstanceRecycleState target_state, Transaction* txn);
+
     // scan and recycle expired indexes:
     // 1. dropped table, dropped mv
     // 2. half-successtable/index when create
@@ -430,6 +440,9 @@ public:
                                        const SnapshotPB& snapshot_pb);
 
 private:
+    // returns 0 for success otherwise error
+    int remove_instance_key();
+
     // returns 0 for success otherwise error
     int init_obj_store_accessors();
 

--- a/cloud/src/recycler/recycler.h
+++ b/cloud/src/recycler/recycler.h
@@ -292,11 +292,11 @@ public:
 
     int recycle_deleted_instance_metadata();
 
-    int update_instance_recycled_state(InstanceRecycleState expected_state,
-                                       InstanceRecycleState target_state);
+    int update_instance_recycle_state(InstanceRecycleState expected_state,
+                                      InstanceRecycleState target_state);
 
-    int update_instance_recycled_state(InstanceRecycleState expected_state,
-                                       InstanceRecycleState target_state, Transaction* txn);
+    int update_instance_recycle_state(InstanceRecycleState expected_state,
+                                      InstanceRecycleState target_state, Transaction* txn);
 
     // scan and recycle expired indexes:
     // 1. dropped table, dropped mv

--- a/cloud/src/recycler/recycler_service.cpp
+++ b/cloud/src/recycler/recycler_service.cpp
@@ -400,7 +400,7 @@ void RecyclerServiceImpl::check_instance(const std::string& instance_id, MetaSer
 }
 
 std::pair<MetaServiceCode, std::string> RecyclerServiceImpl::skip_instance_data_cleanup(
-        const std::string& instance_id, InstanceRecycleState target_state) {
+        const std::string& instance_id) {
     std::unique_ptr<Transaction> txn;
     TxnErrorCode err = txn_kv_->create_txn(&txn);
     if (err != TxnErrorCode::TXN_OK) {
@@ -432,19 +432,27 @@ std::pair<MetaServiceCode, std::string> RecyclerServiceImpl::skip_instance_data_
         LOG(WARNING) << msg;
         return {MetaServiceCode::INVALID_ARGUMENT, std::move(msg)};
     }
-    const auto current_state = instance.recycled_state();
-    if (current_state != INSTANCE_RECYCLE_STATE_CLEANUP_PENDING) {
+    if (instance.recycle_state() != INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING) {
         std::string msg = fmt::format(
-                "invalid instance recycled state, instance_id={}, current_state={}, "
-                "target_state={}",
-                instance_id, InstanceRecycleState_Name(current_state),
-                InstanceRecycleState_Name(target_state));
+                "failed to set instance recycle state, instance state should be {}"
+                ", current_state={}"
+                ", instance_id={}",
+                INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING, instance.recycle_state(), instance_id);
+        LOG(WARNING) << msg;
+        return {MetaServiceCode::INVALID_ARGUMENT, std::move(msg)};
+    }
+    if (instance.has_multi_version_status() &&
+        instance.multi_version_status() != MultiVersionStatus::MULTI_VERSION_DISABLED) {
+        std::string msg = fmt::format(
+                "cannot skip instance data cleanup for a multi-version instance, instance_id={}, "
+                "multi_version_status={}",
+                instance_id, MultiVersionStatus_Name(instance.multi_version_status()));
         LOG(WARNING) << msg;
         return {MetaServiceCode::INVALID_ARGUMENT, std::move(msg)};
     }
 
-    instance.set_recycled_state(target_state);
-    instance.set_recycled_state_update_time_ms(
+    instance.set_recycle_state(INSTANCE_RECYCLE_STATE_METADATA_CLEANUP_PENDING);
+    instance.set_recycle_state_update_time_ms(
             std::chrono::duration_cast<std::chrono::milliseconds>(
                     std::chrono::system_clock::now().time_since_epoch())
                     .count());
@@ -463,8 +471,6 @@ std::pair<MetaServiceCode, std::string> RecyclerServiceImpl::skip_instance_data_
         return {MetaServiceCode::KV_TXN_COMMIT_ERR, std::move(msg)};
     }
 
-    LOG(INFO) << "set instance recycle state, instance_id=" << instance_id
-              << " recycled_state=" << InstanceRecycleState_Name(target_state);
     return {MetaServiceCode::OK, "OK"};
 }
 

--- a/cloud/src/recycler/recycler_service.cpp
+++ b/cloud/src/recycler/recycler_service.cpp
@@ -425,6 +425,7 @@ std::pair<MetaServiceCode, std::string> RecyclerServiceImpl::skip_instance_data_
         LOG(WARNING) << msg;
         return {MetaServiceCode::PROTOBUF_PARSE_ERR, std::move(msg)};
     }
+    auto current_state = instance.recycle_state();
     if (instance.status() != InstanceInfoPB::DELETED) {
         std::string msg = fmt::format(
                 "failed to set instance recycle state, instance is not deleted, instance_id={}",
@@ -432,12 +433,12 @@ std::pair<MetaServiceCode, std::string> RecyclerServiceImpl::skip_instance_data_
         LOG(WARNING) << msg;
         return {MetaServiceCode::INVALID_ARGUMENT, std::move(msg)};
     }
-    if (instance.recycle_state() != INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING) {
+    if (current_state != INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING) {
         std::string msg = fmt::format(
                 "failed to set instance recycle state, instance state should be {}"
                 ", current_state={}"
                 ", instance_id={}",
-                INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING, instance.recycle_state(), instance_id);
+                INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING, current_state, instance_id);
         LOG(WARNING) << msg;
         return {MetaServiceCode::INVALID_ARGUMENT, std::move(msg)};
     }
@@ -470,6 +471,9 @@ std::pair<MetaServiceCode, std::string> RecyclerServiceImpl::skip_instance_data_
         LOG(WARNING) << msg << " instance_id=" << instance_id;
         return {MetaServiceCode::KV_TXN_COMMIT_ERR, std::move(msg)};
     }
+    LOG(WARNING) << "successfully skipped instance data cleanup, instance_id=" << instance_id
+                 << " current_state=" << InstanceRecycleState_Name(current_state)
+                 << " target_state=" << InstanceRecycleState_Name(instance.recycle_state());
 
     return {MetaServiceCode::OK, "OK"};
 }

--- a/cloud/src/recycler/recycler_service.cpp
+++ b/cloud/src/recycler/recycler_service.cpp
@@ -27,6 +27,7 @@
 #include <rapidjson/stringbuffer.h>
 
 #include <algorithm>
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <numeric>
@@ -396,6 +397,75 @@ void RecyclerServiceImpl::check_instance(const std::string& instance_id, MetaSer
         }
         checker_->pending_instance_cond_.notify_all();
     }
+}
+
+std::pair<MetaServiceCode, std::string> RecyclerServiceImpl::skip_instance_data_cleanup(
+        const std::string& instance_id, InstanceRecycleState target_state) {
+    std::unique_ptr<Transaction> txn;
+    TxnErrorCode err = txn_kv_->create_txn(&txn);
+    if (err != TxnErrorCode::TXN_OK) {
+        std::string msg = fmt::format("failed to create txn, err={}", err);
+        LOG(WARNING) << msg << " instance_id=" << instance_id;
+        return {MetaServiceCode::KV_TXN_CREATE_ERR, std::move(msg)};
+    }
+
+    std::string key = instance_key({instance_id});
+    std::string value;
+    err = txn->get(key, &value);
+    if (err != TxnErrorCode::TXN_OK) {
+        std::string msg =
+                fmt::format("failed to get instance, instance_id={}, err={}", instance_id, err);
+        LOG(WARNING) << msg;
+        return {MetaServiceCode::KV_TXN_GET_ERR, std::move(msg)};
+    }
+
+    InstanceInfoPB instance;
+    if (!instance.ParseFromString(value)) {
+        std::string msg = fmt::format("malformed instance info, key={}", hex(key));
+        LOG(WARNING) << msg;
+        return {MetaServiceCode::PROTOBUF_PARSE_ERR, std::move(msg)};
+    }
+    if (instance.status() != InstanceInfoPB::DELETED) {
+        std::string msg = fmt::format(
+                "failed to set instance recycle state, instance is not deleted, instance_id={}",
+                instance_id);
+        LOG(WARNING) << msg;
+        return {MetaServiceCode::INVALID_ARGUMENT, std::move(msg)};
+    }
+    const auto current_state = instance.recycled_state();
+    if (current_state != INSTANCE_RECYCLE_STATE_CLEANUP_PENDING) {
+        std::string msg = fmt::format(
+                "invalid instance recycled state, instance_id={}, current_state={}, "
+                "target_state={}",
+                instance_id, InstanceRecycleState_Name(current_state),
+                InstanceRecycleState_Name(target_state));
+        LOG(WARNING) << msg;
+        return {MetaServiceCode::INVALID_ARGUMENT, std::move(msg)};
+    }
+
+    instance.set_recycled_state(target_state);
+    instance.set_recycled_state_update_time_ms(
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::system_clock::now().time_since_epoch())
+                    .count());
+    if (!instance.SerializeToString(&value)) {
+        std::string msg = "failed to serialize InstanceInfoPB";
+        LOG(WARNING) << msg << " instance_id=" << instance_id;
+        return {MetaServiceCode::PROTOBUF_SERIALIZE_ERR, std::move(msg)};
+    }
+
+    txn->atomic_add(system_meta_service_instance_update_key(), 1);
+    txn->put(key, value);
+    err = txn->commit();
+    if (err != TxnErrorCode::TXN_OK) {
+        std::string msg = fmt::format("failed to commit kv txn, err={}", err);
+        LOG(WARNING) << msg << " instance_id=" << instance_id;
+        return {MetaServiceCode::KV_TXN_COMMIT_ERR, std::move(msg)};
+    }
+
+    LOG(INFO) << "set instance recycle state, instance_id=" << instance_id
+              << " recycled_state=" << InstanceRecycleState_Name(target_state);
+    return {MetaServiceCode::OK, "OK"};
 }
 
 void recycle_copy_jobs(const std::shared_ptr<TxnKv>& txn_kv, const std::string& instance_id,

--- a/cloud/src/recycler/recycler_service.h
+++ b/cloud/src/recycler/recycler_service.h
@@ -50,6 +50,9 @@ public:
 
     void check_instance(const std::string& instance_id, MetaServiceCode& code, std::string& msg);
 
+    std::pair<MetaServiceCode, std::string> skip_instance_data_cleanup(
+            const std::string& instance_id, InstanceRecycleState target_state);
+
     std::shared_ptr<TxnKv> txn_kv() { return txn_kv_; }
     Recycler* recycler() { return recycler_; }
     Checker* checker() { return checker_; }

--- a/cloud/src/recycler/recycler_service.h
+++ b/cloud/src/recycler/recycler_service.h
@@ -51,7 +51,7 @@ public:
     void check_instance(const std::string& instance_id, MetaServiceCode& code, std::string& msg);
 
     std::pair<MetaServiceCode, std::string> skip_instance_data_cleanup(
-            const std::string& instance_id, InstanceRecycleState target_state);
+            const std::string& instance_id);
 
     std::shared_ptr<TxnKv> txn_kv() { return txn_kv_; }
     Recycler* recycler() { return recycler_; }

--- a/cloud/src/recycler/recycler_snapshot.cpp
+++ b/cloud/src/recycler/recycler_snapshot.cpp
@@ -40,8 +40,8 @@
 namespace doris::cloud {
 
 int InstanceRecycler::recycle_cluster_snapshots() {
-    if (instance_info_.recycled_state() == INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED ||
-        instance_info_.recycled_state() == INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED) {
+    if (instance_info_.recycle_state() == INSTANCE_RECYCLE_STATE_METADATA_CLEANUP_PENDING ||
+        instance_info_.recycle_state() == INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED) {
         return 0;
     }
     return snapshot_manager_->recycle_snapshots(this);

--- a/cloud/src/recycler/recycler_snapshot.cpp
+++ b/cloud/src/recycler/recycler_snapshot.cpp
@@ -40,6 +40,10 @@
 namespace doris::cloud {
 
 int InstanceRecycler::recycle_cluster_snapshots() {
+    if (instance_info_.recycled_state() == INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED ||
+        instance_info_.recycled_state() == INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED) {
+        return 0;
+    }
     return snapshot_manager_->recycle_snapshots(this);
 }
 

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -599,9 +599,15 @@ TEST(MetaServiceTest, CreateInstanceTest) {
         AlterInstanceResponse retry_res;
         meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
                                      &req, &retry_res, nullptr);
-        ASSERT_EQ(retry_res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
-        ASSERT_NE(retry_res.status().msg().find("instance has already been recycled"),
+        ASSERT_EQ(retry_res.status().code(), MetaServiceCode::OK);
+        ASSERT_EQ(retry_res.status().msg().find("instance has already been recycled"),
                   std::string::npos);
+        val.clear();
+        ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+        ASSERT_EQ(txn->get(key, &val), TxnErrorCode::TXN_OK);
+        instance.ParseFromString(val);
+        ASSERT_EQ(instance.status(), InstanceInfoPB::DELETED);
+        ASSERT_EQ(instance.recycle_state(), INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
     }
 
     // case: normal refresh instance

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -591,6 +591,17 @@ TEST(MetaServiceTest, CreateInstanceTest) {
         instance.ParseFromString(val);
         ASSERT_EQ(instance.status(), InstanceInfoPB::DELETED);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+
+        instance.set_recycled_state(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+        txn->put(key, instance.SerializeAsString());
+        ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+        AlterInstanceResponse retry_res;
+        meta_service->alter_instance(reinterpret_cast<::google::protobuf::RpcController*>(&cntl),
+                                     &req, &retry_res, nullptr);
+        ASSERT_EQ(retry_res.status().code(), MetaServiceCode::INVALID_ARGUMENT);
+        ASSERT_NE(retry_res.status().msg().find("instance has already been recycled"),
+                  std::string::npos);
     }
 
     // case: normal refresh instance

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -592,7 +592,7 @@ TEST(MetaServiceTest, CreateInstanceTest) {
         ASSERT_EQ(instance.status(), InstanceInfoPB::DELETED);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
 
-        instance.set_recycled_state(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+        instance.set_recycle_state(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
         txn->put(key, instance.SerializeAsString());
         ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
 

--- a/cloud/test/recycle_versioned_keys_test.cpp
+++ b/cloud/test/recycle_versioned_keys_test.cpp
@@ -1859,6 +1859,8 @@ TEST(RecycleVersionedKeysTest, RecycleDeletedInstance) {
     {
         // Recycle deleted instance
         ASSERT_EQ(recycler.recycle_deleted_instance(), 0);
+        ASSERT_EQ(recycler.recycle_deleted_instance(), 0);
+        ASSERT_EQ(recycler.recycle_deleted_instance(), 0);
     }
 
     {
@@ -1889,6 +1891,11 @@ TEST(RecycleVersionedKeysTest, RecycleDeletedInstance) {
         std::string log_key = versioned::log_key_prefix(instance_id);
         std::string log_key_end = versioned::log_key_prefix(instance_id + '\x00');
         ASSERT_EQ(count_range(txn_kv.get(), log_key, log_key_end), 0) << dump_range(txn_kv.get());
+
+        std::string instance_key_st = instance_key(instance_id);
+        std::string instance_key_ed = instance_key(instance_id + '\x00');
+        ASSERT_EQ(count_range(txn_kv.get(), instance_key_st, instance_key_ed), 0)
+                << dump_range(txn_kv.get());
 
         for (int i = 1; i < rowsets.size(); ++i) {
             std::unique_ptr<ListIterator> list_iter;

--- a/cloud/test/recycler_operation_log_test.cpp
+++ b/cloud/test/recycler_operation_log_test.cpp
@@ -2516,8 +2516,10 @@ TEST(RecycleOperationLogTest, RecycleDeletedInstance) {
     }
 
     ASSERT_EQ(recycler.recycle_deleted_instance(), 0);
+    ASSERT_EQ(recycler.recycle_deleted_instance(), 0);
+    ASSERT_EQ(recycler.recycle_deleted_instance(), 0);
 
-    // Verify all keys are deleted, expecting the instance_update
+    // Verify all data keys are deleted, keeping the instance status and instance_update keys.
     ASSERT_EQ(count_range(txn_kv.get()), 1) << dump_range(txn_kv.get());
 }
 

--- a/cloud/test/recycler_test.cpp
+++ b/cloud/test/recycler_test.cpp
@@ -3693,8 +3693,8 @@ TEST(RecyclerTest, recycle_deleted_instance) {
     }
 
     ASSERT_EQ(0, recycler.recycle_deleted_instance());
-    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING,
-              recycler.instance_info().recycled_state());
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING,
+              recycler.instance_info().recycle_state());
 
     {
         // No thing to recycle
@@ -3714,11 +3714,11 @@ TEST(RecyclerTest, recycle_deleted_instance) {
     }
 
     ASSERT_EQ(0, recycler.recycle_deleted_instance());
-    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED,
-              recycler.instance_info().recycled_state());
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_METADATA_CLEANUP_PENDING,
+              recycler.instance_info().recycle_state());
     ASSERT_EQ(0, recycler.recycle_deleted_instance());
     ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED,
-              recycler.instance_info().recycled_state());
+              recycler.instance_info().recycle_state());
     ASSERT_EQ(0, recycler.recycle_deleted_instance());
 
     {
@@ -3790,7 +3790,7 @@ TEST(RecyclerTest, recycle_deleted_instance) {
     }
 }
 
-TEST(RecyclerTest, init_deleted_instance_with_terminal_recycled_state) {
+TEST(RecyclerTest, init_deleted_instance_with_terminal_recycle_state) {
     auto txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<MemTxnKv>());
     ASSERT_NE(txn_kv.get(), nullptr);
     ASSERT_EQ(txn_kv->init(), 0);
@@ -3798,8 +3798,7 @@ TEST(RecyclerTest, init_deleted_instance_with_terminal_recycled_state) {
     InstanceInfoPB instance_info;
     instance_info.set_instance_id(instance_id);
     instance_info.set_status(InstanceInfoPB::DELETED);
-    instance_info.set_recycled_state(
-            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+    instance_info.set_recycle_state(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
     instance_info.add_resource_ids("deleted_vault");
 
     InstanceRecycler recycler(txn_kv, instance_info, thread_group,
@@ -3808,7 +3807,7 @@ TEST(RecyclerTest, init_deleted_instance_with_terminal_recycled_state) {
     ASSERT_EQ(recycler.do_recycle(), 0);
 }
 
-TEST(RecyclerTest, recycle_legacy_deleted_instance_without_recycled_state) {
+TEST(RecyclerTest, recycle_legacy_deleted_instance_without_recycle_state) {
     auto txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<MemTxnKv>());
     ASSERT_NE(txn_kv.get(), nullptr);
     ASSERT_EQ(txn_kv->init(), 0);
@@ -3817,9 +3816,9 @@ TEST(RecyclerTest, recycle_legacy_deleted_instance_without_recycled_state) {
     instance_info.set_instance_id(instance_id);
     instance_info.set_status(InstanceInfoPB::DELETED);
     instance_info.add_obj_info()->set_id("legacy_instance_obj");
-    ASSERT_FALSE(instance_info.has_recycled_state());
-    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING,
-              instance_info.recycled_state());
+    ASSERT_FALSE(instance_info.has_recycle_state());
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING,
+              instance_info.recycle_state());
     put_instance_info(txn_kv.get(), instance_info);
 
     InstanceRecycler recycler(txn_kv, instance_info, thread_group,
@@ -3832,12 +3831,12 @@ TEST(RecyclerTest, recycle_legacy_deleted_instance_without_recycled_state) {
     std::string value;
     ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_id}), &value));
     ASSERT_TRUE(instance_info.ParseFromString(value));
-    ASSERT_TRUE(instance_info.has_recycled_state());
-    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED,
-              instance_info.recycled_state());
+    ASSERT_TRUE(instance_info.has_recycle_state());
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_METADATA_CLEANUP_PENDING,
+              instance_info.recycle_state());
 }
 
-TEST(RecyclerTest, reject_stale_instance_recycled_state_update) {
+TEST(RecyclerTest, reject_stale_instance_recycle_state_update) {
     auto txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<MemTxnKv>());
     ASSERT_NE(txn_kv.get(), nullptr);
     ASSERT_EQ(txn_kv->init(), 0);
@@ -3845,22 +3844,23 @@ TEST(RecyclerTest, reject_stale_instance_recycled_state_update) {
     InstanceInfoPB stale_instance;
     stale_instance.set_instance_id(instance_id);
     stale_instance.set_status(InstanceInfoPB::DELETED);
-    stale_instance.set_recycled_state(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
+    stale_instance.set_recycle_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING);
 
     InstanceInfoPB latest_instance = stale_instance;
-    latest_instance.set_recycled_state(
+    latest_instance.set_recycle_state(
             InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
     put_instance_info(txn_kv.get(), latest_instance);
 
     InstanceRecycler stale_recycler(txn_kv, stale_instance, thread_group,
                                     std::make_shared<TxnLazyCommitter>(txn_kv));
-    ASSERT_NE(stale_recycler.update_instance_recycled_state(
-                      InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING,
+    ASSERT_NE(stale_recycler.update_instance_recycle_state(
+                      InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING,
                       InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED),
               0);
-    ASSERT_NE(stale_recycler.update_instance_recycled_state(
-                      InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING,
-                      InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED),
+    ASSERT_NE(stale_recycler.update_instance_recycle_state(
+                      InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING,
+                      InstanceRecycleState::INSTANCE_RECYCLE_STATE_METADATA_CLEANUP_PENDING),
               0);
 
     std::unique_ptr<Transaction> txn;
@@ -3869,7 +3869,7 @@ TEST(RecyclerTest, reject_stale_instance_recycled_state_update) {
     ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_id}), &value));
     ASSERT_TRUE(latest_instance.ParseFromString(value));
     ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED,
-              latest_instance.recycled_state());
+              latest_instance.recycle_state());
 }
 
 TEST(RecyclerServiceTest, skip_instance_data_cleanup) {
@@ -3877,118 +3877,84 @@ TEST(RecyclerServiceTest, skip_instance_data_cleanup) {
     ASSERT_NE(txn_kv.get(), nullptr);
     ASSERT_EQ(txn_kv->init(), 0);
 
+    const std::string test_instance_id = "skip_instance_data_cleanup_instance";
+    RecyclerServiceImpl service(txn_kv, nullptr, nullptr, nullptr);
+    auto get_instance_info = [&](InstanceInfoPB* instance_info) {
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+        std::string value;
+        ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({test_instance_id}), &value));
+        ASSERT_TRUE(instance_info->ParseFromString(value));
+    };
+
     InstanceInfoPB instance_info;
-    instance_info.set_instance_id("set_recycled_state_instance");
+    instance_info.set_instance_id(test_instance_id);
     instance_info.set_status(InstanceInfoPB::DELETED);
-    instance_info.set_recycled_state(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
+    instance_info.set_recycle_state(INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING);
+    ASSERT_FALSE(instance_info.has_multi_version_status());
     put_instance_info(txn_kv.get(), instance_info);
 
-    RecyclerServiceImpl service(txn_kv, nullptr, nullptr, nullptr);
-    auto [code, msg] = service.skip_instance_data_cleanup(
-            instance_info.instance_id(),
-            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+    auto [code, msg] = service.skip_instance_data_cleanup(instance_info.instance_id());
     ASSERT_EQ(code, MetaServiceCode::OK) << msg;
 
-    std::unique_ptr<Transaction> txn;
-    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
-    std::string value;
-    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_info.instance_id()}), &value));
-    ASSERT_TRUE(instance_info.ParseFromString(value));
-    ASSERT_EQ(instance_info.recycled_state(),
-              InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
-    ASSERT_GT(instance_info.recycled_state_update_time_ms(), 0);
+    InstanceInfoPB persisted_instance;
+    get_instance_info(&persisted_instance);
+    ASSERT_FALSE(persisted_instance.has_multi_version_status());
+    ASSERT_EQ(persisted_instance.recycle_state(), INSTANCE_RECYCLE_STATE_METADATA_CLEANUP_PENDING);
+    ASSERT_GT(persisted_instance.recycle_state_update_time_ms(), 0);
 
-    std::tie(code, msg) = service.skip_instance_data_cleanup(
-            instance_info.instance_id(),
-            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
-    ASSERT_EQ(code, MetaServiceCode::INVALID_ARGUMENT);
-    ASSERT_NE(msg.find("current_state=INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED"),
-              std::string::npos)
-            << msg;
-    ASSERT_NE(msg.find("target_state=INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED"),
-              std::string::npos)
-            << msg;
-
-    std::tie(code, msg) = service.skip_instance_data_cleanup(
-            instance_info.instance_id(),
-            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
-    ASSERT_EQ(code, MetaServiceCode::INVALID_ARGUMENT);
-    ASSERT_NE(msg.find("current_state=INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED"),
-              std::string::npos)
-            << msg;
-    ASSERT_NE(msg.find("target_state=INSTANCE_RECYCLE_STATE_CLEANUP_PENDING"), std::string::npos)
-            << msg;
+    instance_info.set_multi_version_status(MULTI_VERSION_DISABLED);
+    instance_info.set_recycle_state(INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING);
+    instance_info.clear_recycle_state_update_time_ms();
+    put_instance_info(txn_kv.get(), instance_info);
 
     auto call_http = [&](std::string_view query) {
         brpc::Controller ctrl;
         ctrl.http_request().uri() = fmt::format("/?{}", query);
         return process_skip_instance_data_cleanup(&service, &ctrl);
     };
-    const std::string invalid_recycled_state_msg =
-            "invalid recycled_state, supported values: "
-            "INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED";
-
     auto response = call_http("");
     ASSERT_EQ(response.status_code, 400) << response.body;
     ASSERT_EQ(response.msg, "instance_id is empty");
 
-    response = call_http("instance_id=set_recycled_state_instance");
-    ASSERT_EQ(response.status_code, 400) << response.body;
-    ASSERT_EQ(response.msg, "recycled_state is empty");
-
-    response = call_http(
-            "instance_id=set_recycled_state_instance&recycled_state="
-            "INSTANCE_RECYCLE_STATE_UNSPECIFIED");
-    ASSERT_EQ(response.status_code, 400) << response.body;
-    ASSERT_EQ(response.msg, invalid_recycled_state_msg);
-
-    response = call_http(
-            "instance_id=set_recycled_state_instance&recycled_state="
-            "INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED");
-    ASSERT_EQ(response.status_code, 400) << response.body;
-    ASSERT_EQ(response.msg, invalid_recycled_state_msg);
-
-    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
-    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_info.instance_id()}), &value));
-    ASSERT_TRUE(instance_info.ParseFromString(value));
-    ASSERT_EQ(instance_info.recycled_state(),
-              InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
-
-    instance_info.set_recycled_state(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
-    put_instance_info(txn_kv.get(), instance_info);
-    response = call_http(
-            "instance_id=set_recycled_state_instance&recycled_state="
-            "INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED");
+    response = call_http(fmt::format("instance_id={}", test_instance_id));
     ASSERT_EQ(response.status_code, 200) << response.body;
     ASSERT_EQ(response.msg, "OK");
 
-    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
-    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_info.instance_id()}), &value));
-    ASSERT_TRUE(instance_info.ParseFromString(value));
-    ASSERT_EQ(instance_info.recycled_state(),
-              InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+    get_instance_info(&persisted_instance);
+    ASSERT_EQ(persisted_instance.multi_version_status(), MULTI_VERSION_DISABLED);
+    ASSERT_EQ(persisted_instance.recycle_state(), INSTANCE_RECYCLE_STATE_METADATA_CLEANUP_PENDING);
+    ASSERT_GT(persisted_instance.recycle_state_update_time_ms(), 0);
 
-    instance_info.set_recycled_state(
-            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
-    put_instance_info(txn_kv.get(), instance_info);
-    std::tie(code, msg) = service.skip_instance_data_cleanup(
-            instance_info.instance_id(),
-            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
-    ASSERT_EQ(code, MetaServiceCode::INVALID_ARGUMENT);
-    ASSERT_NE(msg.find("current_state=INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED"), std::string::npos)
-            << msg;
+    constexpr std::array unsupported_multi_version_statuses {
+            MULTI_VERSION_WRITE_ONLY,
+            MULTI_VERSION_READ_WRITE,
+            MULTI_VERSION_ENABLED,
+    };
+    for (auto multi_version_status : unsupported_multi_version_statuses) {
+        instance_info.set_multi_version_status(multi_version_status);
+        instance_info.set_recycle_state(INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING);
+        instance_info.set_recycle_state_update_time_ms(123);
+        put_instance_info(txn_kv.get(), instance_info);
 
-    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
-    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_info.instance_id()}), &value));
-    ASSERT_TRUE(instance_info.ParseFromString(value));
-    ASSERT_EQ(instance_info.recycled_state(),
-              InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+        std::tie(code, msg) = service.skip_instance_data_cleanup(instance_info.instance_id());
+        ASSERT_EQ(code, MetaServiceCode::INVALID_ARGUMENT)
+                << MultiVersionStatus_Name(multi_version_status);
+        ASSERT_EQ(msg,
+                  fmt::format("cannot skip instance data cleanup for a multi-version instance, "
+                              "instance_id={}, multi_version_status={}",
+                              test_instance_id, MultiVersionStatus_Name(multi_version_status)));
+
+        get_instance_info(&persisted_instance);
+        ASSERT_EQ(persisted_instance.multi_version_status(), multi_version_status);
+        ASSERT_EQ(persisted_instance.recycle_state(), INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING);
+        ASSERT_EQ(persisted_instance.recycle_state_update_time_ms(), 123);
+    }
 
     instance_info.set_status(InstanceInfoPB::NORMAL);
+    instance_info.clear_multi_version_status();
     put_instance_info(txn_kv.get(), instance_info);
-    std::tie(code, msg) = service.skip_instance_data_cleanup(
-            instance_info.instance_id(),
-            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+    std::tie(code, msg) = service.skip_instance_data_cleanup(instance_info.instance_id());
     ASSERT_EQ(code, MetaServiceCode::INVALID_ARGUMENT);
     ASSERT_NE(msg.find("instance is not deleted"), std::string::npos) << msg;
 }

--- a/cloud/test/recycler_test.cpp
+++ b/cloud/test/recycler_test.cpp
@@ -3800,6 +3800,7 @@ TEST(RecyclerTest, init_deleted_instance_with_terminal_recycle_state) {
     instance_info.set_status(InstanceInfoPB::DELETED);
     instance_info.set_recycle_state(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
     instance_info.add_resource_ids("deleted_vault");
+    put_instance_info(txn_kv.get(), instance_info);
 
     InstanceRecycler recycler(txn_kv, instance_info, thread_group,
                               std::make_shared<TxnLazyCommitter>(txn_kv));

--- a/cloud/test/recycler_test.cpp
+++ b/cloud/test/recycler_test.cpp
@@ -42,6 +42,7 @@
 #include "common/bvars.h"
 #include "common/config.h"
 #include "common/defer.h"
+#include "common/http_helper.h"
 #include "common/logging.h"
 #include "common/simple_thread_pool.h"
 #include "common/util.h"
@@ -58,6 +59,7 @@
 #include "rate-limiter/rate_limiter.h"
 #include "recycler/checker.h"
 #include "recycler/recycler.cpp"
+#include "recycler/recycler_service.h"
 #include "recycler/storage_vault_accessor.h"
 #include "recycler/util.h"
 #include "recycler/white_black_list.h"
@@ -1152,6 +1154,13 @@ static int create_instance(const std::string& internal_stage_id,
 
     instance_info.set_instance_id(instance_id);
     return 0;
+}
+
+static void put_instance_info(TxnKv* txn_kv, const InstanceInfoPB& instance_info) {
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    txn->put(instance_key({instance_info.instance_id()}), instance_info.SerializeAsString());
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->commit());
 }
 
 static int create_copy_job(TxnKv* txn_kv, const std::string& stage_id, int64_t table_id,
@@ -3611,6 +3620,8 @@ TEST(RecyclerTest, recycle_deleted_instance) {
 
     InstanceInfoPB instance_info;
     create_instance(internal_stage_id, external_stage_id, instance_info);
+    instance_info.set_status(InstanceInfoPB::DELETED);
+    put_instance_info(txn_kv.get(), instance_info);
     InstanceRecycler recycler(txn_kv, instance_info, thread_group,
                               std::make_shared<TxnLazyCommitter>(txn_kv));
     ASSERT_EQ(recycler.init(), 0);
@@ -3682,6 +3693,8 @@ TEST(RecyclerTest, recycle_deleted_instance) {
     }
 
     ASSERT_EQ(0, recycler.recycle_deleted_instance());
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING,
+              recycler.instance_info().recycled_state());
 
     {
         // No thing to recycle
@@ -3701,6 +3714,19 @@ TEST(RecyclerTest, recycle_deleted_instance) {
     }
 
     ASSERT_EQ(0, recycler.recycle_deleted_instance());
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED,
+              recycler.instance_info().recycled_state());
+    ASSERT_EQ(0, recycler.recycle_deleted_instance());
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED,
+              recycler.instance_info().recycled_state());
+    ASSERT_EQ(0, recycler.recycle_deleted_instance());
+
+    {
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+        std::string value;
+        ASSERT_EQ(TxnErrorCode::TXN_KEY_NOT_FOUND, txn->get(instance_key({instance_id}), &value));
+    }
 
     // check if all the objects are deleted
     std::for_each(recycler.accessor_map_.begin(), recycler.accessor_map_.end(),
@@ -3764,6 +3790,209 @@ TEST(RecyclerTest, recycle_deleted_instance) {
     }
 }
 
+TEST(RecyclerTest, init_deleted_instance_with_terminal_recycled_state) {
+    auto txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<MemTxnKv>());
+    ASSERT_NE(txn_kv.get(), nullptr);
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    InstanceInfoPB instance_info;
+    instance_info.set_instance_id(instance_id);
+    instance_info.set_status(InstanceInfoPB::DELETED);
+    instance_info.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+    instance_info.add_resource_ids("deleted_vault");
+
+    InstanceRecycler recycler(txn_kv, instance_info, thread_group,
+                              std::make_shared<TxnLazyCommitter>(txn_kv));
+    ASSERT_EQ(recycler.init(), 0);
+    ASSERT_EQ(recycler.do_recycle(), 0);
+}
+
+TEST(RecyclerTest, recycle_legacy_deleted_instance_without_recycled_state) {
+    auto txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<MemTxnKv>());
+    ASSERT_NE(txn_kv.get(), nullptr);
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    InstanceInfoPB instance_info;
+    instance_info.set_instance_id(instance_id);
+    instance_info.set_status(InstanceInfoPB::DELETED);
+    instance_info.add_obj_info()->set_id("legacy_instance_obj");
+    ASSERT_FALSE(instance_info.has_recycled_state());
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING,
+              instance_info.recycled_state());
+    put_instance_info(txn_kv.get(), instance_info);
+
+    InstanceRecycler recycler(txn_kv, instance_info, thread_group,
+                              std::make_shared<TxnLazyCommitter>(txn_kv));
+    ASSERT_EQ(recycler.init(), 0);
+    ASSERT_EQ(recycler.recycle_deleted_instance(), 0);
+
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    std::string value;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_id}), &value));
+    ASSERT_TRUE(instance_info.ParseFromString(value));
+    ASSERT_TRUE(instance_info.has_recycled_state());
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED,
+              instance_info.recycled_state());
+}
+
+TEST(RecyclerTest, reject_stale_instance_recycled_state_update) {
+    auto txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<MemTxnKv>());
+    ASSERT_NE(txn_kv.get(), nullptr);
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    InstanceInfoPB stale_instance;
+    stale_instance.set_instance_id(instance_id);
+    stale_instance.set_status(InstanceInfoPB::DELETED);
+    stale_instance.set_recycled_state(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
+
+    InstanceInfoPB latest_instance = stale_instance;
+    latest_instance.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+    put_instance_info(txn_kv.get(), latest_instance);
+
+    InstanceRecycler stale_recycler(txn_kv, stale_instance, thread_group,
+                                    std::make_shared<TxnLazyCommitter>(txn_kv));
+    ASSERT_NE(stale_recycler.update_instance_recycled_state(
+                      InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING,
+                      InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED),
+              0);
+    ASSERT_NE(stale_recycler.update_instance_recycled_state(
+                      InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING,
+                      InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED),
+              0);
+
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    std::string value;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_id}), &value));
+    ASSERT_TRUE(latest_instance.ParseFromString(value));
+    ASSERT_EQ(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED,
+              latest_instance.recycled_state());
+}
+
+TEST(RecyclerServiceTest, skip_instance_data_cleanup) {
+    auto txn_kv = std::dynamic_pointer_cast<TxnKv>(std::make_shared<MemTxnKv>());
+    ASSERT_NE(txn_kv.get(), nullptr);
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    InstanceInfoPB instance_info;
+    instance_info.set_instance_id("set_recycled_state_instance");
+    instance_info.set_status(InstanceInfoPB::DELETED);
+    instance_info.set_recycled_state(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
+    put_instance_info(txn_kv.get(), instance_info);
+
+    RecyclerServiceImpl service(txn_kv, nullptr, nullptr, nullptr);
+    auto [code, msg] = service.skip_instance_data_cleanup(
+            instance_info.instance_id(),
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+    ASSERT_EQ(code, MetaServiceCode::OK) << msg;
+
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    std::string value;
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_info.instance_id()}), &value));
+    ASSERT_TRUE(instance_info.ParseFromString(value));
+    ASSERT_EQ(instance_info.recycled_state(),
+              InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+    ASSERT_GT(instance_info.recycled_state_update_time_ms(), 0);
+
+    std::tie(code, msg) = service.skip_instance_data_cleanup(
+            instance_info.instance_id(),
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+    ASSERT_EQ(code, MetaServiceCode::INVALID_ARGUMENT);
+    ASSERT_NE(msg.find("current_state=INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED"),
+              std::string::npos)
+            << msg;
+    ASSERT_NE(msg.find("target_state=INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED"),
+              std::string::npos)
+            << msg;
+
+    std::tie(code, msg) = service.skip_instance_data_cleanup(
+            instance_info.instance_id(),
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
+    ASSERT_EQ(code, MetaServiceCode::INVALID_ARGUMENT);
+    ASSERT_NE(msg.find("current_state=INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED"),
+              std::string::npos)
+            << msg;
+    ASSERT_NE(msg.find("target_state=INSTANCE_RECYCLE_STATE_CLEANUP_PENDING"), std::string::npos)
+            << msg;
+
+    auto call_http = [&](std::string_view query) {
+        brpc::Controller ctrl;
+        ctrl.http_request().uri() = fmt::format("/?{}", query);
+        return process_skip_instance_data_cleanup(&service, &ctrl);
+    };
+    const std::string invalid_recycled_state_msg =
+            "invalid recycled_state, supported values: "
+            "INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED";
+
+    auto response = call_http("");
+    ASSERT_EQ(response.status_code, 400) << response.body;
+    ASSERT_EQ(response.msg, "instance_id is empty");
+
+    response = call_http("instance_id=set_recycled_state_instance");
+    ASSERT_EQ(response.status_code, 400) << response.body;
+    ASSERT_EQ(response.msg, "recycled_state is empty");
+
+    response = call_http(
+            "instance_id=set_recycled_state_instance&recycled_state="
+            "INSTANCE_RECYCLE_STATE_UNSPECIFIED");
+    ASSERT_EQ(response.status_code, 400) << response.body;
+    ASSERT_EQ(response.msg, invalid_recycled_state_msg);
+
+    response = call_http(
+            "instance_id=set_recycled_state_instance&recycled_state="
+            "INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED");
+    ASSERT_EQ(response.status_code, 400) << response.body;
+    ASSERT_EQ(response.msg, invalid_recycled_state_msg);
+
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_info.instance_id()}), &value));
+    ASSERT_TRUE(instance_info.ParseFromString(value));
+    ASSERT_EQ(instance_info.recycled_state(),
+              InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+
+    instance_info.set_recycled_state(InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_PENDING);
+    put_instance_info(txn_kv.get(), instance_info);
+    response = call_http(
+            "instance_id=set_recycled_state_instance&recycled_state="
+            "INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED");
+    ASSERT_EQ(response.status_code, 200) << response.body;
+    ASSERT_EQ(response.msg, "OK");
+
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_info.instance_id()}), &value));
+    ASSERT_TRUE(instance_info.ParseFromString(value));
+    ASSERT_EQ(instance_info.recycled_state(),
+              InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+
+    instance_info.set_recycled_state(
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+    put_instance_info(txn_kv.get(), instance_info);
+    std::tie(code, msg) = service.skip_instance_data_cleanup(
+            instance_info.instance_id(),
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+    ASSERT_EQ(code, MetaServiceCode::INVALID_ARGUMENT);
+    ASSERT_NE(msg.find("current_state=INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED"), std::string::npos)
+            << msg;
+
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn_kv->create_txn(&txn));
+    ASSERT_EQ(TxnErrorCode::TXN_OK, txn->get(instance_key({instance_info.instance_id()}), &value));
+    ASSERT_TRUE(instance_info.ParseFromString(value));
+    ASSERT_EQ(instance_info.recycled_state(),
+              InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+
+    instance_info.set_status(InstanceInfoPB::NORMAL);
+    put_instance_info(txn_kv.get(), instance_info);
+    std::tie(code, msg) = service.skip_instance_data_cleanup(
+            instance_info.instance_id(),
+            InstanceRecycleState::INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED);
+    ASSERT_EQ(code, MetaServiceCode::INVALID_ARGUMENT);
+    ASSERT_NE(msg.find("instance is not deleted"), std::string::npos) << msg;
+}
+
 // Regression test: if commit_rowset is called but the txn is never committed,
 // the rowset stays in meta_rowset_tmp_key with data_rowset_ref_count_key=1.
 // recycle_deleted_instance() must call recycle_tmp_rowsets() first so that
@@ -3783,20 +4012,14 @@ TEST(RecyclerTest, recycle_deleted_instance_with_orphan_tmp_rowset) {
     // Create instance with multi-version read/write and snapshot support
     InstanceInfoPB instance_info;
     instance_info.set_instance_id(instance_id);
+    instance_info.set_status(InstanceInfoPB::DELETED);
     instance_info.set_multi_version_status(MultiVersionStatus::MULTI_VERSION_READ_WRITE);
     instance_info.set_snapshot_switch_status(SnapshotSwitchStatus::SNAPSHOT_SWITCH_ON);
     auto* obj_info = instance_info.add_obj_info();
     obj_info->set_id("orphan_tmp_rowset_test");
 
     // Write instance info to FDB (required by OperationLogRecycleChecker::init())
-    {
-        std::unique_ptr<Transaction> txn;
-        ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
-        std::string key = instance_key({instance_id});
-        std::string val = instance_info.SerializeAsString();
-        txn->put(key, val);
-        ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
-    }
+    put_instance_info(txn_kv.get(), instance_info);
 
     InstanceRecycler recycler(txn_kv, instance_info, thread_group,
                               std::make_shared<TxnLazyCommitter>(txn_kv));

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -100,12 +100,19 @@ enum KeySetType {
     MULTI_VERSION_META_ROWSET = 21;
 }
 
+enum InstanceRecycleState {
+    INSTANCE_RECYCLE_STATE_CLEANUP_PENDING = 0;
+    INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED = 1;
+    INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED = 2;
+}
+
 message InstanceInfoPB {
     enum Status {
         NORMAL = 0;
         DELETED = 1;
         OVERDUE = 2;
     }
+
     optional string user_id = 1;
     optional string instance_id = 2;
     optional string name = 3;
@@ -152,6 +159,10 @@ message InstanceInfoPB {
     // It is not always same as source_instance_id, because the source instance may inherit from another
     // instance during rollback, and the predecessor instance is the real instance which to execute the rollback.
     optional string predecessor_instance_id = 124;
+
+    optional InstanceRecycleState recycled_state = 125 [default = INSTANCE_RECYCLE_STATE_CLEANUP_PENDING];
+    // Last time when recycled_state was updated by a recycle step.
+    optional int64 recycled_state_update_time_ms = 126;
 }
 
 message StagePB {

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -101,8 +101,8 @@ enum KeySetType {
 }
 
 enum InstanceRecycleState {
-    INSTANCE_RECYCLE_STATE_CLEANUP_PENDING = 0;
-    INSTANCE_RECYCLE_STATE_DATA_CLEANUP_COMPLETED = 1;
+    INSTANCE_RECYCLE_STATE_DATA_CLEANUP_PENDING = 0;
+    INSTANCE_RECYCLE_STATE_METADATA_CLEANUP_PENDING = 1;
     INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED = 2;
 }
 
@@ -160,9 +160,9 @@ message InstanceInfoPB {
     // instance during rollback, and the predecessor instance is the real instance which to execute the rollback.
     optional string predecessor_instance_id = 124;
 
-    optional InstanceRecycleState recycled_state = 125 [default = INSTANCE_RECYCLE_STATE_CLEANUP_PENDING];
-    // Last time when recycled_state was updated by a recycle step.
-    optional int64 recycled_state_update_time_ms = 126;
+    optional InstanceRecycleState recycle_state = 125;
+    // Last time when recycle_state was updated by a recycle step.
+    optional int64 recycle_state_update_time_ms = 126;
 }
 
 message StagePB {


### PR DESCRIPTION
### What problem does this PR solve?

Introduce a persistent recycle state for deleted instances to split instance recycling into separate data cleanup and metadata cleanup stages.

The recycle process now transitions through:
```
DATA_CLEANUP_PENDING
-> METADATA_CLEANUP_PENDING
-> CLEANUP_COMPLETED
```

Each transition is persisted so that recycling can resume from the latest state after failures or retries.

Also add an API to skip instance data cleanup by advancing the recycle state directly from DATA_CLEANUP_PENDING to METADATA_CLEANUP_PENDING. Subsequent recycle rounds will skip object data cleanup and continue with metadata cleanup.

Repeated DROP operations preserve the existing recycle state instead of
resetting the recycle process.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

