### PR TITLE
[branch-4.0][test](regression) Clean stale excludes and re-enable validated cases

### DIFF
--- a/regression-test/pipeline/cloud_p0/conf/regression-conf-custom.groovy
+++ b/regression-test/pipeline/cloud_p0/conf/regression-conf-custom.groovy
@@ -30,23 +30,16 @@ excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as th
     "test_be_inject_publish_txn_fail," + // not a case for cloud mode, no need to run
     "test_dump_image," +
     "test_nereids_show_restore," +
-    "test_index_failure_injection," +
     "test_information_schema_external," +
-    "test_profile," +
     "test_publish_timeout," +
-    "test_refresh_mtmv," + // not supported yet
     "test_report_version_missing," +
     "test_set_partition_version," +
     "test_spark_load," +
     "test_index_lowercase_fault_injection," +
-    "test_index_compaction_failure_injection," +
     "test_query_sys_rowsets," + // rowsets sys table
     "test_unique_table_debug_data," + // disable auto compaction
     "test_insert," + // txn insert
     "test_nereids_show_snapshot," +
-    "test_full_compaction_run_status," +
-    "test_topn_fault_injection," +
-    "auto_partition_in_partition_prune," + // inserted data in too many tablets, txn to large. not suitable for cloud.
     "one_col_range_partition," + // inserted data in too many tablets, txn to large. not suitable for cloud.
     "test_nereids_show_backup," +
     "check_meta,"+
@@ -71,15 +64,10 @@ excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as th
 
 excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "external_table_p0," + // run on external pipeline
-    "cloud/multi_cluster," + // run in specific regression pipeline
     "cloud_p0/multi_cluster," + // run in specific regression pipeline
     "cloud_p0/cache," +
     "shape_check," + // run only in p0 is enough
     "nereids_p0/cache," + // run only in p0 is enough
-    "nereids_rules_p0/mv/increment_create," + // run only in p0 is enough
-    "nereids_rules_p0/mv/genera_constant_sql," + // run only in p0 is enough
-    "workload_manager_p1," +
-    "nereids_rules_p0/subquery," +
     "backup_restore," + // not a case for cloud mode, no need to run
     "cold_heat_separation," +
     "storage_medium_p0," +
@@ -87,8 +75,6 @@ excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line 
     "ccr_mow_syncer_p0," +
     "hdfs_vault_p2," +
     "inject_hdfs_vault_p0," +
-    "variant_p0/nested," +
-    "variant_p0/nested/sql," +
     "plsql_p0," + // plsql is not developped any more, add by sk.
     "restore_p0," + // 
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line

--- a/regression-test/pipeline/cloud_p1/conf/regression-conf-custom.groovy
+++ b/regression-test/pipeline/cloud_p1/conf/regression-conf-custom.groovy
@@ -2,17 +2,13 @@ testGroups = "p1"
 //exclude groups and exclude suites is more prior than include groups and include suites.
 excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "stress_test_insert_into," +
-    "test_analyze_stats_p1," +
     "test_broker_load," +
-    "test_profile," +
-    "test_refresh_mtmv," +
     "test_spark_load," +
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "backup_restore," +
     "fault_injection_p0," +
-    "workload_manager_p1," +
     "ccr_syncer_p1," +
     "ccr_mow_syncer_p1," +
     "inverted_index_p1/tpcds_sf1_index," + // in fixing, get result timeout, get result duration 899892 ms

--- a/regression-test/pipeline/external/conf/regression-conf.groovy
+++ b/regression-test/pipeline/external/conf/regression-conf.groovy
@@ -70,23 +70,16 @@ excludeGroups = "p1,p2"
 
 excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "test_dump_image," +
-    "test_index_failure_injection," +
     "test_information_schema_external," +
-    "test_profile," +
     "test_paimon_gcs," +
-    "test_refresh_mtmv," +
     "test_spark_load," +
     "test_broker_load_func," +
-    "test_stream_stub_fault_injection," +
     "test_iceberg_overwrite_with_wrong_partition," +
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 // this directories will not be executed
 excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
-    "cloud," +
     "cloud_p0," +
-    "nereids_rules_p0/subquery," +
-    "workload_manager_p1," +
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 customConf1 = "test_custom_conf_value"

--- a/regression-test/pipeline/nonConcurrent/conf/regression-conf.groovy
+++ b/regression-test/pipeline/nonConcurrent/conf/regression-conf.groovy
@@ -63,6 +63,7 @@ excludeGroups = "p1,p2"
 excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "test_cold_data_compaction_fault_injection," +
     "test_cumu_compaction_delay_fault_injection," + // force 3 replica cause fail
