### PR TITLE
branch-4.1: [fix](fe) Ignore obsolete table meta change journal (#66549)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/journal/JournalEntity.java
@@ -1023,6 +1023,11 @@ public class JournalEntity implements Writable {
                 isRead = true;
                 break;
             }
+            case OperationType.OP_TABLE_META_CHANGE: {
+                Text.readString(in);
+                isRead = true;
+                break;
+            }
             default: {
                 IOException e = new IOException();
                 LOG.error("UNKNOWN Operation Type {}", opCode, e);

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/EditLog.java
@@ -1452,6 +1452,9 @@ public class EditLog {
                     // This log is only used to keep FE/MS cut point in journal timeline.
                     break;
                 }
+                case OperationType.OP_TABLE_META_CHANGE: {
+                    break;
+                }
                 default: {
                     IOException e = new IOException();
                     LOG.error("UNKNOWN Operation Type {}, log id: {}", opCode, logId, e);

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/OperationType.java
@@ -430,6 +430,9 @@ public class OperationType {
 
     public static final short OP_BEGIN_SNAPSHOT = 1100;
     public static final short OP_META_SYNC_POINT = 1101;
+    // Compatibility only. Old 26.0 cloud builds wrote table metadata change
+    // records with this opcode, but replaying them is no longer needed.
+    public static final short OP_TABLE_META_CHANGE = 1102;
 
     /**
      * Get opcode name by op code.


### PR DESCRIPTION
## Proposed changes

- Pick apache/doris#66549 to branch-4.1.
- Recognize OP_TABLE_META_CHANGE opcode 1102, consume the old payload, and do nothing during replay for compatibility with 26.0.4/26.0.5 journals.

## Testing

- sh build.sh --fe