### PR TITLE
[fix](streaming) reset offset provider state when ALTER JOB switches offset to initial

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -541,6 +541,24 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
             mergedSourceProperties.putAll(alterJobCommand.getSourceProperties());
             Map<String, String> newConvertedSourceProperties =
                     buildConvertedSourceProperties(mergedSourceProperties);
+
+            // If the ALTER explicitly sets offset to a splitting mode (initial/snapshot),
+            // the offset provider's cached binlog/split state must be cleared. Without this,
+            // replayIfNeed() would restore the old binlog position from offsetProviderPersist,
+            // noMoreSplits() would return true (believing the snapshot phase is already done),
+            // and the job would be wedged — dispatching tasks from the stale offset instead
+            // of starting a fresh snapshot. The reset makes the provider behave as if the job
+            // were freshly created, so the next handlePendingState() starts from scratch.
+            String newOffset = alterJobCommand.getSourceProperties().get(DataSourceConfigKeys.OFFSET);
+            if (newOffset != null
+                    && (DataSourceConfigKeys.OFFSET_INITIAL.equalsIgnoreCase(newOffset)
+                        || DataSourceConfigKeys.OFFSET_SNAPSHOT.equalsIgnoreCase(newOffset))) {
+                offsetProvider.resetToInitialState();
+                this.offsetProviderPersist = null;
+                log.info("Alter job {}: offset set to '{}'; reset offset provider for fresh snapshot",
+                        getJobId(), newOffset);
+            }
+
             this.sourceProperties = mergedSourceProperties;
             this.convertedSourceProperties = newConvertedSourceProperties;
             logParts.add("source properties: " + alterJobCommand.getSourceProperties());

--- a/fe/fe-core/src/main/java/org/apache/doris/job/offset/SourceOffsetProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/offset/SourceOffsetProvider.java
@@ -216,5 +216,27 @@ public interface SourceOffsetProvider {
         return "";
     }
 
+    /**
+     * Reset all cached offset and split state so the provider behaves as if the job
+     * were freshly created with offset='initial'. Called from {@code alterJob()} when
+     * the operator explicitly sets offset to 'initial' or 'snapshot' to force a fresh
+     * snapshot start.
+     *
+     * <p>Without this reset, the provider's in-memory state (binlog position, finished
+     * splits, split progress) would survive the ALTER. On the next scheduler tick,
+     * {@link #replayIfNeed} would restore the old binlog position, {@link #noMoreSplits()}
+     * would return true (believing the snapshot phase is already complete), and the job
+     * would dispatch a task with the stale offset instead of starting a fresh snapshot.</p>
+     *
+     * <p><b>Distinction from {@code clearSnapshotState()}:</b> that method is called during
+     * the normal snapshot-to-binlog transition and deliberately preserves fields like
+     * {@code currentOffset} and {@code binlogOffsetPersist} that the ongoing binlog phase
+     * depends on. This method clears <em>everything</em>, including those fields, because
+     * it is preparing a genuine fresh start — not a phase transition within an active job.</p>
+     *
+     * <p>Default: no-op. Only JDBC providers carry split/binlog state that needs clearing.</p>
+     */
+    default void resetToInitialState() {}
+
 }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/job/offset/jdbc/JdbcSourceOffsetProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/offset/jdbc/JdbcSourceOffsetProvider.java
@@ -285,6 +285,64 @@ public class JdbcSourceOffsetProvider implements SourceOffsetProvider {
         }
     }
 
