### PR TITLE
[enhancement](variant) Support deep Variant object leaf projection

### DIFF
--- a/be/src/exec/scan/access_path_parser.cpp
+++ b/be/src/exec/scan/access_path_parser.cpp
@@ -436,12 +436,17 @@ Status build_nested_children_from_access_node(format::ColumnDefinition* column,
                                               const format::ColumnDefinition* schema_column,
                                               bool prefer_exact_name_match) {
     DORIS_CHECK(column != nullptr);
+    const auto nested_type = remove_nullable(type);
+    if (nested_type->get_primitive_type() == TYPE_VARIANT &&
+        (node.project_all || node.children.empty())) {
+        column->variant_access_paths.clear();
+        return Status::OK();
+    }
     if (node.project_all || node.children.empty()) {
         return build_all_nested_children_from_schema(column, type, path, schema_column,
                                                      prefer_exact_name_match);
     }
 
-    const auto nested_type = remove_nullable(type);
     switch (nested_type->get_primitive_type()) {
     case TYPE_STRUCT:
         return build_struct_children_from_access_node(
@@ -497,45 +502,8 @@ Status AccessPathParser::build_nested_children(format::ColumnDefinition* column,
     if (is_scanner_materialized_virtual_column(column->name)) {
         return Status::OK();
     }
-    if (remove_nullable(column->type)->get_primitive_type() == TYPE_VARIANT) {
-        column->variant_access_paths.clear();
-        for (const auto& access_path : access_paths) {
-            if (access_path.type != TAccessPathType::DATA ||
-                !access_path.__isset.data_access_path) {
-                return Status::NotSupported(
-                        "AccessPathParser only supports DATA access paths for Variant slot {}",
-                        column->name);
-            }
-            const auto& path = access_path.data_access_path.path;
-            if (path.empty()) {
-                // Match the generic access-path tree: an empty DATA path denotes the whole slot
-                // and dominates every narrower Variant path in the same request.
-                column->variant_access_paths.clear();
-                return Status::OK();
-            }
-            int32_t top_level_id = -1;
-            if (to_lower(path.front()) != to_lower(column->name) &&
-                (!parse_non_negative_int(path.front(), &top_level_id) ||
-                 !column->has_identifier_field_id() ||
-                 top_level_id != column->get_identifier_field_id())) {
-                return Status::NotSupported(
-                        "AccessPathParser access path {} does not match Variant slot {}",
-                        access_path_to_string(path), column->name);
-            }
-            if (path.size() == 1) {
-                // A whole-root access covers every subpath and must disable physical leaf pruning.
-                column->variant_access_paths.clear();
-                return Status::OK();
-            }
-            column->variant_access_paths.emplace_back(path.begin() + 1, path.end());
-        }
-        std::ranges::sort(column->variant_access_paths);
-        column->variant_access_paths.erase(std::unique(column->variant_access_paths.begin(),
-                                                       column->variant_access_paths.end()),
-                                           column->variant_access_paths.end());
-        return Status::OK();
-    }
-    if (!is_complex_type(remove_nullable(column->type)->get_primitive_type())) {
+    const auto column_primitive = remove_nullable(column->type)->get_primitive_type();
+    if (!is_complex_type(column_primitive) && column_primitive != TYPE_VARIANT) {
         return Status::OK();
     }
 

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -1819,12 +1819,11 @@ static bool build_variant_leaf_path_projection(const ColumnMapping& mapping,
                std::ranges::all_of(value.substr(digits_begin),
                                    [](unsigned char c) { return std::isdigit(c); });
     };
-    if (path.size() != 1 || path[0].empty() || path[0] == "NULL" ||
-        path[0].find('.') != std::string::npos || is_numeric_selector(path[0]) ||
-        !mapping.file_local_id.has_value()) {
-        // Thrift currently carries access paths as strings without segment-kind or escaping
-        // metadata. Signed numeric tokens are therefore also ambiguous between an array selector
-        // and an object key, so only a single unambiguous key can be mapped losslessly to a leaf.
+    if (path.empty() || !mapping.file_local_id.has_value() ||
+        std::ranges::any_of(path, is_numeric_selector)) {
+        // The legacy path cannot distinguish a numeric object key from an array index. Preserve
+        // correctness by falling back for the whole path until typed array-index segments exist.
+        // TODO: Support numeric array indexes with an explicitly typed access-path protocol.
         return false;
     }
     *root_projection = LocalColumnIndex::partial_local(*mapping.file_local_id);
@@ -1858,6 +1857,11 @@ static bool build_variant_leaf_path_projection(const ColumnMapping& mapping,
                 return false;
             }
             typed_projection.project_all_children = true;
+        } else if (typed->type == nullptr ||
+                   remove_nullable(typed->type)->get_primitive_type() != TYPE_STRUCT) {
+            // Every intermediate typed_value must be an object. This prevents a legacy untyped
+            // path produced through an array/explode operation from crossing a repeated node.
+            return false;
         }
         current_projection->children.push_back(std::move(typed_projection));
         current_projection = &current_projection->children.back();

--- a/be/src/format_v2/parquet/parquet_profile.cpp
+++ b/be/src/format_v2/parquet/parquet_profile.cpp
@@ -71,6 +71,10 @@ void ParquetProfile::init(RuntimeProfile* profile) {
                                                       parquet_profile, 1);
     variant_leaf_projections = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "VariantLeafProjections",
                                                             TUnit::UNIT, parquet_profile, 1);
+    variant_leaf_projection_row_group_columns = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "VariantLeafProjectionRowGroupColumns", TUnit::UNIT, parquet_profile, 1);
+    variant_full_projection_row_group_columns = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "VariantFullProjectionRowGroupColumns", TUnit::UNIT, parquet_profile, 1);
     pages_skipped_by_data_page_filter = ADD_CHILD_COUNTER_WITH_LEVEL(
             profile, "PagesSkippedByDataPageFilter", TUnit::UNIT, parquet_profile, 1);
     data_page_filter_skip_bytes = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "DataPageFilterSkipBytes",

--- a/be/src/format_v2/parquet/parquet_profile.h
+++ b/be/src/format_v2/parquet/parquet_profile.h
@@ -153,8 +153,11 @@ struct ParquetProfile {
     RuntimeProfile::Counter* selected_row_ranges = nullptr;
     RuntimeProfile::Counter* filtered_group_rows = nullptr;
     RuntimeProfile::Counter* filtered_page_rows = nullptr;
-    // File-level Variant access paths that safely retained a physical typed-leaf projection.
+    // Variant access paths eligible for a row-group physical typed-leaf projection.
     RuntimeProfile::Counter* variant_leaf_projections = nullptr;
+    // Row-group outcomes for candidate Variant projections, counted per projected column opened.
+    RuntimeProfile::Counter* variant_leaf_projection_row_group_columns = nullptr;
+    RuntimeProfile::Counter* variant_full_projection_row_group_columns = nullptr;
 
     // ======== Page Skip ========
     RuntimeProfile::Counter* pages_skipped_by_data_page_filter = nullptr;

--- a/be/src/format_v2/parquet/parquet_reader.cpp
+++ b/be/src/format_v2/parquet/parquet_reader.cpp
@@ -49,7 +49,7 @@ namespace doris::format::parquet {
 struct ParquetReaderScanState {
     ParquetFileContext file_context;
     std::vector<std::unique_ptr<ParquetColumnSchema>> file_schema;
-    RowGroupScanPlan scan_plan;
+    std::shared_ptr<RowGroupScanPlan> scan_plan;
     ParquetScanScheduler scheduler;
     const RuntimeState* runtime_state = nullptr;
     const cctz::time_zone* timezone = nullptr;
@@ -111,9 +111,9 @@ bool collect_variant_terminal_fallback_leaf_ids(const ParquetColumnSchema& schem
 
 namespace {
 
-bool variant_projection_is_fully_shredded_in_row_group(const tparquet::RowGroup& row_group,
-                                                       const ParquetColumnSchema& schema,
-                                                       const format::LocalColumnIndex& projection) {
+bool variant_leaf_projection_is_safe_for_row_group_impl(
+        const tparquet::RowGroup& row_group, const ParquetColumnSchema& schema,
+        const format::LocalColumnIndex& projection) {
     if (schema.kind != ParquetColumnSchemaKind::VARIANT || schema.max_repetition_level != 0 ||
         !format::is_partial_projection(&projection)) {
         return false;
@@ -141,6 +141,12 @@ bool variant_projection_is_fully_shredded_in_row_group(const tparquet::RowGroup&
 
 } // namespace
 
+bool detail::variant_leaf_projection_is_safe_for_row_group(
+        const tparquet::RowGroup& row_group, const ParquetColumnSchema& schema,
+        const format::LocalColumnIndex& projection) {
+    return variant_leaf_projection_is_safe_for_row_group_impl(row_group, schema, projection);
+}
+
 size_t detail::finalize_variant_leaf_projection_for_row_group(const tparquet::RowGroup& row_group,
                                                               const ParquetColumnSchema& schema,
                                                               format::LocalColumnIndex* projection,
@@ -150,7 +156,7 @@ size_t detail::finalize_variant_leaf_projection_for_row_group(const tparquet::Ro
         return 0;
     }
     if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
-        if (variant_projection_is_fully_shredded_in_row_group(row_group, schema, *projection)) {
+        if (variant_leaf_projection_is_safe_for_row_group(row_group, schema, *projection)) {
             return 1;
         }
         // The residual null_count is row-group scoped. Restore the complete Variant wrapper for
@@ -657,7 +663,7 @@ Status ParquetReader::open(std::shared_ptr<format::FileScanRequest> request) {
     // otherwise the same unsupported SELECT could fail or silently succeed depending on data.
     RETURN_IF_ERROR(validate_requested_columns_supported(_state->file_schema, *request_snapshot));
 
-    RowGroupScanPlan row_group_plan;
+    auto row_group_plan = std::make_shared<RowGroupScanPlan>();
     ParquetScanRange scan_range;
     scan_range.start_offset = _file_description->range_start_offset;
     scan_range.size = _file_description->range_size;
@@ -665,11 +671,11 @@ Status ParquetReader::open(std::shared_ptr<format::FileScanRequest> request) {
     // Get selected ranges in row groups according to metadata (Row-Group level index and Page Index including Zonemap, Dictionary, Bloom Filter).
     RETURN_IF_ERROR(plan_parquet_row_groups(
             *_state->file_context.native_metadata, _state->file_schema, *request_snapshot,
-            scan_range, _state->enable_bloom_filter, &row_group_plan, _state->timezone,
+            scan_range, _state->enable_bloom_filter, row_group_plan.get(), _state->timezone,
             _state->runtime_state, &_state->file_context,
             _parquet_profile.column_reader_profile()));
     if (_profile != nullptr) {
-        _parquet_profile.update_pruning_stats(row_group_plan.pruning_stats);
+        _parquet_profile.update_pruning_stats(row_group_plan->pruning_stats);
     }
     // Native page readers admit exact validated page payloads to cache. Do not pre-register whole
     // column chunks here: footer offsets are untrusted and this obsolete range map is not consumed.
@@ -774,7 +780,7 @@ void ParquetReader::_sync_page_cache_profile() {
 }
 
 void ParquetReader::set_condition_cache_context(std::shared_ptr<ConditionCacheContext> ctx) {
-    if (_state == nullptr) {
+    if (_state == nullptr || _state->scan_plan == nullptr) {
         return;
     }
     _state->scheduler.set_condition_cache_context(std::move(ctx));
@@ -787,11 +793,11 @@ void ParquetReader::set_condition_cache_context(std::shared_ptr<ConditionCacheCo
 }
 
 int64_t ParquetReader::get_total_rows() const {
-    if (_state == nullptr) {
+    if (_state == nullptr || _state->scan_plan == nullptr) {
         return 0;
     }
     int64_t rows = 0;
-    for (const auto& row_group_plan : _state->scan_plan.row_groups) {
+    for (const auto& row_group_plan : _state->scan_plan->row_groups) {
         rows += row_group_plan.row_group_rows;
     }
     return rows;
@@ -801,7 +807,8 @@ Status ParquetReader::get_aggregate_result(const format::FileAggregateRequest& r
                                            format::FileAggregateResult* result) {
     SCOPED_TIMER(_parquet_profile.total_time);
     DORIS_CHECK(result != nullptr);
-    if (_state == nullptr || _state->file_context.native_metadata == nullptr) {
+    if (_state == nullptr || _state->file_context.native_metadata == nullptr ||
+        _state->scan_plan == nullptr) {
         return Status::Uninitialized("ParquetReader is not open");
     }
     if (_should_stop()) {
@@ -819,7 +826,7 @@ Status ParquetReader::get_aggregate_result(const format::FileAggregateRequest& r
     // Finish lazy remote probes here; normal scans keep them at current-row-group granularity.
     RETURN_IF_ERROR(finalize_parquet_row_group_plans(
             *_state->file_context.native_metadata, _state->file_schema, *_request,
-            _state->enable_bloom_filter, &_state->scan_plan, _state->timezone,
+            _state->enable_bloom_filter, _state->scan_plan.get(), _state->timezone,
             _state->runtime_state, &_state->file_context, _parquet_profile.column_reader_profile(),
             _profile == nullptr ? nullptr : &_parquet_profile));
 
@@ -837,7 +844,7 @@ Status ParquetReader::get_aggregate_result(const format::FileAggregateRequest& r
     }
 
     // Aggregate row count in all selected row groups. For MIN/MAX aggregate, this is used to determine whether there is no row group selected.
-    for (const auto& row_group_plan : _state->scan_plan.row_groups) {
+    for (const auto& row_group_plan : _state->scan_plan->row_groups) {
         const auto& row_group_metadata = _state->file_context.native_metadata->to_thrift()
                                                  .row_groups[row_group_plan.row_group_id];
         result->count += row_group_metadata.num_rows;
@@ -862,7 +869,7 @@ Status ParquetReader::get_aggregate_result(const format::FileAggregateRequest& r
             return Status::OK();
         }
         result->count = 0;
-        for (const auto& row_group_plan : _state->scan_plan.row_groups) {
+        for (const auto& row_group_plan : _state->scan_plan->row_groups) {
             std::unique_ptr<CountColumnReader> shape_reader;
             RETURN_IF_ERROR(CountColumnReader::create(
                     _state->file_context.native_data_file(), _state->file_context.native_metadata,
@@ -922,7 +929,7 @@ Status ParquetReader::get_aggregate_result(const format::FileAggregateRequest& r
 
         auto& aggregate_column = result->columns[request_column_idx];
         aggregate_column.projection = request.columns[request_column_idx].projection;
-        for (const auto& row_group_plan : _state->scan_plan.row_groups) {
+        for (const auto& row_group_plan : _state->scan_plan->row_groups) {
             const auto& row_group_metadata = _state->file_context.native_metadata->to_thrift()
                                                      .row_groups[row_group_plan.row_group_id];
             DORIS_CHECK(leaf_schema->leaf_column_id >= 0 &&

--- a/be/src/format_v2/parquet/parquet_reader.cpp
+++ b/be/src/format_v2/parquet/parquet_reader.cpp
@@ -72,22 +72,37 @@ const ParquetColumnSchema* schema_child_by_name(const ParquetColumnSchema& schem
     return child_it == schema.children.end() ? nullptr : child_it->get();
 }
 
-bool collect_variant_residual_leaf_ids(const ParquetColumnSchema& schema,
-                                       const format::LocalColumnIndex& projection,
-                                       std::vector<int>* residual_leaf_ids) {
+bool collect_variant_terminal_fallback_leaf_ids(const ParquetColumnSchema& schema,
+                                                const format::LocalColumnIndex& projection,
+                                                std::vector<int>* residual_leaf_ids) {
     DORIS_CHECK(residual_leaf_ids != nullptr);
     const auto* value = schema_child_by_name(schema, "value");
     const auto* typed_value = schema_child_by_name(schema, "typed_value");
-    if (value != nullptr && typed_value != nullptr) {
-        if (value->kind != ParquetColumnSchemaKind::PRIMITIVE || value->leaf_column_id < 0) {
+    if (value != nullptr && value->kind == ParquetColumnSchemaKind::PRIMITIVE &&
+        typed_value != nullptr) {
+        if (value->leaf_column_id < 0) {
             return false;
         }
+        const auto typed_projection_it =
+                std::ranges::find_if(projection.children, [&](const auto& child_projection) {
+                    return child_projection.local_id() == typed_value->local_id;
+                });
+        if (typed_projection_it == projection.children.end()) {
+            return false;
+        }
+        if (typed_value->kind != ParquetColumnSchemaKind::PRIMITIVE) {
+            return collect_variant_terminal_fallback_leaf_ids(*typed_value, *typed_projection_it,
+                                                              residual_leaf_ids);
+        }
+        // Object residual keys are disjoint from shredded keys. Only the fallback paired with the
+        // terminal typed leaf can supply that projected path; ancestor values contain other keys.
         residual_leaf_ids->push_back(value->leaf_column_id);
+        return true;
     }
     for (const auto& child_projection : projection.children) {
         const auto* child = projected_schema_child(schema, child_projection.local_id());
-        if (child == nullptr ||
-            !collect_variant_residual_leaf_ids(*child, child_projection, residual_leaf_ids)) {
+        if (child == nullptr || !collect_variant_terminal_fallback_leaf_ids(
+                                        *child, child_projection, residual_leaf_ids)) {
             return false;
         }
     }
@@ -104,7 +119,7 @@ bool variant_projection_is_fully_shredded_in_row_group(const tparquet::RowGroup&
         return false;
     }
     std::vector<int> residual_leaf_ids;
-    if (!collect_variant_residual_leaf_ids(schema, projection, &residual_leaf_ids) ||
+    if (!collect_variant_terminal_fallback_leaf_ids(schema, projection, &residual_leaf_ids) ||
         residual_leaf_ids.empty()) {
         return false;
     }
@@ -166,8 +181,8 @@ size_t count_variant_leaf_projection_candidates(const ParquetColumnSchema& schem
     if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
         std::vector<int> residual_leaf_ids;
         return schema.max_repetition_level == 0 &&
-                               collect_variant_residual_leaf_ids(schema, projection,
-                                                                 &residual_leaf_ids) &&
+                               collect_variant_terminal_fallback_leaf_ids(schema, projection,
+                                                                          &residual_leaf_ids) &&
                                !residual_leaf_ids.empty()
                        ? 1
                        : 0;

--- a/be/src/format_v2/parquet/parquet_reader.cpp
+++ b/be/src/format_v2/parquet/parquet_reader.cpp
@@ -94,52 +94,57 @@ bool collect_variant_residual_leaf_ids(const ParquetColumnSchema& schema,
     return true;
 }
 
-bool detail::variant_projection_is_fully_shredded(const tparquet::FileMetaData& metadata,
-                                                  const ParquetColumnSchema& schema,
-                                                  const format::LocalColumnIndex& projection) {
+namespace {
+
+bool variant_projection_is_fully_shredded_in_row_group(const tparquet::RowGroup& row_group,
+                                                       const ParquetColumnSchema& schema,
+                                                       const format::LocalColumnIndex& projection) {
     if (schema.kind != ParquetColumnSchemaKind::VARIANT || schema.max_repetition_level != 0 ||
         !format::is_partial_projection(&projection)) {
         return false;
     }
     std::vector<int> residual_leaf_ids;
-    if (!collect_variant_residual_leaf_ids(schema, projection, &residual_leaf_ids)) {
+    if (!collect_variant_residual_leaf_ids(schema, projection, &residual_leaf_ids) ||
+        residual_leaf_ids.empty()) {
         return false;
     }
     std::ranges::sort(residual_leaf_ids);
     residual_leaf_ids.erase(std::unique(residual_leaf_ids.begin(), residual_leaf_ids.end()),
                             residual_leaf_ids.end());
-    for (const auto& row_group : metadata.row_groups) {
-        for (const int leaf_id : residual_leaf_ids) {
-            if (leaf_id < 0 || leaf_id >= static_cast<int>(row_group.columns.size())) {
-                return false;
-            }
-            const auto& chunk = row_group.columns[leaf_id];
-            if (!chunk.__isset.meta_data || !chunk.meta_data.__isset.statistics ||
-                !chunk.meta_data.statistics.__isset.null_count ||
-                chunk.meta_data.statistics.null_count != row_group.num_rows) {
-                return false;
-            }
+    return std::ranges::all_of(residual_leaf_ids, [&](const int leaf_id) {
+        if (leaf_id < 0 || leaf_id >= static_cast<int>(row_group.columns.size())) {
+            return false;
         }
-    }
-    return true;
+        const auto& chunk = row_group.columns[leaf_id];
+        return row_group.num_rows >= 0 && chunk.__isset.meta_data &&
+               chunk.meta_data.num_values == row_group.num_rows &&
+               chunk.meta_data.__isset.statistics &&
+               chunk.meta_data.statistics.__isset.null_count &&
+               chunk.meta_data.statistics.null_count == chunk.meta_data.num_values;
+    });
 }
 
-size_t detail::finalize_variant_leaf_projection(const tparquet::FileMetaData& metadata,
-                                                const ParquetColumnSchema& schema,
-                                                format::LocalColumnIndex* projection) {
+} // namespace
+
+size_t detail::finalize_variant_leaf_projection_for_row_group(const tparquet::RowGroup& row_group,
+                                                              const ParquetColumnSchema& schema,
+                                                              format::LocalColumnIndex* projection,
+                                                              size_t* full_projections) {
     DORIS_CHECK(projection != nullptr);
     if (!format::is_partial_projection(projection)) {
         return 0;
     }
     if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
-        if (variant_projection_is_fully_shredded(metadata, schema, *projection)) {
+        if (variant_projection_is_fully_shredded_in_row_group(row_group, schema, *projection)) {
             return 1;
         }
-        // Unknown residual completeness must restore this Variant wrapper atomically. For a
-        // repeated ancestor, footer null_count is in the leaf-value domain rather than Variant
-        // instances, so variant_projection_is_fully_shredded() deliberately takes this fallback.
+        // The residual null_count is row-group scoped. Restore the complete Variant wrapper for
+        // only this reader so another row group can still keep the typed-leaf projection.
         projection->project_all_children = true;
         projection->children.clear();
+        if (full_projections != nullptr) {
+            ++*full_projections;
+        }
         return 0;
     }
 
@@ -147,29 +152,48 @@ size_t detail::finalize_variant_leaf_projection(const tparquet::FileMetaData& me
     for (auto& child_projection : projection->children) {
         const auto* child_schema = projected_schema_child(schema, child_projection.local_id());
         DORIS_CHECK(child_schema != nullptr);
-        retained += finalize_variant_leaf_projection(metadata, *child_schema, &child_projection);
+        retained += finalize_variant_leaf_projection_for_row_group(
+                row_group, *child_schema, &child_projection, full_projections);
     }
     return retained;
 }
 
-size_t finalize_variant_leaf_projections(
-        const NativeParquetMetadata& metadata,
-        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
-        std::vector<format::LocalColumnIndex>* projections) {
-    DORIS_CHECK(projections != nullptr);
-    size_t retained = 0;
-    for (auto& projection : *projections) {
-        const int32_t local_id = projection.local_id();
-        if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size())) {
-            continue;
-        }
-        if (!file_schema[local_id]->contains_variant) {
-            continue;
-        }
-        retained += detail::finalize_variant_leaf_projection(metadata.to_thrift(),
-                                                             *file_schema[local_id], &projection);
+size_t count_variant_leaf_projection_candidates(const ParquetColumnSchema& schema,
+                                                const format::LocalColumnIndex& projection) {
+    if (!format::is_partial_projection(&projection)) {
+        return 0;
     }
-    return retained;
+    if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
+        std::vector<int> residual_leaf_ids;
+        return schema.max_repetition_level == 0 &&
+                               collect_variant_residual_leaf_ids(schema, projection,
+                                                                 &residual_leaf_ids) &&
+                               !residual_leaf_ids.empty()
+                       ? 1
+                       : 0;
+    }
+    size_t candidates = 0;
+    for (const auto& child_projection : projection.children) {
+        const auto* child_schema = projected_schema_child(schema, child_projection.local_id());
+        DORIS_CHECK(child_schema != nullptr);
+        candidates += count_variant_leaf_projection_candidates(*child_schema, child_projection);
+    }
+    return candidates;
+}
+
+size_t count_variant_leaf_projection_candidates(
+        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        const std::vector<format::LocalColumnIndex>& projections) {
+    size_t candidates = 0;
+    for (const auto& projection : projections) {
+        const int32_t local_id = projection.local_id();
+        if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size()) ||
+            !file_schema[local_id]->contains_variant) {
+            continue;
+        }
+        candidates += count_variant_leaf_projection_candidates(*file_schema[local_id], projection);
+    }
+    return candidates;
 }
 
 Status validate_all_projected_leaves_supported(const ParquetColumnSchema& column_schema) {
@@ -563,19 +587,19 @@ Status ParquetReader::open(std::shared_ptr<format::FileScanRequest> request) {
                     return column->contains_variant;
                 });
     }
-    size_t retained_variant_leaf_projections = 0;
+    size_t variant_leaf_projection_candidates = 0;
     if (_state->file_context.contains_variant) {
-        retained_variant_leaf_projections =
-                finalize_variant_leaf_projections(*_state->file_context.native_metadata,
-                                                  _state->file_schema,
-                                                  &request_snapshot->predicate_columns) +
-                finalize_variant_leaf_projections(*_state->file_context.native_metadata,
-                                                  _state->file_schema,
-                                                  &request_snapshot->non_predicate_columns);
+        // This counter describes leaf candidates without scanning every row group's statistics.
+        // The scheduler profiles the actual per-row-group leaf/full decision separately.
+        variant_leaf_projection_candidates =
+                count_variant_leaf_projection_candidates(_state->file_schema,
+                                                         request_snapshot->predicate_columns) +
+                count_variant_leaf_projection_candidates(_state->file_schema,
+                                                         request_snapshot->non_predicate_columns);
     }
     if (_parquet_profile.variant_leaf_projections != nullptr) {
         COUNTER_UPDATE(_parquet_profile.variant_leaf_projections,
-                       retained_variant_leaf_projections);
+                       variant_leaf_projection_candidates);
     }
     RETURN_IF_ERROR(format::FileReader::open(std::move(request)));
 

--- a/be/src/format_v2/parquet/parquet_reader.h
+++ b/be/src/format_v2/parquet/parquet_reader.h
@@ -36,15 +36,6 @@ namespace doris::format::parquet {
 
 struct ParquetReaderScanState;
 
-namespace detail {
-bool variant_projection_is_fully_shredded(const tparquet::FileMetaData& metadata,
-                                          const ParquetColumnSchema& schema,
-                                          const format::LocalColumnIndex& projection);
-size_t finalize_variant_leaf_projection(const tparquet::FileMetaData& metadata,
-                                        const ParquetColumnSchema& schema,
-                                        format::LocalColumnIndex* projection);
-} // namespace detail
-
 // ============================================================================
 // ============================================================================
 //   init() -> get_schema() -> open(request) -> get_block() [loop] -> close()

--- a/be/src/format_v2/parquet/parquet_scan.cpp
+++ b/be/src/format_v2/parquet/parquet_scan.cpp
@@ -252,27 +252,95 @@ std::vector<format::LocalColumnIndex> physical_non_predicate_columns(
     return columns;
 }
 
-struct VariantRowGroupProjectionCounts {
-    size_t leaf = 0;
-    size_t full = 0;
-};
+const ParquetColumnSchema* projection_schema_child(const ParquetColumnSchema& schema,
+                                                   int32_t local_id) {
+    const auto child = std::ranges::find_if(schema.children, [local_id](const auto& candidate) {
+        return candidate->local_id == local_id;
+    });
+    return child == schema.children.end() ? nullptr : child->get();
+}
 
-VariantRowGroupProjectionCounts finalize_variant_projections_for_row_group(
+void collect_variant_projection_decisions(const tparquet::RowGroup& row_group,
+                                          const ParquetColumnSchema& schema,
+                                          const format::LocalColumnIndex& projection,
+                                          size_t* candidate_ordinal,
+                                          RowGroupReadPlan* row_group_plan) {
+    DORIS_CHECK(candidate_ordinal != nullptr && row_group_plan != nullptr);
+    if (!format::is_partial_projection(&projection)) {
+        return;
+    }
+    if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
+        if (detail::variant_leaf_projection_is_safe_for_row_group(row_group, schema, projection)) {
+            ++row_group_plan->variant_leaf_projection_columns;
+        } else {
+            row_group_plan->full_variant_projection_ordinals.push_back(*candidate_ordinal);
+            ++row_group_plan->variant_full_projection_columns;
+        }
+        ++*candidate_ordinal;
+        return;
+    }
+    for (const auto& child_projection : projection.children) {
+        const auto* child_schema = projection_schema_child(schema, child_projection.local_id());
+        DORIS_CHECK(child_schema != nullptr);
+        collect_variant_projection_decisions(row_group, *child_schema, child_projection,
+                                             candidate_ordinal, row_group_plan);
+    }
+}
+
+void collect_variant_projection_decisions(
         const tparquet::RowGroup& row_group,
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
-        std::vector<format::LocalColumnIndex>* projections) {
+        const std::vector<format::LocalColumnIndex>& projections, size_t* candidate_ordinal,
+        RowGroupReadPlan* row_group_plan) {
+    for (const auto& projection : projections) {
+        const int32_t local_id = projection.local_id();
+        if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size()) ||
+            file_schema[local_id] == nullptr || !file_schema[local_id]->contains_variant) {
+            continue;
+        }
+        collect_variant_projection_decisions(row_group, *file_schema[local_id], projection,
+                                             candidate_ordinal, row_group_plan);
+    }
+}
+
+void apply_variant_projection_decisions(const ParquetColumnSchema& schema,
+                                        format::LocalColumnIndex* projection,
+                                        std::span<const size_t> full_ordinals,
+                                        size_t* candidate_ordinal) {
+    DORIS_CHECK(projection != nullptr && candidate_ordinal != nullptr);
+    if (!format::is_partial_projection(projection)) {
+        return;
+    }
+    if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
+        if (std::ranges::binary_search(full_ordinals, *candidate_ordinal)) {
+            projection->project_all_children = true;
+            projection->children.clear();
+        }
+        ++*candidate_ordinal;
+        return;
+    }
+    for (auto& child_projection : projection->children) {
+        const auto* child_schema = projection_schema_child(schema, child_projection.local_id());
+        DORIS_CHECK(child_schema != nullptr);
+        apply_variant_projection_decisions(*child_schema, &child_projection, full_ordinals,
+                                           candidate_ordinal);
+    }
+}
+
+void apply_variant_projection_decisions(
+        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        std::vector<format::LocalColumnIndex>* projections, std::span<const size_t> full_ordinals,
+        size_t* candidate_ordinal) {
     DORIS_CHECK(projections != nullptr);
-    VariantRowGroupProjectionCounts counts;
     for (auto& projection : *projections) {
         const int32_t local_id = projection.local_id();
         if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size()) ||
-            !file_schema[local_id]->contains_variant) {
+            file_schema[local_id] == nullptr || !file_schema[local_id]->contains_variant) {
             continue;
         }
-        counts.leaf += detail::finalize_variant_leaf_projection_for_row_group(
-                row_group, *file_schema[local_id], &projection, &counts.full);
+        apply_variant_projection_decisions(*file_schema[local_id], &projection, full_ordinals,
+                                           candidate_ordinal);
     }
-    return counts;
 }
 
 void prepare_row_group_physical_projection(
@@ -280,45 +348,89 @@ void prepare_row_group_physical_projection(
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const format::FileScanRequest& request, RowGroupReadPlan* row_group_plan) {
     DORIS_CHECK(row_group_plan != nullptr);
-    const auto may_project_variant_leaf = [&](const auto& projections) {
-        return std::ranges::any_of(projections, [&](const auto& projection) {
-            const int32_t local_id = projection.local_id();
-            return local_id >= 0 && local_id < static_cast<int32_t>(file_schema.size()) &&
-                   file_schema[local_id] != nullptr && file_schema[local_id]->contains_variant &&
-                   format::is_partial_projection(&projection);
-        });
-    };
-    if (!may_project_variant_leaf(request.predicate_columns) &&
-        !may_project_variant_leaf(request.non_predicate_columns)) {
-        row_group_plan->physical_predicate_columns = {};
-        row_group_plan->physical_non_predicate_columns = {};
-        row_group_plan->has_row_group_physical_projection = false;
-        row_group_plan->variant_leaf_projection_columns = 0;
-        row_group_plan->variant_full_projection_columns = 0;
-        return;
-    }
-    row_group_plan->physical_predicate_columns = request.predicate_columns;
-    row_group_plan->physical_non_predicate_columns = request.non_predicate_columns;
-    const auto predicate_counts = finalize_variant_projections_for_row_group(
-            row_group, file_schema, &row_group_plan->physical_predicate_columns);
-    const auto non_predicate_counts = finalize_variant_projections_for_row_group(
-            row_group, file_schema, &row_group_plan->physical_non_predicate_columns);
-    row_group_plan->variant_leaf_projection_columns =
-            predicate_counts.leaf + non_predicate_counts.leaf;
-    row_group_plan->variant_full_projection_columns =
-            predicate_counts.full + non_predicate_counts.full;
-    row_group_plan->has_row_group_physical_projection = true;
+    row_group_plan->full_variant_projection_ordinals.clear();
+    row_group_plan->variant_leaf_projection_columns = 0;
+    row_group_plan->variant_full_projection_columns = 0;
+    size_t candidate_ordinal = 0;
+    collect_variant_projection_decisions(row_group, file_schema, request.predicate_columns,
+                                         &candidate_ordinal, row_group_plan);
+    collect_variant_projection_decisions(row_group, file_schema, request.non_predicate_columns,
+                                         &candidate_ordinal, row_group_plan);
 }
 
-std::optional<format::FileScanRequest> physical_request_for_row_group(
-        const format::FileScanRequest& request, const RowGroupReadPlan& row_group_plan) {
-    if (!row_group_plan.has_row_group_physical_projection) {
-        return std::nullopt;
+void collect_physical_leaf_column_ids(const ParquetColumnSchema& schema,
+                                      const format::LocalColumnIndex& projection,
+                                      std::span<const size_t> full_ordinals,
+                                      size_t* candidate_ordinal,
+                                      std::unordered_set<int>* leaf_column_ids) {
+    DORIS_CHECK(candidate_ordinal != nullptr && leaf_column_ids != nullptr);
+    if (projection.project_all_children) {
+        collect_all_leaf_column_ids(schema, leaf_column_ids);
+        return;
     }
-    auto physical_request = request;
-    physical_request.predicate_columns = row_group_plan.physical_predicate_columns;
-    physical_request.non_predicate_columns = row_group_plan.physical_non_predicate_columns;
-    return std::optional<format::FileScanRequest>(std::move(physical_request));
+    if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
+        if (std::ranges::binary_search(full_ordinals, *candidate_ordinal)) {
+            collect_all_leaf_column_ids(schema, leaf_column_ids);
+            ++*candidate_ordinal;
+            return;
+        }
+        ++*candidate_ordinal;
+        collect_projected_leaf_column_ids(schema, projection, leaf_column_ids);
+        return;
+    }
+    if (projection.children.empty()) {
+        collect_all_leaf_column_ids(schema, leaf_column_ids);
+        return;
+    }
+    for (const auto& child_projection : projection.children) {
+        const auto* child_schema = projection_schema_child(schema, child_projection.local_id());
+        DORIS_CHECK(child_schema != nullptr);
+        collect_physical_leaf_column_ids(*child_schema, child_projection, full_ordinals,
+                                         candidate_ordinal, leaf_column_ids);
+    }
+}
+
+std::unordered_set<int> physical_leaf_column_ids_for_row_group(
+        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        const format::FileScanRequest& request, const RowGroupReadPlan& row_group_plan) {
+    std::unordered_set<int> leaf_column_ids;
+    size_t candidate_ordinal = 0;
+    const auto collect_projection = [&](const format::LocalColumnIndex& projection) {
+        const int32_t local_id = projection.local_id();
+        if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size()) ||
+            file_schema[local_id] == nullptr) {
+            return;
+        }
+        collect_physical_leaf_column_ids(*file_schema[local_id], projection,
+                                         row_group_plan.full_variant_projection_ordinals,
+                                         &candidate_ordinal, &leaf_column_ids);
+    };
+    for (const auto& projection : request.predicate_columns) {
+        collect_projection(projection);
+    }
+    for (const auto& projection : request.non_predicate_columns) {
+        if (!request.is_count_star_placeholder(projection.column_id())) {
+            collect_projection(projection);
+        }
+    }
+    return leaf_column_ids;
+}
+
+void materialize_row_group_projection(
+        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        const format::FileScanRequest& request, const RowGroupReadPlan& row_group_plan,
+        format::FileScanRequest* physical_request) {
+    DORIS_CHECK(physical_request != nullptr);
+    physical_request->predicate_columns = request.predicate_columns;
+    physical_request->non_predicate_columns = request.non_predicate_columns;
+    physical_request->count_star_placeholder_columns = request.count_star_placeholder_columns;
+    size_t candidate_ordinal = 0;
+    apply_variant_projection_decisions(file_schema, &physical_request->predicate_columns,
+                                       row_group_plan.full_variant_projection_ordinals,
+                                       &candidate_ordinal);
+    apply_variant_projection_decisions(file_schema, &physical_request->non_predicate_columns,
+                                       row_group_plan.full_variant_projection_ordinals,
+                                       &candidate_ordinal);
 }
 
 void materialize_count_star_placeholders(const format::FileScanRequest& request, size_t rows,
@@ -516,30 +628,21 @@ Status finalize_native_row_group_read_plan(
     }
     row_group_plan->expensive_pruning_pending = false;
     const auto& thrift = metadata.to_thrift();
-    const auto physical_request_storage = physical_request_for_row_group(request, *row_group_plan);
-    const auto& physical_request =
-            physical_request_storage.has_value() ? *physical_request_storage : request;
+    const auto requested_leaf_ids =
+            physical_leaf_column_ids_for_row_group(file_schema, request, *row_group_plan);
     const std::vector<int> candidate {row_group_plan->row_group_id};
     std::vector<int> metadata_selected;
     RETURN_IF_ERROR(select_row_groups_by_metadata(
-            thrift, file_schema, physical_request, &candidate, &metadata_selected,
-            enable_bloom_filter, pruning_stats, timezone, runtime_state, file_context,
-            column_reader_profile, ParquetMetadataProbeMode::EXPENSIVE_ONLY));
+            thrift, file_schema, request, &candidate, &metadata_selected, enable_bloom_filter,
+            pruning_stats, timezone, runtime_state, file_context, column_reader_profile,
+            ParquetMetadataProbeMode::EXPENSIVE_ONLY, &requested_leaf_ids));
     if (metadata_selected.empty()) {
         *selected = false;
         return Status::OK();
     }
 
-    std::unordered_set<int> requested_leaf_ids;
-    for (const auto& projection : request_scan_columns(physical_request)) {
-        const auto local_id = projection.local_id();
-        if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size())) {
-            continue;
-        }
-        collect_projected_leaf_column_ids(*file_schema[local_id], projection, &requested_leaf_ids);
-    }
     std::unordered_map<int, NativeParquetPageIndex> page_indexes;
-    if (can_use_parquet_page_index(physical_request, runtime_state)) {
+    if (can_use_parquet_page_index(request, runtime_state)) {
         RETURN_IF_ERROR(file_context->load_native_page_indexes(
                 row_group_plan->row_group_id, requested_leaf_ids, &page_indexes,
                 &pruning_stats->read_page_index_time, &pruning_stats->parse_page_index_time));
@@ -548,8 +651,8 @@ Status finalize_native_row_group_read_plan(
     std::map<int, ParquetPageSkipPlan> page_skip_plans;
     RETURN_IF_ERROR(select_row_group_ranges_by_native_page_index(
             thrift, thrift.row_groups[row_group_plan->row_group_id], page_indexes, file_schema,
-            physical_request, row_group_plan->row_group_rows, &page_selected_ranges,
-            &page_skip_plans, pruning_stats, timezone, runtime_state));
+            request, row_group_plan->row_group_rows, &page_selected_ranges, &page_skip_plans,
+            pruning_stats, timezone, runtime_state));
     row_group_plan->selected_ranges =
             intersect_row_ranges(row_group_plan->selected_ranges, page_selected_ranges);
     row_group_plan->page_skip_plans = std::move(page_skip_plans);
@@ -614,16 +717,14 @@ Status plan_parquet_row_groups(const NativeParquetMetadata& metadata,
     std::vector<RowGroupReadPlan> metadata_selected_plans;
     metadata_selected_plans.reserve(plan->row_groups.size());
     for (auto& row_group_plan : plan->row_groups) {
-        const auto physical_request_storage =
-                physical_request_for_row_group(request, row_group_plan);
-        const auto& physical_request =
-                physical_request_storage.has_value() ? *physical_request_storage : request;
+        const auto requested_leaf_ids =
+                physical_leaf_column_ids_for_row_group(file_schema, request, row_group_plan);
         const std::vector<int> candidate {row_group_plan.row_group_id};
         std::vector<int> metadata_selected;
         RETURN_IF_ERROR(select_row_groups_by_metadata(
-                metadata.to_thrift(), file_schema, physical_request, &candidate, &metadata_selected,
+                metadata.to_thrift(), file_schema, request, &candidate, &metadata_selected,
                 enable_bloom_filter, &plan->pruning_stats, timezone, runtime_state, file_context,
-                column_reader_profile, ParquetMetadataProbeMode::FOOTER_ONLY));
+                column_reader_profile, ParquetMetadataProbeMode::FOOTER_ONLY, &requested_leaf_ids));
         if (!metadata_selected.empty()) {
             metadata_selected_plans.push_back(std::move(row_group_plan));
         }
@@ -926,9 +1027,10 @@ std::vector<RowRange> filter_ranges_by_condition_cache(const std::vector<RowRang
 
 } // namespace
 
-void ParquetScanScheduler::set_plan(RowGroupScanPlan plan) {
-    _enable_bloom_filter = plan.enable_bloom_filter;
-    _row_group_plans = std::move(plan.row_groups);
+void ParquetScanScheduler::set_plan(std::shared_ptr<RowGroupScanPlan> plan) {
+    DORIS_CHECK(plan != nullptr);
+    _enable_bloom_filter = plan->enable_bloom_filter;
+    _scan_plan = std::move(plan);
     _condition_cache_filtered_rows = 0;
     _predicate_filtered_rows = 0;
     _remaining_plans_need_replanning = false;
@@ -937,14 +1039,14 @@ void ParquetScanScheduler::set_plan(RowGroupScanPlan plan) {
 
 void ParquetScanScheduler::set_condition_cache_context(std::shared_ptr<ConditionCacheContext> ctx) {
     _condition_cache_ctx = std::move(ctx);
-    if (!_condition_cache_ctx || !_condition_cache_ctx->filter_result || _row_group_plans.empty()) {
+    if (!_condition_cache_ctx || !_condition_cache_ctx->filter_result || empty()) {
         return;
     }
 
     if (!_condition_cache_ctx->is_hit) {
         _condition_cache_ctx->base_granule =
-                _row_group_plans.front().first_file_row / ConditionCacheContext::GRANULE_SIZE;
-        const auto& last_plan = _row_group_plans.back();
+                _scan_plan->row_groups.front().first_file_row / ConditionCacheContext::GRANULE_SIZE;
+        const auto& last_plan = _scan_plan->row_groups.back();
         const int64_t end_granule = (last_plan.first_file_row + last_plan.row_group_rows +
                                      ConditionCacheContext::GRANULE_SIZE - 1) /
                                     ConditionCacheContext::GRANULE_SIZE;
@@ -956,8 +1058,8 @@ void ParquetScanScheduler::set_condition_cache_context(std::shared_ptr<Condition
     }
 
     std::vector<RowGroupReadPlan> filtered_plans;
-    filtered_plans.reserve(_row_group_plans.size());
-    for (auto& plan : _row_group_plans) {
+    filtered_plans.reserve(_scan_plan->row_groups.size());
+    for (auto& plan : _scan_plan->row_groups) {
         const int64_t old_rows = count_range_rows(plan.selected_ranges);
         plan.selected_ranges = filter_ranges_by_condition_cache(
                 plan.selected_ranges, *_condition_cache_ctx->filter_result, plan.first_file_row,
@@ -968,7 +1070,7 @@ void ParquetScanScheduler::set_condition_cache_context(std::shared_ptr<Condition
             filtered_plans.push_back(std::move(plan));
         }
     }
-    _row_group_plans = std::move(filtered_plans);
+    _scan_plan->row_groups = std::move(filtered_plans);
     reset();
 }
 
@@ -1158,8 +1260,9 @@ Status ParquetScanScheduler::open_next_row_group(
         const format::FileScanRequest& request, bool* has_row_group) {
     *has_row_group = false;
     RowGroupReadPlan* selected_plan = nullptr;
-    while (_next_row_group_plan_idx < _row_group_plans.size()) {
-        RowGroupReadPlan& candidate_plan = _row_group_plans[_next_row_group_plan_idx++];
+    DORIS_CHECK(_scan_plan != nullptr);
+    while (_next_row_group_plan_idx < _scan_plan->row_groups.size()) {
+        RowGroupReadPlan& candidate_plan = _scan_plan->row_groups[_next_row_group_plan_idx++];
         // Probe only the row group about to execute. This keeps LIMIT/cancellation latency
         // independent of the number of later remote row groups while preserving eager footer
         // statistics pruning during open.
@@ -1176,17 +1279,15 @@ Status ParquetScanScheduler::open_next_row_group(
             const auto& row_group = file_context.native_metadata->to_thrift()
                                             .row_groups[candidate_plan.row_group_id];
             prepare_row_group_physical_projection(row_group, file_schema, request, &candidate_plan);
-            const auto physical_request_storage =
-                    physical_request_for_row_group(request, candidate_plan);
-            const auto& physical_request =
-                    physical_request_storage.has_value() ? *physical_request_storage : request;
+            const auto requested_leaf_ids =
+                    physical_leaf_column_ids_for_row_group(file_schema, request, candidate_plan);
             const std::vector<int> candidate {candidate_plan.row_group_id};
             std::vector<int> footer_selected;
             RETURN_IF_ERROR(select_row_groups_by_metadata(
-                    file_context.native_metadata->to_thrift(), file_schema, physical_request,
-                    &candidate, &footer_selected, _enable_bloom_filter, &deferred_stats, _timezone,
+                    file_context.native_metadata->to_thrift(), file_schema, request, &candidate,
+                    &footer_selected, _enable_bloom_filter, &deferred_stats, _timezone,
                     _runtime_state, &file_context, _scan_profile.column_reader_profile,
-                    ParquetMetadataProbeMode::FOOTER_ONLY));
+                    ParquetMetadataProbeMode::FOOTER_ONLY, &requested_leaf_ids));
             if (footer_selected.empty()) {
                 if (_parquet_profile != nullptr) {
                     _parquet_profile->update_deferred_pruning_stats(deferred_stats, false);
@@ -1225,18 +1326,13 @@ Status ParquetScanScheduler::open_next_row_group(
 
     const auto& row_group_metadata =
             file_context.native_metadata->to_thrift().row_groups[row_group_idx];
-    _current_row_group_request = std::make_unique<format::FileScanRequest>();
-    _current_row_group_request->predicate_columns =
-            row_group_plan.has_row_group_physical_projection
-                    ? row_group_plan.physical_predicate_columns
-                    : request.predicate_columns;
-    _current_row_group_request->non_predicate_columns =
-            row_group_plan.has_row_group_physical_projection
-                    ? row_group_plan.physical_non_predicate_columns
-                    : request.non_predicate_columns;
-    _current_row_group_request->count_star_placeholder_columns =
-            request.count_star_placeholder_columns;
-    const auto& row_group_request = *_current_row_group_request;
+    if (row_group_plan.has_row_group_physical_projection()) {
+        _current_row_group_request = std::make_unique<format::FileScanRequest>();
+        materialize_row_group_projection(file_schema, request, row_group_plan,
+                                         _current_row_group_request.get());
+    }
+    const auto& row_group_request =
+            _current_row_group_request != nullptr ? *_current_row_group_request : request;
     _current_row_group_rows = row_group_metadata.num_rows;
     DORIS_CHECK(_current_row_group_rows == row_group_plan.row_group_rows);
     DORIS_CHECK(_current_row_group_rows > 0);
@@ -2720,10 +2816,10 @@ Status ParquetScanScheduler::read_current_row_group_batch(
         // Do not prefetch lazy output columns until at least one row survives filtering. This is
         // the same decision point where the v2 reader switches from predicate-only reads to
         // materializing non-predicate columns, so fully filtered batches avoid unnecessary IO.
-        DORIS_CHECK(_current_row_group_request != nullptr);
+        const auto& physical_request =
+                _current_row_group_request != nullptr ? *_current_row_group_request : request;
         RETURN_IF_ERROR(prefetch_current_row_group_columns(
-                file_context, file_schema,
-                physical_non_predicate_columns(*_current_row_group_request),
+                file_context, file_schema, physical_non_predicate_columns(physical_request),
                 &_current_non_predicate_prefetched));
     }
 

--- a/be/src/format_v2/parquet/parquet_scan.cpp
+++ b/be/src/format_v2/parquet/parquet_scan.cpp
@@ -16,6 +16,7 @@
 #include "format_v2/parquet/parquet_scan.h"
 
 #include <algorithm>
+#include <atomic>
 #include <iterator>
 #include <limits>
 #include <memory>
@@ -103,6 +104,22 @@ bool should_sample_adaptive_predicate(size_t samples, size_t batch_sequence) {
 }
 
 } // namespace detail
+
+#ifdef BE_TEST
+namespace detail {
+namespace {
+std::atomic<size_t> physical_leaf_set_builds = 0;
+}
+
+void reset_physical_leaf_set_build_count() {
+    physical_leaf_set_builds.store(0, std::memory_order_relaxed);
+}
+
+size_t physical_leaf_set_build_count() {
+    return physical_leaf_set_builds.load(std::memory_order_relaxed);
+}
+} // namespace detail
+#endif
 
 namespace {
 
@@ -390,9 +407,12 @@ void collect_physical_leaf_column_ids(const ParquetColumnSchema& schema,
     }
 }
 
-std::unordered_set<int> physical_leaf_column_ids_for_row_group(
+std::unordered_set<int> request_leaf_column_ids(
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
-        const format::FileScanRequest& request, const RowGroupReadPlan& row_group_plan) {
+        const format::FileScanRequest& request) {
+#ifdef BE_TEST
+    detail::physical_leaf_set_builds.fetch_add(1, std::memory_order_relaxed);
+#endif
     std::unordered_set<int> leaf_column_ids;
     size_t candidate_ordinal = 0;
     const auto collect_projection = [&](const format::LocalColumnIndex& projection) {
@@ -401,9 +421,8 @@ std::unordered_set<int> physical_leaf_column_ids_for_row_group(
             file_schema[local_id] == nullptr) {
             return;
         }
-        collect_physical_leaf_column_ids(*file_schema[local_id], projection,
-                                         row_group_plan.full_variant_projection_ordinals,
-                                         &candidate_ordinal, &leaf_column_ids);
+        collect_physical_leaf_column_ids(*file_schema[local_id], projection, {}, &candidate_ordinal,
+                                         &leaf_column_ids);
     };
     for (const auto& projection : request.predicate_columns) {
         collect_projection(projection);
@@ -412,6 +431,58 @@ std::unordered_set<int> physical_leaf_column_ids_for_row_group(
         if (!request.is_count_star_placeholder(projection.column_id())) {
             collect_projection(projection);
         }
+    }
+    return leaf_column_ids;
+}
+
+void collect_full_variant_leaf_delta(const ParquetColumnSchema& schema,
+                                     const format::LocalColumnIndex& projection,
+                                     std::span<const size_t> full_ordinals,
+                                     size_t* candidate_ordinal,
+                                     std::unordered_set<int>* leaf_column_ids) {
+    DORIS_CHECK(candidate_ordinal != nullptr && leaf_column_ids != nullptr);
+    if (!format::is_partial_projection(&projection)) {
+        return;
+    }
+    if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
+        if (std::ranges::binary_search(full_ordinals, *candidate_ordinal)) {
+            collect_all_leaf_column_ids(schema, leaf_column_ids);
+        }
+        ++*candidate_ordinal;
+        return;
+    }
+    for (const auto& child_projection : projection.children) {
+        const auto* child_schema = projection_schema_child(schema, child_projection.local_id());
+        DORIS_CHECK(child_schema != nullptr);
+        collect_full_variant_leaf_delta(*child_schema, child_projection, full_ordinals,
+                                        candidate_ordinal, leaf_column_ids);
+    }
+}
+
+std::optional<std::unordered_set<int>> row_group_leaf_column_ids(
+        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        const format::FileScanRequest& request, const RowGroupReadPlan& row_group_plan,
+        const std::unordered_set<int>& request_leaf_ids) {
+    if (row_group_plan.full_variant_projection_ordinals.empty()) {
+        return std::nullopt;
+    }
+    auto leaf_column_ids = request_leaf_ids;
+    size_t candidate_ordinal = 0;
+    const auto collect_projection = [&](const format::LocalColumnIndex& projection) {
+        const int32_t local_id = projection.local_id();
+        if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size()) ||
+            file_schema[local_id] == nullptr || !file_schema[local_id]->contains_variant) {
+            return;
+        }
+        collect_full_variant_leaf_delta(*file_schema[local_id], projection,
+                                        row_group_plan.full_variant_projection_ordinals,
+                                        &candidate_ordinal, &leaf_column_ids);
+    };
+    for (const auto& projection : request.predicate_columns) {
+        collect_projection(projection);
+    }
+    for (const auto& projection : request.non_predicate_columns) {
+        collect_projection(projection);
     }
     return leaf_column_ids;
 }
@@ -616,10 +687,10 @@ Status finalize_native_row_group_read_plan(
         const NativeParquetMetadata& metadata,
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const format::FileScanRequest& request, bool enable_bloom_filter,
-        RowGroupReadPlan* row_group_plan, ParquetPruningStats* pruning_stats,
-        const cctz::time_zone* timezone, const RuntimeState* runtime_state,
-        ParquetFileContext* file_context, const ParquetColumnReaderProfile& column_reader_profile,
-        bool* selected) {
+        const std::unordered_set<int>& request_leaf_ids, RowGroupReadPlan* row_group_plan,
+        ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone,
+        const RuntimeState* runtime_state, ParquetFileContext* file_context,
+        const ParquetColumnReaderProfile& column_reader_profile, bool* selected) {
     DORIS_CHECK(row_group_plan != nullptr && pruning_stats != nullptr && file_context != nullptr &&
                 selected != nullptr);
     *selected = true;
@@ -628,8 +699,10 @@ Status finalize_native_row_group_read_plan(
     }
     row_group_plan->expensive_pruning_pending = false;
     const auto& thrift = metadata.to_thrift();
-    const auto requested_leaf_ids =
-            physical_leaf_column_ids_for_row_group(file_schema, request, *row_group_plan);
+    const auto row_group_leaf_ids =
+            row_group_leaf_column_ids(file_schema, request, *row_group_plan, request_leaf_ids);
+    const auto& requested_leaf_ids =
+            row_group_leaf_ids.has_value() ? *row_group_leaf_ids : request_leaf_ids;
     const std::vector<int> candidate {row_group_plan->row_group_id};
     std::vector<int> metadata_selected;
     RETURN_IF_ERROR(select_row_groups_by_metadata(
@@ -706,6 +779,7 @@ Status plan_parquet_row_groups(const NativeParquetMetadata& metadata,
     DORIS_CHECK(plan != nullptr && file_context != nullptr);
     plan->row_groups.clear();
     plan->pruning_stats = {};
+    plan->requested_leaf_column_ids = request_leaf_column_ids(file_schema, request);
     plan->enable_bloom_filter = enable_bloom_filter;
     std::vector<int64_t> row_group_first_rows;
     std::vector<int> scan_range_selected;
@@ -717,8 +791,11 @@ Status plan_parquet_row_groups(const NativeParquetMetadata& metadata,
     std::vector<RowGroupReadPlan> metadata_selected_plans;
     metadata_selected_plans.reserve(plan->row_groups.size());
     for (auto& row_group_plan : plan->row_groups) {
-        const auto requested_leaf_ids =
-                physical_leaf_column_ids_for_row_group(file_schema, request, row_group_plan);
+        const auto row_group_leaf_ids = row_group_leaf_column_ids(
+                file_schema, request, row_group_plan, plan->requested_leaf_column_ids);
+        const auto& requested_leaf_ids = row_group_leaf_ids.has_value()
+                                                 ? *row_group_leaf_ids
+                                                 : plan->requested_leaf_column_ids;
         const std::vector<int> candidate {row_group_plan.row_group_id};
         std::vector<int> metadata_selected;
         RETURN_IF_ERROR(select_row_groups_by_metadata(
@@ -749,9 +826,9 @@ Status finalize_parquet_row_group_plans(
         ParquetPruningStats deferred_stats;
         bool selected = false;
         RETURN_IF_ERROR(finalize_native_row_group_read_plan(
-                metadata, file_schema, request, enable_bloom_filter, &row_group_plan,
-                &deferred_stats, timezone, runtime_state, file_context, column_reader_profile,
-                &selected));
+                metadata, file_schema, request, enable_bloom_filter,
+                plan->requested_leaf_column_ids, &row_group_plan, &deferred_stats, timezone,
+                runtime_state, file_context, column_reader_profile, &selected));
         if (parquet_profile != nullptr) {
             parquet_profile->update_deferred_pruning_stats(deferred_stats, selected);
         }
@@ -1034,6 +1111,7 @@ void ParquetScanScheduler::set_plan(std::shared_ptr<RowGroupScanPlan> plan) {
     _condition_cache_filtered_rows = 0;
     _predicate_filtered_rows = 0;
     _remaining_plans_need_replanning = false;
+    _requested_leaf_ids_need_refresh = false;
     reset();
 }
 
@@ -1111,6 +1189,7 @@ void ParquetScanScheduler::activate_pending_scan_request_at_row_group_boundary()
     // Footer plans and adaptive ordering describe the previous predicate snapshot. Reusing either
     // after a late runtime filter would miss pruning or bias the new predicate order with stale data.
     _remaining_plans_need_replanning = true;
+    _requested_leaf_ids_need_refresh = true;
     _predicate_schedule = {};
     _predicate_positions_scratch.clear();
     _predicate_indices_by_position_scratch.clear();
@@ -1261,6 +1340,12 @@ Status ParquetScanScheduler::open_next_row_group(
     *has_row_group = false;
     RowGroupReadPlan* selected_plan = nullptr;
     DORIS_CHECK(_scan_plan != nullptr);
+    if (_requested_leaf_ids_need_refresh) {
+        // A runtime-filter refresh changes the immutable projection baseline exactly once; later
+        // row groups only apply their full-Variant fallback delta to this rebuilt set.
+        _scan_plan->requested_leaf_column_ids = request_leaf_column_ids(file_schema, request);
+        _requested_leaf_ids_need_refresh = false;
+    }
     while (_next_row_group_plan_idx < _scan_plan->row_groups.size()) {
         RowGroupReadPlan& candidate_plan = _scan_plan->row_groups[_next_row_group_plan_idx++];
         // Probe only the row group about to execute. This keeps LIMIT/cancellation latency
@@ -1279,8 +1364,11 @@ Status ParquetScanScheduler::open_next_row_group(
             const auto& row_group = file_context.native_metadata->to_thrift()
                                             .row_groups[candidate_plan.row_group_id];
             prepare_row_group_physical_projection(row_group, file_schema, request, &candidate_plan);
-            const auto requested_leaf_ids =
-                    physical_leaf_column_ids_for_row_group(file_schema, request, candidate_plan);
+            const auto row_group_leaf_ids = row_group_leaf_column_ids(
+                    file_schema, request, candidate_plan, _scan_plan->requested_leaf_column_ids);
+            const auto& requested_leaf_ids = row_group_leaf_ids.has_value()
+                                                     ? *row_group_leaf_ids
+                                                     : _scan_plan->requested_leaf_column_ids;
             const std::vector<int> candidate {candidate_plan.row_group_id};
             std::vector<int> footer_selected;
             RETURN_IF_ERROR(select_row_groups_by_metadata(
@@ -1298,8 +1386,8 @@ Status ParquetScanScheduler::open_next_row_group(
         bool selected = false;
         RETURN_IF_ERROR(finalize_native_row_group_read_plan(
                 *file_context.native_metadata, file_schema, request, _enable_bloom_filter,
-                &candidate_plan, &deferred_stats, _timezone, _runtime_state, &file_context,
-                _scan_profile.column_reader_profile, &selected));
+                _scan_plan->requested_leaf_column_ids, &candidate_plan, &deferred_stats, _timezone,
+                _runtime_state, &file_context, _scan_profile.column_reader_profile, &selected));
         if (_parquet_profile != nullptr) {
             _parquet_profile->update_deferred_pruning_stats(deferred_stats, selected);
         }

--- a/be/src/format_v2/parquet/parquet_scan.cpp
+++ b/be/src/format_v2/parquet/parquet_scan.cpp
@@ -275,6 +275,52 @@ VariantRowGroupProjectionCounts finalize_variant_projections_for_row_group(
     return counts;
 }
 
+void prepare_row_group_physical_projection(
+        const tparquet::RowGroup& row_group,
+        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        const format::FileScanRequest& request, RowGroupReadPlan* row_group_plan) {
+    DORIS_CHECK(row_group_plan != nullptr);
+    const auto may_project_variant_leaf = [&](const auto& projections) {
+        return std::ranges::any_of(projections, [&](const auto& projection) {
+            const int32_t local_id = projection.local_id();
+            return local_id >= 0 && local_id < static_cast<int32_t>(file_schema.size()) &&
+                   file_schema[local_id] != nullptr && file_schema[local_id]->contains_variant &&
+                   format::is_partial_projection(&projection);
+        });
+    };
+    if (!may_project_variant_leaf(request.predicate_columns) &&
+        !may_project_variant_leaf(request.non_predicate_columns)) {
+        row_group_plan->physical_predicate_columns = {};
+        row_group_plan->physical_non_predicate_columns = {};
+        row_group_plan->has_row_group_physical_projection = false;
+        row_group_plan->variant_leaf_projection_columns = 0;
+        row_group_plan->variant_full_projection_columns = 0;
+        return;
+    }
+    row_group_plan->physical_predicate_columns = request.predicate_columns;
+    row_group_plan->physical_non_predicate_columns = request.non_predicate_columns;
+    const auto predicate_counts = finalize_variant_projections_for_row_group(
+            row_group, file_schema, &row_group_plan->physical_predicate_columns);
+    const auto non_predicate_counts = finalize_variant_projections_for_row_group(
+            row_group, file_schema, &row_group_plan->physical_non_predicate_columns);
+    row_group_plan->variant_leaf_projection_columns =
+            predicate_counts.leaf + non_predicate_counts.leaf;
+    row_group_plan->variant_full_projection_columns =
+            predicate_counts.full + non_predicate_counts.full;
+    row_group_plan->has_row_group_physical_projection = true;
+}
+
+std::optional<format::FileScanRequest> physical_request_for_row_group(
+        const format::FileScanRequest& request, const RowGroupReadPlan& row_group_plan) {
+    if (!row_group_plan.has_row_group_physical_projection) {
+        return std::nullopt;
+    }
+    auto physical_request = request;
+    physical_request.predicate_columns = row_group_plan.physical_predicate_columns;
+    physical_request.non_predicate_columns = row_group_plan.physical_non_predicate_columns;
+    return std::optional<format::FileScanRequest>(std::move(physical_request));
+}
+
 void materialize_count_star_placeholders(const format::FileScanRequest& request, size_t rows,
                                          Block* file_block) {
     DORIS_CHECK(file_block != nullptr);
@@ -470,19 +516,22 @@ Status finalize_native_row_group_read_plan(
     }
     row_group_plan->expensive_pruning_pending = false;
     const auto& thrift = metadata.to_thrift();
+    const auto physical_request_storage = physical_request_for_row_group(request, *row_group_plan);
+    const auto& physical_request =
+            physical_request_storage.has_value() ? *physical_request_storage : request;
     const std::vector<int> candidate {row_group_plan->row_group_id};
     std::vector<int> metadata_selected;
     RETURN_IF_ERROR(select_row_groups_by_metadata(
-            thrift, file_schema, request, &candidate, &metadata_selected, enable_bloom_filter,
-            pruning_stats, timezone, runtime_state, file_context, column_reader_profile,
-            ParquetMetadataProbeMode::EXPENSIVE_ONLY));
+            thrift, file_schema, physical_request, &candidate, &metadata_selected,
+            enable_bloom_filter, pruning_stats, timezone, runtime_state, file_context,
+            column_reader_profile, ParquetMetadataProbeMode::EXPENSIVE_ONLY));
     if (metadata_selected.empty()) {
         *selected = false;
         return Status::OK();
     }
 
     std::unordered_set<int> requested_leaf_ids;
-    for (const auto& projection : request_scan_columns(request)) {
+    for (const auto& projection : request_scan_columns(physical_request)) {
         const auto local_id = projection.local_id();
         if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size())) {
             continue;
@@ -490,7 +539,7 @@ Status finalize_native_row_group_read_plan(
         collect_projected_leaf_column_ids(*file_schema[local_id], projection, &requested_leaf_ids);
     }
     std::unordered_map<int, NativeParquetPageIndex> page_indexes;
-    if (can_use_parquet_page_index(request, runtime_state)) {
+    if (can_use_parquet_page_index(physical_request, runtime_state)) {
         RETURN_IF_ERROR(file_context->load_native_page_indexes(
                 row_group_plan->row_group_id, requested_leaf_ids, &page_indexes,
                 &pruning_stats->read_page_index_time, &pruning_stats->parse_page_index_time));
@@ -499,8 +548,8 @@ Status finalize_native_row_group_read_plan(
     std::map<int, ParquetPageSkipPlan> page_skip_plans;
     RETURN_IF_ERROR(select_row_group_ranges_by_native_page_index(
             thrift, thrift.row_groups[row_group_plan->row_group_id], page_indexes, file_schema,
-            request, row_group_plan->row_group_rows, &page_selected_ranges, &page_skip_plans,
-            pruning_stats, timezone, runtime_state));
+            physical_request, row_group_plan->row_group_rows, &page_selected_ranges,
+            &page_skip_plans, pruning_stats, timezone, runtime_state));
     row_group_plan->selected_ranges =
             intersect_row_ranges(row_group_plan->selected_ranges, page_selected_ranges);
     row_group_plan->page_skip_plans = std::move(page_skip_plans);
@@ -536,6 +585,7 @@ Status build_native_row_group_read_plans(
         row_group_plan.row_group_rows = row_group.num_rows;
         row_group_plan.selected_ranges = {{.start = 0, .length = row_group.num_rows}};
         row_group_plan.expensive_pruning_pending = true;
+        prepare_row_group_physical_projection(row_group, file_schema, request, &row_group_plan);
         plan->row_groups.push_back(std::move(row_group_plan));
     }
     return Status::OK();
@@ -558,14 +608,28 @@ Status plan_parquet_row_groups(const NativeParquetMetadata& metadata,
     std::vector<int> scan_range_selected;
     RETURN_IF_ERROR(detail::select_native_row_groups_by_scan_range(
             metadata.to_thrift(), scan_range, &row_group_first_rows, &scan_range_selected));
-    std::vector<int> metadata_selected;
-    RETURN_IF_ERROR(select_row_groups_by_metadata(
-            metadata.to_thrift(), file_schema, request, &scan_range_selected, &metadata_selected,
-            enable_bloom_filter, &plan->pruning_stats, timezone, runtime_state, file_context,
-            column_reader_profile, ParquetMetadataProbeMode::FOOTER_ONLY));
     RETURN_IF_ERROR(build_native_row_group_read_plans(metadata, file_schema, request,
-                                                      metadata_selected, row_group_first_rows, plan,
-                                                      timezone, runtime_state, file_context));
+                                                      scan_range_selected, row_group_first_rows,
+                                                      plan, timezone, runtime_state, file_context));
+    std::vector<RowGroupReadPlan> metadata_selected_plans;
+    metadata_selected_plans.reserve(plan->row_groups.size());
+    for (auto& row_group_plan : plan->row_groups) {
+        const auto physical_request_storage =
+                physical_request_for_row_group(request, row_group_plan);
+        const auto& physical_request =
+                physical_request_storage.has_value() ? *physical_request_storage : request;
+        const std::vector<int> candidate {row_group_plan.row_group_id};
+        std::vector<int> metadata_selected;
+        RETURN_IF_ERROR(select_row_groups_by_metadata(
+                metadata.to_thrift(), file_schema, physical_request, &candidate, &metadata_selected,
+                enable_bloom_filter, &plan->pruning_stats, timezone, runtime_state, file_context,
+                column_reader_profile, ParquetMetadataProbeMode::FOOTER_ONLY));
+        if (!metadata_selected.empty()) {
+            metadata_selected_plans.push_back(std::move(row_group_plan));
+        }
+    }
+    plan->row_groups = std::move(metadata_selected_plans);
+    plan->pruning_stats.total_row_groups = cast_set<int64_t>(scan_range_selected.size());
     plan->pruning_stats.selected_row_groups = plan->row_groups.size();
     return Status::OK();
 }
@@ -1109,11 +1173,18 @@ Status ParquetScanScheduler::open_next_row_group(
             candidate_plan.expensive_pruning_pending = true;
             candidate_plan.page_skip_plans.clear();
             candidate_plan.offset_indexes.clear();
+            const auto& row_group = file_context.native_metadata->to_thrift()
+                                            .row_groups[candidate_plan.row_group_id];
+            prepare_row_group_physical_projection(row_group, file_schema, request, &candidate_plan);
+            const auto physical_request_storage =
+                    physical_request_for_row_group(request, candidate_plan);
+            const auto& physical_request =
+                    physical_request_storage.has_value() ? *physical_request_storage : request;
             const std::vector<int> candidate {candidate_plan.row_group_id};
             std::vector<int> footer_selected;
             RETURN_IF_ERROR(select_row_groups_by_metadata(
-                    file_context.native_metadata->to_thrift(), file_schema, request, &candidate,
-                    &footer_selected, _enable_bloom_filter, &deferred_stats, _timezone,
+                    file_context.native_metadata->to_thrift(), file_schema, physical_request,
+                    &candidate, &footer_selected, _enable_bloom_filter, &deferred_stats, _timezone,
                     _runtime_state, &file_context, _scan_profile.column_reader_profile,
                     ParquetMetadataProbeMode::FOOTER_ONLY));
             if (footer_selected.empty()) {
@@ -1155,20 +1226,16 @@ Status ParquetScanScheduler::open_next_row_group(
     const auto& row_group_metadata =
             file_context.native_metadata->to_thrift().row_groups[row_group_idx];
     _current_row_group_request = std::make_unique<format::FileScanRequest>();
-    _current_row_group_request->predicate_columns = request.predicate_columns;
-    _current_row_group_request->non_predicate_columns = request.non_predicate_columns;
+    _current_row_group_request->predicate_columns =
+            row_group_plan.has_row_group_physical_projection
+                    ? row_group_plan.physical_predicate_columns
+                    : request.predicate_columns;
+    _current_row_group_request->non_predicate_columns =
+            row_group_plan.has_row_group_physical_projection
+                    ? row_group_plan.physical_non_predicate_columns
+                    : request.non_predicate_columns;
     _current_row_group_request->count_star_placeholder_columns =
             request.count_star_placeholder_columns;
-    VariantRowGroupProjectionCounts variant_projection_counts;
-    if (file_context.contains_variant) {
-        const auto predicate_counts = finalize_variant_projections_for_row_group(
-                row_group_metadata, file_schema, &_current_row_group_request->predicate_columns);
-        const auto non_predicate_counts = finalize_variant_projections_for_row_group(
-                row_group_metadata, file_schema,
-                &_current_row_group_request->non_predicate_columns);
-        variant_projection_counts.leaf = predicate_counts.leaf + non_predicate_counts.leaf;
-        variant_projection_counts.full = predicate_counts.full + non_predicate_counts.full;
-    }
     const auto& row_group_request = *_current_row_group_request;
     _current_row_group_rows = row_group_metadata.num_rows;
     DORIS_CHECK(_current_row_group_rows == row_group_plan.row_group_rows);
@@ -1313,10 +1380,12 @@ Status ParquetScanScheduler::open_next_row_group(
                 &_current_non_predicate_prefetched));
     }
     if (_parquet_profile != nullptr) {
-        update_counter_if_not_null(_parquet_profile->variant_leaf_projection_row_group_columns,
-                                   cast_set<int64_t>(variant_projection_counts.leaf));
-        update_counter_if_not_null(_parquet_profile->variant_full_projection_row_group_columns,
-                                   cast_set<int64_t>(variant_projection_counts.full));
+        update_counter_if_not_null(
+                _parquet_profile->variant_leaf_projection_row_group_columns,
+                cast_set<int64_t>(row_group_plan.variant_leaf_projection_columns));
+        update_counter_if_not_null(
+                _parquet_profile->variant_full_projection_row_group_columns,
+                cast_set<int64_t>(row_group_plan.variant_full_projection_columns));
     }
     *has_row_group = true;
     return Status::OK();

--- a/be/src/format_v2/parquet/parquet_scan.cpp
+++ b/be/src/format_v2/parquet/parquet_scan.cpp
@@ -252,6 +252,29 @@ std::vector<format::LocalColumnIndex> physical_non_predicate_columns(
     return columns;
 }
 
+struct VariantRowGroupProjectionCounts {
+    size_t leaf = 0;
+    size_t full = 0;
+};
+
+VariantRowGroupProjectionCounts finalize_variant_projections_for_row_group(
+        const tparquet::RowGroup& row_group,
+        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        std::vector<format::LocalColumnIndex>* projections) {
+    DORIS_CHECK(projections != nullptr);
+    VariantRowGroupProjectionCounts counts;
+    for (auto& projection : *projections) {
+        const int32_t local_id = projection.local_id();
+        if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size()) ||
+            !file_schema[local_id]->contains_variant) {
+            continue;
+        }
+        counts.leaf += detail::finalize_variant_leaf_projection_for_row_group(
+                row_group, *file_schema[local_id], &projection, &counts.full);
+    }
+    return counts;
+}
+
 void materialize_count_star_placeholders(const format::FileScanRequest& request, size_t rows,
                                          Block* file_block) {
     DORIS_CHECK(file_block != nullptr);
@@ -941,6 +964,7 @@ void ParquetScanScheduler::reset_current_row_group() {
     _has_current_row_group = false;
     _current_predicate_columns.clear();
     _current_non_predicate_columns.clear();
+    _current_row_group_request.reset();
     _current_dictionary_filters.clear();
     _current_dictionary_residual_conjuncts.clear();
     _current_row_group_rows = 0;
@@ -1017,11 +1041,12 @@ const detail::PredicateConjunctSchedule& ParquetScanScheduler::predicate_conjunc
 }
 
 std::vector<format::LocalColumnIndex> ParquetScanScheduler::adaptive_predicate_prefetch_columns(
-        const format::FileScanRequest& request) {
+        const format::FileScanRequest& request,
+        const std::vector<format::LocalColumnIndex>& physical_predicate_columns) {
     std::vector<size_t> positions;
     std::unordered_map<size_t, const format::LocalColumnIndex*> columns_by_position;
-    columns_by_position.reserve(request.predicate_columns.size());
-    for (const auto& column : request.predicate_columns) {
+    columns_by_position.reserve(physical_predicate_columns.size());
+    for (const auto& column : physical_predicate_columns) {
         const auto position_it = request.local_positions.find(column.column_id());
         DORIS_CHECK(position_it != request.local_positions.end());
         const size_t position = position_it->second.value();
@@ -1129,6 +1154,22 @@ Status ParquetScanScheduler::open_next_row_group(
 
     const auto& row_group_metadata =
             file_context.native_metadata->to_thrift().row_groups[row_group_idx];
+    _current_row_group_request = std::make_unique<format::FileScanRequest>();
+    _current_row_group_request->predicate_columns = request.predicate_columns;
+    _current_row_group_request->non_predicate_columns = request.non_predicate_columns;
+    _current_row_group_request->count_star_placeholder_columns =
+            request.count_star_placeholder_columns;
+    VariantRowGroupProjectionCounts variant_projection_counts;
+    if (file_context.contains_variant) {
+        const auto predicate_counts = finalize_variant_projections_for_row_group(
+                row_group_metadata, file_schema, &_current_row_group_request->predicate_columns);
+        const auto non_predicate_counts = finalize_variant_projections_for_row_group(
+                row_group_metadata, file_schema,
+                &_current_row_group_request->non_predicate_columns);
+        variant_projection_counts.leaf = predicate_counts.leaf + non_predicate_counts.leaf;
+        variant_projection_counts.full = predicate_counts.full + non_predicate_counts.full;
+    }
+    const auto& row_group_request = *_current_row_group_request;
     _current_row_group_rows = row_group_metadata.num_rows;
     DORIS_CHECK(_current_row_group_rows == row_group_plan.row_group_rows);
     DORIS_CHECK(_current_row_group_rows > 0);
@@ -1165,6 +1206,7 @@ Status ParquetScanScheduler::open_next_row_group(
     _current_non_predicate_columns.clear();
     _current_dictionary_filters.clear();
     RETURN_IF_ERROR(prepare_current_dictionary_filters(file_context, file_schema, request,
+                                                       row_group_request.predicate_columns,
                                                        row_group_idx, row_group_metadata));
     // Dictionary probing is complete, so the native data-page readers can now share the same
     // row-group-scoped MergeRangeFileReader policy as v1. Sharing one wrapper is important: a
@@ -1175,7 +1217,7 @@ Status ParquetScanScheduler::open_next_row_group(
             thrift_metadata.__isset.created_by ? thrift_metadata.created_by : std::string {});
     std::vector<ParquetPageCacheRange> native_ranges;
     RETURN_IF_ERROR(detail::build_native_prefetch_ranges(
-            thrift_metadata, file_schema, request_scan_columns(request), row_group_idx,
+            thrift_metadata, file_schema, request_scan_columns(row_group_request), row_group_idx,
             file_context.native_file->size(), compat.parquet_816_padding, &native_ranges));
     if (request.non_predicate_positions.empty()) {
         _current_merge_range_active = file_context.set_native_random_access_ranges(
@@ -1189,7 +1231,7 @@ Status ParquetScanScheduler::open_next_row_group(
                 {}, 0, _profile, _merge_read_slice_size);
     }
 
-    for (const auto& col : request.predicate_columns) {
+    for (const auto& col : row_group_request.predicate_columns) {
         const auto local_id = col.column_id();
         if (_current_predicate_columns.contains(local_id)) {
             continue;
@@ -1225,11 +1267,12 @@ Status ParquetScanScheduler::open_next_row_group(
     // BufferedFileStreamReader later consumes the same Doris file-cache blocks; prefetch never
     // changes row/column materialization order.
     if (!_current_merge_range_active) {
-        const auto prefetch_columns = adaptive_predicate_prefetch_columns(request);
+        const auto prefetch_columns =
+                adaptive_predicate_prefetch_columns(request, row_group_request.predicate_columns);
         RETURN_IF_ERROR(prefetch_current_row_group_columns(
                 file_context, file_schema, prefetch_columns, &_current_predicate_prefetched));
     }
-    for (const auto& col : request.non_predicate_columns) {
+    for (const auto& col : row_group_request.non_predicate_columns) {
         const auto local_id = col.column_id();
         if (request.is_count_star_placeholder(col.column_id())) {
             continue;
@@ -1265,9 +1308,15 @@ Status ParquetScanScheduler::open_next_row_group(
         // With no row-level filters there is no lazy-read decision to wait for, so start warming
         // output chunks immediately after their readers are created. Filtered scans still defer
         // this until at least one row survives the predicate phase.
-        RETURN_IF_ERROR(prefetch_current_row_group_columns(file_context, file_schema,
-                                                           physical_non_predicate_columns(request),
-                                                           &_current_non_predicate_prefetched));
+        RETURN_IF_ERROR(prefetch_current_row_group_columns(
+                file_context, file_schema, physical_non_predicate_columns(row_group_request),
+                &_current_non_predicate_prefetched));
+    }
+    if (_parquet_profile != nullptr) {
+        update_counter_if_not_null(_parquet_profile->variant_leaf_projection_row_group_columns,
+                                   cast_set<int64_t>(variant_projection_counts.leaf));
+        update_counter_if_not_null(_parquet_profile->variant_full_projection_row_group_columns,
+                                   cast_set<int64_t>(variant_projection_counts.full));
     }
     *has_row_group = true;
     return Status::OK();
@@ -1735,7 +1784,8 @@ Status build_dictionary_entry_filter(size_t block_position,
 Status ParquetScanScheduler::prepare_current_dictionary_filters(
         ParquetFileContext& file_context,
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
-        const format::FileScanRequest& request, int row_group_idx,
+        const format::FileScanRequest& request,
+        const std::vector<format::LocalColumnIndex>& physical_predicate_columns, int row_group_idx,
         const tparquet::RowGroup& row_group_metadata) {
     _current_dictionary_filters.clear();
     _current_dictionary_residual_conjuncts.clear();
@@ -1752,7 +1802,7 @@ Status ParquetScanScheduler::prepare_current_dictionary_filters(
     }
 
     SCOPED_TIMER(_scan_profile.dict_filter_rewrite_time);
-    for (const auto& col : request.predicate_columns) {
+    for (const auto& col : physical_predicate_columns) {
         const auto local_id = col.column_id();
         if (!local_id.is_valid() || local_id.value() >= static_cast<int32_t>(file_schema.size())) {
             continue;
@@ -2601,9 +2651,11 @@ Status ParquetScanScheduler::read_current_row_group_batch(
         // Do not prefetch lazy output columns until at least one row survives filtering. This is
         // the same decision point where the v2 reader switches from predicate-only reads to
         // materializing non-predicate columns, so fully filtered batches avoid unnecessary IO.
-        RETURN_IF_ERROR(prefetch_current_row_group_columns(file_context, file_schema,
-                                                           physical_non_predicate_columns(request),
-                                                           &_current_non_predicate_prefetched));
+        DORIS_CHECK(_current_row_group_request != nullptr);
+        RETURN_IF_ERROR(prefetch_current_row_group_columns(
+                file_context, file_schema,
+                physical_non_predicate_columns(*_current_row_group_request),
+                &_current_non_predicate_prefetched));
     }
 
     if (selected_rows > _batch_size) {

--- a/be/src/format_v2/parquet/parquet_scan.h
+++ b/be/src/format_v2/parquet/parquet_scan.h
@@ -81,6 +81,9 @@ size_t finalize_variant_leaf_projection_for_row_group(const tparquet::RowGroup& 
                                                       const ParquetColumnSchema& schema,
                                                       format::LocalColumnIndex* projection,
                                                       size_t* full_projections = nullptr);
+bool variant_leaf_projection_is_safe_for_row_group(const tparquet::RowGroup& row_group,
+                                                   const ParquetColumnSchema& schema,
+                                                   const format::LocalColumnIndex& projection);
 
 std::vector<size_t> order_adaptive_predicates(
         const std::vector<size_t>& positions,
@@ -122,16 +125,18 @@ struct RowGroupReadPlan {
     // Deferred planning transfers parsed indexes to execution so narrowed scans never issue the
     // same remote index reads a second time while opening the row group.
     std::unordered_map<int, tparquet::OffsetIndex> offset_indexes;
-    // Variant leaf/full selection is row-group scoped and must be fixed before footer byte
-    // accounting, metadata probes, page indexes, prefetch, and physical readers use the request.
-    std::vector<format::LocalColumnIndex> physical_predicate_columns;
-    std::vector<format::LocalColumnIndex> physical_non_predicate_columns;
-    bool has_row_group_physical_projection = false;
+    // Candidate ordinals refer to a deterministic traversal of the immutable request projection.
+    // Only full fallbacks are retained, keeping the row-group delta independent of projection size.
+    std::vector<size_t> full_variant_projection_ordinals;
     size_t variant_leaf_projection_columns = 0;
     size_t variant_full_projection_columns = 0;
     // Footer statistics are cheap and eager. Remote dictionary/Bloom/page-index probes fill the
     // remaining fields only when this row group reaches the scheduler.
     bool expensive_pruning_pending = false;
+
+    bool has_row_group_physical_projection() const {
+        return !full_variant_projection_ordinals.empty();
+    }
 };
 
 struct RowGroupScanPlan {
@@ -179,7 +184,7 @@ class ParquetScanScheduler {
 public:
     static constexpr int64_t DEFAULT_READ_BATCH_SIZE = 4096;
 
-    void set_plan(RowGroupScanPlan plan);
+    void set_plan(std::shared_ptr<RowGroupScanPlan> plan);
     void set_page_skip_profile(ParquetPageSkipProfile page_skip_profile) {
         _page_skip_profile = page_skip_profile;
     }
@@ -211,7 +216,7 @@ public:
         _batch_size = batch_size == 0 ? 1 : static_cast<int64_t>(batch_size);
     }
     void reset();
-    bool empty() const { return _row_group_plans.empty(); }
+    bool empty() const { return _scan_plan == nullptr || _scan_plan->row_groups.empty(); }
     int64_t condition_cache_filtered_rows() const { return _condition_cache_filtered_rows; }
     int64_t predicate_filtered_rows() const { return _predicate_filtered_rows; }
     int64_t raw_rows_read() const { return _raw_rows_read; }
@@ -269,8 +274,8 @@ private:
     void mark_condition_cache_granules(const SelectionVector& selection, uint16_t selected_rows,
                                        int64_t batch_first_file_row);
 
-    std::vector<RowGroupReadPlan> _row_group_plans; // row group queue to scan
-    size_t _next_row_group_plan_idx = 0;            // index of the next row group to process
+    std::shared_ptr<RowGroupScanPlan> _scan_plan; // shared with the reader's aggregate path
+    size_t _next_row_group_plan_idx = 0;          // index of the next row group to process
 
     bool _has_current_row_group = false;
     // Readers retain pointers into this immutable row-group map, so it must outlive both maps below.

--- a/be/src/format_v2/parquet/parquet_scan.h
+++ b/be/src/format_v2/parquet/parquet_scan.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -104,6 +105,10 @@ Status select_native_row_groups_by_scan_range(const tparquet::FileMetaData& meta
                                               const ParquetScanRange& scan_range,
                                               std::vector<int64_t>* row_group_first_rows,
                                               std::vector<int>* selected_row_groups);
+#ifdef BE_TEST
+void reset_physical_leaf_set_build_count();
+size_t physical_leaf_set_build_count();
+#endif
 } // namespace detail
 
 // ============================================================================
@@ -142,6 +147,8 @@ struct RowGroupReadPlan {
 struct RowGroupScanPlan {
     std::vector<RowGroupReadPlan> row_groups; // row groups selected after pruning
     ParquetPruningStats pruning_stats;        // pruning statistics
+    // Row-group plans only add full-fallback leaves to this immutable request-level baseline.
+    std::unordered_set<int> requested_leaf_column_ids;
     bool enable_bloom_filter = false;
 };
 
@@ -337,6 +344,7 @@ private:
     std::shared_ptr<format::FileScanRequest> _active_request;
     std::shared_ptr<format::FileScanRequest> _pending_request;
     bool _remaining_plans_need_replanning = false;
+    bool _requested_leaf_ids_need_refresh = false;
     detail::PredicateConjunctSchedule _predicate_schedule;
     std::vector<size_t> _predicate_positions_scratch;
     std::unordered_map<size_t, size_t> _predicate_indices_by_position_scratch;

--- a/be/src/format_v2/parquet/parquet_scan.h
+++ b/be/src/format_v2/parquet/parquet_scan.h
@@ -77,6 +77,11 @@ struct AdaptivePredicateStats {
     size_t samples = 0;
 };
 
+size_t finalize_variant_leaf_projection_for_row_group(const tparquet::RowGroup& row_group,
+                                                      const ParquetColumnSchema& schema,
+                                                      format::LocalColumnIndex* projection,
+                                                      size_t* full_projections = nullptr);
+
 std::vector<size_t> order_adaptive_predicates(
         const std::vector<size_t>& positions,
         const std::unordered_map<size_t, AdaptivePredicateStats>& stats);
@@ -218,7 +223,8 @@ private:
     const detail::PredicateConjunctSchedule& predicate_conjunct_schedule(
             const format::FileScanRequest& request);
     std::vector<format::LocalColumnIndex> adaptive_predicate_prefetch_columns(
-            const format::FileScanRequest& request);
+            const format::FileScanRequest& request,
+            const std::vector<format::LocalColumnIndex>& physical_predicate_columns);
 
     Status open_next_row_group(ParquetFileContext& file_context,
                                const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
@@ -235,8 +241,9 @@ private:
     Status prepare_current_dictionary_filters(
             ParquetFileContext& file_context,
             const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
-            const format::FileScanRequest& request, int row_group_idx,
-            const tparquet::RowGroup& row_group_metadata);
+            const format::FileScanRequest& request,
+            const std::vector<format::LocalColumnIndex>& physical_predicate_columns,
+            int row_group_idx, const tparquet::RowGroup& row_group_metadata);
 
     Status prefetch_current_row_group_columns(
             ParquetFileContext& file_context,
@@ -261,6 +268,9 @@ private:
     bool _has_current_row_group = false;
     // Readers retain pointers into this immutable row-group map, so it must outlive both maps below.
     std::unordered_map<int, tparquet::OffsetIndex> _current_offset_indexes;
+    // The logical request remains immutable across the file. This row-group copy owns only the
+    // physical projections used by readers and deferred prefetch.
+    std::unique_ptr<format::FileScanRequest> _current_row_group_request;
     // File-local ids are signed because virtual columns use reserved negative values. Keeping the
     // typed id as the map key prevents GLOBAL_ROWID_COLUMN_ID from wrapping to a storage ColumnId.
     std::map<format::LocalColumnId, std::unique_ptr<ParquetColumnReader>>

--- a/be/src/format_v2/parquet/parquet_scan.h
+++ b/be/src/format_v2/parquet/parquet_scan.h
@@ -122,6 +122,13 @@ struct RowGroupReadPlan {
     // Deferred planning transfers parsed indexes to execution so narrowed scans never issue the
     // same remote index reads a second time while opening the row group.
     std::unordered_map<int, tparquet::OffsetIndex> offset_indexes;
+    // Variant leaf/full selection is row-group scoped and must be fixed before footer byte
+    // accounting, metadata probes, page indexes, prefetch, and physical readers use the request.
+    std::vector<format::LocalColumnIndex> physical_predicate_columns;
+    std::vector<format::LocalColumnIndex> physical_non_predicate_columns;
+    bool has_row_group_physical_projection = false;
+    size_t variant_leaf_projection_columns = 0;
+    size_t variant_full_projection_columns = 0;
     // Footer statistics are cheap and eager. Remote dictionary/Bloom/page-index probes fill the
     // remaining fields only when this row group reaches the scheduler.
     bool expensive_pruning_pending = false;

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -599,7 +599,7 @@ const ParquetColumnSchema* child_named(const ParquetColumnSchema& parent, std::s
 }
 
 struct ResolvedVariantShredding {
-    const ParquetColumnSchema* fallback_value = nullptr;
+    std::vector<const ParquetColumnSchema*> fallback_values;
     const ParquetColumnSchema* typed_value = nullptr;
 };
 
@@ -701,11 +701,15 @@ std::optional<ResolvedVariantShredding> resolve_variant_shredding(
     if (wrapper == nullptr || wrapper->kind != ParquetColumnSchemaKind::VARIANT) {
         return std::nullopt;
     }
+    std::vector<const ParquetColumnSchema*> fallback_values;
     for (const auto& component : predicate.path) {
+        const auto* fallback = child_named(*wrapper, "value");
         const auto* typed_object = child_named(*wrapper, "typed_value");
-        if (typed_object == nullptr || typed_object->kind != ParquetColumnSchemaKind::STRUCT) {
+        if (fallback == nullptr || fallback->kind != ParquetColumnSchemaKind::PRIMITIVE ||
+            typed_object == nullptr || typed_object->kind != ParquetColumnSchemaKind::STRUCT) {
             return std::nullopt;
         }
+        fallback_values.push_back(fallback);
         wrapper = child_named(*typed_object, component);
         if (wrapper == nullptr || wrapper->kind != ParquetColumnSchemaKind::STRUCT) {
             return std::nullopt;
@@ -726,7 +730,9 @@ std::optional<ResolvedVariantShredding> resolve_variant_shredding(
         !expr_zonemap::data_types_compatible(predicate.comparison_type, predicate.literal_type)) {
         return std::nullopt;
     }
-    return ResolvedVariantShredding {.fallback_value = fallback, .typed_value = typed};
+    fallback_values.push_back(fallback);
+    return ResolvedVariantShredding {.fallback_values = std::move(fallback_values),
+                                     .typed_value = typed};
 }
 
 bool fallback_is_all_null(const tparquet::RowGroup& row_group,
@@ -740,6 +746,17 @@ bool fallback_is_all_null(const tparquet::RowGroup& row_group,
            chunk.meta_data.num_values == row_group.num_rows && chunk.meta_data.__isset.statistics &&
            chunk.meta_data.statistics.__isset.null_count &&
            chunk.meta_data.statistics.null_count == chunk.meta_data.num_values;
+}
+
+bool variant_fallbacks_are_all_null(
+        const tparquet::RowGroup& row_group,
+        const std::vector<const ParquetColumnSchema*>& fallback_values) {
+    // A residual value at any wrapper can shadow its typed descendant, so every ancestor must be
+    // proven empty before typed-leaf statistics are a sound pruning proof.
+    return !fallback_values.empty() &&
+           std::ranges::all_of(fallback_values, [&](const auto* fallback) {
+               return fallback != nullptr && fallback_is_all_null(row_group, *fallback);
+           });
 }
 
 bool variant_statistics_exclude(const VariantShreddedPredicate& predicate,
@@ -1025,7 +1042,7 @@ bool check_shredded_variant_statistics(
         const auto shredding = resolve_variant_shredding(file_schema, request, *predicate);
         if (!shredding.has_value() || shredding->typed_value->leaf_column_id < 0 ||
             shredding->typed_value->leaf_column_id >= static_cast<int>(row_group.columns.size()) ||
-            !fallback_is_all_null(row_group, *shredding->fallback_value) ||
+            !variant_fallbacks_are_all_null(row_group, shredding->fallback_values) ||
             !variant_metadata_predicate_is_type_safe(*shredding->typed_value) ||
             !detail::has_supported_type_defined_order(metadata,
                                                       shredding->typed_value->leaf_column_id)) {
@@ -1921,7 +1938,7 @@ Status select_row_group_ranges_by_native_page_index(
         }
         const auto shredding = resolve_variant_shredding(file_schema, request, *predicate);
         if (!shredding.has_value() || shredding->typed_value->leaf_column_id < 0 ||
-            !fallback_is_all_null(row_group, *shredding->fallback_value) ||
+            !variant_fallbacks_are_all_null(row_group, shredding->fallback_values) ||
             !variant_metadata_predicate_is_type_safe(*shredding->typed_value) ||
             !detail::has_supported_type_defined_order(metadata,
                                                       shredding->typed_value->leaf_column_id)) {

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -599,7 +599,7 @@ const ParquetColumnSchema* child_named(const ParquetColumnSchema& parent, std::s
 }
 
 struct ResolvedVariantShredding {
-    std::vector<const ParquetColumnSchema*> fallback_values;
+    const ParquetColumnSchema* fallback_value = nullptr;
     const ParquetColumnSchema* typed_value = nullptr;
 };
 
@@ -701,7 +701,6 @@ std::optional<ResolvedVariantShredding> resolve_variant_shredding(
     if (wrapper == nullptr || wrapper->kind != ParquetColumnSchemaKind::VARIANT) {
         return std::nullopt;
     }
-    std::vector<const ParquetColumnSchema*> fallback_values;
     for (const auto& component : predicate.path) {
         const auto* fallback = child_named(*wrapper, "value");
         const auto* typed_object = child_named(*wrapper, "typed_value");
@@ -709,7 +708,6 @@ std::optional<ResolvedVariantShredding> resolve_variant_shredding(
             typed_object == nullptr || typed_object->kind != ParquetColumnSchemaKind::STRUCT) {
             return std::nullopt;
         }
-        fallback_values.push_back(fallback);
         wrapper = child_named(*typed_object, component);
         if (wrapper == nullptr || wrapper->kind != ParquetColumnSchemaKind::STRUCT) {
             return std::nullopt;
@@ -730,9 +728,7 @@ std::optional<ResolvedVariantShredding> resolve_variant_shredding(
         !expr_zonemap::data_types_compatible(predicate.comparison_type, predicate.literal_type)) {
         return std::nullopt;
     }
-    fallback_values.push_back(fallback);
-    return ResolvedVariantShredding {.fallback_values = std::move(fallback_values),
-                                     .typed_value = typed};
+    return ResolvedVariantShredding {.fallback_value = fallback, .typed_value = typed};
 }
 
 bool fallback_is_all_null(const tparquet::RowGroup& row_group,
@@ -746,17 +742,6 @@ bool fallback_is_all_null(const tparquet::RowGroup& row_group,
            chunk.meta_data.num_values == row_group.num_rows && chunk.meta_data.__isset.statistics &&
            chunk.meta_data.statistics.__isset.null_count &&
            chunk.meta_data.statistics.null_count == chunk.meta_data.num_values;
-}
-
-bool variant_fallbacks_are_all_null(
-        const tparquet::RowGroup& row_group,
-        const std::vector<const ParquetColumnSchema*>& fallback_values) {
-    // A residual value at any wrapper can shadow its typed descendant, so every ancestor must be
-    // proven empty before typed-leaf statistics are a sound pruning proof.
-    return !fallback_values.empty() &&
-           std::ranges::all_of(fallback_values, [&](const auto* fallback) {
-               return fallback != nullptr && fallback_is_all_null(row_group, *fallback);
-           });
 }
 
 bool variant_statistics_exclude(const VariantShreddedPredicate& predicate,
@@ -1042,7 +1027,10 @@ bool check_shredded_variant_statistics(
         const auto shredding = resolve_variant_shredding(file_schema, request, *predicate);
         if (!shredding.has_value() || shredding->typed_value->leaf_column_id < 0 ||
             shredding->typed_value->leaf_column_id >= static_cast<int>(row_group.columns.size()) ||
-            !variant_fallbacks_are_all_null(row_group, shredding->fallback_values) ||
+            // Partially shredded object residuals contain only keys not present in typed_value,
+            // so ancestors cannot shadow this path. The terminal fallback is the sole guard.
+            shredding->fallback_value == nullptr ||
+            !fallback_is_all_null(row_group, *shredding->fallback_value) ||
             !variant_metadata_predicate_is_type_safe(*shredding->typed_value) ||
             !detail::has_supported_type_defined_order(metadata,
                                                       shredding->typed_value->leaf_column_id)) {
@@ -1938,7 +1926,8 @@ Status select_row_group_ranges_by_native_page_index(
         }
         const auto shredding = resolve_variant_shredding(file_schema, request, *predicate);
         if (!shredding.has_value() || shredding->typed_value->leaf_column_id < 0 ||
-            !variant_fallbacks_are_all_null(row_group, shredding->fallback_values) ||
+            shredding->fallback_value == nullptr ||
+            !fallback_is_all_null(row_group, *shredding->fallback_value) ||
             !variant_metadata_predicate_is_type_safe(*shredding->typed_value) ||
             !detail::has_supported_type_defined_order(metadata,
                                                       shredding->typed_value->leaf_column_id)) {

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -1233,21 +1233,25 @@ ParquetRowGroupPruneReason native_bloom_filter_prune_reason(
 int64_t native_requested_compressed_bytes(
         const tparquet::RowGroup& row_group,
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
-        const format::FileScanRequest& request) {
+        const format::FileScanRequest& request, const std::unordered_set<int>* requested_leaf_ids) {
     std::set<int> leaf_column_ids;
-    auto collect_projection = [&](const format::LocalColumnIndex& projection) {
-        const int32_t local_id = projection.local_id();
-        if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size()) ||
-            file_schema[local_id] == nullptr) {
-            return;
+    if (requested_leaf_ids != nullptr) {
+        leaf_column_ids.insert(requested_leaf_ids->begin(), requested_leaf_ids->end());
+    } else {
+        auto collect_projection = [&](const format::LocalColumnIndex& projection) {
+            const int32_t local_id = projection.local_id();
+            if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size()) ||
+                file_schema[local_id] == nullptr) {
+                return;
+            }
+            collect_filtered_leaf_ids(*file_schema[local_id], &projection, &leaf_column_ids);
+        };
+        for (const auto& projection : request.predicate_columns) {
+            collect_projection(projection);
         }
-        collect_filtered_leaf_ids(*file_schema[local_id], &projection, &leaf_column_ids);
-    };
-    for (const auto& projection : request.predicate_columns) {
-        collect_projection(projection);
-    }
-    for (const auto& projection : request.non_predicate_columns) {
-        collect_projection(projection);
+        for (const auto& projection : request.non_predicate_columns) {
+            collect_projection(projection);
+        }
     }
     int64_t bytes = 0;
     for (const int leaf_column_id : leaf_column_ids) {
@@ -1272,7 +1276,7 @@ Status select_row_groups_by_metadata(
         ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone,
         const RuntimeState* runtime_state, ParquetFileContext* file_context,
         const ParquetColumnReaderProfile& column_reader_profile,
-        ParquetMetadataProbeMode probe_mode) {
+        ParquetMetadataProbeMode probe_mode, const std::unordered_set<int>* requested_leaf_ids) {
     int64_t timer_sink = 0;
     SCOPED_RAW_TIMER(pruning_stats == nullptr ? &timer_sink
                                               : &pruning_stats->row_group_filter_time);
@@ -1338,8 +1342,8 @@ Status select_row_groups_by_metadata(
         }
         if (pruning_stats != nullptr) {
             pruning_stats->filtered_group_rows += row_group.num_rows;
-            pruning_stats->filtered_bytes +=
-                    native_requested_compressed_bytes(row_group, file_schema, request);
+            pruning_stats->filtered_bytes += native_requested_compressed_bytes(
+                    row_group, file_schema, request, requested_leaf_ids);
             if (prune_reason == ParquetRowGroupPruneReason::STATISTICS) {
                 ++pruning_stats->filtered_row_groups_by_statistics;
             } else if (prune_reason == ParquetRowGroupPruneReason::DICTIONARY) {

--- a/be/src/format_v2/parquet/parquet_statistics.h
+++ b/be/src/format_v2/parquet/parquet_statistics.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "common/status.h"
@@ -142,7 +143,8 @@ Status select_row_groups_by_metadata(
         ParquetPruningStats* pruning_stats, const cctz::time_zone* timezone = nullptr,
         const RuntimeState* runtime_state = nullptr, ParquetFileContext* file_context = nullptr,
         const ParquetColumnReaderProfile& column_reader_profile = {},
-        ParquetMetadataProbeMode probe_mode = ParquetMetadataProbeMode::ALL);
+        ParquetMetadataProbeMode probe_mode = ParquetMetadataProbeMode::ALL,
+        const std::unordered_set<int>* requested_leaf_ids = nullptr);
 
 Status select_row_group_ranges_by_native_page_index(
         const tparquet::FileMetaData& metadata, const tparquet::RowGroup& row_group,

--- a/be/src/format_v2/parquet/reader/variant_column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/variant_column_reader.cpp
@@ -789,6 +789,14 @@ public:
                 if (typed_schema->kind != ParquetColumnSchemaKind::PRIMITIVE ||
                     check_and_get_column<ColumnNullable>(*typed) == nullptr) {
                     update_counter(_profile.variant_direct_leaf_unsupported_fallbacks, 1);
+                    if (!_complete) {
+                        // Binary element_at evaluates complex prefixes before the validated leaf.
+                        // Serialize only retained descendants so projected-out fields stay hidden.
+                        if (auto normalized = find_normalized_value(path); normalized.has_value()) {
+                            return VariantShreddedTypedValue {
+                                    .column = nullptr, .type = nullptr, .normalized = *normalized};
+                        }
+                    }
                     return std::nullopt;
                 }
                 if (!supports_direct_typed_variant_state(*typed_schema)) {
@@ -862,10 +870,12 @@ public:
                 return normalize_projected_primitive_leaf(*typed_schema, typed);
             }
         }
-        if (!_complete) {
-            return std::nullopt;
+        if (_complete) {
+            return normalize_materialized_path(materialized_column(), path);
         }
-        return normalize_materialized_path(materialized_column(), path);
+        // Binary element_at chains request complex prefixes before their validated primitive leaf.
+        // Reconstruct only retained descendants so an omitted field can never become observable.
+        return normalize_materialized_path(serialized_column(), path);
     }
 
     const ColumnVariantV2& materialized_column() const override {

--- a/be/test/exec/scan/access_path_parser_test.cpp
+++ b/be/test/exec/scan/access_path_parser_test.cpp
@@ -128,7 +128,7 @@ TEST(AccessPathParserTest, IgnoresPrimitiveColumnsAndScannerVirtualColumns) {
     EXPECT_TRUE(rowid.children.empty());
 }
 
-TEST(AccessPathParserTest, PreservesVariantObjectKeysForPhysicalShreddingProjection) {
+TEST(AccessPathParserTest, PreservesVariantPathsForPhysicalShreddingProjection) {
     auto variant = root_column(100, "v", std::make_shared<DataTypeVariantV2>());
     auto status = AccessPathParser::build_nested_children(
             &variant,
@@ -153,16 +153,39 @@ TEST(AccessPathParserTest, PreservesVariantObjectKeysForPhysicalShreddingProject
     EXPECT_TRUE(variant.variant_access_paths.empty());
 }
 
+TEST(AccessPathParserTest, MergesMultipleVariantAccessPaths) {
+    auto variant = root_column(100, "v", std::make_shared<DataTypeVariantV2>());
+    auto status = AccessPathParser::build_nested_children(
+            &variant,
+            std::vector<TColumnAccessPath> {data_access_path({"100", "profile", "city"}),
+                                            data_access_path({"100", "profile", "age"}),
+                                            data_access_path({"100", "profile", "city"})},
+            nullptr);
+    ASSERT_TRUE(status.ok()) << status;
+    const std::vector<std::vector<std::string>> expected = {{"profile", "age"},
+                                                            {"profile", "city"}};
+    EXPECT_EQ(variant.variant_access_paths, expected);
+
+    status = AccessPathParser::build_nested_children(
+            &variant,
+            std::vector<TColumnAccessPath> {data_access_path({"100", "profile"}),
+                                            data_access_path({"100", "profile", "city"})},
+            nullptr);
+    ASSERT_TRUE(status.ok()) << status;
+    const std::vector<std::vector<std::string>> prefix_expected = {{"profile"}};
+    EXPECT_EQ(variant.variant_access_paths, prefix_expected);
+}
+
 TEST(AccessPathParserTest, SeparatesFinalAndPredicateComplexAccessPaths) {
     auto variant = root_column(100, "v", std::make_shared<DataTypeVariantV2>());
     auto status = AccessPathParser::build_nested_children(
             &variant, std::vector<TColumnAccessPath> {data_access_path({"v"})},
-            std::vector<TColumnAccessPath> {data_access_path({"v", "n"})}, nullptr);
+            std::vector<TColumnAccessPath> {data_access_path({"v", "profile", "age"})}, nullptr);
     ASSERT_TRUE(status.ok()) << status;
     EXPECT_TRUE(variant.variant_access_paths.empty());
     ASSERT_TRUE(variant.has_predicate_access_paths);
     EXPECT_EQ(variant.predicate_variant_access_paths,
-              (std::vector<std::vector<std::string>> {{"n"}}));
+              (std::vector<std::vector<std::string>> {{"profile", "age"}}));
 
     auto int_type = std::make_shared<DataTypeInt32>();
     auto struct_type =
@@ -186,32 +209,35 @@ TEST(AccessPathParserTest, PreservesVariantPathsNestedInComplexColumns) {
     auto structure = root_column(100, "s", struct_type);
     auto status = AccessPathParser::build_nested_children(
             &structure,
-            std::vector<TColumnAccessPath> {data_access_path({"s", "payload", "typed_col"})},
+            std::vector<TColumnAccessPath> {data_access_path({"s", "payload", "profile", "city"})},
             nullptr);
     ASSERT_TRUE(status.ok()) << status;
     ASSERT_EQ(structure.children.size(), 1);
     EXPECT_EQ(structure.children[0].variant_access_paths,
-              (std::vector<std::vector<std::string>> {{"typed_col"}}));
+              (std::vector<std::vector<std::string>> {{"profile", "city"}}));
 
     auto array = root_column(101, "items", std::make_shared<DataTypeArray>(variant_type));
     status = AccessPathParser::build_nested_children(
-            &array, std::vector<TColumnAccessPath> {data_access_path({"items", "*", "kind"})},
+            &array,
+            std::vector<TColumnAccessPath> {data_access_path({"items", "*", "details", "kind"})},
             nullptr);
     ASSERT_TRUE(status.ok()) << status;
     ASSERT_EQ(array.children.size(), 1);
     EXPECT_EQ(array.children[0].variant_access_paths,
-              (std::vector<std::vector<std::string>> {{"kind"}}));
+              (std::vector<std::vector<std::string>> {{"details", "kind"}}));
 
     auto map = root_column(
             102, "attrs",
             std::make_shared<DataTypeMap>(std::make_shared<DataTypeString>(), variant_type));
     status = AccessPathParser::build_nested_children(
-            &map, std::vector<TColumnAccessPath> {data_access_path({"attrs", "*", "enabled"})},
+            &map,
+            std::vector<TColumnAccessPath> {data_access_path({"attrs", "*", "flags", "enabled"})},
             nullptr);
     ASSERT_TRUE(status.ok()) << status;
     const auto* value = find_child_by_name(map, "value");
     ASSERT_NE(value, nullptr);
-    EXPECT_EQ(value->variant_access_paths, (std::vector<std::vector<std::string>> {{"enabled"}}));
+    EXPECT_EQ(value->variant_access_paths,
+              (std::vector<std::vector<std::string>> {{"flags", "enabled"}}));
 }
 
 // Scenario: reject unsupported top-level inputs before recursive type parsing, including META

--- a/be/test/format_v2/column_mapper_test.cpp
+++ b/be/test/format_v2/column_mapper_test.cpp
@@ -4191,7 +4191,7 @@ TEST(ColumnMapperTest, ArrayAndMapNestedVariantPathsReachPhysicalTypedLeaf) {
     }
 }
 
-TEST(ColumnMapperTest, VariantLeafProjectionRequiresLosslessObjectPath) {
+TEST(ColumnMapperTest, VariantLeafProjectionRejectsNumericSegmentsAndMissingPaths) {
     auto field_wrapper = struct_name_col(
             "typed_col", {name_col("value", varbinary(), 0), name_col("typed_value", i64(), 1)}, 0);
     auto dotted_wrapper = struct_name_col(
@@ -4215,9 +4215,8 @@ TEST(ColumnMapperTest, VariantLeafProjectionRequiresLosslessObjectPath) {
                              name_col("value", varbinary(), 1), std::move(typed_value)};
 
     for (const std::vector<std::string>& path :
-         {std::vector<std::string> {"a.b"}, std::vector<std::string> {"a", "b"},
-          std::vector<std::string> {"1"}, std::vector<std::string> {"-1"},
-          std::vector<std::string> {"+1"}, std::vector<std::string> {"NULL"}}) {
+         {std::vector<std::string> {"a", "b"}, std::vector<std::string> {"1"},
+          std::vector<std::string> {"-1"}, std::vector<std::string> {"+1"}}) {
         auto table_variant = field_id_col("v", 10, variant_v2());
         table_variant.variant_access_paths = {path};
         ParquetColumnMapper mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
@@ -4227,6 +4226,68 @@ TEST(ColumnMapperTest, VariantLeafProjectionRequiresLosslessObjectPath) {
         ASSERT_EQ(request.non_predicate_columns.size(), 1);
         EXPECT_TRUE(request.non_predicate_columns[0].project_all_children)
                 << "unsafe Variant path must fall back to the complete physical subtree";
+    }
+
+    for (const std::vector<std::string>& path :
+         {std::vector<std::string> {"a.b"}, std::vector<std::string> {"NULL"}}) {
+        auto table_variant = field_id_col("v", 10, variant_v2());
+        table_variant.variant_access_paths = {path};
+        ParquetColumnMapper mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
+        ASSERT_TRUE(mapper.create_mapping({table_variant}, {}, {file_variant}).ok());
+        FileScanRequest request;
+        ASSERT_TRUE(mapper.create_scan_request({}, {table_variant}, &request).ok());
+        ASSERT_EQ(request.non_predicate_columns.size(), 1);
+        EXPECT_FALSE(request.non_predicate_columns[0].project_all_children)
+                << "non-numeric object keys must preserve their exact spelling";
+    }
+
+    auto mixed_table_variant = field_id_col("v", 10, variant_v2());
+    mixed_table_variant.variant_access_paths = {{"typed_col"}, {"1"}};
+    ParquetColumnMapper mixed_mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
+    ASSERT_TRUE(mixed_mapper.create_mapping({mixed_table_variant}, {}, {file_variant}).ok());
+    FileScanRequest mixed_request;
+    ASSERT_TRUE(mixed_mapper.create_scan_request({}, {mixed_table_variant}, &mixed_request).ok());
+    ASSERT_EQ(mixed_request.non_predicate_columns.size(), 1);
+    EXPECT_TRUE(mixed_request.non_predicate_columns[0].project_all_children)
+            << "one unsupported path must conservatively disable the merged leaf projection";
+}
+
+TEST(ColumnMapperTest, VariantDeepObjectPathProjectsPhysicalTypedLeaf) {
+    auto city_wrapper = struct_name_col(
+            "city", {name_col("value", varbinary(), 0), name_col("typed_value", i64(), 1)}, 0);
+    auto age_wrapper = struct_name_col(
+            "age", {name_col("value", varbinary(), 0), name_col("typed_value", i64(), 1)}, 1);
+    auto object_typed_value =
+            struct_name_col("typed_value", {std::move(city_wrapper), std::move(age_wrapper)}, 1);
+    auto object_wrapper = struct_name_col(
+            "profile", {name_col("value", varbinary(), 0), std::move(object_typed_value)}, 0);
+    auto root_typed_value = struct_name_col("typed_value", {std::move(object_wrapper)}, 2);
+    auto file_variant = field_id_col("v", 10, variant_v2(), 0);
+    file_variant.children = {name_col("metadata", varbinary(), 0),
+                             name_col("value", varbinary(), 1), std::move(root_typed_value)};
+
+    auto table_variant = field_id_col("v", 10, variant_v2());
+    table_variant.variant_access_paths = {{"profile", "city"}, {"profile", "age"}};
+    ParquetColumnMapper mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
+    ASSERT_TRUE(mapper.create_mapping({table_variant}, {}, {file_variant}).ok());
+    FileScanRequest request;
+    ASSERT_TRUE(mapper.create_scan_request({}, {table_variant}, &request).ok());
+    ASSERT_EQ(request.non_predicate_columns.size(), 1);
+    const auto& root = request.non_predicate_columns[0];
+    ASSERT_FALSE(root.project_all_children);
+    ASSERT_EQ(root.children.size(), 1);
+    EXPECT_EQ(root.children[0].local_id(), 2);
+    ASSERT_EQ(root.children[0].children.size(), 1);
+    EXPECT_EQ(root.children[0].children[0].local_id(), 0);
+    ASSERT_EQ(root.children[0].children[0].children.size(), 1);
+    EXPECT_EQ(root.children[0].children[0].children[0].local_id(), 1);
+    const auto& object_typed = root.children[0].children[0].children[0];
+    ASSERT_EQ(object_typed.children.size(), 2);
+    EXPECT_EQ(object_typed.children[0].local_id(), 0);
+    EXPECT_EQ(object_typed.children[1].local_id(), 1);
+    for (const auto& projected_leaf_wrapper : object_typed.children) {
+        ASSERT_EQ(projected_leaf_wrapper.children.size(), 1);
+        EXPECT_EQ(projected_leaf_wrapper.children[0].local_id(), 1);
     }
 }
 
@@ -4240,6 +4301,27 @@ TEST(ColumnMapperTest, VariantLeafProjectionRequiresObjectTypedValue) {
 
     auto table_variant = field_id_col("v", 10, variant_v2());
     table_variant.variant_access_paths = {{"element"}};
+    ParquetColumnMapper mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
+    ASSERT_TRUE(mapper.create_mapping({table_variant}, {}, {file_variant}).ok());
+    FileScanRequest request;
+    ASSERT_TRUE(mapper.create_scan_request({}, {table_variant}, &request).ok());
+    ASSERT_EQ(request.non_predicate_columns.size(), 1);
+    EXPECT_TRUE(request.non_predicate_columns[0].project_all_children);
+}
+
+TEST(ColumnMapperTest, VariantDeepLeafProjectionRejectsRepeatedAncestor) {
+    auto element_wrapper = struct_name_col(
+            "element", {name_col("value", varbinary(), 0), name_col("typed_value", i64(), 1)}, 0);
+    auto array_typed_value = array_col("typed_value", -1, std::move(element_wrapper), 1);
+    auto array_wrapper = struct_name_col(
+            "arr", {name_col("value", varbinary(), 0), std::move(array_typed_value)}, 0);
+    auto root_typed_value = struct_name_col("typed_value", {std::move(array_wrapper)}, 2);
+    auto file_variant = field_id_col("v", 10, variant_v2(), 0);
+    file_variant.children = {name_col("metadata", varbinary(), 0),
+                             name_col("value", varbinary(), 1), std::move(root_typed_value)};
+
+    auto table_variant = field_id_col("v", 10, variant_v2());
+    table_variant.variant_access_paths = {{"arr", "element"}};
     ParquetColumnMapper mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
     ASSERT_TRUE(mapper.create_mapping({table_variant}, {}, {file_variant}).ok());
     FileScanRequest request;

--- a/be/test/format_v2/parquet/parquet_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_reader_test.cpp
@@ -29,6 +29,7 @@
 #include <array>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <map>
 #include <memory>
 #include <numeric>
@@ -78,12 +79,64 @@
 #include "storage/index/zone_map/zonemap_filter_result.h"
 #include "storage/segment/condition_cache.h"
 #include "storage/utils.h"
+#include "util/coding.h"
 #include "util/defer_op.h"
+#include "util/thrift_util.h"
 
 namespace doris {
 namespace {
 
 constexpr int64_t ROW_COUNT = 5;
+
+void duplicate_variant_fixture_with_unsafe_second_row_group(const std::string& source_path,
+                                                            const std::string& output_path) {
+    std::filesystem::copy_file(source_path, output_path,
+                               std::filesystem::copy_options::overwrite_existing);
+    std::ifstream input(output_path, std::ios::binary | std::ios::ate);
+    DORIS_CHECK(input.good());
+    const auto input_size = static_cast<std::streamoff>(input.tellg());
+    DORIS_CHECK(input_size >= static_cast<std::streamoff>(8));
+    std::vector<uint8_t> file_bytes(cast_set<size_t>(input_size));
+    input.seekg(0);
+    input.read(reinterpret_cast<char*>(file_bytes.data()), cast_set<std::streamsize>(input_size));
+    DORIS_CHECK(input.good());
+    DORIS_CHECK(memcmp(file_bytes.data() + file_bytes.size() - 4, "PAR1", 4) == 0);
+
+    const uint32_t footer_size = decode_fixed32_le(file_bytes.data() + file_bytes.size() - 8);
+    DORIS_CHECK(footer_size <= file_bytes.size() - 8);
+    const size_t footer_offset = file_bytes.size() - 8 - footer_size;
+    uint32_t thrift_size = footer_size;
+    tparquet::FileMetaData metadata;
+    DORIS_CHECK(
+            deserialize_thrift_msg(file_bytes.data() + footer_offset, &thrift_size, true, &metadata)
+                    .ok());
+    DORIS_CHECK(metadata.row_groups.size() == 1);
+    DORIS_CHECK(metadata.row_groups[0].columns.size() > 2);
+    // Reuse the immutable chunks to isolate the scheduler decision: each row-group reader owns an
+    // independent cursor, while the second footer entry deliberately cannot prove an empty residual.
+    auto second_row_group = metadata.row_groups[0];
+    auto& root_residual = second_row_group.columns[2].meta_data.statistics;
+    DORIS_CHECK(root_residual.__isset.null_count);
+    root_residual.__set_null_count(second_row_group.num_rows - 1);
+    metadata.row_groups.push_back(std::move(second_row_group));
+    metadata.__set_num_rows(metadata.num_rows * 2);
+
+    file_bytes.resize(footer_offset);
+    std::vector<uint8_t> footer;
+    ThriftSerializer serializer(/*compact=*/true, 1024);
+    DORIS_CHECK(serializer.serialize(&metadata, &footer).ok());
+    file_bytes.insert(file_bytes.end(), footer.begin(), footer.end());
+    std::array<uint8_t, sizeof(uint32_t)> encoded_footer_size {};
+    encode_fixed32_le(encoded_footer_size.data(), cast_set<uint32_t>(footer.size()));
+    file_bytes.insert(file_bytes.end(), encoded_footer_size.begin(), encoded_footer_size.end());
+    file_bytes.insert(file_bytes.end(), {'P', 'A', 'R', '1'});
+
+    std::ofstream output(output_path, std::ios::binary | std::ios::trunc);
+    output.write(reinterpret_cast<const char*>(file_bytes.data()),
+                 cast_set<std::streamsize>(file_bytes.size()));
+    output.close();
+    DORIS_CHECK(output.good());
+}
 
 format::LocalColumnIndex field_projection(int32_t column_id) {
     return format::LocalColumnIndex {.index = column_id};
@@ -1775,25 +1828,49 @@ TEST(ParquetVariantProjectionTest, ResidualStatisticsGuardPhysicalLeafProjection
         tparquet::Statistics statistics;
         statistics.__set_null_count(leaf == 1 || leaf == 2 ? 10 : 0);
         tparquet::ColumnMetaData column_metadata;
+        column_metadata.__set_num_values(10);
         column_metadata.__set_statistics(std::move(statistics));
         tparquet::ColumnChunk chunk;
         chunk.__set_meta_data(std::move(column_metadata));
         row_group.columns.push_back(std::move(chunk));
     }
-    tparquet::FileMetaData metadata;
-    metadata.row_groups.push_back(row_group);
-    EXPECT_TRUE(format::parquet::detail::variant_projection_is_fully_shredded(metadata, *root,
-                                                                              projection));
+    auto row_group_projection = projection;
+    size_t full_projections = 0;
+    EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
+                      row_group, *root, &row_group_projection, &full_projections),
+              1);
+    EXPECT_FALSE(row_group_projection.project_all_children);
+    EXPECT_EQ(full_projections, 0);
 
-    metadata.row_groups[0].columns[2].meta_data.statistics.__set_null_count(9);
-    EXPECT_FALSE(format::parquet::detail::variant_projection_is_fully_shredded(metadata, *root,
-                                                                               projection));
-    metadata.row_groups[0].columns[2].meta_data.__isset.statistics = false;
-    EXPECT_FALSE(format::parquet::detail::variant_projection_is_fully_shredded(metadata, *root,
-                                                                               projection));
+    row_group.columns[2].meta_data.statistics.__set_null_count(9);
+    row_group_projection = projection;
+    full_projections = 0;
+    EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
+                      row_group, *root, &row_group_projection, &full_projections),
+              0);
+    EXPECT_TRUE(row_group_projection.project_all_children);
+    EXPECT_EQ(full_projections, 1);
+    row_group.columns[2].meta_data.__set_num_values(9);
+    row_group.columns[2].meta_data.statistics.__set_null_count(9);
+    row_group_projection = projection;
+    full_projections = 0;
+    EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
+                      row_group, *root, &row_group_projection, &full_projections),
+              0);
+    EXPECT_TRUE(row_group_projection.project_all_children);
+    EXPECT_EQ(full_projections, 1);
+    row_group.columns[2].meta_data.__set_num_values(10);
+    row_group.columns[2].meta_data.__isset.statistics = false;
+    row_group_projection = projection;
+    full_projections = 0;
+    EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
+                      row_group, *root, &row_group_projection, &full_projections),
+              0);
+    EXPECT_TRUE(row_group_projection.project_all_children);
+    EXPECT_EQ(full_projections, 1);
 }
 
-TEST(ParquetVariantProjectionTest, FinalizesNestedVariantProjectionRecursively) {
+TEST(ParquetVariantProjectionTest, FinalizesNestedVariantProjectionPerRowGroup) {
     using format::parquet::ParquetColumnSchema;
     using format::parquet::ParquetColumnSchemaKind;
     auto node = [](std::string name, int32_t local_id, ParquetColumnSchemaKind kind,
@@ -1831,28 +1908,28 @@ TEST(ParquetVariantProjectionTest, FinalizesNestedVariantProjectionRecursively) 
         tparquet::Statistics statistics;
         statistics.__set_null_count(leaf == 1 || leaf == 2 ? 10 : 0);
         tparquet::ColumnMetaData column_metadata;
+        column_metadata.__set_num_values(10);
         column_metadata.__set_statistics(std::move(statistics));
         tparquet::ColumnChunk chunk;
         chunk.__set_meta_data(std::move(column_metadata));
         row_group.columns.push_back(std::move(chunk));
     }
-    tparquet::FileMetaData metadata;
-    metadata.row_groups.push_back(row_group);
-
-    EXPECT_EQ(
-            format::parquet::detail::finalize_variant_leaf_projection(metadata, *root, &projection),
-            1);
+    EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
+                      row_group, *root, &projection),
+              1);
     EXPECT_FALSE(projection.children[0].project_all_children);
 
     auto fallback = projection;
-    metadata.row_groups[0].columns[2].meta_data.statistics.__set_null_count(9);
-    EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection(metadata, *root, &fallback),
+    row_group.columns[2].meta_data.statistics.__set_null_count(9);
+    EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
+                      row_group, *root, &fallback),
               0);
     EXPECT_TRUE(fallback.children[0].project_all_children);
 
     auto repeated = projection;
     root->children[0]->max_repetition_level = 1;
-    EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection(metadata, *root, &repeated),
+    EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
+                      row_group, *root, &repeated),
               0);
     EXPECT_TRUE(repeated.children[0].project_all_children);
 }
@@ -1924,6 +2001,10 @@ TEST_F(NewParquetReaderTest, ReadsFullyShreddedVariantTypedLeafProjection) {
     EXPECT_EQ(profile.get_counter("VariantDirectLeafRows")->value(), rows);
     ASSERT_NE(profile.get_counter("VariantReconstructedRows"), nullptr);
     EXPECT_EQ(profile.get_counter("VariantReconstructedRows")->value(), 0);
+    ASSERT_NE(profile.get_counter("VariantLeafProjectionRowGroupColumns"), nullptr);
+    EXPECT_EQ(profile.get_counter("VariantLeafProjectionRowGroupColumns")->value(), 1);
+    ASSERT_NE(profile.get_counter("VariantFullProjectionRowGroupColumns"), nullptr);
+    EXPECT_EQ(profile.get_counter("VariantFullProjectionRowGroupColumns")->value(), 0);
     const std::array missing_path {VariantShreddedPathSegment {
             .kind = VariantShreddedPathSegment::Kind::OBJECT_KEY, .key = StringRef("missing")}};
     EXPECT_FALSE(variants.find_shredded_typed_value(missing_path).has_value());
@@ -1986,6 +2067,77 @@ TEST_F(NewParquetReaderTest, ReadsFullyShreddedVariantTypedLeafProjection) {
                     assert_cast<const ColumnNullable&>(*gathered_match->column).get_nested_column())
                     .get_data()[0],
             first_value + 2);
+}
+
+TEST_F(NewParquetReaderTest, SwitchesVariantLeafProjectionPerRowGroup) {
+    const char* source_root = std::getenv("ROOT");
+    ASSERT_NE(source_root, nullptr);
+    const std::string source_path =
+            std::string(source_root) +
+            "/regression-test/data/external_table_p0/iceberg/iceberg_variant_shredded.parquet";
+    ASSERT_TRUE(std::filesystem::exists(source_path));
+    _file_path = (_test_dir / "iceberg_variant_mixed_row_groups.parquet").string();
+    duplicate_variant_fixture_with_unsafe_second_row_group(source_path, _file_path);
+
+    RuntimeProfile profile("variant_row_group_projection_switch");
+    auto reader = create_reader(0, -1, &profile);
+    reader->set_batch_size(1024);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    ASSERT_TRUE(reader->init(&state).ok());
+    std::vector<format::ColumnDefinition> schema;
+    ASSERT_TRUE(reader->get_schema(&schema).ok());
+    ASSERT_EQ(schema.size(), 2);
+
+    auto find_child = [](const std::vector<format::ColumnDefinition>& children,
+                         std::string_view name) -> const format::ColumnDefinition* {
+        const auto it = std::ranges::find_if(
+                children, [name](const auto& child) { return child.name == name; });
+        return it == children.end() ? nullptr : &*it;
+    };
+    const auto* root_typed = find_child(schema[1].children, "typed_value");
+    ASSERT_NE(root_typed, nullptr);
+    const auto* n_wrapper = find_child(root_typed->children, "n");
+    ASSERT_NE(n_wrapper, nullptr);
+    const auto* n_typed = find_child(n_wrapper->children, "typed_value");
+    ASSERT_NE(n_typed, nullptr);
+
+    auto projection = format::LocalColumnIndex::partial_local(schema[1].local_id);
+    projection.children.push_back(format::LocalColumnIndex::partial_local(root_typed->local_id));
+    projection.children.back().children.push_back(
+            format::LocalColumnIndex::partial_local(n_wrapper->local_id));
+    projection.children.back().children.back().children.push_back(
+            format::LocalColumnIndex::local(n_typed->local_id));
+    auto request = std::make_shared<format::FileScanRequest>();
+    request->non_predicate_columns.push_back(std::move(projection));
+    request->local_positions.emplace(format::LocalColumnId(schema[1].local_id),
+                                     format::LocalIndex(0));
+    ASSERT_TRUE(reader->open(request).ok());
+    ASSERT_NE(profile.get_counter("VariantLeafProjections"), nullptr);
+    EXPECT_EQ(profile.get_counter("VariantLeafProjections")->value(), 1);
+
+    Block block;
+    block.insert({schema[1].type->create_column(), schema[1].type, "v"});
+    size_t rows = 0;
+    bool eof = false;
+    while (!eof) {
+        size_t batch_rows = 0;
+        ASSERT_TRUE(reader->get_block(&block, &batch_rows, &eof).ok());
+        rows += batch_rows;
+    }
+    EXPECT_EQ(rows, 8192);
+    ASSERT_NE(profile.get_counter("VariantLeafProjectionRowGroupColumns"), nullptr);
+    EXPECT_EQ(profile.get_counter("VariantLeafProjectionRowGroupColumns")->value(), 1);
+    ASSERT_NE(profile.get_counter("VariantFullProjectionRowGroupColumns"), nullptr);
+    EXPECT_EQ(profile.get_counter("VariantFullProjectionRowGroupColumns")->value(), 1);
+
+    const auto& nullable = assert_cast<const ColumnNullable&>(*block.get_by_position(0).column);
+    const auto& variants = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());
+    const std::array path {VariantShreddedPathSegment {
+            .kind = VariantShreddedPathSegment::Kind::OBJECT_KEY, .key = StringRef("n")}};
+    const auto match = variants.find_shredded_typed_value(path);
+    ASSERT_TRUE(match.has_value());
+    ASSERT_TRUE(match->column);
+    EXPECT_EQ(match->column->size(), rows);
 }
 
 TEST_F(NewParquetReaderTest, ShreddedVariantPredicateUsesTypedLeafPageIndexWithRootOutput) {

--- a/be/test/format_v2/parquet/parquet_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_reader_test.cpp
@@ -2018,11 +2018,13 @@ TEST(ParquetVariantProjectionTest, FinalizesPhysicalProjectionBeforeFooterPrunin
             {chunk(tparquet::Type::INT32, 0, 10, 1, 2), chunk(tparquet::Type::BYTE_ARRAY, 0, 20),
              chunk(tparquet::Type::BYTE_ARRAY, 10, 30), chunk(tparquet::Type::BYTE_ARRAY, 9, 40),
              chunk(tparquet::Type::INT32, 1, 50)});
+    auto leaf_row_group = row_group;
+    leaf_row_group.columns[3] = chunk(tparquet::Type::BYTE_ARRAY, 10, 40);
     tparquet::ColumnOrder order;
     order.__set_TYPE_ORDER(tparquet::TypeDefinedOrder());
     tparquet::FileMetaData thrift_metadata;
-    thrift_metadata.__set_num_rows(10);
-    thrift_metadata.__set_row_groups({row_group});
+    thrift_metadata.__set_num_rows(20);
+    thrift_metadata.__set_row_groups({row_group, leaf_row_group});
     thrift_metadata.__set_column_orders({order, order, order, order, order});
     format::parquet::NativeParquetMetadata metadata(std::move(thrift_metadata), 0);
 
@@ -2047,20 +2049,24 @@ TEST(ParquetVariantProjectionTest, FinalizesPhysicalProjectionBeforeFooterPrunin
                                                          &plan, nullptr, nullptr, &file_context)
                         .ok());
     EXPECT_TRUE(plan.row_groups.empty());
-    // Footer accounting must use the row-group fallback shape: id plus all four Variant leaves.
-    EXPECT_EQ(plan.pruning_stats.filtered_bytes, 150);
+    // Footer accounting uses id plus all Variant leaves for the first row group (150 bytes), then
+    // id plus the retained typed leaf for the fully shredded row group (60 bytes).
+    EXPECT_EQ(plan.pruning_stats.filtered_bytes, 210);
 
     request.conjuncts.clear();
     ASSERT_TRUE(format::parquet::plan_parquet_row_groups(metadata, schema, request,
                                                          {.start_offset = 0, .size = -1}, false,
                                                          &plan, nullptr, nullptr, &file_context)
                         .ok());
-    ASSERT_EQ(plan.row_groups.size(), 1);
-    EXPECT_TRUE(plan.row_groups[0].has_row_group_physical_projection);
-    ASSERT_EQ(plan.row_groups[0].physical_non_predicate_columns.size(), 1);
-    EXPECT_TRUE(plan.row_groups[0].physical_non_predicate_columns[0].project_all_children);
+    ASSERT_EQ(plan.row_groups.size(), 2);
+    EXPECT_TRUE(plan.row_groups[0].has_row_group_physical_projection());
+    EXPECT_EQ(plan.row_groups[0].full_variant_projection_ordinals, std::vector<size_t> {0});
     EXPECT_EQ(plan.row_groups[0].variant_leaf_projection_columns, 0);
     EXPECT_EQ(plan.row_groups[0].variant_full_projection_columns, 1);
+    EXPECT_FALSE(plan.row_groups[1].has_row_group_physical_projection());
+    EXPECT_TRUE(plan.row_groups[1].full_variant_projection_ordinals.empty());
+    EXPECT_EQ(plan.row_groups[1].variant_leaf_projection_columns, 1);
+    EXPECT_EQ(plan.row_groups[1].variant_full_projection_columns, 0);
 }
 
 TEST(ParquetVariantProjectionTest, FinalizesNestedVariantProjectionPerRowGroup) {

--- a/be/test/format_v2/parquet/parquet_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_reader_test.cpp
@@ -88,11 +88,8 @@ namespace {
 
 constexpr int64_t ROW_COUNT = 5;
 
-void duplicate_variant_fixture_with_unsafe_second_row_group(const std::string& source_path,
-                                                            const std::string& output_path) {
-    std::filesystem::copy_file(source_path, output_path,
-                               std::filesystem::copy_options::overwrite_existing);
-    std::ifstream input(output_path, std::ios::binary | std::ios::ate);
+void annotate_variant_schema(const std::string& file_path) {
+    std::ifstream input(file_path, std::ios::binary | std::ios::ate);
     DORIS_CHECK(input.good());
     const auto input_size = static_cast<std::streamoff>(input.tellg());
     DORIS_CHECK(input_size >= static_cast<std::streamoff>(8));
@@ -110,16 +107,13 @@ void duplicate_variant_fixture_with_unsafe_second_row_group(const std::string& s
     DORIS_CHECK(
             deserialize_thrift_msg(file_bytes.data() + footer_offset, &thrift_size, true, &metadata)
                     .ok());
-    DORIS_CHECK(metadata.row_groups.size() == 1);
-    DORIS_CHECK(metadata.row_groups[0].columns.size() > 2);
-    // Reuse the immutable chunks to isolate the scheduler decision: each row-group reader owns an
-    // independent cursor, while the second footer entry deliberately cannot prove an empty residual.
-    auto second_row_group = metadata.row_groups[0];
-    auto& root_residual = second_row_group.columns[2].meta_data.statistics;
-    DORIS_CHECK(root_residual.__isset.null_count);
-    root_residual.__set_null_count(second_row_group.num_rows - 1);
-    metadata.row_groups.push_back(std::move(second_row_group));
-    metadata.__set_num_rows(metadata.num_rows * 2);
+    input.close();
+    const auto schema_it = std::ranges::find_if(
+            metadata.schema, [](const auto& element) { return element.name == "v"; });
+    DORIS_CHECK(schema_it != metadata.schema.end());
+    schema_it->__set_logicalType(tparquet::LogicalType());
+    schema_it->logicalType.__set_VARIANT(tparquet::VariantType());
+    schema_it->logicalType.VARIANT.__set_specification_version(1);
 
     file_bytes.resize(footer_offset);
     std::vector<uint8_t> footer;
@@ -131,7 +125,7 @@ void duplicate_variant_fixture_with_unsafe_second_row_group(const std::string& s
     file_bytes.insert(file_bytes.end(), encoded_footer_size.begin(), encoded_footer_size.end());
     file_bytes.insert(file_bytes.end(), {'P', 'A', 'R', '1'});
 
-    std::ofstream output(output_path, std::ios::binary | std::ios::trunc);
+    std::ofstream output(file_path, std::ios::binary | std::ios::trunc);
     output.write(reinterpret_cast<const char*>(file_bytes.data()),
                  cast_set<std::streamsize>(file_bytes.size()));
     output.close();
@@ -864,6 +858,74 @@ void write_parquet_file(const std::string& file_path, int64_t row_group_size = R
     builder.compression(::parquet::Compression::UNCOMPRESSED);
     PARQUET_THROW_NOT_OK(::parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), out,
                                                       row_group_size, builder.build()));
+}
+
+void write_mixed_variant_row_groups(const std::string& file_path) {
+    auto n_type = arrow::struct_({arrow::field("value", arrow::binary(), true),
+                                  arrow::field("typed_value", arrow::int32(), true)});
+    auto padding_type = arrow::struct_({arrow::field("value", arrow::binary(), true),
+                                        arrow::field("typed_value", arrow::utf8(), true)});
+    auto typed_value_type = arrow::struct_(
+            {arrow::field("n", n_type, false), arrow::field("padding", padding_type, false)});
+    auto variant_type = arrow::struct_({arrow::field("metadata", arrow::binary(), false),
+                                        arrow::field("value", arrow::binary(), true),
+                                        arrow::field("typed_value", typed_value_type, true)});
+
+    auto metadata_builder = std::make_shared<arrow::BinaryBuilder>();
+    auto root_value_builder = std::make_shared<arrow::BinaryBuilder>();
+    auto n_value_builder = std::make_shared<arrow::BinaryBuilder>();
+    auto n_typed_builder = std::make_shared<arrow::Int32Builder>();
+    auto n_builder = std::make_shared<arrow::StructBuilder>(
+            n_type, arrow::default_memory_pool(),
+            std::vector<std::shared_ptr<arrow::ArrayBuilder>> {n_value_builder, n_typed_builder});
+    auto padding_value_builder = std::make_shared<arrow::BinaryBuilder>();
+    auto padding_typed_builder = std::make_shared<arrow::StringBuilder>();
+    auto padding_builder = std::make_shared<arrow::StructBuilder>(
+            padding_type, arrow::default_memory_pool(),
+            std::vector<std::shared_ptr<arrow::ArrayBuilder>> {padding_value_builder,
+                                                               padding_typed_builder});
+    auto typed_value_builder = std::make_shared<arrow::StructBuilder>(
+            typed_value_type, arrow::default_memory_pool(),
+            std::vector<std::shared_ptr<arrow::ArrayBuilder>> {n_builder, padding_builder});
+    arrow::StructBuilder variant_builder(
+            variant_type, arrow::default_memory_pool(),
+            std::vector<std::shared_ptr<arrow::ArrayBuilder>> {metadata_builder, root_value_builder,
+                                                               typed_value_builder});
+
+    const std::string metadata("\x11\x02\x00\x01\x08npadding", 13);
+    for (int row = 0; row < 2; ++row) {
+        ASSERT_TRUE(variant_builder.Append().ok());
+        ASSERT_TRUE(metadata_builder->Append(metadata).ok());
+        ASSERT_TRUE(root_value_builder->AppendNull().ok());
+        ASSERT_TRUE(typed_value_builder->Append().ok());
+        ASSERT_TRUE(n_builder->Append().ok());
+        if (row == 0) {
+            ASSERT_TRUE(n_value_builder->AppendNull().ok());
+            ASSERT_TRUE(n_typed_builder->Append(1).ok());
+        } else {
+            const std::string residual("\x0dn/a", 4);
+            ASSERT_TRUE(n_value_builder->Append(residual).ok());
+            ASSERT_TRUE(n_typed_builder->AppendNull().ok());
+        }
+        ASSERT_TRUE(padding_builder->Append().ok());
+        ASSERT_TRUE(padding_value_builder->AppendNull().ok());
+        ASSERT_TRUE(padding_typed_builder->Append("x").ok());
+    }
+
+    auto schema = arrow::schema(
+            {arrow::field("id", arrow::int32(), false), arrow::field("v", variant_type, false)});
+    auto table =
+            arrow::Table::Make(schema, {build_int32_array({1, 2}), finish_array(&variant_builder)});
+    auto file_result = arrow::io::FileOutputStream::Open(file_path);
+    ASSERT_TRUE(file_result.ok()) << file_result.status();
+    std::shared_ptr<arrow::io::FileOutputStream> out = *file_result;
+    ::parquet::WriterProperties::Builder writer_properties;
+    writer_properties.compression(::parquet::Compression::UNCOMPRESSED);
+    writer_properties.disable_dictionary();
+    PARQUET_THROW_NOT_OK(::parquet::arrow::WriteTable(*table, arrow::default_memory_pool(), out, 1,
+                                                      writer_properties.build()));
+    ASSERT_TRUE(out->Close().ok());
+    annotate_variant_schema(file_path);
 }
 
 void write_unannotated_binary_parquet_file(const std::string& file_path) {
@@ -1842,6 +1904,18 @@ TEST(ParquetVariantProjectionTest, ResidualStatisticsGuardPhysicalLeafProjection
     EXPECT_FALSE(row_group_projection.project_all_children);
     EXPECT_EQ(full_projections, 0);
 
+    // A conforming partially shredded object keeps unrelated keys in the ancestor residual. The
+    // requested field is still complete when its own value column is all null.
+    row_group.columns[1].meta_data.statistics.__set_null_count(9);
+    row_group_projection = projection;
+    full_projections = 0;
+    EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
+                      row_group, *root, &row_group_projection, &full_projections),
+              1);
+    EXPECT_FALSE(row_group_projection.project_all_children);
+    EXPECT_EQ(full_projections, 0);
+    row_group.columns[1].meta_data.statistics.__set_null_count(10);
+
     row_group.columns[2].meta_data.statistics.__set_null_count(9);
     row_group_projection = projection;
     full_projections = 0;
@@ -1868,6 +1942,125 @@ TEST(ParquetVariantProjectionTest, ResidualStatisticsGuardPhysicalLeafProjection
               0);
     EXPECT_TRUE(row_group_projection.project_all_children);
     EXPECT_EQ(full_projections, 1);
+}
+
+TEST(ParquetVariantProjectionTest, FinalizesPhysicalProjectionBeforeFooterPruning) {
+    using format::parquet::ParquetColumnSchema;
+    using format::parquet::ParquetColumnSchemaKind;
+    auto primitive = [](std::string name, int32_t local_id, int leaf_id,
+                        tparquet::Type::type physical_type, DataTypePtr type) {
+        auto result = std::make_unique<ParquetColumnSchema>();
+        result->name = std::move(name);
+        result->local_id = local_id;
+        result->kind = ParquetColumnSchemaKind::PRIMITIVE;
+        result->leaf_column_id = leaf_id;
+        result->type = std::move(type);
+        result->type_descriptor.doris_type = result->type;
+        result->type_descriptor.physical_type = physical_type;
+        return result;
+    };
+    auto bytes = [&](std::string name, int32_t local_id, int leaf_id) {
+        return primitive(std::move(name), local_id, leaf_id, tparquet::Type::BYTE_ARRAY,
+                         make_nullable(std::make_shared<DataTypeString>()));
+    };
+
+    std::vector<std::unique_ptr<ParquetColumnSchema>> schema;
+    schema.push_back(primitive("id", 0, 0, tparquet::Type::INT32,
+                               make_nullable(std::make_shared<DataTypeInt32>())));
+    auto variant = std::make_unique<ParquetColumnSchema>();
+    variant->name = "v";
+    variant->local_id = 1;
+    variant->kind = ParquetColumnSchemaKind::VARIANT;
+    variant->contains_variant = true;
+    variant->type = make_nullable(std::make_shared<DataTypeVariantV2>());
+    variant->children.push_back(bytes("metadata", 0, 1));
+    variant->children.push_back(bytes("value", 1, 2));
+    auto typed_object = std::make_unique<ParquetColumnSchema>();
+    typed_object->name = "typed_value";
+    typed_object->local_id = 2;
+    typed_object->kind = ParquetColumnSchemaKind::STRUCT;
+    auto field = std::make_unique<ParquetColumnSchema>();
+    field->name = "n";
+    field->local_id = 0;
+    field->kind = ParquetColumnSchemaKind::STRUCT;
+    field->children.push_back(bytes("value", 0, 3));
+    field->children.push_back(primitive("typed_value", 1, 4, tparquet::Type::INT32,
+                                        make_nullable(std::make_shared<DataTypeInt32>())));
+    typed_object->children.push_back(std::move(field));
+    variant->children.push_back(std::move(typed_object));
+    schema.push_back(std::move(variant));
+
+    auto chunk = [](tparquet::Type::type type, int64_t null_count, int64_t compressed_size,
+                    std::optional<int32_t> min_value = std::nullopt,
+                    std::optional<int32_t> max_value = std::nullopt) {
+        tparquet::Statistics statistics;
+        statistics.__set_null_count(null_count);
+        if (min_value.has_value() && max_value.has_value()) {
+            std::string min_bytes(sizeof(int32_t), '\0');
+            std::string max_bytes(sizeof(int32_t), '\0');
+            encode_fixed32_le(reinterpret_cast<uint8_t*>(min_bytes.data()), *min_value);
+            encode_fixed32_le(reinterpret_cast<uint8_t*>(max_bytes.data()), *max_value);
+            statistics.__set_min_value(std::move(min_bytes));
+            statistics.__set_max_value(std::move(max_bytes));
+        }
+        tparquet::ColumnMetaData column_metadata;
+        column_metadata.__set_type(type);
+        column_metadata.__set_num_values(10);
+        column_metadata.__set_total_compressed_size(compressed_size);
+        column_metadata.__set_statistics(std::move(statistics));
+        tparquet::ColumnChunk result;
+        result.__set_meta_data(std::move(column_metadata));
+        return result;
+    };
+    tparquet::RowGroup row_group;
+    row_group.__set_num_rows(10);
+    row_group.__set_columns(
+            {chunk(tparquet::Type::INT32, 0, 10, 1, 2), chunk(tparquet::Type::BYTE_ARRAY, 0, 20),
+             chunk(tparquet::Type::BYTE_ARRAY, 10, 30), chunk(tparquet::Type::BYTE_ARRAY, 9, 40),
+             chunk(tparquet::Type::INT32, 1, 50)});
+    tparquet::ColumnOrder order;
+    order.__set_TYPE_ORDER(tparquet::TypeDefinedOrder());
+    tparquet::FileMetaData thrift_metadata;
+    thrift_metadata.__set_num_rows(10);
+    thrift_metadata.__set_row_groups({row_group});
+    thrift_metadata.__set_column_orders({order, order, order, order, order});
+    format::parquet::NativeParquetMetadata metadata(std::move(thrift_metadata), 0);
+
+    auto leaf_projection = format::LocalColumnIndex::partial_local(1);
+    leaf_projection.children.push_back(format::LocalColumnIndex::partial_local(2));
+    leaf_projection.children.back().children.push_back(format::LocalColumnIndex::partial_local(0));
+    leaf_projection.children.back().children.back().children.push_back(
+            format::LocalColumnIndex::local(1));
+    format::FileScanRequest request;
+    request.predicate_columns = {format::LocalColumnIndex::local(0)};
+    request.non_predicate_columns = {std::move(leaf_projection)};
+    request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    request.local_positions.emplace(format::LocalColumnId(1), format::LocalIndex(1));
+    request.conjuncts.push_back(create_int32_greater_than_conjunct(0, 50));
+
+    format::parquet::ParquetFileContext file_context;
+    file_context.native_metadata = &metadata;
+    file_context.contains_variant = true;
+    format::parquet::RowGroupScanPlan plan;
+    ASSERT_TRUE(format::parquet::plan_parquet_row_groups(metadata, schema, request,
+                                                         {.start_offset = 0, .size = -1}, false,
+                                                         &plan, nullptr, nullptr, &file_context)
+                        .ok());
+    EXPECT_TRUE(plan.row_groups.empty());
+    // Footer accounting must use the row-group fallback shape: id plus all four Variant leaves.
+    EXPECT_EQ(plan.pruning_stats.filtered_bytes, 150);
+
+    request.conjuncts.clear();
+    ASSERT_TRUE(format::parquet::plan_parquet_row_groups(metadata, schema, request,
+                                                         {.start_offset = 0, .size = -1}, false,
+                                                         &plan, nullptr, nullptr, &file_context)
+                        .ok());
+    ASSERT_EQ(plan.row_groups.size(), 1);
+    EXPECT_TRUE(plan.row_groups[0].has_row_group_physical_projection);
+    ASSERT_EQ(plan.row_groups[0].physical_non_predicate_columns.size(), 1);
+    EXPECT_TRUE(plan.row_groups[0].physical_non_predicate_columns[0].project_all_children);
+    EXPECT_EQ(plan.row_groups[0].variant_leaf_projection_columns, 0);
+    EXPECT_EQ(plan.row_groups[0].variant_full_projection_columns, 1);
 }
 
 TEST(ParquetVariantProjectionTest, FinalizesNestedVariantProjectionPerRowGroup) {
@@ -2070,14 +2263,8 @@ TEST_F(NewParquetReaderTest, ReadsFullyShreddedVariantTypedLeafProjection) {
 }
 
 TEST_F(NewParquetReaderTest, SwitchesVariantLeafProjectionPerRowGroup) {
-    const char* source_root = std::getenv("ROOT");
-    ASSERT_NE(source_root, nullptr);
-    const std::string source_path =
-            std::string(source_root) +
-            "/regression-test/data/external_table_p0/iceberg/iceberg_variant_shredded.parquet";
-    ASSERT_TRUE(std::filesystem::exists(source_path));
     _file_path = (_test_dir / "iceberg_variant_mixed_row_groups.parquet").string();
-    duplicate_variant_fixture_with_unsafe_second_row_group(source_path, _file_path);
+    write_mixed_variant_row_groups(_file_path);
 
     RuntimeProfile profile("variant_row_group_projection_switch");
     auto reader = create_reader(0, -1, &profile);
@@ -2124,7 +2311,7 @@ TEST_F(NewParquetReaderTest, SwitchesVariantLeafProjectionPerRowGroup) {
         ASSERT_TRUE(reader->get_block(&block, &batch_rows, &eof).ok());
         rows += batch_rows;
     }
-    EXPECT_EQ(rows, 8192);
+    EXPECT_EQ(rows, 2);
     ASSERT_NE(profile.get_counter("VariantLeafProjectionRowGroupColumns"), nullptr);
     EXPECT_EQ(profile.get_counter("VariantLeafProjectionRowGroupColumns")->value(), 1);
     ASSERT_NE(profile.get_counter("VariantFullProjectionRowGroupColumns"), nullptr);
@@ -2136,8 +2323,14 @@ TEST_F(NewParquetReaderTest, SwitchesVariantLeafProjectionPerRowGroup) {
             .kind = VariantShreddedPathSegment::Kind::OBJECT_KEY, .key = StringRef("n")}};
     const auto match = variants.find_shredded_typed_value(path);
     ASSERT_TRUE(match.has_value());
-    ASSERT_TRUE(match->column);
-    EXPECT_EQ(match->column->size(), rows);
+    ASSERT_TRUE(match->normalized);
+    EXPECT_EQ(match->normalized->size(), rows);
+    std::vector<std::string> values;
+    for (size_t row = 0; row < rows; ++row) {
+        values.push_back(schema[1].type->to_string(*match->normalized, row,
+                                                   DataTypeSerDe::get_default_format_options()));
+    }
+    EXPECT_EQ(values, std::vector<std::string>({"1", R"("n/a")"}));
 }
 
 TEST_F(NewParquetReaderTest, ShreddedVariantPredicateUsesTypedLeafPageIndexWithRootOutput) {

--- a/be/test/format_v2/parquet/parquet_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_reader_test.cpp
@@ -2069,6 +2069,52 @@ TEST(ParquetVariantProjectionTest, FinalizesPhysicalProjectionBeforeFooterPrunin
     EXPECT_EQ(plan.row_groups[1].variant_full_projection_columns, 0);
 }
 
+TEST(ParquetVariantProjectionTest, ReusesWideNonVariantLeafSetAcrossRowGroups) {
+    constexpr int COLUMN_COUNT = 64;
+    constexpr int ROW_GROUP_COUNT = 3;
+    std::vector<std::unique_ptr<format::parquet::ParquetColumnSchema>> schema;
+    format::FileScanRequest request;
+    for (int column = 0; column < COLUMN_COUNT; ++column) {
+        auto field = std::make_unique<format::parquet::ParquetColumnSchema>();
+        field->name = fmt::format("c{}", column);
+        field->local_id = column;
+        field->leaf_column_id = column;
+        field->kind = format::parquet::ParquetColumnSchemaKind::PRIMITIVE;
+        field->type = make_nullable(std::make_shared<DataTypeInt32>());
+        field->type_descriptor.doris_type = field->type;
+        field->type_descriptor.physical_type = tparquet::Type::INT32;
+        schema.push_back(std::move(field));
+        request.non_predicate_columns.push_back(format::LocalColumnIndex::local(column));
+        request.local_positions.emplace(format::LocalColumnId(column), format::LocalIndex(column));
+    }
+
+    tparquet::ColumnMetaData column_metadata;
+    column_metadata.__set_type(tparquet::Type::INT32);
+    column_metadata.__set_num_values(10);
+    column_metadata.__set_total_compressed_size(1);
+    tparquet::ColumnChunk chunk;
+    chunk.__set_meta_data(std::move(column_metadata));
+    tparquet::RowGroup row_group;
+    row_group.__set_num_rows(10);
+    row_group.__set_columns(std::vector<tparquet::ColumnChunk>(COLUMN_COUNT, chunk));
+    tparquet::FileMetaData thrift_metadata;
+    thrift_metadata.__set_num_rows(ROW_GROUP_COUNT * 10);
+    thrift_metadata.__set_row_groups(std::vector<tparquet::RowGroup>(ROW_GROUP_COUNT, row_group));
+    format::parquet::NativeParquetMetadata metadata(std::move(thrift_metadata), 0);
+    format::parquet::ParquetFileContext file_context;
+    file_context.native_metadata = &metadata;
+    file_context.contains_variant = false;
+    format::parquet::RowGroupScanPlan plan;
+
+    format::parquet::detail::reset_physical_leaf_set_build_count();
+    ASSERT_TRUE(format::parquet::plan_parquet_row_groups(metadata, schema, request,
+                                                         {.start_offset = 0, .size = -1}, false,
+                                                         &plan, nullptr, nullptr, &file_context)
+                        .ok());
+    EXPECT_EQ(plan.row_groups.size(), ROW_GROUP_COUNT);
+    EXPECT_EQ(format::parquet::detail::physical_leaf_set_build_count(), 1);
+}
+
 TEST(ParquetVariantProjectionTest, FinalizesNestedVariantProjectionPerRowGroup) {
     using format::parquet::ParquetColumnSchema;
     using format::parquet::ParquetColumnSchemaKind;

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -2120,15 +2120,13 @@ TEST(ParquetScanConditionCacheTest, HitKeepsCachedBaseWhenCurrentPlanStartsLater
              .selected_ranges = {{.start = 0, .length = ConditionCacheContext::GRANULE_SIZE}},
              .page_skip_plans = {},
              .offset_indexes = {},
-             .physical_predicate_columns = {},
-             .physical_non_predicate_columns = {},
-             .has_row_group_physical_projection = false,
+             .full_variant_projection_ordinals = {},
              .variant_leaf_projection_columns = 0,
              .variant_full_projection_columns = 0,
              .expensive_pruning_pending = false});
 
     format::parquet::ParquetScanScheduler scheduler;
-    scheduler.set_plan(std::move(plan));
+    scheduler.set_plan(std::make_shared<format::parquet::RowGroupScanPlan>(std::move(plan)));
     auto ctx = std::make_shared<ConditionCacheContext>();
     ctx->is_hit = true;
     ctx->base_granule = 0;

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -2119,7 +2119,13 @@ TEST(ParquetScanConditionCacheTest, HitKeepsCachedBaseWhenCurrentPlanStartsLater
              .row_group_rows = ConditionCacheContext::GRANULE_SIZE,
              .selected_ranges = {{.start = 0, .length = ConditionCacheContext::GRANULE_SIZE}},
              .page_skip_plans = {},
-             .offset_indexes = {}});
+             .offset_indexes = {},
+             .physical_predicate_columns = {},
+             .physical_non_predicate_columns = {},
+             .has_row_group_physical_projection = false,
+             .variant_leaf_projection_columns = 0,
+             .variant_full_projection_columns = 0,
+             .expensive_pruning_pending = false});
 
     format::parquet::ParquetScanScheduler scheduler;
     scheduler.set_plan(std::move(plan));

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -1528,8 +1528,8 @@ TEST(NativeParquetStatisticsTest, ShreddedVariantTypedValueDrivesPageFiltering) 
                         .ok());
     EXPECT_EQ(selected_row_groups, std::vector<int>({0}));
 
-    // A root residual can contain the requested nested path even when that path's own fallback is
-    // all null. Every wrapper from the Variant root to the typed leaf must prove completeness.
+    // Object residual keys are disjoint from shredded fields, so an unrelated root residual must
+    // not disable statistics for a complete nested field.
     footer_only_metadata = metadata;
     footer_only_metadata.row_groups[0].columns[3].meta_data.statistics.__set_max_value(
             encode_int32(2));
@@ -1539,7 +1539,7 @@ TEST(NativeParquetStatisticsTest, ShreddedVariantTypedValueDrivesPageFiltering) 
                         nullptr, nullptr, nullptr, nullptr, {},
                         format::parquet::ParquetMetadataProbeMode::FOOTER_ONLY)
                         .ok());
-    EXPECT_EQ(selected_row_groups, std::vector<int>({0}));
+    EXPECT_TRUE(selected_row_groups.empty());
 
     // A contradictory non-repeated value count cannot prove that every row lacks fallback bytes.
     footer_only_metadata = metadata;
@@ -1597,8 +1597,8 @@ TEST(NativeParquetStatisticsTest, ShreddedVariantTypedValueDrivesPageFiltering) 
                         &selected_ranges, &skip_plans, nullptr)
                         .ok());
     ASSERT_EQ(selected_ranges.size(), 1);
-    EXPECT_EQ(selected_ranges[0].start, 0);
-    EXPECT_EQ(selected_ranges[0].length, 100);
+    EXPECT_EQ(selected_ranges[0].start, 50);
+    EXPECT_EQ(selected_ranges[0].length, 50);
 
     // Direct Variant numeric comparisons coerce integral literals to a wide DECIMAL domain.
     request.conjuncts = {variant_path_gt_conjunct(50, false, true)};

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -1528,7 +1528,23 @@ TEST(NativeParquetStatisticsTest, ShreddedVariantTypedValueDrivesPageFiltering) 
                         .ok());
     EXPECT_EQ(selected_row_groups, std::vector<int>({0}));
 
+    // A root residual can contain the requested nested path even when that path's own fallback is
+    // all null. Every wrapper from the Variant root to the typed leaf must prove completeness.
+    footer_only_metadata = metadata;
+    footer_only_metadata.row_groups[0].columns[3].meta_data.statistics.__set_max_value(
+            encode_int32(2));
+    footer_only_metadata.row_groups[0].columns[1].meta_data.statistics.__set_null_count(99);
+    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
+                        footer_only_metadata, schema, request, nullptr, &selected_row_groups, false,
+                        nullptr, nullptr, nullptr, nullptr, {},
+                        format::parquet::ParquetMetadataProbeMode::FOOTER_ONLY)
+                        .ok());
+    EXPECT_EQ(selected_row_groups, std::vector<int>({0}));
+
     // A contradictory non-repeated value count cannot prove that every row lacks fallback bytes.
+    footer_only_metadata = metadata;
+    footer_only_metadata.row_groups[0].columns[3].meta_data.statistics.__set_max_value(
+            encode_int32(2));
     footer_only_metadata.row_groups[0].columns[2].meta_data.__set_num_values(99);
     footer_only_metadata.row_groups[0].columns[2].meta_data.statistics.__set_null_count(99);
     ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
@@ -1573,6 +1589,16 @@ TEST(NativeParquetStatisticsTest, ShreddedVariantTypedValueDrivesPageFiltering) 
     EXPECT_EQ(selected_ranges[0].length, 50);
     EXPECT_EQ(pruning_stats.page_index_read_calls, 1);
     EXPECT_EQ(pruning_stats.filtered_page_rows, 50);
+
+    auto row_group_with_root_residual = metadata.row_groups[0];
+    row_group_with_root_residual.columns[1].meta_data.statistics.__set_null_count(99);
+    ASSERT_TRUE(format::parquet::select_row_group_ranges_by_native_page_index(
+                        metadata, row_group_with_root_residual, page_indexes, schema, request, 100,
+                        &selected_ranges, &skip_plans, nullptr)
+                        .ok());
+    ASSERT_EQ(selected_ranges.size(), 1);
+    EXPECT_EQ(selected_ranges[0].start, 0);
+    EXPECT_EQ(selected_ranges[0].length, 100);
 
     // Direct Variant numeric comparisons coerce integral literals to a wide DECIMAL domain.
     request.conjuncts = {variant_path_gt_conjunct(50, false, true)};

--- a/be/test/format_v2/parquet/variant_column_reader_test.cpp
+++ b/be/test/format_v2/parquet/variant_column_reader_test.cpp
@@ -142,6 +142,36 @@ ParquetColumnSchema shredded_named_object_schema(std::string field_name) {
     return schema;
 }
 
+ParquetColumnSchema shredded_deep_object_schema() {
+    auto schema = unshredded_schema();
+    auto root_typed = std::make_unique<ParquetColumnSchema>();
+    root_typed->name = "typed_value";
+    root_typed->kind = ParquetColumnSchemaKind::STRUCT;
+
+    auto profile = std::make_unique<ParquetColumnSchema>();
+    profile->name = "profile";
+    profile->kind = ParquetColumnSchemaKind::STRUCT;
+    auto profile_typed = std::make_unique<ParquetColumnSchema>();
+    profile_typed->name = "typed_value";
+    profile_typed->kind = ParquetColumnSchemaKind::STRUCT;
+
+    auto address = std::make_unique<ParquetColumnSchema>();
+    address->name = "address";
+    address->kind = ParquetColumnSchemaKind::STRUCT;
+    auto address_typed = std::make_unique<ParquetColumnSchema>();
+    address_typed->name = "typed_value";
+    address_typed->kind = ParquetColumnSchemaKind::PRIMITIVE;
+    address_typed->type = make_nullable(std::make_shared<DataTypeInt64>());
+    address_typed->type_descriptor.integer_bit_width = 64;
+
+    address->children.push_back(std::move(address_typed));
+    profile_typed->children.push_back(std::move(address));
+    profile->children.push_back(std::move(profile_typed));
+    root_typed->children.push_back(std::move(profile));
+    schema.children.push_back(std::move(root_typed));
+    return schema;
+}
+
 ParquetColumnSchema shredded_binary_object_schema() {
     auto schema = shredded_object_schema();
     auto* leaf = schema.children.back()->children[0]->children[0].get();
@@ -237,6 +267,35 @@ MutableColumnPtr projected_shredded_object_physical(const std::vector<int64_t>& 
             ColumnNullable::create(std::move(object), ColumnUInt8::create(values.size(), 0)));
     auto root = ColumnStruct::create(std::move(root_fields));
     return ColumnNullable::create(std::move(root), ColumnUInt8::create(values.size(), 0));
+}
+
+MutableColumnPtr projected_shredded_deep_object_physical(const std::vector<int64_t>& values) {
+    auto integers = ColumnInt64::create();
+    integers->get_data().assign(values.begin(), values.end());
+    MutableColumns address_wrapper_fields;
+    address_wrapper_fields.push_back(
+            ColumnNullable::create(std::move(integers), ColumnUInt8::create(values.size(), 0)));
+    auto address_wrapper = ColumnStruct::create(std::move(address_wrapper_fields));
+
+    MutableColumns profile_object_fields;
+    profile_object_fields.push_back(ColumnNullable::create(std::move(address_wrapper),
+                                                           ColumnUInt8::create(values.size(), 0)));
+    auto profile_object = ColumnStruct::create(std::move(profile_object_fields));
+
+    MutableColumns profile_wrapper_fields;
+    profile_wrapper_fields.push_back(ColumnNullable::create(std::move(profile_object),
+                                                            ColumnUInt8::create(values.size(), 0)));
+    auto profile_wrapper = ColumnStruct::create(std::move(profile_wrapper_fields));
+
+    MutableColumns root_object_fields;
+    root_object_fields.push_back(ColumnNullable::create(std::move(profile_wrapper),
+                                                        ColumnUInt8::create(values.size(), 0)));
+    auto root_object = ColumnStruct::create(std::move(root_object_fields));
+    MutableColumns root_fields;
+    root_fields.push_back(
+            ColumnNullable::create(std::move(root_object), ColumnUInt8::create(values.size(), 0)));
+    return ColumnNullable::create(ColumnStruct::create(std::move(root_fields)),
+                                  ColumnUInt8::create(values.size(), 0));
 }
 
 MutableColumnPtr projected_shredded_int32_object_physical(const std::vector<int32_t>& values) {
@@ -2337,6 +2396,64 @@ TEST(VariantColumnReaderTest, ProjectedShreddedStateRejectsRootMaterialization) 
     const auto& variants = assert_cast<const ColumnVariantV2&>(
             assert_cast<const ColumnNullable&>(*output).get_nested_column());
     EXPECT_THROW((void)variants.get_value_ref(0), Exception);
+}
+
+TEST(VariantColumnReaderTest, ProjectedShreddedStateServesBinaryDeepPathChain) {
+    auto schema = shredded_deep_object_schema();
+    schema.local_id = 0;
+    schema.children[2]->local_id = 2;
+    auto* profile = schema.children[2]->children[0].get();
+    profile->local_id = 0;
+    profile->children[0]->local_id = 0;
+    auto* address = profile->children[0]->children[0].get();
+    address->local_id = 0;
+    address->children[0]->local_id = 0;
+
+    auto projection = format::LocalColumnIndex::partial_local(0);
+    projection.children.push_back(format::LocalColumnIndex::partial_local(2));
+    projection.children.back().children.push_back(format::LocalColumnIndex::partial_local(0));
+    projection.children.back().children.back().children.push_back(
+            format::LocalColumnIndex::partial_local(0));
+    projection.children.back().children.back().children.back().children.push_back(
+            format::LocalColumnIndex::partial_local(0));
+    projection.children.back().children.back().children.back().children.back().children.push_back(
+            format::LocalColumnIndex::local(0));
+
+    VariantMaterializationNode plan;
+    plan.schema = &schema;
+    plan.contains_variant = true;
+    plan.variant_projection = std::move(projection);
+    plan.variant_state_schema = create_variant_state_schema(schema, &*plan.variant_projection);
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(
+            materialize_variant_columns(plan, projected_shredded_deep_object_physical({17}), output)
+                    .ok());
+    const auto& root = assert_cast<const ColumnVariantV2&>(
+            assert_cast<const ColumnNullable&>(*output).get_nested_column());
+    EXPECT_THROW((void)root.get_value_ref(0), Exception);
+
+    const std::array profile_segment {
+            VariantElementV2PathSegment::object_key(StringRef("profile"))};
+    std::unique_ptr<ResolvedVariantElementV2Path> profile_path;
+    ASSERT_TRUE(resolve_variant_element_v2_path(profile_segment, &profile_path).ok());
+    ColumnPtr profile_value;
+    const Status profile_status =
+            extract_variant_element_v2(root, *profile_path, {}, &profile_value);
+    ASSERT_TRUE(profile_status.ok()) << profile_status;
+    const auto& profile_value_variant = assert_cast<const ColumnVariantV2&>(
+            assert_cast<const ColumnNullable&>(*profile_value).get_nested_column());
+
+    const std::array address_segment {
+            VariantElementV2PathSegment::object_key(StringRef("address"))};
+    std::unique_ptr<ResolvedVariantElementV2Path> address_path;
+    ASSERT_TRUE(resolve_variant_element_v2_path(address_segment, &address_path).ok());
+    ColumnPtr address_value;
+    const Status address_status =
+            extract_variant_element_v2(profile_value_variant, *address_path, {}, &address_value);
+    ASSERT_TRUE(address_status.ok()) << address_status;
+    const auto& address_value_variant = assert_cast<const ColumnVariantV2&>(
+            assert_cast<const ColumnNullable&>(*address_value).get_nested_column());
+    EXPECT_EQ(address_value_variant.get_value_ref(0).get_int(), 17);
 }
 
 TEST(VariantColumnReaderTest, AlignsNestedPrimitiveNullabilityAroundVariant) {

--- a/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/paimon/run13.sql
+++ b/docker/thirdparties/docker-compose/iceberg/scripts/create_preinstalled_scripts/paimon/run13.sql
@@ -25,12 +25,12 @@ create table variant_shredded (
 partitioned by (event_date)
 tblproperties (
     'file.format' = 'parquet',
-    'parquet.variant.shreddingSchema' = '{"type":"ROW","fields":[{"name":"payload","type":{"type":"ROW","fields":[{"name":"name","type":"STRING"},{"name":"age","type":"INT"},{"name":"profile","type":{"type":"ROW","fields":[{"name":"city","type":"STRING"}]}}]}}]}'
+    'parquet.variant.shreddingSchema' = '{"type":"ROW","fields":[{"name":"payload","type":{"type":"ROW","fields":[{"name":"name","type":"STRING"},{"name":"age","type":"INT"},{"name":"profile","type":{"type":"ROW","fields":[{"name":"city","type":"STRING"},{"name":"address","type":{"type":"ROW","fields":[{"name":"city","type":"STRING"},{"name":"zip","type":"INT"},{"name":"rank","type":"INT"}]}}]}}]}}]}'
 );
 
 insert into variant_shredded values
-    (1, date '2026-06-01', parse_json('{"name":"alice","age":18,"profile":{"city":"beijing"},"tags":["flink","paimon"],"extra":"shredded"}')),
-    (2, date '2026-06-01', parse_json('{"name":"bob","age":30,"profile":{"city":"shanghai"},"tags":["doris"]}'));
+    (1, date '2026-06-01', parse_json('{"name":"alice","age":18,"profile":{"city":"beijing","address":{"city":"beijing","zip":100000,"rank":1}},"tags":["flink","paimon"],"extra":"shredded"}')),
+    (2, date '2026-06-01', parse_json('{"name":"bob","age":30,"profile":{"city":"shanghai","address":{"city":"shanghai","zip":200000,"rank":2}},"tags":["doris"]}'));
 
 drop table if exists variant_mixed_us;
 create table variant_mixed_us (

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathPlanCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathPlanCollector.java
@@ -92,6 +92,10 @@ public class AccessPathPlanCollector extends DefaultPlanVisitor<Void, StatementC
                     for (Expression child : function.children()) {
                         exprCollector.collect(child);
                     }
+                } else if (function.arity() == 1 && function.child(0).getDataType().isVariantType()) {
+                    // A generator may change the Variant container kind, which the legacy path
+                    // cannot encode. Preserve the whole input container so residual values stay visible.
+                    exprCollector.collect(function.child(0));
                 } else {
                     for (CollectAccessPathResult accessPath : accessPaths) {
                         List<String> path = accessPath.getPath();
@@ -99,14 +103,9 @@ public class AccessPathPlanCollector extends DefaultPlanVisitor<Void, StatementC
                             // $c$1.VALUES.b
                             CollectorContext argumentContext = new CollectorContext(context, false);
                             argumentContext.setType(accessPath.getType());
-                            if (function.child(0).getDataType().isVariantType()) {
-                                argumentContext.getAccessPathBuilder()
-                                        .addSuffix(path.subList(1, path.size()));
-                            } else {
-                                argumentContext.getAccessPathBuilder()
-                                        .addSuffix(AccessPathInfo.ACCESS_ALL)
-                                        .addSuffix(path.subList(1, path.size()));
-                            }
+                            argumentContext.getAccessPathBuilder()
+                                    .addSuffix(AccessPathInfo.ACCESS_ALL)
+                                    .addSuffix(path.subList(1, path.size()));
                             function.child(0).accept(exprCollector, argumentContext);
                             continue;
                         } else if (path.size() >= 2) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathPlanCollector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/AccessPathPlanCollector.java
@@ -116,8 +116,10 @@ public class AccessPathPlanCollector extends DefaultPlanVisitor<Void, StatementC
                             CollectorContext argumentContext = new CollectorContext(context, false);
                             argumentContext.setType(accessPath.getType());
                             if (function.child(colIndex).getDataType().isVariantType()) {
-                                argumentContext.getAccessPathBuilder()
-                                        .addSuffix(path.subList(2, path.size()));
+                                // Every Variant argument determines the generated array shape, so
+                                // an output-field path must not narrow the input container.
+                                exprCollector.collect(function.child(colIndex));
+                                continue;
                             } else {
                                 argumentContext.getAccessPathBuilder()
                                         .addSuffix(AccessPathInfo.ACCESS_ALL)

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/NestedColumnPruning.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/NestedColumnPruning.java
@@ -45,7 +45,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.TreeMultimap;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -131,8 +130,14 @@ public class NestedColumnPruning implements CustomRewriter {
         Map<Slot, DataTypeAccessTree> slotIdToPredicateAccessTree = new LinkedHashMap<>();
         Map<Slot, DataType> variantSlots = new LinkedHashMap<>();
 
-        Comparator<Pair<TAccessPathType, List<String>>> pathComparator = Comparator.comparing(
-                l -> StringUtils.join(l.second, "."));
+        // Segment-wise comparison preserves the distinction between the key "a.b" and path a/b.
+        Comparator<Pair<TAccessPathType, List<String>>> pathComparator = (left, right) -> {
+            int comparison = comparePathSegments(left.second, right.second);
+            if (comparison != 0) {
+                return comparison;
+            }
+            return left.first.compareTo(right.first);
+        };
 
         Multimap<Integer, Pair<TAccessPathType, List<String>>> allAccessPaths = TreeMultimap.create(
                 Comparator.naturalOrder(), pathComparator);
@@ -261,6 +266,17 @@ public class NestedColumnPruning implements CustomRewriter {
             return ImmutableList.of(accessPath);
         }
         return paths;
+    }
+
+    private static int comparePathSegments(List<String> left, List<String> right) {
+        int commonLength = Math.min(left.size(), right.size());
+        for (int index = 0; index < commonLength; index++) {
+            int comparison = left.get(index).compareTo(right.get(index));
+            if (comparison != 0) {
+                return comparison;
+            }
+        }
+        return Integer.compare(left.size(), right.size());
     }
 
     /** DataTypeAccessTree */

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneNestedColumnTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneNestedColumnTest.java
@@ -141,6 +141,43 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
     }
 
     @Test
+    public void testVariantNumericSegmentsKeepLegacyPath() throws Exception {
+        withVariantSubPathPruningDisabled(() -> {
+            assertColumn("select v['0']['city'] from variant_tbl",
+                    "variant",
+                    ImmutableList.of(path("v", "0", "city")),
+                    ImmutableList.of());
+            assertColumn("select v[0]['city'] from variant_tbl",
+                    "variant",
+                    ImmutableList.of(path("v", "0", "city")),
+                    ImmutableList.of());
+            assertColumn("select v['0'], v[0] from variant_tbl",
+                    "variant",
+                    ImmutableList.of(path("v", "0")),
+                    ImmutableList.of());
+        });
+    }
+
+    @Test
+    public void testVariantMultipleObjectAccessPaths() throws Exception {
+        withVariantSubPathPruningDisabled(() -> {
+            assertColumn("select v['profile']['city'], v['profile']['age'] from variant_tbl",
+                    "variant",
+                    ImmutableList.of(
+                            path("v", "profile", "age"),
+                            path("v", "profile", "city")),
+                    ImmutableList.of());
+
+            assertColumn("select v['a.b'], v['a']['b'] from variant_tbl",
+                    "variant",
+                    ImmutableList.of(
+                            path("v", "a", "b"),
+                            path("v", "a.b")),
+                    ImmutableList.of());
+        });
+    }
+
+    @Test
     public void testVariantMultiProjectionAccessPaths() throws Exception {
         assertVariantSubColumnSlots("select v['a'], v['b']['c'] from variant_tbl",
                 ImmutableList.of(
@@ -226,7 +263,10 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
     public void testExplodeVariantWithOuterPredicateAccessPath() throws Exception {
         assertAllAccessPathsContain("select x['x'] from variant_tbl lateral view explode(v['arr']) tmp as x "
                         + "where v['filter']['k'] = 1 and x['y'] is not null",
-                ImmutableList.of(path("v", "arr", "x"), path("v", "arr", "y"), path("v", "filter", "k")),
+                ImmutableList.of(
+                        path("v", "arr", "x"),
+                        path("v", "arr", "y"),
+                        path("v", "filter", "k")),
                 ImmutableList.of());
     }
 
@@ -1226,6 +1266,25 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
         TColumnAccessPath accessPath = new TColumnAccessPath(TAccessPathType.DATA);
         accessPath.data_access_path = new TDataAccessPath(ImmutableList.copyOf(path));
         return accessPath;
+    }
+
+    private void withVariantSubPathPruningDisabled(CheckedRunnable runnable) throws Exception {
+        String disabledRules = String.join(",",
+                connectContext.getSessionVariable().getDisableNereidsRuleNames());
+        connectContext.getSessionVariable().setDisableNereidsRules(
+                disabledRules.isEmpty()
+                        ? "VARIANT_SUB_PATH_PRUNING"
+                        : disabledRules + ",VARIANT_SUB_PATH_PRUNING");
+        try {
+            runnable.run();
+        } finally {
+            connectContext.getSessionVariable().setDisableNereidsRules(disabledRules);
+        }
+    }
+
+    @FunctionalInterface
+    private interface CheckedRunnable {
+        void run() throws Exception;
     }
 
     private TColumnAccessPath metaPath(String... path) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneNestedColumnTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneNestedColumnTest.java
@@ -236,7 +236,7 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
     public void testExplodeVariantAccessPath() throws Exception {
         assertColumn("select x['k'] from variant_tbl lateral view explode(v) tmp as x",
                 "variant",
-                ImmutableList.of(path("v", "k")),
+                ImmutableList.of(path("v")),
                 ImmutableList.of()
         );
     }
@@ -245,7 +245,7 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
     public void testExplodeVariantProjectAndFilterAccessPath() throws Exception {
         assertColumn("select x['x'] from variant_tbl lateral view explode(v['arr']) tmp as x where x['y'] is not null",
                 "variant",
-                ImmutableList.of(path("v", "arr", "x"), path("v", "arr", "y")),
+                ImmutableList.of(path("v", "arr")),
                 ImmutableList.of()
         );
     }
@@ -254,7 +254,7 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
     public void testExplodeVariantMultiLevelFieldAccessPath() throws Exception {
         assertColumn("select x['a']['b'] from variant_tbl lateral view explode(v['arr']) tmp as x",
                 "variant",
-                ImmutableList.of(path("v", "arr", "a", "b")),
+                ImmutableList.of(path("v", "arr")),
                 ImmutableList.of()
         );
     }
@@ -264,8 +264,7 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
         assertAllAccessPathsContain("select x['x'] from variant_tbl lateral view explode(v['arr']) tmp as x "
                         + "where v['filter']['k'] = 1 and x['y'] is not null",
                 ImmutableList.of(
-                        path("v", "arr", "x"),
-                        path("v", "arr", "y"),
+                        path("v", "arr"),
                         path("v", "filter", "k")),
                 ImmutableList.of());
     }
@@ -275,7 +274,7 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
         assertColumn("select x['m'] from (select v as a from variant_tbl) t lateral view explode(a['arr']) tmp as x "
                         + "where x['n'] is not null",
                 "variant",
-                ImmutableList.of(path("v", "arr", "m"), path("v", "arr", "n")),
+                ImmutableList.of(path("v", "arr")),
                 ImmutableList.of()
         );
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneNestedColumnTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/PruneNestedColumnTest.java
@@ -280,6 +280,26 @@ public class PruneNestedColumnTest extends TestWithFeService implements MemoPatt
     }
 
     @Test
+    public void testMultiArgumentExplodePreservesVariantContainers() throws Exception {
+        assertColumn("select x1['k'] from variant_tbl lateral view explode(v, v) tmp as x1, x2",
+                "variant",
+                ImmutableList.of(path("v")),
+                ImmutableList.of());
+
+        assertColumns("select x1['k'] from variant_tbl "
+                        + "lateral view explode(v['a'], v['b']) tmp as x1, x2",
+                ImmutableList.of(
+                        Triple.of("variant", ImmutableList.of(path("v", "a")), ImmutableList.of()),
+                        Triple.of("variant", ImmutableList.of(path("v", "b")), ImmutableList.of())));
+
+        assertColumn("select x1['k'] from variant_tbl "
+                        + "lateral view explode_outer(v, v) tmp as x1, x2",
+                "variant",
+                ImmutableList.of(path("v")),
+                ImmutableList.of());
+    }
+
+    @Test
     public void testStruct() throws Throwable {
         assertColumn("select element_at(s, 1) from tbl",
                 "struct<city:text>",

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/VariantPruningLogicTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/VariantPruningLogicTest.java
@@ -143,7 +143,7 @@ public class VariantPruningLogicTest extends TestWithFeService {
     public void testExplodeWholeVariantAccessPaths() throws Exception {
         assertAllAccessPathsContain(
                 "select x['k'] from variant_tbl lateral view explode(v) tmp as x",
-                ImmutableList.of(path("v", "k")),
+                ImmutableList.of(path("v")),
                 ImmutableList.of()
         );
     }
@@ -154,8 +154,7 @@ public class VariantPruningLogicTest extends TestWithFeService {
                 "select x['x'] from variant_tbl lateral view explode(v['arr']) tmp as x "
                         + "where v['filter']['k'] = 1 and x['y'] is not null",
                 ImmutableList.of(
-                        path("v", "arr", "x"),
-                        path("v", "arr", "y"),
+                        path("v", "arr"),
                         path("v", "filter", "k")
                 ),
                 ImmutableList.of()
@@ -166,7 +165,7 @@ public class VariantPruningLogicTest extends TestWithFeService {
     public void testExplodeVariantDeepNestedAccessPaths() throws Exception {
         assertAllAccessPathsContain(
                 "select x['a']['b'][0]['c'] from variant_tbl lateral view explode(v['arr']) tmp as x",
-                ImmutableList.of(path("v", "arr", "a", "b", "0", "c")),
+                ImmutableList.of(path("v", "arr")),
                 ImmutableList.of()
         );
     }
@@ -180,7 +179,7 @@ public class VariantPruningLogicTest extends TestWithFeService {
                         + "where x['a']['b'] = 1 and t2.v['k'] is not null "
                         + "group by cast(t2.v['k'] as string)",
                 ImmutableList.of(
-                        path("v", "arr", "a", "b"),
+                        path("v", "arr"),
                         path("v", "k")
                 ),
                 ImmutableList.of()
@@ -192,7 +191,7 @@ public class VariantPruningLogicTest extends TestWithFeService {
         assertAllAccessPathsContain(
                 "select sum(cast(x['metric'] as int)) from variant_tbl lateral view explode(v['arr']) tmp as x "
                         + "where x['metric'] is not null",
-                ImmutableList.of(path("v", "arr", "metric")),
+                ImmutableList.of(path("v", "arr")),
                 ImmutableList.of()
         );
     }
@@ -201,7 +200,7 @@ public class VariantPruningLogicTest extends TestWithFeService {
     public void testExplodeOuterAccessPaths() throws Exception {
         assertAllAccessPathsContain(
                 "select x['k'] from variant_tbl lateral view explode_outer(v['arr']) tmp as x",
-                ImmutableList.of(path("v", "arr", "k")),
+                ImmutableList.of(path("v", "arr")),
                 ImmutableList.of()
         );
     }

--- a/regression-test/data/external_table_p0/iceberg/test_iceberg_variant_read.out
+++ b/regression-test/data/external_table_p0/iceberg/test_iceberg_variant_read.out
@@ -35,6 +35,10 @@
 2	BOB	21	2.5	false	7	sh
 9	CAROL	41	4.5	true	11	bj
 
+-- !variant_deep_object_fallback --
+1	CN	1
+2	US	2
+
 -- !variant_filter --
 11	null	60
 3	same	30

--- a/regression-test/data/external_table_p0/paimon/test_paimon_catalog_variant.out
+++ b/regression-test/data/external_table_p0/paimon/test_paimon_catalog_variant.out
@@ -77,7 +77,11 @@ payload	variant<PROPERTIES ("variant_max_subcolumns_count" = "0","variant_enable
 2	bob
 
 -- !native_shredded_projection --
-2	bob	30	\N
+2	bob	30	\N	shanghai	200000
+
+-- !native_shredded_deep_object_projection --
+1	100000	1
+2	200000	2
 
 -- !native_mixed_us_partitions --
 1	2026-06-01	alice	18	unshredded

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_variant_read.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_variant_read.groovy
@@ -133,6 +133,17 @@ suite("test_iceberg_variant_read",
             (10, parse_json('{"name":"dave","n":50,"ratio":5.5,"ok":false,"arr":[7,8],"nested":{"city":"sz"}}')),
             (11, parse_json('{"name":null,"n":60,"ratio":6.5,"ok":true,"arr":[9,10],"nested":{"city":null}}'));
 
+        DROP TABLE IF EXISTS demo.${dbName}.variant_deep_object;
+        CREATE TABLE demo.${dbName}.variant_deep_object (id INT, v VARIANT) USING iceberg
+        TBLPROPERTIES (
+            'format-version'='3',
+            'write.format.default'='parquet',
+            'write.parquet.shred-variants'='false'
+        );
+        INSERT INTO demo.${dbName}.variant_deep_object VALUES
+            (1, parse_json('{"profile":{"address":{"country":{"code":"CN","rank":1}}}}')),
+            (2, parse_json('{"profile":{"address":{"country":{"code":"US","rank":2}}}}'));
+
         DROP TABLE IF EXISTS demo.${dbName}.variant_root_arrays;
         CREATE TABLE demo.${dbName}.variant_root_arrays (id INT, v VARIANT) USING iceberg
         TBLPROPERTIES (
@@ -603,6 +614,14 @@ public class AppendVariantEqualityDelete {
                CAST(v['nested']['city'] AS STRING)
         FROM variant_values
         WHERE id IN (1, 2, 9, 10, 11)
+        ORDER BY id
+    """
+
+    order_qt_variant_deep_object_fallback """
+        SELECT id,
+               CAST(v['profile']['address']['country']['code'] AS STRING),
+               CAST(v['profile']['address']['country']['rank'] AS INT)
+        FROM variant_deep_object
         ORDER BY id
     """
 

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_catalog_variant.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_catalog_variant.groovy
@@ -283,21 +283,30 @@ suite("test_paimon_catalog_variant", "p0,external,doris,external_docker,external
         """
         assertEquals(2, deepProjectionRows.size())
         String deepProjectionProfile = new ProfileAction(context).getProfileBySql(
-                deepProjectionToken, ["VariantLeafProjections"], 30000L, 500L)
-        def leafProjectionValues = deepProjectionProfile =~
-                /(?m)^\s*(?:-\s*)?VariantLeafProjections:\s+([^\n]+)/
-        long leafProjectionCount = 0L
-        while (leafProjectionValues.find()) {
-            def exactValue = leafProjectionValues.group(1).toString() =~ /\(([0-9,]+)\)/
-            def displayedValue = leafProjectionValues.group(1).toString() =~ /([0-9,]+)/
-            if (exactValue.find()) {
-                leafProjectionCount += Long.parseLong(exactValue.group(1).replace(",", ""))
-            } else if (displayedValue.find()) {
-                leafProjectionCount += Long.parseLong(displayedValue.group(1).replace(",", ""))
+                deepProjectionToken,
+                ["VariantLeafProjectionRowGroupColumns", "VariantFullProjectionRowGroupColumns"],
+                30000L, 500L)
+        def counterSum = { String profile, String counterName ->
+            def values = profile =~
+                    /(?m)^\s*(?:-\s*)?${counterName}:\s+([^\n]+)/
+            long total = 0L
+            while (values.find()) {
+                def exactValue = values.group(1).toString() =~ /\(([0-9,]+)\)/
+                def displayedValue = values.group(1).toString() =~ /([0-9,]+)/
+                if (exactValue.find()) {
+                    total += Long.parseLong(exactValue.group(1).replace(",", ""))
+                } else if (displayedValue.find()) {
+                    total += Long.parseLong(displayedValue.group(1).replace(",", ""))
+                }
             }
+            return total
         }
-        assertTrue(leafProjectionCount > 0,
+        assertTrue(counterSum(deepProjectionProfile,
+                        "VariantLeafProjectionRowGroupColumns") > 0,
                 "Paimon Native did not project the deeply shredded Variant object leaves")
+        assertEquals(0L, counterSum(deepProjectionProfile,
+                        "VariantFullProjectionRowGroupColumns"),
+                "Paimon Native unexpectedly fell back to full Variant row-group projection")
         sql """set enable_profile = false"""
 
         order_qt_native_mixed_us_partitions """

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_catalog_variant.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_catalog_variant.groovy
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import org.apache.doris.regression.action.ProfileAction
+
 suite("test_paimon_catalog_variant", "p0,external,doris,external_docker,external_docker_doris") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled != null && enabled.equalsIgnoreCase("true")) {
@@ -252,11 +254,51 @@ suite("test_paimon_catalog_variant", "p0,external,doris,external_docker,external
             select id,
                    cast(payload['name'] as string),
                    cast(payload['age'] as int),
-                   cast(payload['extra'] as string)
+                   cast(payload['extra'] as string),
+                   cast(payload['profile']['address']['city'] as string),
+                   cast(payload['profile']['address']['zip'] as int)
             from variant_shredded
             where cast(payload['age'] as int) >= 20
             order by id
         """
+
+        order_qt_native_shredded_deep_object_projection """
+            select id,
+                   cast(payload['profile']['address']['zip'] as int),
+                   cast(payload['profile']['address']['rank'] as int)
+            from variant_shredded
+            order by id
+        """
+
+        sql """set enable_profile = true"""
+        sql """set profile_level = 2"""
+        String deepProjectionToken =
+                "paimon_variant_deep_object_projection_" + UUID.randomUUID().toString()
+        List<List<Object>> deepProjectionRows = sql """
+            select '${deepProjectionToken}', id,
+                   cast(payload['profile']['address']['zip'] as int),
+                   cast(payload['profile']['address']['rank'] as int)
+            from variant_shredded
+            order by id
+        """
+        assertEquals(2, deepProjectionRows.size())
+        String deepProjectionProfile = new ProfileAction(context).getProfileBySql(
+                deepProjectionToken, ["VariantLeafProjections"], 30000L, 500L)
+        def leafProjectionValues = deepProjectionProfile =~
+                /(?m)^\s*(?:-\s*)?VariantLeafProjections:\s+([^\n]+)/
+        long leafProjectionCount = 0L
+        while (leafProjectionValues.find()) {
+            def exactValue = leafProjectionValues.group(1).toString() =~ /\(([0-9,]+)\)/
+            def displayedValue = leafProjectionValues.group(1).toString() =~ /([0-9,]+)/
+            if (exactValue.find()) {
+                leafProjectionCount += Long.parseLong(exactValue.group(1).replace(",", ""))
+            } else if (displayedValue.find()) {
+                leafProjectionCount += Long.parseLong(displayedValue.group(1).replace(",", ""))
+            }
+        }
+        assertTrue(leafProjectionCount > 0,
+                "Paimon Native did not project the deeply shredded Variant object leaves")
+        sql """set enable_profile = false"""
 
         order_qt_native_mixed_us_partitions """
             select id,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

File Scanner V2 carried Variant access paths as a list of string segments, but the BE Parquet mapper only projected one top-level shredded leaf. Deep object paths therefore fell back even when every nested `typed_value` wrapper was physically available. The FE access-path comparator also joined segments with dots, so an object key such as `a.b` could collide with the nested path `a/b` before the paths reached BE.

This change reuses the existing access-path list without any Thrift or Proto change. It compares FE paths segment by segment, merges sibling and prefix paths through the shared BE access-path tree, and traverses arbitrary-depth object `typed_value` wrappers for Iceberg and Paimon native Parquet scans. Numeric segments, repeated ancestors, missing leaves, unshredded files, and ambiguous physical leaf identities conservatively fall back to the complete Variant root. Numeric array indexes remain unsupported with a TODO for typed path segments.

### Release note

Support arbitrary-depth object-only Variant leaf projection for Iceberg and Paimon native Parquet scans.

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. Iceberg and Paimon native Parquet scans can physically project deeply shredded Variant object leaves while preserving conservative fallback behavior.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label