### PR TITLE
[fix](fe) Make storage medium deserialization case-insensitive

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TableProperty.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -545,7 +546,7 @@ public class TableProperty implements GsonPostProcessable {
         if (Strings.isNullOrEmpty(storageMediumStr)) {
             storageMedium = null;
         } else {
-            storageMedium = TStorageMedium.valueOf(storageMediumStr);
+            storageMedium = TStorageMedium.valueOf(storageMediumStr.toUpperCase(Locale.ROOT));
         }
         return this;
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/TablePropertyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/TablePropertyTest.java
@@ -18,13 +18,17 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.common.util.PropertyAnalyzer;
+import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.resource.Tag;
+import org.apache.doris.thrift.TStorageMedium;
 
 import com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 public class TablePropertyTest {
@@ -114,6 +118,26 @@ public class TablePropertyTest {
         Assert.assertFalse(tableProperty.hasInvalidDynamicPartition());
         Assert.assertEquals(3, tableProperty.getDynamicPartitionProperty().getEnd());
         Assert.assertEquals(1, tableProperty.getDynamicPartitionProperty().getBuckets());
+    }
+
+    @Test
+    public void testStorageMediumIsCaseInsensitiveAfterSerialization() {
+        List<String> storageMediumValues = Arrays.asList("hdd", "HDD", "HdD", "ssd", "SSD", "SsD");
+        for (String storageMediumValue : storageMediumValues) {
+            Map<String, String> properties = Maps.newHashMap();
+            properties.put(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM, storageMediumValue);
+            TableProperty tableProperty = new TableProperty(properties).buildStorageMedium();
+
+            String serialized = GsonUtils.GSON.toJson(tableProperty);
+            TableProperty deserialized = GsonUtils.GSON.fromJson(serialized, TableProperty.class);
+
+            TStorageMedium expectedStorageMedium = storageMediumValue.equalsIgnoreCase("hdd")
+                    ? TStorageMedium.HDD : TStorageMedium.SSD;
+            Assert.assertEquals(expectedStorageMedium, tableProperty.getStorageMedium());
+            Assert.assertEquals(expectedStorageMedium, deserialized.getStorageMedium());
+            Assert.assertEquals(storageMediumValue,
+                    deserialized.getProperties().get(PropertyAnalyzer.PROPERTIES_STORAGE_MEDIUM));
+        }
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

TableProperty rebuilt the storage medium with TStorageMedium.valueOf() during Gson post-processing. Since valueOf() is case-sensitive, persisted storage_medium values such as "ssd", "hdd", or mixed-case variants could throw IllegalArgumentException while loading metadata and cause checkpoint
failure.

Normalize the persisted value with Locale.ROOT before converting it to TStorageMedium. Add a serialization round-trip unit test covering uppercase, lowercase, and mixed-case HDD and SSD values.

```
2026-08-10 14:15:56,415 WARN (leaderCheckpointer|109) [Checkpoint.runAfterCatalogReady():92] failed to do checkpoint.
org.apache.doris.common.CheckpointException: java.lang.reflect.InvocationTargetException
    at org.apache.doris.master.Checkpoint.doCheckpoint(Checkpoint.java:194)
    at org.apache.doris.master.Checkpoint.runAfterCatalogReady(Checkpoint.java:90)
    at org.apache.doris.common.util.MasterDaemon.runOneCycle(MasterDaemon.java:58)
    at org.apache.doris.common.util.Daemon.run(Daemon.java:119)
Caused by: java.io.IOException: java.lang.reflect.InvocationTargetException
    at org.apache.doris.persist.meta.MetaReader.read(MetaReader.java:129)
    at org.apache.doris.catalog.Env.loadImage(Env.java:2384)
    at org.apache.doris.master.Checkpoint.doCheckpoint(Checkpoint.java:183)
    ... 3 more
Caused by: java.lang.reflect.InvocationTargetException
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:568)
    at org.apache.doris.persist.meta.MetaReader.read(MetaReader.java:126)
    ... 5 more
Caused by: java.lang.IllegalArgumentException: No enum constant org.apache.doris.thrift.TStorageMedium.hdd
    at java.base/java.lang.Enum.valueOf(Enum.java:273)
    at org.apache.doris.thrift.TStorageMedium.valueOf(TStorageMedium.java:10)
    at org.apache.doris.catalog.TableProperty.buildStorageMedium(TableProperty.java:548)
    at org.apache.doris.catalog.TableProperty.gsonPostProcess(TableProperty.java:955)
    at org.apache.doris.persist.gson.GsonUtilsBase$PostProcessTypeAdapterFactory$1.read(GsonUtilsBase.java:366)
    at org.apache.doris.persist.gson.GsonUtilsBase$PreProcessTypeAdapterFactory$1.read(GsonUtilsBase.java:343)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.readIntoField(ReflectiveTypeAdapterFactory.java:212)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$FieldReflectionAdapter.readField(ReflectiveTypeAdapterFactory.java:433)
    at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:393)
    at org.apache.doris.persist.gson.GsonUtilsBase$PostProcessTypeAdapterFactory$1.read(GsonUtilsBase.java:364)
    at org.apache.doris.persist.gson.GsonUtilsBase$PreProcessTypeAdapterFactory$1.read(GsonUtilsBase.java:343)
    at com.google.gson.TypeAdapter.fromJsonTree(TypeAdapter.java:299)
    at org.apache.doris.persist.gson.RuntimeTypeAdapterFactory$1.read(RuntimeTypeAdapterFactory.java:330)
    at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:204)
    at com.google.gson.Gson.fromJson(Gson.java:1227)
    at com.google.gson.Gson.fromJson(Gson.java:1137)
    at com.google.gson.Gson.fromJson(Gson.java:1047)
    at com.google.gson.Gson.fromJson(Gson.java:982)
    at org.apache.doris.catalog.Table.read(Table.java:467)
    at org.apache.doris.catalog.Database.readTables(Database.java:672)
    at org.apache.doris.catalog.Database.read(Database.java:650)
    at org.apache.doris.catalog.Database.read(Database.java:637)
    at org.apache.doris.datasource.InternalCatalog.loadDb(InternalCatalog.java:3861)
    at org.apache.doris.catalog.Env.loadDb(Env.java:2455)
    ... 10 more
```

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

