### PR TITLE
[fix](fe) Ignore obsolete table meta change journal

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
@@ -1034,6 +1034,11 @@ public class JournalEntity implements Writable {
                 isRead = true;
                 break;
             }
+            case OperationType.OP_TABLE_META_CHANGE: {
+                Text.readString(in);
+                isRead = true;
+                break;
+            }
             case OperationType.OP_TSO_TIMESTAMP_WINDOW_END: {
                 data = TSOTimestamp.read(in);
                 isRead = true;

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1490,6 +1490,9 @@ public class EditLog {
                     // This log is only used to keep FE/MS cut point in journal timeline.
                     break;
                 }
+                case OperationType.OP_TABLE_META_CHANGE: {
+                    break;
+                }
                 case OperationType.OP_TSO_TIMESTAMP_WINDOW_END: {
                     env.getTSOService().replayWindowEndTSO((TSOTimestamp) journal.getData());
                     break;

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -435,6 +435,9 @@ public class OperationType {
 
     public static final short OP_BEGIN_SNAPSHOT = 1100;
     public static final short OP_META_SYNC_POINT = 1101;
+    // Compatibility only. Old 26.0 cloud builds wrote table metadata change
+    // records with this opcode, but replaying them is no longer needed.
+    public static final short OP_TABLE_META_CHANGE = 1102;
 
     public static final short OP_TSO_TIMESTAMP_WINDOW_END = 1200;
 


### PR DESCRIPTION
## Proposed changes

Add compatibility for obsolete `OP_TABLE_META_CHANGE` journal entries written by old 26.0 cloud builds. FE now recognizes opcode `1102`, consumes the old JSON payload, and does nothing during replay.

This prevents upgrade replay from failing with `UNKNOWN Operation Type 1102`.

## Testing

- `sh build.sh --fe`