### PR TITLE
[fix](test) Unset Paimon Variant shredding property

### DIFF
--- a/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/paimon/run13.sql
+++ b/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/paimon/run13.sql
@@ -63,8 +63,10 @@ tblproperties (
 
 insert into variant_mixed_su values
     (1, date '2026-06-01', parse_json('{"name":"alice","age":18,"layout":"shredded"}'));
-alter table variant_mixed_su set tblproperties (
-    'parquet.variant.shreddingSchema' = ''
+-- Paimon 1.4.2 parses every present shredding schema as JSON, so remove the property
+-- before writing unshredded files.
+alter table variant_mixed_su unset tblproperties (
+    'parquet.variant.shreddingSchema'
 );
 insert into variant_mixed_su values
     (2, date '2026-07-01', parse_json('{"name":"bob","age":30,"layout":"unshredded"}'));


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #66503

Problem Summary:

Paimon 1.4.2 parses every present Variant shredding schema property as JSON. The Paimon Variant fixture attempted to disable shredding by setting the property to an empty string, so the following unshredded insert failed and left the mixed-layout table with only its shredded row.

This change removes the property with `UNSET TBLPROPERTIES` before writing the unshredded file. It preserves the intended shredded-to-unshredded mixed-file coverage.

### Check List

- Test
  - [x] Regression test fixture
  - [x] Manual test

Validation:

- Verified the fixture no longer contains an empty shredding schema property.
- Ran the shredded-to-unshredded write sequence in Spark/Paimon and confirmed both rows were returned.
- `git diff --check`

- Behavior changed:
  - [x] No production behavior change; this fixes test data generation.

- Does this need documentation?
  - [x] No.
