### PR TITLE
[feature](fe) Add byte-weighted metadata cache framework

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/CacheFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/CacheFactory.java
@@ -24,6 +24,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.github.benmanes.caffeine.cache.Ticker;
+import com.github.benmanes.caffeine.cache.Weigher;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Duration;
@@ -70,22 +71,49 @@ public class CacheFactory {
 
     // Build a loading cache, without executor, it will use fork-join pool for refresh
     public <K, V> LoadingCache<K, V> buildCache(CacheLoader<K, V> cacheLoader) {
-        Caffeine<Object, Object> builder = buildWithParams();
+        Caffeine<Object, Object> builder = buildSizeBoundedWithParams();
         return builder.build(cacheLoader);
     }
 
     // Build a loading cache, with executor, it will use given executor for refresh
     public <K, V> LoadingCache<K, V> buildCache(CacheLoader<K, V> cacheLoader,
             ExecutorService executor) {
-        Caffeine<Object, Object> builder = buildWithParams();
+        Caffeine<Object, Object> builder = buildSizeBoundedWithParams();
         builder.executor(executor);
+        return builder.build(cacheLoader);
+    }
+
+    /**
+     * Build a loading cache bounded by weight instead of entry count.
+     */
+    public <K, V> LoadingCache<K, V> buildCacheWithWeight(CacheLoader<K, V> cacheLoader,
+            ExecutorService executor, long maxWeight, Weigher<K, V> weigher) {
+        Caffeine<K, V> builder = buildWithParams()
+                .maximumWeight(maxWeight)
+                .weigher(weigher);
+        builder.executor(executor);
+        return builder.build(cacheLoader);
+    }
+
+    /**
+     * Build a loading cache bounded by weight with a synchronous removal listener.
+     */
+    public <K, V> LoadingCache<K, V> buildCacheWithWeightAndSyncRemovalListener(CacheLoader<K, V> cacheLoader,
+            long maxWeight, Weigher<K, V> weigher, RemovalListener<K, V> removalListener) {
+        Caffeine<K, V> builder = buildWithParams()
+                .maximumWeight(maxWeight)
+                .weigher(weigher);
+        if (removalListener != null) {
+            builder.removalListener(removalListener);
+        }
+        builder.executor(Runnable::run);  // Sync execution to avoid thread pool deadlock
         return builder.build(cacheLoader);
     }
 
     // Build cache with sync removal listener to prevent deadlock when listener calls invalidateAll()
     public <K, V> LoadingCache<K, V> buildCacheWithSyncRemovalListener(CacheLoader<K, V> cacheLoader,
             RemovalListener<K, V> removalListener) {
-        Caffeine<Object, Object> builder = buildWithParams();
+        Caffeine<Object, Object> builder = buildSizeBoundedWithParams();
         if (removalListener != null) {
             builder.removalListener(removalListener);
         }
@@ -96,7 +124,7 @@ public class CacheFactory {
     // Build an async loading cache
     public <K, V> AsyncLoadingCache<K, V> buildAsyncCache(AsyncCacheLoader<K, V> cacheLoader,
             ExecutorService executor) {
-        Caffeine<Object, Object> builder = buildWithParams();
+        Caffeine<Object, Object> builder = buildSizeBoundedWithParams();
         builder.executor(executor);
         return builder.buildAsync(cacheLoader);
     }
@@ -104,8 +132,6 @@ public class CacheFactory {
     @NotNull
     private Caffeine<Object, Object> buildWithParams() {
         Caffeine<Object, Object> builder = Caffeine.newBuilder();
-        builder.maximumSize(maxSize);
-
         if (expireAfterAccessSec.isPresent()) {
             builder.expireAfterAccess(Duration.ofSeconds(expireAfterAccessSec.getAsLong()));
         }
@@ -121,5 +147,10 @@ public class CacheFactory {
             builder.ticker(ticker);
         }
         return builder;
+    }
+
+    @NotNull
+    private Caffeine<Object, Object> buildSizeBoundedWithParams() {
+        return buildWithParams().maximumSize(maxSize);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/ParseUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/ParseUtil.java
@@ -70,6 +70,36 @@ public class ParseUtil {
         return dataVolumn;
     }
 
+    /**
+     * Parse a data volume while allowing zero and rejecting arithmetic overflow.
+     */
+    public static long analyzeDataVolumeAllowZero(String dataVolumnStr) throws AnalysisException {
+        long dataVolumn;
+        Matcher m = dataVolumnPattern.matcher(dataVolumnStr);
+        if (!m.matches()) {
+            throw new AnalysisException("invalid data volume expression:" + dataVolumnStr);
+        }
+        try {
+            dataVolumn = Long.parseLong(m.group(1));
+        } catch (NumberFormatException nfe) {
+            throw new AnalysisException("invalid data volume:" + m.group(1));
+        }
+
+        String unit = "B";
+        String tmpUnit = m.group(2);
+        if (!Strings.isNullOrEmpty(tmpUnit)) {
+            unit = tmpUnit.toUpperCase();
+        }
+        if (!validDataVolumnUnitMultiplier.containsKey(unit)) {
+            throw new AnalysisException("invalid unit:" + tmpUnit);
+        }
+        try {
+            return Math.multiplyExact(dataVolumn, validDataVolumnUnitMultiplier.get(unit));
+        } catch (ArithmeticException e) {
+            throw new AnalysisException("data volume is too large:" + dataVolumnStr);
+        }
+    }
+
     public static long analyzeReplicaNumber(String replicaNumberStr) throws AnalysisException {
         long replicaNumber = 0;
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/AbstractExternalMetaCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/AbstractExternalMetaCache.java
@@ -300,7 +300,7 @@ public abstract class AbstractExternalMetaCache implements ExternalMetaCache {
                 wrapSchemaValidator(entryDef.getLoader(), entryDef.getValueType()),
                 cacheSpec,
                 refreshExecutor, entryDef.isAutoRefresh(), entryDef.isContextualOnly(),
-                MetaCacheEntry.defaultObjectStripeCount());
+                MetaCacheEntry.defaultObjectStripeCount(), entryDef.getSizeEstimator());
     }
 
     private <K, V> Function<K, V> wrapSchemaValidator(Function<K, V> loader, Class<V> valueType) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/CacheSpec.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/CacheSpec.java
@@ -17,7 +17,9 @@
 
 package org.apache.doris.datasource.metacache;
 
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.util.ParseUtil;
 
 import org.apache.commons.lang3.math.NumberUtils;
 
@@ -33,7 +35,9 @@ import java.util.OptionalLong;
  * <ul>
  *   <li>enable=false disables cache</li>
  *   <li>ttlSecond=0 disables cache, ttlSecond=-1 means no expiration</li>
- *   <li>capacity=0 disables cache; capacity is count-based</li>
+ *   <li>capacity=0 disables a count-bounded cache</li>
+ *   <li>when maxWeight is present, it replaces capacity as the effective bound</li>
+ *   <li>maxWeight accepts an optional binary unit such as KB, MB, or GB; a bare number means bytes</li>
  * </ul>
  */
 public final class CacheSpec {
@@ -43,19 +47,26 @@ public final class CacheSpec {
     private static final String KEY_ENABLE = ".enable";
     private static final String KEY_TTL_SECOND = ".ttl-second";
     private static final String KEY_CAPACITY = ".capacity";
+    private static final String KEY_MAX_WEIGHT = ".max-weight";
 
     private final boolean enable;
     private final long ttlSecond;
     private final long capacity;
+    private final OptionalLong maxWeight;
 
-    private CacheSpec(boolean enable, long ttlSecond, long capacity) {
+    private CacheSpec(boolean enable, long ttlSecond, long capacity, OptionalLong maxWeight) {
         this.enable = enable;
         this.ttlSecond = ttlSecond;
         this.capacity = capacity;
+        this.maxWeight = Objects.requireNonNull(maxWeight, "maxWeight is required");
     }
 
     public static CacheSpec of(boolean enable, long ttlSecond, long capacity) {
-        return new CacheSpec(enable, ttlSecond, capacity);
+        return new CacheSpec(enable, ttlSecond, capacity, OptionalLong.empty());
+    }
+
+    public static CacheSpec ofWeight(boolean enable, long ttlSecond, long capacity, long maxWeight) {
+        return new CacheSpec(enable, ttlSecond, capacity, OptionalLong.of(maxWeight));
     }
 
     public static PropertySpec.Builder propertySpecBuilder() {
@@ -77,12 +88,14 @@ public final class CacheSpec {
         boolean enable = getBooleanProperty(properties, propertySpec.getEnableKey(), propertySpec.isDefaultEnable());
         long ttlSecond = getLongProperty(properties, propertySpec.getTtlKey(), propertySpec.getDefaultTtlSecond());
         long capacity = getLongProperty(properties, propertySpec.getCapacityKey(), propertySpec.getDefaultCapacity());
-        return of(enable, ttlSecond, capacity);
+        OptionalLong maxWeight = getOptionalDataSizeProperty(
+                properties, propertySpec.getMaxWeightKey(), propertySpec.getDefaultMaxWeight());
+        return new CacheSpec(enable, ttlSecond, capacity, maxWeight);
     }
 
     /**
      * Build a cache spec from catalog properties by standard external meta cache key pattern:
-     * meta.cache.&lt;engine&gt;.&lt;entry&gt;.(enable|ttl-second|capacity)
+     * meta.cache.&lt;engine&gt;.&lt;entry&gt;.(enable|ttl-second|capacity|max-weight)
      */
     public static CacheSpec fromProperties(Map<String, String> properties,
             String engine, String entryName, CacheSpec defaultSpec) {
@@ -95,6 +108,7 @@ public final class CacheSpec {
                 .enable(cacheKeyPrefix + KEY_ENABLE, defaultSpec.isEnable())
                 .ttl(cacheKeyPrefix + KEY_TTL_SECOND, defaultSpec.getTtlSecond())
                 .capacity(cacheKeyPrefix + KEY_CAPACITY, defaultSpec.getCapacity())
+                .maxWeight(cacheKeyPrefix + KEY_MAX_WEIGHT, defaultSpec.getMaxWeight())
                 .build();
     }
 
@@ -193,6 +207,26 @@ public final class CacheSpec {
         return NumberUtils.toLong(value, defaultValue);
     }
 
+    private static OptionalLong getOptionalDataSizeProperty(
+            Map<String, String> properties, String key, OptionalLong defaultValue) {
+        if (key == null) {
+            return defaultValue;
+        }
+        String value = properties.get(key);
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            return OptionalLong.of(ParseUtil.analyzeDataVolumeAllowZero(value));
+        } catch (AnalysisException e) {
+            throw invalidDataSizeProperty(key, value);
+        }
+    }
+
+    private static IllegalArgumentException invalidDataSizeProperty(String key, String value) {
+        return new IllegalArgumentException("The parameter " + key + " is wrong, value is " + value);
+    }
+
     public boolean isEnable() {
         return enable;
     }
@@ -205,6 +239,20 @@ public final class CacheSpec {
         return capacity;
     }
 
+    public OptionalLong getMaxWeight() {
+        return maxWeight;
+    }
+
+    public boolean isWeightBounded() {
+        return maxWeight.isPresent();
+    }
+
+    public boolean isCacheEnabled() {
+        return enable
+                && ttlSecond != CACHE_TTL_DISABLE_CACHE
+                && maxWeight.orElse(capacity) != 0L;
+    }
+
     public static final class PropertySpec {
         private final String enableKey;
         private final boolean defaultEnable;
@@ -212,15 +260,20 @@ public final class CacheSpec {
         private final long defaultTtlSecond;
         private final String capacityKey;
         private final long defaultCapacity;
+        private final String maxWeightKey;
+        private final OptionalLong defaultMaxWeight;
 
         private PropertySpec(String enableKey, boolean defaultEnable, String ttlKey,
-                long defaultTtlSecond, String capacityKey, long defaultCapacity) {
+                long defaultTtlSecond, String capacityKey, long defaultCapacity,
+                String maxWeightKey, OptionalLong defaultMaxWeight) {
             this.enableKey = enableKey;
             this.defaultEnable = defaultEnable;
             this.ttlKey = ttlKey;
             this.defaultTtlSecond = defaultTtlSecond;
             this.capacityKey = capacityKey;
             this.defaultCapacity = defaultCapacity;
+            this.maxWeightKey = maxWeightKey;
+            this.defaultMaxWeight = defaultMaxWeight;
         }
 
         public String getEnableKey() {
@@ -247,6 +300,14 @@ public final class CacheSpec {
             return defaultCapacity;
         }
 
+        public String getMaxWeightKey() {
+            return maxWeightKey;
+        }
+
+        public OptionalLong getDefaultMaxWeight() {
+            return defaultMaxWeight;
+        }
+
         public static final class Builder {
             private String enableKey;
             private boolean defaultEnable;
@@ -254,6 +315,8 @@ public final class CacheSpec {
             private long defaultTtlSecond;
             private String capacityKey;
             private long defaultCapacity;
+            private String maxWeightKey;
+            private OptionalLong defaultMaxWeight = OptionalLong.empty();
 
             public Builder enable(String key, boolean defaultValue) {
                 this.enableKey = key;
@@ -273,6 +336,12 @@ public final class CacheSpec {
                 return this;
             }
 
+            public Builder maxWeight(String key, OptionalLong defaultValue) {
+                this.maxWeightKey = Objects.requireNonNull(key, "maxWeightKey is required");
+                this.defaultMaxWeight = Objects.requireNonNull(defaultValue, "defaultMaxWeight is required");
+                return this;
+            }
+
             public PropertySpec build() {
                 return new PropertySpec(
                         Objects.requireNonNull(enableKey, "enableKey is required"),
@@ -280,7 +349,9 @@ public final class CacheSpec {
                         Objects.requireNonNull(ttlKey, "ttlKey is required"),
                         defaultTtlSecond,
                         Objects.requireNonNull(capacityKey, "capacityKey is required"),
-                        defaultCapacity);
+                        defaultCapacity,
+                        maxWeightKey,
+                        defaultMaxWeight);
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCacheEntry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCacheEntry.java
@@ -23,6 +23,7 @@ import org.apache.doris.common.Config;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Policy;
 import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.google.common.base.Preconditions;
@@ -116,6 +117,13 @@ public class MetaCacheEntry<K, V> {
                 defaultObjectStripeCount(), null, false);
     }
 
+    public MetaCacheEntry(String name, @Nullable Function<K, V> loader, CacheSpec cacheSpec,
+            ExecutorService refreshExecutor, boolean autoRefresh, boolean contextualOnly,
+            @Nullable MetaCacheSizeEstimator<K, V> sizeEstimator) {
+        this(name, loader, cacheSpec, refreshExecutor, autoRefresh, contextualOnly,
+                defaultObjectStripeCount(), sizeEstimator, null, false);
+    }
+
     public MetaCacheEntry(String name, Function<K, V> loader, CacheSpec cacheSpec, ExecutorService refreshExecutor,
             boolean autoRefresh, int stripeCount) {
         this(name, loader, cacheSpec, refreshExecutor, autoRefresh, false, stripeCount, null, false);
@@ -124,6 +132,13 @@ public class MetaCacheEntry<K, V> {
     public MetaCacheEntry(String name, @Nullable Function<K, V> loader, CacheSpec cacheSpec,
             ExecutorService refreshExecutor, boolean autoRefresh, boolean contextualOnly, int stripeCount) {
         this(name, loader, cacheSpec, refreshExecutor, autoRefresh, contextualOnly, stripeCount, null, false);
+    }
+
+    public MetaCacheEntry(String name, @Nullable Function<K, V> loader, CacheSpec cacheSpec,
+            ExecutorService refreshExecutor, boolean autoRefresh, boolean contextualOnly, int stripeCount,
+            @Nullable MetaCacheSizeEstimator<K, V> sizeEstimator) {
+        this(name, loader, cacheSpec, refreshExecutor, autoRefresh, contextualOnly,
+                stripeCount, sizeEstimator, null, false);
     }
 
     public static <K, V> MetaCacheEntry<K, V> withSyncRemovalListener(String name, Function<K, V> loader,
@@ -147,9 +162,40 @@ public class MetaCacheEntry<K, V> {
                 true);
     }
 
+    public static <K, V> MetaCacheEntry<K, V> withSyncRemovalListener(String name, Function<K, V> loader,
+            CacheSpec cacheSpec, ExecutorService refreshExecutor, MetaCacheSizeEstimator<K, V> sizeEstimator,
+            RemovalListener<K, V> removalListener) {
+        return withSyncRemovalListener(name, loader, cacheSpec, refreshExecutor,
+                defaultObjectStripeCount(), sizeEstimator, removalListener);
+    }
+
+    public static <K, V> MetaCacheEntry<K, V> withSyncRemovalListener(String name, Function<K, V> loader,
+            CacheSpec cacheSpec, ExecutorService refreshExecutor, int stripeCount,
+            MetaCacheSizeEstimator<K, V> sizeEstimator, RemovalListener<K, V> removalListener) {
+        return new MetaCacheEntry<>(
+                name,
+                loader,
+                cacheSpec,
+                refreshExecutor,
+                false,
+                false,
+                stripeCount,
+                Objects.requireNonNull(sizeEstimator, "sizeEstimator can not be null"),
+                Objects.requireNonNull(removalListener, "removalListener can not be null"),
+                true);
+    }
+
     private MetaCacheEntry(String name, @Nullable Function<K, V> loader, CacheSpec cacheSpec,
             ExecutorService refreshExecutor, boolean autoRefresh, boolean contextualOnly,
             int stripeCount, @Nullable RemovalListener<K, V> removalListener, boolean syncRemovalListener) {
+        this(name, loader, cacheSpec, refreshExecutor, autoRefresh, contextualOnly,
+                stripeCount, null, removalListener, syncRemovalListener);
+    }
+
+    private MetaCacheEntry(String name, @Nullable Function<K, V> loader, CacheSpec cacheSpec,
+            ExecutorService refreshExecutor, boolean autoRefresh, boolean contextualOnly,
+            int stripeCount, @Nullable MetaCacheSizeEstimator<K, V> sizeEstimator,
+            @Nullable RemovalListener<K, V> removalListener, boolean syncRemovalListener) {
         this.name = Objects.requireNonNull(name, "name can not be null");
         if (contextualOnly) {
             if (loader != null) {
@@ -170,6 +216,9 @@ public class MetaCacheEntry<K, V> {
         this.loader = loader;
         this.cacheSpec = Objects.requireNonNull(cacheSpec, "cacheSpec can not be null");
         this.autoRefresh = autoRefresh;
+        if (cacheSpec.isWeightBounded() && sizeEstimator == null) {
+            throw new IllegalArgumentException("max-weight requires an entry size estimator: " + name);
+        }
         if (stripeCount < 1) {
             throw new IllegalArgumentException("stripeCount must be positive");
         }
@@ -180,15 +229,14 @@ public class MetaCacheEntry<K, V> {
             stripeStates.set(0, new StripeState<>());
         }
         Objects.requireNonNull(refreshExecutor, "refreshExecutor can not be null");
-        this.effectiveEnabled = CacheSpec.isCacheEnabled(
-                this.cacheSpec.isEnable(), this.cacheSpec.getTtlSecond(), this.cacheSpec.getCapacity());
+        this.effectiveEnabled = this.cacheSpec.isCacheEnabled();
         OptionalLong expireAfterAccessSec =
                 effectiveEnabled ? CacheSpec.toExpireAfterAccess(this.cacheSpec.getTtlSecond()) : OptionalLong.empty();
         OptionalLong refreshAfterWriteSec =
                 effectiveEnabled && autoRefresh
                         ? OptionalLong.of(Config.external_cache_refresh_time_minutes * 60)
                         : OptionalLong.empty();
-        long maxSize = effectiveEnabled ? this.cacheSpec.getCapacity() : 0L;
+        long maxSize = effectiveEnabled && !cacheSpec.isWeightBounded() ? this.cacheSpec.getCapacity() : 0L;
         CacheFactory cacheFactory = new CacheFactory(
                 expireAfterAccessSec,
                 refreshAfterWriteSec,
@@ -197,7 +245,22 @@ public class MetaCacheEntry<K, V> {
                 null);
         // Build through a dedicated loader so refresh results admitted under an older generation are rejected.
         CacheLoader<K, V> cacheLoader = newCacheLoader();
-        if (syncRemovalListener) {
+        if (cacheSpec.isWeightBounded()) {
+            long maxWeight = effectiveEnabled ? cacheSpec.getMaxWeight().getAsLong() : 0L;
+            if (syncRemovalListener) {
+                this.loadingData = cacheFactory.buildCacheWithWeightAndSyncRemovalListener(
+                        cacheLoader,
+                        maxWeight,
+                        (key, value) -> toCaffeineWeight(sizeEstimator.estimateBytes(key, value)),
+                        removalListener);
+            } else {
+                this.loadingData = cacheFactory.buildCacheWithWeight(
+                        cacheLoader,
+                        refreshExecutor,
+                        maxWeight,
+                        (key, value) -> toCaffeineWeight(sizeEstimator.estimateBytes(key, value)));
+            }
+        } else if (syncRemovalListener) {
             this.loadingData = cacheFactory.buildCacheWithSyncRemovalListener(cacheLoader, removalListener);
         } else {
             this.loadingData = cacheFactory.buildCache(cacheLoader, refreshExecutor);
@@ -207,6 +270,13 @@ public class MetaCacheEntry<K, V> {
 
     public String name() {
         return name;
+    }
+
+    private int toCaffeineWeight(long estimatedBytes) {
+        if (estimatedBytes < 0L) {
+            throw new IllegalStateException("entry size estimator returned a negative weight: " + name);
+        }
+        return estimatedBytes >= Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) estimatedBytes;
     }
 
     public V get(K key) {
@@ -373,7 +443,11 @@ public class MetaCacheEntry<K, V> {
     }
 
     public MetaCacheEntryStats stats() {
+        // Keep statistics reads lightweight and side-effect free. Caffeine policy values may be briefly stale while
+        // asynchronous maintenance is pending; querying stats must not trigger expiration or removal listeners.
         CacheStats cacheStats = loadingData.stats();
+        Policy.Eviction<K, V> evictionPolicy = loadingData.policy().eviction()
+                .orElseThrow(() -> new IllegalStateException("cache has no eviction policy: " + name));
         long successCount = loadSuccessCount.get();
         long failureCount = loadFailureCount.get();
         long totalLoadTime = totalLoadTimeNanos.get();
@@ -384,7 +458,10 @@ public class MetaCacheEntry<K, V> {
                 autoRefresh,
                 cacheSpec.getTtlSecond(),
                 cacheSpec.getCapacity(),
+                cacheSpec.isWeightBounded(),
+                cacheSpec.getMaxWeight().orElse(-1L),
                 data.estimatedSize(),
+                evictionPolicy.weightedSize().orElse(-1L),
                 cacheStats.requestCount(),
                 cacheStats.hitCount(),
                 cacheStats.missCount(),
@@ -394,6 +471,7 @@ public class MetaCacheEntry<K, V> {
                 totalLoadTime,
                 totalLoadCount == 0 ? 0D : (double) totalLoadTime / totalLoadCount,
                 cacheStats.evictionCount(),
+                cacheStats.evictionWeight(),
                 invalidateCount.get(),
                 lastLoadSuccessTimeMs.get(),
                 lastLoadFailureTimeMs.get(),

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCacheEntryDef.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCacheEntryDef.java
@@ -101,10 +101,12 @@ public final class MetaCacheEntryDef<K, V> {
     private final boolean autoRefresh;
     private final boolean contextualOnly;
     private final MetaCacheEntryInvalidation<K> invalidation;
+    @Nullable
+    private final MetaCacheSizeEstimator<K, V> sizeEstimator;
 
     private MetaCacheEntryDef(String name, Class<K> keyType, Class<V> valueType,
             @Nullable Function<K, V> loader, CacheSpec defaultCacheSpec, boolean autoRefresh, boolean contextualOnly,
-            MetaCacheEntryInvalidation<K> invalidation) {
+            MetaCacheEntryInvalidation<K> invalidation, @Nullable MetaCacheSizeEstimator<K, V> sizeEstimator) {
         this.name = Objects.requireNonNull(name, "entry name is required");
         this.keyType = Objects.requireNonNull(keyType, "entry key type is required");
         this.valueType = Objects.requireNonNull(valueType, "entry value type is required");
@@ -123,6 +125,7 @@ public final class MetaCacheEntryDef<K, V> {
         this.autoRefresh = autoRefresh;
         this.contextualOnly = contextualOnly;
         this.invalidation = Objects.requireNonNull(invalidation, "entry invalidation is required");
+        this.sizeEstimator = sizeEstimator;
     }
 
     /**
@@ -142,7 +145,7 @@ public final class MetaCacheEntryDef<K, V> {
     public static <K, V> MetaCacheEntryDef<K, V> of(String name, Class<K> keyType, Class<V> valueType,
             Function<K, V> loader, CacheSpec defaultCacheSpec, MetaCacheEntryInvalidation<K> invalidation) {
         return new MetaCacheEntryDef<>(name, keyType, valueType, loader, defaultCacheSpec, true, false,
-                invalidation);
+                invalidation, null);
     }
 
     /**
@@ -164,7 +167,7 @@ public final class MetaCacheEntryDef<K, V> {
             Function<K, V> loader, CacheSpec defaultCacheSpec, boolean autoRefresh,
             MetaCacheEntryInvalidation<K> invalidation) {
         return new MetaCacheEntryDef<>(name, keyType, valueType, loader, defaultCacheSpec, autoRefresh, false,
-                invalidation);
+                invalidation, null);
     }
 
     /**
@@ -179,7 +182,15 @@ public final class MetaCacheEntryDef<K, V> {
             String name, Class<K> keyType, Class<V> valueType, CacheSpec defaultCacheSpec,
             MetaCacheEntryInvalidation<K> invalidation) {
         return new MetaCacheEntryDef<>(name, keyType, valueType, null, defaultCacheSpec, false, true,
-                invalidation);
+                invalidation, null);
+    }
+
+    /**
+     * Return a copy of this definition with the estimator used by a maximum-weight cache.
+     */
+    public MetaCacheEntryDef<K, V> withSizeEstimator(MetaCacheSizeEstimator<K, V> estimator) {
+        return new MetaCacheEntryDef<>(name, keyType, valueType, loader, defaultCacheSpec, autoRefresh,
+                contextualOnly, invalidation, Objects.requireNonNull(estimator, "entry size estimator is required"));
     }
 
     /**
@@ -231,5 +242,10 @@ public final class MetaCacheEntryDef<K, V> {
 
     public MetaCacheEntryInvalidation<K> getInvalidation() {
         return invalidation;
+    }
+
+    @Nullable
+    public MetaCacheSizeEstimator<K, V> getSizeEstimator() {
+        return sizeEstimator;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCacheEntryStats.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCacheEntryStats.java
@@ -30,6 +30,8 @@ import java.util.Objects;
  *
  * <p>For last-load timestamps, {@code -1} means no corresponding event happened yet.
  * {@code lastError} keeps the latest load failure message; empty string means no failure recorded.
+ * Snapshots do not trigger Caffeine maintenance, so size, weight, and eviction values may be briefly stale while
+ * asynchronous maintenance is pending.
  */
 public final class MetaCacheEntryStats {
     private final boolean configEnabled;
@@ -37,7 +39,10 @@ public final class MetaCacheEntryStats {
     private final boolean autoRefresh;
     private final long ttlSecond;
     private final long capacity;
+    private final boolean weightBounded;
+    private final long maxWeight;
     private final long estimatedSize;
+    private final long estimatedWeight;
     private final long requestCount;
     private final long hitCount;
     private final long missCount;
@@ -47,6 +52,7 @@ public final class MetaCacheEntryStats {
     private final long totalLoadTimeNanos;
     private final double averageLoadPenaltyNanos;
     private final long evictionCount;
+    private final long evictionWeight;
     private final long invalidateCount;
     private final long lastLoadSuccessTimeMs;
     private final long lastLoadFailureTimeMs;
@@ -61,7 +67,10 @@ public final class MetaCacheEntryStats {
             boolean autoRefresh,
             long ttlSecond,
             long capacity,
+            boolean weightBounded,
+            long maxWeight,
             long estimatedSize,
+            long estimatedWeight,
             long requestCount,
             long hitCount,
             long missCount,
@@ -71,6 +80,7 @@ public final class MetaCacheEntryStats {
             long totalLoadTimeNanos,
             double averageLoadPenaltyNanos,
             long evictionCount,
+            long evictionWeight,
             long invalidateCount,
             long lastLoadSuccessTimeMs,
             long lastLoadFailureTimeMs,
@@ -80,7 +90,10 @@ public final class MetaCacheEntryStats {
         this.autoRefresh = autoRefresh;
         this.ttlSecond = ttlSecond;
         this.capacity = capacity;
+        this.weightBounded = weightBounded;
+        this.maxWeight = maxWeight;
         this.estimatedSize = estimatedSize;
+        this.estimatedWeight = estimatedWeight;
         this.requestCount = requestCount;
         this.hitCount = hitCount;
         this.missCount = missCount;
@@ -90,6 +103,7 @@ public final class MetaCacheEntryStats {
         this.totalLoadTimeNanos = totalLoadTimeNanos;
         this.averageLoadPenaltyNanos = averageLoadPenaltyNanos;
         this.evictionCount = evictionCount;
+        this.evictionWeight = evictionWeight;
         this.invalidateCount = invalidateCount;
         this.lastLoadSuccessTimeMs = lastLoadSuccessTimeMs;
         this.lastLoadFailureTimeMs = lastLoadFailureTimeMs;
@@ -101,7 +115,7 @@ public final class MetaCacheEntryStats {
     }
 
     /**
-     * Effective cache enable state evaluated by {@link CacheSpec#isCacheEnabled(boolean, long, long)}.
+     * Effective cache enable state evaluated by {@link CacheSpec#isCacheEnabled()}.
      */
     public boolean isEffectiveEnabled() {
         return effectiveEnabled;
@@ -119,8 +133,26 @@ public final class MetaCacheEntryStats {
         return capacity;
     }
 
+    public boolean isWeightBounded() {
+        return weightBounded;
+    }
+
+    /**
+     * Returns the configured maximum weight in bytes, or -1 for a count-bounded cache.
+     */
+    public long getMaxWeight() {
+        return maxWeight;
+    }
+
     public long getEstimatedSize() {
         return estimatedSize;
+    }
+
+    /**
+     * Returns Caffeine's current weighted size in bytes, or -1 for a count-bounded cache.
+     */
+    public long getEstimatedWeight() {
+        return estimatedWeight;
     }
 
     public long getRequestCount() {
@@ -160,6 +192,10 @@ public final class MetaCacheEntryStats {
 
     public long getEvictionCount() {
         return evictionCount;
+    }
+
+    public long getEvictionWeight() {
+        return evictionWeight;
     }
 
     public double getEvictionRate() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCacheSizeEstimator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCacheSizeEstimator.java
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.metacache;
+
+/**
+ * Estimates the retained heap bytes owned by one cache key/value entry.
+ *
+ * <p>The estimator runs when Caffeine admits or replaces an entry, so implementations should be deterministic and
+ * inexpensive. Results must be non-negative. Values larger than {@link Integer#MAX_VALUE} are saturated because
+ * Caffeine's weigher API uses an integer weight.
+ */
+@FunctionalInterface
+public interface MetaCacheSizeEstimator<K, V> {
+    long estimateBytes(K key, V value);
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/common/util/ParseUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/util/ParseUtilTest.java
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.apache.doris.common.AnalysisException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ParseUtilTest {
+
+    @Test
+    public void testLegacyDataVolumeStillRejectsZero() throws Exception {
+        Assert.assertEquals(1024L, ParseUtil.analyzeDataVolume("1KB"));
+        Assert.assertThrows(AnalysisException.class, () -> ParseUtil.analyzeDataVolume("0GB"));
+    }
+
+    @Test
+    public void testStrictDataVolumeAllowsZeroAndRejectsOverflow() throws Exception {
+        Assert.assertEquals(0L, ParseUtil.analyzeDataVolumeAllowZero("0GB"));
+        Assert.assertEquals(512L * 1024 * 1024, ParseUtil.analyzeDataVolumeAllowZero("512MB"));
+        Assert.assertThrows(AnalysisException.class,
+                () -> ParseUtil.analyzeDataVolumeAllowZero("9223372036854775807KB"));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/metacache/AbstractExternalMetaCacheTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/metacache/AbstractExternalMetaCacheTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 public class AbstractExternalMetaCacheTest {
 
@@ -67,6 +68,46 @@ public class AbstractExternalMetaCacheTest {
                     2L, "schema", SchemaCacheKey.class, SchemaCacheValue.class);
             Assert.assertFalse(disabledEntry.stats().isEffectiveEnabled());
             Assert.assertEquals(0, disabledEntry.initializedStripeCountForTest());
+        } finally {
+            refreshExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testMaximumWeightRequiresRegisteredEntryEstimator() {
+        ExecutorService refreshExecutor = Executors.newSingleThreadExecutor();
+        try {
+            TestExternalMetaCache cache = new TestExternalMetaCache(refreshExecutor);
+            Map<String, String> properties = Maps.newHashMap();
+            properties.put("meta.cache.test_engine.schema.max-weight", "5");
+
+            IllegalArgumentException exception = Assert.assertThrows(
+                    IllegalArgumentException.class, () -> cache.initCatalog(1L, properties));
+            Assert.assertTrue(exception.getMessage().contains("size estimator"));
+        } finally {
+            refreshExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testRegisteredEntryEstimatorEnablesMaximumWeight() throws Exception {
+        ExecutorService refreshExecutor = Executors.newSingleThreadExecutor();
+        try {
+            WeightedExternalMetaCache cache = new WeightedExternalMetaCache(refreshExecutor);
+            Map<String, String> properties = Maps.newHashMap();
+            properties.put("meta.cache.weighted_engine.value.max-weight", "5");
+            cache.initCatalog(1L, properties);
+
+            MetaCacheEntry<String, Integer> entry = cache.entry(1L, "value", String.class, Integer.class);
+            entry.put("first", 4);
+            entry.put("second", 4);
+            // Wait for Caffeine's queued maintenance without making the statistics read trigger it.
+            refreshExecutor.submit(() -> null).get(3L, TimeUnit.SECONDS);
+
+            MetaCacheEntryStats stats = entry.stats();
+            Assert.assertTrue(stats.isWeightBounded());
+            Assert.assertEquals(5L, stats.getMaxWeight());
+            Assert.assertTrue(stats.getEstimatedWeight() <= 5L);
         } finally {
             refreshExecutor.shutdownNow();
         }
@@ -157,6 +198,19 @@ public class AbstractExternalMetaCacheTest {
                             new Column("ID", PrimitiveType.INT))),
                     CacheSpec.of(true, CacheSpec.CACHE_NO_TTL, 10L),
                     MetaCacheEntryInvalidation.forNameMapping(SchemaCacheKey::getNameMapping)));
+        }
+    }
+
+    private static final class WeightedExternalMetaCache extends AbstractExternalMetaCache {
+        private WeightedExternalMetaCache(ExecutorService refreshExecutor) {
+            super("weighted_engine", refreshExecutor);
+            registerEntry(MetaCacheEntryDef.of(
+                    "value",
+                    String.class,
+                    Integer.class,
+                    String::length,
+                    CacheSpec.of(true, CacheSpec.CACHE_NO_TTL, 100L))
+                    .withSizeEstimator((key, value) -> value));
         }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/metacache/CacheSpecTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/metacache/CacheSpecTest.java
@@ -68,6 +68,7 @@ public class CacheSpecTest {
     public void testFromPropertiesWithEngineEntryKeys() {
         Map<String, String> properties = Maps.newHashMap();
         properties.put("meta.cache.hive.schema.ttl-second", "0");
+        properties.put("meta.cache.hive.schema.max-weight", "4KB");
 
         CacheSpec defaultSpec = CacheSpec.fromProperties(
                 Maps.newHashMap(),
@@ -79,6 +80,47 @@ public class CacheSpecTest {
         Assert.assertTrue(spec.isEnable());
         Assert.assertEquals(0, spec.getTtlSecond());
         Assert.assertEquals(100, spec.getCapacity());
+        Assert.assertTrue(spec.isWeightBounded());
+        Assert.assertEquals(4096L, spec.getMaxWeight().getAsLong());
+    }
+
+    @Test
+    public void testFromPropertiesRejectsInvalidMaximumWeight() {
+        String key = "meta.cache.test.schema.max-weight";
+        CacheSpec defaultSpec = CacheSpec.of(true, 60L, 100L);
+        Map<String, String> properties = Maps.newHashMap();
+
+        for (String invalidValue : new String[] {
+                "abc", "-1MB", "1.5GB", "1XB", "9223372036854775808", "9223372036854775807KB"}) {
+            properties.put(key, invalidValue);
+            IllegalArgumentException exception = Assert.assertThrows(
+                    IllegalArgumentException.class,
+                    () -> CacheSpec.fromProperties(properties, "test", "schema", defaultSpec));
+            Assert.assertEquals(
+                    "The parameter " + key + " is wrong, value is " + invalidValue,
+                    exception.getMessage());
+        }
+    }
+
+    @Test
+    public void testFromPropertiesParsesMaximumWeightUnitsAndZero() {
+        String key = "meta.cache.test.schema.max-weight";
+        CacheSpec defaultSpec = CacheSpec.of(true, 60L, 100L);
+        Map<String, String> properties = Maps.newHashMap();
+
+        properties.put(key, "4096");
+        CacheSpec byteSpec = CacheSpec.fromProperties(properties, "test", "schema", defaultSpec);
+        Assert.assertEquals(4096L, byteSpec.getMaxWeight().getAsLong());
+
+        properties.put(key, "512MB");
+        CacheSpec megabyteSpec = CacheSpec.fromProperties(properties, "test", "schema", defaultSpec);
+        Assert.assertEquals(512L * 1024 * 1024, megabyteSpec.getMaxWeight().getAsLong());
+        Assert.assertTrue(megabyteSpec.isCacheEnabled());
+
+        properties.put(key, "0GB");
+        CacheSpec disabledSpec = CacheSpec.fromProperties(properties, "test", "schema", defaultSpec);
+        Assert.assertEquals(0L, disabledSpec.getMaxWeight().getAsLong());
+        Assert.assertFalse(disabledSpec.isCacheEnabled());
     }
 
     @Test
@@ -118,6 +160,11 @@ public class CacheSpecTest {
         Assert.assertFalse(disabled.isEnable());
         Assert.assertEquals(60, disabled.getTtlSecond());
         Assert.assertEquals(100, disabled.getCapacity());
+
+        CacheSpec weighted = CacheSpec.ofWeight(true, 60, 100, 1024);
+        Assert.assertTrue(weighted.isWeightBounded());
+        Assert.assertEquals(1024L, weighted.getMaxWeight().getAsLong());
+        Assert.assertTrue(weighted.isCacheEnabled());
     }
 
     @Test
@@ -147,6 +194,8 @@ public class CacheSpecTest {
         Assert.assertFalse(CacheSpec.isCacheEnabled(false, CacheSpec.CACHE_NO_TTL, 1));
         Assert.assertFalse(CacheSpec.isCacheEnabled(true, 0, 1));
         Assert.assertFalse(CacheSpec.isCacheEnabled(true, CacheSpec.CACHE_NO_TTL, 0));
+        Assert.assertTrue(CacheSpec.ofWeight(true, CacheSpec.CACHE_NO_TTL, 0, 1).isCacheEnabled());
+        Assert.assertFalse(CacheSpec.ofWeight(true, CacheSpec.CACHE_NO_TTL, 1, 0).isCacheEnabled());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/metacache/MetaCacheEntryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/metacache/MetaCacheEntryTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.datasource.metacache;
 import org.apache.doris.common.Config;
 
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.Assert;
@@ -33,6 +34,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -220,6 +222,97 @@ public class MetaCacheEntryTest {
 
             LoadingCache<String, Integer> loadingCache = extractLoadingCache(entry);
             Assert.assertFalse(loadingCache.policy().refreshAfterWrite().isPresent());
+        } finally {
+            refreshExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testMaximumWeightUsesEstimatorAndExposesWeightStats() throws Exception {
+        ExecutorService refreshExecutor = Executors.newSingleThreadExecutor();
+        try {
+            MetaCacheEntry<String, Integer> entry = new MetaCacheEntry<>(
+                    "weighted",
+                    String::length,
+                    CacheSpec.ofWeight(true, CacheSpec.CACHE_NO_TTL, 100L, 5L),
+                    refreshExecutor,
+                    false,
+                    false,
+                    (key, value) -> value);
+
+            entry.put("first", 4);
+            waitUntil(() -> entry.stats().getEstimatedWeight() == 4L);
+            entry.put("second", 4);
+            waitUntil(() -> entry.stats().getEvictionCount() == 1L);
+
+            MetaCacheEntryStats stats = entry.stats();
+            Assert.assertTrue(stats.isWeightBounded());
+            Assert.assertEquals(5L, stats.getMaxWeight());
+            Assert.assertTrue(stats.getEstimatedWeight() <= 5L);
+            Assert.assertEquals(1L, stats.getEvictionCount());
+            Assert.assertEquals(4L, stats.getEvictionWeight());
+        } finally {
+            refreshExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testMaximumWeightRequiresEstimator() {
+        ExecutorService refreshExecutor = Executors.newSingleThreadExecutor();
+        try {
+            IllegalArgumentException exception = Assert.assertThrows(
+                    IllegalArgumentException.class,
+                    () -> new MetaCacheEntry<>(
+                            "weighted",
+                            String::length,
+                            CacheSpec.ofWeight(true, CacheSpec.CACHE_NO_TTL, 100L, 5L),
+                            refreshExecutor,
+                            false));
+            Assert.assertTrue(exception.getMessage().contains("size estimator"));
+        } finally {
+            refreshExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testMaximumWeightRejectsNegativeEstimatorResult() {
+        ExecutorService refreshExecutor = Executors.newSingleThreadExecutor();
+        try {
+            MetaCacheEntry<String, Integer> entry = new MetaCacheEntry<>(
+                    "weighted",
+                    String::length,
+                    CacheSpec.ofWeight(true, CacheSpec.CACHE_NO_TTL, 100L, 5L),
+                    refreshExecutor,
+                    false,
+                    false,
+                    (key, value) -> -1L);
+
+            IllegalStateException exception = Assert.assertThrows(
+                    IllegalStateException.class, () -> entry.put("key", 1));
+            Assert.assertTrue(exception.getMessage().contains("negative weight"));
+        } finally {
+            refreshExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testMaximumWeightSaturatesEstimatorResultToCaffeineLimit() throws Exception {
+        ExecutorService refreshExecutor = Executors.newSingleThreadExecutor();
+        try {
+            MetaCacheEntry<String, Integer> entry = new MetaCacheEntry<>(
+                    "weighted",
+                    String::length,
+                    CacheSpec.ofWeight(true, CacheSpec.CACHE_NO_TTL, 100L, Integer.MAX_VALUE),
+                    refreshExecutor,
+                    false,
+                    false,
+                    (key, value) -> Long.MAX_VALUE);
+
+            entry.put("key", 1);
+            waitUntil(() -> entry.stats().getEstimatedWeight() == Integer.MAX_VALUE);
+            MetaCacheEntryStats stats = entry.stats();
+            Assert.assertEquals(1L, stats.getEstimatedSize());
+            Assert.assertEquals(Integer.MAX_VALUE, stats.getEstimatedWeight());
         } finally {
             refreshExecutor.shutdownNow();
         }
@@ -1074,6 +1167,36 @@ public class MetaCacheEntryTest {
             Assert.assertFalse(extractLoadingCache(entry).policy().refreshAfterWrite().isPresent());
             entry.invalidateAll();
             Assert.assertEquals(1, removalCounter.get());
+        } finally {
+            refreshExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testMaximumWeightEvictionRunsSyncRemovalListener() throws Exception {
+        ExecutorService refreshExecutor = Executors.newSingleThreadExecutor();
+        try {
+            CacheSpec cacheSpec = CacheSpec.ofWeight(true, CacheSpec.CACHE_NO_TTL, 100L, 5L);
+            AtomicInteger removalCounter = new AtomicInteger();
+            AtomicReference<RemovalCause> removalCause = new AtomicReference<>();
+            MetaCacheEntry<String, Integer> entry = MetaCacheEntry.withSyncRemovalListener(
+                    "weighted-sync-listener",
+                    String::length,
+                    cacheSpec,
+                    refreshExecutor,
+                    (key, value) -> value,
+                    (key, value, cause) -> {
+                        removalCounter.incrementAndGet();
+                        removalCause.set(cause);
+                    });
+
+            entry.put("first", 4);
+            entry.put("second", 4);
+
+            Assert.assertEquals(1, removalCounter.get());
+            Assert.assertEquals(RemovalCause.SIZE, removalCause.get());
+            Assert.assertEquals(1L, entry.stats().getEstimatedSize());
+            Assert.assertEquals(4L, entry.stats().getEstimatedWeight());
         } finally {
             refreshExecutor.shutdownNow();
         }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

External metadata caches are currently bounded only by entry count, so entries with very different memory footprints are treated equally. This PR adds framework support for an optional catalog-level `max-weight`, an entry-specific size estimator contract, mutually exclusive Caffeine size/weight construction, saturated integer weight conversion, and weighted cache statistics.

It also completes the framework by supporting weighted caches with synchronous removal listeners, accepting binary size suffixes such as `512MB` while retaining bare-byte compatibility, strictly rejecting malformed, negative, and overflowing values, and keeping statistics reads lightweight and side-effect free.

Existing entries continue to use `maximumSize` unless they explicitly register an estimator and configure `max-weight`. Catalog-specific Iceberg and Paimon estimators and `information_schema` exposure are intentionally not included.

#### What the framework does

For a cache entry that opts in, the framework asks its `MetaCacheSizeEstimator` to estimate the bytes retained by each key/value pair and passes that value to Caffeine's `Weigher`. Caffeine then bounds the cache with `maximumWeight` instead of `maximumSize`. Oversized estimates are saturated to Caffeine's integer weight limit, negative estimates are rejected, and weight-based eviction also works with synchronous removal listeners.

An entry opts in explicitly when its definition registers an estimator:

```java
MetaCacheEntryDef.of(...)
        .withSizeEstimator((key, value) -> estimatedBytes);
```

This keeps estimation entry-specific: the owner of each metadata type decides what its key/value pair retains. This PR does not add a generic JVM object-size utility or automatically enable weighted eviction for existing entries.

#### Future catalog configuration

After an engine entry registers an estimator, a catalog can select weighted eviction with the standard entry property:

```properties
meta.cache.<engine>.<entry>.enable=true
meta.cache.<engine>.<entry>.ttl-second=3600
meta.cache.<engine>.<entry>.max-weight=512MB
```

`max-weight` accepts binary `B`, `KB`, `MB`, `GB`, `TB`, and `PB` suffixes (case-insensitive); a bare integer remains bytes for compatibility. For example, `512MB` is parsed as `512 * 1024 * 1024` bytes. Malformed, negative, decimal, unknown-unit, and overflowing values are rejected. A configured `max-weight` without an entry estimator is also rejected.

Count-bounded mode remains unchanged: omit `max-weight` and configure `capacity` as before.

#### Configuration relationships

| Setting | Relationship and effect |
| --- | --- |
| `enable` | Master switch. `false` disables the entry cache. |
| `ttl-second` | Independent time policy. `0` disables the cache, `-1` means no expiration, and a positive value enables expire-after-access. |
| `max-weight` vs. `capacity` | Alternative bounds, not additive. If `max-weight` is present, weighted mode is selected and `capacity` is ignored; otherwise count-based `capacity` is used. |
| Selected bound value | A selected bound of `0` disables the cache. |
| TTL vs. selected bound | Both policies can be active together. At runtime an entry may be removed when either the TTL expires or the selected count/weight bound requires eviction. |

In short, effective enablement is `enable && ttl-second != 0 && selected-bound != 0`, where `selected-bound` is `max-weight` when present and `capacity` otherwise.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - `./run-fe-ut.sh --run org.apache.doris.common.util.ParseUtilTest,org.apache.doris.common.CacheFactoryTest,org.apache.doris.datasource.metacache.CacheSpecTest,org.apache.doris.datasource.metacache.MetaCacheEntryTest,org.apache.doris.datasource.metacache.AbstractExternalMetaCacheTest` (80 tests passed)
        - `DISABLE_BUILD_UI=ON ./build.sh --fe` (passed, including Checkstyle)
    - [ ] Manual test
    - [ ] No need to test or manual test

- Behavior changed:
    - [ ] No.
    - [x] Yes. Entries that register an estimator and configure `max-weight` use weighted eviction, invalid values are rejected, and statistics reads no longer trigger Caffeine maintenance.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
