### PR TITLE
[refactor](storage) move fixed partial-update fill into FixedPartialUpdateFillStage

### DIFF
--- a/be/src/storage/rowset/segment_creator.cpp
+++ b/be/src/storage/rowset/segment_creator.cpp
@@ -71,7 +71,8 @@ segment_v2::TransformExecContext make_transform_exec_context(RowsetWriterContext
             .rowset_ctx = &context,
             .rowset_id = context.rowset_id,
             .segment_id = segment_id,
-            .derived_column = {}};
+            .derived_column = {},
+            .partial_update_stats = {}};
 }
 
 } // namespace
@@ -118,6 +119,12 @@ Status SegmentFlusher::transform_block(Block* block, int32_t segment_id,
     auto transform_ctx = make_transform_exec_context(_context, segment_id);
     RETURN_IF_ERROR_OR_CATCH_EXCEPTION(
             segment_v2::build_transform_chain(_context).apply(transform_ctx, block));
+    // fold the fill stages' probe counters into the flusher totals; the horizontal
+    // writer no longer sees partial-update rows
+    _num_rows_updated += transform_ctx.partial_update_stats.num_rows_updated;
+    _num_rows_deleted += transform_ctx.partial_update_stats.num_rows_deleted;
+    _num_rows_new_added += transform_ctx.partial_update_stats.num_rows_new_added;
+    _num_rows_filtered += transform_ctx.partial_update_stats.num_rows_filtered;
     *derived_column = std::move(transform_ctx.derived_column);
     return Status::OK();
 }
