### PR TITLE
[fix](external catalog) Handle incomplete table ownership

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -792,6 +792,9 @@ public abstract class ExternalDatabase<T extends ExternalTable>
     public boolean registerTable(TableIf tableIf) {
         makeSureInitialized();
         T table = (T) tableIf;
+        // Replayed metadata may lose these non-persistent owner references, so restore them before publication.
+        table.setCatalog(extCatalog);
+        table.setDb(this);
         if (LOG.isDebugEnabled()) {
             LOG.debug("create table [{}]", table.getName());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalDatabase.java
@@ -792,9 +792,6 @@ public abstract class ExternalDatabase<T extends ExternalTable>
     public boolean registerTable(TableIf tableIf) {
         makeSureInitialized();
         T table = (T) tableIf;
-        // Replayed metadata may lose these non-persistent owner references, so restore them before publication.
-        table.setCatalog(extCatalog);
-        table.setDb(this);
         if (LOG.isDebugEnabled()) {
             LOG.debug("create table [{}]", table.getName());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CollectRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CollectRelation.java
@@ -263,7 +263,7 @@ public class CollectRelation implements AnalysisRuleFactory {
                 cascadesContext.getStatementContext());
         if (shouldCollect) {
             DatabaseIf database = table.getDatabase();
-            // MTMV rewrite is optional, so incomplete replayed ownership must not abort the query.
+            // MTMV rewrite is optional, so malformed ownership metadata must not abort the query.
             if (database == null || database.getCatalog() == null) {
                 LOG.warn("Skip collecting MTMV candidates for table {} because its owner metadata is incomplete",
                         table.getName());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CollectRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CollectRelation.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.rules.analysis;
 
+import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.MaterializedIndexMeta;
@@ -261,6 +262,13 @@ public class CollectRelation implements AnalysisRuleFactory {
         boolean shouldCollect = MaterializedViewUtils.containMaterializedViewHook(
                 cascadesContext.getStatementContext());
         if (shouldCollect) {
+            DatabaseIf database = table.getDatabase();
+            // MTMV rewrite is optional, so incomplete replayed ownership must not abort the query.
+            if (database == null || database.getCatalog() == null) {
+                LOG.warn("Skip collecting MTMV candidates for table {} because its owner metadata is incomplete",
+                        table.getName());
+                return;
+            }
             boolean isDebugEnabled = LOG.isDebugEnabled();
             Set<MTMV> mtmvSet = Env.getCurrentEnv().getMtmvService().getRelationManager()
                     .getCandidateMTMVs(Lists.newArrayList(new BaseTableInfo(table)));

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalDatabaseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalDatabaseTest.java
@@ -498,6 +498,31 @@ public class ExternalDatabaseTest extends TestWithFeService {
     }
 
     @Test
+    public void testImageRestoreLazyLoadRebuildsTableOwnerReferences() {
+        Map<String, String> props = Maps.newHashMap();
+        props.put("catalog_provider.class", DatabaseCatalogProvider.class.getName());
+        TestExternalCatalog catalog = new TestExternalCatalog(303L, "image_owner_test", "", props, "");
+        catalog.setInitializedForTest(true);
+        TestExternalDatabase db = new TestExternalDatabase(catalog, 304L, "db1", "db1");
+        db.setInitializedForTest(true);
+        catalog.addDatabaseForTest(db);
+        db.addTableForTest(new TestExternalTable(305L, "tbl_base", "tbl_base", catalog, db));
+
+        String json = GsonUtils.GSON.toJson(catalog, CatalogIf.class);
+        Assertions.assertFalse(json.contains("tbl_base"));
+        TestExternalCatalog restored =
+                (TestExternalCatalog) GsonUtils.GSON.fromJson(json, CatalogIf.class);
+        restored.setInitializedForTest(true);
+
+        ExternalDatabase<? extends ExternalTable> restoredDb = restored.getDbNullable("db1");
+        ExternalTable restoredTable = restoredDb.getTableNullable("tbl_base");
+
+        Assertions.assertSame(restored, restoredTable.getCatalog());
+        Assertions.assertSame(restoredDb, restoredTable.getDatabase());
+        Assertions.assertDoesNotThrow(() -> new BaseTableInfo(restoredTable));
+    }
+
+    @Test
     public void testGetTableForReplayByIdReturnsEmptyWhenDatabaseIsUninitialized() {
         InspectableCatalog catalog = new InspectableCatalog();
         InspectableDatabase db = new InspectableDatabase(catalog, 302L, "db1", "db1");
@@ -654,22 +679,6 @@ public class ExternalDatabaseTest extends TestWithFeService {
         } finally {
             NameMissTableCatalogProvider.reset();
         }
-    }
-
-    @Test
-    public void testRegisterTableRestoresExternalTableOwnerReferences() {
-        InspectableCatalog catalog = new InspectableCatalog();
-        InspectableDatabase db = new InspectableDatabase(catalog, 560L, "db1", "db1");
-        db.setInitializedForTest(true);
-        TestExternalTable table = new TestExternalTable(561L, "tbl_event", "tbl_event", catalog, db);
-        table.setCatalog(null);
-        table.setDb(null);
-
-        db.registerTable(table);
-
-        Assertions.assertSame(catalog, table.getCatalog());
-        Assertions.assertSame(db, table.getDatabase());
-        Assertions.assertDoesNotThrow(() -> new BaseTableInfo(table));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalDatabaseTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalDatabaseTest.java
@@ -35,6 +35,7 @@ import org.apache.doris.datasource.metacache.NameCacheValue;
 import org.apache.doris.datasource.test.TestExternalCatalog;
 import org.apache.doris.datasource.test.TestExternalDatabase;
 import org.apache.doris.datasource.test.TestExternalTable;
+import org.apache.doris.mtmv.BaseTableInfo;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.utframe.TestWithFeService;
 
@@ -653,6 +654,22 @@ public class ExternalDatabaseTest extends TestWithFeService {
         } finally {
             NameMissTableCatalogProvider.reset();
         }
+    }
+
+    @Test
+    public void testRegisterTableRestoresExternalTableOwnerReferences() {
+        InspectableCatalog catalog = new InspectableCatalog();
+        InspectableDatabase db = new InspectableDatabase(catalog, 560L, "db1", "db1");
+        db.setInitializedForTest(true);
+        TestExternalTable table = new TestExternalTable(561L, "tbl_event", "tbl_event", catalog, db);
+        table.setCatalog(null);
+        table.setDb(null);
+
+        db.registerTable(table);
+
+        Assertions.assertSame(catalog, table.getCatalog());
+        Assertions.assertSame(db, table.getDatabase());
+        Assertions.assertDoesNotThrow(() -> new BaseTableInfo(table));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CollectRelationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/CollectRelationTest.java
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.analysis;
+
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.nereids.CascadesContext;
+import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.nereids.rules.exploration.mv.InitMaterializationContextHook;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+
+public class CollectRelationTest {
+
+    @Test
+    public void testCollectMTMVCandidatesSkipsTableWithoutDatabase() throws Exception {
+        TableIf table = Mockito.mock(TableIf.class);
+        Mockito.when(table.getName()).thenReturn("tbl_without_owner");
+        CascadesContext cascadesContext = Mockito.mock(CascadesContext.class);
+        StatementContext statementContext = Mockito.mock(StatementContext.class);
+        Mockito.when(cascadesContext.getStatementContext()).thenReturn(statementContext);
+        Mockito.when(statementContext.getPlannerHooks()).thenReturn(
+                Collections.singleton(InitMaterializationContextHook.INSTANCE));
+
+        Method collectMethod = CollectRelation.class.getDeclaredMethod(
+                "collectMTMVCandidates", TableIf.class, CascadesContext.class);
+        collectMethod.setAccessible(true);
+
+        Assertions.assertDoesNotThrow(
+                () -> collectMethod.invoke(new CollectRelation(false), table, cascadesContext));
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Malformed external-table ownership metadata can cause optional materialized-view candidate collection to abort an otherwise valid query when `BaseTableInfo` is constructed.

Current image serialization does not persist external object caches. After an image round trip, lazy loading rebuilds tables with their catalog and database owners. The fix therefore keeps the recovery lifecycle unchanged and makes MTMV candidate collection skip only malformed table metadata.

Related issue: #58441

### Test

- Added an image round-trip and lazy-load test that verifies owner references are rebuilt before `BaseTableInfo` construction.
- Added a unit test that verifies MTMV candidate collection does not fail a query when owner metadata is incomplete.
- Ran `ExternalDatabaseTest` and `CollectRelationTest`: 35 tests passed, 0 failures.
- FE Checkstyle passed as part of the FE unit-test build.

### Release note

None.

### Check List (For Author)

- Test
  - [x] Unit Test
- Behavior changed
  - [x] No.
- Does this need documentation?
  - [x] No.
