### PR TITLE
[fix](streaming) avoid infinite retry when cloud mode job progress is not found

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -196,6 +196,12 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
     @Setter
     private transient volatile boolean needRebuildReader = true;
 
+    // Set to true when MetaService returns STREAMING_JOB_PROGRESS_NOT_FOUND during replay.
+    // Prevents repeated RPC calls on subsequent scheduler ticks for the same job.
+    // The job will proceed using its configured offset instead of cloud-persisted progress.
+    // Intentionally transient: resets on FE restart so replay can re-attempt after MetaService recovery.
+    private transient volatile boolean cloudProgressMissing = false;
+
     // The sampling window starts at the beginning of the sampling window.
     // If the error rate exceeds `max_filter_ratio` within the window, the sampling fails.
     @Setter
@@ -1035,8 +1041,9 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         }
         try {
             modifyPropertiesInternal(replayJob.getProperties());
-            // When the pause state is restarted, it also needs to be updated
-            if (Config.isCloudMode()) {
+            // When the pause state is restarted, it also needs to be updated.
+            // Skip if we already know progress is missing — avoid repeated pointless RPCs during replay.
+            if (Config.isCloudMode() && !cloudProgressMissing) {
                 replayOnCloudMode();
             }
         } catch (Exception e) {
@@ -1387,6 +1394,8 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         StreamingTaskTxnCommitAttachment attachment =
                 (StreamingTaskTxnCommitAttachment) txnState.getTxnCommitAttachment();
         updateJobStatisticAndOffset(attachment, false);
+        // Progress now exists in MetaService; clear the missing flag so future replays can recover.
+        cloudProgressMissing = false;
     }
 
     @Override
@@ -1411,7 +1420,21 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         return dbId;
     }
 
-    public void replayOnCloudMode() throws JobException {
+    /**
+     * Recover job statistics and offset from MetaService (cloud mode).
+     *
+     * @return true if cloud progress was successfully recovered; false if progress was not found
+     *         in MetaService (STREAMING_JOB_PROGRESS_NOT_FOUND). When false, the job should
+     *         proceed using its configured offset property rather than cloud-persisted progress.
+     * @throws JobException on transient MetaService errors (network, unknown codes) that warrant retry
+     */
+    public boolean replayOnCloudMode() throws JobException {
+        // Once we know progress is missing, skip further RPC attempts — the answer won't change
+        // within the same FE lifetime unless the job successfully commits a new task.
+        if (cloudProgressMissing) {
+            return false;
+        }
+
         Cloud.GetStreamingTaskCommitAttachRequest.Builder builder =
                 Cloud.GetStreamingTaskCommitAttachRequest.newBuilder()
                         .setRequestIp(FrontendOptions.getLocalHostAddressCached());
@@ -1423,22 +1446,26 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
         try {
             response = MetaServiceProxy.getInstance().getStreamingTaskCommitAttach(builder.build());
             if (response.getStatus().getCode() != Cloud.MetaServiceCode.OK) {
-                log.warn("failed to get streaming task commit attach, response: {}", response);
                 if (response.getStatus().getCode() == Cloud.MetaServiceCode.STREAMING_JOB_PROGRESS_NOT_FOUND) {
-                    log.warn("not found streaming job progress, response: {}", response);
-                    return;
+                    cloudProgressMissing = true;
+                    log.warn("Cloud progress not found for streaming job {} (db_id={}). "
+                            + "Job will start from configured offset instead of cloud-persisted progress. "
+                            + "MetaService response: {}", getJobId(), getDbId(), response.getStatus().getMsg());
+                    return false;
                 } else {
+                    log.warn("failed to get streaming task commit attach, response: {}", response);
                     throw new JobException(response.getStatus().getMsg());
                 }
             }
         } catch (RpcException e) {
-            log.info("failed to get streaming task commit attach {}", response, e);
+            log.warn("RPC failed when getting streaming task commit attach for job {}", getJobId(), e);
             throw new JobException(e.getMessage());
         }
 
         StreamingTaskTxnCommitAttachment commitAttach =
                 new StreamingTaskTxnCommitAttachment(response.getCommitAttach());
         updateCloudJobStatisticAndOffset(commitAttach, true);
+        return true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingJobSchedulerTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingJobSchedulerTask.java
@@ -57,7 +57,11 @@ public class StreamingJobSchedulerTask extends AbstractTask {
     private void handlePendingState() throws JobException {
         if (Config.isCloudMode()) {
             try {
-                streamingInsertJob.replayOnCloudMode();
+                boolean progressRecovered = streamingInsertJob.replayOnCloudMode();
+                if (!progressRecovered) {
+                    log.info("Cloud progress missing for job {}; proceeding with configured offset",
+                            streamingInsertJob.getJobId());
+                }
             } catch (JobException e) {
                 streamingInsertJob.setFailureReason(
                     new FailureReason(InternalErrorCode.INTERNAL_ERR, e.getMessage()));


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #66560

Related PR: #66559 (independent fix in the same subsystem)

Problem Summary:

In compute-storage-decoupled (cloud) mode, `replayOnCloudMode()` asks MetaService for a streaming job's persisted progress. When MetaService answers `STREAMING_JOB_PROGRESS_NOT_FOUND` (expected for newly created jobs that have not yet committed a transaction), the method logs a warning and returns `void`. The caller — `handlePendingState()` in `StreamingJobSchedulerTask` — cannot distinguish "no progress exists" from "progress loaded successfully", so it repeats the RPC on every scheduler tick indefinitely.

**Consequences:**
- The job is stuck in PENDING forever
- FE log fills with repeated WARN messages
- During journal replay at FE startup, every `UPDATE_JOB` edit-log entry triggers a doomed RPC

**Fix:**
- Change `replayOnCloudMode()` return type from `void` to `boolean` (returns `false` on NOT_FOUND)
- Add a `transient volatile boolean cloudProgressMissing` flag that short-circuits subsequent attempts
- Clear the flag in `afterCommitted()` when the job commits its first transaction (progress now exists in MetaService)
- Guard the journal-replay call site with `!cloudProgressMissing` to avoid repeated RPCs during startup

The flag is intentionally `transient` (not serialized): it resets on FE restart, giving MetaService another chance if the issue was temporary. A permanent NOT_FOUND is the expected state for newly created jobs — the fix simply allows the job to proceed rather than spinning.

### Release note

Fix streaming insert job stuck in PENDING state with infinite MetaService retries in compute-storage-decoupled (cloud) mode. When MetaService returns STREAMING_JOB_PROGRESS_NOT_FOUND, the job now proceeds with its configured offset instead of retrying indefinitely.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (all round) — verified on a compute-storage-decoupled cluster: new job transitions from PENDING to RUNNING within one scheduler tick, log spam eliminated
    - [ ] No need to test or manually tested. Explain why:
- [ ] This is a refactor/code-cleanup without behavior change.
- Code quality <!-- Confirm the following: -->
    - [x] Does not introduce new code style issues (checked with `checkstyle`)
    - [x] Does not introduce new `@Nullable` warnings
    - [x] Boundary conditions and error handling are adequate

### Note to Reviewers

A unit test mocking `MetaServiceProxy` to return `STREAMING_JOB_PROGRESS_NOT_FOUND` and asserting the method returns `false` / the flag suppresses a second call is feasible and straightforward. I have not included one in this PR — happy to add it if reviewers prefer. The behavioral correctness was verified on a live cluster.

CC @JNSimba — as the streaming-job subsystem maintainer.

If this should be backported to 4.1, please apply the `dev/4.1.x` label (I cannot as a non-committer).