+    /**
+     * Reset ALL offset/split state so the provider re-enters the "freshly created, offset=initial"
+     * code path on the next {@link #replayIfNeed} call.
+     *
+     * <p><b>When this is called:</b> the operator runs PAUSE JOB → ALTER JOB ... offset='initial'
+     * → RESUME JOB to force a fresh snapshot. Without clearing the cached state, the provider would
+     * still hold the old binlog position and {@code noMoreSplits()} would return true, causing the
+     * job to dispatch tasks from the stale offset instead of starting a fresh snapshot.</p>
+     *
+     * <p><b>Relationship to {@link #clearSnapshotState()}:</b> that method is invoked during the
+     * <em>normal</em> snapshot-to-binlog transition inside {@link #updateOffset}. It deliberately
+     * preserves {@code currentOffset}, {@code binlogOffsetPersist}, and {@code endBinlogOffset}
+     * because the binlog phase that follows depends on them. This method is a strict superset: it
+     * calls {@code clearSnapshotState()} for the split/progress subset, then also clears the
+     * binlog-phase fields, because the intent is a complete fresh start — not a phase transition.</p>
+     *
+     * <p>Thread safety: acquires {@code splitsLock} for fields it guards. The caller must ensure
+     * no concurrent streaming task is running (the job must be PAUSED).</p>
+     *
+     * <p><b>Field-by-field clearing (exhaustive):</b></p>
+     * <ul>
+     *   <li>{@code remainingSplits} — cleared via clearSnapshotState()</li>
+     *   <li>{@code finishedSplits} — cleared via clearSnapshotState()</li>
+     *   <li>{@code chunkHighWatermarkMap} — cleared via clearSnapshotState()</li>
+     *   <li>{@code committedSplitProgress} — cleared via clearSnapshotState()</li>
+     *   <li>{@code cdcSplitProgress} — cleared via clearSnapshotState()</li>
+     *   <li>{@code currentOffset} — set to null (prevents getNextOffset from returning stale binlog)</li>
+     *   <li>{@code binlogOffsetPersist} — set to null (prevents replayIfNeed from restoring old offset)</li>
+     *   <li>{@code endBinlogOffset} — set to null (stale end offset from previous binlog phase)</li>
+     *   <li>{@code tableSchemas} — set to null (schema may change; will be re-fetched)</li>
+     *   <li>{@code hasMoreData} — set to true (fresh start should assume data exists)</li>
+     *   <li>{@code boundBackendId} — set to 0 (old pinning was for the binlog reader)</li>
+     * </ul>
+     * <p>Fields intentionally preserved:</p>
+     * <ul>
+     *   <li>{@code jobId}, {@code sourceType}, {@code sourceProperties}, {@code snapshotParallelism}
+     *       — identity/configuration, not state</li>
+     *   <li>{@code cloudCluster} — routing config, set externally</li>
+     *   <li>{@code cachedSyncTables} — will be re-set by replayIfNeed from the job's syncTables</li>
+     * </ul>
+     */
+    @Override
+    public void resetToInitialState() {
+        synchronized (splitsLock) {
+            clearSnapshotState();
+            this.hasMoreData = true;
+        }
+        // Fields outside splitsLock: these are only read/written under the job's write lock
+        // or from the single scheduler thread — safe to clear here because the job is PAUSED.
+        this.currentOffset = null;
+        this.binlogOffsetPersist = null;
+        this.endBinlogOffset = null;
+        this.tableSchemas = null;
+        this.boundBackendId = 0;
+        log.info("Reset offset provider to initial state (job {}): cleared all split/binlog state",
+                getJobId());
+    }
+
     public boolean shouldPersistOffset(long lastPersistTimeMs, long currentTimeMs) {
         synchronized (splitsLock) {
             if (currentOffset == null || !currentOffset.snapshotSplit()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/job/offset/jdbc/JdbcSourceOffsetProviderResetTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/job/offset/jdbc/JdbcSourceOffsetProviderResetTest.java
@@ -1,0 +1,210 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.job.offset.jdbc;
+
+import org.apache.doris.job.cdc.DataSourceConfigKeys;
+import org.apache.doris.job.cdc.split.BinlogSplit;
+import org.apache.doris.job.cdc.split.SnapshotSplit;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for {@link JdbcSourceOffsetProvider#resetToInitialState()}.
+ */
+public class JdbcSourceOffsetProviderResetTest {
+
+    @Test
+    public void testResetClearsAllStateAfterBinlogPhase() {
+        JdbcSourceOffsetProvider provider = createProviderInBinlogPhase();
+
+        provider.resetToInitialState();
+
+        // All split/binlog state must be cleared
+        Assert.assertNull(provider.currentOffset);
+        Assert.assertNull(provider.binlogOffsetPersist);
+        Assert.assertNull(provider.endBinlogOffset);
+        Assert.assertNull(provider.tableSchemas);
+        Assert.assertTrue(provider.chunkHighWatermarkMap.isEmpty());
+        Assert.assertTrue(provider.remainingSplits.isEmpty());
+        Assert.assertTrue(provider.finishedSplits.isEmpty());
+        Assert.assertTrue(provider.hasMoreData);
+        Assert.assertEquals(0, provider.boundBackendId);
+        assertProgressCleared(provider.committedSplitProgress);
+        assertProgressCleared(provider.cdcSplitProgress);
+    }
+
+    @Test
+    public void testResetPreservesConfiguration() {
+        JdbcSourceOffsetProvider provider = createProviderInBinlogPhase();
+        provider.setJobId(42L);
+        provider.setCloudCluster("test-cluster");
+
+        provider.resetToInitialState();
+
+        Assert.assertEquals(Long.valueOf(42L), provider.getJobId());
+        Assert.assertEquals("test-cluster", provider.getCloudCluster());
+        Assert.assertNotNull(provider.getSourceProperties());
+    }
+
+    @Test
+    public void testResetPreservesCachedSyncTables() {
+        JdbcSourceOffsetProvider provider = createProviderInBinlogPhase();
+        List<String> syncTables = new ArrayList<>();
+        syncTables.add("orders");
+        syncTables.add("users");
+        provider.cachedSyncTables = syncTables;
+
+        provider.resetToInitialState();
+
+        // cachedSyncTables preserved — replayIfNeed re-sets it from the job
+        Assert.assertSame(syncTables, provider.cachedSyncTables);
+    }
+
+    @Test
+    public void testNoMoreSplitsReturnsFalseAfterReset() {
+        JdbcSourceOffsetProvider provider = createProviderInBinlogPhase();
+        // Before reset: binlog phase, noMoreSplits() returns true
+        Assert.assertTrue(provider.noMoreSplits());
+
+        // Configure sourceProperties so checkNeedSplitChunks returns true (offset=initial)
+        provider.getSourceProperties().put(DataSourceConfigKeys.OFFSET, DataSourceConfigKeys.OFFSET_INITIAL);
+        provider.cachedSyncTables = new ArrayList<>();
+        provider.cachedSyncTables.add("orders");
+
+        provider.resetToInitialState();
+
+        // After reset with offset=initial and a table to split: noMoreSplits() returns false
+        // because cdcSplitProgress is cleared (currentSplittingTable == null) but
+        // computeCdcRemainingTables() finds "orders" untouched.
+        Assert.assertFalse(provider.noMoreSplits());
+    }
+
+    @Test
+    public void testResetIsIdempotent() {
+        JdbcSourceOffsetProvider provider = createProviderInBinlogPhase();
+
+        provider.resetToInitialState();
+        provider.resetToInitialState();
+
+        Assert.assertNull(provider.currentOffset);
+        Assert.assertNull(provider.binlogOffsetPersist);
+        Assert.assertTrue(provider.hasMoreData);
+    }
+
+    @Test
+    public void testResetClearsSnapshotPhaseState() {
+        JdbcSourceOffsetProvider provider = createProviderInSnapshotPhase();
+
+        provider.resetToInitialState();
+
+        Assert.assertNull(provider.currentOffset);
+        Assert.assertTrue(provider.remainingSplits.isEmpty());
+        Assert.assertTrue(provider.finishedSplits.isEmpty());
+        Assert.assertTrue(provider.chunkHighWatermarkMap.isEmpty());
+        assertProgressCleared(provider.committedSplitProgress);
+        assertProgressCleared(provider.cdcSplitProgress);
+    }
+
+    // --- helpers ---
+
+    private static JdbcSourceOffsetProvider createProviderInBinlogPhase() {
+        Map<String, String> sourceProps = new HashMap<>();
+        sourceProps.put(DataSourceConfigKeys.OFFSET, DataSourceConfigKeys.OFFSET_LATEST);
+        JdbcSourceOffsetProvider provider = new JdbcSourceOffsetProvider(1L,
+                org.apache.doris.job.common.DataSourceType.MYSQL, sourceProps);
+
+        // Simulate binlog phase state
+        Map<String, String> binlogOffset = new HashMap<>();
+        binlogOffset.put("file", "binlog.000003");
+        binlogOffset.put("pos", "154");
+        BinlogSplit binlogSplit = new BinlogSplit(binlogOffset);
+        provider.currentOffset = new JdbcOffset(Collections.singletonList(binlogSplit));
+        provider.binlogOffsetPersist = new HashMap<>(binlogOffset);
+        provider.binlogOffsetPersist.put(JdbcSourceOffsetProvider.SPLIT_ID, BinlogSplit.BINLOG_SPLIT_ID);
+        provider.endBinlogOffset = Collections.singletonMap("file", "binlog.000005");
+        provider.tableSchemas = "{\"orders\":{\"id\":\"INT\"}}";
+        provider.hasMoreData = false;
+        provider.boundBackendId = 12345L;
+
+        // Add some snapshot history
+        SnapshotSplit finished = new SnapshotSplit("orders:0", "test_db.orders",
+                Collections.singletonList("id"), new Object[]{0L}, new Object[]{100L},
+                Collections.singletonMap("file", "binlog.000001"));
+        provider.finishedSplits.add(finished);
+        provider.chunkHighWatermarkMap
+                .computeIfAbsent("test_db.orders", k -> new HashMap<>())
+                .put("orders:0", finished.getHighWatermark());
+
+        provider.committedSplitProgress = new JdbcSourceOffsetProvider.SplitProgress();
+        provider.committedSplitProgress.setCurrentSplittingTable("orders");
+        provider.committedSplitProgress.setNextSplitStart(new Object[]{100L});
+        provider.committedSplitProgress.setNextSplitId(1);
+
+        provider.cdcSplitProgress = new JdbcSourceOffsetProvider.SplitProgress();
+        provider.cdcSplitProgress.setCurrentSplittingTable("orders");
+        provider.cdcSplitProgress.setNextSplitStart(new Object[]{100L});
+        provider.cdcSplitProgress.setNextSplitId(1);
+
+        return provider;
+    }
+
+    private static JdbcSourceOffsetProvider createProviderInSnapshotPhase() {
+        Map<String, String> sourceProps = new HashMap<>();
+        sourceProps.put(DataSourceConfigKeys.OFFSET, DataSourceConfigKeys.OFFSET_INITIAL);
+        JdbcSourceOffsetProvider provider = new JdbcSourceOffsetProvider(2L,
+                org.apache.doris.job.common.DataSourceType.MYSQL, sourceProps);
+
+        SnapshotSplit remaining = new SnapshotSplit("orders:1", "test_db.orders",
+                Collections.singletonList("id"), new Object[]{100L}, new Object[]{200L},
+                null);
+        SnapshotSplit finished = new SnapshotSplit("orders:0", "test_db.orders",
+                Collections.singletonList("id"), new Object[]{0L}, new Object[]{100L},
+                Collections.singletonMap("file", "binlog.000001"));
+
+        provider.remainingSplits.add(remaining);
+        provider.finishedSplits.add(finished);
+        provider.chunkHighWatermarkMap
+                .computeIfAbsent("test_db.orders", k -> new HashMap<>())
+                .put("orders:0", finished.getHighWatermark());
+
+        provider.currentOffset = new JdbcOffset(Collections.singletonList(finished));
+
+        provider.committedSplitProgress = new JdbcSourceOffsetProvider.SplitProgress();
+        provider.committedSplitProgress.setCurrentSplittingTable("orders");
+        provider.committedSplitProgress.setNextSplitStart(new Object[]{100L});
+        provider.committedSplitProgress.setNextSplitId(1);
+
+        provider.cdcSplitProgress = provider.committedSplitProgress.copy();
+
+        return provider;
+    }
+
+    private static void assertProgressCleared(JdbcSourceOffsetProvider.SplitProgress progress) {
+        Assert.assertNotNull(progress);
+        Assert.assertNull(progress.getCurrentSplittingTable());
+        Assert.assertNull(progress.getNextSplitStart());
+        Assert.assertNull(progress.getNextSplitId());
+    }
+}


### PR DESCRIPTION

## Proposed changes

Related PR: #66559 (independent fix in the same subsystem)

### Problem Summary

When an operator runs `PAUSE JOB` → `ALTER JOB ... offset='initial'` → `RESUME JOB` to force a fresh CDC snapshot, `JdbcSourceOffsetProvider` still holds the old binlog position and split progress in memory. On the next scheduler tick the job dispatches a task from the stale offset instead of starting a fresh snapshot. The operator believes they reset the job; they did not.

**Why this is not just `clearSnapshotState()`:** The existing `clearSnapshotState()` method is invoked during the *normal* snapshot-to-binlog transition inside `updateOffset()`. It deliberately preserves `currentOffset`, `binlogOffsetPersist`, and `endBinlogOffset` because the incoming binlog phase depends on them. Our new `resetToInitialState()` is a strict superset: it calls `clearSnapshotState()` for the split/progress subset, then also clears the binlog-phase fields (`currentOffset`, `binlogOffsetPersist`, `endBinlogOffset`, `tableSchemas`, `hasMoreData`, `boundBackendId`), because the intent is a complete fresh start — not a phase transition within an active job.

### Fix

1. Add `SourceOffsetProvider.resetToInitialState()` as a `default` no-op method on the interface (S3 and other providers are unaffected).
2. Implement in `JdbcSourceOffsetProvider`: clear all cached split and binlog state (11 fields — see exhaustive list in the Javadoc).
3. In `StreamingInsertJob.alterJob()`: when the ALTER explicitly sets `offset` to `initial` or `snapshot`, call `resetToInitialState()` and null out `offsetProviderPersist` so that `replayIfNeed()` takes the fresh-start branch.

After the reset, the next `handlePendingState()` tick sees empty state and initiates a full snapshot — identical to a brand-new job.

### Field-by-field reset audit

| Field | Cleared? | Reason |
|-------|----------|--------|
| `remainingSplits` | ✅ via clearSnapshotState | Stale snapshot chunks |
| `finishedSplits` | ✅ via clearSnapshotState | Old split records |
| `chunkHighWatermarkMap` | ✅ via clearSnapshotState | Old HW would prevent re-splitting |
| `committedSplitProgress` | ✅ via clearSnapshotState | Stale cursor |
| `cdcSplitProgress` | ✅ via clearSnapshotState | Stale cursor; `noMoreSplits()` would return wrong answer |
| `currentOffset` | ✅ → null | Prevents `getNextOffset` from returning stale binlog |
| `binlogOffsetPersist` | ✅ → null | Prevents `replayIfNeed` from restoring old offset |
| `endBinlogOffset` | ✅ → null | Stale end offset from previous phase |
| `tableSchemas` | ✅ → null | Schema may have changed; will be re-fetched |
| `hasMoreData` | ✅ → true | Fresh start should assume data exists |
| `boundBackendId` | ✅ → 0 | Old pinning was for the binlog reader; snapshot may use different BE |
| `jobId` | preserved | Identity |
| `sourceType` | preserved | Configuration |
| `sourceProperties` | preserved | Updated by alterJob itself |
| `snapshotParallelism` | preserved | Configuration |
| `cloudCluster` | preserved | Routing config, set externally |
| `cachedSyncTables` | preserved | Re-set by replayIfNeed from job.getSyncTables() |

## Issue Number

Closes #66562

## Checklist

- [x] I have read the [Contributing to Apache Doris](https://doris.apache.org/community/how-to-contribute) guide.
- [x] I have completed the CLA agreement (via first-time PR bot prompt).
- [x] I have reviewed the [PR naming conventions](https://doris.apache.org/community/how-to-contribute/pull-request#pull-request-title).
- [x] I have added appropriate tests (unit test for `resetToInitialState` covering binlog-phase reset, snapshot-phase reset, idempotency, `noMoreSplits` correctness, and configuration preservation).

---

cc @JNSimba — you maintain the streaming job subsystem; this touches the offset provider interface and the `alterJob()` flow.

Please also consider applying `dev/4.1.x` label for backport — this bug affects any 4.1.x user attempting manual CDC recovery via ALTER JOB.
