### PR TITLE
[improvement](lance) Balance fragment splits by row count

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceMetadataLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceMetadataLoader.java
@@ -86,7 +86,8 @@ public final class LanceMetadataLoader {
             List<LanceTableMetadata.LanceFragmentInfo> fragments = new ArrayList<>();
             for (Fragment fragment : dataset.getFragments()) {
                 fragments.add(new LanceTableMetadata.LanceFragmentInfo(
-                        fragment.getId(), fragment.metadata().getNumRows()));
+                        fragment.getId(), fragment.metadata().getNumRows(),
+                        fragment.metadata().getPhysicalRows()));
             }
             return new LanceTableMetadata(datasetUri, resolvedVersion, dataset.getSchema(), fragments,
                     backendStorageOptions);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceTableMetadata.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceTableMetadata.java
@@ -68,18 +68,30 @@ public class LanceTableMetadata {
     public static class LanceFragmentInfo {
         private final long id;
         private final long rowCount;
+        private final long physicalRows;
 
-        public LanceFragmentInfo(long id, long rowCount) {
+        public LanceFragmentInfo(long id, long rowCount, long physicalRows) {
             this.id = id;
             this.rowCount = rowCount;
+            this.physicalRows = physicalRows;
         }
 
         public long getId() {
             return id;
         }
 
+        /** Logical rows after deletions, used for row-count statistics. */
         public long getRowCount() {
             return rowCount;
+        }
+
+        /**
+         * Physical rows on disk before deletions. The pinned BE legacy reader reads and merges
+         * physical batches before applying the deletion vector, so scan work scales with this
+         * value rather than the post-deletion row count. Used for split scheduling weight.
+         */
+        public long getPhysicalRows() {
+            return physicalRows;
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/source/LanceScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/source/LanceScanNode.java
@@ -154,14 +154,23 @@ public class LanceScanNode extends FileQueryScanNode {
             plannedVersion = metadata.getVersion();
             plannedFragments = metadata.getFragments().size();
             Set<Long> fragmentIds = new HashSet<>();
-            List<Split> splits = new ArrayList<>(plannedFragments);
+            long targetRows = 1;
             for (LanceTableMetadata.LanceFragmentInfo fragment : metadata.getFragments()) {
                 if (!fragmentIds.add(fragment.getId())) {
                     throw new UserException("Duplicate Lance fragment id " + fragment.getId()
                             + " at dataset version " + metadata.getVersion());
                 }
-                splits.add(new LanceSplit(metadata.getDatasetUri(), metadata.getVersion(),
-                        fragment.getId(), fragment.getRowCount()));
+                targetRows = Math.max(targetRows, Math.max(fragment.getRowCount(), 1));
+            }
+
+            // Use the largest fragment as one standard split so smaller fragments keep
+            // their relative row-count weight during backend assignment.
+            List<Split> splits = new ArrayList<>(plannedFragments);
+            for (LanceTableMetadata.LanceFragmentInfo fragment : metadata.getFragments()) {
+                LanceSplit split = new LanceSplit(metadata.getDatasetUri(), metadata.getVersion(),
+                        fragment.getId(), fragment.getRowCount());
+                split.setTargetSplitSize(targetRows);
+                splits.add(split);
             }
             return splits;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/source/LanceScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/source/LanceScanNode.java
@@ -160,15 +160,16 @@ public class LanceScanNode extends FileQueryScanNode {
                     throw new UserException("Duplicate Lance fragment id " + fragment.getId()
                             + " at dataset version " + metadata.getVersion());
                 }
-                targetRows = Math.max(targetRows, Math.max(fragment.getRowCount(), 1));
+                targetRows = Math.max(targetRows, Math.max(fragment.getPhysicalRows(), 1));
             }
 
             // Use the largest fragment as one standard split so smaller fragments keep
-            // their relative row-count weight during backend assignment.
+            // their relative row-count weight during backend assignment. Physical rows drive
+            // the weight because the BE legacy reader scans physical batches before deletions.
             List<Split> splits = new ArrayList<>(plannedFragments);
             for (LanceTableMetadata.LanceFragmentInfo fragment : metadata.getFragments()) {
                 LanceSplit split = new LanceSplit(metadata.getDatasetUri(), metadata.getVersion(),
-                        fragment.getId(), fragment.getRowCount());
+                        fragment.getId(), fragment.getPhysicalRows());
                 split.setTargetSplitSize(targetRows);
                 splits.add(split);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/tvf/source/TVFScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/tvf/source/TVFScanNode.java
@@ -31,6 +31,7 @@ import org.apache.doris.datasource.FileSplit;
 import org.apache.doris.datasource.FileSplit.FileSplitCreator;
 import org.apache.doris.datasource.FileSplitter;
 import org.apache.doris.datasource.TableFormatType;
+import org.apache.doris.datasource.lance.LanceTableMetadata;
 import org.apache.doris.datasource.lance.source.LanceSplit;
 import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.planner.ScanContext;
@@ -192,9 +193,19 @@ public class TVFScanNode extends FileQueryScanNode {
             throw new UserException(
                     "S3 Lance TVF metadata was not initialized with a fixed dataset version");
         }
-        List<Split> splits = new ArrayList<>(tableValuedFunction.getLanceFragmentIds().size());
-        for (Long fragmentId : tableValuedFunction.getLanceFragmentIds()) {
-            splits.add(new LanceSplit(tableValuedFunction.getFilePath(), version, fragmentId, 1));
+        List<LanceTableMetadata.LanceFragmentInfo> fragments = tableValuedFunction.getLanceFragments();
+        // Mirror LanceScanNode: use the largest fragment as one standard split so smaller fragments
+        // keep their relative physical-row weight, keeping the catalog and S3/file TVF paths in sync.
+        long targetRows = 1;
+        for (LanceTableMetadata.LanceFragmentInfo fragment : fragments) {
+            targetRows = Math.max(targetRows, Math.max(fragment.getPhysicalRows(), 1));
+        }
+        List<Split> splits = new ArrayList<>(fragments.size());
+        for (LanceTableMetadata.LanceFragmentInfo fragment : fragments) {
+            LanceSplit split = new LanceSplit(tableValuedFunction.getFilePath(), version,
+                    fragment.getId(), fragment.getPhysicalRows());
+            split.setTargetSplitSize(targetRows);
+            splits.add(split);
         }
         return splits;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
@@ -138,7 +138,7 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
     public FileFormatProperties fileFormatProperties;
     private long tableId;
     private long lanceDatasetVersion = -1;
-    private List<Long> lanceFragmentIds = Collections.emptyList();
+    private List<LanceTableMetadata.LanceFragmentInfo> lanceFragments = Collections.emptyList();
 
     public abstract TFileType getTFileType();
 
@@ -162,8 +162,8 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
         return lanceDatasetVersion;
     }
 
-    public List<Long> getLanceFragmentIds() {
-        return lanceFragmentIds;
+    public List<LanceTableMetadata.LanceFragmentInfo> getLanceFragments() {
+        return lanceFragments;
     }
 
     public Map<String, String> getBackendConnectProperties() {
@@ -358,7 +358,8 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
             throw new AnalysisException("Lance returned an invalid dataset version: "
                     + metadata.getVersion());
         }
-        List<Long> fragmentIds = new ArrayList<>(metadata.getFragments().size());
+        List<LanceTableMetadata.LanceFragmentInfo> fragments =
+                new ArrayList<>(metadata.getFragments().size());
         Set<Long> uniqueIds = new HashSet<>();
         for (LanceTableMetadata.LanceFragmentInfo fragment : metadata.getFragments()) {
             long fragmentId = fragment.getId();
@@ -368,7 +369,7 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
             if (!uniqueIds.add(fragmentId)) {
                 throw new AnalysisException("Lance returned duplicate fragment id: " + fragmentId);
             }
-            fragmentIds.add(fragmentId);
+            fragments.add(fragment);
         }
 
         List<Column> lanceColumns = new ArrayList<>(metadata.getSchema().getFields().size());
@@ -390,7 +391,7 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
         }
 
         lanceDatasetVersion = metadata.getVersion();
-        lanceFragmentIds = Collections.unmodifiableList(fragmentIds);
+        lanceFragments = Collections.unmodifiableList(fragments);
         columns = lanceColumns;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/FileTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/FileTableValuedFunction.java
@@ -22,6 +22,7 @@ import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.lance.LanceTableMetadata;
 import org.apache.doris.datasource.property.storage.AbstractS3CompatibleProperties;
 import org.apache.doris.datasource.property.storage.AzureProperties;
 import org.apache.doris.datasource.property.storage.HdfsCompatibleProperties;
@@ -100,8 +101,8 @@ public class FileTableValuedFunction extends ExternalFileTableValuedFunction {
     }
 
     @Override
-    public List<Long> getLanceFragmentIds() {
-        return delegateTvf.getLanceFragmentIds();
+    public List<LanceTableMetadata.LanceFragmentInfo> getLanceFragments() {
+        return delegateTvf.getLanceFragments();
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceSnapshotTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceSnapshotTest.java
@@ -88,7 +88,7 @@ public class LanceSnapshotTest {
     private static LanceTableMetadata metadata(long version, Field field) {
         return new LanceTableMetadata("s3://bucket/table.lance", version,
                 new Schema(Collections.singletonList(field)),
-                Collections.singletonList(new LanceTableMetadata.LanceFragmentInfo(version, 1)),
+                Collections.singletonList(new LanceTableMetadata.LanceFragmentInfo(version, 1, 1)),
                 Collections.singletonMap("s3.endpoint", "http://minio:9000"));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/source/LanceScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/source/LanceScanNodeTest.java
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.lance.source;
+
+import org.apache.doris.analysis.TupleDescriptor;
+import org.apache.doris.analysis.TupleId;
+import org.apache.doris.datasource.lance.LanceTableMetadata;
+import org.apache.doris.planner.PlanNodeId;
+import org.apache.doris.planner.ScanContext;
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.spi.Split;
+
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class LanceScanNodeTest {
+
+    @Test
+    public void testFragmentRowsDetermineSplitWeights() throws Exception {
+        LanceTableMetadata metadata = new LanceTableMetadata(
+                "s3://bucket/table.lance",
+                42,
+                new Schema(Collections.emptyList()),
+                Arrays.asList(
+                        new LanceTableMetadata.LanceFragmentInfo(7, 1000),
+                        new LanceTableMetadata.LanceFragmentInfo(11, 250),
+                        new LanceTableMetadata.LanceFragmentInfo(13, 0)),
+                Collections.emptyMap());
+        LanceScanNode node = new LanceScanNode(
+                new PlanNodeId(0),
+                new TupleDescriptor(new TupleId(0)),
+                false,
+                new SessionVariable(),
+                ScanContext.EMPTY);
+        java.lang.reflect.Field metadataField = LanceScanNode.class.getDeclaredField("plannedMetadata");
+        metadataField.setAccessible(true);
+        metadataField.set(node, metadata);
+
+        List<Split> splits = node.getSplits(2);
+
+        Assert.assertEquals(3, splits.size());
+        assertSplit(splits.get(0), 7, 1000, 100);
+        assertSplit(splits.get(1), 11, 1000, 25);
+        assertSplit(splits.get(2), 13, 1000, 1);
+    }
+
+    private static void assertSplit(Split split, long fragmentId, long targetRows, long weight) {
+        LanceSplit lanceSplit = (LanceSplit) split;
+        Assert.assertEquals(fragmentId, lanceSplit.getFragmentId());
+        Assert.assertEquals(targetRows, lanceSplit.getTargetSplitSize().longValue());
+        Assert.assertEquals(weight, lanceSplit.getSplitWeight().getRawValue());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/source/LanceScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/source/LanceScanNodeTest.java
@@ -42,19 +42,12 @@ public class LanceScanNodeTest {
                 42,
                 new Schema(Collections.emptyList()),
                 Arrays.asList(
-                        new LanceTableMetadata.LanceFragmentInfo(7, 1000),
-                        new LanceTableMetadata.LanceFragmentInfo(11, 250),
-                        new LanceTableMetadata.LanceFragmentInfo(13, 0)),
+                        new LanceTableMetadata.LanceFragmentInfo(7, 1000, 1000),
+                        new LanceTableMetadata.LanceFragmentInfo(11, 250, 250),
+                        new LanceTableMetadata.LanceFragmentInfo(13, 0, 0)),
                 Collections.emptyMap());
-        LanceScanNode node = new LanceScanNode(
-                new PlanNodeId(0),
-                new TupleDescriptor(new TupleId(0)),
-                false,
-                new SessionVariable(),
-                ScanContext.EMPTY);
-        java.lang.reflect.Field metadataField = LanceScanNode.class.getDeclaredField("plannedMetadata");
-        metadataField.setAccessible(true);
-        metadataField.set(node, metadata);
+        LanceScanNode node = newNode();
+        setMetadata(node, metadata);
 
         List<Split> splits = node.getSplits(2);
 
@@ -62,6 +55,45 @@ public class LanceScanNodeTest {
         assertSplit(splits.get(0), 7, 1000, 100);
         assertSplit(splits.get(1), 11, 1000, 25);
         assertSplit(splits.get(2), 13, 1000, 1);
+    }
+
+    @Test
+    public void testDeletionHeavyFragmentKeepsPhysicalScanWeight() throws Exception {
+        // Both fragments read 1000 physical rows, but one has 990 tombstones so its logical
+        // row count is only 10. The pinned BE legacy reader still scans all physical rows, so
+        // both fragments must keep the standard weight instead of underweighting the
+        // tombstone-heavy one to the minimum.
+        LanceTableMetadata metadata = new LanceTableMetadata(
+                "s3://bucket/table.lance",
+                42,
+                new Schema(Collections.emptyList()),
+                Arrays.asList(
+                        new LanceTableMetadata.LanceFragmentInfo(7, 1000, 1000),
+                        new LanceTableMetadata.LanceFragmentInfo(11, 10, 1000)),
+                Collections.emptyMap());
+        LanceScanNode node = newNode();
+        setMetadata(node, metadata);
+
+        List<Split> splits = node.getSplits(2);
+
+        Assert.assertEquals(2, splits.size());
+        assertSplit(splits.get(0), 7, 1000, 100);
+        assertSplit(splits.get(1), 11, 1000, 100);
+    }
+
+    private static LanceScanNode newNode() {
+        return new LanceScanNode(
+                new PlanNodeId(0),
+                new TupleDescriptor(new TupleId(0)),
+                false,
+                new SessionVariable(),
+                ScanContext.EMPTY);
+    }
+
+    private static void setMetadata(LanceScanNode node, LanceTableMetadata metadata) throws Exception {
+        java.lang.reflect.Field metadataField = LanceScanNode.class.getDeclaredField("plannedMetadata");
+        metadataField.setAccessible(true);
+        metadataField.set(node, metadata);
     }
 
     private static void assertSplit(Split split, long fragmentId, long targetRows, long weight) {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/tvf/source/TVFScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/tvf/source/TVFScanNodeTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.analysis.TupleId;
 import org.apache.doris.catalog.FunctionGenTable;
 import org.apache.doris.datasource.FileQueryScanNode;
 import org.apache.doris.datasource.FileSplitter;
+import org.apache.doris.datasource.lance.LanceTableMetadata;
 import org.apache.doris.datasource.lance.source.LanceSplit;
 import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.planner.ScanContext;
@@ -127,7 +128,9 @@ public class TVFScanNodeTest {
         Mockito.when(tvf.isLanceFormat()).thenReturn(true);
         Mockito.when(tvf.getFilePath()).thenReturn("s3://bucket/table.lance");
         Mockito.when(tvf.getLanceDatasetVersion()).thenReturn(42L);
-        Mockito.when(tvf.getLanceFragmentIds()).thenReturn(Arrays.asList(7L, 11L));
+        Mockito.when(tvf.getLanceFragments()).thenReturn(Arrays.asList(
+                new LanceTableMetadata.LanceFragmentInfo(7, 1000, 1000),
+                new LanceTableMetadata.LanceFragmentInfo(11, 250, 250)));
         desc.setTable(table);
 
         TVFScanNode node = new TVFScanNode(new PlanNodeId(0), desc, false, sv, ScanContext.EMPTY);
@@ -138,6 +141,9 @@ public class TVFScanNodeTest {
         Assert.assertEquals("s3://bucket/table.lance", first.getDatasetUri());
         Assert.assertEquals(42L, first.getVersion());
         Assert.assertEquals(7L, first.getFragmentId());
+        // The S3/file TVF path must weight fragments by physical rows, in sync with LanceScanNode.
+        Assert.assertEquals(100L, first.getSplitWeight().getRawValue());
+        Assert.assertEquals(25L, ((LanceSplit) splits.get(1)).getSplitWeight().getRawValue());
 
         TFileRangeDesc range = new TFileRangeDesc();
         node.setScanParams(range, first);


### PR DESCRIPTION
### What problem does this PR solve?

Lance fragment metadata already carries the visible row count, and `LanceSplit` stores it as `selfSplitWeight`. However, `FileSplit#getSplitWeight` only uses that value when a common `targetSplitSize` is set. As a result, all Lance fragments currently have the same standard scheduling weight regardless of row count, which can cause uneven scan work across BEs when fragment sizes differ.

This PR uses the largest fragment row count as one standard split and assigns smaller fragments a proportional weight. It changes only FE scheduling metadata:

- split count and fragment order are unchanged;
- dataset version and fragment IDs are unchanged;
- BE scan and query result semantics are unchanged.

### Verification

- Added `LanceScanNodeTest` covering fragment row counts `1000`, `250`, and `0`, which map to raw split weights `100`, `25`, and the minimum `1`.
- `mvn validate -pl fe-core -am -DskipTests` passed for all 15 FE reactor modules with zero Checkstyle violations.
- The targeted unit test is included for standard Doris CI. The local machine only has JDK 11 and lacks the project-pinned Thrift 0.16 generated sources, while this branch requires JDK 17.

### Check List

- [x] Unit test
- [x] No protocol change
- [x] No query result behavior change
- [x] No documentation change required