+    "test_decimalv2_common," + // to be fix
     "zzz_the_end_sentinel_do_not_touch"// keep this line as the last line
 
 // this directories will not be executed

--- a/regression-test/pipeline/nonConcurrent/conf/regression-conf.groovy
+++ b/regression-test/pipeline/nonConcurrent/conf/regression-conf.groovy
@@ -63,10 +63,6 @@ excludeGroups = "p1,p2"
 excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "test_cold_data_compaction_fault_injection," +
     "test_cumu_compaction_delay_fault_injection," + // force 3 replica cause fail
-    "test_full_compaction_run_status," + // unstable
-    "test_routine_load_timeout_value," + // to be fix
-    "test_decimalv2_common," + // to be fix
-    "test_insert_error_url," + // cause stop grace fail
     "zzz_the_end_sentinel_do_not_touch"// keep this line as the last line
 
 // this directories will not be executed

--- a/regression-test/pipeline/p0/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p0/conf/regression-conf.groovy
@@ -62,25 +62,15 @@ excludeGroups = "p1,p2"
 
 excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "test_dump_image," +
-    "test_index_failure_injection," +
-    "test_profile," +
-    "test_refresh_mtmv," +
     "test_spark_load," +
     "test_broker_load_func," +
-    "test_index_compaction_failure_injection," +
-    "test_full_compaction_run_status," +
-    "test_topn_fault_injection," + 
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 // this directories will not be executed
 excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
-    "cloud," +
     "cloud_p0," +
-    "workload_manager_p1," +
     "plsql_p0," + // plsql is not developped any more, add by sk
     "restore_p0," +
-    "variant_p0/nested," +
-    "variant_p0/nested/sql," +
     "zzz_the_end_sentinel_do_not_touch"// keep this line as the last line
 
 customConf1 = "test_custom_conf_value"

--- a/regression-test/pipeline/p1/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p1/conf/regression-conf.groovy
@@ -60,6 +60,9 @@ excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as th
 // this dir will not be executed
 excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "fault_injection_p0," +
+    "tpcds_sf1_unique_p1/spill," + // in fixing, MEM_LIMIT_EXCEEDED
+    "tpcds_sf1_p1/spill_test," + // in fixing, MEM_LIMIT_EXCEEDED
+    "tpch_sf0.1_p1/spill," + // in fixing, MEM_LIMIT_EXCEEDED
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 cacheDataPath="/data/regression/"

--- a/regression-test/pipeline/p1/conf/regression-conf.groovy
+++ b/regression-test/pipeline/p1/conf/regression-conf.groovy
@@ -53,20 +53,13 @@ testGroups = ""
 testSuites = ""
 // this suites will not be executed
 excludeSuites = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
-    "test_analyze_stats_p1," +
     "test_broker_load," +
-    "test_profile," +
-    "test_refresh_mtmv," +
     "test_spark_load," +
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 // this dir will not be executed
 excludeDirectories = "000_the_start_sentinel_do_not_touch," + // keep this line as the first line
     "fault_injection_p0," +
-    "workload_manager_p1," +
-    "tpcds_sf1_unique_p1/spill," + // in fixing, MEM_LIMIT_EXCEEDED
-    "tpcds_sf1_p1/spill_test," + // in fixing, MEM_LIMIT_EXCEEDED
-    "tpch_sf0.1_p1/spill," + // in fixing, MEM_LIMIT_EXCEEDED
     "zzz_the_end_sentinel_do_not_touch" // keep this line as the last line
 
 cacheDataPath="/data/regression/"


### PR DESCRIPTION
## What
- Remove 38 exclude entries whose directory or suite no longer exists on branch-4.0.
- Re-enable 4 candidates with direct, unmuted runtime success.

## Re-enabled coverage
- Cloud P0: nereids_rules_p0/mv/genera_constant_sql
- Cloud P0: nereids_rules_p0/mv/increment_create
- NonConcurrent: test_insert_error_url
- NonConcurrent: test_routine_load_timeout_value

## Validation
- Cloud P0 #1017220: finished/SUCCESS; all 43 tests under the two MV directories passed and were not muted.
- NonConcurrent #1017222: both retained suites passed and were not muted.
- test_decimalv2_common failed with a golden-result mismatch and is excluded again.
- The three P1 spill directories had no valid target execution and remain excluded.
- Final audit-to-diff result: 42 removals (38 stale + 4 validated); exclude sentinels preserved; git diff --check passed.