### PR TITLE
[fix](fe) give ConfField.description a single string in the streaming-job config

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1174,8 +1174,8 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true)
     public static int streaming_task_min_timeout_sec = 300;
 
-    @ConfField(mutable = true, masterOnly = true, description = {
-            "Minimum interval in seconds between snapshot offset persistence operations"})
+    @ConfField(mutable = true, masterOnly = true,
+            description = "Minimum interval in seconds between snapshot offset persistence operations")
     public static int streaming_job_snapshot_offset_persist_interval_sec = 300;
 
     @ConfField(mutable = true, masterOnly = true)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #66342, #66238

Problem Summary:

master does not compile. `fe-common` fails at

```
Config.java:[1177,65] annotation value not of an allowable type
```

#66342 retyped `ConfigBase.ConfField.description()` from `String[]` to `String` and rewrote all 419 call sites accordingly. #66238 landed shortly after with

```java
@ConfField(mutable = true, masterOnly = true, description = {
        "Minimum interval in seconds between snapshot offset persistence operations"})
public static int streaming_job_snapshot_offset_persist_interval_sec = 300;
```

written against the older `String[]` signature. The two changes are textually disjoint, so git merges them without a conflict and neither pull request could see the other — each was green on its own base.

The seven further errors reported in the same module are secondary. The bad annotation value aborts the annotation-processing round, so lombok never contributes its generated members, and `@Slf4j`'s `log` plus `@AllArgsConstructor`/`@Data`'s constructors go missing:

```
DiskUtils.java:[70,13] cannot find symbol
JobBaseConfig ... constructor cannot be applied to given types
AbstractSourceSplit ... constructor cannot be applied to given types
```

All seven disappear once the annotation value is fixed; nothing else in the tree needed a change.

This is the only remaining array-form description under `fe/` (`grep -rnE 'description\s*=\s*\{'`), and the wrapped-argument layout matches the neighbouring long descriptions such as `max_create_table_timeout_second`.

`ConfigTest.testConfFieldDescriptionsAreEnglishStrings`, the guard #66342 added, reflects over the annotation at runtime, so it cannot catch a compile-time signature mismatch; it passes here because the text is already English.

Verified on a clean checkout of master `4e3c1b84dd5`:

- reproduced the failure before the change, and confirmed all eight errors are gone after it
- full FE reactor `mvn test-compile` (checkstyle included): **74/74 modules SUCCESS**
- `fe-common` module tests: **157 tests, 0 failures, 0 skipped**, including `ConfigTest.testConfFieldDescriptionsAreEnglishStrings`
- the tests both colliding PRs added — `StreamingInsertJobOffsetPersistenceTest`, `JdbcSourceOffsetProviderOffsetTest`, `SessionVariablesTest`: **39 tests, 0 failures, 0 skipped**

### Release note

None

### Check List (For Author)

- Test
    - [x] No need to test or manual test. Explain why:
        - [x] Previous test can cover this change.

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.