### PR TITLE
[branch-3.1][test](regression) Clean stale excludes

### DIFF
--- a/regression-test/pipeline/cloud_p0/conf/regression-conf-custom.groovy
+++ b/regression-test/pipeline/cloud_p0/conf/regression-conf-custom.groovy
@@ -29,26 +29,18 @@ excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as th
     "set_replica_status," + // not a case for cloud mode, no need to run
     "test_be_inject_publish_txn_fail," + // not a case for cloud mode, no need to run
     "test_dump_image," +
-    "test_nereids_show_restore," +
-    "test_index_failure_injection," +
     "test_information_schema_external," +
     "test_profile," +
     "test_publish_timeout," +
-    "test_refresh_mtmv," + // not supported yet
     "test_report_version_missing," +
     "test_set_partition_version," +
     "test_spark_load," +
     "test_index_lowercase_fault_injection," +
-    "test_index_compaction_failure_injection," +
     "test_query_sys_rowsets," + // rowsets sys table
     "test_unique_table_debug_data," + // disable auto compaction
     "test_insert," + // txn insert
-    "test_nereids_show_snapshot," +
-    "test_full_compaction_run_status," +
     "test_topn_fault_injection," +
-    "auto_partition_in_partition_prune," + // inserted data in too many tablets, txn to large. not suitable for cloud.
     "one_col_range_partition," + // inserted data in too many tablets, txn to large. not suitable for cloud.
-    "test_nereids_show_backup," +
     "check_meta,"+
     "test_checker,"+
     "test_recycler_expired_stage_objects," +
@@ -71,10 +63,8 @@ excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as th
 
 excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "external_table_p0," + // run on external pipeline
-    "cloud/multi_cluster," + // run in specific regression pipeline
     "cloud_p0/multi_cluster," + // run in specific regression pipeline
     "cloud_p0/cache," +
-    "workload_manager_p1," +
     "nereids_rules_p0/subquery," +
     "backup_restore," + // not a case for cloud mode, no need to run
     "cold_heat_separation," +

--- a/regression-test/pipeline/cloud_p1/conf/regression-conf-custom.groovy
+++ b/regression-test/pipeline/cloud_p1/conf/regression-conf-custom.groovy
@@ -2,23 +2,17 @@ testGroups = "p1"
 //exclude groups and exclude suites is more prior than include groups and include suites.
 excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "stress_test_insert_into," +
-    "test_analyze_stats_p1," +
     "test_broker_load," +
     "test_profile," +
-    "test_refresh_mtmv," +
     "test_spark_load," +
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "backup_restore," +
     "fault_injection_p0," +
-    "workload_manager_p1," +
     "ccr_syncer_p1," +
     "ccr_mow_syncer_p1," +
     "inverted_index_p1/tpcds_sf1_index," + // in fixing, get result timeout, get result duration 899892 ms
-    "tpcds_sf1_unique_p1/spill," + // in fixing, MEM_LIMIT_EXCEEDED
-    "tpcds_sf1_p1/spill_test," + // in fixing, MEM_LIMIT_EXCEEDED
-    "tpch_sf0.1_p1/spill," + // in fixing, MEM_LIMIT_EXCEEDED
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 max_failure_num = 50

--- a/regression-test/pipeline/external/conf/regression-conf.groovy
+++ b/regression-test/pipeline/external/conf/regression-conf.groovy
@@ -64,22 +64,17 @@ excludeGroups = ""
 
 excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "test_dump_image," +
-    "test_index_failure_injection," +
     "test_information_schema_external," +
     "test_profile," +
-    "test_refresh_mtmv," +
     "test_spark_load," +
     "test_broker_load_func," +
-    "test_stream_stub_fault_injection," +
     "test_iceberg_overwrite_with_wrong_partition," +
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 // this directories will not be executed
 excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
-    "cloud," +
     "cloud_p0," +
     "nereids_rules_p0/subquery," +
-    "workload_manager_p1," +
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 customConf1 = "test_custom_conf_value"

--- a/regression-test/pipeline/nonConcurrent/conf/regression-conf.groovy
+++ b/regression-test/pipeline/nonConcurrent/conf/regression-conf.groovy
@@ -70,9 +70,7 @@ excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as th
 // this directories will not be executed
 excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "variant_github_events_nonConcurrent_p2," +
-    "variant_github_events_new_p2," +
     "hdfs_vault_p2," +
-    "nereids_p0/hbo," +
     "cloud_p0/multi_cluster," +
     "zzz_the_end_sentinel_do_not_touch"// keep this line as the last line
 

--- a/regression-test/pipeline/p0/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p0/conf/regression-conf.groovy
@@ -64,29 +64,16 @@ excludeGroups = ""
 
 excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "test_dump_image," +
-    "test_index_failure_injection," +
-    "test_compaction_uniq_cluster_keys_with_delete," +
-    "test_compaction_uniq_keys_cluster_key," +
-    "test_pk_uk_case_cluster," +
-    "test_point_query_ck," +
-    "test_rowstore_ck," +
-    "test_point_query_partition_ck," +
     "test_profile," +
-    "test_refresh_mtmv," +
     "test_spark_load," +
     "test_broker_load_func," +
-    "test_index_compaction_failure_injection," +
-    "test_full_compaction_run_status," +
     "test_topn_fault_injection," + 
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 // this directories will not be executed
 excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
-    "cloud," +
     "cloud_p0," +
     "nereids_rules_p0/subquery," +
-    "unique_with_mow_c_p0," +
-    "workload_manager_p1," +
     "plsql_p0," + // plsql is not developped any more, add by sk
     "variant_p0/nested," +
     "zzz_the_end_sentinel_do_not_touch"// keep this line as the last line

--- a/regression-test/pipeline/p1/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p1/conf/regression-conf.groovy
@@ -53,17 +53,14 @@ testGroups = ""
 testSuites = ""
 // this suites will not be executed
 excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
-    "test_analyze_stats_p1," +
     "test_broker_load," +
     "test_profile," +
-    "test_refresh_mtmv," +
     "test_spark_load," +
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 // this dir will not be executed
 excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "fault_injection_p0," +
-    "workload_manager_p1," +
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 cacheDataPath="/data/regression/"


### PR DESCRIPTION
## What
- Remove 39 exclude entries whose directory or suite no longer exists on branch-3.1.
- Do not change any live-case exclusion.

## Validation
- Exact audit-to-diff result: 39 stale removals.
- Exclude sentinels preserved.
- git diff --check passed.