@@ -330,10 +337,6 @@ Status SegmentFlusher::_flush_segment_writer(std::unique_ptr<segment_v2::Segment
     total_timer.start();
 
     uint32_t row_num = writer->num_rows_written();
-    _num_rows_updated += writer->num_rows_updated();
-    _num_rows_deleted += writer->num_rows_deleted();
-    _num_rows_new_added += writer->num_rows_new_added();
-    _num_rows_filtered += writer->num_rows_filtered();
 
     if (row_num == 0) {
         return Status::OK();
@@ -447,7 +450,9 @@ Status SegmentCreator::add_block(const Block* block) {
         segment_v2::DerivedColumn derived_column;
         RETURN_IF_ERROR(
                 _segment_flusher.transform_block(shared_block, /*segment_id=*/-1, &derived_column));
-        return segment_v2::materialize_derived_columns(derived_column, shared_block);
+        RETURN_IF_ERROR_OR_CATCH_EXCEPTION(
+                segment_v2::materialize_derived_columns(derived_column, shared_block));
+        return Status::OK();
     };
 
     if (_flush_writer == nullptr) {

--- a/be/src/storage/segment/segment_writer.cpp
+++ b/be/src/storage/segment/segment_writer.cpp
@@ -55,7 +55,6 @@
 #include "storage/index/short_key_index.h"
 #include "storage/iterator/olap_data_convertor.h"
 #include "storage/key_coder.h"
-#include "storage/mow/historical_row_fetcher.h"
 #include "storage/mow/key_probe.h"
 #include "storage/olap_common.h"
 #include "storage/olap_define.h"
@@ -65,7 +64,6 @@
 #include "storage/segment/column_writer.h" // ColumnWriter
 #include "storage/segment/encoding_info.h"
 #include "storage/segment/external_col_meta_util.h"
-#include "storage/segment/historical_row_retriever.h"
 #include "storage/segment/page_io.h"
 #include "storage/segment/page_pointer.h"
 #include "storage/segment/segment_loader.h"
@@ -76,7 +74,6 @@
 #include "storage/utils.h"
 #include "util/coding.h"
 #include "util/faststring.h"
-#include "util/jsonb/serialize.h"
 #include "util/simd/bits.h"
 namespace doris {
 namespace segment_v2 {
@@ -336,295 +333,18 @@ Status SegmentWriter::_create_writers(const TabletSchemaSPtr& tablet_schema,
     return Status::OK();
 }
 
-void SegmentWriter::_serialize_block_to_row_column(Block& block) {
-    if (block.rows() == 0) {
-        return;
-    }
-    MonotonicStopWatch watch;
-    watch.start();
-    int row_column_id = 0;
-    for (int i = 0; i < _tablet_schema->num_columns(); ++i) {
-        if (_tablet_schema->column(i).is_row_store_column()) {
-            auto row_store_column_ptr = block.get_by_position(i).column->clone_empty();
-            auto* row_store_column = static_cast<ColumnString*>(row_store_column_ptr.get());
-            DataTypeSerDeSPtrs serdes = create_data_type_serdes(block.get_data_types());
-            JsonbSerializeUtil::block_to_jsonb(*_tablet_schema, block, *row_store_column,
-                                               cast_set<int>(_tablet_schema->num_columns()), serdes,
-                                               {_tablet_schema->row_columns_uids().begin(),
-                                                _tablet_schema->row_columns_uids().end()});
-            block.replace_by_position(i, std::move(row_store_column_ptr));
-            break;
-        }
-    }
-
-    VLOG_DEBUG << "serialize , num_rows:" << block.rows() << ", row_column_id:" << row_column_id
-               << ", total_byte_size:" << block.allocated_bytes() << ", serialize_cost(us)"
-               << watch.elapsed_time() / 1000;
-}
-
-Status SegmentWriter::probe_key_for_mow(
-        const MowKeyProbe& probe, std::string key, std::size_t segment_pos,
-        bool have_input_seq_column, bool have_delete_sign,
-        const std::vector<RowsetSharedPtr>& specified_rowsets,
-        std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
-        bool& has_default_or_nullable, std::vector<bool>& use_default_or_null_flag,
-        const std::function<void(const RowLocation& loc, const RowsetSharedPtr& rowset)>& found_cb,
-        const std::function<Status()>& not_found_cb, PartialUpdateStats& stats) {
-    ProbeOutcome outcome =
-            DORIS_TRY(probe.probe(key, segment_pos, have_input_seq_column, have_delete_sign,
-                                  specified_rowsets, segment_caches, stats));
-    if (outcome.result == KeyProbeResult::NOT_FOUND) {
-        if (!have_delete_sign) {
-            RETURN_IF_ERROR(not_found_cb());
-        }
-        has_default_or_nullable = true;
-        use_default_or_null_flag.emplace_back(true);
-        return Status::OK();
-    }
-    if (outcome.use_default_or_null) {
-        has_default_or_nullable = true;
-        use_default_or_null_flag.emplace_back(true);
-    } else {
-        // partial update should not contain invisible columns
-        use_default_or_null_flag.emplace_back(false);
-        found_cb(outcome.loc, outcome.rowset);
-    }
-    return Status::OK();
-}
-
-Status SegmentWriter::partial_update_preconditions_check(size_t row_pos) {
-    if (!_is_mow()) {
-        auto msg = fmt::format(
-                "Can only do partial update on merge-on-write unique table, but found: "
-                "keys_type={}, _opts.enable_unique_key_merge_on_write={}, tablet_id={}",
-                _tablet_schema->keys_type(), _opts.enable_unique_key_merge_on_write,
-                _tablet->tablet_id());
-        DCHECK(false) << msg;
-        return Status::InternalError<false>(msg);
-    }
-    if (_opts.rowset_ctx->partial_update_info == nullptr) {
-        auto msg =
-                fmt::format("partial_update_info should not be nullptr, please check, tablet_id={}",
-                            _tablet->tablet_id());
-        DCHECK(false) << msg;
-        return Status::InternalError<false>(msg);
-    }
-    if (!_opts.rowset_ctx->partial_update_info->is_fixed_partial_update()) {
-        auto msg = fmt::format(
-                "in fixed partial update code, but update_mode={}, please check, tablet_id={}",
-                _opts.rowset_ctx->partial_update_info->update_mode(), _tablet->tablet_id());
-        DCHECK(false) << msg;
-        return Status::InternalError<false>(msg);
-    }
-    if (row_pos != 0) {
-        auto msg = fmt::format("row_pos should be 0, but found {}, tablet_id={}", row_pos,
-                               _tablet->tablet_id());
-        DCHECK(false) << msg;
-        return Status::InternalError<false>(msg);
-    }
-    return Status::OK();
-}
-
-// for partial update, we should do following steps to fill content of block:
-// 1. set block data to data convertor, and get all key_column's converted slice
-// 2. get pk of input block, and read missing columns
-//       2.1 first find key location{rowset_id, segment_id, row_id}
-//       2.2 build read plan to read by batch
-//       2.3 fill block
-// 3. set columns to data convertor and then write all columns
-Status SegmentWriter::append_block_with_partial_content(const Block* block, size_t row_pos,
-                                                        size_t num_rows) {
-    if (block->columns() < _tablet_schema->num_key_columns() ||
-        block->columns() >= _tablet_schema->num_columns()) {
-        return Status::InvalidArgument(
-                fmt::format("illegal partial update block columns: {}, num key columns: {}, total "
-                            "schema columns: {}",
-                            block->columns(), _tablet_schema->num_key_columns(),
-                            _tablet_schema->num_columns()));
-    }
-    RETURN_IF_ERROR(partial_update_preconditions_check(row_pos));
-
-    // find missing column cids
-    const auto& missing_cids = _opts.rowset_ctx->partial_update_info->missing_cids;
-    const auto& including_cids = _opts.rowset_ctx->partial_update_info->update_cids;
-
-    // create full block and fill with input columns
-    auto full_block = _tablet_schema->create_block();
-    size_t input_id = 0;
-    for (auto i : including_cids) {
-        const auto& input_column = block->get_by_position(input_id++);
-        auto& full_column = full_block.get_by_position(i);
-        full_column.column = input_column.column;
-        full_column.type = input_column.type;
-    }
-
-    if (_opts.rowset_ctx->write_type != DataWriteType::TYPE_COMPACTION &&
-        _tablet_schema->num_variant_columns() > 0) {
-        RETURN_IF_ERROR(variant_util::parse_and_materialize_variant_columns(
-                full_block, *_tablet_schema, including_cids));
-    }
-    RETURN_IF_ERROR(_olap_data_convertor->set_source_content_with_specifid_columns(
-            &full_block, row_pos, num_rows, including_cids));
-
-    bool have_input_seq_column = false;
-    // write including columns
-    std::vector<IOlapColumnDataAccessor*> key_columns;
-    IOlapColumnDataAccessor* seq_column = nullptr;
-    size_t segment_start_pos = 0;
-    for (auto cid : including_cids) {
-        // here we get segment column row num before append data.
-        segment_start_pos = _column_writers[cid]->get_next_rowid();
-        // olap data convertor alway start from id = 0
-        auto converted_result = _olap_data_convertor->convert_column_data(cid);
-        if (!converted_result.first.ok()) {
-            return converted_result.first;
-        }
-        if (cid < _key_encoder.num_sort_key_columns()) {
-            key_columns.push_back(converted_result.second);
-        } else if (_tablet_schema->has_sequence_col() &&
-                   cid == _tablet_schema->sequence_col_idx()) {
-            seq_column = converted_result.second;
-            have_input_seq_column = true;
-        }
-        RETURN_IF_ERROR(_column_writers[cid]->append(converted_result.second->get_nullmap(),
-                                                     converted_result.second->get_data(),
-                                                     num_rows));
-    }
-
-    bool has_default_or_nullable = false;
-    std::vector<bool> use_default_or_null_flag;
-    use_default_or_null_flag.reserve(num_rows);
-    const auto* delete_signs =
-            BaseTablet::get_delete_sign_column_data(full_block, row_pos + num_rows);
-
-    const std::vector<RowsetSharedPtr>& specified_rowsets = _mow_context->rowset_ptrs;
-    std::vector<std::unique_ptr<SegmentCacheHandle>> segment_caches(specified_rowsets.size());
-
-    // the horizontal writer never runs flexible partial update
-    MowKeyProbe probe = MowKeyProbe::for_partial_update(
-            _tablet.get(), _tablet_schema.get(), _tablet_schema->has_sequence_col(), _mow_context,
-            _opts.rowset_ctx->rowset_id, _segment_id, /*flexible=*/false);
-    // owns the rowset pins and the read plan for the historical read below
-    HistoricalRowFetcher fetcher {_opts.rowset_ctx->make_historical_row_retriever_context()};
-
-    // locate rows in base data
-    PartialUpdateStats stats;
-
-    for (size_t block_pos = row_pos; block_pos < row_pos + num_rows; block_pos++) {
-        // block   segment
-        //   2   ->   0
-        //   3   ->   1
-        //   4   ->   2
-        //   5   ->   3
-        // here row_pos = 2, num_rows = 4.
-        size_t delta_pos = block_pos - row_pos;
-        size_t segment_pos = segment_start_pos + delta_pos;
-        std::string key = encode_mow_key_invalidate_cache(
-                _key_encoder, key_columns, seq_column, delta_pos, have_input_seq_column,
-                _opts.rowset_ctx->tablet_id, *_tablet_schema, _opts.write_type);
-        // If the table have sequence column, and the include-cids don't contain the sequence
-        // column, we need to update the primary key index builder at the end of this method.
-        // At that time, we have a valid sequence column to encode the key with seq col.
-        if (!_tablet_schema->has_sequence_col() || have_input_seq_column) {
-            RETURN_IF_ERROR(_primary_key_index_builder->add_item(key));
-        }
-
-        // mark key with delete sign as deleted.
-        bool have_delete_sign = (delete_signs != nullptr && delete_signs[block_pos] != 0);
-
-        auto not_found_cb = [&]() {
-            return _opts.rowset_ctx->partial_update_info->handle_new_key(
-                    *_tablet_schema, [&]() -> std::string {
-                        return block->dump_one_line(
-                                block_pos, cast_set<int>(_key_encoder.num_sort_key_columns()));
-                    });
-        };
-        auto update_read_plan = [&](const RowLocation& loc, const RowsetSharedPtr& rowset) {
-            // keep the rowset alive until the historical read below is done
-            fetcher.pin_rowset(rowset);
-            fetcher.plan_fixed_read(loc, segment_pos);
-        };
-        RETURN_IF_ERROR(probe_key_for_mow(probe, std::move(key), segment_pos, have_input_seq_column,
-                                          have_delete_sign, specified_rowsets, segment_caches,
-                                          has_default_or_nullable, use_default_or_null_flag,
-                                          update_read_plan, not_found_cb, stats));
-    }
-    CHECK_EQ(use_default_or_null_flag.size(), num_rows);
-
-    if (config::enable_merge_on_write_correctness_check) {
-        _tablet->add_sentinel_mark_to_delete_bitmap(_mow_context->delete_bitmap.get(),
-                                                    *_mow_context->rowset_ids);
-    }
-
-    // read to fill full block
-    RETURN_IF_ERROR(fetcher.fill_missing_columns(*_tablet_schema, full_block,
-                                                 use_default_or_null_flag, has_default_or_nullable,
-                                                 cast_set<uint32_t>(segment_start_pos), block));
-
-    if (_tablet_schema->num_variant_columns() > 0) {
-        RETURN_IF_ERROR(variant_util::parse_and_materialize_variant_columns(
-                full_block, *_tablet_schema, missing_cids));
-    }
-
-    // convert block to row store format
-    _serialize_block_to_row_column(full_block);
-
-    // convert missing columns and send to column writer
-    RETURN_IF_ERROR(_olap_data_convertor->set_source_content_with_specifid_columns(
-            &full_block, row_pos, num_rows, missing_cids));
-    for (auto cid : missing_cids) {
-        auto converted_result = _olap_data_convertor->convert_column_data(cid);
-        if (!converted_result.first.ok()) {
-            return converted_result.first;
-        }
-        if (_tablet_schema->has_sequence_col() && !have_input_seq_column &&
-            cid == _tablet_schema->sequence_col_idx()) {
-            DCHECK_EQ(seq_column, nullptr);
-            seq_column = converted_result.second;
-        }
-        RETURN_IF_ERROR(_column_writers[cid]->append(converted_result.second->get_nullmap(),
-                                                     converted_result.second->get_data(),
-                                                     num_rows));
-    }
-    _num_rows_updated += stats.num_rows_updated;
-    _num_rows_deleted += stats.num_rows_deleted;
-    _num_rows_new_added += stats.num_rows_new_added;
-    _num_rows_filtered += stats.num_rows_filtered;
-    if (_tablet_schema->has_sequence_col() && !have_input_seq_column) {
-        DCHECK_NE(seq_column, nullptr);
-        if (_num_rows_written != row_pos ||
-            _primary_key_index_builder->num_rows() != _num_rows_written) {
-            return Status::InternalError(
-                    "Correctness check failed, _num_rows_written: {}, row_pos: {}, primary key "
-                    "index builder num rows: {}",
-                    _num_rows_written, row_pos, _primary_key_index_builder->num_rows());
-        }
-        RETURN_IF_ERROR(_generate_primary_key_index(key_columns, seq_column, num_rows, false));
-    }
-
-    _num_rows_written += num_rows;
-    DCHECK_EQ(_primary_key_index_builder->num_rows(), _num_rows_written)
-            << "primary key index builder num rows(" << _primary_key_index_builder->num_rows()
-            << ") not equal to segment writer's num rows written(" << _num_rows_written << ")";
-    _olap_data_convertor->clear_source_content();
-
-    return Status::OK();
-}
-
 Status SegmentWriter::append_block(const Block* block, size_t row_pos, size_t num_rows) {
+    // Fixed partial update blocks arrive full-width, already filled by the transform
+    // chain; only the flexible mode still needs the vertical writer.
     if (_opts.rowset_ctx->partial_update_info &&
         _opts.rowset_ctx->partial_update_info->is_partial_update() &&
         _opts.write_type == DataWriteType::TYPE_DIRECT &&
-        !_opts.rowset_ctx->is_transient_rowset_writer) {
-        if (_opts.rowset_ctx->partial_update_info->is_fixed_partial_update()) {
-            RETURN_IF_ERROR(append_block_with_partial_content(block, row_pos, num_rows));
-        } else {
-            return Status::NotSupported<false>(
-                    "SegmentWriter doesn't support flexible partial update, please set "
-                    "enable_vertical_segment_writer=true in be.conf on all BEs to use "
-                    "VerticalSegmentWriter.");
-        }
-        return Status::OK();
+        !_opts.rowset_ctx->is_transient_rowset_writer &&
+        !_opts.rowset_ctx->partial_update_info->is_fixed_partial_update()) {
+        return Status::NotSupported<false>(
+                "SegmentWriter doesn't support flexible partial update, please set "
+                "enable_vertical_segment_writer=true in be.conf on all BEs to use "
+                "VerticalSegmentWriter.");
     }
     if (block->columns() < _column_writers.size()) {
         return Status::InternalError(

--- a/be/src/storage/segment/segment_writer.h
+++ b/be/src/storage/segment/segment_writer.h
@@ -23,7 +23,6 @@
 #include <stddef.h>
 
 #include <cstdint>
-#include <functional>
 #include <map>
 #include <memory> // unique_ptr
 #include <string>
@@ -33,7 +32,6 @@
 #include "storage/index/index_file_writer.h"
 #include "storage/key/row_key_encoder.h"
 #include "storage/olap_define.h"
-#include "storage/partial_update_info.h"
 #include "storage/segment/column_writer.h"
 #include "storage/segment/segment_index_file_cache_loader.h"
 #include "storage/tablet/tablet.h"
@@ -66,7 +64,6 @@ extern const char* k_segment_magic;
 extern const uint32_t k_segment_magic_length;
 
 class VariantStatsCaculator;
-class MowKeyProbe;
 
 struct SegmentWriterOptions {
     uint32_t num_rows_per_block = 1024;
@@ -94,32 +91,12 @@ public:
     virtual Status init(const std::vector<uint32_t>& col_ids, bool has_key);
 
     virtual Status append_block(const Block* block, size_t row_pos, size_t num_rows);
-    // Thin wrapper over MowKeyProbe that translates a ProbeOutcome back into the out-parameters the
-    // partial update fill loop uses. `found_cb` receives the rowset that holds `loc` and must keep
-    // it alive for the historical read.
-    Status probe_key_for_mow(
-            const MowKeyProbe& probe, std::string key, std::size_t segment_pos,
-            bool have_input_seq_column, bool have_delete_sign,
-            const std::vector<RowsetSharedPtr>& specified_rowsets,
-            std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
-            bool& has_default_or_nullable, std::vector<bool>& use_default_or_null_flag,
-            const std::function<void(const RowLocation& loc, const RowsetSharedPtr& rowset)>&
-                    found_cb,
-            const std::function<Status()>& not_found_cb, PartialUpdateStats& stats);
-    Status partial_update_preconditions_check(size_t row_pos);
-    Status append_block_with_partial_content(const Block* block, size_t row_pos, size_t num_rows);
 
     int64_t max_row_to_add(size_t row_avg_size_in_bytes);
 
     uint64_t estimate_segment_size();
 
     uint32_t num_rows_written() const { return _num_rows_written; }
-
-    // for partial update
-    int64_t num_rows_updated() const { return _num_rows_updated; }
-    int64_t num_rows_deleted() const { return _num_rows_deleted; }
-    int64_t num_rows_new_added() const { return _num_rows_new_added; }
-    int64_t num_rows_filtered() const { return _num_rows_filtered; }
 
     uint32_t row_count() const { return _row_count; }
 
@@ -175,7 +152,6 @@ private:
     void set_min_max_key(const Slice& key);
     void set_min_key(const Slice& key);
     void set_max_key(const Slice& key);
-    void _serialize_block_to_row_column(Block& block);
     Status _generate_primary_key_index(
             const std::vector<IOlapColumnDataAccessor*>& primary_key_columns,
             IOlapColumnDataAccessor* seq_column, size_t num_rows, bool need_sort);
@@ -225,12 +201,6 @@ protected:
     // _num_rows_written means row count already written in this current column group
     uint32_t _num_rows_written = 0;
 
-    /** for partial update stats **/
-    int64_t _num_rows_updated = 0;
-    int64_t _num_rows_new_added = 0;
-    int64_t _num_rows_deleted = 0;
-    // number of rows filtered in strict mode partial update
-    int64_t _num_rows_filtered = 0;
     // _row_count means total row count of this segment
     // In vertical compaction row count is recorded when key columns group finish
     //  and _num_rows_written will be updated in value column group

--- a/be/src/storage/segment/vertical_segment_writer.cpp
+++ b/be/src/storage/segment/vertical_segment_writer.cpp
@@ -60,7 +60,6 @@
 #include "storage/index/short_key_index.h"
 #include "storage/iterator/olap_data_convertor.h"
 #include "storage/key_coder.h"
-#include "storage/mow/historical_row_fetcher.h"
 #include "storage/mow/key_probe.h"
 #include "storage/olap_common.h"
 #include "storage/partial_update_info.h"
@@ -446,8 +445,7 @@ Status VerticalSegmentWriter::_finalize_column_writer_and_update_meta(size_t cid
     return Status::OK();
 }
 
-Status VerticalSegmentWriter::_partial_update_preconditions_check(size_t row_pos,
-                                                                  bool is_flexible_update) {
+Status VerticalSegmentWriter::_partial_update_preconditions_check(size_t row_pos) {
     if (!_is_mow()) {
         auto msg = fmt::format(
                 "Can only do partial update on merge-on-write unique table, but found: "
@@ -464,23 +462,13 @@ Status VerticalSegmentWriter::_partial_update_preconditions_check(size_t row_pos
         DCHECK(false) << msg;
         return Status::InternalError<false>(msg);
     }
-    if (!is_flexible_update) {
-        if (!_opts.rowset_ctx->partial_update_info->is_fixed_partial_update()) {
-            auto msg = fmt::format(
-                    "in fixed partial update code, but update_mode={}, please check, tablet_id={}",
-                    _opts.rowset_ctx->partial_update_info->update_mode(), _tablet->tablet_id());
-            DCHECK(false) << msg;
-            return Status::InternalError<false>(msg);
-        }
-    } else {
-        if (!_opts.rowset_ctx->partial_update_info->is_flexible_partial_update()) {
-            auto msg = fmt::format(
-                    "in flexible partial update code, but update_mode={}, please check, "
-                    "tablet_id={}",
-                    _opts.rowset_ctx->partial_update_info->update_mode(), _tablet->tablet_id());
-            DCHECK(false) << msg;
-            return Status::InternalError<false>(msg);
-        }
+    if (!_opts.rowset_ctx->partial_update_info->is_flexible_partial_update()) {
+        auto msg = fmt::format(
+                "in flexible partial update code, but update_mode={}, please check, "
+                "tablet_id={}",
+                _opts.rowset_ctx->partial_update_info->update_mode(), _tablet->tablet_id());
+        DCHECK(false) << msg;
+        return Status::InternalError<false>(msg);
     }
     if (row_pos != 0) {
         auto msg = fmt::format("row_pos should be 0, but found {}, tablet_id={}", row_pos,
@@ -491,206 +479,9 @@ Status VerticalSegmentWriter::_partial_update_preconditions_check(size_t row_pos
     return Status::OK();
 }
 
-// for partial update, we should do following steps to fill content of block:
-// 1. set block data to data convertor, and get all key_column's converted slice
-// 2. get pk of input block, and read missing columns
-//       2.1 first find key location{rowset_id, segment_id, row_id}
-//       2.2 build read plan to read by batch
-//       2.3 fill block
-// 3. set columns to data convertor and then write all columns
-Status VerticalSegmentWriter::_append_block_with_partial_content(RowsInBlock& data,
-                                                                 Block& full_block) {
-    DBUG_EXECUTE_IF("_append_block_with_partial_content.block", DBUG_BLOCK);
-
-    RETURN_IF_ERROR(_partial_update_preconditions_check(data.row_pos, false));
-    // create full block and fill with input columns
-    full_block = _tablet_schema->create_block();
-    const auto& including_cids = _opts.rowset_ctx->partial_update_info->update_cids;
-    size_t input_id = 0;
-    for (auto i : including_cids) {
-        const auto& input_column = data.block->get_by_position(input_id++);
-        auto& full_column = full_block.get_by_position(i);
-        full_column.column = input_column.column;
-        full_column.type = input_column.type;
-    }
-
-    if (_opts.rowset_ctx->write_type != DataWriteType::TYPE_COMPACTION &&
-        _tablet_schema->num_variant_columns() > 0) {
-        RETURN_IF_ERROR(variant_util::parse_and_materialize_variant_columns(
-                full_block, *_tablet_schema, including_cids));
-    }
-    bool have_input_seq_column = false;
-    // write including columns
-    std::vector<IOlapColumnDataAccessor*> key_columns;
-    IOlapColumnDataAccessor* seq_column = nullptr;
-    uint32_t segment_start_pos = 0;
-    for (auto cid : including_cids) {
-        RETURN_IF_ERROR(_create_column_writer(cid, _tablet_schema->column(cid), _tablet_schema));
-        RETURN_IF_ERROR(_olap_data_convertor->set_source_content_with_specifid_columns(
-                &full_block, data.row_pos, data.num_rows, std::vector<uint32_t> {cid}));
-        // here we get segment column row num before append data.
-        segment_start_pos = cast_set<uint32_t>(_column_writers[cid]->get_next_rowid());
-        // olap data convertor alway start from id = 0
-        auto [status, column] = _olap_data_convertor->convert_column_data(cid);
-        if (!status.ok()) {
-            return status;
-        }
-        if (cid < _key_encoder.num_sort_key_columns()) {
-            key_columns.push_back(column);
-        } else if (_tablet_schema->has_sequence_col() &&
-                   cid == _tablet_schema->sequence_col_idx()) {
-            seq_column = column;
-            have_input_seq_column = true;
-        }
-        RETURN_IF_ERROR(_column_writers[cid]->append(column->get_nullmap(), column->get_data(),
-                                                     data.num_rows));
-        RETURN_IF_ERROR(_finalize_column_writer_and_update_meta(cid));
-        // Don't clear source content for key columns and sequence column here,
-        // as they will be used later for key encoding and _generate_primary_key_index().
-        // They will be cleared at the end of this method.
-        bool is_key_column = (cid < _key_encoder.num_sort_key_columns());
-        bool is_seq_column = (_tablet_schema->has_sequence_col() &&
-                              cid == _tablet_schema->sequence_col_idx() && have_input_seq_column);
-        if (!is_key_column && !is_seq_column) {
-            _olap_data_convertor->clear_source_content(cid);
-        }
-    }
-
-    bool has_default_or_nullable = false;
-    std::vector<bool> use_default_or_null_flag;
-    use_default_or_null_flag.reserve(data.num_rows);
-    const auto* delete_signs =
-            BaseTablet::get_delete_sign_column_data(full_block, data.row_pos + data.num_rows);
-
-    DBUG_EXECUTE_IF("VerticalSegmentWriter._append_block_with_partial_content.sleep",
-                    { sleep(60); })
-    const std::vector<RowsetSharedPtr>& specified_rowsets = _mow_context->rowset_ptrs;
-    std::vector<std::unique_ptr<SegmentCacheHandle>> segment_caches(specified_rowsets.size());
-
-    MowKeyProbe probe = MowKeyProbe::for_partial_update(
-            _tablet.get(), _tablet_schema.get(), _tablet_schema->has_sequence_col(), _mow_context,
-            _opts.rowset_ctx->rowset_id, _segment_id, /*flexible=*/false);
-    // owns the rowset pins and the read plan for the historical read below
-    HistoricalRowFetcher fetcher {_opts.rowset_ctx->make_historical_row_retriever_context()};
-
-    // locate rows in base data
-    PartialUpdateStats stats;
-
-    for (size_t block_pos = data.row_pos; block_pos < data.row_pos + data.num_rows; block_pos++) {
-        // block   segment
-        //   2   ->   0
-        //   3   ->   1
-        //   4   ->   2
-        //   5   ->   3
-        // here row_pos = 2, num_rows = 4.
-        size_t delta_pos = block_pos - data.row_pos;
-        size_t segment_pos = segment_start_pos + delta_pos;
-        std::string key = encode_mow_key_invalidate_cache(
-                _key_encoder, key_columns, seq_column, delta_pos, have_input_seq_column,
-                _opts.rowset_ctx->tablet_id, *_tablet_schema, _opts.write_type);
-        // If the table have sequence column, and the include-cids don't contain the sequence
-        // column, we need to update the primary key index builder at the end of this method.
-        // At that time, we have a valid sequence column to encode the key with seq col.
-        if (!_tablet_schema->has_sequence_col() || have_input_seq_column) {
-            RETURN_IF_ERROR(_primary_key_index_builder->add_item(key));
-        }
-
-        // mark key with delete sign as deleted.
-        bool have_delete_sign = (delete_signs != nullptr && delete_signs[block_pos] != 0);
-
-        auto not_found_cb = [&]() {
-            return _opts.rowset_ctx->partial_update_info->handle_new_key(
-                    *_tablet_schema, [&]() -> std::string {
-                        return data.block->dump_one_line(
-                                block_pos, cast_set<int>(_key_encoder.num_sort_key_columns()));
-                    });
-        };
-        auto update_read_plan = [&](const RowLocation& loc, const RowsetSharedPtr& rowset) {
-            // keep the rowset alive until the historical read below is done
-            fetcher.pin_rowset(rowset);
-            fetcher.plan_fixed_read(loc, segment_pos);
-        };
-        RETURN_IF_ERROR(_probe_key_for_mow(
-                probe, std::move(key), segment_pos, have_input_seq_column, have_delete_sign,
-                specified_rowsets, segment_caches, has_default_or_nullable,
-                use_default_or_null_flag, update_read_plan, not_found_cb, stats));
-    }
-    CHECK_EQ(use_default_or_null_flag.size(), data.num_rows);
-
-    if (config::enable_merge_on_write_correctness_check) {
-        _tablet->add_sentinel_mark_to_delete_bitmap(_mow_context->delete_bitmap.get(),
-                                                    *_mow_context->rowset_ids);
-    }
-
-    // read to fill full_block
-    RETURN_IF_ERROR(fetcher.fill_missing_columns(*_tablet_schema, full_block,
-                                                 use_default_or_null_flag, has_default_or_nullable,
-                                                 segment_start_pos, data.block));
-
-    if (_tablet_schema->num_variant_columns() > 0) {
-        RETURN_IF_ERROR(variant_util::parse_and_materialize_variant_columns(
-                full_block, *_tablet_schema, _opts.rowset_ctx->partial_update_info->missing_cids));
-    }
-
-    // convert missing columns and send to column writer
-    const auto& missing_cids = _opts.rowset_ctx->partial_update_info->missing_cids;
-    for (auto cid : missing_cids) {
-        RETURN_IF_ERROR(_create_column_writer(cid, _tablet_schema->column(cid), _tablet_schema));
-        if (_tablet_schema->column(cid).is_row_store_column()) {
-            RETURN_IF_ERROR(_append_row_store_column(full_block, data.row_pos, data.num_rows, cid));
-            RETURN_IF_ERROR(_finalize_column_writer_and_update_meta(cid));
-            continue;
-        }
-        RETURN_IF_ERROR(_olap_data_convertor->set_source_content_with_specifid_columns(
-                &full_block, data.row_pos, data.num_rows, std::vector<uint32_t> {cid}));
-        auto [status, column] = _olap_data_convertor->convert_column_data(cid);
-        if (!status.ok()) {
-            return status;
-        }
-        if (_tablet_schema->has_sequence_col() && !have_input_seq_column &&
-            cid == _tablet_schema->sequence_col_idx()) {
-            DCHECK_EQ(seq_column, nullptr);
-            seq_column = column;
-        }
-        RETURN_IF_ERROR(_column_writers[cid]->append(column->get_nullmap(), column->get_data(),
-                                                     data.num_rows));
-        RETURN_IF_ERROR(_finalize_column_writer_and_update_meta(cid));
-        // Don't clear source content for sequence column here if it will be used later
-        // in _generate_primary_key_index(). It will be cleared at the end of this method.
-        bool is_seq_column = (_tablet_schema->has_sequence_col() && !have_input_seq_column &&
-                              cid == _tablet_schema->sequence_col_idx());
-        if (!is_seq_column) {
-            _olap_data_convertor->clear_source_content(cid);
-        }
-    }
-
-    _num_rows_updated += stats.num_rows_updated;
-    _num_rows_deleted += stats.num_rows_deleted;
-    _num_rows_new_added += stats.num_rows_new_added;
-    _num_rows_filtered += stats.num_rows_filtered;
-    if (_tablet_schema->has_sequence_col() && !have_input_seq_column) {
-        DCHECK_NE(seq_column, nullptr);
-        if (_num_rows_written != data.row_pos ||
-            _primary_key_index_builder->num_rows() != _num_rows_written) {
-            return Status::InternalError(
-                    "Correctness check failed, _num_rows_written: {}, row_pos: {}, primary key "
-                    "index builder num rows: {}",
-                    _num_rows_written, data.row_pos, _primary_key_index_builder->num_rows());
-        }
-        RETURN_IF_ERROR(_generate_primary_key_index(key_columns, seq_column, data.num_rows, false));
-    }
-
-    _num_rows_written += data.num_rows;
-    DCHECK_EQ(_primary_key_index_builder->num_rows(), _num_rows_written)
-            << "primary key index builder num rows(" << _primary_key_index_builder->num_rows()
-            << ") not equal to segment writer's num rows written(" << _num_rows_written << ")";
-    _olap_data_convertor->clear_source_content();
-    return Status::OK();
-}
-
 Status VerticalSegmentWriter::_append_block_with_flexible_partial_content(RowsInBlock& data,
                                                                           Block& full_block) {
-    RETURN_IF_ERROR(_partial_update_preconditions_check(data.row_pos, true));
+    RETURN_IF_ERROR(_partial_update_preconditions_check(data.row_pos));
 
     // data.block has the same schema with full_block
     DCHECK(data.block->columns() == _tablet_schema->num_columns());
@@ -959,28 +750,10 @@ Status VerticalSegmentWriter::_generate_flexible_read_plan(
 }
 
 Status VerticalSegmentWriter::batch_block(const Block* block, size_t row_pos, size_t num_rows) {
-    if (_opts.rowset_ctx->partial_update_info &&
-        _opts.rowset_ctx->partial_update_info->is_partial_update() &&
-        _opts.write_type == DataWriteType::TYPE_DIRECT &&
-        !_opts.rowset_ctx->is_transient_rowset_writer) {
-        if (_opts.rowset_ctx->partial_update_info->is_flexible_partial_update()) {
-            if (block->columns() != _tablet_schema->num_columns()) {
-                return Status::InvalidArgument(
-                        "illegal flexible partial update block columns, block columns = {}, "
-                        "tablet_schema columns = {}",
-                        block->dump_structure(), _tablet_schema->dump_structure());
-            }
-        } else {
-            if (block->columns() < _tablet_schema->num_key_columns() ||
-                block->columns() >= _tablet_schema->num_columns()) {
-                return Status::InvalidArgument(fmt::format(
-                        "illegal partial update block columns: {}, num key columns: {}, total "
-                        "schema columns: {}",
-                        block->columns(), _tablet_schema->num_key_columns(),
-                        _tablet_schema->num_columns()));
-            }
-        }
-    } else if (block->columns() != _tablet_schema->num_columns()) {
+    // Every block arrives full-width: fixed partial update blocks are widened by the
+    // transform chain before they reach this writer, flexible ones carry the full
+    // schema plus the skip bitmap by contract.
+    if (block->columns() != _tablet_schema->num_columns()) {
         return Status::InvalidArgument(
                 "illegal block columns, block columns = {}, tablet_schema columns = {}",
                 block->dump_structure(), _tablet_schema->dump_structure());
@@ -990,19 +763,16 @@ Status VerticalSegmentWriter::batch_block(const Block* block, size_t row_pos, si
 }
 
 Status VerticalSegmentWriter::write_batch() {
+    // Only flexible partial update still fills inside this writer; fixed blocks were
+    // filled by the transform chain and take the regular path below.
     if (_opts.rowset_ctx->partial_update_info &&
         _opts.rowset_ctx->partial_update_info->is_partial_update() &&
         _opts.write_type == DataWriteType::TYPE_DIRECT &&
-        !_opts.rowset_ctx->is_transient_rowset_writer) {
-        bool is_flexible_partial_update =
-                _opts.rowset_ctx->partial_update_info->is_flexible_partial_update();
+        !_opts.rowset_ctx->is_transient_rowset_writer &&
+        _opts.rowset_ctx->partial_update_info->is_flexible_partial_update()) {
         Block full_block;
         for (auto& data : _batched_blocks) {
-            if (is_flexible_partial_update) {
-                RETURN_IF_ERROR(_append_block_with_flexible_partial_content(data, full_block));
-            } else {
-                RETURN_IF_ERROR(_append_block_with_partial_content(data, full_block));
-            }
+            RETURN_IF_ERROR(_append_block_with_flexible_partial_content(data, full_block));
         }
         return Status::OK();
     }

--- a/be/src/storage/segment/vertical_segment_writer.h
+++ b/be/src/storage/segment/vertical_segment_writer.h
@@ -27,6 +27,7 @@
 #include <memory> // unique_ptr
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "common/status.h" // Status
@@ -165,9 +166,8 @@ private:
     Status _append_generated_column(const DerivedColumnGenerator& generator, const Block& block,
                                     size_t row_pos, size_t num_rows, uint32_t cid);
     // Thin wrapper over MowKeyProbe that translates a ProbeOutcome back into the out-parameters the
-    // partial update fill loops use. `found_cb` receives the rowset that holds `loc`: the fixed
-    // path pins it in its HistoricalRowFetcher, the flexible path in `_rsid_to_rowset`, which its
-    // fill still reads from.
+    // flexible partial update fill loop uses. `found_cb` receives the rowset that holds `loc` and
+    // pins it in `_rsid_to_rowset`, which the fill still reads from.
     Status _probe_key_for_mow(
             const MowKeyProbe& probe, std::string key, std::size_t segment_pos,
             bool have_input_seq_column, bool have_delete_sign,
@@ -177,8 +177,7 @@ private:
             const std::function<void(const RowLocation& loc, const RowsetSharedPtr& rowset)>&
                     found_cb,
             const std::function<Status()>& not_found_cb, PartialUpdateStats& stats);
-    Status _partial_update_preconditions_check(size_t row_pos, bool is_flexible_update);
-    Status _append_block_with_partial_content(RowsInBlock& data, Block& full_block);
+    Status _partial_update_preconditions_check(size_t row_pos);
     Status _append_block_with_flexible_partial_content(RowsInBlock& data, Block& full_block);
     Status _generate_encoded_default_seq_value(const TabletSchema& tablet_schema,
                                                const PartialUpdateInfo& info,

--- a/be/src/storage/transform/block_transform.cpp
+++ b/be/src/storage/transform/block_transform.cpp
@@ -29,6 +29,7 @@
 #include "storage/partial_update_info.h"
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/tablet/tablet_schema.h"
+#include "storage/transform/partial_update_fill.h"
 #include "util/jsonb/serialize.h"
 
 namespace doris::segment_v2 {
@@ -195,14 +196,23 @@ BlockTransformChain build_transform_chain(const RowsetWriterContext& context) {
                                         context.partial_update_info->is_partial_update() &&
                                         context.write_type == DataWriteType::TYPE_DIRECT &&
                                         !context.is_transient_rowset_writer;
-    if (is_partial_update_load) {
-        // Partial update loads only get validated here for now: the segment
-        // writers still do their own fill, parse and row-store work until the
-        // fill stages move into the chain.
-        return BlockTransformChain {std::move(stages)};
-    }
     const bool rebuild_row_store = context.write_type == DataWriteType::TYPE_DIRECT ||
                                    context.write_type == DataWriteType::TYPE_SCHEMA_CHANGE;
+    if (is_partial_update_load) {
+        if (context.partial_update_info->is_fixed_partial_update()) {
+            stages.push_back(std::make_shared<FixedPartialUpdateFillStage>());
+            // The legacy fixed path parsed both provided and missing Variant
+            // columns before rebuilding RowStore. A partial update load is always
+            // TYPE_DIRECT, so the row store is always rebuilt.
+            stages.push_back(std::make_shared<VariantParseStage>());
+            stages.push_back(std::make_shared<RowStoreFillStage>());
+            return BlockTransformChain {std::move(stages)};
+        }
+        // Flexible partial update only gets validated here for now: the vertical
+        // writer does its own fill, parse and row-store work until that fill
+        // stage moves into the chain.
+        return BlockTransformChain {std::move(stages)};
+    }
     // Direct and schema-change writers rebuilt RowStore from the raw Variant
     // representation, then parsed Variant for its column writer.
     if (rebuild_row_store) {

--- a/be/src/storage/transform/block_transform.h
+++ b/be/src/storage/transform/block_transform.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <map>
 #include <memory>
 #include <string_view>
 #include <utility>
@@ -73,6 +72,9 @@ struct TransformExecContext {
     // --- outputs ---
     // the derived column for the writer to generate in batches; null generator = none
     DerivedColumn derived_column;
+    // probe counters of the partial-update fill stages; the flush seam folds them
+    // into the flusher totals
+    PartialUpdateStats partial_update_stats;
 };
 
 // One Block -> Block step run before the segment writers. apply() may mutate
@@ -86,7 +88,8 @@ public:
 };
 
 // An ordered list of transforms. Building one is cheap, so the seams build it
-// per flush; it is immutable and shareable across concurrent flushes.
+// for each transformed block; it is immutable and shareable across concurrent
+// flushes.
 class BlockTransformChain {
 public:
     BlockTransformChain() = default;
@@ -119,8 +122,9 @@ private:
 //   - compaction: empty (rows are already final)
 //   - binlog sub-writer: empty for now (RowBinlogSegmentWriter still derives
 //     the binlog rows itself; a later change moves that in here)
-//   - partial update: [Validate] for now (the segment writers still do their
-//     own fill, parse and row-store work; later changes move the fill in here)
+//   - fixed partial update: [Validate, FixedPartialUpdateFill, VariantParse, RowStoreFill]
+//   - flexible partial update: [Validate] for now (the vertical writer still does
+//     its own fill, parse and row-store work; a later change moves that in here)
 //   - direct / schema change / transient flush: [Validate, RowStoreFill, VariantParse]
 // RowStoreFill is omitted when the write type does not rebuild the row-store column.
 BlockTransformChain build_transform_chain(const RowsetWriterContext& context);

--- a/be/src/storage/transform/partial_update_fill.cpp
+++ b/be/src/storage/transform/partial_update_fill.cpp
@@ -1,0 +1,162 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/transform/partial_update_fill.h"
+
+#include <algorithm>
+
+#include "common/cast_set.h"
+#include "common/config.h"
+#include "core/block/block.h"
+#include "storage/iterator/olap_data_convertor.h"
+#include "storage/key/row_key_encoder.h"
+#include "storage/mow/historical_row_fetcher.h"
+#include "storage/mow/key_probe.h"
+#include "storage/partial_update_info.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/segment/segment_loader.h"
+#include "storage/tablet/base_tablet.h"
+#include "storage/tablet/tablet_schema.h"
+#include "storage/transform/transform_util.h"
+#include "util/debug_points.h"
+
+namespace doris::segment_v2 {
+
+namespace {
+
+// Re-adds the merge-on-write sentinel mark to the delete bitmap, when the
+// correctness check is on.
+void maybe_add_sentinel_mark(TransformExecContext& ctx) {
+    if (config::enable_merge_on_write_correctness_check) {
+        ctx.tablet->add_sentinel_mark_to_delete_bitmap(ctx.mow_context->delete_bitmap.get(),
+                                                       *ctx.mow_context->rowset_ids);
+    }
+}
+
+// The probe + read-plan loop of the fixed fill. For each row: encode the key
+// (with seq suffix when the load provides one), probe the load's rowset
+// snapshot, register a brand-new key on a miss, then either flag the row for
+// default fill or plan a whole-row historical read.
+Status probe_and_plan(TransformExecContext& ctx, RowKeyEncoder& key_encoder, MowKeyProbe& probe,
+                      HistoricalRowFetcher& fetcher,
+                      const std::vector<RowsetSharedPtr>& specified_rowsets,
+                      std::vector<std::unique_ptr<SegmentCacheHandle>>& segment_caches,
+                      const std::vector<IOlapColumnDataAccessor*>& key_columns,
+                      IOlapColumnDataAccessor* seq_column, const signed char* delete_signs,
+                      size_t num_rows, Block* block, std::vector<bool>& use_default_or_null_flag,
+                      bool& has_default_or_nullable) {
+    const TabletSchema& schema = *ctx.tablet_schema;
+    PartialUpdateInfo& info = *ctx.partial_update_info;
+    const bool have_input_seq_column = (seq_column != nullptr);
+
+    use_default_or_null_flag.reserve(num_rows);
+    for (size_t pos = 0; pos < num_rows; ++pos) {
+        // Encode without touching the row cache: the writer's key index build
+        // invalidates every row's cache entry under the same conditions, so the
+        // erase runs once there, not twice.
+        // one block == one fresh segment: segment_pos == block row index
+        std::string key = key_encoder.full_encode_primary_keys(key_columns, pos);
+        if (have_input_seq_column) {
+            key_encoder.append_seq_suffix(&key, seq_column, pos);
+        }
+        const bool have_delete_sign = (delete_signs != nullptr && delete_signs[pos] != 0);
+        ProbeOutcome out = DORIS_TRY(probe.probe(key, /*segment_pos=*/pos, have_input_seq_column,
+                                                 have_delete_sign, specified_rowsets,
+                                                 segment_caches, ctx.partial_update_stats));
+        if (out.result == KeyProbeResult::NOT_FOUND && !have_delete_sign) {
+            RETURN_IF_ERROR(info.handle_new_key(schema, [&]() -> std::string {
+                return block->dump_one_line(pos, cast_set<int>(schema.num_key_columns()));
+            }));
+        }
+        has_default_or_nullable |= out.use_default_or_null;
+        use_default_or_null_flag.emplace_back(out.use_default_or_null);
+        if (!out.use_default_or_null) {
+            fetcher.pin_rowset(out.rowset);
+            fetcher.plan_fixed_read(out.loc, pos);
+        }
+    }
+    CHECK_EQ(use_default_or_null_flag.size(), num_rows);
+    return Status::OK();
+}
+
+} // namespace
+
+Status FixedPartialUpdateFillStage::apply(TransformExecContext& ctx, Block* block) const {
+    DBUG_EXECUTE_IF("_append_block_with_partial_content.block", DBUG_BLOCK);
+
+    const TabletSchemaSPtr& tablet_schema = ctx.tablet_schema;
+    const TabletSchema& schema = *tablet_schema;
+    auto& info = *ctx.partial_update_info;
+    const size_t num_rows = block->rows();
+
+    // 1. widen the narrow input to the full schema. The input also keeps any
+    //    generated auto-inc column at the tail, which fill_missing_columns()
+    //    reads from `block` by name.
+    const auto& update_cids = info.update_cids;
+    Block full_block = widen_partial_update_block(schema, update_cids, *block);
+
+    // 2. key-only conversion with stage-local encoder + convertor
+    RowKeyEncoder key_encoder(schema, /*mow=*/true);
+    // FE forbids partial update on mow tables with cluster keys; everything
+    // below assumes sort keys == schema keys
+    DCHECK_EQ(key_encoder.num_sort_key_columns(), schema.num_key_columns());
+    OlapBlockDataConvertor convertor;
+    convertor.resize(schema.num_columns());
+    std::vector<IOlapColumnDataAccessor*> key_columns;
+    RETURN_IF_ERROR(convert_key_columns(convertor, schema, full_block, num_rows, key_columns));
+    IOlapColumnDataAccessor* seq_column = nullptr;
+    if (schema.has_sequence_col()) {
+        const auto seq_cid = cast_set<uint32_t>(schema.sequence_col_idx());
+        const bool have_input_seq_column =
+                std::find(update_cids.begin(), update_cids.end(), seq_cid) != update_cids.end();
+        if (have_input_seq_column) {
+            RETURN_IF_ERROR(convert_seq_column(convertor, schema, full_block, seq_cid, num_rows,
+                                               seq_column));
+        }
+    }
+
+    // 3. probe every key against the load's rowset snapshot
+    DBUG_EXECUTE_IF("VerticalSegmentWriter._append_block_with_partial_content.sleep",
+                    { sleep(60); })
+    const std::vector<RowsetSharedPtr>& specified_rowsets = ctx.mow_context->rowset_ptrs;
+    std::vector<std::unique_ptr<SegmentCacheHandle>> segment_caches(specified_rowsets.size());
+
+    MowKeyProbe probe = MowKeyProbe::for_partial_update(
+            ctx.tablet.get(), tablet_schema.get(), schema.has_sequence_col(), ctx.mow_context,
+            ctx.rowset_id, cast_set<uint32_t>(ctx.segment_id), /*flexible=*/false);
+    HistoricalRowFetcher fetcher(ctx.rowset_ctx->make_historical_row_retriever_context());
+
+    bool has_default_or_nullable = false;
+    std::vector<bool> use_default_or_null_flag;
+    const auto* delete_signs = BaseTablet::get_delete_sign_column_data(full_block, num_rows);
+    RETURN_IF_ERROR(probe_and_plan(ctx, key_encoder, probe, fetcher, specified_rowsets,
+                                   segment_caches, key_columns, seq_column, delete_signs, num_rows,
+                                   block, use_default_or_null_flag, has_default_or_nullable));
+
+    maybe_add_sentinel_mark(ctx);
+
+    // 4. read history / defaults into the missing columns
+    RETURN_IF_ERROR(fetcher.fill_missing_columns(schema, full_block, use_default_or_null_flag,
+                                                 has_default_or_nullable,
+                                                 /*segment_start_pos=*/0, block));
+
+    // 5. swap in the full-width block; downstream it looks like a plain upsert
+    block->swap(full_block);
+    return Status::OK();
+}
+
+} // namespace doris::segment_v2

--- a/be/src/storage/transform/partial_update_fill.h
+++ b/be/src/storage/transform/partial_update_fill.h
@@ -1,0 +1,34 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "storage/transform/block_transform.h"
+
+namespace doris::segment_v2 {
+
+// Fixed partial update (UPDATE_FIXED_COLUMNS): widen the narrow input to the
+// full schema, probe each key against the load's rowset snapshot, and fill the
+// missing columns from history or defaults. Delete-bitmap marks are written
+// right away inside apply(); probe counters land in ctx.partial_update_stats.
+class FixedPartialUpdateFillStage : public BlockTransform {
+public:
+    Status apply(TransformExecContext& ctx, Block* block) const override;
+    std::string_view name() const override { return "FixedPartialUpdateFill"; }
+};
+
+} // namespace doris::segment_v2

--- a/be/src/storage/transform/transform_util.cpp
+++ b/be/src/storage/transform/transform_util.cpp
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/transform/transform_util.h"
+
+#include "common/cast_set.h"
+#include "core/block/block.h"
+#include "storage/iterator/olap_data_convertor.h"
+#include "storage/tablet/tablet_schema.h"
+
+namespace doris::segment_v2 {
+
+Status convert_key_columns(OlapBlockDataConvertor& convertor, const TabletSchema& schema,
+                           const Block& block, size_t num_rows,
+                           std::vector<IOlapColumnDataAccessor*>& key_columns) {
+    key_columns.clear();
+    const uint32_t num_key_columns = cast_set<uint32_t>(schema.num_key_columns());
+    for (uint32_t cid = 0; cid < num_key_columns; ++cid) {
+        convertor.add_column_data_convertor_at(schema.column(cid), cid);
+        RETURN_IF_ERROR(convertor.set_source_content_with_specifid_column(
+                block.get_by_position(cid), 0, num_rows, cid));
+        auto [st, column] = convertor.convert_column_data(cid);
+        RETURN_IF_ERROR(st);
+        key_columns.push_back(column);
+    }
+    return Status::OK();
+}
+
+Status convert_seq_column(OlapBlockDataConvertor& convertor, const TabletSchema& schema,
+                          const Block& block, size_t src_pos, size_t num_rows,
+                          IOlapColumnDataAccessor*& seq_column) {
+    const auto seq_cid = cast_set<uint32_t>(schema.sequence_col_idx());
+    convertor.add_column_data_convertor_at(schema.column(seq_cid), seq_cid);
+    RETURN_IF_ERROR(convertor.set_source_content_with_specifid_column(
+            block.get_by_position(src_pos), 0, num_rows, seq_cid));
+    auto [st, column] = convertor.convert_column_data(seq_cid);
+    RETURN_IF_ERROR(st);
+    seq_column = column;
+    return Status::OK();
+}
+
+Block widen_partial_update_block(const TabletSchema& schema,
+                                 const std::vector<uint32_t>& update_cids, const Block& narrow) {
+    Block full_block = schema.create_block();
+    size_t input_id = 0;
+    for (auto cid : update_cids) {
+        // Carry the input's type along with its column: a variant V2 input column
+        // is typed differently from the slot the schema-created block holds.
+        const auto& input_column = narrow.get_by_position(input_id++);
+        auto& full_column = full_block.get_by_position(cid);
+        full_column.column = input_column.column;
+        full_column.type = input_column.type;
+    }
+    return full_block;
+}
+
+} // namespace doris::segment_v2

--- a/be/src/storage/transform/transform_util.h
+++ b/be/src/storage/transform/transform_util.h
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "common/status.h"
+
+namespace doris {
+class Block;
+class TabletSchema;
+class IOlapColumnDataAccessor;
+class OlapBlockDataConvertor;
+
+namespace segment_v2 {
+
+// Helpers shared by more than one block transform stage.
+
+// Converts the key columns [0, num_key_columns) of `block` to OLAP data accessors.
+Status convert_key_columns(OlapBlockDataConvertor& convertor, const TabletSchema& schema,
+                           const Block& block, size_t num_rows,
+                           std::vector<IOlapColumnDataAccessor*>& key_columns);
+
+// Converts the sequence column at input position `src_pos` to an OLAP data accessor.
+Status convert_seq_column(OlapBlockDataConvertor& convertor, const TabletSchema& schema,
+                          const Block& block, size_t src_pos, size_t num_rows,
+                          IOlapColumnDataAccessor*& seq_column);
+
+// Widens a narrow fixed partial-update block to the full `schema`; missing columns stay empty.
+Block widen_partial_update_block(const TabletSchema& schema,
+                                 const std::vector<uint32_t>& update_cids, const Block& narrow);
+
+} // namespace segment_v2
+} // namespace doris

--- a/be/test/storage/mow/mow_transform_test_base.h
+++ b/be/test/storage/mow/mow_transform_test_base.h
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <numeric>
 #include <string>
 #include <vector>
 
@@ -40,6 +41,8 @@
 #include "storage/rowset/beta_rowset.h"
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_reader.h"
+#include "storage/rowset/rowset_reader_context.h"
 #include "storage/rowset/rowset_writer.h"
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/segment/historical_row_retriever.h"
@@ -137,6 +140,125 @@ protected:
         auto schema = std::make_shared<TabletSchema>();
         schema->init_from_pb(pb);
         return schema;
+    }
+
+    // (k INT key, v INT NOT NULL without default, delete-sign) UNIQUE_KEYS MoW schema: the shape
+    // whose missing column can neither be defaulted nor nulled in strict-mode partial update.
+    TabletSchemaSPtr create_mow_schema_required_value() {
+        TabletSchemaPB pb;
+        pb.set_keys_type(UNIQUE_KEYS);
+        pb.set_num_short_key_columns(1);
+        pb.set_num_rows_per_row_block(1024);
+        pb.set_compress_kind(COMPRESS_LZ4);
+        pb.set_next_column_unique_id(10);
+
+        auto add_col = [&](int uid, const std::string& name, const std::string& type, bool is_key,
+                           bool nullable, const std::string& def = "") {
+            ColumnPB* c = pb.add_column();
+            c->set_unique_id(uid);
+            c->set_name(name);
+            c->set_type(type);
+            c->set_is_key(is_key);
+            c->set_length(type == "TINYINT" ? 1 : 4);
+            c->set_index_length(type == "TINYINT" ? 1 : 4);
+            c->set_is_nullable(nullable);
+            c->set_aggregation("NONE");
+            if (!def.empty()) {
+                c->set_default_value(def);
+            }
+        };
+        add_col(0, "k", "INT", true, false);
+        add_col(1, "v", "INT", false, /*nullable=*/false); // NOT NULL, no default
+        add_col(2, DELETE_SIGN, "TINYINT", false, false, std::to_string(0));
+        pb.set_delete_sign_idx(2);
+
+        auto schema = std::make_shared<TabletSchema>();
+        schema->init_from_pb(pb);
+        return schema;
+    }
+
+    // Flushes `blocks` one segment each through the real rowset writer with the
+    // partial-update context set, i.e. through the transform chain's fill path.
+    // `stats_out`, when given, receives the writer-level partial update counters
+    // (the chain's probe counters folded into the flusher totals).
+    Status flush_partial_rowset_segments(
+            const TabletSchemaSPtr& schema, int64_t rowset_numeric_id, int64_t version,
+            const TabletSharedPtr& tablet, const std::shared_ptr<MowContext>& mow_context,
+            const std::shared_ptr<PartialUpdateInfo>& partial_update_info,
+            const std::vector<Block*>& blocks, RowsetSharedPtr* rowset,
+            PartialUpdateStats* stats_out = nullptr) {
+        RowsetWriterContext context;
+        TabletSharedPtr unused_tablet;
+        make_rowset_ctx(schema, rowset_numeric_id, version, &context, &unused_tablet);
+        context.tablet = tablet;
+        context.data_dir = tablet->data_dir();
+        context.mow_context = mow_context;
+        context.partial_update_info = partial_update_info;
+        context.is_transient_rowset_writer = false;
+        context.segments_overlap = NONOVERLAPPING;
+        context.max_rows_per_segment = 1024;
+        context.enable_segcompaction = false;
+
+        auto writer_result = RowsetFactory::create_rowset_writer(*_engine, context, false);
+        if (!writer_result.has_value()) {
+            return writer_result.error();
+        }
+        auto writer = std::move(writer_result).value();
+        int32_t segment_id = 0;
+        for (Block* block : blocks) {
+            RETURN_IF_ERROR(writer->flush_memtable(block, segment_id++, nullptr));
+        }
+        RETURN_IF_ERROR(writer->flush());
+        if (stats_out != nullptr) {
+            stats_out->num_rows_updated = writer->num_rows_updated();
+            stats_out->num_rows_deleted = writer->num_rows_deleted();
+            stats_out->num_rows_new_added = writer->num_rows_new_added();
+            stats_out->num_rows_filtered = writer->num_rows_filtered();
+        }
+        return writer->build(*rowset);
+    }
+
+    Status flush_partial_rowset(const TabletSchemaSPtr& schema, int64_t rowset_numeric_id,
+                                int64_t version, const TabletSharedPtr& tablet,
+                                const std::shared_ptr<MowContext>& mow_context,
+                                const std::shared_ptr<PartialUpdateInfo>& partial_update_info,
+                                Block* block, RowsetSharedPtr* rowset,
+                                PartialUpdateStats* stats_out = nullptr) {
+        return flush_partial_rowset_segments(schema, rowset_numeric_id, version, tablet,
+                                             mow_context, partial_update_info, {block}, rowset,
+                                             stats_out);
+    }
+
+    // Reads every row of `rowset` back into `output` in key order, all columns.
+    Status read_rowset(const RowsetSharedPtr& rowset, const TabletSchemaSPtr& schema,
+                       Block* output) {
+        std::vector<uint32_t> return_columns(schema->num_columns());
+        std::iota(return_columns.begin(), return_columns.end(), 0);
+        RowsetReaderContext context;
+        context.tablet_schema = schema;
+        context.return_columns = &return_columns;
+        context.need_ordered_result = true;
+        OlapReaderStatistics statistics;
+        context.stats = &statistics;
+
+        RowsetReaderSharedPtr reader;
+        RETURN_IF_ERROR(rowset->create_reader(&reader));
+        RETURN_IF_ERROR(reader->init(&context));
+        *output = schema->create_block_by_cids(return_columns);
+        while (true) {
+            Block batch = schema->create_block_by_cids(return_columns);
+            auto status = reader->next_batch(&batch);
+            if (status.is<ErrorCode::END_OF_FILE>()) {
+                return Status::OK();
+            }
+            RETURN_IF_ERROR(status);
+            auto guard = output->mutate_columns_scoped();
+            auto& output_columns = guard.mutable_columns();
+            for (size_t cid = 0; cid < output_columns.size(); ++cid) {
+                output_columns[cid]->insert_range_from(*batch.get_by_position(cid).column, 0,
+                                                       batch.rows());
+            }
+        }
     }
 
     // (k INT key, v VARIANT, delete-sign) UNIQUE_KEYS MoW schema, for the variant parse stage.

--- a/be/test/storage/transform/fixed_partial_update_test.cpp
+++ b/be/test/storage/transform/fixed_partial_update_test.cpp
@@ -1,0 +1,829 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Full-branch-coverage tests for the FIXED partial-update fill path and the
+// MowKeyProbe branches it drives. The fill path under test is
+// FixedPartialUpdateFillStage::apply -> probe_and_plan -> MowKeyProbe::probe
+// -> FixedReadPlan::{read_columns_by_plan,fill_missing_columns}.
+//
+// Branch map (each TEST_F names the ids it pins):
+//   B1 key found -> old row read from history      B2 key missing -> defaults
+//   B3 higher seq wins    B4 equal seq wins        B5 lower seq loses
+//   B6 delete sign on existing key                 B7 delete sign + seq table
+//   B8 delete sign on new key                      B9 provided column kept
+//   B10 new-key ERROR policy                       B11 old-row delete-bitmap mark
+//   B12 required column missing on new key         B13 stats counters
+//   B14 row-store table fill via the row store read path
+//
+// Oracle values are ported from the deleted writer implementations
+// (SegmentWriter::append_block_with_partial_content and
+// VerticalSegmentWriter::_append_block_with_partial_content), with weak
+// `cardinality() >= N` style assertions upgraded to exact delete-bitmap
+// membership + exact cardinality + exact PartialUpdateStats.
+
+#include <gtest/gtest.h>
+
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "common/config.h"
+#include "core/column/column_string.h"
+#include "storage/mow/mow_transform_test_base.h"
+#include "storage/partial_update_info.h"
+#include "storage/tablet/tablet_meta.h"
+#include "storage/transform/block_transform.h"
+#include "storage/transform/partial_update_fill.h"
+
+namespace doris {
+
+using segment_v2::FixedPartialUpdateFillStage;
+using segment_v2::TransformExecContext;
+
+class FixedPartialUpdateTest : public MowTransformTestBase {
+protected:
+    // The per-write RowsetWriterContext the stage reads through
+    // ctx.rowset_ctx->make_historical_row_retriever_context().
+    void fill_rowset_ctx(RowsetWriterContext* rwc, const TabletSchemaSPtr& schema,
+                         const TabletSharedPtr& tablet, std::shared_ptr<PartialUpdateInfo> pui,
+                         const RowsetId& new_rsid) {
+        rwc->tablet_id = kTabletId;
+        rwc->tablet = tablet;
+        rwc->tablet_schema = schema;
+        rwc->partial_update_info = std::move(pui);
+        rwc->is_transient_rowset_writer = false;
+        rwc->write_type = DataWriteType::TYPE_DIRECT;
+        rwc->rowset_id = new_rsid;
+    }
+
+    TransformExecContext make_exec_ctx(const TabletSchemaSPtr& schema,
+                                       const TabletSharedPtr& tablet,
+                                       const std::shared_ptr<MowContext>& mow,
+                                       const std::shared_ptr<PartialUpdateInfo>& pui,
+                                       RowsetWriterContext* rwc, const RowsetId& new_rsid) {
+        TransformExecContext ctx;
+        ctx.tablet_schema = schema;
+        ctx.write_type = DataWriteType::TYPE_DIRECT;
+        ctx.tablet = tablet;
+        ctx.mow_context = mow;
+        ctx.partial_update_info = pui;
+        ctx.rowset_ctx = rwc;
+        ctx.rowset_id = new_rsid;
+        ctx.segment_id = 0;
+        return ctx;
+    }
+
+    // Runs the fixed-PU fill stage with the correctness sentinel disabled (it
+    // requires real visible rowsets), restoring the config afterwards.
+    static Status run_stage(TransformExecContext& ctx, Block* block) {
+        auto saved = config::enable_merge_on_write_correctness_check;
+        config::enable_merge_on_write_correctness_check = false;
+        FixedPartialUpdateFillStage stage;
+        auto st = stage.apply(ctx, block);
+        config::enable_merge_on_write_correctness_check = saved;
+        return st;
+    }
+
+    // True iff the delete bitmap has `row_id` marked under the TEMP version for
+    // {rowset_id, segment_id}.
+    static bool marked(const std::shared_ptr<MowContext>& mow, const RowsetId& rsid,
+                       uint32_t segment_id, uint32_t row_id) {
+        return mow->delete_bitmap->contains({rsid, segment_id, DeleteBitmap::TEMP_VERSION_COMMON},
+                                            row_id);
+    }
+};
+
+// B1/B2/B11/B13: existing keys take old `v` from history (column store), the new
+// key takes the column default; old rows of the two existing keys are marked.
+TEST_F(FixedPartialUpdateTest, FixedFillFromHistoryAndDefault) {
+    auto schema = create_mow_schema(/*has_seq=*/false); // k(0) v(1) delete_sign(2)
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 3001, 2, {{1, 11}, {2, 22}, {3, 33}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k"}, false, 0, 0, "UTC", "")
+                        .ok());
+
+    RowsetId new_rsid;
+    new_rsid.init(3002);
+    RowsetWriterContext rwc;
+    fill_rowset_ctx(&rwc, schema, tablet, pui, new_rsid);
+    TransformExecContext ctx = make_exec_ctx(schema, tablet, mow, pui, &rwc, new_rsid);
+
+    // narrow input: only the key column, rows = existing 1, 3 and brand-new 99
+    Block block = schema->create_block_by_cids({0});
+    IColumn* kc = block.get_by_position(0).column->assert_mutable().get();
+    for (int32_t k : {1, 3, 99}) {
+        kc->insert_data(reinterpret_cast<const char*>(&k), sizeof(int32_t));
+    }
+
+    auto st = run_stage(ctx, &block);
+    ASSERT_TRUE(st.ok()) << st;
+
+    ASSERT_EQ(block.columns(), schema->num_columns()); // expanded to the full schema
+    ASSERT_EQ(block.rows(), 3);
+    // keys kept in input order
+    EXPECT_EQ(read_int(block, 0, 0), 1);
+    EXPECT_EQ(read_int(block, 0, 1), 3);
+    EXPECT_EQ(read_int(block, 0, 2), 99);
+    // v: old value for existing keys, default 0 for the brand-new key
+    EXPECT_EQ(read_int(block, 1, 0), 11);
+    EXPECT_EQ(read_int(block, 1, 1), 33);
+    EXPECT_EQ(read_int(block, 1, 2), 0);
+    EXPECT_FALSE(read_is_null(block, 1, 0));
+    EXPECT_FALSE(read_is_null(block, 1, 2)); // a default-0 cell is a real 0, not NULL
+
+    // exact marks: old rows for keys 1 (history rid0) and 3 (history rid2) only;
+    // key 99 was brand-new so nothing is marked for it.
+    const RowsetId hist = rowset->rowset_id();
+    EXPECT_TRUE(marked(mow, hist, 0, 0));  // key 1
+    EXPECT_TRUE(marked(mow, hist, 0, 2));  // key 3
+    EXPECT_FALSE(marked(mow, hist, 0, 1)); // key 2 untouched by this load
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 2U);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_updated, 2);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_new_added, 1);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_deleted, 0);
+}
+
+// B2/B11/B13: with a seq column, incoming seq (10) > history seq (5) -> FOUND,
+// new wins; missing v read from history, old row marked.
+TEST_F(FixedPartialUpdateTest, FixedSeqColumnHigherSeqWins) {
+    auto schema = create_mow_schema(/*has_seq=*/true); // k(0) v(1) seq(2) delete_sign(3)
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 3201, 2, {{1, 11, 5, 0}}, &tablet); // key 1: v=11, seq=5
+    auto mow = make_mow_context(100, {rowset});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k", SEQUENCE_COL}, false, 0, 0,
+                          "UTC", "")
+                        .ok());
+    RowsetId new_rsid;
+    new_rsid.init(3202);
+    RowsetWriterContext rwc;
+    fill_rowset_ctx(&rwc, schema, tablet, pui, new_rsid);
+    TransformExecContext ctx = make_exec_ctx(schema, tablet, mow, pui, &rwc, new_rsid);
+
+    // narrow input {k, seq} in update_cids order: key 1 with seq 10 > old seq 5
+    Block block = schema->create_block_by_cids({0, 2});
+    {
+        auto guard = block.mutate_columns_scoped();
+        auto& cols = guard.mutable_columns();
+        int32_t k = 1;
+        int32_t seq = 10;
+        cols[0]->insert_data(reinterpret_cast<const char*>(&k), sizeof(int32_t));
+        cols[1]->insert_data(reinterpret_cast<const char*>(&seq), sizeof(int32_t));
+    }
+
+    auto st = run_stage(ctx, &block);
+    ASSERT_TRUE(st.ok()) << st;
+
+    ASSERT_EQ(block.rows(), 1);
+    EXPECT_EQ(read_int(block, 0, 0), 1);  // key
+    EXPECT_EQ(read_int(block, 1, 0), 11); // missing v read from history (incoming seq wins)
+    EXPECT_EQ(read_int(block, 2, 0), 10); // provided seq kept
+
+    // FOUND -> old row (history rid0) marked, treated as an update.
+    EXPECT_TRUE(marked(mow, rowset->rowset_id(), 0, 0));
+    EXPECT_FALSE(marked(mow, new_rsid, 0, 0)); // not a self-mark
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 1U);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_updated, 1);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_deleted, 0);
+}
+
+// B2 boundary: incoming seq == history seq -> segment lookup returns OK (not
+// KEY_ALREADY_EXISTS), so FOUND/new-wins; v read from history, old row marked.
+TEST_F(FixedPartialUpdateTest, FixedSeqColumnEqualSeqNewWins) {
+    auto schema = create_mow_schema(/*has_seq=*/true);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 3271, 2, {{2, 22, 10, 0}}, &tablet); // key 2: v=22, seq=10
+    auto mow = make_mow_context(100, {rowset});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k", SEQUENCE_COL}, false, 0, 0,
+                          "UTC", "")
+                        .ok());
+    RowsetId new_rsid;
+    new_rsid.init(3272);
+    RowsetWriterContext rwc;
+    fill_rowset_ctx(&rwc, schema, tablet, pui, new_rsid);
+    TransformExecContext ctx = make_exec_ctx(schema, tablet, mow, pui, &rwc, new_rsid);
+
+    Block block = schema->create_block_by_cids({0, 2});
+    {
+        auto guard = block.mutate_columns_scoped();
+        auto& cols = guard.mutable_columns();
+        int32_t k = 2;
+        int32_t seq = 10; // == history seq -> new still wins
+        cols[0]->insert_data(reinterpret_cast<const char*>(&k), sizeof(int32_t));
+        cols[1]->insert_data(reinterpret_cast<const char*>(&seq), sizeof(int32_t));
+    }
+
+    auto st = run_stage(ctx, &block);
+    ASSERT_TRUE(st.ok()) << st;
+
+    ASSERT_EQ(block.rows(), 1);
+    EXPECT_EQ(read_int(block, 1, 0), 22); // equal-seq is FOUND -> read history, not default
+    EXPECT_EQ(read_int(block, 2, 0), 10);
+    EXPECT_TRUE(marked(mow, rowset->rowset_id(), 0, 0)); // old row marked (update)
+    EXPECT_FALSE(marked(mow, new_rsid, 0, 0));           // not a self-mark
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 1U);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_updated, 1);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_deleted, 0);
+}
+
+// B3/B4/B8: incoming seq (5) < history seq (10) -> FOUND_NEWER, the losing NEW
+// row self-marks {new_rsid, seg_id, segment_pos}, v falls back to default.
+TEST_F(FixedPartialUpdateTest, FixedSeqColumnLowerSeqLoses) {
+    auto schema = create_mow_schema(/*has_seq=*/true);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 3211, 2, {{1, 11, 10, 0}}, &tablet); // key 1: v=11, seq=10
+    auto mow = make_mow_context(100, {rowset});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k", SEQUENCE_COL}, false, 0, 0,
+                          "UTC", "")
+                        .ok());
+    RowsetId new_rsid;
+    new_rsid.init(3212);
+    RowsetWriterContext rwc;
+    fill_rowset_ctx(&rwc, schema, tablet, pui, new_rsid);
+    TransformExecContext ctx = make_exec_ctx(schema, tablet, mow, pui, &rwc, new_rsid);
+
+    Block block = schema->create_block_by_cids({0, 2});
+    {
+        auto guard = block.mutate_columns_scoped();
+        auto& cols = guard.mutable_columns();
+        int32_t k = 1;
+        int32_t seq = 5; // < old seq 10 -> incoming loses
+        cols[0]->insert_data(reinterpret_cast<const char*>(&k), sizeof(int32_t));
+        cols[1]->insert_data(reinterpret_cast<const char*>(&seq), sizeof(int32_t));
+    }
+
+    auto st = run_stage(ctx, &block);
+    ASSERT_TRUE(st.ok()) << st;
+
+    ASSERT_EQ(block.rows(), 1);
+    EXPECT_EQ(read_int(block, 1, 0), 0); // v = default (incoming loses, no history read)
+    EXPECT_EQ(read_int(block, 2, 0), 5); // provided seq kept
+
+    // B8 self-mark semantics: on FOUND_NEWER the NEW row at its own segment_pos
+    // (row 0 of the writing segment) is marked -- the history old row is NOT.
+    EXPECT_TRUE(marked(mow, new_rsid, 0, 0));             // losing new row self-marked
+    EXPECT_FALSE(marked(mow, rowset->rowset_id(), 0, 0)); // history old row untouched
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 1U);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_deleted, 1);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_updated, 0);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_new_added, 0);
+}
+
+// B8/B11 at non-zero coordinates: the self-mark must land at the probe's own
+// {writing rowset, writing segment, row position}, not at {segment 0, row 0}.
+// Every other test runs with ctx.segment_id == 0 and the interesting row at
+// pos 0, where a hardcoded zero would pass; this one puts the seq-loser at
+// pos 1 of segment 1.
+TEST_F(FixedPartialUpdateTest, SelfMarkUsesSegmentIdAndRowPosition) {
+    auto schema = create_mow_schema(/*has_seq=*/true);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 3251, 2, {{1, 11, 10, 0}}, &tablet); // key 1: seq=10
+    auto mow = make_mow_context(100, {rowset});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k", SEQUENCE_COL}, false, 0, 0,
+                          "UTC", "")
+                        .ok());
+    RowsetId new_rsid;
+    new_rsid.init(3252);
+    RowsetWriterContext rwc;
+    fill_rowset_ctx(&rwc, schema, tablet, pui, new_rsid);
+    TransformExecContext ctx = make_exec_ctx(schema, tablet, mow, pui, &rwc, new_rsid);
+    ctx.segment_id = 1; // this block lands in segment 1 of the new rowset
+
+    Block block = schema->create_block_by_cids({0, 2});
+    {
+        auto guard = block.mutate_columns_scoped();
+        auto& cols = guard.mutable_columns();
+        for (const auto& [k, seq] : std::vector<std::pair<int32_t, int32_t>> {{99, 7}, {1, 5}}) {
+            cols[0]->insert_data(reinterpret_cast<const char*>(&k), sizeof(int32_t));
+            cols[1]->insert_data(reinterpret_cast<const char*>(&seq), sizeof(int32_t));
+        }
+    }
+
+    auto st = run_stage(ctx, &block);
+    ASSERT_TRUE(st.ok()) << st;
+
+    // pos 1 (key 1, seq 5 < 10) loses -> self-marked at exactly {new_rsid, 1, 1}
+    EXPECT_TRUE(marked(mow, new_rsid, /*segment_id=*/1, /*row_id=*/1));
+    EXPECT_FALSE(marked(mow, new_rsid, 0, 1));            // not under segment 0
+    EXPECT_FALSE(marked(mow, new_rsid, 1, 0));            // not at row 0
+    EXPECT_FALSE(marked(mow, rowset->rowset_id(), 0, 0)); // history old row untouched
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 1U);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_deleted, 1);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_new_added, 1); // key 99
+}
+
+// The MoW correctness-check sentinel: with the config on, the stage marks every
+// rowset of the load's snapshot with the sentinel entry that the publish-phase
+// check consumes. Every other test disables the config, so this is the one
+// place that pins maybe_add_sentinel_mark actually running.
+TEST_F(FixedPartialUpdateTest, SentinelMarkAddedWhenCorrectnessCheckOn) {
+    auto schema = create_mow_schema(/*has_seq=*/false);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 3261, 2, {{1, 11}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k"}, false, 0, 0, "UTC", "")
+                        .ok());
+    RowsetId new_rsid;
+    new_rsid.init(3262);
+    RowsetWriterContext rwc;
+    fill_rowset_ctx(&rwc, schema, tablet, pui, new_rsid);
+    TransformExecContext ctx = make_exec_ctx(schema, tablet, mow, pui, &rwc, new_rsid);
+
+    Block block = schema->create_block_by_cids({0});
+    int32_t k = 1;
+    block.get_by_position(0).column->assert_mutable()->insert_data(
+            reinterpret_cast<const char*>(&k), sizeof(int32_t));
+
+    // run WITH the correctness check on -- the sentinel only needs the snapshot's
+    // rowset ids, which the fixture populates
+    auto saved = config::enable_merge_on_write_correctness_check;
+    config::enable_merge_on_write_correctness_check = true;
+    FixedPartialUpdateFillStage stage;
+    auto st = stage.apply(ctx, &block);
+    config::enable_merge_on_write_correctness_check = saved;
+    ASSERT_TRUE(st.ok()) << st;
+
+    EXPECT_TRUE(mow->delete_bitmap->contains({rowset->rowset_id(), DeleteBitmap::INVALID_SEGMENT_ID,
+                                              DeleteBitmap::TEMP_VERSION_COMMON},
+                                             DeleteBitmap::ROWSET_SENTINEL_MARK));
+}
+
+// B5: delete on an existing key WITHOUT a seq column -> delete_sign_skip=true ->
+// the old row is NOT read (v=default), but the old row is still marked.
+TEST_F(FixedPartialUpdateTest, FixedDeleteSignExistingKey) {
+    auto schema = create_mow_schema(/*has_seq=*/false); // k(0) v(1) delete_sign(2)
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 3221, 2, {{1, 11}}, &tablet); // key 1: v=11
+    auto mow = make_mow_context(100, {rowset});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k", DELETE_SIGN}, false, 0, 0,
+                          "UTC", "")
+                        .ok());
+    RowsetId new_rsid;
+    new_rsid.init(3222);
+    RowsetWriterContext rwc;
+    fill_rowset_ctx(&rwc, schema, tablet, pui, new_rsid);
+    TransformExecContext ctx = make_exec_ctx(schema, tablet, mow, pui, &rwc, new_rsid);
+
+    // narrow input {k, delete_sign}: delete the existing key 1
+    Block block = schema->create_block_by_cids({0, 2});
+    {
+        auto guard = block.mutate_columns_scoped();
+        auto& cols = guard.mutable_columns();
+        int32_t k = 1;
+        int8_t ds = 1;
+        cols[0]->insert_data(reinterpret_cast<const char*>(&k), sizeof(int32_t));
+        cols[1]->insert_data(reinterpret_cast<const char*>(&ds), sizeof(int8_t));
+    }
+
+    auto st = run_stage(ctx, &block);
+    ASSERT_TRUE(st.ok()) << st;
+
+    ASSERT_EQ(block.rows(), 1);
+    EXPECT_EQ(read_int(block, 0, 0), 1);     // key
+    EXPECT_EQ(read_int(block, 1, 0), 0);     // v default (no-seq table: old row not read)
+    EXPECT_EQ(read_tinyint(block, 2, 0), 1); // delete sign kept
+
+    // FOUND-but-default still marks the OLD row (it is an update, not a self-mark).
+    EXPECT_TRUE(marked(mow, rowset->rowset_id(), 0, 0));
+    EXPECT_FALSE(marked(mow, new_rsid, 0, 0));
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 1U);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_updated, 1);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_deleted, 0);
+}
+
+// B7: delete on an existing key WITH a seq column -> the !_has_sequence_col guard
+// makes delete_sign_skip=false, so the old row IS read (v=history, not default);
+// contrast FixedDeleteSignExistingKey above which fills the default. History v
+// must differ from the default 0 for this to be observable.
+TEST_F(FixedPartialUpdateTest, FixedDeleteSignSeqTableReadsOldRow) {
+    auto schema = create_mow_schema(/*has_seq=*/true); // k(0) v(1) seq(2) delete_sign(3)
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 3281, 2, {{1, 11, 7, 0}}, &tablet); // key 1: v=11, seq=7
+    auto mow = make_mow_context(100, {rowset});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k", SEQUENCE_COL, DELETE_SIGN},
+                          false, 0, 0, "UTC", "")
+                        .ok());
+    RowsetId new_rsid;
+    new_rsid.init(3282);
+    RowsetWriterContext rwc;
+    fill_rowset_ctx(&rwc, schema, tablet, pui, new_rsid);
+    TransformExecContext ctx = make_exec_ctx(schema, tablet, mow, pui, &rwc, new_rsid);
+
+    // narrow input {k, seq, delete_sign} in cid order: delete key 1 with seq 9 (>= old 7
+    // so FOUND, not FOUND_NEWER).
+    Block block = schema->create_block_by_cids({0, 2, 3});
+    {
+        auto guard = block.mutate_columns_scoped();
+        auto& cols = guard.mutable_columns();
+        int32_t k = 1;
+        int32_t seq = 9;
+        int8_t ds = 1;
+        cols[0]->insert_data(reinterpret_cast<const char*>(&k), sizeof(int32_t));
+        cols[1]->insert_data(reinterpret_cast<const char*>(&seq), sizeof(int32_t));
+        cols[2]->insert_data(reinterpret_cast<const char*>(&ds), sizeof(int8_t));
+    }
+
+    auto st = run_stage(ctx, &block);
+    ASSERT_TRUE(st.ok()) << st;
+
+    ASSERT_EQ(block.rows(), 1);
+    EXPECT_EQ(read_int(block, 0, 0), 1);     // key 1
+    EXPECT_EQ(read_int(block, 1, 0), 11);    // v = HISTORY (seq-table guard reads old row)
+    EXPECT_FALSE(read_is_null(block, 1, 0)); // a real read value, not NULL
+    EXPECT_EQ(read_int(block, 2, 0), 9);     // provided seq kept
+    EXPECT_EQ(read_tinyint(block, 3, 0), 1); // delete sign kept
+
+    EXPECT_TRUE(marked(mow, rowset->rowset_id(), 0, 0)); // old row marked (FOUND update)
+    EXPECT_FALSE(marked(mow, new_rsid, 0, 0));
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 1U);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_updated, 1);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_deleted, 0);
+}
+
+// B1/B12: delete on a brand-new key -> handle_new_key short-circuited for a
+// delete (ERROR policy must NOT fire), tombstone kept with defaults.
+TEST_F(FixedPartialUpdateTest, FixedDeleteSignNewKey) {
+    auto schema = create_mow_schema(/*has_seq=*/false);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 3231, 2, {{1, 11}}, &tablet); // only key 1 exists
+    auto mow = make_mow_context(100, {rowset});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::ERROR, {"k", DELETE_SIGN}, false, 0, 0,
+                          "UTC", "")
+                        .ok());
+    RowsetId new_rsid;
+    new_rsid.init(3232);
+    RowsetWriterContext rwc;
+    fill_rowset_ctx(&rwc, schema, tablet, pui, new_rsid);
+    TransformExecContext ctx = make_exec_ctx(schema, tablet, mow, pui, &rwc, new_rsid);
+
+    // delete a key that is not in the table; ERROR policy must NOT fire for a delete
+    Block block = schema->create_block_by_cids({0, 2});
+    {
+        auto guard = block.mutate_columns_scoped();
+        auto& cols = guard.mutable_columns();
+        int32_t k = 99;
+        int8_t ds = 1;
+        cols[0]->insert_data(reinterpret_cast<const char*>(&k), sizeof(int32_t));
+        cols[1]->insert_data(reinterpret_cast<const char*>(&ds), sizeof(int8_t));
+    }
+
+    auto st = run_stage(ctx, &block);
+    ASSERT_TRUE(st.ok()) << st;
+
+    ASSERT_EQ(block.rows(), 1);
+    EXPECT_EQ(read_int(block, 0, 0), 99);    // key kept
+    EXPECT_EQ(read_int(block, 1, 0), 0);     // v default (no old row)
+    EXPECT_EQ(read_tinyint(block, 2, 0), 1); // delete sign kept
+
+    // NOT_FOUND -> nothing marked; it is counted as a new add even for a delete.
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 0U);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_new_added, 1);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_updated, 0);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_deleted, 0);
+}
+
+// B11: a provided value column is kept as-is; only columns not in the update list
+// are filled from history.
+TEST_F(FixedPartialUpdateTest, FixedProvidedValueKept) {
+    auto schema = create_mow_schema(/*has_seq=*/false);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 3241, 2, {{1, 11}}, &tablet); // history v=11
+    auto mow = make_mow_context(100, {rowset});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k", "v"}, false, 0, 0, "UTC", "")
+                        .ok());
+    RowsetId new_rsid;
+    new_rsid.init(3242);
+    RowsetWriterContext rwc;
+    fill_rowset_ctx(&rwc, schema, tablet, pui, new_rsid);
+    TransformExecContext ctx = make_exec_ctx(schema, tablet, mow, pui, &rwc, new_rsid);
+
+    // narrow input {k, v}: provide a new v for the existing key 1
+    Block block = schema->create_block_by_cids({0, 1});
+    {
+        auto guard = block.mutate_columns_scoped();
+        auto& cols = guard.mutable_columns();
+        int32_t k = 1;
+        int32_t v = 88;
+        cols[0]->insert_data(reinterpret_cast<const char*>(&k), sizeof(int32_t));
+        cols[1]->insert_data(reinterpret_cast<const char*>(&v), sizeof(int32_t));
+    }
+
+    auto st = run_stage(ctx, &block);
+    ASSERT_TRUE(st.ok()) << st;
+
+    ASSERT_EQ(block.rows(), 1);
+    EXPECT_EQ(read_int(block, 1, 0), 88); // provided v kept, not the history value 11
+
+    EXPECT_TRUE(marked(mow, rowset->rowset_id(), 0, 0)); // old row marked
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 1U);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_updated, 1);
+}
+
+// B9: ERROR new-key policy rejects a brand-new (non-delete) key.
+TEST_F(FixedPartialUpdateTest, FixedNewKeyErrorPolicyRejected) {
+    auto schema = create_mow_schema(/*has_seq=*/false);
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 3251, 2, {{1, 11}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::ERROR, {"k"}, false, 0, 0, "UTC", "")
+                        .ok());
+    RowsetId new_rsid;
+    new_rsid.init(3252);
+    RowsetWriterContext rwc;
+    fill_rowset_ctx(&rwc, schema, tablet, pui, new_rsid);
+    TransformExecContext ctx = make_exec_ctx(schema, tablet, mow, pui, &rwc, new_rsid);
+
+    Block block = schema->create_block_by_cids({0});
+    int32_t k = 99; // not in the table
+    block.get_by_position(0).column->assert_mutable()->insert_data(
+            reinterpret_cast<const char*>(&k), sizeof(int32_t));
+
+    auto st = run_stage(ctx, &block);
+    EXPECT_FALSE(st.ok());
+    EXPECT_NE(st.to_string().find("Can't append new rows"), std::string::npos) << st;
+}
+
+// B10: APPEND policy, a brand-new key whose not-in-update-list column is NOT NULL
+// and has no default cannot be inserted -> rejected.
+TEST_F(FixedPartialUpdateTest, FixedNewKeyAppendRequiredColumnMissing) {
+    auto schema =
+            create_mow_schema_required_value(); // k(0) v(1) NOT NULL no-default, delete_sign(2)
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 3261, 2, {{1, 11}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k"}, false, 0, 0, "UTC", "")
+                        .ok());
+    RowsetId new_rsid;
+    new_rsid.init(3262);
+    RowsetWriterContext rwc;
+    fill_rowset_ctx(&rwc, schema, tablet, pui, new_rsid);
+    TransformExecContext ctx = make_exec_ctx(schema, tablet, mow, pui, &rwc, new_rsid);
+
+    Block block = schema->create_block_by_cids({0});
+    int32_t k = 99; // brand-new key; v is not in the update list, NOT NULL, no default
+    block.get_by_position(0).column->assert_mutable()->insert_data(
+            reinterpret_cast<const char*>(&k), sizeof(int32_t));
+
+    auto st = run_stage(ctx, &block);
+    EXPECT_FALSE(st.ok());
+    EXPECT_NE(st.to_string().find("should have default value or be nullable"), std::string::npos)
+            << st;
+}
+
+// B14: row-store schema -> read_columns_by_plan takes the
+// fetch_value_through_row_column path. The existing key's missing `v` must be
+// restored from the row column (== history 11, != default 0); the new key takes
+// the default. Cross-checked against the column-store result.
+TEST_F(FixedPartialUpdateTest, FixedRowStoreReadPath) {
+    auto schema = create_row_store_schema(); // k(0) v(1) delete_sign(2) __DORIS_ROW_STORE_COL__(3)
+    ASSERT_TRUE(schema->has_row_store_for_all_columns());
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 3291, 2, {{1, 11}, {2, 22}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k"}, false, 0, 0, "UTC", "")
+                        .ok());
+    RowsetId new_rsid;
+    new_rsid.init(3292);
+    RowsetWriterContext rwc;
+    fill_rowset_ctx(&rwc, schema, tablet, pui, new_rsid);
+    TransformExecContext ctx = make_exec_ctx(schema, tablet, mow, pui, &rwc, new_rsid);
+
+    // narrow input {k}: two existing keys -- both read v back through the row
+    // column. (No brand-new key here: the non-nullable hidden row-store column
+    // cannot be defaulted for a newly inserted row under non-strict append.)
+    Block block = schema->create_block_by_cids({0});
+    IColumn* kc = block.get_by_position(0).column->assert_mutable().get();
+    for (int32_t k : {1, 2}) {
+        kc->insert_data(reinterpret_cast<const char*>(&k), sizeof(int32_t));
+    }
+
+    auto st = run_stage(ctx, &block);
+    ASSERT_TRUE(st.ok()) << st;
+
+    ASSERT_EQ(block.columns(), schema->num_columns());
+    ASSERT_EQ(block.rows(), 2);
+    EXPECT_EQ(read_int(block, 0, 0), 1);
+    EXPECT_EQ(read_int(block, 0, 1), 2);
+    // v for both keys restored through the row column (history 11 / 22 != default 0).
+    EXPECT_EQ(read_int(block, 1, 0), 11);
+    EXPECT_EQ(read_int(block, 1, 1), 22);
+    EXPECT_FALSE(read_is_null(block, 1, 0));
+    EXPECT_FALSE(read_is_null(block, 1, 1));
+    // delete_sign is a missing cid here too and must round-trip from the row store.
+    EXPECT_EQ(read_tinyint(block, 2, 0), 0);
+    EXPECT_EQ(read_tinyint(block, 2, 1), 0);
+
+    EXPECT_TRUE(marked(mow, rowset->rowset_id(), 0, 0)); // key 1 old row (rowid 0)
+    EXPECT_TRUE(marked(mow, rowset->rowset_id(), 0, 1)); // key 2 old row (rowid 1)
+    EXPECT_EQ(mow->delete_bitmap->cardinality(), 2U);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_updated, 2);
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_new_added, 0);
+
+    // Cross-check: the same data over a column-store schema yields the same v.
+    {
+        auto cs_schema = create_mow_schema(/*has_seq=*/false); // k(0) v(1) delete_sign(2)
+        ASSERT_FALSE(cs_schema->has_row_store_for_all_columns());
+        TabletSharedPtr cs_tablet;
+        auto cs_rowset = write_rowset(cs_schema, 3293, 2, {{1, 11}, {2, 22}}, &cs_tablet);
+        auto cs_mow = make_mow_context(100, {cs_rowset});
+        auto cs_pui = std::make_shared<PartialUpdateInfo>();
+        ASSERT_TRUE(cs_pui->init(kTabletId, 1, *cs_schema,
+                                 UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                                 PartialUpdateNewRowPolicyPB::APPEND, {"k"}, false, 0, 0, "UTC", "")
+                            .ok());
+        RowsetId cs_new_rsid;
+        cs_new_rsid.init(3294);
+        RowsetWriterContext cs_rwc;
+        fill_rowset_ctx(&cs_rwc, cs_schema, cs_tablet, cs_pui, cs_new_rsid);
+        TransformExecContext cs_ctx =
+                make_exec_ctx(cs_schema, cs_tablet, cs_mow, cs_pui, &cs_rwc, cs_new_rsid);
+
+        Block cs_block = cs_schema->create_block_by_cids({0});
+        IColumn* cs_kc = cs_block.get_by_position(0).column->assert_mutable().get();
+        for (int32_t k : {1, 2}) {
+            cs_kc->insert_data(reinterpret_cast<const char*>(&k), sizeof(int32_t));
+        }
+        auto cs_st = run_stage(cs_ctx, &cs_block);
+        ASSERT_TRUE(cs_st.ok()) << cs_st;
+        EXPECT_EQ(read_int(cs_block, 1, 0), read_int(block, 1, 0)); // 11 both paths
+        EXPECT_EQ(read_int(cs_block, 1, 1), read_int(block, 1, 1)); // 22 both paths
+    }
+}
+
+// End-to-end writer coverage: the transform chain expands the narrow fixed-update block, the
+// generic VerticalSegmentWriter persists it, and RowsetReader must recover the same logical rows.
+// Physical column/page order is intentionally not asserted.
+TEST_F(FixedPartialUpdateTest, VerticalWriterPersistsFilledRows) {
+    auto schema = create_mow_schema(/*has_seq=*/true);
+    TabletSharedPtr tablet;
+    auto history = write_rowset(schema, 3701, 2, {{1, 11, 5, 0}}, &tablet);
+    auto mow = make_mow_context(100, {history});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k", SEQUENCE_COL}, false, 0, 0,
+                          "UTC", "")
+                        .ok());
+
+    Block block = schema->create_block_by_cids({0, 2});
+    {
+        auto guard = block.mutate_columns_scoped();
+        auto& columns = guard.mutable_columns();
+        for (const auto& [key, sequence] :
+             std::vector<std::pair<int32_t, int32_t>> {{1, 10}, {99, 7}}) {
+            columns[0]->insert_data(reinterpret_cast<const char*>(&key), sizeof(key));
+            columns[1]->insert_data(reinterpret_cast<const char*>(&sequence), sizeof(sequence));
+        }
+    }
+
+    const bool saved_vertical_writer = config::enable_vertical_segment_writer;
+    const bool saved_correctness_check = config::enable_merge_on_write_correctness_check;
+    config::enable_vertical_segment_writer = true;
+    config::enable_merge_on_write_correctness_check = false;
+    RowsetSharedPtr output;
+    PartialUpdateStats flushed_stats;
+    const auto flush_status = flush_partial_rowset(schema, 3702, 3, tablet, mow, pui, &block,
+                                                   &output, &flushed_stats);
+    config::enable_vertical_segment_writer = saved_vertical_writer;
+    config::enable_merge_on_write_correctness_check = saved_correctness_check;
+    ASSERT_TRUE(flush_status.ok()) << flush_status;
+    ASSERT_NE(output, nullptr);
+    ASSERT_EQ(output->rowset_meta()->num_rows(), 2);
+    // the chain's probe counters were folded into the flusher totals: key 1 was an
+    // update, key 99 brand new -- and the vertical writer contributed nothing extra
+    EXPECT_EQ(flushed_stats.num_rows_updated, 1);
+    EXPECT_EQ(flushed_stats.num_rows_new_added, 1);
+    EXPECT_EQ(flushed_stats.num_rows_deleted, 0);
+    EXPECT_EQ(flushed_stats.num_rows_filtered, 0);
+
+    Block persisted;
+    ASSERT_TRUE(read_rowset(output, schema, &persisted).ok());
+    ASSERT_EQ(persisted.rows(), 2);
+    ASSERT_EQ(persisted.columns(), schema->num_columns());
+    EXPECT_EQ(read_int(persisted, 0, 0), 1);
+    EXPECT_EQ(read_int(persisted, 1, 0), 11); // restored from history
+    EXPECT_EQ(read_int(persisted, 2, 0), 10); // provided sequence
+    EXPECT_EQ(read_tinyint(persisted, 3, 0), 0);
+    EXPECT_EQ(read_int(persisted, 0, 1), 99);
+    EXPECT_EQ(read_int(persisted, 1, 1), 0); // default for a new key
+    EXPECT_EQ(read_int(persisted, 2, 1), 7);
+    EXPECT_EQ(read_tinyint(persisted, 3, 1), 0);
+
+    auto beta_rowset = std::dynamic_pointer_cast<BetaRowset>(output);
+    ASSERT_NE(beta_rowset, nullptr);
+    std::vector<segment_v2::SegmentSharedPtr> segments;
+    ASSERT_TRUE(beta_rowset->load_segments(&segments).ok());
+    ASSERT_EQ(segments.size(), 1);
+    RowKeyEncoder encoder(*schema, true);
+    for (const auto& [row_id, key, sequence] :
+         std::vector<std::tuple<uint32_t, int32_t, int32_t>> {{0, 1, 10}, {1, 99, 7}}) {
+        std::string persisted_key;
+        ASSERT_TRUE(segments[0]->read_key_by_rowid(row_id, &persisted_key).ok());
+        EXPECT_EQ(persisted_key, encode_key_with_seq(schema, encoder, key, sequence));
+    }
+}
+
+// The hidden RowStore column is streamed through DerivedColumnGenerator rather than the normal
+// schema-column loop. Verify that the generic Vertical writer persists exactly the rebuilt cells.
+TEST_F(FixedPartialUpdateTest, VerticalWriterPersistsRebuiltRowStore) {
+    auto schema = create_row_store_schema();
+    TabletSharedPtr tablet;
+    auto history = write_rowset(schema, 3731, 2, {{1, 11}, {2, 22}}, &tablet);
+    auto mow = make_mow_context(100, {history});
+
+    Block historical_rows;
+    ASSERT_TRUE(read_rowset(history, schema, &historical_rows).ok());
+    ASSERT_EQ(historical_rows.rows(), 2);
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k"}, false, 0, 0, "UTC", "")
+                        .ok());
+    Block block = schema->create_block_by_cids({0});
+    auto* keys = block.get_by_position(0).column->assert_mutable().get();
+    for (const int32_t key : {1, 2}) {
+        keys->insert_data(reinterpret_cast<const char*>(&key), sizeof(key));
+    }
+
+    const bool saved_vertical_writer = config::enable_vertical_segment_writer;
+    const bool saved_correctness_check = config::enable_merge_on_write_correctness_check;
+    config::enable_vertical_segment_writer = true;
+    config::enable_merge_on_write_correctness_check = false;
+    RowsetSharedPtr output;
+    const auto flush_status =
+            flush_partial_rowset(schema, 3732, 3, tablet, mow, pui, &block, &output);
+    config::enable_vertical_segment_writer = saved_vertical_writer;
+    config::enable_merge_on_write_correctness_check = saved_correctness_check;
+    ASSERT_TRUE(flush_status.ok()) << flush_status;
+    ASSERT_NE(output, nullptr);
+
+    Block persisted;
+    ASSERT_TRUE(read_rowset(output, schema, &persisted).ok());
+    ASSERT_EQ(persisted.rows(), 2);
+    const auto& historical_row_store =
+            assert_cast<const ColumnString&>(*historical_rows.get_by_position(3).column);
+    const auto& persisted_row_store =
+            assert_cast<const ColumnString&>(*persisted.get_by_position(3).column);
+    for (size_t row = 0; row < 2; ++row) {
+        EXPECT_EQ(read_int(persisted, 0, row), static_cast<int32_t>(row + 1));
+        EXPECT_EQ(read_int(persisted, 1, row), static_cast<int32_t>((row + 1) * 11));
+        EXPECT_EQ(read_tinyint(persisted, 2, row), 0);
+        EXPECT_EQ(persisted_row_store.get_data_at(row).to_string(),
+                  historical_row_store.get_data_at(row).to_string());
+    }
+}
+
+} // namespace doris

