### PR TITLE
[fix](fe) Quote dictionary data load identifiers

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/dictionary/DictionaryManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/dictionary/DictionaryManager.java
@@ -35,6 +35,7 @@ import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateDictionaryInfo;
 import org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoDictionaryCommand;
 import org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand;
+import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.persist.CreateDictionaryPersistInfo;
 import org.apache.doris.persist.DictionaryDecreaseVersionInfo;
 import org.apache.doris.persist.DictionaryIncreaseVersionInfo;
@@ -412,31 +413,30 @@ public class DictionaryManager extends MasterDaemon implements Writable {
                     + dictionary.getStatus().name());
         }
 
-        if (ctx == null) { // for run with scheduler, not by command.
-            // priv check is done in relative(caller) command. so use ADMIN here is ok.
-            ctx = InsertTask.makeConnectContext(UserIdentity.ADMIN, dictionary.getDbName());
-        }
-
-        // not use rerfresh command's executor to avoid potential problems.
-        String insertSql = "insert into " + dictionary.getDbName() + "." + dictionary.getName() + " select * from "
-                + dictionary.getSourceCtlName() + "." + dictionary.getSourceDbName() + "."
-                + dictionary.getSourceTableName();
-        StmtExecutor executor = new StmtExecutor(ctx, insertSql);
-        NereidsParser parser = new NereidsParser();
-        InsertIntoTableCommand baseCommand = (InsertIntoTableCommand) parser.parseSingle(insertSql);
-        LOG.info("Loading to dictionary {} with query {}. adaptive: {}", dictionary.getName(), ctx.queryId(),
-                adaptiveLoad);
-        if (!baseCommand.getLabelName().isPresent()) {
-            baseCommand.setLabelName(Optional.of(DICTIONARY_JOB_ID + "_" + ctx.queryId().toString()));
-        }
-        if (baseCommand.getJobId() == 0) {
-            baseCommand.setJobId(DICTIONARY_JOB_ID);
-        }
-
-        InsertIntoDictionaryCommand command = new InsertIntoDictionaryCommand(baseCommand, dictionary, adaptiveLoad);
-
-        // run with sync by status.
         try {
+            if (ctx == null) { // for run with scheduler, not by command.
+                // priv check is done in relative(caller) command. so use ADMIN here is ok.
+                ctx = InsertTask.makeConnectContext(UserIdentity.ADMIN, dictionary.getDbName());
+            }
+
+            // not use rerfresh command's executor to avoid potential problems.
+            String insertSql = buildDataLoadSql(dictionary);
+            StmtExecutor executor = new StmtExecutor(ctx, insertSql);
+            NereidsParser parser = new NereidsParser();
+            InsertIntoTableCommand baseCommand = (InsertIntoTableCommand) parser.parseSingle(insertSql);
+            LOG.info("Loading to dictionary {} with query {}. adaptive: {}", dictionary.getName(), ctx.queryId(),
+                    adaptiveLoad);
+            if (!baseCommand.getLabelName().isPresent()) {
+                baseCommand.setLabelName(Optional.of(DICTIONARY_JOB_ID + "_" + ctx.queryId().toString()));
+            }
+            if (baseCommand.getJobId() == 0) {
+                baseCommand.setJobId(DICTIONARY_JOB_ID);
+            }
+
+            InsertIntoDictionaryCommand command = new InsertIntoDictionaryCommand(baseCommand, dictionary,
+                    adaptiveLoad);
+
+            // run with sync by status.
             // avoid to generate EmptySetNode making us not able to get base table version.
             ctx.getSessionVariable().setVarOnce(SessionVariable.DISABLE_NEREIDS_RULES,
                     "OLAP_SCAN_PARTITION_PRUNE,PRUNE_EMPTY_PARTITION");
@@ -522,6 +522,12 @@ public class DictionaryManager extends MasterDaemon implements Writable {
         }
         LOG.info("Dictionary {} refresh succeed. now version is {}. used src version {}", dictionary.getName(),
                 dictionary.getVersion(), ctx.getStatementContext().getDictionaryUsedSrcVersion());
+    }
+
+    static String buildDataLoadSql(Dictionary dictionary) {
+        String targetName = Utils.qualifiedNameWithBackquote(dictionary.getFullQualifiers());
+        String sourceName = Utils.qualifiedNameWithBackquote(dictionary.getSourceQualifiedName());
+        return "insert into " + targetName + " select * from " + sourceName;
     }
 
     private boolean commitNowVersion(ConnectContext ctx, Dictionary dictionary) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundDictionarySink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/analyzer/UnboundDictionarySink.java
