### PR TITLE
[fix](build) Exclude javax.resource:connector from BDB JE dependency

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -950,6 +950,15 @@ under the License.
                         <groupId>org.checkerframework</groupId>
                         <artifactId>checker</artifactId>
                     </exclusion>
+                    <!-- BDB JE only references javax.resource in its optional JCA resource
+                         adapter (com.sleepycat.je.jca.ra), which embedded FE never uses.
+                         javax.resource:connector:1.0 has no jar in Maven Central (only a pom)
+                         and its historical host (repo.grails.org) is unreliable, so pulling it
+                         breaks the build in many environments. Exclude it. -->
+                    <exclusion>
+                        <groupId>javax.resource</groupId>
+                        <artifactId>connector</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 


### PR DESCRIPTION
org.apache.doris:je transitively pulls in javax.resource:connector:1.0, whose jar was never published to Maven Central (only the pom is there) and whose historical host (repo.grails.org) is frequently unreachable. As a result the FE build fails resolving the artifact in many environments:

  Could not find artifact javax.resource:connector:jar:1.0 in central ...

BDB JE only references javax.resource in its optional JCA resource adapter (com.sleepycat.je.jca.ra), which the embedded FE never uses, so the artifact is not needed at compile or runtime. Exclude it from the je dependency management entry, alongside the existing ant/checker exclusions.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