--- a/be/test/storage/transform/validate_stage_test.cpp
+++ b/be/test/storage/transform/validate_stage_test.cpp
@@ -24,6 +24,7 @@
 #include <string_view>
 #include <vector>
 
+#include "common/config.h"
 #include "common/status.h"
 #include "storage/mow/mow_transform_test_base.h"
 #include "storage/partial_update_info.h"
@@ -121,10 +122,9 @@ TEST_F(ValidateStageTest, CompositionTransientPartialUpdateDegradesToNoFill) {
               (V {"Validate", "RowStoreFill", "VariantParse"}));
 }
 
-// Partial update loads only get validated by the chain for now: the segment
-// writers still own the fill, parse and row-store work. The fill stages take
-// this slot when they move into the chain.
-TEST_F(ValidateStageTest, CompositionPartialUpdateValidateOnly) {
+// TYPE_DIRECT + fixed PU -> the fixed fill stage sits between Validate and Parse;
+// the legacy fixed path parsed variants before rebuilding RowStore.
+TEST_F(ValidateStageTest, CompositionFixedPartialUpdate) {
     using V = std::vector<std::string_view>;
     auto schema = create_mow_schema(/*has_seq=*/false);
     auto fixed = std::make_shared<PartialUpdateInfo>();
@@ -133,8 +133,15 @@ TEST_F(ValidateStageTest, CompositionPartialUpdateValidateOnly) {
                         .ok());
     RowsetWriterContext c = direct_rwc(schema);
     c.partial_update_info = fixed;
-    EXPECT_EQ(build_transform_chain(c).stage_names(), (V {"Validate"}));
+    EXPECT_EQ(build_transform_chain(c).stage_names(),
+              (V {"Validate", "FixedPartialUpdateFill", "VariantParse", "RowStoreFill"}));
+}
 
+// Flexible partial update only gets validated by the chain for now: the vertical
+// writer still owns its fill, parse and row-store work. The flexible fill stage
+// takes this slot when it moves into the chain.
+TEST_F(ValidateStageTest, CompositionFlexiblePartialUpdateValidateOnly) {
+    using V = std::vector<std::string_view>;
     auto fschema = create_flexible_mow_schema();
     auto flexible = std::make_shared<PartialUpdateInfo>();
     ASSERT_TRUE(flexible->init(kTabletId, 1, *fschema,
@@ -255,6 +262,60 @@ TEST_F(ValidateStageTest, V4_PartialUpdateRejectsWithoutSegmentId) {
     EXPECT_FALSE(st.ok());
     EXPECT_EQ(st.code(), ErrorCode::INTERNAL_ERROR) << st;
     EXPECT_NE(st.to_string().find("flush_single_block"), std::string::npos) << st;
+}
+
+// V5: fixed PU, legal narrow width (num_key <= columns < num_columns) -> accepted
+// and the fill runs end-to-end (the old value is read back from history).
+TEST_F(ValidateStageTest, V5_FixedPartialUpdateAcceptsNarrowWidth) {
+    auto schema = create_mow_schema(/*has_seq=*/false); // k(0) v(1) delete_sign(2)
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 8301, 2, {{1, 11}, {2, 22}, {3, 33}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k"}, false, 0, 0, "UTC", "")
+                        .ok());
+    RowsetId new_rsid;
+    new_rsid.init(8302);
+
+    RowsetWriterContext rwc = direct_rwc(schema);
+    rwc.tablet_id = kTabletId;
+    rwc.tablet = tablet;
+    rwc.partial_update_info = pui;
+    rwc.rowset_id = new_rsid;
+
+    auto chain = build_transform_chain(rwc);
+    ASSERT_FALSE(chain.empty());
+
+    TransformExecContext ctx;
+    ctx.tablet_schema = schema;
+    ctx.write_type = DataWriteType::TYPE_DIRECT;
+    ctx.tablet = tablet;
+    ctx.mow_context = mow;
+    ctx.partial_update_info = pui;
+    ctx.rowset_ctx = &rwc;
+    ctx.rowset_id = new_rsid;
+    ctx.segment_id = 0;
+
+    Block block = schema->create_block_by_cids({0}); // narrow: key only, in [1, 3)
+    IColumn* kc = block.get_by_position(0).column->assert_mutable().get();
+    for (int32_t k : {1, 3}) {
+        kc->insert_data(reinterpret_cast<const char*>(&k), sizeof(int32_t));
+    }
+
+    auto saved = config::enable_merge_on_write_correctness_check;
+    config::enable_merge_on_write_correctness_check = false;
+    auto st = chain.apply(ctx, &block);
+    config::enable_merge_on_write_correctness_check = saved;
+    ASSERT_TRUE(st.ok()) << st;
+
+    ASSERT_EQ(block.columns(), schema->num_columns());
+    ASSERT_EQ(block.rows(), 2);
+    EXPECT_EQ(read_int(block, 1, 0), 11); // old v for key 1
+    EXPECT_EQ(read_int(block, 1, 1), 33); // old v for key 3
+    // the probe counted one update per existing key
+    EXPECT_EQ(ctx.partial_update_stats.num_rows_updated, 2);
 }
 
 // V6 + V7: fixed PU rejects both a too-wide block (columns >= num_columns) and a

--- a/be/test/storage/transform/variant_rowstore_test.cpp
+++ b/be/test/storage/transform/variant_rowstore_test.cpp
@@ -27,6 +27,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "common/config.h"
 #include "core/block/block.h"
 #include "core/column/column_string.h"
 #include "core/column/column_variant.h"
@@ -62,6 +63,30 @@ protected:
         ctx.rowset_ctx = rwc;
         ctx.segment_id = segment_id;
         return ctx;
+    }
+
+    // (k INT key, v VARIANT, delete-sign, vv INT nullable default 0) -- a variant
+    // schema with one extra fixed value column so a fixed partial update can omit
+    // some columns and exercise VariantParse on the fill-widened full block.
+    TabletSchemaSPtr create_variant_pu_schema() {
+        TabletSchemaPB pb;
+        create_variant_schema()->to_schema_pb(&pb);
+        pb.set_next_column_unique_id(11);
+        ColumnPB* c = pb.add_column();
+        c->set_unique_id(3);
+        c->set_name("vv");
+        c->set_type("INT");
+        c->set_is_key(false);
+        c->set_length(4);
+        c->set_index_length(4);
+        c->set_is_nullable(true);
+        c->set_aggregation("NONE");
+        c->set_default_value(std::to_string(0));
+        pb.set_delete_sign_idx(2);
+
+        auto schema = std::make_shared<TabletSchema>();
+        schema->init_from_pb(pb);
+        return schema;
     }
 
     // create_variant_schema() plus the hidden row-store column, so one table
@@ -248,6 +273,77 @@ TEST_F(VariantRowStoreTest, VariantParseEmptyBlock) {
     ASSERT_TRUE(chain.apply(ctx, &block).ok());
     EXPECT_EQ(block.columns(), schema->num_columns());
     EXPECT_EQ(block.rows(), 0);
+}
+
+// A fixed partial update + variant table. The full chain runs the fill FIRST
+// (widening the narrow {k,v} block to full width, default-filling the omitted vv
+// and delete_sign), THEN VariantParse on that full-width block. Asserting the
+// block widened to 4 columns AND the carried variant still finalized +
+// round-trips proves parse saw the widened block. Empty history -> both keys are
+// brand-new APPENDs (vv/delete_sign take defaults).
+TEST_F(VariantRowStoreTest, VariantParseAfterPartialUpdateFill) {
+    auto schema = create_variant_pu_schema(); // k(0) v VARIANT(1) delete_sign(2) vv(3)
+    ASSERT_EQ(schema->num_variant_columns(), 1U);
+
+    auto tablet = make_tablet(schema, 8001);
+    auto mow = make_mow_context(100, {}); // empty history -> every key is new
+
+    // fixed PU on {k, v}: vv + delete_sign omitted (default-filled); v carries the
+    // new variant data.
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k", "v"}, false, 0, 0, "UTC", "")
+                        .ok());
+    RowsetId new_rsid;
+    new_rsid.init(8002);
+    RowsetWriterContext rwc = direct_rwc(schema);
+    rwc.tablet_id = kTabletId;
+    rwc.tablet = tablet;
+    rwc.partial_update_info = pui;
+    rwc.rowset_id = new_rsid;
+
+    // the built chain places the fill before VariantParse
+    auto chain = build_transform_chain(rwc);
+    EXPECT_EQ(chain.stage_names(),
+              (std::vector<std::string_view> {"Validate", "FixedPartialUpdateFill", "VariantParse",
+                                              "RowStoreFill"}));
+
+    TransformExecContext ctx = exec_ctx(schema, &rwc);
+    ctx.tablet = tablet;
+    ctx.mow_context = mow;
+    ctx.partial_update_info = pui;
+    ctx.rowset_id = new_rsid;
+
+    // narrow block in update_cids order {k, v}: 2 rows, k = 1 and 3
+    Block block = schema->create_block_by_cids({0, 1});
+    IColumn* kc = block.get_by_position(0).column->assert_mutable().get();
+    int32_t k1 = 1;
+    kc->insert_data(reinterpret_cast<const char*>(&k1), sizeof(int32_t));
+    insert_variant_json(block, 1, R"({"p":7})");
+    int32_t k3 = 3;
+    kc->insert_data(reinterpret_cast<const char*>(&k3), sizeof(int32_t));
+    insert_variant_json(block, 1, R"({"p":8})");
+
+    auto saved = config::enable_merge_on_write_correctness_check;
+    config::enable_merge_on_write_correctness_check = false;
+    auto st = chain.apply(ctx, &block);
+    config::enable_merge_on_write_correctness_check = saved;
+    ASSERT_TRUE(st.ok()) << st;
+
+    // the chain widened to full width and kept both rows
+    ASSERT_EQ(block.columns(), schema->num_columns()); // 4
+    ASSERT_EQ(block.rows(), 2);
+    // VariantParse ran on the widened block: the carried variant finalized and
+    // round-trips to its inserted key/value (a parse on the narrow pre-fill block
+    // could not have left a finalized variant in a 4-column block).
+    const auto* parsed = assert_cast<const ColumnVariant*>(block.get_by_position(1).column.get());
+    EXPECT_TRUE(parsed->is_finalized());
+    EXPECT_NE(variant_row_json(block, 1, 0).find(R"("p":7)"), std::string::npos);
+    EXPECT_NE(variant_row_json(block, 1, 1).find(R"("p":8)"), std::string::npos);
+    // vv was the omitted column for brand-new keys -> default 0 (the fill widened
+    // the block before parse touched it).
+    EXPECT_EQ(read_int(block, 3, 0), 0);
+    EXPECT_EQ(read_int(block, 3, 1), 0);
 }
 
 // ===========================================================================
@@ -542,6 +638,72 @@ TEST_F(VariantRowStoreTest, RowStorePumpSingleOversize) {
     const auto& dst_str = assert_cast<const ColumnString&>(*dst);
     ASSERT_EQ(dst_str.size(), 1U);
     EXPECT_GT(dst_str.get_data_at(0).size, 0U);
+}
+
+// A fixed partial update on a row-store table. The chain runs the fill FIRST
+// (widening {k} to full width and reading v/delete_sign from history), then
+// RowStoreFill registers the generator on the full-width block. Materializing
+// must reflect the post-fill final values (v from history).
+TEST_F(VariantRowStoreTest, RowStoreFillAfterPartialUpdate) {
+    auto schema = create_row_store_schema(); // k(0) v(1) delete_sign(2) row_store(3)
+
+    // history: k=1 -> v=11, k=2 -> v=22
+    TabletSharedPtr tablet;
+    auto rowset = write_rowset(schema, 8101, 2, {{1, 11}, {2, 22}}, &tablet);
+    auto mow = make_mow_context(100, {rowset});
+
+    auto pui = std::make_shared<PartialUpdateInfo>();
+    ASSERT_TRUE(pui->init(kTabletId, 1, *schema, UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS,
+                          PartialUpdateNewRowPolicyPB::APPEND, {"k"}, false, 0, 0, "UTC", "")
+                        .ok());
+    RowsetId new_rsid;
+    new_rsid.init(8102);
+    RowsetWriterContext rwc = direct_rwc(schema);
+    rwc.tablet_id = kTabletId;
+    rwc.tablet = tablet;
+    rwc.partial_update_info = pui;
+    rwc.rowset_id = new_rsid;
+
+    auto chain = build_transform_chain(rwc);
+    EXPECT_EQ(chain.stage_names(),
+              (std::vector<std::string_view> {"Validate", "FixedPartialUpdateFill", "VariantParse",
+                                              "RowStoreFill"}));
+
+    TransformExecContext ctx = exec_ctx(schema, &rwc);
+    ctx.tablet = tablet;
+    ctx.mow_context = mow;
+    ctx.partial_update_info = pui;
+    ctx.rowset_id = new_rsid;
+
+    Block block = schema->create_block_by_cids({0}); // narrow: key only
+    IColumn* kc = block.get_by_position(0).column->assert_mutable().get();
+    for (int32_t kk : {1, 2}) {
+        kc->insert_data(reinterpret_cast<const char*>(&kk), sizeof(int32_t));
+    }
+
+    auto saved = config::enable_merge_on_write_correctness_check;
+    config::enable_merge_on_write_correctness_check = false;
+    auto st = chain.apply(ctx, &block);
+    config::enable_merge_on_write_correctness_check = saved;
+    ASSERT_TRUE(st.ok()) << st;
+
+    // widened to full width; generator registered on the post-fill block
+    ASSERT_EQ(block.columns(), schema->num_columns()); // 4
+    ASSERT_EQ(block.rows(), 2);
+    ASSERT_NE(ctx.derived_column.second, nullptr);
+    ASSERT_EQ(ctx.derived_column.first, 3U);
+
+    ASSERT_TRUE(materialize_derived_columns(ctx.derived_column, &block).ok());
+    const auto& rs_str = assert_cast<const ColumnString&>(*block.get_by_position(3).column);
+    ASSERT_EQ(rs_str.size(), 2U);
+
+    // each JSONB cell reflects the filled value: v read from history (11, 22).
+    Block d0 = decode_row_store_cell(schema, rs_str.get_data_at(0));
+    Block d1 = decode_row_store_cell(schema, rs_str.get_data_at(1));
+    EXPECT_EQ(read_int(d0, 0, 0), 1);  // k
+    EXPECT_EQ(read_int(d0, 1, 0), 11); // v from history
+    EXPECT_EQ(read_int(d1, 0, 0), 2);
+    EXPECT_EQ(read_int(d1, 1, 0), 22);
 }
 
 } // namespace doris


### PR DESCRIPTION


Fourth PR of the #64674 split stack (#65492, #66151, #66528). The fixed partial-update fill moves out of both segment writers into the transform chain: fixed PU loads now run [Validate, FixedPartialUpdateFill, VariantParse, RowStoreFill], so the fill widens the narrow block, probes each key via MowKeyProbe::for_partial_update, reads old rows through a per-block HistoricalRowFetcher, and hands the writers a plain full-width upsert. 


### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

