### PR TITLE
[opt](planner) Enable Nereids distribute planner after upgrade

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -1112,6 +1112,9 @@ public class VariableMgr {
             VariableMgr.refreshDefaultSessionVariables(updateInfo,
                     SessionVariable.ENABLE_SQL_CACHE,
                     String.valueOf(true));
+            VariableMgr.refreshDefaultSessionVariables(updateInfo,
+                    SessionVariable.ENABLE_NEREIDS_DISTRIBUTE_PLANNER,
+                    String.valueOf(true));
         }
         if (currentVariableVersion < GlobalVariable.CURRENT_VARIABLE_VERSION) {
             VariableMgr.refreshDefaultSessionVariables(updateInfo,

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/VariableMgrTest.java
@@ -106,6 +106,31 @@ public class VariableMgrTest extends TestWithFeService {
     }
 
     @Test
+    public void testEnableNereidsDistributePlannerAfterUpgrade() {
+        SessionVariable defaultSessionVariable = VariableMgr.getDefaultSessionVariable();
+        boolean originalValue = defaultSessionVariable.isEnableNereidsDistributePlanner();
+        boolean originalEnableSqlCache = defaultSessionVariable.isEnableSqlCache();
+        boolean originalAnsiBehavior = GlobalVariable.enable_ansi_query_organization_behavior;
+        boolean originalTypeCoercionBehavior = GlobalVariable.enableNewTypeCoercionBehavior;
+        int originalVersion = GlobalVariable.variableVersion;
+        try {
+            defaultSessionVariable.setEnableNereidsDistributePlanner(false);
+            GlobalVariable.variableVersion = GlobalVariable.VARIABLE_VERSION_300;
+
+            VariableMgr.forceUpdateVariables();
+
+            Assertions.assertTrue(VariableMgr.newSessionVariable().isEnableNereidsDistributePlanner());
+            Assertions.assertEquals(GlobalVariable.CURRENT_VARIABLE_VERSION, GlobalVariable.variableVersion);
+        } finally {
+            defaultSessionVariable.setEnableNereidsDistributePlanner(originalValue);
+            defaultSessionVariable.setEnableSqlCache(originalEnableSqlCache);
+            GlobalVariable.enable_ansi_query_organization_behavior = originalAnsiBehavior;
+            GlobalVariable.enableNewTypeCoercionBehavior = originalTypeCoercionBehavior;
+            GlobalVariable.variableVersion = originalVersion;
+        }
+    }
+
+    @Test
     public void testAutoCommitConvert() throws Exception {
         // boolean var with ConvertBoolToLongMethod annotation
         VariableExpr desc = new VariableExpr("autocommit");


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: New installations default enable_nereids_distribute_planner to true, but clusters upgrading from a variable version below 400 restore the persisted global session default from their image. Clusters that persisted the previous false default would therefore continue using the legacy distribute planner after upgrading to 4.0. Add enable_nereids_distribute_planner to the existing variable-version-400 migration so that the 3.x-to-4.0 upgrade enables it. The migration uses the existing global-variable edit-log path and does not change clusters whose variable version is already 400.

### Release note

Clusters upgrading to 4.0 now enable the Nereids distribute planner by default.

### Check List (For Author)

- Test: Unit Test
    - `VariableMgrTest#testEnableNereidsDistributePlannerAfterUpgrade`
    - FE Checkstyle for fe-core
- Behavior changed: Yes. Clusters upgrading from a variable version below 400 default to the Nereids distribute planner.
- Does this need documentation: No