@@ -53,7 +53,7 @@ public class UnboundDictionarySink<CHILD_TYPE extends Plan> extends UnboundLogic
      */
     public UnboundDictionarySink(Dictionary dictionary, CHILD_TYPE child, boolean adaptiveLoad) {
         // all the empty arguments is like UnboundTableSink
-        super(ImmutableList.copyOf(dictionary.getNameWithFullQualifiers().split("\\.")), // nameParts
+        super(ImmutableList.copyOf(dictionary.getFullQualifiers()), // nameParts
                 PlanType.LOGICAL_UNBOUND_DICTIONARY_SINK, // type
                 ImmutableList.of(), // outputExprs
                 Optional.empty(), // groupExpression

--- a/fe/fe-core/src/test/java/org/apache/doris/dictionary/DictionaryManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/dictionary/DictionaryManagerTest.java
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.dictionary;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.nereids.analyzer.UnboundDictionarySink;
+import org.apache.doris.nereids.analyzer.UnboundRelation;
+import org.apache.doris.nereids.analyzer.UnboundTableSink;
+import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoDictionaryCommand;
+import org.apache.doris.nereids.trees.plans.commands.insert.InsertIntoTableCommand;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.qe.ConnectContext;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+public class DictionaryManagerTest {
+
+    @Test
+    public void testBuildDataLoadSqlQuotesIdentifierParts() {
+        List<String> targetName = ImmutableList.of("target.with` db", "dict.with` union all select 1");
+        List<String> targetFullName = ImmutableList.of("internal", targetName.get(0), targetName.get(1));
+        List<String> sourceName = ImmutableList.of(
+                "internal` catalog", "source` db", "src` union all select k, v from secret.tbl");
+        Dictionary dictionary = Mockito.mock(Dictionary.class);
+        Mockito.when(dictionary.getDbName()).thenReturn(targetName.get(0));
+        Mockito.when(dictionary.getName()).thenReturn(targetName.get(1));
+        Mockito.when(dictionary.getFullQualifiers()).thenReturn(targetFullName);
+        Mockito.when(dictionary.getSourceQualifiedName()).thenReturn(sourceName);
+        Mockito.when(dictionary.getColumnNames()).thenReturn(ImmutableList.of("k", "v"));
+
+        String insertSql = DictionaryManager.buildDataLoadSql(dictionary);
+
+        Assertions.assertEquals("insert into `internal`.`target.with`` db`.`dict.with`` union all select 1` "
+                + "select * from `internal`` catalog`.`source`` db`."
+                + "`src`` union all select k, v from secret.tbl`", insertSql);
+        ConnectContext context = new ConnectContext();
+        context.setEnv(Env.getCurrentEnv());
+        context.changeDefaultCatalog("external_catalog");
+        context.setThreadLocalInfo();
+        try {
+            InsertIntoTableCommand command = (InsertIntoTableCommand) new NereidsParser().parseSingle(insertSql);
+            LogicalPlan query = command.getLogicalQuery();
+            Assertions.assertInstanceOf(UnboundTableSink.class, query);
+            Assertions.assertEquals(targetFullName, ((UnboundTableSink<?>) query).getNameParts());
+
+            InsertIntoDictionaryCommand dictionaryCommand = new InsertIntoDictionaryCommand(command, dictionary, false);
+            LogicalPlan dictionaryQuery = dictionaryCommand.getLogicalQuery();
+            Assertions.assertInstanceOf(UnboundDictionarySink.class, dictionaryQuery);
+            Assertions.assertEquals(targetFullName, ((UnboundDictionarySink<?>) dictionaryQuery).getNameParts());
+
+            List<UnboundRelation> sourceRelations = dictionaryQuery.collectToList(UnboundRelation.class::isInstance);
+            Assertions.assertEquals(1, sourceRelations.size());
+            Assertions.assertEquals(sourceName, sourceRelations.get(0).getNameParts());
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+
+    @Test
+    public void testDataLoadRestoresStatusWhenCommandPreparationFails() {
+        Dictionary dictionary = Mockito.mock(Dictionary.class);
+        Mockito.when(dictionary.getStatus()).thenReturn(Dictionary.DictionaryStatus.NORMAL);
+        Mockito.when(dictionary.trySetStatus(Dictionary.DictionaryStatus.LOADING)).thenReturn(true);
+        Mockito.when(dictionary.getFullQualifiers()).thenThrow(new IllegalStateException("invalid target"));
+
+        DictionaryManager manager = new DictionaryManager();
+        ConnectContext context = new ConnectContext();
+        Assertions.assertThrows(IllegalStateException.class, () -> manager.dataLoad(context, dictionary, false));
+
+        Mockito.verify(dictionary).trySetStatus(Dictionary.DictionaryStatus.LOADING);
+        Mockito.verify(dictionary).trySetStatus(Dictionary.DictionaryStatus.NORMAL);
+        Mockito.verify(dictionary).setLastUpdateResult("invalid target");
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: DORIS-27640

Related PR: #66218

Problem Summary: Dictionary refresh rebuilt its internal `INSERT ... SELECT` statement by concatenating raw target and source object names. Identifier text containing SQL syntax could therefore change the parsed query structure. Quote and escape every identifier component with the existing Nereids helper.

The dictionary sink conversion also rebuilt structured target qualifiers by joining and splitting on `.`, which broke legal database or dictionary names containing dots. Keep the structured qualifier list through that conversion.

Fully qualify the internal dictionary target so manual refresh does not inherit an external current catalog. Command preparation now runs inside the existing status-recovery block, preventing preparation errors from leaving a dictionary in `LOADING`.

### Release note

Fix dictionary refresh for quoted object names.

### Check List (For Author)

- Test: Added parser/dictionary-sink tests for dots, embedded backticks, spaces, SQL-looking identifier text, external current-catalog independence, and command-preparation status recovery
- Local test: Not run because the required thirdparty `protoc` binary is unavailable in this worktree; official FE UT was triggered on the PR
- Behavior changed: Yes; dictionary load SQL now treats all metadata names strictly as identifiers
- Does this need documentation: No
