### PR TITLE
branch-4.1: [fix](paimon) manage JNI writer lifecycle and spill

### DIFF
--- a/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
+++ b/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
@@ -54,58 +54,108 @@ void throw_java_io_exception(JNIEnv* env, const std::string& message) {
     env->DeleteLocalRef(exception_class);
 }
 
-jstring get_paimon_spill_directory(JNIEnv* env, jclass, jlong spill_session_handle) {
+jobjectArray get_paimon_spill_directories(JNIEnv* env, jclass, jlong spill_session_handle) {
     auto* spill_session = reinterpret_cast<ExternalSpillSession*>(spill_session_handle);
     if (spill_session == nullptr) {
         throw_java_io_exception(env, "Paimon external spill session is null");
         return nullptr;
     }
 
-    std::string path;
-    Status st = spill_session->get_path(&path);
+    std::vector<std::string> paths;
+    Status st = spill_session->get_paths(&paths);
     if (!st.ok()) {
         throw_java_io_exception(env, st.to_string());
         return nullptr;
     }
-    return env->NewStringUTF(path.c_str());
+    jclass string_class = env->FindClass("java/lang/String");
+    if (string_class == nullptr) {
+        return nullptr;
+    }
+    jobjectArray result =
+            env->NewObjectArray(static_cast<jsize>(paths.size()), string_class, nullptr);
+    env->DeleteLocalRef(string_class);
+    if (result == nullptr) {
+        return nullptr;
+    }
+    for (jsize i = 0; i < static_cast<jsize>(paths.size()); ++i) {
+        jstring path = env->NewStringUTF(paths[i].c_str());
+        if (path == nullptr) {
+            return nullptr;
+        }
+        env->SetObjectArrayElement(result, i, path);
+        env->DeleteLocalRef(path);
+        if (env->ExceptionCheck()) {
+            return nullptr;
+        }
+    }
+    return result;
 }
 
-void reserve_paimon_spill(JNIEnv* env, jclass, jlong spill_session_handle, jlong bytes) {
+void reserve_paimon_spill(JNIEnv* env, jclass, jlong spill_session_handle, jstring path,
+                          jlong bytes) {
     auto* spill_session = reinterpret_cast<ExternalSpillSession*>(spill_session_handle);
-    if (spill_session == nullptr) {
-        throw_java_io_exception(env, "Paimon external spill session is null");
+    if (spill_session == nullptr || path == nullptr) {
+        throw_java_io_exception(env, "Paimon external spill session or path is null");
         return;
     }
-    Status st = spill_session->reserve(bytes);
+    const char* path_chars = env->GetStringUTFChars(path, nullptr);
+    if (path_chars == nullptr) {
+        return;
+    }
+    std::string native_path(path_chars);
+    env->ReleaseStringUTFChars(path, path_chars);
+    Status st = spill_session->reserve(native_path, bytes);
     if (!st.ok()) {
         throw_java_io_exception(env, st.to_string());
     }
 }
 
-void update_paimon_spill_accounting(JNIEnv*, jclass, jlong spill_session_handle,
+void update_paimon_spill_accounting(JNIEnv* env, jclass, jlong spill_session_handle, jstring path,
                                     jlong current_bytes_delta, jlong write_bytes,
                                     jlong read_bytes) {
     auto* spill_session = reinterpret_cast<ExternalSpillSession*>(spill_session_handle);
-    if (spill_session == nullptr) {
+    if (spill_session == nullptr || path == nullptr) {
         return;
     }
-    spill_session->update_accounting(current_bytes_delta, write_bytes, read_bytes);
+    const char* path_chars = env->GetStringUTFChars(path, nullptr);
+    if (path_chars == nullptr) {
+        return;
+    }
+    std::string native_path(path_chars);
+    env->ReleaseStringUTFChars(path, path_chars);
+    spill_session->update_accounting(native_path, current_bytes_delta, write_bytes, read_bytes);
+}
+
+void reconcile_paimon_spill(JNIEnv* env, jclass, jlong spill_session_handle) {
+    auto* spill_session = reinterpret_cast<ExternalSpillSession*>(spill_session_handle);
+    if (spill_session == nullptr) {
+        throw_java_io_exception(env, "Paimon external spill session is null");
+        return;
+    }
+    Status st = spill_session->reconcile_direct_file_usage();
+    if (!st.ok()) {
+        throw_java_io_exception(env, st.to_string());
+    }
 }
 
 Status register_paimon_spill_natives(JNIEnv* env, jclass writer_class) {
-    static char get_spill_directory_name[] = "getPaimonSpillDirectory";
-    static char get_spill_directory_signature[] = "(J)Ljava/lang/String;";
+    static char get_spill_directories_name[] = "getPaimonSpillDirectories";
+    static char get_spill_directories_signature[] = "(J)[Ljava/lang/String;";
     static char reserve_spill_name[] = "reservePaimonSpill";
-    static char reserve_spill_signature[] = "(JJ)V";
+    static char reserve_spill_signature[] = "(JLjava/lang/String;J)V";
     static char update_spill_name[] = "updatePaimonSpillAccounting";
-    static char update_spill_signature[] = "(JJJJ)V";
+    static char update_spill_signature[] = "(JLjava/lang/String;JJJ)V";
+    static char reconcile_spill_name[] = "reconcilePaimonSpill";
+    static char reconcile_spill_signature[] = "(J)V";
     static ::JNINativeMethod methods[] = {
-            {get_spill_directory_name, get_spill_directory_signature,
-             reinterpret_cast<void*>(&get_paimon_spill_directory)},
+            {get_spill_directories_name, get_spill_directories_signature,
+             reinterpret_cast<void*>(&get_paimon_spill_directories)},
             {reserve_spill_name, reserve_spill_signature,
              reinterpret_cast<void*>(&reserve_paimon_spill)},
             {update_spill_name, update_spill_signature,
              reinterpret_cast<void*>(&update_paimon_spill_accounting)},
+            {reconcile_spill_name, reconcile_spill_signature,
+             reinterpret_cast<void*>(&reconcile_paimon_spill)},
     };
     if (env->RegisterNatives(writer_class, methods,
                              static_cast<jint>(sizeof(methods) / sizeof(methods[0]))) != JNI_OK) {

--- a/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
+++ b/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
@@ -54,85 +54,54 @@ void throw_java_io_exception(JNIEnv* env, const std::string& message) {
     env->DeleteLocalRef(exception_class);
 }
 
-std::string java_string_to_string(JNIEnv* env, jstring value) {
-    if (value == nullptr) {
-        return {};
-    }
-    const char* chars = env->GetStringUTFChars(value, nullptr);
-    if (chars == nullptr) {
-        return {};
-    }
-    std::string result(chars);
-    env->ReleaseStringUTFChars(value, chars);
-    return result;
-}
-
-jobjectArray create_paimon_spill_directories(JNIEnv* env, jclass, jlong spill_directory_handle) {
-    auto* spill_directory = reinterpret_cast<ExternalSpillDirectory*>(spill_directory_handle);
-    if (spill_directory == nullptr) {
-        throw_java_io_exception(env, "Paimon external spill directory is null");
+jstring get_paimon_spill_directory(JNIEnv* env, jclass, jlong spill_session_handle) {
+    auto* spill_session = reinterpret_cast<ExternalSpillSession*>(spill_session_handle);
+    if (spill_session == nullptr) {
+        throw_java_io_exception(env, "Paimon external spill session is null");
         return nullptr;
     }
 
-    std::vector<std::string> paths;
-    Status st = spill_directory->get_paths(&paths);
+    std::string path;
+    Status st = spill_session->get_path(&path);
     if (!st.ok()) {
         throw_java_io_exception(env, st.to_string());
         return nullptr;
     }
-    jclass string_class = env->FindClass("java/lang/String");
-    jobjectArray result =
-            env->NewObjectArray(static_cast<jsize>(paths.size()), string_class, nullptr);
-    for (size_t i = 0; i < paths.size(); ++i) {
-        jstring path = env->NewStringUTF(paths[i].c_str());
-        env->SetObjectArrayElement(result, static_cast<jsize>(i), path);
-        env->DeleteLocalRef(path);
-    }
-    env->DeleteLocalRef(string_class);
-    return result;
+    return env->NewStringUTF(path.c_str());
 }
 
-void reserve_paimon_spill(JNIEnv* env, jclass, jlong spill_directory_handle, jstring path,
-                          jlong bytes) {
-    auto* spill_directory = reinterpret_cast<ExternalSpillDirectory*>(spill_directory_handle);
-    if (spill_directory == nullptr) {
-        throw_java_io_exception(env, "Paimon external spill directory is null");
+void reserve_paimon_spill(JNIEnv* env, jclass, jlong spill_session_handle, jlong bytes) {
+    auto* spill_session = reinterpret_cast<ExternalSpillSession*>(spill_session_handle);
+    if (spill_session == nullptr) {
+        throw_java_io_exception(env, "Paimon external spill session is null");
         return;
     }
-    std::string native_path = java_string_to_string(env, path);
-    if (env->ExceptionCheck()) {
-        return;
-    }
-    Status st = spill_directory->reserve(native_path, bytes);
+    Status st = spill_session->reserve(bytes);
     if (!st.ok()) {
         throw_java_io_exception(env, st.to_string());
     }
 }
 
-void update_paimon_spill_accounting(JNIEnv* env, jclass, jlong spill_directory_handle, jstring path,
+void update_paimon_spill_accounting(JNIEnv*, jclass, jlong spill_session_handle,
                                     jlong current_bytes_delta, jlong write_bytes,
                                     jlong read_bytes) {
-    auto* spill_directory = reinterpret_cast<ExternalSpillDirectory*>(spill_directory_handle);
-    if (spill_directory == nullptr) {
+    auto* spill_session = reinterpret_cast<ExternalSpillSession*>(spill_session_handle);
+    if (spill_session == nullptr) {
         return;
     }
-    std::string native_path = java_string_to_string(env, path);
-    if (env->ExceptionCheck()) {
-        return;
-    }
-    spill_directory->update_accounting(native_path, current_bytes_delta, write_bytes, read_bytes);
+    spill_session->update_accounting(current_bytes_delta, write_bytes, read_bytes);
 }
 
 Status register_paimon_spill_natives(JNIEnv* env, jclass writer_class) {
-    static char create_spill_directories_name[] = "createPaimonSpillDirectories";
-    static char create_spill_directories_signature[] = "(J)[Ljava/lang/String;";
+    static char get_spill_directory_name[] = "getPaimonSpillDirectory";
+    static char get_spill_directory_signature[] = "(J)Ljava/lang/String;";
     static char reserve_spill_name[] = "reservePaimonSpill";
-    static char reserve_spill_signature[] = "(JLjava/lang/String;J)V";
+    static char reserve_spill_signature[] = "(JJ)V";
     static char update_spill_name[] = "updatePaimonSpillAccounting";
-    static char update_spill_signature[] = "(JLjava/lang/String;JJJ)V";
+    static char update_spill_signature[] = "(JJJJ)V";
     static ::JNINativeMethod methods[] = {
-            {create_spill_directories_name, create_spill_directories_signature,
-             reinterpret_cast<void*>(&create_paimon_spill_directories)},
+            {get_spill_directory_name, get_spill_directory_signature,
+             reinterpret_cast<void*>(&get_paimon_spill_directory)},
             {reserve_spill_name, reserve_spill_signature,
              reinterpret_cast<void*>(&reserve_paimon_spill)},
             {update_spill_name, update_spill_signature,
@@ -154,7 +123,7 @@ std::atomic<bool>& paimon_jni_close_failed() {
 
 struct RetainedPaimonResources {
     std::unique_ptr<PaimonJniMemoryManager> memory_manager;
-    std::unique_ptr<ExternalSpillDirectory> spill_directory;
+    std::unique_ptr<ExternalSpillSession> spill_session;
 };
 
 std::mutex& retained_resources_mutex() {
@@ -168,18 +137,18 @@ std::vector<RetainedPaimonResources>& retained_resources() {
 }
 
 void retain_resources_after_failed_close(std::unique_ptr<PaimonJniMemoryManager> memory_manager,
-                                         std::unique_ptr<ExternalSpillDirectory> spill_directory) {
+                                         std::unique_ptr<ExternalSpillSession> spill_session) {
     // An unconfirmed Java close means a background Paimon task may still reference this manager's
     // native pages or spill callbacks. Quarantine both resources and stop admitting new writers so
     // repeated failures cannot accumulate process-lifetime resources without a bound.
     paimon_jni_close_failed().store(true, std::memory_order_release);
-    if (memory_manager == nullptr && spill_directory == nullptr) {
+    if (memory_manager == nullptr && spill_session == nullptr) {
         return;
     }
     std::lock_guard<std::mutex> lock(retained_resources_mutex());
     retained_resources().emplace_back(RetainedPaimonResources {
             .memory_manager = std::move(memory_manager),
-            .spill_directory = std::move(spill_directory),
+            .spill_session = std::move(spill_session),
     });
 }
 
@@ -213,7 +182,7 @@ Status JniPaimonWriteBackend::close() {
     if (_jni_writer_obj == nullptr && _jni_writer_cls == nullptr) {
         _memory_manager.reset();
         _arrow_schema.reset();
-        _spill_directory.reset();
+        _spill_session.reset();
         _opened = false;
         return Status::OK();
     }
@@ -228,10 +197,10 @@ Status JniPaimonWriteBackend::close() {
         _jni_writer_cls = nullptr;
         if (java_users_may_exist) {
             retain_resources_after_failed_close(std::move(_memory_manager),
-                                                std::move(_spill_directory));
+                                                std::move(_spill_session));
         } else {
             _memory_manager.reset();
-            _spill_directory.reset();
+            _spill_session.reset();
         }
         _arrow_schema.reset();
         _opened = false;
@@ -257,7 +226,7 @@ Status JniPaimonWriteBackend::close() {
 
     if (close_status.ok()) {
         _memory_manager.reset();
-        _spill_directory.reset();
+        _spill_session.reset();
     } else {
         if (_memory_manager != nullptr) {
             LOG(WARNING)
@@ -267,8 +236,7 @@ Status JniPaimonWriteBackend::close() {
         }
         // Paimon may still have asynchronous tasks using Doris-backed pages or spill callbacks.
         // Retain ownership until process exit and fence subsequent writer admission.
-        retain_resources_after_failed_close(std::move(_memory_manager),
-                                            std::move(_spill_directory));
+        retain_resources_after_failed_close(std::move(_memory_manager), std::move(_spill_session));
     }
     _arrow_schema.reset();
     _opened = false;
@@ -380,14 +348,14 @@ Status JniPaimonWriteBackend::open(const TPaimonTableSink& sink, RuntimeState* s
         return Status::JniError("Failed to create global PaimonJniWriter object reference");
     }
 
-    // Step 4: Create a lazy query-scoped spill session. Java requests paths only when the table has
-    // write-buffer spill enabled, so memory-only writers do not depend on spill storage.
+    // Step 4: Create a lazy query-scoped spill session. Java requests its path only when Paimon
+    // first uses the IOManager, so a memory-only writer does not depend on spill storage.
     auto* spill_file_manager = state->exec_env()->spill_file_mgr();
     if (spill_file_manager != nullptr) {
         auto spill_relative_path =
                 fmt::format("{}-{}", PAIMON_JNI_WRITER_IO_TMP_DIR, spill_file_manager->next_id());
-        RETURN_IF_ERROR(spill_file_manager->create_external_spill_directory(
-                spill_relative_path, state->get_query_ctx(), &_spill_directory));
+        RETURN_IF_ERROR(spill_file_manager->create_external_spill_session(
+                spill_relative_path, state->get_query_ctx(), &_spill_session));
     }
 
     // Step 5: Build Java arguments and call PaimonJniWriter.open().
@@ -415,7 +383,7 @@ Status JniPaimonWriteBackend::open(const TPaimonTableSink& sink, RuntimeState* s
             static_cast<jlong>(sink.transaction_id), j_commit_user, open_mode.overwrite,
             open_mode.changelog, j_time_zone, static_cast<jlong>(_memory_manager->memory_limit()),
             reinterpret_cast<jlong>(_memory_manager.get()),
-            _spill_directory == nullptr ? 0 : reinterpret_cast<jlong>(_spill_directory.get()));
+            _spill_session == nullptr ? 0 : reinterpret_cast<jlong>(_spill_session.get()));
     Status st = _check_jni_exception(env, "open PaimonJniWriter");
 
     if (st.ok()) {

--- a/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
+++ b/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
@@ -126,19 +126,6 @@ void update_paimon_spill_accounting(JNIEnv* env, jclass, jlong spill_session_han
     spill_session->update_accounting(native_path, current_bytes_delta, write_bytes, read_bytes);
 }
 
-void reconcile_paimon_spill(JNIEnv* env, jclass, jlong spill_session_handle,
-                            jboolean allow_release) {
-    auto* spill_session = reinterpret_cast<ExternalSpillSession*>(spill_session_handle);
-    if (spill_session == nullptr) {
-        throw_java_io_exception(env, "Paimon external spill session is null");
-        return;
-    }
-    Status st = spill_session->reconcile_direct_file_usage(allow_release == JNI_TRUE);
-    if (!st.ok()) {
-        throw_java_io_exception(env, st.to_string());
-    }
-}
-
 Status register_paimon_spill_natives(JNIEnv* env, jclass writer_class) {
     static char get_spill_directories_name[] = "getPaimonSpillDirectories";
     static char get_spill_directories_signature[] = "(J)[Ljava/lang/String;";
@@ -146,8 +133,6 @@ Status register_paimon_spill_natives(JNIEnv* env, jclass writer_class) {
     static char reserve_spill_signature[] = "(JLjava/lang/String;J)V";
     static char update_spill_name[] = "updatePaimonSpillAccounting";
     static char update_spill_signature[] = "(JLjava/lang/String;JJJ)V";
-    static char reconcile_spill_name[] = "reconcilePaimonSpill";
-    static char reconcile_spill_signature[] = "(JZ)V";
     static ::JNINativeMethod methods[] = {
             {get_spill_directories_name, get_spill_directories_signature,
              reinterpret_cast<void*>(&get_paimon_spill_directories)},
@@ -155,8 +140,6 @@ Status register_paimon_spill_natives(JNIEnv* env, jclass writer_class) {
              reinterpret_cast<void*>(&reserve_paimon_spill)},
             {update_spill_name, update_spill_signature,
              reinterpret_cast<void*>(&update_paimon_spill_accounting)},
-            {reconcile_spill_name, reconcile_spill_signature,
-             reinterpret_cast<void*>(&reconcile_paimon_spill)},
     };
     if (env->RegisterNatives(writer_class, methods,
                              static_cast<jint>(sizeof(methods) / sizeof(methods[0]))) != JNI_OK) {

--- a/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
+++ b/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
@@ -22,6 +22,7 @@
 #include <arrow/io/memory.h>
 #include <arrow/ipc/reader.h>
 #include <arrow/record_batch.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <atomic>
@@ -33,44 +34,153 @@
 #include "common/check.h"
 #include "common/logging.h"
 #include "exec/sink/writer/paimon/paimon_jni_memory_manager.h"
+#include "exec/spill/spill_file_manager.h"
 #include "format/arrow/arrow_block_convertor.h"
 #include "runtime/exec_env.h"
+#include "runtime/query_context.h"
 #include "runtime/runtime_state.h"
 #include "util/defer_op.h"
 #include "util/jni-util.h"
 #include "util/pretty_printer.h"
-#include "util/string_util.h"
 
 namespace doris {
 
 namespace {
 constexpr std::string_view PAIMON_JNI_WRITER_IO_TMP_DIR = "paimon_jni_writer_io_tmp";
 
+void throw_java_io_exception(JNIEnv* env, const std::string& message) {
+    jclass exception_class = env->FindClass("java/io/IOException");
+    env->ThrowNew(exception_class, message.c_str());
+    env->DeleteLocalRef(exception_class);
+}
+
+std::string java_string_to_string(JNIEnv* env, jstring value) {
+    if (value == nullptr) {
+        return {};
+    }
+    const char* chars = env->GetStringUTFChars(value, nullptr);
+    if (chars == nullptr) {
+        return {};
+    }
+    std::string result(chars);
+    env->ReleaseStringUTFChars(value, chars);
+    return result;
+}
+
+jobjectArray create_paimon_spill_directories(JNIEnv* env, jclass, jlong spill_directory_handle) {
+    auto* spill_directory = reinterpret_cast<ExternalSpillDirectory*>(spill_directory_handle);
+    if (spill_directory == nullptr) {
+        throw_java_io_exception(env, "Paimon external spill directory is null");
+        return nullptr;
+    }
+
+    std::vector<std::string> paths;
+    Status st = spill_directory->get_paths(&paths);
+    if (!st.ok()) {
+        throw_java_io_exception(env, st.to_string());
+        return nullptr;
+    }
+    jclass string_class = env->FindClass("java/lang/String");
+    jobjectArray result =
+            env->NewObjectArray(static_cast<jsize>(paths.size()), string_class, nullptr);
+    for (size_t i = 0; i < paths.size(); ++i) {
+        jstring path = env->NewStringUTF(paths[i].c_str());
+        env->SetObjectArrayElement(result, static_cast<jsize>(i), path);
+        env->DeleteLocalRef(path);
+    }
+    env->DeleteLocalRef(string_class);
+    return result;
+}
+
+void reserve_paimon_spill(JNIEnv* env, jclass, jlong spill_directory_handle, jstring path,
+                          jlong bytes) {
+    auto* spill_directory = reinterpret_cast<ExternalSpillDirectory*>(spill_directory_handle);
+    if (spill_directory == nullptr) {
+        throw_java_io_exception(env, "Paimon external spill directory is null");
+        return;
+    }
+    std::string native_path = java_string_to_string(env, path);
+    if (env->ExceptionCheck()) {
+        return;
+    }
+    Status st = spill_directory->reserve(native_path, bytes);
+    if (!st.ok()) {
+        throw_java_io_exception(env, st.to_string());
+    }
+}
+
+void update_paimon_spill_accounting(JNIEnv* env, jclass, jlong spill_directory_handle, jstring path,
+                                    jlong current_bytes_delta, jlong write_bytes,
+                                    jlong read_bytes) {
+    auto* spill_directory = reinterpret_cast<ExternalSpillDirectory*>(spill_directory_handle);
+    if (spill_directory == nullptr) {
+        return;
+    }
+    std::string native_path = java_string_to_string(env, path);
+    if (env->ExceptionCheck()) {
+        return;
+    }
+    spill_directory->update_accounting(native_path, current_bytes_delta, write_bytes, read_bytes);
+}
+
+Status register_paimon_spill_natives(JNIEnv* env, jclass writer_class) {
+    static char create_spill_directories_name[] = "createPaimonSpillDirectories";
+    static char create_spill_directories_signature[] = "(J)[Ljava/lang/String;";
+    static char reserve_spill_name[] = "reservePaimonSpill";
+    static char reserve_spill_signature[] = "(JLjava/lang/String;J)V";
+    static char update_spill_name[] = "updatePaimonSpillAccounting";
+    static char update_spill_signature[] = "(JLjava/lang/String;JJJ)V";
+    static ::JNINativeMethod methods[] = {
+            {create_spill_directories_name, create_spill_directories_signature,
+             reinterpret_cast<void*>(&create_paimon_spill_directories)},
+            {reserve_spill_name, reserve_spill_signature,
+             reinterpret_cast<void*>(&reserve_paimon_spill)},
+            {update_spill_name, update_spill_signature,
+             reinterpret_cast<void*>(&update_paimon_spill_accounting)},
+    };
+    if (env->RegisterNatives(writer_class, methods,
+                             static_cast<jint>(sizeof(methods) / sizeof(methods[0]))) != JNI_OK) {
+        RETURN_IF_ERROR(Jni::Env::GetJniExceptionMsg(
+                env, true, "JNI exception registering Paimon spill native methods: "));
+        return Status::JniError("Failed to register Paimon spill native methods");
+    }
+    return Status::OK();
+}
+
 std::atomic<bool>& paimon_jni_close_failed() {
     static std::atomic<bool> failed {false};
     return failed;
 }
 
-std::mutex& retained_memory_managers_mutex() {
+struct RetainedPaimonResources {
+    std::unique_ptr<PaimonJniMemoryManager> memory_manager;
+    std::unique_ptr<ExternalSpillDirectory> spill_directory;
+};
+
+std::mutex& retained_resources_mutex() {
     static auto* mutex = new std::mutex();
     return *mutex;
 }
 
-std::vector<std::unique_ptr<PaimonJniMemoryManager>>& retained_memory_managers() {
-    static auto* managers = new std::vector<std::unique_ptr<PaimonJniMemoryManager>>();
-    return *managers;
+std::vector<RetainedPaimonResources>& retained_resources() {
+    static auto* resources = new std::vector<RetainedPaimonResources>();
+    return *resources;
 }
 
-void retain_memory_after_failed_close(std::unique_ptr<PaimonJniMemoryManager> manager) {
+void retain_resources_after_failed_close(std::unique_ptr<PaimonJniMemoryManager> memory_manager,
+                                         std::unique_ptr<ExternalSpillDirectory> spill_directory) {
     // An unconfirmed Java close means a background Paimon task may still reference this manager's
-    // native pages. Quarantine the manager and stop admitting new writers so repeated failures
-    // cannot accumulate process-lifetime native memory without a bound.
+    // native pages or spill callbacks. Quarantine both resources and stop admitting new writers so
+    // repeated failures cannot accumulate process-lifetime resources without a bound.
     paimon_jni_close_failed().store(true, std::memory_order_release);
-    if (manager == nullptr) {
+    if (memory_manager == nullptr && spill_directory == nullptr) {
         return;
     }
-    std::lock_guard<std::mutex> lock(retained_memory_managers_mutex());
-    retained_memory_managers().emplace_back(std::move(manager));
+    std::lock_guard<std::mutex> lock(retained_resources_mutex());
+    retained_resources().emplace_back(RetainedPaimonResources {
+            .memory_manager = std::move(memory_manager),
+            .spill_directory = std::move(spill_directory),
+    });
 }
 
 } // namespace
@@ -80,18 +190,17 @@ void retain_memory_after_failed_close(std::unique_ptr<PaimonJniMemoryManager> ma
 // ────────────────────────────────────────────────────────────
 
 static constexpr const char* PAIMON_JNI_WRITER_CLASS = "org/apache/doris/paimon/PaimonJniWriter";
-static constexpr const char* SCANNER_LOADER_CLASS =
-        "org/apache/doris/common/classloader/ScannerLoader";
-
 const char* const PAIMON_JNI_WRITER_OPEN_SIGNATURE =
         "(Ljava/lang/String;Ljava/util/Map;[Ljava/lang/String;JLjava/lang/String;ZZLjava/lang/"
-        "String;Ljava/lang/String;JJ)V";
+        "String;JJJ)V";
 
 PaimonJniWriterOpenMode PaimonJniWriterOpenMode::from_write_mode(
         TPaimonWriteMode::type write_mode) {
     return {static_cast<jboolean>(write_mode == TPaimonWriteMode::OVERWRITE),
             static_cast<jboolean>(write_mode == TPaimonWriteMode::CHANGELOG)};
 }
+
+JniPaimonWriteBackend::JniPaimonWriteBackend() = default;
 
 JniPaimonWriteBackend::~JniPaimonWriteBackend() {
     Status st = close();
@@ -104,6 +213,7 @@ Status JniPaimonWriteBackend::close() {
     if (_jni_writer_obj == nullptr && _jni_writer_cls == nullptr) {
         _memory_manager.reset();
         _arrow_schema.reset();
+        _spill_directory.reset();
         _opened = false;
         return Status::OK();
     }
@@ -117,9 +227,11 @@ Status JniPaimonWriteBackend::close() {
         _jni_writer_obj = nullptr;
         _jni_writer_cls = nullptr;
         if (java_users_may_exist) {
-            retain_memory_after_failed_close(std::move(_memory_manager));
+            retain_resources_after_failed_close(std::move(_memory_manager),
+                                                std::move(_spill_directory));
         } else {
             _memory_manager.reset();
+            _spill_directory.reset();
         }
         _arrow_schema.reset();
         _opened = false;
@@ -145,6 +257,7 @@ Status JniPaimonWriteBackend::close() {
 
     if (close_status.ok()) {
         _memory_manager.reset();
+        _spill_directory.reset();
     } else {
         if (_memory_manager != nullptr) {
             LOG(WARNING)
@@ -152,10 +265,10 @@ Status JniPaimonWriteBackend::close() {
                     << PrettyPrinter::print_bytes(_memory_manager->memory_limit()) << ", peak="
                     << PrettyPrinter::print_bytes(_memory_manager->native_peak_allocated_bytes());
         }
-        // Paimon may still have asynchronous flush or compaction tasks using MemorySegments backed
-        // by these pages. Retain this failed writer's ownership until process exit to prevent UAF;
-        // retain_memory_after_failed_close also fences subsequent Paimon JNI writer admission.
-        retain_memory_after_failed_close(std::move(_memory_manager));
+        // Paimon may still have asynchronous tasks using Doris-backed pages or spill callbacks.
+        // Retain ownership until process exit and fence subsequent writer admission.
+        retain_resources_after_failed_close(std::move(_memory_manager),
+                                            std::move(_spill_directory));
     }
     _arrow_schema.reset();
     _opened = false;
@@ -170,46 +283,6 @@ Status JniPaimonWriteBackend::_check_jni_exception(JNIEnv* env, const std::strin
         return st;
     }
     return Status::OK();
-}
-
-Status JniPaimonWriteBackend::_load_writer_class(JNIEnv* env, jclass* writer_class) {
-    jclass loader_class = env->FindClass(SCANNER_LOADER_CLASS);
-    RETURN_IF_ERROR(_check_jni_exception(env, "find ScannerLoader"));
-
-    jmethodID loader_constructor = env->GetMethodID(loader_class, "<init>", "()V");
-    jmethodID get_loaded_class = env->GetMethodID(loader_class, "getLoadedClass",
-                                                  "(Ljava/lang/String;)Ljava/lang/Class;");
-    RETURN_IF_ERROR(_check_jni_exception(env, "resolve ScannerLoader methods"));
-
-    jobject loader = env->NewObject(loader_class, loader_constructor);
-    jstring class_name = env->NewStringUTF(PAIMON_JNI_WRITER_CLASS);
-    auto* loaded_class =
-            static_cast<jclass>(env->CallObjectMethod(loader, get_loaded_class, class_name));
-    RETURN_IF_ERROR(_check_jni_exception(env, "load PaimonJniWriter"));
-
-    *writer_class = loaded_class;
-    env->DeleteLocalRef(class_name);
-    env->DeleteLocalRef(loader);
-    env->DeleteLocalRef(loader_class);
-    return Status::OK();
-}
-
-static jobject _to_java_options(JNIEnv* env, const std::map<std::string, std::string>& options) {
-    jclass map_cls = env->FindClass("java/util/HashMap");
-    jmethodID map_ctor = env->GetMethodID(map_cls, "<init>", "()V");
-    jmethodID put_method = env->GetMethodID(
-            map_cls, "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
-
-    jobject map_obj = env->NewObject(map_cls, map_ctor);
-    for (const auto& kv : options) {
-        jstring key = env->NewStringUTF(kv.first.c_str());
-        jstring val = env->NewStringUTF(kv.second.c_str());
-        env->CallObjectMethod(map_obj, put_method, key, val);
-        env->DeleteLocalRef(key);
-        env->DeleteLocalRef(val);
-    }
-    env->DeleteLocalRef(map_cls);
-    return map_obj;
 }
 
 static Status _get_paimon_arrow_schema(JNIEnv* env, jobject writer, jmethodID get_schema_id,
@@ -243,7 +316,6 @@ static Status _get_paimon_arrow_schema(JNIEnv* env, jobject writer, jmethodID ge
     *schema = reader_result.ValueOrDie()->schema();
     return Status::OK();
 }
-
 Status JniPaimonWriteBackend::open(const TPaimonTableSink& sink, RuntimeState* state,
                                    RuntimeProfile* profile) {
     if (paimon_jni_close_failed().load(std::memory_order_acquire)) {
@@ -269,14 +341,25 @@ Status JniPaimonWriteBackend::open(const TPaimonTableSink& sink, RuntimeState* s
 
     JNIEnv* env = nullptr;
     RETURN_IF_ERROR(Jni::Env::Get(&env));
+    if (env->PushLocalFrame(32) != JNI_OK) {
+        Status st = _check_jni_exception(env, "create PaimonJniWriter open local reference frame");
+        return st.ok() ? Status::InternalError("Failed to create JNI local reference frame") : st;
+    }
+    Defer pop_local_frame([&]() { env->PopLocalFrame(nullptr); });
 
     // Step 1: Load PaimonJniWriter class through ScannerLoader (Paimon jars are
     // not on the default application classpath, so FindClass won't work).
-    jclass local_cls = nullptr;
-    RETURN_IF_ERROR(_load_writer_class(env, &local_cls));
-    _jni_writer_cls = static_cast<jclass>(env->NewGlobalRef(local_cls));
-    env->DeleteLocalRef(local_cls);
+    Jni::LocalObject local_writer_class;
+    RETURN_IF_ERROR(
+            Jni::Util::get_jni_scanner_class(env, PAIMON_JNI_WRITER_CLASS, &local_writer_class));
+    auto writer_class = static_cast<jclass>(local_writer_class.get());
+    _jni_writer_cls = static_cast<jclass>(env->NewGlobalRef(writer_class));
+    RETURN_IF_ERROR(_check_jni_exception(env, "create global PaimonJniWriter class reference"));
+    if (_jni_writer_cls == nullptr) {
+        return Status::JniError("Failed to create global PaimonJniWriter class reference");
+    }
     RETURN_IF_ERROR(PaimonJniMemoryManager::register_natives(env, _jni_writer_cls));
+    RETURN_IF_ERROR(register_paimon_spill_natives(env, _jni_writer_cls));
 
     // Step 2: Cache JNI method IDs for write, prepareCommit, abort, close.
     jmethodID open_id = env->GetMethodID(_jni_writer_cls, "open", PAIMON_JNI_WRITER_OPEN_SIGNATURE);
@@ -285,54 +368,55 @@ Status JniPaimonWriteBackend::open(const TPaimonTableSink& sink, RuntimeState* s
     _prepare_commit_id = env->GetMethodID(_jni_writer_cls, "prepareCommit", "()[[B");
     _abort_id = env->GetMethodID(_jni_writer_cls, "abort", "()V");
     _close_id = env->GetMethodID(_jni_writer_cls, "close", "()V");
-    RETURN_IF_ERROR(_check_jni_exception(env, "GetMethodID"));
+    RETURN_IF_ERROR(_check_jni_exception(env, "resolve PaimonJniWriter methods"));
 
     // Step 3: Create the Java PaimonJniWriter instance.
     jmethodID ctor_id = env->GetMethodID(_jni_writer_cls, "<init>", "()V");
     jobject local_obj = env->NewObject(_jni_writer_cls, ctor_id);
-    RETURN_IF_ERROR(_check_jni_exception(env, "NewObject"));
+    RETURN_IF_ERROR(_check_jni_exception(env, "create PaimonJniWriter"));
     _jni_writer_obj = env->NewGlobalRef(local_obj);
-    env->DeleteLocalRef(local_obj);
+    RETURN_IF_ERROR(_check_jni_exception(env, "create global PaimonJniWriter object reference"));
+    if (_jni_writer_obj == nullptr) {
+        return Status::JniError("Failed to create global PaimonJniWriter object reference");
+    }
 
-    // Step 4: Build Java arguments and call PaimonJniWriter.open().
+    // Step 4: Create a lazy query-scoped spill session. Java requests paths only when the table has
+    // write-buffer spill enabled, so memory-only writers do not depend on spill storage.
+    auto* spill_file_manager = state->exec_env()->spill_file_mgr();
+    if (spill_file_manager != nullptr) {
+        auto spill_relative_path =
+                fmt::format("{}-{}", PAIMON_JNI_WRITER_IO_TMP_DIR, spill_file_manager->next_id());
+        RETURN_IF_ERROR(spill_file_manager->create_external_spill_directory(
+                spill_relative_path, state->get_query_ctx(), &_spill_directory));
+    }
+
+    // Step 5: Build Java arguments and call PaimonJniWriter.open().
     const std::map<std::string, std::string> empty_config;
     jstring j_serialized_table = env->NewStringUTF(sink.serialized_table.c_str());
-    jobject j_hadoop_config =
-            _to_java_options(env, sink.__isset.hadoop_config ? sink.hadoop_config : empty_config);
+    Jni::LocalObject j_hadoop_config;
+    RETURN_IF_ERROR(Jni::Util::convert_to_java_map(
+            env, sink.__isset.hadoop_config ? sink.hadoop_config : empty_config, &j_hadoop_config));
     jstring j_commit_user = env->NewStringUTF(sink.commit_user.c_str());
     jstring j_time_zone = env->NewStringUTF(state->timezone().c_str());
-    std::vector<std::string> spill_directories;
-    for (const auto& store_path : state->exec_env()->store_paths()) {
-        spill_directories.push_back(store_path.path + "/" +
-                                    std::string(PAIMON_JNI_WRITER_IO_TMP_DIR));
-    }
-    DORIS_CHECK(!spill_directories.empty());
-    jstring j_spill_directories = env->NewStringUTF(join(spill_directories, ":").c_str());
 
     jclass string_cls = env->FindClass("java/lang/String");
     jobjectArray j_cols =
             env->NewObjectArray(static_cast<jsize>(sink.column_names.size()), string_cls, nullptr);
     for (size_t i = 0; i < sink.column_names.size(); ++i) {
-        jstring str = env->NewStringUTF(sink.column_names[i].c_str());
-        env->SetObjectArrayElement(j_cols, static_cast<jsize>(i), str);
-        env->DeleteLocalRef(str);
+        jstring column_name = env->NewStringUTF(sink.column_names[i].c_str());
+        env->SetObjectArrayElement(j_cols, static_cast<jsize>(i), column_name);
+        env->DeleteLocalRef(column_name);
     }
+    RETURN_IF_ERROR(_check_jni_exception(env, "build PaimonJniWriter open arguments"));
 
     PaimonJniWriterOpenMode open_mode = PaimonJniWriterOpenMode::from_write_mode(sink.write_mode);
-    env->CallVoidMethod(_jni_writer_obj, open_id, j_serialized_table, j_hadoop_config, j_cols,
-                        static_cast<jlong>(sink.transaction_id), j_commit_user, open_mode.overwrite,
-                        open_mode.changelog, j_time_zone, j_spill_directories,
-                        static_cast<jlong>(_memory_manager->memory_limit()),
-                        reinterpret_cast<jlong>(_memory_manager.get()));
-    Status st = _check_jni_exception(env, "open");
-
-    env->DeleteLocalRef(j_serialized_table);
-    env->DeleteLocalRef(j_hadoop_config);
-    env->DeleteLocalRef(j_commit_user);
-    env->DeleteLocalRef(j_time_zone);
-    env->DeleteLocalRef(j_spill_directories);
-    env->DeleteLocalRef(j_cols);
-    env->DeleteLocalRef(string_cls);
+    env->CallVoidMethod(
+            _jni_writer_obj, open_id, j_serialized_table, j_hadoop_config.get(), j_cols,
+            static_cast<jlong>(sink.transaction_id), j_commit_user, open_mode.overwrite,
+            open_mode.changelog, j_time_zone, static_cast<jlong>(_memory_manager->memory_limit()),
+            reinterpret_cast<jlong>(_memory_manager.get()),
+            _spill_directory == nullptr ? 0 : reinterpret_cast<jlong>(_spill_directory.get()));
+    Status st = _check_jni_exception(env, "open PaimonJniWriter");
 
     if (st.ok()) {
         st = _get_paimon_arrow_schema(env, _jni_writer_obj, get_arrow_schema_id, &_arrow_schema);

--- a/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
+++ b/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
@@ -126,13 +126,14 @@ void update_paimon_spill_accounting(JNIEnv* env, jclass, jlong spill_session_han
     spill_session->update_accounting(native_path, current_bytes_delta, write_bytes, read_bytes);
 }
 
-void reconcile_paimon_spill(JNIEnv* env, jclass, jlong spill_session_handle) {
+void reconcile_paimon_spill(JNIEnv* env, jclass, jlong spill_session_handle,
+                            jboolean allow_release) {
     auto* spill_session = reinterpret_cast<ExternalSpillSession*>(spill_session_handle);
     if (spill_session == nullptr) {
         throw_java_io_exception(env, "Paimon external spill session is null");
         return;
     }
-    Status st = spill_session->reconcile_direct_file_usage();
+    Status st = spill_session->reconcile_direct_file_usage(allow_release == JNI_TRUE);
     if (!st.ok()) {
         throw_java_io_exception(env, st.to_string());
     }
@@ -146,7 +147,7 @@ Status register_paimon_spill_natives(JNIEnv* env, jclass writer_class) {
     static char update_spill_name[] = "updatePaimonSpillAccounting";
     static char update_spill_signature[] = "(JLjava/lang/String;JJJ)V";
     static char reconcile_spill_name[] = "reconcilePaimonSpill";
-    static char reconcile_spill_signature[] = "(J)V";
+    static char reconcile_spill_signature[] = "(JZ)V";
     static ::JNINativeMethod methods[] = {
             {get_spill_directories_name, get_spill_directories_signature,
              reinterpret_cast<void*>(&get_paimon_spill_directories)},

--- a/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.h
+++ b/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.h
@@ -35,6 +35,7 @@ class Schema;
 
 namespace doris {
 
+class ExternalSpillDirectory;
 class RuntimeState;
 
 extern const char* const PAIMON_JNI_WRITER_OPEN_SIGNATURE;
@@ -57,6 +58,7 @@ struct PaimonJniWriterOpenMode {
 /// common backend contract.
 class JniPaimonWriteBackend final : public IPaimonWriteBackend {
 public:
+    JniPaimonWriteBackend();
     ~JniPaimonWriteBackend() override;
 
     Status open(const TPaimonTableSink& sink, RuntimeState* state,
@@ -67,7 +69,6 @@ public:
 
 private:
     Status _check_jni_exception(JNIEnv* env, const std::string& method_name);
-    Status _load_writer_class(JNIEnv* env, jclass* writer_class);
     void _refresh_memory_profile();
 
     // JNI global references — live for the duration of this backend.
@@ -82,6 +83,7 @@ private:
 
     std::unique_ptr<PaimonJniMemoryManager> _memory_manager;
     std::shared_ptr<arrow::Schema> _arrow_schema;
+    std::unique_ptr<ExternalSpillDirectory> _spill_directory;
     RuntimeProfile::Counter* _native_page_memory_limit = nullptr;
     RuntimeProfile::Counter* _native_page_memory_peak = nullptr;
     bool _opened = false;

--- a/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.h
+++ b/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.h
@@ -35,7 +35,7 @@ class Schema;
 
 namespace doris {
 
-class ExternalSpillDirectory;
+class ExternalSpillSession;
 class RuntimeState;
 
 extern const char* const PAIMON_JNI_WRITER_OPEN_SIGNATURE;
@@ -83,7 +83,7 @@ private:
 
     std::unique_ptr<PaimonJniMemoryManager> _memory_manager;
     std::shared_ptr<arrow::Schema> _arrow_schema;
-    std::unique_ptr<ExternalSpillDirectory> _spill_directory;
+    std::unique_ptr<ExternalSpillSession> _spill_session;
     RuntimeProfile::Counter* _native_page_memory_limit = nullptr;
     RuntimeProfile::Counter* _native_page_memory_peak = nullptr;
     bool _opened = false;

--- a/be/src/exec/spill/spill_file_manager.cpp
+++ b/be/src/exec/spill/spill_file_manager.cpp
@@ -527,8 +527,7 @@ Status SpillFileManager::_try_delete_query_spill_directory(const std::string& qu
         return Status::OK();
     }
     if (it->second.external_leases > 0) {
-        return Status::InternalError("external spill directory is still in use: {}",
-                                     query_dir);
+        return Status::InternalError("external spill directory is still in use: {}", query_dir);
     }
     DBUG_EXECUTE_IF("fault_inject::spill_file_manager::delete_query_spill_directory", {
         return Status::Error<INTERNAL_ERROR>("injected query spill directory deletion failure");
@@ -583,8 +582,8 @@ void SpillFileManager::_retry_pending_query_spill_directories() {
         }
         if (failed_count % log_interval == 0) {
             LOG(WARNING) << fmt::format(
-                    "failed to retry deleting spill query directory, dir {}, error: {}",
-                    query_dir, status.to_string());
+                    "failed to retry deleting spill query directory, dir {}, error: {}", query_dir,
+                    status.to_string());
         }
     }
 }

--- a/be/src/exec/spill/spill_file_manager.cpp
+++ b/be/src/exec/spill/spill_file_manager.cpp
@@ -25,7 +25,6 @@
 #include <limits>
 #include <memory>
 #include <string>
-#include <unordered_set>
 #include <utility>
 
 #include "common/logging.h"
@@ -65,26 +64,16 @@ Status ExternalSpillSession::get_paths(std::vector<std::string>* paths) {
         return Status::InvalidArgument("External spill paths output must not be null");
     }
     std::lock_guard lock(_mutex);
-    if (_managed_paths.empty()) {
+    if (_data_dir == nullptr) {
         RETURN_IF_ERROR(_manager->_initialize_external_spill_session(this));
     }
-    paths->clear();
-    for (const auto& managed_path : _managed_paths) {
-        paths->emplace_back(managed_path.path);
-    }
+    *paths = {_path};
     return Status::OK();
 }
 
-ExternalSpillSession::ManagedPath* ExternalSpillSession::_find_managed_path(
-        const std::string& path) {
-    for (auto& managed_path : _managed_paths) {
-        if (path == managed_path.path ||
-            (path.size() > managed_path.path.size() && path.starts_with(managed_path.path) &&
-             path[managed_path.path.size()] == '/')) {
-            return &managed_path;
-        }
-    }
-    return nullptr;
+bool ExternalSpillSession::_contains(const std::string& path) const {
+    return path == _path ||
+           (path.size() > _path.size() && path.starts_with(_path) && path[_path.size()] == '/');
 }
 
 Status ExternalSpillSession::reserve(const std::string& path, int64_t bytes) {
@@ -93,22 +82,20 @@ Status ExternalSpillSession::reserve(const std::string& path, int64_t bytes) {
     }
 
     std::lock_guard lock(_mutex);
-    auto* managed_path = _find_managed_path(path);
-    if (managed_path == nullptr) {
+    if (_data_dir == nullptr || !_contains(path)) {
         return Status::InvalidArgument("External spill path is not managed by Doris: {}", path);
     }
-    const int64_t accounted_bytes =
-            managed_path->buffer_accounted_bytes + managed_path->direct_file_accounted_bytes;
-    if (bytes > std::numeric_limits<int64_t>::max() - accounted_bytes) {
+    if (bytes > std::numeric_limits<int64_t>::max() - _accounted_bytes) {
         return Status::InvalidArgument("External spill reservation overflows: bytes={}", bytes);
     }
-    if (!managed_path->data_dir->try_reserve_spill_data(bytes)) {
+    if (_data_dir->reach_capacity_limit(bytes)) {
         return Status::Error<ErrorCode::DISK_REACH_CAPACITY_LIMIT>(
                 "External spill write exceeds the Doris spill storage limit: path={}, bytes={}",
                 path, bytes);
     }
-    managed_path->buffer_accounted_bytes += bytes;
-    managed_path->buffer_accounted_bytes_by_path[path] += bytes;
+    // Match SpillFileWriter: check capacity before the write, then account the accepted bytes.
+    _data_dir->update_spill_data_usage(bytes);
+    _accounted_bytes += bytes;
     return Status::OK();
 }
 
@@ -118,27 +105,18 @@ void ExternalSpillSession::update_accounting(const std::string& path, int64_t cu
     SpillDataDir* data_dir = nullptr;
     {
         std::lock_guard lock(_mutex);
-        auto* managed_path = _find_managed_path(path);
-        if (managed_path == nullptr) {
+        if (_data_dir == nullptr || !_contains(path)) {
             LOG(WARNING) << "Ignoring accounting for unmanaged external spill path: " << path;
             return;
         }
-        data_dir = managed_path->data_dir;
+        data_dir = _data_dir;
         if (current_bytes_delta < 0) {
             const int64_t requested_release =
                     current_bytes_delta == std::numeric_limits<int64_t>::min()
                             ? std::numeric_limits<int64_t>::max()
                             : -current_bytes_delta;
-            auto path_it = managed_path->buffer_accounted_bytes_by_path.find(path);
-            if (path_it == managed_path->buffer_accounted_bytes_by_path.end()) {
-                return;
-            }
-            released_bytes = std::min(requested_release, path_it->second);
-            path_it->second -= released_bytes;
-            if (path_it->second == 0) {
-                managed_path->buffer_accounted_bytes_by_path.erase(path_it);
-            }
-            managed_path->buffer_accounted_bytes -= released_bytes;
+            released_bytes = std::min(requested_release, _accounted_bytes);
+            _accounted_bytes -= released_bytes;
         }
     }
     if (released_bytes > 0) {
@@ -152,106 +130,6 @@ void ExternalSpillSession::update_accounting(const std::string& path, int64_t cu
         _resource_context->io_context()->update_spill_read_bytes_from_local_storage(read_bytes);
         _manager->update_spill_read_bytes(read_bytes);
     }
-}
-
-Status ExternalSpillSession::reconcile_direct_file_usage(bool allow_release) {
-    struct ObservedPathUsage {
-        std::string path;
-        std::unordered_set<std::string> buffer_paths;
-        uintmax_t bytes = 0;
-    };
-    std::vector<ObservedPathUsage> observed_paths;
-    {
-        std::lock_guard lock(_mutex);
-        observed_paths.reserve(_managed_paths.size());
-        for (const auto& managed_path : _managed_paths) {
-            ObservedPathUsage observed_path {
-                    .path = managed_path.path,
-                    .buffer_paths = {},
-                    .bytes = 0,
-            };
-            for (const auto& buffer_entry : managed_path.buffer_accounted_bytes_by_path) {
-                observed_path.buffer_paths.emplace(buffer_entry.first);
-            }
-            observed_paths.emplace_back(std::move(observed_path));
-        }
-    }
-
-    // Do not hold the session mutex while walking the filesystem. Buffer callbacks can continue to
-    // reserve and release capacity while a rate-limited raw-file observation is in progress.
-    for (auto& observed_path : observed_paths) {
-        uintmax_t actual_bytes = 0;
-        std::error_code ec;
-        if (std::filesystem::exists(observed_path.path, ec)) {
-            std::filesystem::recursive_directory_iterator iterator(
-                    observed_path.path, std::filesystem::directory_options::skip_permission_denied,
-                    ec);
-            const std::filesystem::recursive_directory_iterator end;
-            while (!ec && iterator != end) {
-                if (iterator->is_regular_file(ec)) {
-                    const auto file_path = iterator->path().string();
-                    if (!observed_path.buffer_paths.contains(file_path)) {
-                        const auto file_bytes = iterator->file_size(ec);
-                        if (!ec) {
-                            if (file_bytes > std::numeric_limits<uintmax_t>::max() - actual_bytes) {
-                                return Status::InternalError(
-                                        "Paimon spill directory size overflow: {}",
-                                        observed_path.path);
-                            }
-                            actual_bytes += file_bytes;
-                        }
-                    }
-                }
-                iterator.increment(ec);
-            }
-        }
-        if (ec) {
-            return Status::IOError("Failed to inspect Paimon spill directory {}: {}",
-                                   observed_path.path, ec.message());
-        }
-        observed_path.bytes = actual_bytes;
-    }
-
-    std::lock_guard lock(_mutex);
-    for (size_t i = 0; i < observed_paths.size(); ++i) {
-        auto& managed_path = _managed_paths[i];
-        // Account only files not already covered by BufferFileWriter callbacks.
-        const uintmax_t direct_file_bytes = observed_paths[i].bytes;
-        const uintmax_t accounted_direct_file_bytes =
-                static_cast<uintmax_t>(managed_path.direct_file_accounted_bytes);
-        if (direct_file_bytes < accounted_direct_file_bytes && allow_release) {
-            const int64_t released_bytes =
-                    static_cast<int64_t>(accounted_direct_file_bytes - direct_file_bytes);
-            managed_path.direct_file_accounted_bytes -= released_bytes;
-            managed_path.data_dir->update_spill_data_usage(-released_bytes);
-        }
-        if (direct_file_bytes <= accounted_direct_file_bytes) {
-            // Non-final observations stay conservative while compaction can mutate raw files.
-            continue;
-        }
-        const uintmax_t delta = direct_file_bytes - accounted_direct_file_bytes;
-        if (delta > static_cast<uintmax_t>(std::numeric_limits<int64_t>::max())) {
-            return Status::InternalError("Paimon spill directory is too large to account: {}",
-                                         managed_path.path);
-        }
-        const int64_t delta_bytes = static_cast<int64_t>(delta);
-        const int64_t accounted_bytes =
-                managed_path.buffer_accounted_bytes + managed_path.direct_file_accounted_bytes;
-        if (delta_bytes > std::numeric_limits<int64_t>::max() - accounted_bytes) {
-            return Status::InternalError("Paimon spill accounting overflows: {}",
-                                         managed_path.path);
-        }
-        if (!managed_path.data_dir->try_reserve_spill_data(delta_bytes)) {
-            return Status::Error<ErrorCode::DISK_REACH_CAPACITY_LIMIT>(
-                    "Paimon direct-file spill exceeds the Doris spill storage limit: path={}, "
-                    "bytes={}",
-                    managed_path.path, delta_bytes);
-        }
-        managed_path.direct_file_accounted_bytes += delta_bytes;
-        _resource_context->io_context()->update_spill_write_bytes_to_local_storage(delta_bytes);
-        _manager->update_spill_write_bytes(delta_bytes);
-    }
-    return Status::OK();
 }
 
 SpillFileManager::~SpillFileManager() {
@@ -372,12 +250,17 @@ std::vector<SpillDataDir*> SpillFileManager::_get_stores_for_spill(
 
 Status SpillFileManager::create_spill_file(const std::string& relative_path,
                                            SpillFileSPtr& spill_file) {
-    SpillDataDir* data_dir = _get_store_for_spill();
-    if (data_dir == nullptr) {
+    auto data_dirs = _get_stores_for_spill(TStorageMedium::type::SSD);
+    if (data_dirs.empty()) {
+        data_dirs = _get_stores_for_spill(TStorageMedium::type::HDD);
+    }
+    if (data_dirs.empty()) {
         return Status::Error<ErrorCode::NO_AVAILABLE_ROOT_PATH>(
                 "no available disk can be used for spill.");
     }
 
+    // Select the first available data dir (sorted by usage ascending)
+    SpillDataDir* data_dir = data_dirs.front();
     spill_file = std::make_shared<SpillFile>(data_dir, relative_path);
     return Status::OK();
 }
@@ -399,88 +282,57 @@ Status SpillFileManager::_initialize_external_spill_session(ExternalSpillSession
     if (query_context == nullptr) {
         return Status::Cancelled("Query ended before the external spill session was initialized");
     }
-    auto data_dirs = _get_stores_for_spill();
-    if (data_dirs.empty()) {
+    auto* data_dir = _get_store_for_spill();
+    if (data_dir == nullptr) {
         return Status::Error<ErrorCode::NO_AVAILABLE_ROOT_PATH>(
                 "no available disk can be used for spill.");
     }
 
-    for (auto* data_dir : data_dirs) {
-        auto query_dir = data_dir->get_spill_data_path(spill_session->_query_id);
-        {
-            // Once the lease is visible, query teardown queues the query directory for the existing
-            // GC retry path instead of deleting it under an external writer.
-            std::lock_guard lock(_query_spill_directories_mutex);
-            auto it = _query_spill_directories
-                              .try_emplace(query_dir,
-                                           QuerySpillDirectoryState {
-                                                   .failed_count = 0,
-                                                   .data_dir = data_dir,
-                                                   .external_accounted_bytes = 0,
-                                                   .external_leases = 0,
-                                                   .delete_requested = false,
-                                           })
-                              .first;
-            DCHECK(it->second.data_dir == data_dir);
-            ++it->second.external_leases;
-        }
-        query_context->record_spill_data_dir(data_dir);
-        spill_session->_managed_paths.emplace_back(ExternalSpillSession::ManagedPath {
-                .data_dir = data_dir,
-                .path = query_dir + "/" + spill_session->_relative_path,
-                .buffer_accounted_bytes = 0,
-                .buffer_accounted_bytes_by_path = {},
-                .direct_file_accounted_bytes = 0,
-        });
+    const auto query_dir = data_dir->get_spill_data_path(spill_session->_query_id);
+    {
+        // QueryContext teardown uses the regular pending-deletion path while this lease is live.
+        std::lock_guard lock(_pending_query_spill_directories_mutex);
+        ++_external_spill_directory_leases[query_dir];
     }
+    query_context->record_spill_data_dir(data_dir);
+    spill_session->_data_dir = data_dir;
+    spill_session->_path = query_dir + "/" + spill_session->_relative_path;
     return Status::OK();
 }
 
 void SpillFileManager::_release_external_spill_session(ExternalSpillSession* spill_session) {
     std::lock_guard session_lock(spill_session->_mutex);
-    std::lock_guard directory_lock(_query_spill_directories_mutex);
-    for (const auto& managed_path : spill_session->_managed_paths) {
-        auto query_dir = managed_path.data_dir->get_spill_data_path(spill_session->_query_id);
-        auto it = _query_spill_directories.find(query_dir);
-        DCHECK(it != _query_spill_directories.end());
-        if (it == _query_spill_directories.end()) {
-            continue;
-        }
-        auto& directory = it->second;
-        DCHECK(directory.data_dir == managed_path.data_dir);
-        DCHECK_GT(directory.external_leases, 0);
-        const int64_t accounted_bytes =
-                managed_path.buffer_accounted_bytes + managed_path.direct_file_accounted_bytes;
-        if (accounted_bytes > 0) {
-            // A confirmed Java close can still leave files behind when eager physical cleanup
-            // fails. Keep those bytes charged until deletion of the query directory succeeds.
-            if (accounted_bytes >
-                std::numeric_limits<int64_t>::max() - directory.external_accounted_bytes) {
-                LOG(ERROR) << "Pending external spill accounting overflow for " << query_dir;
-            } else {
-                directory.external_accounted_bytes += accounted_bytes;
-            }
-        }
-        --directory.external_leases;
-        if (directory.external_leases == 0 && !directory.delete_requested &&
-            directory.external_accounted_bytes == 0) {
-            _query_spill_directories.erase(it);
-        }
+    if (spill_session->_data_dir == nullptr) {
+        return;
+    }
+
+    if (spill_session->_accounted_bytes > 0) {
+        // Match SpillFile::gc(): QueryContext owns physical cleanup and its retry path, while the
+        // writer releases logical usage when its lifetime ends.
+        spill_session->_data_dir->update_spill_data_usage(-spill_session->_accounted_bytes);
+        spill_session->_accounted_bytes = 0;
+    }
+
+    const auto query_dir = spill_session->_data_dir->get_spill_data_path(spill_session->_query_id);
+    std::lock_guard directory_lock(_pending_query_spill_directories_mutex);
+    auto it = _external_spill_directory_leases.find(query_dir);
+    DCHECK(it != _external_spill_directory_leases.end());
+    if (it == _external_spill_directory_leases.end()) {
+        return;
+    }
+    DCHECK_GT(it->second, 0);
+    if (--it->second == 0) {
+        _external_spill_directory_leases.erase(it);
     }
 }
 
 SpillDataDir* SpillFileManager::_get_store_for_spill() {
-    auto data_dirs = _get_stores_for_spill();
-    // Select the first available data dir (sorted by usage ascending).
-    return data_dirs.empty() ? nullptr : data_dirs.front();
-}
-
-std::vector<SpillDataDir*> SpillFileManager::_get_stores_for_spill() {
     auto data_dirs = _get_stores_for_spill(TStorageMedium::type::SSD);
     if (data_dirs.empty()) {
         data_dirs = _get_stores_for_spill(TStorageMedium::type::HDD);
     }
-    return data_dirs;
+    // Select the first available data dir (sorted by usage ascending).
+    return data_dirs.empty() ? nullptr : data_dirs.front();
 }
 
 void SpillFileManager::delete_spill_file(SpillFileSPtr spill_file) {
@@ -493,70 +345,39 @@ void SpillFileManager::delete_spill_file(SpillFileSPtr spill_file) {
 
 void SpillFileManager::delete_query_spill_directory(const std::string& query_id,
                                                     SpillDataDir* data_dir) {
-    auto query_dir = data_dir->get_spill_data_path(query_id);
-    {
-        std::lock_guard lock(_query_spill_directories_mutex);
-        auto it = _query_spill_directories
-                          .try_emplace(query_dir,
-                                       QuerySpillDirectoryState {
-                                               .failed_count = 0,
-                                               .data_dir = data_dir,
-                                               .external_accounted_bytes = 0,
-                                               .external_leases = 0,
-                                               .delete_requested = false,
-                                       })
-                          .first;
-        DCHECK(it->second.data_dir == data_dir);
-        it->second.delete_requested = true;
-    }
+    PendingQuerySpillDirectory pending_directory {
+            .query_dir = data_dir->get_spill_data_path(query_id),
+    };
 
-    auto status = _try_delete_query_spill_directory(query_dir);
+    auto status = _try_delete_query_spill_directory(pending_directory);
     if (!status.ok()) {
-        std::lock_guard lock(_query_spill_directories_mutex);
-        auto it = _query_spill_directories.find(query_dir);
-        if (it != _query_spill_directories.end()) {
-            ++it->second.failed_count;
-        }
+        std::lock_guard lock(_pending_query_spill_directories_mutex);
+        ++pending_directory.failed_count;
+        _pending_query_spill_directories.emplace_back(std::move(pending_directory));
     }
 }
 
-Status SpillFileManager::_try_delete_query_spill_directory(const std::string& query_dir) {
-    std::unique_lock lock(_query_spill_directories_mutex);
-    auto it = _query_spill_directories.find(query_dir);
-    if (it == _query_spill_directories.end() || !it->second.delete_requested) {
-        return Status::OK();
-    }
-    if (it->second.external_leases > 0) {
-        return Status::InternalError("external spill directory is still in use: {}", query_dir);
+Status SpillFileManager::_try_delete_query_spill_directory(
+        const PendingQuerySpillDirectory& pending_directory) {
+    {
+        std::lock_guard lock(_pending_query_spill_directories_mutex);
+        if (_external_spill_directory_leases.contains(pending_directory.query_dir)) {
+            return Status::InternalError("external spill directory is still in use: {}",
+                                         pending_directory.query_dir);
+        }
     }
     DBUG_EXECUTE_IF("fault_inject::spill_file_manager::delete_query_spill_directory", {
         return Status::Error<INTERNAL_ERROR>("injected query spill directory deletion failure");
     });
     const auto& fs = io::global_local_filesystem();
-    auto status = fs->delete_directory(query_dir);
-    if (!status.ok()) {
-        return status;
-    }
-
-    auto* data_dir = it->second.data_dir;
-    const int64_t accounted_bytes = it->second.external_accounted_bytes;
-    _query_spill_directories.erase(it);
-    lock.unlock();
-    if (accounted_bytes > 0) {
-        data_dir->update_spill_data_usage(-accounted_bytes);
-    }
-    return Status::OK();
+    return fs->delete_directory(pending_directory.query_dir);
 }
 
 void SpillFileManager::_retry_pending_query_spill_directories() {
-    std::vector<std::string> pending_directories;
+    std::vector<PendingQuerySpillDirectory> pending_directories;
     {
-        std::lock_guard lock(_query_spill_directories_mutex);
-        for (const auto& [query_dir, directory] : _query_spill_directories) {
-            if (directory.delete_requested && directory.external_leases == 0) {
-                pending_directories.emplace_back(query_dir);
-            }
-        }
+        std::lock_guard lock(_pending_query_spill_directories_mutex);
+        pending_directories.swap(_pending_query_spill_directories);
     }
     DBUG_EXECUTE_IF(
             "fault_inject::spill_file_manager::retry_pending_query_spill_directories_after_drain",
@@ -565,25 +386,26 @@ void SpillFileManager::_retry_pending_query_spill_directories() {
     // Limit repeated warnings for a persistently unavailable directory while retaining it for
     // every subsequent retry.
     constexpr int log_interval = 5;
-    for (const auto& query_dir : pending_directories) {
-        auto status = _try_delete_query_spill_directory(query_dir);
+    std::vector<PendingQuerySpillDirectory> failed_directories;
+    for (auto& pending_directory : pending_directories) {
+        auto status = _try_delete_query_spill_directory(pending_directory);
         if (status.ok()) {
             continue;
         }
 
-        int failed_count = 0;
-        {
-            std::lock_guard lock(_query_spill_directories_mutex);
-            auto it = _query_spill_directories.find(query_dir);
-            if (it == _query_spill_directories.end()) {
-                continue;
-            }
-            failed_count = ++it->second.failed_count;
-        }
-        if (failed_count % log_interval == 0) {
+        ++pending_directory.failed_count;
+        if (pending_directory.failed_count % log_interval == 0) {
             LOG(WARNING) << fmt::format(
-                    "failed to retry deleting spill query directory, dir {}, error: {}", query_dir,
-                    status.to_string());
+                    "failed to retry deleting spill query directory, dir {}, error: {}",
+                    pending_directory.query_dir, status.to_string());
+        }
+        failed_directories.emplace_back(std::move(pending_directory));
+    }
+
+    if (!failed_directories.empty()) {
+        std::lock_guard lock(_pending_query_spill_directories_mutex);
+        for (auto& pending_directory : failed_directories) {
+            _pending_query_spill_directories.emplace_back(std::move(pending_directory));
         }
     }
 }
@@ -772,11 +594,7 @@ bool SpillDataDir::reach_capacity_limit(int64_t incoming_data_size) {
     if (_reach_disk_capacity_limit(incoming_data_size)) {
         return true;
     }
-    // A root already at its spill limit must not be returned by the zero-byte availability probe
-    // used during path selection. Still allow a positive reservation to fill the final bytes
-    // exactly, matching try_reserve_spill_data().
-    if (_spill_data_bytes >= _spill_data_limit_bytes ||
-        incoming_data_size > _spill_data_limit_bytes - _spill_data_bytes) {
+    if (_spill_data_bytes + incoming_data_size > _spill_data_limit_bytes) {
         LOG_EVERY_T(WARNING, 1) << fmt::format(
                 "spill data reach limit, path: {}, capacity: {}, limit: {}, used: {}, "
                 "available: "
@@ -791,20 +609,6 @@ bool SpillDataDir::reach_capacity_limit(int64_t incoming_data_size) {
         return true;
     }
     return false;
-}
-
-bool SpillDataDir::try_reserve_spill_data(int64_t incoming_data_size) {
-    if (incoming_data_size < 0) {
-        return false;
-    }
-    std::lock_guard<std::mutex> l(_mutex);
-    if (_reach_disk_capacity_limit(incoming_data_size) ||
-        incoming_data_size > _spill_data_limit_bytes - _spill_data_bytes) {
-        return false;
-    }
-    _spill_data_bytes += incoming_data_size;
-    spill_disk_data_size->set_value(_spill_data_bytes);
-    return true;
 }
 std::string SpillDataDir::debug_string() {
     return fmt::format(

--- a/be/src/exec/spill/spill_file_manager.cpp
+++ b/be/src/exec/spill/spill_file_manager.cpp
@@ -43,99 +43,82 @@
 namespace doris {
 #include "common/compile_check_begin.h"
 
-ExternalSpillDirectory::ExternalSpillDirectory(SpillFileManager* manager,
-                                               QueryContext* query_context,
-                                               std::string relative_path)
+ExternalSpillSession::ExternalSpillSession(SpillFileManager* manager, QueryContext* query_context,
+                                           std::string relative_path)
         : _manager(manager),
-          _query_context(query_context),
+          _query_context(query_context->weak_from_this()),
           _resource_context(query_context->resource_ctx()),
           _query_id(print_id(query_context->query_id())),
           _relative_path(std::move(relative_path)) {
     DCHECK(_manager != nullptr);
-    DCHECK(_query_context != nullptr);
+    DCHECK(!_query_context.expired());
     DCHECK(_resource_context != nullptr);
 }
 
-ExternalSpillDirectory::~ExternalSpillDirectory() {
+ExternalSpillSession::~ExternalSpillSession() {
     {
         std::lock_guard lock(_mutex);
-        if (_managed_path.has_value() && _managed_path->accounted_bytes > 0) {
-            _managed_path->data_dir->update_spill_data_usage(-_managed_path->accounted_bytes);
-            _managed_path->accounted_bytes = 0;
+        if (_accounted_bytes > 0) {
+            _data_dir->update_spill_data_usage(-_accounted_bytes);
+            _accounted_bytes = 0;
         }
     }
-    _manager->_release_external_spill_directory(this);
+    _manager->_release_external_spill_session(this);
 }
 
-Status ExternalSpillDirectory::get_paths(std::vector<std::string>* paths) {
-    if (paths == nullptr) {
-        return Status::InvalidArgument("External spill paths output must not be null");
+Status ExternalSpillSession::get_path(std::string* path) {
+    if (path == nullptr) {
+        return Status::InvalidArgument("External spill path output must not be null");
     }
     std::lock_guard lock(_mutex);
-    if (!_managed_path.has_value()) {
-        RETURN_IF_ERROR(_manager->_initialize_external_spill_directory(this));
+    if (_data_dir == nullptr) {
+        RETURN_IF_ERROR(_manager->_initialize_external_spill_session(this));
     }
-    paths->clear();
-    paths->emplace_back(_managed_path->path);
+    *path = _path;
     return Status::OK();
 }
 
-ExternalSpillDirectory::ManagedPath* ExternalSpillDirectory::_find_managed_path(
-        const std::string& path) {
-    if (_managed_path.has_value() &&
-        (path == _managed_path->path ||
-         (path.size() > _managed_path->path.size() && path.starts_with(_managed_path->path) &&
-          path[_managed_path->path.size()] == '/'))) {
-        return &*_managed_path;
-    }
-    return nullptr;
-}
-
-Status ExternalSpillDirectory::reserve(const std::string& path, int64_t bytes) {
+Status ExternalSpillSession::reserve(int64_t bytes) {
     if (bytes <= 0) {
         return Status::InvalidArgument("External spill reservation must be positive: {}", bytes);
     }
 
     std::lock_guard lock(_mutex);
-    auto* managed_path = _find_managed_path(path);
-    if (managed_path == nullptr) {
-        return Status::InvalidArgument("External spill path is not managed by Doris: {}", path);
+    if (_data_dir == nullptr) {
+        return Status::InvalidArgument("External spill path has not been initialized");
     }
-    if (bytes > std::numeric_limits<int64_t>::max() - managed_path->accounted_bytes) {
+    if (bytes > std::numeric_limits<int64_t>::max() - _accounted_bytes) {
         return Status::InvalidArgument("External spill reservation overflows: bytes={}", bytes);
     }
-    if (!managed_path->data_dir->try_reserve_spill_data(bytes)) {
+    if (!_data_dir->try_reserve_spill_data(bytes)) {
         return Status::Error<ErrorCode::DISK_REACH_CAPACITY_LIMIT>(
                 "External spill write exceeds the Doris spill storage limit: path={}, bytes={}",
-                path, bytes);
+                _path, bytes);
     }
-    managed_path->accounted_bytes += bytes;
+    _accounted_bytes += bytes;
     return Status::OK();
 }
 
-void ExternalSpillDirectory::update_accounting(const std::string& path, int64_t current_bytes_delta,
-                                               int64_t write_bytes, int64_t read_bytes) {
+void ExternalSpillSession::update_accounting(int64_t current_bytes_delta, int64_t write_bytes,
+                                             int64_t read_bytes) {
     int64_t released_bytes = 0;
-    SpillDataDir* data_dir = nullptr;
     {
         std::lock_guard lock(_mutex);
-        auto* managed_path = _find_managed_path(path);
-        if (managed_path == nullptr) {
-            LOG(WARNING) << "Ignoring accounting for unmanaged external spill path: " << path;
+        if (_data_dir == nullptr) {
+            LOG(WARNING) << "Ignoring accounting for an uninitialized external spill session";
             return;
         }
-        data_dir = managed_path->data_dir;
         if (current_bytes_delta < 0) {
             const int64_t requested_release =
                     current_bytes_delta == std::numeric_limits<int64_t>::min()
                             ? std::numeric_limits<int64_t>::max()
                             : -current_bytes_delta;
-            released_bytes = std::min(requested_release, managed_path->accounted_bytes);
-            managed_path->accounted_bytes -= released_bytes;
+            released_bytes = std::min(requested_release, _accounted_bytes);
+            _accounted_bytes -= released_bytes;
         }
     }
     if (released_bytes > 0) {
-        data_dir->update_spill_data_usage(-released_bytes);
+        _data_dir->update_spill_data_usage(-released_bytes);
     }
     if (write_bytes > 0) {
         _resource_context->io_context()->update_spill_write_bytes_to_local_storage(write_bytes);
@@ -275,52 +258,51 @@ Status SpillFileManager::create_spill_file(const std::string& relative_path,
     return Status::OK();
 }
 
-Status SpillFileManager::create_external_spill_directory(
+Status SpillFileManager::create_external_spill_session(
         const std::string& relative_path, QueryContext* query_context,
-        std::unique_ptr<ExternalSpillDirectory>* spill_directory) {
-    if (query_context == nullptr || spill_directory == nullptr) {
+        std::unique_ptr<ExternalSpillSession>* spill_session) {
+    if (query_context == nullptr || spill_session == nullptr) {
         return Status::InvalidArgument(
-                "External spill directory requires QueryContext and output session");
+                "External spill session requires QueryContext and output session");
     }
 
-    spill_directory->reset(new ExternalSpillDirectory(this, query_context, relative_path));
+    spill_session->reset(new ExternalSpillSession(this, query_context, relative_path));
     return Status::OK();
 }
 
-Status SpillFileManager::_initialize_external_spill_directory(
-        ExternalSpillDirectory* spill_directory) {
+Status SpillFileManager::_initialize_external_spill_session(ExternalSpillSession* spill_session) {
+    auto query_context = spill_session->_query_context.lock();
+    if (query_context == nullptr) {
+        return Status::Cancelled("Query ended before the external spill session was initialized");
+    }
     auto* data_dir = _get_store_for_spill();
     if (data_dir == nullptr) {
         return Status::Error<ErrorCode::NO_AVAILABLE_ROOT_PATH>(
                 "no available disk can be used for spill.");
     }
 
-    std::string path = data_dir->get_spill_data_path(spill_directory->_query_id) + "/" +
-                       spill_directory->_relative_path;
+    std::string path = data_dir->get_spill_data_path(spill_session->_query_id) + "/" +
+                       spill_session->_relative_path;
     {
         // Once the lease is visible, query teardown queues the query directory for the existing GC
         // retry path instead of deleting it under an external writer. Paimon's IOManager creates
         // its own nested channel directory lazily below this managed path.
         std::lock_guard lock(_external_spill_leases_mutex);
-        ++_external_spill_leases[data_dir->get_spill_data_path(spill_directory->_query_id)];
+        ++_external_spill_leases[data_dir->get_spill_data_path(spill_session->_query_id)];
     }
-    spill_directory->_query_context->record_spill_data_dir(data_dir);
-    spill_directory->_managed_path.emplace(ExternalSpillDirectory::ManagedPath {
-            .data_dir = data_dir,
-            .path = std::move(path),
-    });
+    query_context->record_spill_data_dir(data_dir);
+    spill_session->_data_dir = data_dir;
+    spill_session->_path = std::move(path);
     return Status::OK();
 }
 
-void SpillFileManager::_release_external_spill_directory(
-        const ExternalSpillDirectory* spill_directory) {
-    if (!spill_directory->_managed_path.has_value()) {
+void SpillFileManager::_release_external_spill_session(const ExternalSpillSession* spill_session) {
+    if (spill_session->_data_dir == nullptr) {
         return;
     }
     {
         std::lock_guard lock(_external_spill_leases_mutex);
-        auto query_dir = spill_directory->_managed_path->data_dir->get_spill_data_path(
-                spill_directory->_query_id);
+        auto query_dir = spill_session->_data_dir->get_spill_data_path(spill_session->_query_id);
         auto it = _external_spill_leases.find(query_dir);
         if (it != _external_spill_leases.end() && --it->second == 0) {
             _external_spill_leases.erase(it);

--- a/be/src/exec/spill/spill_file_manager.cpp
+++ b/be/src/exec/spill/spill_file_manager.cpp
@@ -57,23 +57,6 @@ ExternalSpillSession::ExternalSpillSession(SpillFileManager* manager, QueryConte
 }
 
 ExternalSpillSession::~ExternalSpillSession() {
-    {
-        std::lock_guard lock(_mutex);
-        for (auto& managed_path : _managed_paths) {
-            const int64_t accounted_bytes =
-                    managed_path.buffer_accounted_bytes + managed_path.direct_file_accounted_bytes;
-            if (accounted_bytes > 0) {
-                // A confirmed Java close can still leave files behind when eager physical cleanup
-                // fails. Keep those bytes charged after this callback object is destroyed; query
-                // directory GC releases them only after deletion actually succeeds.
-                _manager->_transfer_external_spill_accounting(
-                        managed_path.data_dir->get_spill_data_path(_query_id),
-                        managed_path.data_dir, accounted_bytes);
-                managed_path.buffer_accounted_bytes = 0;
-                managed_path.direct_file_accounted_bytes = 0;
-            }
-        }
-    }
     _manager->_release_external_spill_session(this);
 }
 
@@ -182,7 +165,11 @@ Status ExternalSpillSession::reconcile_direct_file_usage(bool allow_release) {
         std::lock_guard lock(_mutex);
         observed_paths.reserve(_managed_paths.size());
         for (const auto& managed_path : _managed_paths) {
-            ObservedPathUsage observed_path {.path = managed_path.path};
+            ObservedPathUsage observed_path {
+                    .path = managed_path.path,
+                    .buffer_paths = {},
+                    .bytes = 0,
+            };
             for (const auto& buffer_entry : managed_path.buffer_accounted_bytes_by_path) {
                 observed_path.buffer_paths.emplace(buffer_entry.first);
             }
@@ -419,70 +406,67 @@ Status SpillFileManager::_initialize_external_spill_session(ExternalSpillSession
     }
 
     for (auto* data_dir : data_dirs) {
-        std::string path = data_dir->get_spill_data_path(spill_session->_query_id) + "/" +
-                           spill_session->_relative_path;
+        auto query_dir = data_dir->get_spill_data_path(spill_session->_query_id);
         {
             // Once the lease is visible, query teardown queues the query directory for the existing
             // GC retry path instead of deleting it under an external writer.
-            std::lock_guard lock(_external_spill_leases_mutex);
-            ++_external_spill_leases[data_dir->get_spill_data_path(spill_session->_query_id)];
+            std::lock_guard lock(_query_spill_directories_mutex);
+            auto it = _query_spill_directories
+                              .try_emplace(query_dir,
+                                           QuerySpillDirectoryState {
+                                                   .failed_count = 0,
+                                                   .data_dir = data_dir,
+                                                   .external_accounted_bytes = 0,
+                                                   .external_leases = 0,
+                                                   .delete_requested = false,
+                                           })
+                              .first;
+            DCHECK(it->second.data_dir == data_dir);
+            ++it->second.external_leases;
         }
         query_context->record_spill_data_dir(data_dir);
         spill_session->_managed_paths.emplace_back(ExternalSpillSession::ManagedPath {
                 .data_dir = data_dir,
-                .path = std::move(path),
+                .path = query_dir + "/" + spill_session->_relative_path,
+                .buffer_accounted_bytes = 0,
+                .buffer_accounted_bytes_by_path = {},
+                .direct_file_accounted_bytes = 0,
         });
     }
     return Status::OK();
 }
 
-void SpillFileManager::_release_external_spill_session(const ExternalSpillSession* spill_session) {
+void SpillFileManager::_release_external_spill_session(ExternalSpillSession* spill_session) {
+    std::lock_guard session_lock(spill_session->_mutex);
+    std::lock_guard directory_lock(_query_spill_directories_mutex);
     for (const auto& managed_path : spill_session->_managed_paths) {
-        std::lock_guard lock(_external_spill_leases_mutex);
         auto query_dir = managed_path.data_dir->get_spill_data_path(spill_session->_query_id);
-        auto it = _external_spill_leases.find(query_dir);
-        if (it != _external_spill_leases.end() && --it->second == 0) {
-            _external_spill_leases.erase(it);
+        auto it = _query_spill_directories.find(query_dir);
+        DCHECK(it != _query_spill_directories.end());
+        if (it == _query_spill_directories.end()) {
+            continue;
+        }
+        auto& directory = it->second;
+        DCHECK(directory.data_dir == managed_path.data_dir);
+        DCHECK_GT(directory.external_leases, 0);
+        const int64_t accounted_bytes =
+                managed_path.buffer_accounted_bytes + managed_path.direct_file_accounted_bytes;
+        if (accounted_bytes > 0) {
+            // A confirmed Java close can still leave files behind when eager physical cleanup
+            // fails. Keep those bytes charged until deletion of the query directory succeeds.
+            if (accounted_bytes >
+                std::numeric_limits<int64_t>::max() - directory.external_accounted_bytes) {
+                LOG(ERROR) << "Pending external spill accounting overflow for " << query_dir;
+            } else {
+                directory.external_accounted_bytes += accounted_bytes;
+            }
+        }
+        --directory.external_leases;
+        if (directory.external_leases == 0 && !directory.delete_requested &&
+            directory.external_accounted_bytes == 0) {
+            _query_spill_directories.erase(it);
         }
     }
-}
-
-void SpillFileManager::_transfer_external_spill_accounting(const std::string& query_dir,
-                                                           SpillDataDir* data_dir, int64_t bytes) {
-    DCHECK(data_dir != nullptr);
-    DCHECK_GT(bytes, 0);
-    std::lock_guard lock(_pending_external_spill_accounting_mutex);
-    auto it = _pending_external_spill_accounting
-                      .try_emplace(query_dir, PendingExternalSpillAccounting {.data_dir = data_dir})
-                      .first;
-    DCHECK(it->second.data_dir == data_dir);
-    if (bytes > std::numeric_limits<int64_t>::max() - it->second.bytes) {
-        LOG(ERROR) << "Pending external spill accounting overflow for " << query_dir;
-        // Preserve the existing charge rather than risk releasing more bytes than were reserved.
-        return;
-    }
-    it->second.bytes += bytes;
-}
-
-void SpillFileManager::_release_pending_external_spill_accounting(const std::string& query_dir) {
-    PendingExternalSpillAccounting accounting;
-    {
-        std::lock_guard lock(_pending_external_spill_accounting_mutex);
-        auto it = _pending_external_spill_accounting.find(query_dir);
-        if (it == _pending_external_spill_accounting.end()) {
-            return;
-        }
-        accounting = it->second;
-        _pending_external_spill_accounting.erase(it);
-    }
-    if (accounting.bytes > 0) {
-        accounting.data_dir->update_spill_data_usage(-accounting.bytes);
-    }
-}
-
-bool SpillFileManager::_has_external_spill_lease(const std::string& query_dir) {
-    std::lock_guard lock(_external_spill_leases_mutex);
-    return _external_spill_leases.contains(query_dir);
 }
 
 SpillDataDir* SpillFileManager::_get_store_for_spill() {
@@ -509,42 +493,71 @@ void SpillFileManager::delete_spill_file(SpillFileSPtr spill_file) {
 
 void SpillFileManager::delete_query_spill_directory(const std::string& query_id,
                                                     SpillDataDir* data_dir) {
-    PendingQuerySpillDirectory pending_directory {
-            .query_dir = data_dir->get_spill_data_path(query_id),
-    };
+    auto query_dir = data_dir->get_spill_data_path(query_id);
+    {
+        std::lock_guard lock(_query_spill_directories_mutex);
+        auto it = _query_spill_directories
+                          .try_emplace(query_dir,
+                                       QuerySpillDirectoryState {
+                                               .failed_count = 0,
+                                               .data_dir = data_dir,
+                                               .external_accounted_bytes = 0,
+                                               .external_leases = 0,
+                                               .delete_requested = false,
+                                       })
+                          .first;
+        DCHECK(it->second.data_dir == data_dir);
+        it->second.delete_requested = true;
+    }
 
-    auto status = _try_delete_query_spill_directory(pending_directory);
+    auto status = _try_delete_query_spill_directory(query_dir);
     if (!status.ok()) {
-        std::lock_guard lock(_pending_query_spill_directories_mutex);
-        ++pending_directory.failed_count;
-        _pending_query_spill_directories.emplace_back(std::move(pending_directory));
+        std::lock_guard lock(_query_spill_directories_mutex);
+        auto it = _query_spill_directories.find(query_dir);
+        if (it != _query_spill_directories.end()) {
+            ++it->second.failed_count;
+        }
     }
 }
 
-Status SpillFileManager::_try_delete_query_spill_directory(
-        const PendingQuerySpillDirectory& pending_directory) {
-    std::unique_lock lock(_external_spill_leases_mutex);
-    if (_external_spill_leases.contains(pending_directory.query_dir)) {
+Status SpillFileManager::_try_delete_query_spill_directory(const std::string& query_dir) {
+    std::unique_lock lock(_query_spill_directories_mutex);
+    auto it = _query_spill_directories.find(query_dir);
+    if (it == _query_spill_directories.end() || !it->second.delete_requested) {
+        return Status::OK();
+    }
+    if (it->second.external_leases > 0) {
         return Status::InternalError("external spill directory is still in use: {}",
-                                     pending_directory.query_dir);
+                                     query_dir);
     }
     DBUG_EXECUTE_IF("fault_inject::spill_file_manager::delete_query_spill_directory", {
         return Status::Error<INTERNAL_ERROR>("injected query spill directory deletion failure");
     });
     const auto& fs = io::global_local_filesystem();
-    auto status = fs->delete_directory(pending_directory.query_dir);
-    lock.unlock();
-    if (status.ok()) {
-        _release_pending_external_spill_accounting(pending_directory.query_dir);
+    auto status = fs->delete_directory(query_dir);
+    if (!status.ok()) {
+        return status;
     }
-    return status;
+
+    auto* data_dir = it->second.data_dir;
+    const int64_t accounted_bytes = it->second.external_accounted_bytes;
+    _query_spill_directories.erase(it);
+    lock.unlock();
+    if (accounted_bytes > 0) {
+        data_dir->update_spill_data_usage(-accounted_bytes);
+    }
+    return Status::OK();
 }
 
 void SpillFileManager::_retry_pending_query_spill_directories() {
-    std::vector<PendingQuerySpillDirectory> pending_directories;
+    std::vector<std::string> pending_directories;
     {
-        std::lock_guard lock(_pending_query_spill_directories_mutex);
-        pending_directories.swap(_pending_query_spill_directories);
+        std::lock_guard lock(_query_spill_directories_mutex);
+        for (const auto& [query_dir, directory] : _query_spill_directories) {
+            if (directory.delete_requested && directory.external_leases == 0) {
+                pending_directories.emplace_back(query_dir);
+            }
+        }
     }
     DBUG_EXECUTE_IF(
             "fault_inject::spill_file_manager::retry_pending_query_spill_directories_after_drain",
@@ -553,30 +566,25 @@ void SpillFileManager::_retry_pending_query_spill_directories() {
     // Limit repeated warnings for a persistently unavailable directory while retaining it for
     // every subsequent retry.
     constexpr int log_interval = 5;
-    std::vector<PendingQuerySpillDirectory> failed_directories;
-    for (auto& pending_directory : pending_directories) {
-        if (_has_external_spill_lease(pending_directory.query_dir)) {
-            failed_directories.emplace_back(std::move(pending_directory));
-            continue;
-        }
-        auto status = _try_delete_query_spill_directory(pending_directory);
+    for (const auto& query_dir : pending_directories) {
+        auto status = _try_delete_query_spill_directory(query_dir);
         if (status.ok()) {
             continue;
         }
 
-        ++pending_directory.failed_count;
-        if (pending_directory.failed_count % log_interval == 0) {
+        int failed_count = 0;
+        {
+            std::lock_guard lock(_query_spill_directories_mutex);
+            auto it = _query_spill_directories.find(query_dir);
+            if (it == _query_spill_directories.end()) {
+                continue;
+            }
+            failed_count = ++it->second.failed_count;
+        }
+        if (failed_count % log_interval == 0) {
             LOG(WARNING) << fmt::format(
                     "failed to retry deleting spill query directory, dir {}, error: {}",
-                    pending_directory.query_dir, status.to_string());
-        }
-        failed_directories.emplace_back(std::move(pending_directory));
-    }
-
-    if (!failed_directories.empty()) {
-        std::lock_guard lock(_pending_query_spill_directories_mutex);
-        for (auto& pending_directory : failed_directories) {
-            _pending_query_spill_directories.emplace_back(std::move(pending_directory));
+                    query_dir, status.to_string());
         }
     }
 }

--- a/be/src/exec/spill/spill_file_manager.cpp
+++ b/be/src/exec/spill/spill_file_manager.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
@@ -31,14 +32,120 @@
 #include "exec/spill/spill_file.h"
 #include "io/fs/file_system.h"
 #include "io/fs/local_file_system.h"
+#include "runtime/query_context.h"
 #include "storage/olap_define.h"
 #include "util/debug_points.h"
 #include "util/parse_util.h"
 #include "util/pretty_printer.h"
 #include "util/time.h"
+#include "util/uid_util.h"
 
 namespace doris {
 #include "common/compile_check_begin.h"
+
+ExternalSpillDirectory::ExternalSpillDirectory(SpillFileManager* manager,
+                                               QueryContext* query_context,
+                                               std::string relative_path)
+        : _manager(manager),
+          _query_context(query_context),
+          _resource_context(query_context->resource_ctx()),
+          _query_id(print_id(query_context->query_id())),
+          _relative_path(std::move(relative_path)) {
+    DCHECK(_manager != nullptr);
+    DCHECK(_query_context != nullptr);
+    DCHECK(_resource_context != nullptr);
+}
+
+ExternalSpillDirectory::~ExternalSpillDirectory() {
+    {
+        std::lock_guard lock(_mutex);
+        if (_managed_path.has_value() && _managed_path->accounted_bytes > 0) {
+            _managed_path->data_dir->update_spill_data_usage(-_managed_path->accounted_bytes);
+            _managed_path->accounted_bytes = 0;
+        }
+    }
+    _manager->_release_external_spill_directory(this);
+}
+
+Status ExternalSpillDirectory::get_paths(std::vector<std::string>* paths) {
+    if (paths == nullptr) {
+        return Status::InvalidArgument("External spill paths output must not be null");
+    }
+    std::lock_guard lock(_mutex);
+    if (!_managed_path.has_value()) {
+        RETURN_IF_ERROR(_manager->_initialize_external_spill_directory(this));
+    }
+    paths->clear();
+    paths->emplace_back(_managed_path->path);
+    return Status::OK();
+}
+
+ExternalSpillDirectory::ManagedPath* ExternalSpillDirectory::_find_managed_path(
+        const std::string& path) {
+    if (_managed_path.has_value() &&
+        (path == _managed_path->path ||
+         (path.size() > _managed_path->path.size() && path.starts_with(_managed_path->path) &&
+          path[_managed_path->path.size()] == '/'))) {
+        return &*_managed_path;
+    }
+    return nullptr;
+}
+
+Status ExternalSpillDirectory::reserve(const std::string& path, int64_t bytes) {
+    if (bytes <= 0) {
+        return Status::InvalidArgument("External spill reservation must be positive: {}", bytes);
+    }
+
+    std::lock_guard lock(_mutex);
+    auto* managed_path = _find_managed_path(path);
+    if (managed_path == nullptr) {
+        return Status::InvalidArgument("External spill path is not managed by Doris: {}", path);
+    }
+    if (bytes > std::numeric_limits<int64_t>::max() - managed_path->accounted_bytes) {
+        return Status::InvalidArgument("External spill reservation overflows: bytes={}", bytes);
+    }
+    if (!managed_path->data_dir->try_reserve_spill_data(bytes)) {
+        return Status::Error<ErrorCode::DISK_REACH_CAPACITY_LIMIT>(
+                "External spill write exceeds the Doris spill storage limit: path={}, bytes={}",
+                path, bytes);
+    }
+    managed_path->accounted_bytes += bytes;
+    return Status::OK();
+}
+
+void ExternalSpillDirectory::update_accounting(const std::string& path, int64_t current_bytes_delta,
+                                               int64_t write_bytes, int64_t read_bytes) {
+    int64_t released_bytes = 0;
+    SpillDataDir* data_dir = nullptr;
+    {
+        std::lock_guard lock(_mutex);
+        auto* managed_path = _find_managed_path(path);
+        if (managed_path == nullptr) {
+            LOG(WARNING) << "Ignoring accounting for unmanaged external spill path: " << path;
+            return;
+        }
+        data_dir = managed_path->data_dir;
+        if (current_bytes_delta < 0) {
+            const int64_t requested_release =
+                    current_bytes_delta == std::numeric_limits<int64_t>::min()
+                            ? std::numeric_limits<int64_t>::max()
+                            : -current_bytes_delta;
+            released_bytes = std::min(requested_release, managed_path->accounted_bytes);
+            managed_path->accounted_bytes -= released_bytes;
+        }
+    }
+    if (released_bytes > 0) {
+        data_dir->update_spill_data_usage(-released_bytes);
+    }
+    if (write_bytes > 0) {
+        _resource_context->io_context()->update_spill_write_bytes_to_local_storage(write_bytes);
+        _manager->update_spill_write_bytes(write_bytes);
+    }
+    if (read_bytes > 0) {
+        _resource_context->io_context()->update_spill_read_bytes_from_local_storage(read_bytes);
+        _manager->update_spill_read_bytes(read_bytes);
+    }
+}
 
 SpillFileManager::~SpillFileManager() {
     // QueryContext destruction can still queue failed deletions after stop(), for example while
@@ -158,19 +265,86 @@ std::vector<SpillDataDir*> SpillFileManager::_get_stores_for_spill(
 
 Status SpillFileManager::create_spill_file(const std::string& relative_path,
                                            SpillFileSPtr& spill_file) {
-    auto data_dirs = _get_stores_for_spill(TStorageMedium::type::SSD);
-    if (data_dirs.empty()) {
-        data_dirs = _get_stores_for_spill(TStorageMedium::type::HDD);
-    }
-    if (data_dirs.empty()) {
+    SpillDataDir* data_dir = _get_store_for_spill();
+    if (data_dir == nullptr) {
         return Status::Error<ErrorCode::NO_AVAILABLE_ROOT_PATH>(
                 "no available disk can be used for spill.");
     }
 
-    // Select the first available data dir (sorted by usage ascending)
-    SpillDataDir* data_dir = data_dirs.front();
     spill_file = std::make_shared<SpillFile>(data_dir, relative_path);
     return Status::OK();
+}
+
+Status SpillFileManager::create_external_spill_directory(
+        const std::string& relative_path, QueryContext* query_context,
+        std::unique_ptr<ExternalSpillDirectory>* spill_directory) {
+    if (query_context == nullptr || spill_directory == nullptr) {
+        return Status::InvalidArgument(
+                "External spill directory requires QueryContext and output session");
+    }
+
+    spill_directory->reset(new ExternalSpillDirectory(this, query_context, relative_path));
+    return Status::OK();
+}
+
+Status SpillFileManager::_initialize_external_spill_directory(
+        ExternalSpillDirectory* spill_directory) {
+    auto* data_dir = _get_store_for_spill();
+    if (data_dir == nullptr) {
+        return Status::Error<ErrorCode::NO_AVAILABLE_ROOT_PATH>(
+                "no available disk can be used for spill.");
+    }
+
+    std::string path = data_dir->get_spill_data_path(spill_directory->_query_id) + "/" +
+                       spill_directory->_relative_path;
+    {
+        // Once the lease is visible, query teardown queues the query directory for the existing GC
+        // retry path instead of deleting it under an external writer. Paimon's IOManager creates
+        // its own nested channel directory lazily below this managed path.
+        std::lock_guard lock(_external_spill_leases_mutex);
+        ++_external_spill_leases[data_dir->get_spill_data_path(spill_directory->_query_id)];
+    }
+    spill_directory->_query_context->record_spill_data_dir(data_dir);
+    spill_directory->_managed_path.emplace(ExternalSpillDirectory::ManagedPath {
+            .data_dir = data_dir,
+            .path = std::move(path),
+    });
+    return Status::OK();
+}
+
+void SpillFileManager::_release_external_spill_directory(
+        const ExternalSpillDirectory* spill_directory) {
+    if (!spill_directory->_managed_path.has_value()) {
+        return;
+    }
+    {
+        std::lock_guard lock(_external_spill_leases_mutex);
+        auto query_dir = spill_directory->_managed_path->data_dir->get_spill_data_path(
+                spill_directory->_query_id);
+        auto it = _external_spill_leases.find(query_dir);
+        if (it != _external_spill_leases.end() && --it->second == 0) {
+            _external_spill_leases.erase(it);
+        }
+    }
+}
+
+bool SpillFileManager::_has_external_spill_lease(const std::string& query_dir) {
+    std::lock_guard lock(_external_spill_leases_mutex);
+    return _external_spill_leases.contains(query_dir);
+}
+
+SpillDataDir* SpillFileManager::_get_store_for_spill() {
+    auto data_dirs = _get_stores_for_spill();
+    // Select the first available data dir (sorted by usage ascending).
+    return data_dirs.empty() ? nullptr : data_dirs.front();
+}
+
+std::vector<SpillDataDir*> SpillFileManager::_get_stores_for_spill() {
+    auto data_dirs = _get_stores_for_spill(TStorageMedium::type::SSD);
+    if (data_dirs.empty()) {
+        data_dirs = _get_stores_for_spill(TStorageMedium::type::HDD);
+    }
+    return data_dirs;
 }
 
 void SpillFileManager::delete_spill_file(SpillFileSPtr spill_file) {
@@ -197,6 +371,11 @@ void SpillFileManager::delete_query_spill_directory(const std::string& query_id,
 
 Status SpillFileManager::_try_delete_query_spill_directory(
         const PendingQuerySpillDirectory& pending_directory) {
+    std::lock_guard lock(_external_spill_leases_mutex);
+    if (_external_spill_leases.contains(pending_directory.query_dir)) {
+        return Status::InternalError("external spill directory is still in use: {}",
+                                     pending_directory.query_dir);
+    }
     DBUG_EXECUTE_IF("fault_inject::spill_file_manager::delete_query_spill_directory", {
         return Status::Error<INTERNAL_ERROR>("injected query spill directory deletion failure");
     });
@@ -219,6 +398,10 @@ void SpillFileManager::_retry_pending_query_spill_directories() {
     constexpr int log_interval = 5;
     std::vector<PendingQuerySpillDirectory> failed_directories;
     for (auto& pending_directory : pending_directories) {
+        if (_has_external_spill_lease(pending_directory.query_dir)) {
+            failed_directories.emplace_back(std::move(pending_directory));
+            continue;
+        }
         auto status = _try_delete_query_spill_directory(pending_directory);
         if (status.ok()) {
             continue;
@@ -440,6 +623,20 @@ bool SpillDataDir::reach_capacity_limit(int64_t incoming_data_size) {
         return true;
     }
     return false;
+}
+
+bool SpillDataDir::try_reserve_spill_data(int64_t incoming_data_size) {
+    if (incoming_data_size < 0) {
+        return false;
+    }
+    std::lock_guard<std::mutex> l(_mutex);
+    if (_reach_disk_capacity_limit(incoming_data_size) ||
+        incoming_data_size > _spill_data_limit_bytes - _spill_data_bytes) {
+        return false;
+    }
+    _spill_data_bytes += incoming_data_size;
+    spill_disk_data_size->set_value(_spill_data_bytes);
+    return true;
 }
 std::string SpillDataDir::debug_string() {
     return fmt::format(

--- a/be/src/exec/spill/spill_file_manager.cpp
+++ b/be/src/exec/spill/spill_file_manager.cpp
@@ -58,67 +58,93 @@ ExternalSpillSession::ExternalSpillSession(SpillFileManager* manager, QueryConte
 ExternalSpillSession::~ExternalSpillSession() {
     {
         std::lock_guard lock(_mutex);
-        if (_accounted_bytes > 0) {
-            _data_dir->update_spill_data_usage(-_accounted_bytes);
-            _accounted_bytes = 0;
+        for (auto& managed_path : _managed_paths) {
+            const int64_t accounted_bytes =
+                    managed_path.buffer_accounted_bytes + managed_path.direct_file_accounted_bytes;
+            if (accounted_bytes > 0) {
+                managed_path.data_dir->update_spill_data_usage(-accounted_bytes);
+                managed_path.buffer_accounted_bytes = 0;
+                managed_path.direct_file_accounted_bytes = 0;
+            }
         }
     }
     _manager->_release_external_spill_session(this);
 }
 
-Status ExternalSpillSession::get_path(std::string* path) {
-    if (path == nullptr) {
-        return Status::InvalidArgument("External spill path output must not be null");
+Status ExternalSpillSession::get_paths(std::vector<std::string>* paths) {
+    if (paths == nullptr) {
+        return Status::InvalidArgument("External spill paths output must not be null");
     }
     std::lock_guard lock(_mutex);
-    if (_data_dir == nullptr) {
+    if (_managed_paths.empty()) {
         RETURN_IF_ERROR(_manager->_initialize_external_spill_session(this));
     }
-    *path = _path;
+    paths->clear();
+    for (const auto& managed_path : _managed_paths) {
+        paths->emplace_back(managed_path.path);
+    }
     return Status::OK();
 }
 
-Status ExternalSpillSession::reserve(int64_t bytes) {
+ExternalSpillSession::ManagedPath* ExternalSpillSession::_find_managed_path(
+        const std::string& path) {
+    for (auto& managed_path : _managed_paths) {
+        if (path == managed_path.path ||
+            (path.size() > managed_path.path.size() && path.starts_with(managed_path.path) &&
+             path[managed_path.path.size()] == '/')) {
+            return &managed_path;
+        }
+    }
+    return nullptr;
+}
+
+Status ExternalSpillSession::reserve(const std::string& path, int64_t bytes) {
     if (bytes <= 0) {
         return Status::InvalidArgument("External spill reservation must be positive: {}", bytes);
     }
 
     std::lock_guard lock(_mutex);
-    if (_data_dir == nullptr) {
-        return Status::InvalidArgument("External spill path has not been initialized");
+    auto* managed_path = _find_managed_path(path);
+    if (managed_path == nullptr) {
+        return Status::InvalidArgument("External spill path is not managed by Doris: {}", path);
     }
-    if (bytes > std::numeric_limits<int64_t>::max() - _accounted_bytes) {
+    const int64_t accounted_bytes =
+            managed_path->buffer_accounted_bytes + managed_path->direct_file_accounted_bytes;
+    if (bytes > std::numeric_limits<int64_t>::max() - accounted_bytes) {
         return Status::InvalidArgument("External spill reservation overflows: bytes={}", bytes);
     }
-    if (!_data_dir->try_reserve_spill_data(bytes)) {
+    if (!managed_path->data_dir->try_reserve_spill_data(bytes)) {
         return Status::Error<ErrorCode::DISK_REACH_CAPACITY_LIMIT>(
                 "External spill write exceeds the Doris spill storage limit: path={}, bytes={}",
-                _path, bytes);
+                path, bytes);
     }
-    _accounted_bytes += bytes;
+    managed_path->buffer_accounted_bytes += bytes;
     return Status::OK();
 }
 
-void ExternalSpillSession::update_accounting(int64_t current_bytes_delta, int64_t write_bytes,
-                                             int64_t read_bytes) {
+void ExternalSpillSession::update_accounting(const std::string& path, int64_t current_bytes_delta,
+                                             int64_t write_bytes, int64_t read_bytes) {
     int64_t released_bytes = 0;
+    SpillDataDir* data_dir = nullptr;
     {
         std::lock_guard lock(_mutex);
-        if (_data_dir == nullptr) {
-            LOG(WARNING) << "Ignoring accounting for an uninitialized external spill session";
+        auto* managed_path = _find_managed_path(path);
+        if (managed_path == nullptr) {
+            LOG(WARNING) << "Ignoring accounting for unmanaged external spill path: " << path;
             return;
         }
+        data_dir = managed_path->data_dir;
         if (current_bytes_delta < 0) {
             const int64_t requested_release =
                     current_bytes_delta == std::numeric_limits<int64_t>::min()
                             ? std::numeric_limits<int64_t>::max()
                             : -current_bytes_delta;
-            released_bytes = std::min(requested_release, _accounted_bytes);
-            _accounted_bytes -= released_bytes;
+            released_bytes = std::min(requested_release, managed_path->buffer_accounted_bytes);
+            managed_path->buffer_accounted_bytes -= released_bytes;
         }
     }
     if (released_bytes > 0) {
-        _data_dir->update_spill_data_usage(-released_bytes);
+        data_dir->update_spill_data_usage(-released_bytes);
     }
     if (write_bytes > 0) {
         _resource_context->io_context()->update_spill_write_bytes_to_local_storage(write_bytes);
@@ -128,6 +154,69 @@ void ExternalSpillSession::update_accounting(int64_t current_bytes_delta, int64_
         _resource_context->io_context()->update_spill_read_bytes_from_local_storage(read_bytes);
         _manager->update_spill_read_bytes(read_bytes);
     }
+}
+
+Status ExternalSpillSession::reconcile_direct_file_usage() {
+    std::lock_guard lock(_mutex);
+    for (auto& managed_path : _managed_paths) {
+        uintmax_t actual_bytes = 0;
+        std::error_code ec;
+        if (std::filesystem::exists(managed_path.path, ec)) {
+            std::filesystem::recursive_directory_iterator iterator(
+                    managed_path.path, std::filesystem::directory_options::skip_permission_denied,
+                    ec);
+            const std::filesystem::recursive_directory_iterator end;
+            while (!ec && iterator != end) {
+                if (iterator->is_regular_file(ec)) {
+                    const auto file_bytes = iterator->file_size(ec);
+                    if (!ec) {
+                        if (file_bytes > std::numeric_limits<uintmax_t>::max() - actual_bytes) {
+                            return Status::InternalError("Paimon spill directory size overflow: {}",
+                                                         managed_path.path);
+                        }
+                        actual_bytes += file_bytes;
+                    }
+                }
+                iterator.increment(ec);
+            }
+        }
+        if (ec) {
+            return Status::IOError("Failed to inspect Paimon spill directory {}: {}",
+                                   managed_path.path, ec.message());
+        }
+
+        // Buffer channel bytes are reserved before their writes. Everything else observed below
+        // the managed root belongs to Paimon implementations which write raw files directly.
+        const uintmax_t buffer_bytes = static_cast<uintmax_t>(managed_path.buffer_accounted_bytes);
+        const uintmax_t direct_file_bytes =
+                actual_bytes > buffer_bytes ? actual_bytes - buffer_bytes : 0;
+        if (direct_file_bytes <= static_cast<uintmax_t>(managed_path.direct_file_accounted_bytes)) {
+            // Keep this conservative while asynchronous compaction may still mutate raw files.
+            continue;
+        }
+        const uintmax_t delta = direct_file_bytes - managed_path.direct_file_accounted_bytes;
+        if (delta > static_cast<uintmax_t>(std::numeric_limits<int64_t>::max())) {
+            return Status::InternalError("Paimon spill directory is too large to account: {}",
+                                         managed_path.path);
+        }
+        const int64_t delta_bytes = static_cast<int64_t>(delta);
+        const int64_t accounted_bytes =
+                managed_path.buffer_accounted_bytes + managed_path.direct_file_accounted_bytes;
+        if (delta_bytes > std::numeric_limits<int64_t>::max() - accounted_bytes) {
+            return Status::InternalError("Paimon spill accounting overflows: {}",
+                                         managed_path.path);
+        }
+        if (!managed_path.data_dir->try_reserve_spill_data(delta_bytes)) {
+            return Status::Error<ErrorCode::DISK_REACH_CAPACITY_LIMIT>(
+                    "Paimon direct-file spill exceeds the Doris spill storage limit: path={}, "
+                    "bytes={}",
+                    managed_path.path, delta_bytes);
+        }
+        managed_path.direct_file_accounted_bytes += delta_bytes;
+        _resource_context->io_context()->update_spill_write_bytes_to_local_storage(delta_bytes);
+        _manager->update_spill_write_bytes(delta_bytes);
+    }
+    return Status::OK();
 }
 
 SpillFileManager::~SpillFileManager() {
@@ -275,34 +364,34 @@ Status SpillFileManager::_initialize_external_spill_session(ExternalSpillSession
     if (query_context == nullptr) {
         return Status::Cancelled("Query ended before the external spill session was initialized");
     }
-    auto* data_dir = _get_store_for_spill();
-    if (data_dir == nullptr) {
+    auto data_dirs = _get_stores_for_spill();
+    if (data_dirs.empty()) {
         return Status::Error<ErrorCode::NO_AVAILABLE_ROOT_PATH>(
                 "no available disk can be used for spill.");
     }
 
-    std::string path = data_dir->get_spill_data_path(spill_session->_query_id) + "/" +
-                       spill_session->_relative_path;
-    {
-        // Once the lease is visible, query teardown queues the query directory for the existing GC
-        // retry path instead of deleting it under an external writer. Paimon's IOManager creates
-        // its own nested channel directory lazily below this managed path.
-        std::lock_guard lock(_external_spill_leases_mutex);
-        ++_external_spill_leases[data_dir->get_spill_data_path(spill_session->_query_id)];
+    for (auto* data_dir : data_dirs) {
+        std::string path = data_dir->get_spill_data_path(spill_session->_query_id) + "/" +
+                           spill_session->_relative_path;
+        {
+            // Once the lease is visible, query teardown queues the query directory for the existing
+            // GC retry path instead of deleting it under an external writer.
+            std::lock_guard lock(_external_spill_leases_mutex);
+            ++_external_spill_leases[data_dir->get_spill_data_path(spill_session->_query_id)];
+        }
+        query_context->record_spill_data_dir(data_dir);
+        spill_session->_managed_paths.emplace_back(ExternalSpillSession::ManagedPath {
+                .data_dir = data_dir,
+                .path = std::move(path),
+        });
     }
-    query_context->record_spill_data_dir(data_dir);
-    spill_session->_data_dir = data_dir;
-    spill_session->_path = std::move(path);
     return Status::OK();
 }
 
 void SpillFileManager::_release_external_spill_session(const ExternalSpillSession* spill_session) {
-    if (spill_session->_data_dir == nullptr) {
-        return;
-    }
-    {
+    for (const auto& managed_path : spill_session->_managed_paths) {
         std::lock_guard lock(_external_spill_leases_mutex);
-        auto query_dir = spill_session->_data_dir->get_spill_data_path(spill_session->_query_id);
+        auto query_dir = managed_path.data_dir->get_spill_data_path(spill_session->_query_id);
         auto it = _external_spill_leases.find(query_dir);
         if (it != _external_spill_leases.end() && --it->second == 0) {
             _external_spill_leases.erase(it);

--- a/be/src/exec/spill/spill_file_manager.cpp
+++ b/be/src/exec/spill/spill_file_manager.cpp
@@ -25,6 +25,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <utility>
 
 #include "common/logging.h"
@@ -62,7 +63,12 @@ ExternalSpillSession::~ExternalSpillSession() {
             const int64_t accounted_bytes =
                     managed_path.buffer_accounted_bytes + managed_path.direct_file_accounted_bytes;
             if (accounted_bytes > 0) {
-                managed_path.data_dir->update_spill_data_usage(-accounted_bytes);
+                // A confirmed Java close can still leave files behind when eager physical cleanup
+                // fails. Keep those bytes charged after this callback object is destroyed; query
+                // directory GC releases them only after deletion actually succeeds.
+                _manager->_transfer_external_spill_accounting(
+                        managed_path.data_dir->get_spill_data_path(_query_id),
+                        managed_path.data_dir, accounted_bytes);
                 managed_path.buffer_accounted_bytes = 0;
                 managed_path.direct_file_accounted_bytes = 0;
             }
@@ -119,6 +125,7 @@ Status ExternalSpillSession::reserve(const std::string& path, int64_t bytes) {
                 path, bytes);
     }
     managed_path->buffer_accounted_bytes += bytes;
+    managed_path->buffer_accounted_bytes_by_path[path] += bytes;
     return Status::OK();
 }
 
@@ -139,7 +146,15 @@ void ExternalSpillSession::update_accounting(const std::string& path, int64_t cu
                     current_bytes_delta == std::numeric_limits<int64_t>::min()
                             ? std::numeric_limits<int64_t>::max()
                             : -current_bytes_delta;
-            released_bytes = std::min(requested_release, managed_path->buffer_accounted_bytes);
+            auto path_it = managed_path->buffer_accounted_bytes_by_path.find(path);
+            if (path_it == managed_path->buffer_accounted_bytes_by_path.end()) {
+                return;
+            }
+            released_bytes = std::min(requested_release, path_it->second);
+            path_it->second -= released_bytes;
+            if (path_it->second == 0) {
+                managed_path->buffer_accounted_bytes_by_path.erase(path_it);
+            }
             managed_path->buffer_accounted_bytes -= released_bytes;
         }
     }
@@ -156,25 +171,48 @@ void ExternalSpillSession::update_accounting(const std::string& path, int64_t cu
     }
 }
 
-Status ExternalSpillSession::reconcile_direct_file_usage() {
-    std::lock_guard lock(_mutex);
-    for (auto& managed_path : _managed_paths) {
+Status ExternalSpillSession::reconcile_direct_file_usage(bool allow_release) {
+    struct ObservedPathUsage {
+        std::string path;
+        std::unordered_set<std::string> buffer_paths;
+        uintmax_t bytes = 0;
+    };
+    std::vector<ObservedPathUsage> observed_paths;
+    {
+        std::lock_guard lock(_mutex);
+        observed_paths.reserve(_managed_paths.size());
+        for (const auto& managed_path : _managed_paths) {
+            ObservedPathUsage observed_path {.path = managed_path.path};
+            for (const auto& buffer_entry : managed_path.buffer_accounted_bytes_by_path) {
+                observed_path.buffer_paths.emplace(buffer_entry.first);
+            }
+            observed_paths.emplace_back(std::move(observed_path));
+        }
+    }
+
+    // Do not hold the session mutex while walking the filesystem. Buffer callbacks can continue to
+    // reserve and release capacity while a rate-limited raw-file observation is in progress.
+    for (auto& observed_path : observed_paths) {
         uintmax_t actual_bytes = 0;
         std::error_code ec;
-        if (std::filesystem::exists(managed_path.path, ec)) {
+        if (std::filesystem::exists(observed_path.path, ec)) {
             std::filesystem::recursive_directory_iterator iterator(
-                    managed_path.path, std::filesystem::directory_options::skip_permission_denied,
+                    observed_path.path, std::filesystem::directory_options::skip_permission_denied,
                     ec);
             const std::filesystem::recursive_directory_iterator end;
             while (!ec && iterator != end) {
                 if (iterator->is_regular_file(ec)) {
-                    const auto file_bytes = iterator->file_size(ec);
-                    if (!ec) {
-                        if (file_bytes > std::numeric_limits<uintmax_t>::max() - actual_bytes) {
-                            return Status::InternalError("Paimon spill directory size overflow: {}",
-                                                         managed_path.path);
+                    const auto file_path = iterator->path().string();
+                    if (!observed_path.buffer_paths.contains(file_path)) {
+                        const auto file_bytes = iterator->file_size(ec);
+                        if (!ec) {
+                            if (file_bytes > std::numeric_limits<uintmax_t>::max() - actual_bytes) {
+                                return Status::InternalError(
+                                        "Paimon spill directory size overflow: {}",
+                                        observed_path.path);
+                            }
+                            actual_bytes += file_bytes;
                         }
-                        actual_bytes += file_bytes;
                     }
                 }
                 iterator.increment(ec);
@@ -182,19 +220,29 @@ Status ExternalSpillSession::reconcile_direct_file_usage() {
         }
         if (ec) {
             return Status::IOError("Failed to inspect Paimon spill directory {}: {}",
-                                   managed_path.path, ec.message());
+                                   observed_path.path, ec.message());
         }
+        observed_path.bytes = actual_bytes;
+    }
 
-        // Buffer channel bytes are reserved before their writes. Everything else observed below
-        // the managed root belongs to Paimon implementations which write raw files directly.
-        const uintmax_t buffer_bytes = static_cast<uintmax_t>(managed_path.buffer_accounted_bytes);
-        const uintmax_t direct_file_bytes =
-                actual_bytes > buffer_bytes ? actual_bytes - buffer_bytes : 0;
-        if (direct_file_bytes <= static_cast<uintmax_t>(managed_path.direct_file_accounted_bytes)) {
-            // Keep this conservative while asynchronous compaction may still mutate raw files.
+    std::lock_guard lock(_mutex);
+    for (size_t i = 0; i < observed_paths.size(); ++i) {
+        auto& managed_path = _managed_paths[i];
+        // Account only files not already covered by BufferFileWriter callbacks.
+        const uintmax_t direct_file_bytes = observed_paths[i].bytes;
+        const uintmax_t accounted_direct_file_bytes =
+                static_cast<uintmax_t>(managed_path.direct_file_accounted_bytes);
+        if (direct_file_bytes < accounted_direct_file_bytes && allow_release) {
+            const int64_t released_bytes =
+                    static_cast<int64_t>(accounted_direct_file_bytes - direct_file_bytes);
+            managed_path.direct_file_accounted_bytes -= released_bytes;
+            managed_path.data_dir->update_spill_data_usage(-released_bytes);
+        }
+        if (direct_file_bytes <= accounted_direct_file_bytes) {
+            // Non-final observations stay conservative while compaction can mutate raw files.
             continue;
         }
-        const uintmax_t delta = direct_file_bytes - managed_path.direct_file_accounted_bytes;
+        const uintmax_t delta = direct_file_bytes - accounted_direct_file_bytes;
         if (delta > static_cast<uintmax_t>(std::numeric_limits<int64_t>::max())) {
             return Status::InternalError("Paimon spill directory is too large to account: {}",
                                          managed_path.path);
@@ -399,6 +447,39 @@ void SpillFileManager::_release_external_spill_session(const ExternalSpillSessio
     }
 }
 
+void SpillFileManager::_transfer_external_spill_accounting(const std::string& query_dir,
+                                                           SpillDataDir* data_dir, int64_t bytes) {
+    DCHECK(data_dir != nullptr);
+    DCHECK_GT(bytes, 0);
+    std::lock_guard lock(_pending_external_spill_accounting_mutex);
+    auto it = _pending_external_spill_accounting
+                      .try_emplace(query_dir, PendingExternalSpillAccounting {.data_dir = data_dir})
+                      .first;
+    DCHECK(it->second.data_dir == data_dir);
+    if (bytes > std::numeric_limits<int64_t>::max() - it->second.bytes) {
+        LOG(ERROR) << "Pending external spill accounting overflow for " << query_dir;
+        // Preserve the existing charge rather than risk releasing more bytes than were reserved.
+        return;
+    }
+    it->second.bytes += bytes;
+}
+
+void SpillFileManager::_release_pending_external_spill_accounting(const std::string& query_dir) {
+    PendingExternalSpillAccounting accounting;
+    {
+        std::lock_guard lock(_pending_external_spill_accounting_mutex);
+        auto it = _pending_external_spill_accounting.find(query_dir);
+        if (it == _pending_external_spill_accounting.end()) {
+            return;
+        }
+        accounting = it->second;
+        _pending_external_spill_accounting.erase(it);
+    }
+    if (accounting.bytes > 0) {
+        accounting.data_dir->update_spill_data_usage(-accounting.bytes);
+    }
+}
+
 bool SpillFileManager::_has_external_spill_lease(const std::string& query_dir) {
     std::lock_guard lock(_external_spill_leases_mutex);
     return _external_spill_leases.contains(query_dir);
@@ -442,7 +523,7 @@ void SpillFileManager::delete_query_spill_directory(const std::string& query_id,
 
 Status SpillFileManager::_try_delete_query_spill_directory(
         const PendingQuerySpillDirectory& pending_directory) {
-    std::lock_guard lock(_external_spill_leases_mutex);
+    std::unique_lock lock(_external_spill_leases_mutex);
     if (_external_spill_leases.contains(pending_directory.query_dir)) {
         return Status::InternalError("external spill directory is still in use: {}",
                                      pending_directory.query_dir);
@@ -451,7 +532,12 @@ Status SpillFileManager::_try_delete_query_spill_directory(
         return Status::Error<INTERNAL_ERROR>("injected query spill directory deletion failure");
     });
     const auto& fs = io::global_local_filesystem();
-    return fs->delete_directory(pending_directory.query_dir);
+    auto status = fs->delete_directory(pending_directory.query_dir);
+    lock.unlock();
+    if (status.ok()) {
+        _release_pending_external_spill_accounting(pending_directory.query_dir);
+    }
+    return status;
 }
 
 void SpillFileManager::_retry_pending_query_spill_directories() {
@@ -679,7 +765,11 @@ bool SpillDataDir::reach_capacity_limit(int64_t incoming_data_size) {
     if (_reach_disk_capacity_limit(incoming_data_size)) {
         return true;
     }
-    if (_spill_data_bytes + incoming_data_size > _spill_data_limit_bytes) {
+    // A root already at its spill limit must not be returned by the zero-byte availability probe
+    // used during path selection. Still allow a positive reservation to fill the final bytes
+    // exactly, matching try_reserve_spill_data().
+    if (_spill_data_bytes >= _spill_data_limit_bytes ||
+        incoming_data_size > _spill_data_limit_bytes - _spill_data_bytes) {
         LOG_EVERY_T(WARNING, 1) << fmt::format(
                 "spill data reach limit, path: {}, capacity: {}, limit: {}, used: {}, "
                 "available: "

--- a/be/src/exec/spill/spill_file_manager.h
+++ b/be/src/exec/spill/spill_file_manager.h
@@ -133,7 +133,7 @@ public:
 
     // Account files written directly below an IOManager temp directory by Paimon components which
     // do not use BufferFileWriter (for example lookup stores and RocksDB global indexes).
-    Status reconcile_direct_file_usage();
+    Status reconcile_direct_file_usage(bool allow_release);
 
 private:
     friend class SpillFileManager;
@@ -142,6 +142,7 @@ private:
         SpillDataDir* data_dir;
         std::string path;
         int64_t buffer_accounted_bytes = 0;
+        std::unordered_map<std::string, int64_t> buffer_accounted_bytes_by_path;
         int64_t direct_file_accounted_bytes = 0;
     };
 
@@ -203,12 +204,20 @@ private:
         std::string query_dir;
     };
 
+    struct PendingExternalSpillAccounting {
+        SpillDataDir* data_dir = nullptr;
+        int64_t bytes = 0;
+    };
+
     void _init_metrics();
     Status _init_spill_store_map();
     void _spill_gc_thread_callback();
     Status _try_delete_query_spill_directory(const PendingQuerySpillDirectory& pending_directory);
     void _retry_pending_query_spill_directories();
     Status _initialize_external_spill_session(ExternalSpillSession* spill_session);
+    void _transfer_external_spill_accounting(const std::string& query_dir, SpillDataDir* data_dir,
+                                             int64_t bytes);
+    void _release_pending_external_spill_accounting(const std::string& query_dir);
     void _release_external_spill_session(const ExternalSpillSession* spill_session);
     bool _has_external_spill_lease(const std::string& query_dir);
     std::vector<SpillDataDir*> _get_stores_for_spill(TStorageMedium::type storage_medium);
@@ -222,6 +231,10 @@ private:
 
     std::mutex _pending_query_spill_directories_mutex;
     std::vector<PendingQuerySpillDirectory> _pending_query_spill_directories;
+
+    std::mutex _pending_external_spill_accounting_mutex;
+    std::unordered_map<std::string, PendingExternalSpillAccounting>
+            _pending_external_spill_accounting;
 
     std::mutex _external_spill_leases_mutex;
     std::unordered_map<std::string, size_t> _external_spill_leases;

--- a/be/src/exec/spill/spill_file_manager.h
+++ b/be/src/exec/spill/spill_file_manager.h
@@ -64,9 +64,6 @@ public:
     // return true if limit reached, otherwise, return false.
     bool reach_capacity_limit(int64_t incoming_data_size);
 
-    // Atomically check the capacity limit and reserve spill usage for a writer.
-    bool try_reserve_spill_data(int64_t incoming_data_size);
-
     Status update_capacity();
 
     void update_spill_data_usage(int64_t incoming_data_size) {
@@ -119,7 +116,8 @@ private:
     IntGauge* spill_disk_has_spill_gc_data = nullptr;
 };
 
-// Owns one external writer's Doris spill directories, capacity reservation and I/O accounting.
+// Adapts one external writer to the same root selection, capacity accounting and query cleanup
+// used by Doris spill files.
 class ExternalSpillSession {
 public:
     ~ExternalSpillSession();
@@ -131,31 +129,21 @@ public:
     void update_accounting(const std::string& path, int64_t current_bytes_delta,
                            int64_t write_bytes, int64_t read_bytes);
 
-    // Account files written directly below an IOManager temp directory by Paimon components which
-    // do not use BufferFileWriter (for example lookup stores and RocksDB global indexes).
-    Status reconcile_direct_file_usage(bool allow_release);
-
 private:
     friend class SpillFileManager;
 
-    struct ManagedPath {
-        SpillDataDir* data_dir;
-        std::string path;
-        int64_t buffer_accounted_bytes = 0;
-        std::unordered_map<std::string, int64_t> buffer_accounted_bytes_by_path;
-        int64_t direct_file_accounted_bytes = 0;
-    };
-
     ExternalSpillSession(SpillFileManager* manager, QueryContext* query_context,
                          std::string relative_path);
-    ManagedPath* _find_managed_path(const std::string& path);
+    bool _contains(const std::string& path) const;
 
     SpillFileManager* _manager;
     std::weak_ptr<QueryContext> _query_context;
     std::shared_ptr<ResourceContext> _resource_context;
     std::string _query_id;
     std::string _relative_path;
-    std::vector<ManagedPath> _managed_paths;
+    SpillDataDir* _data_dir = nullptr;
+    std::string _path;
+    int64_t _accounted_bytes = 0;
     std::mutex _mutex;
 };
 
@@ -199,26 +187,19 @@ public:
 private:
     friend class ExternalSpillSession;
 
-    // Query-directory lifecycle shared by regular spill cleanup and external spill users. An
-    // external session may finish before or after QueryContext requests deletion, so leases,
-    // residual accounting and the deletion request must be kept in one state object.
-    struct QuerySpillDirectoryState {
+    struct PendingQuerySpillDirectory {
         int failed_count {0};
-        SpillDataDir* data_dir = nullptr;
-        int64_t external_accounted_bytes = 0;
-        size_t external_leases = 0;
-        bool delete_requested = false;
+        std::string query_dir;
     };
 
     void _init_metrics();
     Status _init_spill_store_map();
     void _spill_gc_thread_callback();
-    Status _try_delete_query_spill_directory(const std::string& query_dir);
+    Status _try_delete_query_spill_directory(const PendingQuerySpillDirectory& pending_directory);
     void _retry_pending_query_spill_directories();
     Status _initialize_external_spill_session(ExternalSpillSession* spill_session);
     void _release_external_spill_session(ExternalSpillSession* spill_session);
     std::vector<SpillDataDir*> _get_stores_for_spill(TStorageMedium::type storage_medium);
-    std::vector<SpillDataDir*> _get_stores_for_spill();
     SpillDataDir* _get_store_for_spill();
 
     std::unordered_map<std::string, std::unique_ptr<SpillDataDir>> _spill_store_map;
@@ -226,8 +207,12 @@ private:
     CountDownLatch _stop_background_threads_latch;
     std::shared_ptr<Thread> _spill_gc_thread;
 
-    std::mutex _query_spill_directories_mutex;
-    std::unordered_map<std::string, QuerySpillDirectoryState> _query_spill_directories;
+    // Query cleanup uses the regular pending-deletion path. External leases only defer deletion
+    // while an SDK task can still access the same query directory; filesystem I/O never holds this
+    // mutex.
+    std::mutex _pending_query_spill_directories_mutex;
+    std::vector<PendingQuerySpillDirectory> _pending_query_spill_directories;
+    std::unordered_map<std::string, size_t> _external_spill_directory_leases;
 
     std::atomic_uint64_t id_ = 0;
 

--- a/be/src/exec/spill/spill_file_manager.h
+++ b/be/src/exec/spill/spill_file_manager.h
@@ -20,7 +20,6 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
-#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -120,39 +119,31 @@ private:
     IntGauge* spill_disk_has_spill_gc_data = nullptr;
 };
 
-// Owns the Doris-side lifecycle and accounting for a directory written by an external spill
-// implementation. The external writer owns the physical files, while this session owns capacity
-// reservations and query/global spill metrics.
-class ExternalSpillDirectory {
+// Owns one external writer's Doris spill directory, capacity reservation and I/O accounting.
+class ExternalSpillSession {
 public:
-    ~ExternalSpillDirectory();
+    ~ExternalSpillSession();
 
-    Status get_paths(std::vector<std::string>* paths);
+    Status get_path(std::string* path);
 
-    Status reserve(const std::string& path, int64_t bytes);
+    Status reserve(int64_t bytes);
 
-    void update_accounting(const std::string& path, int64_t current_bytes_delta,
-                           int64_t write_bytes, int64_t read_bytes);
+    void update_accounting(int64_t current_bytes_delta, int64_t write_bytes, int64_t read_bytes);
 
 private:
     friend class SpillFileManager;
 
-    struct ManagedPath {
-        SpillDataDir* data_dir;
-        std::string path;
-        int64_t accounted_bytes = 0;
-    };
-
-    ExternalSpillDirectory(SpillFileManager* manager, QueryContext* query_context,
-                           std::string relative_path);
-    ManagedPath* _find_managed_path(const std::string& path);
+    ExternalSpillSession(SpillFileManager* manager, QueryContext* query_context,
+                         std::string relative_path);
 
     SpillFileManager* _manager;
-    QueryContext* _query_context;
+    std::weak_ptr<QueryContext> _query_context;
     std::shared_ptr<ResourceContext> _resource_context;
     std::string _query_id;
     std::string _relative_path;
-    std::optional<ManagedPath> _managed_path;
+    SpillDataDir* _data_dir = nullptr;
+    std::string _path;
+    int64_t _accounted_bytes = 0;
     std::mutex _mutex;
 };
 
@@ -172,10 +163,10 @@ public:
     Status create_spill_file(const std::string& relative_path, SpillFileSPtr& spill_file);
 
     // Create a lazy managed session for an external spill implementation. A spill root is selected
-    // and registered only when the external implementation actually requests its path.
-    Status create_external_spill_directory(
-            const std::string& relative_path, QueryContext* query_context,
-            std::unique_ptr<ExternalSpillDirectory>* spill_directory);
+    // and registered only when the external implementation first requests its path.
+    Status create_external_spill_session(const std::string& relative_path,
+                                         QueryContext* query_context,
+                                         std::unique_ptr<ExternalSpillSession>* spill_session);
 
     /// Get a unique ID for constructing spill file paths.
     uint64_t next_id() { return id_++; }
@@ -194,7 +185,7 @@ public:
     void update_spill_read_bytes(int64_t bytes) { _spill_read_bytes_counter->increment(bytes); }
 
 private:
-    friend class ExternalSpillDirectory;
+    friend class ExternalSpillSession;
 
     struct PendingQuerySpillDirectory {
         int failed_count {0};
@@ -206,8 +197,8 @@ private:
     void _spill_gc_thread_callback();
     Status _try_delete_query_spill_directory(const PendingQuerySpillDirectory& pending_directory);
     void _retry_pending_query_spill_directories();
-    Status _initialize_external_spill_directory(ExternalSpillDirectory* spill_directory);
-    void _release_external_spill_directory(const ExternalSpillDirectory* spill_directory);
+    Status _initialize_external_spill_session(ExternalSpillSession* spill_session);
+    void _release_external_spill_session(const ExternalSpillSession* spill_session);
     bool _has_external_spill_lease(const std::string& query_dir);
     std::vector<SpillDataDir*> _get_stores_for_spill(TStorageMedium::type storage_medium);
     std::vector<SpillDataDir*> _get_stores_for_spill();

--- a/be/src/exec/spill/spill_file_manager.h
+++ b/be/src/exec/spill/spill_file_manager.h
@@ -64,7 +64,7 @@ public:
     // return true if limit reached, otherwise, return false.
     bool reach_capacity_limit(int64_t incoming_data_size);
 
-    // Atomically check the capacity limit and reserve spill usage for an external writer.
+    // Atomically check the capacity limit and reserve spill usage for a writer.
     bool try_reserve_spill_data(int64_t incoming_data_size);
 
     Status update_capacity();
@@ -199,27 +199,24 @@ public:
 private:
     friend class ExternalSpillSession;
 
-    struct PendingQuerySpillDirectory {
+    // Query-directory lifecycle shared by regular spill cleanup and external spill users. An
+    // external session may finish before or after QueryContext requests deletion, so leases,
+    // residual accounting and the deletion request must be kept in one state object.
+    struct QuerySpillDirectoryState {
         int failed_count {0};
-        std::string query_dir;
-    };
-
-    struct PendingExternalSpillAccounting {
         SpillDataDir* data_dir = nullptr;
-        int64_t bytes = 0;
+        int64_t external_accounted_bytes = 0;
+        size_t external_leases = 0;
+        bool delete_requested = false;
     };
 
     void _init_metrics();
     Status _init_spill_store_map();
     void _spill_gc_thread_callback();
-    Status _try_delete_query_spill_directory(const PendingQuerySpillDirectory& pending_directory);
+    Status _try_delete_query_spill_directory(const std::string& query_dir);
     void _retry_pending_query_spill_directories();
     Status _initialize_external_spill_session(ExternalSpillSession* spill_session);
-    void _transfer_external_spill_accounting(const std::string& query_dir, SpillDataDir* data_dir,
-                                             int64_t bytes);
-    void _release_pending_external_spill_accounting(const std::string& query_dir);
-    void _release_external_spill_session(const ExternalSpillSession* spill_session);
-    bool _has_external_spill_lease(const std::string& query_dir);
+    void _release_external_spill_session(ExternalSpillSession* spill_session);
     std::vector<SpillDataDir*> _get_stores_for_spill(TStorageMedium::type storage_medium);
     std::vector<SpillDataDir*> _get_stores_for_spill();
     SpillDataDir* _get_store_for_spill();
@@ -229,15 +226,8 @@ private:
     CountDownLatch _stop_background_threads_latch;
     std::shared_ptr<Thread> _spill_gc_thread;
 
-    std::mutex _pending_query_spill_directories_mutex;
-    std::vector<PendingQuerySpillDirectory> _pending_query_spill_directories;
-
-    std::mutex _pending_external_spill_accounting_mutex;
-    std::unordered_map<std::string, PendingExternalSpillAccounting>
-            _pending_external_spill_accounting;
-
-    std::mutex _external_spill_leases_mutex;
-    std::unordered_map<std::string, size_t> _external_spill_leases;
+    std::mutex _query_spill_directories_mutex;
+    std::unordered_map<std::string, QuerySpillDirectoryState> _query_spill_directories;
 
     std::atomic_uint64_t id_ = 0;
 

--- a/be/src/exec/spill/spill_file_manager.h
+++ b/be/src/exec/spill/spill_file_manager.h
@@ -20,6 +20,7 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -41,6 +42,8 @@ class AtomicGauge;
 using UIntGauge = AtomicGauge<uint64_t>;
 class MetricEntity;
 struct MetricPrototype;
+class QueryContext;
+class ResourceContext;
 
 class SpillFileManager;
 class SpillDataDir {
@@ -61,6 +64,9 @@ public:
     // check if the capacity reach the limit after adding the incoming data
     // return true if limit reached, otherwise, return false.
     bool reach_capacity_limit(int64_t incoming_data_size);
+
+    // Atomically check the capacity limit and reserve spill usage for an external writer.
+    bool try_reserve_spill_data(int64_t incoming_data_size);
 
     Status update_capacity();
 
@@ -113,6 +119,43 @@ private:
     IntGauge* spill_disk_has_spill_data = nullptr;
     IntGauge* spill_disk_has_spill_gc_data = nullptr;
 };
+
+// Owns the Doris-side lifecycle and accounting for a directory written by an external spill
+// implementation. The external writer owns the physical files, while this session owns capacity
+// reservations and query/global spill metrics.
+class ExternalSpillDirectory {
+public:
+    ~ExternalSpillDirectory();
+
+    Status get_paths(std::vector<std::string>* paths);
+
+    Status reserve(const std::string& path, int64_t bytes);
+
+    void update_accounting(const std::string& path, int64_t current_bytes_delta,
+                           int64_t write_bytes, int64_t read_bytes);
+
+private:
+    friend class SpillFileManager;
+
+    struct ManagedPath {
+        SpillDataDir* data_dir;
+        std::string path;
+        int64_t accounted_bytes = 0;
+    };
+
+    ExternalSpillDirectory(SpillFileManager* manager, QueryContext* query_context,
+                           std::string relative_path);
+    ManagedPath* _find_managed_path(const std::string& path);
+
+    SpillFileManager* _manager;
+    QueryContext* _query_context;
+    std::shared_ptr<ResourceContext> _resource_context;
+    std::string _query_id;
+    std::string _relative_path;
+    std::optional<ManagedPath> _managed_path;
+    std::mutex _mutex;
+};
+
 class SpillFileManager {
 public:
     ~SpillFileManager();
@@ -127,6 +170,12 @@ public:
     // @param relative_path  Operator-formatted path under the spill root,
     //                       e.g. "query_id/sort-node_id-task_id-unique_id"
     Status create_spill_file(const std::string& relative_path, SpillFileSPtr& spill_file);
+
+    // Create a lazy managed session for an external spill implementation. A spill root is selected
+    // and registered only when the external implementation actually requests its path.
+    Status create_external_spill_directory(
+            const std::string& relative_path, QueryContext* query_context,
+            std::unique_ptr<ExternalSpillDirectory>* spill_directory);
 
     /// Get a unique ID for constructing spill file paths.
     uint64_t next_id() { return id_++; }
@@ -145,6 +194,8 @@ public:
     void update_spill_read_bytes(int64_t bytes) { _spill_read_bytes_counter->increment(bytes); }
 
 private:
+    friend class ExternalSpillDirectory;
+
     struct PendingQuerySpillDirectory {
         int failed_count {0};
         std::string query_dir;
@@ -155,7 +206,12 @@ private:
     void _spill_gc_thread_callback();
     Status _try_delete_query_spill_directory(const PendingQuerySpillDirectory& pending_directory);
     void _retry_pending_query_spill_directories();
+    Status _initialize_external_spill_directory(ExternalSpillDirectory* spill_directory);
+    void _release_external_spill_directory(const ExternalSpillDirectory* spill_directory);
+    bool _has_external_spill_lease(const std::string& query_dir);
     std::vector<SpillDataDir*> _get_stores_for_spill(TStorageMedium::type storage_medium);
+    std::vector<SpillDataDir*> _get_stores_for_spill();
+    SpillDataDir* _get_store_for_spill();
 
     std::unordered_map<std::string, std::unique_ptr<SpillDataDir>> _spill_store_map;
 
@@ -164,6 +220,9 @@ private:
 
     std::mutex _pending_query_spill_directories_mutex;
     std::vector<PendingQuerySpillDirectory> _pending_query_spill_directories;
+
+    std::mutex _external_spill_leases_mutex;
+    std::unordered_map<std::string, size_t> _external_spill_leases;
 
     std::atomic_uint64_t id_ = 0;
 

--- a/be/src/exec/spill/spill_file_manager.h
+++ b/be/src/exec/spill/spill_file_manager.h
@@ -119,31 +119,42 @@ private:
     IntGauge* spill_disk_has_spill_gc_data = nullptr;
 };
 
-// Owns one external writer's Doris spill directory, capacity reservation and I/O accounting.
+// Owns one external writer's Doris spill directories, capacity reservation and I/O accounting.
 class ExternalSpillSession {
 public:
     ~ExternalSpillSession();
 
-    Status get_path(std::string* path);
+    Status get_paths(std::vector<std::string>* paths);
 
-    Status reserve(int64_t bytes);
+    Status reserve(const std::string& path, int64_t bytes);
 
-    void update_accounting(int64_t current_bytes_delta, int64_t write_bytes, int64_t read_bytes);
+    void update_accounting(const std::string& path, int64_t current_bytes_delta,
+                           int64_t write_bytes, int64_t read_bytes);
+
+    // Account files written directly below an IOManager temp directory by Paimon components which
+    // do not use BufferFileWriter (for example lookup stores and RocksDB global indexes).
+    Status reconcile_direct_file_usage();
 
 private:
     friend class SpillFileManager;
 
+    struct ManagedPath {
+        SpillDataDir* data_dir;
+        std::string path;
+        int64_t buffer_accounted_bytes = 0;
+        int64_t direct_file_accounted_bytes = 0;
+    };
+
     ExternalSpillSession(SpillFileManager* manager, QueryContext* query_context,
                          std::string relative_path);
+    ManagedPath* _find_managed_path(const std::string& path);
 
     SpillFileManager* _manager;
     std::weak_ptr<QueryContext> _query_context;
     std::shared_ptr<ResourceContext> _resource_context;
     std::string _query_id;
     std::string _relative_path;
-    SpillDataDir* _data_dir = nullptr;
-    std::string _path;
-    int64_t _accounted_bytes = 0;
+    std::vector<ManagedPath> _managed_paths;
     std::mutex _mutex;
 };
 

--- a/be/src/exec/spill/spill_file_writer.cpp
+++ b/be/src/exec/spill/spill_file_writer.cpp
@@ -91,12 +91,27 @@ Status SpillFileWriter::_close_current_part(const std::shared_ptr<SpillFile>& sp
     _part_meta.append((const char*)&_part_max_sub_block_size, sizeof(_part_max_sub_block_size));
     _part_meta.append((const char*)&_part_written_blocks, sizeof(_part_written_blocks));
 
+    int64_t meta_size = _part_meta.size();
+    if (!_data_dir->try_reserve_spill_data(meta_size)) {
+        return Status::Error<ErrorCode::DISK_REACH_CAPACITY_LIMIT>(
+                "spill data total size exceed limit, path: {}, size limit: {}, spill data "
+                "size: {}",
+                _data_dir->path(), PrettyPrinter::print_bytes(_data_dir->get_spill_data_limit()),
+                PrettyPrinter::print_bytes(_data_dir->get_spill_data_bytes()));
+    }
+    bool write_succeeded = false;
+    Defer rollback_reservation([&]() {
+        if (!write_succeeded) {
+            _data_dir->update_spill_data_usage(-meta_size);
+        }
+    });
+
     {
         SCOPED_TIMER(_write_file_timer);
         RETURN_IF_ERROR(_file_writer->append(_part_meta));
     }
+    write_succeeded = true;
 
-    int64_t meta_size = _part_meta.size();
     _part_written_bytes += meta_size;
     _total_written_bytes += meta_size;
     COUNTER_UPDATE(_write_file_total_size, meta_size);
@@ -106,7 +121,6 @@ Status SpillFileWriter::_close_current_part(const std::shared_ptr<SpillFile>& sp
     if (_write_file_current_size) {
         COUNTER_UPDATE(_write_file_current_size, meta_size);
     }
-    _data_dir->update_spill_data_usage(meta_size);
     ExecEnv::GetInstance()->spill_file_mgr()->update_spill_write_bytes(meta_size);
     // Incrementally update SpillFile's accounting so gc() can always
     // decrement the correct amount, even if close() is never called.
@@ -226,7 +240,7 @@ Status SpillFileWriter::_write_internal(const Block& block,
             COUNTER_UPDATE(_memory_used_counter, buff_size);
             Defer defer2 {[&]() { COUNTER_UPDATE(_memory_used_counter, -buff_size); }};
         }
-        if (_data_dir->reach_capacity_limit(buff_size)) {
+        if (!_data_dir->try_reserve_spill_data(buff_size)) {
             return Status::Error<ErrorCode::DISK_REACH_CAPACITY_LIMIT>(
                     "spill data total size exceed limit, path: {}, size limit: {}, spill data "
                     "size: {}",
@@ -235,10 +249,15 @@ Status SpillFileWriter::_write_internal(const Block& block,
                     PrettyPrinter::print_bytes(_data_dir->get_spill_data_bytes()));
         }
 
+        bool write_succeeded = false;
+        Defer rollback_reservation([&]() {
+            if (!write_succeeded) {
+                _data_dir->update_spill_data_usage(-buff_size);
+            }
+        });
         {
             Defer defer {[&]() {
-                if (status.ok()) {
-                    _data_dir->update_spill_data_usage(buff_size);
+                if (write_succeeded) {
                     ExecEnv::GetInstance()->spill_file_mgr()->update_spill_write_bytes(buff_size);
 
                     _part_max_sub_block_size =
@@ -266,6 +285,7 @@ Status SpillFileWriter::_write_internal(const Block& block,
                 SCOPED_TIMER(_write_file_timer);
                 status = _file_writer->append(buff);
                 RETURN_IF_ERROR(status);
+                write_succeeded = true;
             }
         }
     }

--- a/be/src/exec/spill/spill_file_writer.cpp
+++ b/be/src/exec/spill/spill_file_writer.cpp
@@ -91,27 +91,12 @@ Status SpillFileWriter::_close_current_part(const std::shared_ptr<SpillFile>& sp
     _part_meta.append((const char*)&_part_max_sub_block_size, sizeof(_part_max_sub_block_size));
     _part_meta.append((const char*)&_part_written_blocks, sizeof(_part_written_blocks));
 
-    int64_t meta_size = _part_meta.size();
-    if (!_data_dir->try_reserve_spill_data(meta_size)) {
-        return Status::Error<ErrorCode::DISK_REACH_CAPACITY_LIMIT>(
-                "spill data total size exceed limit, path: {}, size limit: {}, spill data "
-                "size: {}",
-                _data_dir->path(), PrettyPrinter::print_bytes(_data_dir->get_spill_data_limit()),
-                PrettyPrinter::print_bytes(_data_dir->get_spill_data_bytes()));
-    }
-    bool write_succeeded = false;
-    Defer rollback_reservation([&]() {
-        if (!write_succeeded) {
-            _data_dir->update_spill_data_usage(-meta_size);
-        }
-    });
-
     {
         SCOPED_TIMER(_write_file_timer);
         RETURN_IF_ERROR(_file_writer->append(_part_meta));
     }
-    write_succeeded = true;
 
+    int64_t meta_size = _part_meta.size();
     _part_written_bytes += meta_size;
     _total_written_bytes += meta_size;
     COUNTER_UPDATE(_write_file_total_size, meta_size);
@@ -121,6 +106,7 @@ Status SpillFileWriter::_close_current_part(const std::shared_ptr<SpillFile>& sp
     if (_write_file_current_size) {
         COUNTER_UPDATE(_write_file_current_size, meta_size);
     }
+    _data_dir->update_spill_data_usage(meta_size);
     ExecEnv::GetInstance()->spill_file_mgr()->update_spill_write_bytes(meta_size);
     // Incrementally update SpillFile's accounting so gc() can always
     // decrement the correct amount, even if close() is never called.
@@ -240,7 +226,7 @@ Status SpillFileWriter::_write_internal(const Block& block,
             COUNTER_UPDATE(_memory_used_counter, buff_size);
             Defer defer2 {[&]() { COUNTER_UPDATE(_memory_used_counter, -buff_size); }};
         }
-        if (!_data_dir->try_reserve_spill_data(buff_size)) {
+        if (_data_dir->reach_capacity_limit(buff_size)) {
             return Status::Error<ErrorCode::DISK_REACH_CAPACITY_LIMIT>(
                     "spill data total size exceed limit, path: {}, size limit: {}, spill data "
                     "size: {}",
@@ -249,15 +235,10 @@ Status SpillFileWriter::_write_internal(const Block& block,
                     PrettyPrinter::print_bytes(_data_dir->get_spill_data_bytes()));
         }
 
-        bool write_succeeded = false;
-        Defer rollback_reservation([&]() {
-            if (!write_succeeded) {
-                _data_dir->update_spill_data_usage(-buff_size);
-            }
-        });
         {
             Defer defer {[&]() {
-                if (write_succeeded) {
+                if (status.ok()) {
+                    _data_dir->update_spill_data_usage(buff_size);
                     ExecEnv::GetInstance()->spill_file_mgr()->update_spill_write_bytes(buff_size);
 
                     _part_max_sub_block_size =
@@ -285,7 +266,6 @@ Status SpillFileWriter::_write_internal(const Block& block,
                 SCOPED_TIMER(_write_file_timer);
                 status = _file_writer->append(buff);
                 RETURN_IF_ERROR(status);
-                write_succeeded = true;
             }
         }
     }

--- a/be/src/util/jni-util.h
+++ b/be/src/util/jni-util.h
@@ -606,6 +606,9 @@ public:
 
     bool uninitialized() const { return _obj == nullptr; }
 
+    // Access the JNI handle without changing ownership.
+    jobject get() const { return _obj; }
+
     void reset(JNIEnv* env) {
         if (_obj == nullptr) {
             return;

--- a/be/test/exec/sink/writer/paimon/paimon_write_backend_test.cpp
+++ b/be/test/exec/sink/writer/paimon/paimon_write_backend_test.cpp
@@ -34,7 +34,7 @@ TEST(PaimonWriteBackendFactoryTest, SelectBackendType) {
 TEST(JniPaimonWriteBackendTest, OpenAbiAndWriteModes) {
     EXPECT_STREQ(
             "(Ljava/lang/String;Ljava/util/Map;[Ljava/lang/String;JLjava/lang/String;ZZLjava/lang/"
-            "String;Ljava/lang/String;JJ)V",
+            "String;JJJ)V",
             PAIMON_JNI_WRITER_OPEN_SIGNATURE);
 
     auto append = PaimonJniWriterOpenMode::from_write_mode(TPaimonWriteMode::APPEND);

--- a/be/test/vec/spill/spill_file_test.cpp
+++ b/be/test/vec/spill/spill_file_test.cpp
@@ -1352,12 +1352,11 @@ TEST_F(SpillFileTest, ManagerAllocatesExternalSpillSessionOnManagedRoot) {
     std::vector<std::string> paths;
     st = spill_session->get_paths(&paths);
     ASSERT_TRUE(st.ok()) << st.to_string();
-    ASSERT_EQ(paths.size(), 2);
+    ASSERT_EQ(paths.size(), 1);
     const std::string first_path = _data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon";
     const std::string second_path =
             _second_data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon";
-    ASSERT_TRUE(std::ranges::find(paths, first_path) != paths.end());
-    ASSERT_TRUE(std::ranges::find(paths, second_path) != paths.end());
+    ASSERT_TRUE(paths.front() == first_path || paths.front() == second_path);
     bool exists = false;
     for (const auto& path : paths) {
         st = io::global_local_filesystem()->exists(path, &exists);
@@ -1386,8 +1385,9 @@ TEST_F(SpillFileTest, ManagerAllocatesExternalSpillSessionOnManagedRoot) {
     ASSERT_TRUE(exists);
 
     spill_session.reset();
-    // The residual file remains charged after the external callback is destroyed.
-    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 768);
+    // Match SpillFile::gc(): logical usage is released with the writer, while QueryContext owns
+    // physical deletion and retries.
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 0);
     ASSERT_EQ(unselected_data_dir->get_spill_data_bytes(), 0);
 
     st = io::global_local_filesystem()->exists(query_dir, &exists);
@@ -1407,10 +1407,9 @@ TEST_F(SpillFileTest, ExternalSpillSessionSkipsFullManagedRoot) {
     auto query_id_str = print_id(query_id);
     auto query_ctx = MockQueryContext::create(query_id);
 
-    _data_dir_ptr->update_spill_data_usage(_data_dir_ptr->get_spill_data_limit());
-    Defer release_full_root([&]() {
-        _data_dir_ptr->update_spill_data_usage(-_data_dir_ptr->get_spill_data_limit());
-    });
+    const int64_t unavailable_bytes = _data_dir_ptr->get_spill_data_limit() + 1;
+    _data_dir_ptr->update_spill_data_usage(unavailable_bytes);
+    Defer release_full_root([&]() { _data_dir_ptr->update_spill_data_usage(-unavailable_bytes); });
 
     std::unique_ptr<ExternalSpillSession> spill_session;
     auto st = ExecEnv::GetInstance()->spill_file_mgr()->create_external_spill_session(
@@ -1424,97 +1423,7 @@ TEST_F(SpillFileTest, ExternalSpillSessionSkipsFullManagedRoot) {
     ASSERT_EQ(paths.front(), _second_data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon");
 }
 
-TEST_F(SpillFileTest, ExternalSpillSessionAccountsDirectFiles) {
-    TUniqueId query_id;
-    query_id.hi = 27;
-    query_id.lo = 28;
-    auto query_ctx = MockQueryContext::create(query_id);
-
-    std::unique_ptr<ExternalSpillSession> spill_session;
-    auto st = ExecEnv::GetInstance()->spill_file_mgr()->create_external_spill_session(
-            "paimon", query_ctx.get(), &spill_session);
-    ASSERT_TRUE(st.ok()) << st.to_string();
-    std::vector<std::string> paths;
-    ASSERT_TRUE(spill_session->get_paths(&paths).ok());
-
-    const std::string raw_file = paths.front() + "/rocksdb/index.sst";
-    _create_residual_file(raw_file);
-    std::filesystem::resize_file(raw_file, 2048);
-    ASSERT_TRUE(spill_session->reconcile_direct_file_usage(false).ok());
-
-    auto* selected_data_dir =
-            paths.front().starts_with(_data_dir_ptr->get_spill_data_path(print_id(query_id)))
-                    ? _data_dir_ptr
-                    : _second_data_dir_ptr;
-    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 2048);
-    spill_session.reset();
-    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 2048);
-    query_ctx.reset();
-    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 0);
-}
-
-TEST_F(SpillFileTest, ExternalSpillSessionFinalReconcileReleasesDeletedDirectFiles) {
-    TUniqueId query_id;
-    query_id.hi = 31;
-    query_id.lo = 32;
-    auto query_ctx = MockQueryContext::create(query_id);
-
-    std::unique_ptr<ExternalSpillSession> spill_session;
-    ASSERT_TRUE(ExecEnv::GetInstance()
-                        ->spill_file_mgr()
-                        ->create_external_spill_session("paimon", query_ctx.get(), &spill_session)
-                        .ok());
-    std::vector<std::string> paths;
-    ASSERT_TRUE(spill_session->get_paths(&paths).ok());
-    auto* selected_data_dir =
-            paths.front().starts_with(_data_dir_ptr->get_spill_data_path(print_id(query_id)))
-                    ? _data_dir_ptr
-                    : _second_data_dir_ptr;
-
-    const std::string raw_file = paths.front() + "/rocksdb/index.sst";
-    _create_residual_file(raw_file);
-    std::filesystem::resize_file(raw_file, 2048);
-    ASSERT_TRUE(spill_session->reconcile_direct_file_usage(false).ok());
-    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 2048);
-
-    ASSERT_TRUE(io::global_local_filesystem()->delete_file(raw_file).ok());
-    ASSERT_TRUE(spill_session->reconcile_direct_file_usage(false).ok());
-    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 2048);
-    ASSERT_TRUE(spill_session->reconcile_direct_file_usage(true).ok());
-    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 0);
-}
-
-TEST_F(SpillFileTest, ExternalSpillSessionDoesNotScanTrackedBufferFiles) {
-    TUniqueId query_id;
-    query_id.hi = 35;
-    query_id.lo = 36;
-    auto query_ctx = MockQueryContext::create(query_id);
-
-    std::unique_ptr<ExternalSpillSession> spill_session;
-    ASSERT_TRUE(ExecEnv::GetInstance()
-                        ->spill_file_mgr()
-                        ->create_external_spill_session("paimon", query_ctx.get(), &spill_session)
-                        .ok());
-    std::vector<std::string> paths;
-    ASSERT_TRUE(spill_session->get_paths(&paths).ok());
-    auto* selected_data_dir =
-            paths.front().starts_with(_data_dir_ptr->get_spill_data_path(print_id(query_id)))
-                    ? _data_dir_ptr
-                    : _second_data_dir_ptr;
-
-    const std::string channel = paths.front() + "/paimon-io/channel";
-    ASSERT_TRUE(spill_session->reserve(channel, 1024).ok());
-    _create_residual_file(channel);
-    std::filesystem::resize_file(channel, 1024);
-    ASSERT_TRUE(spill_session->reconcile_direct_file_usage(false).ok());
-    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 1024);
-
-    ASSERT_TRUE(io::global_local_filesystem()->delete_file(channel).ok());
-    spill_session->update_accounting(channel, -1024, 0, 0);
-    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 0);
-}
-
-TEST_F(SpillFileTest, ExternalSpillAccountingStaysChargedUntilGcRetrySucceeds) {
+TEST_F(SpillFileTest, ExternalSpillDirectoryCleanupRetriesAfterLeaseRelease) {
     ExecEnv::GetInstance()->spill_file_mgr()->stop();
     TUniqueId query_id;
     query_id.hi = 33;
@@ -1543,51 +1452,25 @@ TEST_F(SpillFileTest, ExternalSpillAccountingStaysChargedUntilGcRetrySucceeds) {
         config::enable_debug_points = previous_enable_debug_points;
     });
     auto debug_point = std::make_shared<DebugPoint>();
-    // QueryContext touched every managed root. Fail the first deletion on each root so this test
-    // does not depend on the iteration order of the pending-directory registry.
-    debug_point->execute_limit = static_cast<int64_t>(paths.size());
+    debug_point->execute_limit = 1;
     config::enable_debug_points = true;
     DebugPoints::instance()->add(debug_point_name, debug_point);
 
     query_ctx.reset();
     spill_session.reset();
-    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 1024);
-
-    ExecEnv::GetInstance()->spill_file_mgr()->gc(10000);
-    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 1024);
-    ExecEnv::GetInstance()->spill_file_mgr()->gc(10000);
     ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 0);
-}
 
-TEST_F(SpillFileTest, ExternalSpillSessionRejectsDirectFilesOverCapacity) {
-    TUniqueId query_id;
-    query_id.hi = 29;
-    query_id.lo = 30;
-    auto query_ctx = MockQueryContext::create(query_id);
+    const auto query_dir = selected_data_dir->get_spill_data_path(print_id(query_id));
+    bool exists = false;
+    ASSERT_TRUE(io::global_local_filesystem()->exists(query_dir, &exists).ok());
+    ASSERT_TRUE(exists);
 
-    std::unique_ptr<ExternalSpillSession> spill_session;
-    auto st = ExecEnv::GetInstance()->spill_file_mgr()->create_external_spill_session(
-            "paimon", query_ctx.get(), &spill_session);
-    ASSERT_TRUE(st.ok()) << st.to_string();
-    std::vector<std::string> paths;
-    ASSERT_TRUE(spill_session->get_paths(&paths).ok());
-
-    auto* selected_data_dir =
-            paths.front().starts_with(_data_dir_ptr->get_spill_data_path(print_id(query_id)))
-                    ? _data_dir_ptr
-                    : _second_data_dir_ptr;
-    const int64_t prefilled_bytes = selected_data_dir->get_spill_data_limit() - 1024;
-    selected_data_dir->update_spill_data_usage(prefilled_bytes);
-    Defer release_prefilled_bytes(
-            [&]() { selected_data_dir->update_spill_data_usage(-prefilled_bytes); });
-
-    const std::string raw_file = paths.front() + "/lookup/level-0";
-    _create_residual_file(raw_file);
-    std::filesystem::resize_file(raw_file, 2048);
-    st = spill_session->reconcile_direct_file_usage(false);
-    ASSERT_FALSE(st.ok());
-    ASSERT_NE(st.to_string().find("spill storage limit"), std::string::npos) << st.to_string();
-    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), prefilled_bytes);
+    ExecEnv::GetInstance()->spill_file_mgr()->gc(10000);
+    ASSERT_TRUE(io::global_local_filesystem()->exists(query_dir, &exists).ok());
+    ASSERT_TRUE(exists);
+    ExecEnv::GetInstance()->spill_file_mgr()->gc(10000);
+    ASSERT_TRUE(io::global_local_filesystem()->exists(query_dir, &exists).ok());
+    ASSERT_FALSE(exists);
 }
 
 TEST_F(SpillFileTest, ExternalSpillSessionIsLazyWhenNoRootAvailable) {

--- a/be/test/vec/spill/spill_file_test.cpp
+++ b/be/test/vec/spill/spill_file_test.cpp
@@ -1366,15 +1366,16 @@ TEST_F(SpillFileTest, ManagerAllocatesExternalSpillSessionOnManagedRoot) {
     }
 
     const std::string& selected_path = paths.front();
-    ASSERT_TRUE(spill_session->reserve(selected_path + "/paimon-io-test/channel", 1024).ok());
+    const std::string channel = selected_path + "/paimon-io-test/channel";
+    ASSERT_TRUE(spill_session->reserve(channel, 1024).ok());
     auto* selected_data_dir = selected_path == first_path ? _data_dir_ptr : _second_data_dir_ptr;
     auto* unselected_data_dir =
             selected_data_dir == _data_dir_ptr ? _second_data_dir_ptr : _data_dir_ptr;
     ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 1024);
     ASSERT_EQ(unselected_data_dir->get_spill_data_bytes(), 0);
-    spill_session->update_accounting(selected_path, -256, 0, 0);
+    spill_session->update_accounting(channel, -256, 0, 0);
     ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 768);
-    _create_residual_file(selected_path + "/paimon-io-test/channel");
+    _create_residual_file(channel);
 
     // Query teardown must not remove a directory while an asynchronous external writer can still
     // use its native callback. The regular spill GC handles deferred cleanup after lease release.
@@ -1542,7 +1543,9 @@ TEST_F(SpillFileTest, ExternalSpillAccountingStaysChargedUntilGcRetrySucceeds) {
         config::enable_debug_points = previous_enable_debug_points;
     });
     auto debug_point = std::make_shared<DebugPoint>();
-    debug_point->execute_limit = 1;
+    // QueryContext touched every managed root. Fail the first deletion on each root so this test
+    // does not depend on the iteration order of the pending-directory registry.
+    debug_point->execute_limit = static_cast<int64_t>(paths.size());
     config::enable_debug_points = true;
     DebugPoints::instance()->add(debug_point_name, debug_point);
 

--- a/be/test/vec/spill/spill_file_test.cpp
+++ b/be/test/vec/spill/spill_file_test.cpp
@@ -1337,39 +1337,39 @@ TEST_F(SpillFileTest, ManagerNextId) {
     ASSERT_EQ(id3, id2 + 1);
 }
 
-TEST_F(SpillFileTest, ManagerAllocatesExternalSpillDirectoryOnManagedRoot) {
+TEST_F(SpillFileTest, ManagerAllocatesExternalSpillSessionOnManagedRoot) {
     TUniqueId query_id;
     query_id.hi = 21;
     query_id.lo = 22;
     auto query_id_str = print_id(query_id);
     auto query_ctx = MockQueryContext::create(query_id);
 
-    std::unique_ptr<ExternalSpillDirectory> spill_directory;
-    auto st = ExecEnv::GetInstance()->spill_file_mgr()->create_external_spill_directory(
-            "paimon", query_ctx.get(), &spill_directory);
+    std::unique_ptr<ExternalSpillSession> spill_session;
+    auto st = ExecEnv::GetInstance()->spill_file_mgr()->create_external_spill_session(
+            "paimon", query_ctx.get(), &spill_session);
 
     ASSERT_TRUE(st.ok()) << st.to_string();
-    std::vector<std::string> paths;
-    st = spill_directory->get_paths(&paths);
+    std::string path;
+    st = spill_session->get_path(&path);
     ASSERT_TRUE(st.ok()) << st.to_string();
-    ASSERT_EQ(paths.size(), 1);
-    ASSERT_TRUE(paths[0] == _data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon" ||
-                paths[0] == _second_data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon");
+    ASSERT_TRUE(path == _data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon" ||
+                path == _second_data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon");
     bool exists = false;
-    st = io::global_local_filesystem()->exists(paths[0], &exists);
+    st = io::global_local_filesystem()->exists(path, &exists);
     ASSERT_TRUE(st.ok());
     ASSERT_FALSE(exists);
 
-    ASSERT_TRUE(spill_directory->reserve(paths[0] + "/channel", 1024).ok());
-    auto* selected_data_dir =
-            paths[0] == _data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon"
-                    ? _data_dir_ptr
-                    : _second_data_dir_ptr;
+    ASSERT_TRUE(spill_session->reserve(1024).ok());
+    auto* selected_data_dir = path == _data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon"
+                                      ? _data_dir_ptr
+                                      : _second_data_dir_ptr;
     auto* unselected_data_dir =
             selected_data_dir == _data_dir_ptr ? _second_data_dir_ptr : _data_dir_ptr;
     ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 1024);
     ASSERT_EQ(unselected_data_dir->get_spill_data_bytes(), 0);
-    _create_residual_file(paths[0] + "/paimon-io-test/channel");
+    spill_session->update_accounting(-256, 0, 0);
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 768);
+    _create_residual_file(path + "/paimon-io-test/channel");
 
     // Query teardown must not remove a directory while an asynchronous external writer can still
     // use its native callback. The regular spill GC handles deferred cleanup after lease release.
@@ -1379,7 +1379,7 @@ TEST_F(SpillFileTest, ManagerAllocatesExternalSpillDirectoryOnManagedRoot) {
     ASSERT_TRUE(st.ok());
     ASSERT_TRUE(exists);
 
-    spill_directory.reset();
+    spill_session.reset();
     ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 0);
     ASSERT_EQ(unselected_data_dir->get_spill_data_bytes(), 0);
 
@@ -1392,7 +1392,7 @@ TEST_F(SpillFileTest, ManagerAllocatesExternalSpillDirectoryOnManagedRoot) {
     ASSERT_FALSE(exists);
 }
 
-TEST_F(SpillFileTest, ExternalSpillDirectorySkipsFullManagedRoot) {
+TEST_F(SpillFileTest, ExternalSpillSessionSkipsFullManagedRoot) {
     TUniqueId query_id;
     query_id.hi = 23;
     query_id.lo = 24;
@@ -1404,19 +1404,18 @@ TEST_F(SpillFileTest, ExternalSpillDirectorySkipsFullManagedRoot) {
         _data_dir_ptr->update_spill_data_usage(-_data_dir_ptr->get_spill_data_limit());
     });
 
-    std::unique_ptr<ExternalSpillDirectory> spill_directory;
-    auto st = ExecEnv::GetInstance()->spill_file_mgr()->create_external_spill_directory(
-            "paimon", query_ctx.get(), &spill_directory);
+    std::unique_ptr<ExternalSpillSession> spill_session;
+    auto st = ExecEnv::GetInstance()->spill_file_mgr()->create_external_spill_session(
+            "paimon", query_ctx.get(), &spill_session);
     ASSERT_TRUE(st.ok()) << st.to_string();
 
-    std::vector<std::string> paths;
-    st = spill_directory->get_paths(&paths);
+    std::string path;
+    st = spill_session->get_path(&path);
     ASSERT_TRUE(st.ok()) << st.to_string();
-    ASSERT_EQ(paths, std::vector<std::string> {
-                             _second_data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon"});
+    ASSERT_EQ(path, _second_data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon");
 }
 
-TEST_F(SpillFileTest, ExternalSpillDirectoryIsLazyWhenNoRootAvailable) {
+TEST_F(SpillFileTest, ExternalSpillSessionIsLazyWhenNoRootAvailable) {
     TUniqueId query_id;
     query_id.hi = 25;
     query_id.lo = 26;
@@ -1430,11 +1429,11 @@ TEST_F(SpillFileTest, ExternalSpillDirectoryIsLazyWhenNoRootAvailable) {
                 -_second_data_dir_ptr->get_spill_data_limit());
     });
 
-    std::unique_ptr<ExternalSpillDirectory> spill_directory;
-    auto st = ExecEnv::GetInstance()->spill_file_mgr()->create_external_spill_directory(
-            "paimon", query_ctx.get(), &spill_directory);
+    std::unique_ptr<ExternalSpillSession> spill_session;
+    auto st = ExecEnv::GetInstance()->spill_file_mgr()->create_external_spill_session(
+            "paimon", query_ctx.get(), &spill_session);
     ASSERT_TRUE(st.ok()) << st.to_string();
-    ASSERT_NE(spill_directory, nullptr);
+    ASSERT_NE(spill_session, nullptr);
 }
 
 TEST_F(SpillFileTest, ManagerCreateMultipleFiles) {

--- a/be/test/vec/spill/spill_file_test.cpp
+++ b/be/test/vec/spill/spill_file_test.cpp
@@ -1385,7 +1385,8 @@ TEST_F(SpillFileTest, ManagerAllocatesExternalSpillSessionOnManagedRoot) {
     ASSERT_TRUE(exists);
 
     spill_session.reset();
-    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 0);
+    // The residual file remains charged after the external callback is destroyed.
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 768);
     ASSERT_EQ(unselected_data_dir->get_spill_data_bytes(), 0);
 
     st = io::global_local_filesystem()->exists(query_dir, &exists);
@@ -1395,6 +1396,7 @@ TEST_F(SpillFileTest, ManagerAllocatesExternalSpillSessionOnManagedRoot) {
     st = io::global_local_filesystem()->exists(query_dir, &exists);
     ASSERT_TRUE(st.ok());
     ASSERT_FALSE(exists);
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 0);
 }
 
 TEST_F(SpillFileTest, ExternalSpillSessionSkipsFullManagedRoot) {
@@ -1437,7 +1439,7 @@ TEST_F(SpillFileTest, ExternalSpillSessionAccountsDirectFiles) {
     const std::string raw_file = paths.front() + "/rocksdb/index.sst";
     _create_residual_file(raw_file);
     std::filesystem::resize_file(raw_file, 2048);
-    ASSERT_TRUE(spill_session->reconcile_direct_file_usage().ok());
+    ASSERT_TRUE(spill_session->reconcile_direct_file_usage(false).ok());
 
     auto* selected_data_dir =
             paths.front().starts_with(_data_dir_ptr->get_spill_data_path(print_id(query_id)))
@@ -1445,6 +1447,112 @@ TEST_F(SpillFileTest, ExternalSpillSessionAccountsDirectFiles) {
                     : _second_data_dir_ptr;
     ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 2048);
     spill_session.reset();
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 2048);
+    query_ctx.reset();
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 0);
+}
+
+TEST_F(SpillFileTest, ExternalSpillSessionFinalReconcileReleasesDeletedDirectFiles) {
+    TUniqueId query_id;
+    query_id.hi = 31;
+    query_id.lo = 32;
+    auto query_ctx = MockQueryContext::create(query_id);
+
+    std::unique_ptr<ExternalSpillSession> spill_session;
+    ASSERT_TRUE(ExecEnv::GetInstance()
+                        ->spill_file_mgr()
+                        ->create_external_spill_session("paimon", query_ctx.get(), &spill_session)
+                        .ok());
+    std::vector<std::string> paths;
+    ASSERT_TRUE(spill_session->get_paths(&paths).ok());
+    auto* selected_data_dir =
+            paths.front().starts_with(_data_dir_ptr->get_spill_data_path(print_id(query_id)))
+                    ? _data_dir_ptr
+                    : _second_data_dir_ptr;
+
+    const std::string raw_file = paths.front() + "/rocksdb/index.sst";
+    _create_residual_file(raw_file);
+    std::filesystem::resize_file(raw_file, 2048);
+    ASSERT_TRUE(spill_session->reconcile_direct_file_usage(false).ok());
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 2048);
+
+    ASSERT_TRUE(io::global_local_filesystem()->delete_file(raw_file).ok());
+    ASSERT_TRUE(spill_session->reconcile_direct_file_usage(false).ok());
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 2048);
+    ASSERT_TRUE(spill_session->reconcile_direct_file_usage(true).ok());
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 0);
+}
+
+TEST_F(SpillFileTest, ExternalSpillSessionDoesNotScanTrackedBufferFiles) {
+    TUniqueId query_id;
+    query_id.hi = 35;
+    query_id.lo = 36;
+    auto query_ctx = MockQueryContext::create(query_id);
+
+    std::unique_ptr<ExternalSpillSession> spill_session;
+    ASSERT_TRUE(ExecEnv::GetInstance()
+                        ->spill_file_mgr()
+                        ->create_external_spill_session("paimon", query_ctx.get(), &spill_session)
+                        .ok());
+    std::vector<std::string> paths;
+    ASSERT_TRUE(spill_session->get_paths(&paths).ok());
+    auto* selected_data_dir =
+            paths.front().starts_with(_data_dir_ptr->get_spill_data_path(print_id(query_id)))
+                    ? _data_dir_ptr
+                    : _second_data_dir_ptr;
+
+    const std::string channel = paths.front() + "/paimon-io/channel";
+    ASSERT_TRUE(spill_session->reserve(channel, 1024).ok());
+    _create_residual_file(channel);
+    std::filesystem::resize_file(channel, 1024);
+    ASSERT_TRUE(spill_session->reconcile_direct_file_usage(false).ok());
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 1024);
+
+    ASSERT_TRUE(io::global_local_filesystem()->delete_file(channel).ok());
+    spill_session->update_accounting(channel, -1024, 0, 0);
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 0);
+}
+
+TEST_F(SpillFileTest, ExternalSpillAccountingStaysChargedUntilGcRetrySucceeds) {
+    ExecEnv::GetInstance()->spill_file_mgr()->stop();
+    TUniqueId query_id;
+    query_id.hi = 33;
+    query_id.lo = 34;
+    auto query_ctx = MockQueryContext::create(query_id);
+
+    std::unique_ptr<ExternalSpillSession> spill_session;
+    ASSERT_TRUE(ExecEnv::GetInstance()
+                        ->spill_file_mgr()
+                        ->create_external_spill_session("paimon", query_ctx.get(), &spill_session)
+                        .ok());
+    std::vector<std::string> paths;
+    ASSERT_TRUE(spill_session->get_paths(&paths).ok());
+    auto* selected_data_dir =
+            paths.front().starts_with(_data_dir_ptr->get_spill_data_path(print_id(query_id)))
+                    ? _data_dir_ptr
+                    : _second_data_dir_ptr;
+    ASSERT_TRUE(spill_session->reserve(paths.front() + "/paimon-io/channel", 1024).ok());
+    _create_residual_file(paths.front() + "/paimon-io/channel");
+
+    const bool previous_enable_debug_points = config::enable_debug_points;
+    constexpr auto debug_point_name =
+            "fault_inject::spill_file_manager::delete_query_spill_directory";
+    Defer restore_debug_point([&] {
+        DebugPoints::instance()->remove(debug_point_name);
+        config::enable_debug_points = previous_enable_debug_points;
+    });
+    auto debug_point = std::make_shared<DebugPoint>();
+    debug_point->execute_limit = 1;
+    config::enable_debug_points = true;
+    DebugPoints::instance()->add(debug_point_name, debug_point);
+
+    query_ctx.reset();
+    spill_session.reset();
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 1024);
+
+    ExecEnv::GetInstance()->spill_file_mgr()->gc(10000);
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 1024);
+    ExecEnv::GetInstance()->spill_file_mgr()->gc(10000);
     ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 0);
 }
 
@@ -1473,7 +1581,7 @@ TEST_F(SpillFileTest, ExternalSpillSessionRejectsDirectFilesOverCapacity) {
     const std::string raw_file = paths.front() + "/lookup/level-0";
     _create_residual_file(raw_file);
     std::filesystem::resize_file(raw_file, 2048);
-    st = spill_session->reconcile_direct_file_usage();
+    st = spill_session->reconcile_direct_file_usage(false);
     ASSERT_FALSE(st.ok());
     ASSERT_NE(st.to_string().find("spill storage limit"), std::string::npos) << st.to_string();
     ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), prefilled_bytes);

--- a/be/test/vec/spill/spill_file_test.cpp
+++ b/be/test/vec/spill/spill_file_test.cpp
@@ -1349,27 +1349,32 @@ TEST_F(SpillFileTest, ManagerAllocatesExternalSpillSessionOnManagedRoot) {
             "paimon", query_ctx.get(), &spill_session);
 
     ASSERT_TRUE(st.ok()) << st.to_string();
-    std::string path;
-    st = spill_session->get_path(&path);
+    std::vector<std::string> paths;
+    st = spill_session->get_paths(&paths);
     ASSERT_TRUE(st.ok()) << st.to_string();
-    ASSERT_TRUE(path == _data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon" ||
-                path == _second_data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon");
+    ASSERT_EQ(paths.size(), 2);
+    const std::string first_path = _data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon";
+    const std::string second_path =
+            _second_data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon";
+    ASSERT_TRUE(std::ranges::find(paths, first_path) != paths.end());
+    ASSERT_TRUE(std::ranges::find(paths, second_path) != paths.end());
     bool exists = false;
-    st = io::global_local_filesystem()->exists(path, &exists);
-    ASSERT_TRUE(st.ok());
-    ASSERT_FALSE(exists);
+    for (const auto& path : paths) {
+        st = io::global_local_filesystem()->exists(path, &exists);
+        ASSERT_TRUE(st.ok());
+        ASSERT_FALSE(exists);
+    }
 
-    ASSERT_TRUE(spill_session->reserve(1024).ok());
-    auto* selected_data_dir = path == _data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon"
-                                      ? _data_dir_ptr
-                                      : _second_data_dir_ptr;
+    const std::string& selected_path = paths.front();
+    ASSERT_TRUE(spill_session->reserve(selected_path + "/paimon-io-test/channel", 1024).ok());
+    auto* selected_data_dir = selected_path == first_path ? _data_dir_ptr : _second_data_dir_ptr;
     auto* unselected_data_dir =
             selected_data_dir == _data_dir_ptr ? _second_data_dir_ptr : _data_dir_ptr;
     ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 1024);
     ASSERT_EQ(unselected_data_dir->get_spill_data_bytes(), 0);
-    spill_session->update_accounting(-256, 0, 0);
+    spill_session->update_accounting(selected_path, -256, 0, 0);
     ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 768);
-    _create_residual_file(path + "/paimon-io-test/channel");
+    _create_residual_file(selected_path + "/paimon-io-test/channel");
 
     // Query teardown must not remove a directory while an asynchronous external writer can still
     // use its native callback. The regular spill GC handles deferred cleanup after lease release.
@@ -1409,10 +1414,69 @@ TEST_F(SpillFileTest, ExternalSpillSessionSkipsFullManagedRoot) {
             "paimon", query_ctx.get(), &spill_session);
     ASSERT_TRUE(st.ok()) << st.to_string();
 
-    std::string path;
-    st = spill_session->get_path(&path);
+    std::vector<std::string> paths;
+    st = spill_session->get_paths(&paths);
     ASSERT_TRUE(st.ok()) << st.to_string();
-    ASSERT_EQ(path, _second_data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon");
+    ASSERT_EQ(paths.size(), 1);
+    ASSERT_EQ(paths.front(), _second_data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon");
+}
+
+TEST_F(SpillFileTest, ExternalSpillSessionAccountsDirectFiles) {
+    TUniqueId query_id;
+    query_id.hi = 27;
+    query_id.lo = 28;
+    auto query_ctx = MockQueryContext::create(query_id);
+
+    std::unique_ptr<ExternalSpillSession> spill_session;
+    auto st = ExecEnv::GetInstance()->spill_file_mgr()->create_external_spill_session(
+            "paimon", query_ctx.get(), &spill_session);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    std::vector<std::string> paths;
+    ASSERT_TRUE(spill_session->get_paths(&paths).ok());
+
+    const std::string raw_file = paths.front() + "/rocksdb/index.sst";
+    _create_residual_file(raw_file);
+    std::filesystem::resize_file(raw_file, 2048);
+    ASSERT_TRUE(spill_session->reconcile_direct_file_usage().ok());
+
+    auto* selected_data_dir =
+            paths.front().starts_with(_data_dir_ptr->get_spill_data_path(print_id(query_id)))
+                    ? _data_dir_ptr
+                    : _second_data_dir_ptr;
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 2048);
+    spill_session.reset();
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 0);
+}
+
+TEST_F(SpillFileTest, ExternalSpillSessionRejectsDirectFilesOverCapacity) {
+    TUniqueId query_id;
+    query_id.hi = 29;
+    query_id.lo = 30;
+    auto query_ctx = MockQueryContext::create(query_id);
+
+    std::unique_ptr<ExternalSpillSession> spill_session;
+    auto st = ExecEnv::GetInstance()->spill_file_mgr()->create_external_spill_session(
+            "paimon", query_ctx.get(), &spill_session);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    std::vector<std::string> paths;
+    ASSERT_TRUE(spill_session->get_paths(&paths).ok());
+
+    auto* selected_data_dir =
+            paths.front().starts_with(_data_dir_ptr->get_spill_data_path(print_id(query_id)))
+                    ? _data_dir_ptr
+                    : _second_data_dir_ptr;
+    const int64_t prefilled_bytes = selected_data_dir->get_spill_data_limit() - 1024;
+    selected_data_dir->update_spill_data_usage(prefilled_bytes);
+    Defer release_prefilled_bytes(
+            [&]() { selected_data_dir->update_spill_data_usage(-prefilled_bytes); });
+
+    const std::string raw_file = paths.front() + "/lookup/level-0";
+    _create_residual_file(raw_file);
+    std::filesystem::resize_file(raw_file, 2048);
+    st = spill_session->reconcile_direct_file_usage();
+    ASSERT_FALSE(st.ok());
+    ASSERT_NE(st.to_string().find("spill storage limit"), std::string::npos) << st.to_string();
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), prefilled_bytes);
 }
 
 TEST_F(SpillFileTest, ExternalSpillSessionIsLazyWhenNoRootAvailable) {

--- a/be/test/vec/spill/spill_file_test.cpp
+++ b/be/test/vec/spill/spill_file_test.cpp
@@ -93,7 +93,7 @@ protected:
         auto st = io::global_local_filesystem()->create_directory(spill_data_dir->path(), false);
         ASSERT_TRUE(st.ok()) << "create directory failed: " << st.to_string();
         auto second_spill_data_dir = std::make_unique<SpillDataDir>(
-                _second_spill_dir, 1024L * 1024 * 128, TStorageMedium::HDD);
+                _second_spill_dir, 1024L * 1024 * 128, TStorageMedium::SSD);
         st = io::global_local_filesystem()->create_directory(second_spill_data_dir->path(), false);
         ASSERT_TRUE(st.ok()) << "create directory failed: " << st.to_string();
 
@@ -417,10 +417,15 @@ TEST_F(SpillFileTest, OpenCanRetryAfterFailure) {
         ASSERT_TRUE(st.ok());
     }
 
-    const auto part_path =
+    const auto first_part_path =
             std::filesystem::path(_spill_dir) / "spill" / "test_query" / "open_retry" / "0";
-    const auto backup_path =
-            std::filesystem::path(_spill_dir) / "spill" / "test_query" / "open_retry" / "0.bak";
+    const auto second_part_path =
+            std::filesystem::path(_second_spill_dir) / "spill" / "test_query" / "open_retry" / "0";
+    const auto part_path =
+            std::filesystem::exists(first_part_path) ? first_part_path : second_part_path;
+    ASSERT_TRUE(std::filesystem::exists(part_path));
+    auto backup_path = part_path;
+    backup_path += ".bak";
 
     std::filesystem::rename(part_path, backup_path);
 
@@ -935,13 +940,17 @@ TEST_F(SpillFileTest, GCCleansUpFiles) {
         st = writer->close();
         ASSERT_TRUE(st.ok());
 
-        // Remember the spill directory path
-        spill_file_dir = _data_dir_ptr->get_spill_data_path() + "/test_query/gc_test";
-
-        // Verify directory exists
+        // Remember the selected spill directory path.
         bool exists = false;
-        st = io::global_local_filesystem()->exists(spill_file_dir, &exists);
-        ASSERT_TRUE(st.ok());
+        for (auto* data_dir : {_data_dir_ptr, _second_data_dir_ptr}) {
+            auto candidate = data_dir->get_spill_data_path() + "/test_query/gc_test";
+            st = io::global_local_filesystem()->exists(candidate, &exists);
+            ASSERT_TRUE(st.ok());
+            if (exists) {
+                spill_file_dir = std::move(candidate);
+                break;
+            }
+        }
         ASSERT_TRUE(exists);
 
         // spill_file goes out of scope here, destructor calls gc()
@@ -1295,10 +1304,17 @@ TEST_F(SpillFileTest, DeleteSpillFileThroughManagerSynchronously) {
     st = writer->close();
     ASSERT_TRUE(st.ok());
 
-    auto spill_file_dir = _data_dir_ptr->get_spill_data_path("test_query/mgr_delete");
+    std::string spill_file_dir;
     bool exists = false;
-    st = io::global_local_filesystem()->exists(spill_file_dir, &exists);
-    ASSERT_TRUE(st.ok());
+    for (auto* data_dir : {_data_dir_ptr, _second_data_dir_ptr}) {
+        auto candidate = data_dir->get_spill_data_path("test_query/mgr_delete");
+        st = io::global_local_filesystem()->exists(candidate, &exists);
+        ASSERT_TRUE(st.ok());
+        if (exists) {
+            spill_file_dir = std::move(candidate);
+            break;
+        }
+    }
     ASSERT_TRUE(exists);
 
     ExecEnv::GetInstance()->spill_file_mgr()->delete_spill_file(spill_file);
@@ -1319,6 +1335,106 @@ TEST_F(SpillFileTest, ManagerNextId) {
 
     ASSERT_EQ(id2, id1 + 1);
     ASSERT_EQ(id3, id2 + 1);
+}
+
+TEST_F(SpillFileTest, ManagerAllocatesExternalSpillDirectoryOnManagedRoot) {
+    TUniqueId query_id;
+    query_id.hi = 21;
+    query_id.lo = 22;
+    auto query_id_str = print_id(query_id);
+    auto query_ctx = MockQueryContext::create(query_id);
+
+    std::unique_ptr<ExternalSpillDirectory> spill_directory;
+    auto st = ExecEnv::GetInstance()->spill_file_mgr()->create_external_spill_directory(
+            "paimon", query_ctx.get(), &spill_directory);
+
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    std::vector<std::string> paths;
+    st = spill_directory->get_paths(&paths);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(paths.size(), 1);
+    ASSERT_TRUE(paths[0] == _data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon" ||
+                paths[0] == _second_data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon");
+    bool exists = false;
+    st = io::global_local_filesystem()->exists(paths[0], &exists);
+    ASSERT_TRUE(st.ok());
+    ASSERT_FALSE(exists);
+
+    ASSERT_TRUE(spill_directory->reserve(paths[0] + "/channel", 1024).ok());
+    auto* selected_data_dir =
+            paths[0] == _data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon"
+                    ? _data_dir_ptr
+                    : _second_data_dir_ptr;
+    auto* unselected_data_dir =
+            selected_data_dir == _data_dir_ptr ? _second_data_dir_ptr : _data_dir_ptr;
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 1024);
+    ASSERT_EQ(unselected_data_dir->get_spill_data_bytes(), 0);
+    _create_residual_file(paths[0] + "/paimon-io-test/channel");
+
+    // Query teardown must not remove a directory while an asynchronous external writer can still
+    // use its native callback. The regular spill GC handles deferred cleanup after lease release.
+    query_ctx.reset();
+    auto query_dir = selected_data_dir->get_spill_data_path(query_id_str);
+    st = io::global_local_filesystem()->exists(query_dir, &exists);
+    ASSERT_TRUE(st.ok());
+    ASSERT_TRUE(exists);
+
+    spill_directory.reset();
+    ASSERT_EQ(selected_data_dir->get_spill_data_bytes(), 0);
+    ASSERT_EQ(unselected_data_dir->get_spill_data_bytes(), 0);
+
+    st = io::global_local_filesystem()->exists(query_dir, &exists);
+    ASSERT_TRUE(st.ok());
+    ASSERT_TRUE(exists);
+    ExecEnv::GetInstance()->spill_file_mgr()->gc(10000);
+    st = io::global_local_filesystem()->exists(query_dir, &exists);
+    ASSERT_TRUE(st.ok());
+    ASSERT_FALSE(exists);
+}
+
+TEST_F(SpillFileTest, ExternalSpillDirectorySkipsFullManagedRoot) {
+    TUniqueId query_id;
+    query_id.hi = 23;
+    query_id.lo = 24;
+    auto query_id_str = print_id(query_id);
+    auto query_ctx = MockQueryContext::create(query_id);
+
+    _data_dir_ptr->update_spill_data_usage(_data_dir_ptr->get_spill_data_limit());
+    Defer release_full_root([&]() {
+        _data_dir_ptr->update_spill_data_usage(-_data_dir_ptr->get_spill_data_limit());
+    });
+
+    std::unique_ptr<ExternalSpillDirectory> spill_directory;
+    auto st = ExecEnv::GetInstance()->spill_file_mgr()->create_external_spill_directory(
+            "paimon", query_ctx.get(), &spill_directory);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    std::vector<std::string> paths;
+    st = spill_directory->get_paths(&paths);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_EQ(paths, std::vector<std::string> {
+                             _second_data_dir_ptr->get_spill_data_path(query_id_str) + "/paimon"});
+}
+
+TEST_F(SpillFileTest, ExternalSpillDirectoryIsLazyWhenNoRootAvailable) {
+    TUniqueId query_id;
+    query_id.hi = 25;
+    query_id.lo = 26;
+    auto query_ctx = MockQueryContext::create(query_id);
+
+    _data_dir_ptr->update_spill_data_usage(_data_dir_ptr->get_spill_data_limit());
+    _second_data_dir_ptr->update_spill_data_usage(_second_data_dir_ptr->get_spill_data_limit());
+    Defer release_full_roots([&]() {
+        _data_dir_ptr->update_spill_data_usage(-_data_dir_ptr->get_spill_data_limit());
+        _second_data_dir_ptr->update_spill_data_usage(
+                -_second_data_dir_ptr->get_spill_data_limit());
+    });
+
+    std::unique_ptr<ExternalSpillDirectory> spill_directory;
+    auto st = ExecEnv::GetInstance()->spill_file_mgr()->create_external_spill_directory(
+            "paimon", query_ctx.get(), &spill_directory);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ASSERT_NE(spill_directory, nullptr);
 }
 
 TEST_F(SpillFileTest, ManagerCreateMultipleFiles) {
@@ -1511,7 +1627,8 @@ TEST_F(SpillFileTest, DataDirCapacityTracking) {
                                                                           spill_file);
     ASSERT_TRUE(st.ok());
 
-    auto initial_bytes = _data_dir_ptr->get_spill_data_bytes();
+    auto initial_bytes =
+            _data_dir_ptr->get_spill_data_bytes() + _second_data_dir_ptr->get_spill_data_bytes();
 
     SpillFileWriterSPtr writer;
     st = spill_file->create_writer(_runtime_state.get(), _profile.get(), writer);
@@ -1527,7 +1644,8 @@ TEST_F(SpillFileTest, DataDirCapacityTracking) {
     st = writer->close();
     ASSERT_TRUE(st.ok());
 
-    auto after_write_bytes = _data_dir_ptr->get_spill_data_bytes();
+    auto after_write_bytes =
+            _data_dir_ptr->get_spill_data_bytes() + _second_data_dir_ptr->get_spill_data_bytes();
     ASSERT_GT(after_write_bytes, initial_bytes);
 }
 

--- a/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/DorisIOManager.java
+++ b/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/DorisIOManager.java
@@ -23,27 +23,34 @@ import org.apache.paimon.disk.FileIOChannel;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.memory.Buffer;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.channels.FileChannel;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
-/** Paimon IOManager adapter which charges temporary channel I/O to one Doris spill session. */
+/** Paimon IOManager adapter which charges temporary I/O to Doris spill management. */
 final class DorisIOManager implements IOManager {
     interface SpillAccountant {
-        String getSpillDirectory() throws IOException;
+        String[] getSpillDirectories() throws IOException;
 
-        void reserve(long bytes) throws IOException;
+        void reserve(String path, long bytes) throws IOException;
 
-        void rollback(long bytes);
+        void rollback(String path, long bytes);
 
-        void commitWrite(long bytes);
+        void commitWrite(String path, long bytes);
 
-        void recordRead(long bytes);
+        void recordRead(String path, long bytes);
 
-        void release(long bytes);
+        void release(String path, long bytes);
+
+        void reconcile() throws IOException;
     }
 
     private final SpillAccountant accountant;
+    private final Map<String, Long> channelBytes = new ConcurrentHashMap<>();
+    private final Map<String, Integer> activeChannelWriters = new ConcurrentHashMap<>();
     private volatile IOManager delegate;
 
     static DorisIOManager create(long nativeSpillSession) {
@@ -63,11 +70,11 @@ final class DorisIOManager implements IOManager {
         if (delegate == null) {
             synchronized (this) {
                 if (delegate == null) {
-                    String spillDirectory = accountant.getSpillDirectory();
-                    if (spillDirectory == null || spillDirectory.isEmpty()) {
-                        throw new IOException("Doris spill manager returned no available directory");
+                    String[] spillDirectories = accountant.getSpillDirectories();
+                    if (spillDirectories == null || spillDirectories.length == 0) {
+                        throw new IOException("Doris spill manager returned no available directories");
                     }
-                    delegate = IOManager.create(spillDirectory);
+                    delegate = IOManager.create(spillDirectories);
                 }
             }
         }
@@ -109,6 +116,9 @@ final class DorisIOManager implements IOManager {
 
     @Override
     public BufferFileWriter createBufferFileWriter(FileIOChannel.ID channelID) throws IOException {
+        // ExternalBuffer clears old channels with File.delete(), bypassing IOManager deletion.
+        // Reconcile once per writer so those files do not retain Doris spill quota indefinitely.
+        releaseDeletedChannels();
         return new AccountingBufferFileWriter(delegate().createBufferFileWriter(channelID), this);
     }
 
@@ -121,17 +131,68 @@ final class DorisIOManager implements IOManager {
     public void close() throws Exception {
         IOManager initializedDelegate = delegate;
         if (initializedDelegate != null) {
-            initializedDelegate.close();
+            try {
+                initializedDelegate.close();
+            } finally {
+                releaseDeletedChannels();
+            }
         }
     }
 
-    private static long channelSize(FileIOChannel.ID channelID) {
-        return channelID.getPathFile().isFile() ? channelID.getPathFile().length() : 0;
+    void reconcile() throws IOException {
+        releaseDeletedChannels();
+        accountant.reconcile();
     }
 
-    private void releaseIfDeleted(FileIOChannel.ID channelID, long bytes) {
-        if (bytes > 0 && !channelID.getPathFile().exists()) {
-            accountant.release(bytes);
+    private boolean releaseDeletedChannels() {
+        boolean releasedAny = false;
+        for (Map.Entry<String, Long> entry : channelBytes.entrySet()) {
+            if (!activeChannelWriters.containsKey(entry.getKey())
+                    && !new File(entry.getKey()).exists()
+                    && channelBytes.remove(entry.getKey(), entry.getValue())) {
+                accountant.release(entry.getKey(), entry.getValue());
+                releasedAny = true;
+            }
+        }
+        return releasedAny;
+    }
+
+    private void reserveWrite(FileIOChannel.ID channelID, long bytes) throws IOException {
+        String path = channelID.getPath();
+        activeChannelWriters.merge(path, 1, Integer::sum);
+        boolean accounted = false;
+        boolean tracked = false;
+        try {
+            try {
+                accountant.reserve(path, bytes);
+            } catch (IOException reserveFailure) {
+                if (!releaseDeletedChannels()) {
+                    throw reserveFailure;
+                }
+                accountant.reserve(path, bytes);
+            }
+            accounted = true;
+            channelBytes.merge(path, bytes, Long::sum);
+            tracked = true;
+        } finally {
+            if (!tracked) {
+                if (accounted) {
+                    accountant.rollback(path, bytes);
+                }
+                finishWrite(channelID);
+            }
+        }
+    }
+
+    private void finishWrite(FileIOChannel.ID channelID) {
+        activeChannelWriters.computeIfPresent(channelID.getPath(),
+                (ignored, writers) -> writers == 1 ? null : writers - 1);
+    }
+
+    private void releaseChannel(FileIOChannel.ID channelID) {
+        Long released = channelBytes.remove(channelID.getPath());
+        if (released != null) {
+            accountant.release(channelID.getPath(), released);
         }
     }
 
@@ -143,33 +204,42 @@ final class DorisIOManager implements IOManager {
         }
 
         @Override
-        public String getSpillDirectory() throws IOException {
-            return PaimonJniWriter.getPaimonSpillDirectory(nativeSpillSession);
+        public String[] getSpillDirectories() throws IOException {
+            return PaimonJniWriter.getPaimonSpillDirectories(nativeSpillSession);
         }
 
         @Override
-        public void reserve(long bytes) throws IOException {
-            PaimonJniWriter.reservePaimonSpill(nativeSpillSession, bytes);
+        public void reserve(String path, long bytes) throws IOException {
+            PaimonJniWriter.reservePaimonSpill(nativeSpillSession, path, bytes);
         }
 
         @Override
-        public void rollback(long bytes) {
-            PaimonJniWriter.updatePaimonSpillAccounting(nativeSpillSession, -bytes, 0, 0);
+        public void rollback(String path, long bytes) {
+            PaimonJniWriter.updatePaimonSpillAccounting(
+                    nativeSpillSession, path, -bytes, 0, 0);
         }
 
         @Override
-        public void commitWrite(long bytes) {
-            PaimonJniWriter.updatePaimonSpillAccounting(nativeSpillSession, 0, bytes, 0);
+        public void commitWrite(String path, long bytes) {
+            PaimonJniWriter.updatePaimonSpillAccounting(
+                    nativeSpillSession, path, 0, bytes, 0);
         }
 
         @Override
-        public void recordRead(long bytes) {
-            PaimonJniWriter.updatePaimonSpillAccounting(nativeSpillSession, 0, 0, bytes);
+        public void recordRead(String path, long bytes) {
+            PaimonJniWriter.updatePaimonSpillAccounting(
+                    nativeSpillSession, path, 0, 0, bytes);
         }
 
         @Override
-        public void release(long bytes) {
-            PaimonJniWriter.updatePaimonSpillAccounting(nativeSpillSession, -bytes, 0, 0);
+        public void release(String path, long bytes) {
+            PaimonJniWriter.updatePaimonSpillAccounting(
+                    nativeSpillSession, path, -bytes, 0, 0);
+        }
+
+        @Override
+        public void reconcile() throws IOException {
+            PaimonJniWriter.reconcilePaimonSpill(nativeSpillSession);
         }
     }
 
@@ -185,10 +255,10 @@ final class DorisIOManager implements IOManager {
         @Override
         public void writeBlock(Buffer buffer) throws IOException {
             long bytes = Integer.BYTES + buffer.getSize();
-            manager.accountant.reserve(bytes);
+            manager.reserveWrite(getChannelID(), bytes);
             try {
                 delegate.writeBlock(buffer);
-                manager.accountant.commitWrite(bytes);
+                manager.accountant.commitWrite(getChannelID().getPath(), bytes);
             } catch (IOException | RuntimeException writeFailure) {
                 try {
                     delegate.closeAndDelete();
@@ -196,9 +266,11 @@ final class DorisIOManager implements IOManager {
                     writeFailure.addSuppressed(cleanupFailure);
                 }
                 if (!getChannelID().getPathFile().exists()) {
-                    manager.accountant.rollback(bytes);
+                    manager.releaseChannel(getChannelID());
                 }
                 throw writeFailure;
+            } finally {
+                manager.finishWrite(getChannelID());
             }
         }
 
@@ -224,11 +296,12 @@ final class DorisIOManager implements IOManager {
 
         @Override
         public void deleteChannel() {
-            long bytes = channelSize(getChannelID());
             try {
                 delegate.deleteChannel();
             } finally {
-                manager.releaseIfDeleted(getChannelID(), bytes);
+                if (!getChannelID().getPathFile().exists()) {
+                    manager.releaseChannel(getChannelID());
+                }
             }
         }
 
@@ -239,11 +312,12 @@ final class DorisIOManager implements IOManager {
 
         @Override
         public void closeAndDelete() throws IOException {
-            long bytes = channelSize(getChannelID());
             try {
                 delegate.closeAndDelete();
             } finally {
-                manager.releaseIfDeleted(getChannelID(), bytes);
+                if (!getChannelID().getPathFile().exists()) {
+                    manager.releaseChannel(getChannelID());
+                }
             }
         }
     }
@@ -261,7 +335,8 @@ final class DorisIOManager implements IOManager {
         public void readInto(Buffer buffer) throws IOException {
             long position = delegate.getNioFileChannel().position();
             delegate.readInto(buffer);
-            manager.accountant.recordRead(delegate.getNioFileChannel().position() - position);
+            manager.accountant.recordRead(
+                    getChannelID().getPath(), delegate.getNioFileChannel().position() - position);
         }
 
         @Override
@@ -291,11 +366,12 @@ final class DorisIOManager implements IOManager {
 
         @Override
         public void deleteChannel() {
-            long bytes = channelSize(getChannelID());
             try {
                 delegate.deleteChannel();
             } finally {
-                manager.releaseIfDeleted(getChannelID(), bytes);
+                if (!getChannelID().getPathFile().exists()) {
+                    manager.releaseChannel(getChannelID());
+                }
             }
         }
 
@@ -306,11 +382,12 @@ final class DorisIOManager implements IOManager {
 
         @Override
         public void closeAndDelete() throws IOException {
-            long bytes = channelSize(getChannelID());
             try {
                 delegate.closeAndDelete();
             } finally {
-                manager.releaseIfDeleted(getChannelID(), bytes);
+                if (!getChannelID().getPathFile().exists()) {
+                    manager.releaseChannel(getChannelID());
+                }
             }
         }
     }

--- a/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/DorisIOManager.java
+++ b/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/DorisIOManager.java
@@ -1,0 +1,326 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.paimon;
+
+import org.apache.paimon.disk.BufferFileReader;
+import org.apache.paimon.disk.BufferFileWriter;
+import org.apache.paimon.disk.FileIOChannel;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.memory.Buffer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Paimon IOManager adapter which charges temporary channel I/O to Doris spill management. */
+final class DorisIOManager implements IOManager {
+    interface SpillAccountant {
+        void reserve(String path, long bytes) throws IOException;
+
+        void rollback(String path, long bytes);
+
+        void commitWrite(String path, long bytes);
+
+        void recordRead(String path, long bytes);
+
+        void release(String path, long bytes);
+    }
+
+    private final IOManager delegate;
+    private final SpillAccountant accountant;
+    private final Map<String, Long> channelBytes = new ConcurrentHashMap<>();
+    private final Map<String, Integer> activeChannelWriters = new ConcurrentHashMap<>();
+
+    static DorisIOManager create(String[] tempDirs, long nativeSpillDirectory) {
+        return new DorisIOManager(
+                IOManager.create(tempDirs), new NativeSpillAccountant(nativeSpillDirectory));
+    }
+
+    DorisIOManager(IOManager delegate, SpillAccountant accountant) {
+        this.delegate = delegate;
+        this.accountant = accountant;
+    }
+
+    @Override
+    public FileIOChannel.ID createChannel() {
+        return delegate.createChannel();
+    }
+
+    @Override
+    public FileIOChannel.ID createChannel(String prefix) {
+        return delegate.createChannel(prefix);
+    }
+
+    @Override
+    public String[] tempDirs() {
+        return delegate.tempDirs();
+    }
+
+    @Override
+    public String pickTempDir() {
+        return delegate.pickTempDir();
+    }
+
+    @Override
+    public FileIOChannel.Enumerator createChannelEnumerator() {
+        return delegate.createChannelEnumerator();
+    }
+
+    @Override
+    public BufferFileWriter createBufferFileWriter(FileIOChannel.ID channelID) throws IOException {
+        // Paimon ExternalBuffer.reset() deletes old channel files directly instead of calling the
+        // IOManager deletion methods. Reconcile once per writer instead of scanning all historical
+        // channels before every block written by the same writer.
+        releaseDeletedChannels();
+        return new AccountingBufferFileWriter(delegate.createBufferFileWriter(channelID), this);
+    }
+
+    @Override
+    public BufferFileReader createBufferFileReader(FileIOChannel.ID channelID) throws IOException {
+        return new AccountingBufferFileReader(delegate.createBufferFileReader(channelID), this);
+    }
+
+    @Override
+    public void close() throws Exception {
+        try {
+            delegate.close();
+        } finally {
+            releaseDeletedChannels();
+        }
+    }
+
+    private boolean releaseDeletedChannels() {
+        boolean releasedAny = false;
+        for (Map.Entry<String, Long> entry : channelBytes.entrySet()) {
+            if (!activeChannelWriters.containsKey(entry.getKey())
+                    && !new File(entry.getKey()).exists()
+                    && channelBytes.remove(entry.getKey(), entry.getValue())) {
+                accountant.release(entry.getKey(), entry.getValue());
+                releasedAny = true;
+            }
+        }
+        return releasedAny;
+    }
+
+    private void reserveWrite(FileIOChannel.ID channelID, long bytes) throws IOException {
+        String path = channelID.getPath();
+        activeChannelWriters.merge(path, 1, Integer::sum);
+        boolean accounted = false;
+        boolean tracked = false;
+        try {
+            try {
+                accountant.reserve(path, bytes);
+            } catch (IOException reserveFailure) {
+                // A different ExternalBuffer may have directly deleted an old channel after this
+                // writer was created. Retry only when reconciliation actually released capacity.
+                if (!releaseDeletedChannels()) {
+                    throw reserveFailure;
+                }
+                accountant.reserve(path, bytes);
+            }
+            accounted = true;
+            channelBytes.merge(path, bytes, Long::sum);
+            tracked = true;
+        } finally {
+            if (!tracked) {
+                if (accounted) {
+                    accountant.rollback(path, bytes);
+                }
+                finishWrite(channelID);
+            }
+        }
+    }
+
+    private void finishWrite(FileIOChannel.ID channelID) {
+        activeChannelWriters.computeIfPresent(channelID.getPath(), (ignored, writers) ->
+                writers == 1 ? null : writers - 1);
+    }
+
+    private void releaseChannel(FileIOChannel.ID channelID) {
+        Long released = channelBytes.remove(channelID.getPath());
+        if (released != null) {
+            accountant.release(channelID.getPath(), released);
+        }
+    }
+
+    private static final class NativeSpillAccountant implements SpillAccountant {
+        private final long nativeSpillDirectory;
+
+        private NativeSpillAccountant(long nativeSpillDirectory) {
+            this.nativeSpillDirectory = nativeSpillDirectory;
+        }
+
+        @Override
+        public void reserve(String path, long bytes) throws IOException {
+            PaimonJniWriter.reservePaimonSpill(nativeSpillDirectory, path, bytes);
+        }
+
+        @Override
+        public void rollback(String path, long bytes) {
+            PaimonJniWriter.updatePaimonSpillAccounting(
+                    nativeSpillDirectory, path, -bytes, 0, 0);
+        }
+
+        @Override
+        public void commitWrite(String path, long bytes) {
+            PaimonJniWriter.updatePaimonSpillAccounting(
+                    nativeSpillDirectory, path, 0, bytes, 0);
+        }
+
+        @Override
+        public void recordRead(String path, long bytes) {
+            PaimonJniWriter.updatePaimonSpillAccounting(
+                    nativeSpillDirectory, path, 0, 0, bytes);
+        }
+
+        @Override
+        public void release(String path, long bytes) {
+            PaimonJniWriter.updatePaimonSpillAccounting(
+                    nativeSpillDirectory, path, -bytes, 0, 0);
+        }
+    }
+
+    private static final class AccountingBufferFileWriter implements BufferFileWriter {
+        private final BufferFileWriter delegate;
+        private final DorisIOManager manager;
+
+        private AccountingBufferFileWriter(BufferFileWriter delegate, DorisIOManager manager) {
+            this.delegate = delegate;
+            this.manager = manager;
+        }
+
+        @Override
+        public void writeBlock(Buffer buffer) throws IOException {
+            long bytes = Integer.BYTES + buffer.getSize();
+            manager.reserveWrite(getChannelID(), bytes);
+            try {
+                delegate.writeBlock(buffer);
+                manager.accountant.commitWrite(getChannelID().getPath(), bytes);
+            } finally {
+                manager.finishWrite(getChannelID());
+            }
+        }
+
+        @Override
+        public FileIOChannel.ID getChannelID() {
+            return delegate.getChannelID();
+        }
+
+        @Override
+        public long getSize() throws IOException {
+            return delegate.getSize();
+        }
+
+        @Override
+        public boolean isClosed() {
+            return delegate.isClosed();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public void deleteChannel() {
+            delegate.deleteChannel();
+            if (!getChannelID().getPathFile().exists()) {
+                manager.releaseChannel(getChannelID());
+            }
+        }
+
+        @Override
+        public FileChannel getNioFileChannel() {
+            return delegate.getNioFileChannel();
+        }
+
+        @Override
+        public void closeAndDelete() throws IOException {
+            delegate.closeAndDelete();
+            if (!getChannelID().getPathFile().exists()) {
+                manager.releaseChannel(getChannelID());
+            }
+        }
+    }
+
+    private static final class AccountingBufferFileReader implements BufferFileReader {
+        private final BufferFileReader delegate;
+        private final DorisIOManager manager;
+
+        private AccountingBufferFileReader(BufferFileReader delegate, DorisIOManager manager) {
+            this.delegate = delegate;
+            this.manager = manager;
+        }
+
+        @Override
+        public void readInto(Buffer buffer) throws IOException {
+            long position = delegate.getNioFileChannel().position();
+            delegate.readInto(buffer);
+            manager.accountant.recordRead(
+                    getChannelID().getPath(), delegate.getNioFileChannel().position() - position);
+        }
+
+        @Override
+        public boolean hasReachedEndOfFile() {
+            return delegate.hasReachedEndOfFile();
+        }
+
+        @Override
+        public FileIOChannel.ID getChannelID() {
+            return delegate.getChannelID();
+        }
+
+        @Override
+        public long getSize() throws IOException {
+            return delegate.getSize();
+        }
+
+        @Override
+        public boolean isClosed() {
+            return delegate.isClosed();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public void deleteChannel() {
+            delegate.deleteChannel();
+            if (!getChannelID().getPathFile().exists()) {
+                manager.releaseChannel(getChannelID());
+            }
+        }
+
+        @Override
+        public FileChannel getNioFileChannel() {
+            return delegate.getNioFileChannel();
+        }
+
+        @Override
+        public void closeAndDelete() throws IOException {
+            delegate.closeAndDelete();
+            if (!getChannelID().getPathFile().exists()) {
+                manager.releaseChannel(getChannelID());
+            }
+        }
+    }
+}

--- a/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/DorisIOManager.java
+++ b/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/DorisIOManager.java
@@ -29,6 +29,9 @@ import java.io.UncheckedIOException;
 import java.nio.channels.FileChannel;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 
 /** Paimon IOManager adapter which charges temporary I/O to Doris spill management. */
 final class DorisIOManager implements IOManager {
@@ -45,10 +48,20 @@ final class DorisIOManager implements IOManager {
 
         void release(String path, long bytes);
 
-        void reconcile() throws IOException;
+        void reconcile(boolean allowRelease) throws IOException;
     }
 
+    static final class SpillDirectoryCleanupException extends IOException {
+        private SpillDirectoryCleanupException(Exception cause) {
+            super("Failed to eagerly clean a Paimon spill directory", cause);
+        }
+    }
+
+    private static final long RAW_FILE_RECONCILE_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(5);
     private final SpillAccountant accountant;
+    private final LongSupplier nanoTime;
+    private final long rawFileReconcileIntervalNanos;
+    private final AtomicLong lastRawFileReconcileNanos = new AtomicLong(Long.MIN_VALUE);
     private final Map<String, Long> channelBytes = new ConcurrentHashMap<>();
     private final Map<String, Integer> activeChannelWriters = new ConcurrentHashMap<>();
     private volatile IOManager delegate;
@@ -58,12 +71,19 @@ final class DorisIOManager implements IOManager {
     }
 
     DorisIOManager(SpillAccountant accountant) {
-        this.accountant = accountant;
+        this(null, accountant, System::nanoTime, RAW_FILE_RECONCILE_INTERVAL_NANOS);
     }
 
     DorisIOManager(IOManager delegate, SpillAccountant accountant) {
+        this(delegate, accountant, System::nanoTime, RAW_FILE_RECONCILE_INTERVAL_NANOS);
+    }
+
+    DorisIOManager(IOManager delegate, SpillAccountant accountant,
+            LongSupplier nanoTime, long rawFileReconcileIntervalNanos) {
         this.accountant = accountant;
         this.delegate = delegate;
+        this.nanoTime = nanoTime;
+        this.rawFileReconcileIntervalNanos = rawFileReconcileIntervalNanos;
     }
 
     private IOManager delegate() throws IOException {
@@ -130,18 +150,58 @@ final class DorisIOManager implements IOManager {
     @Override
     public void close() throws Exception {
         IOManager initializedDelegate = delegate;
-        if (initializedDelegate != null) {
-            try {
-                initializedDelegate.close();
-            } finally {
-                releaseDeletedChannels();
+        if (initializedDelegate == null) {
+            return;
+        }
+
+        Exception cleanupFailure = null;
+        try {
+            initializedDelegate.close();
+        } catch (Exception e) {
+            cleanupFailure = e;
+        }
+        releaseDeletedChannels();
+        try {
+            // Writer, compaction and global-index resources are already quiescent. This exact pass
+            // can safely release disappeared raw files as well as charging any residual files.
+            accountant.reconcile(true);
+        } catch (IOException reconciliationFailure) {
+            if (cleanupFailure != null) {
+                reconciliationFailure.addSuppressed(cleanupFailure);
+            }
+            throw reconciliationFailure;
+        }
+        if (cleanupFailure != null) {
+            throw new SpillDirectoryCleanupException(cleanupFailure);
+        }
+    }
+
+    void reconcileIfDue() throws IOException {
+        if (delegate == null) {
+            return;
+        }
+        long now = nanoTime.getAsLong();
+        while (true) {
+            long previous = lastRawFileReconcileNanos.get();
+            if (previous != Long.MIN_VALUE
+                    && now - previous < rawFileReconcileIntervalNanos) {
+                return;
+            }
+            if (lastRawFileReconcileNanos.compareAndSet(previous, now)) {
+                try {
+                    reconcileNow(false);
+                } catch (IOException e) {
+                    lastRawFileReconcileNanos.compareAndSet(now, previous);
+                    throw e;
+                }
+                return;
             }
         }
     }
 
-    void reconcile() throws IOException {
+    void reconcileNow(boolean allowRelease) throws IOException {
         releaseDeletedChannels();
-        accountant.reconcile();
+        accountant.reconcile(allowRelease);
     }
 
     private boolean releaseDeletedChannels() {
@@ -238,8 +298,8 @@ final class DorisIOManager implements IOManager {
         }
 
         @Override
-        public void reconcile() throws IOException {
-            PaimonJniWriter.reconcilePaimonSpill(nativeSpillSession);
+        public void reconcile(boolean allowRelease) throws IOException {
+            PaimonJniWriter.reconcilePaimonSpill(nativeSpillSession, allowRelease);
         }
     }
 

--- a/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/DorisIOManager.java
+++ b/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/DorisIOManager.java
@@ -29,9 +29,6 @@ import java.io.UncheckedIOException;
 import java.nio.channels.FileChannel;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.LongSupplier;
 
 /** Paimon IOManager adapter which charges temporary I/O to Doris spill management. */
 final class DorisIOManager implements IOManager {
@@ -47,8 +44,6 @@ final class DorisIOManager implements IOManager {
         void recordRead(String path, long bytes);
 
         void release(String path, long bytes);
-
-        void reconcile(boolean allowRelease) throws IOException;
     }
 
     static final class SpillDirectoryCleanupException extends IOException {
@@ -57,11 +52,7 @@ final class DorisIOManager implements IOManager {
         }
     }
 
-    private static final long RAW_FILE_RECONCILE_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(5);
     private final SpillAccountant accountant;
-    private final LongSupplier nanoTime;
-    private final long rawFileReconcileIntervalNanos;
-    private final AtomicLong lastRawFileReconcileNanos = new AtomicLong(Long.MIN_VALUE);
     private final Map<String, Long> channelBytes = new ConcurrentHashMap<>();
     private final Map<String, Integer> activeChannelWriters = new ConcurrentHashMap<>();
     private volatile IOManager delegate;
@@ -71,19 +62,12 @@ final class DorisIOManager implements IOManager {
     }
 
     DorisIOManager(SpillAccountant accountant) {
-        this(null, accountant, System::nanoTime, RAW_FILE_RECONCILE_INTERVAL_NANOS);
+        this(null, accountant);
     }
 
     DorisIOManager(IOManager delegate, SpillAccountant accountant) {
-        this(delegate, accountant, System::nanoTime, RAW_FILE_RECONCILE_INTERVAL_NANOS);
-    }
-
-    DorisIOManager(IOManager delegate, SpillAccountant accountant,
-            LongSupplier nanoTime, long rawFileReconcileIntervalNanos) {
         this.accountant = accountant;
         this.delegate = delegate;
-        this.nanoTime = nanoTime;
-        this.rawFileReconcileIntervalNanos = rawFileReconcileIntervalNanos;
     }
 
     private IOManager delegate() throws IOException {
@@ -136,8 +120,8 @@ final class DorisIOManager implements IOManager {
 
     @Override
     public BufferFileWriter createBufferFileWriter(FileIOChannel.ID channelID) throws IOException {
-        // ExternalBuffer clears old channels with File.delete(), bypassing IOManager deletion.
-        // Reconcile once per writer so those files do not retain Doris spill quota indefinitely.
+        // ExternalBuffer clears old buffer channels with File.delete(), bypassing IOManager
+        // deletion. Release those known channels before reserving more space.
         releaseDeletedChannels();
         return new AccountingBufferFileWriter(delegate().createBufferFileWriter(channelID), this);
     }
@@ -154,54 +138,13 @@ final class DorisIOManager implements IOManager {
             return;
         }
 
-        Exception cleanupFailure = null;
         try {
             initializedDelegate.close();
         } catch (Exception e) {
-            cleanupFailure = e;
+            releaseDeletedChannels();
+            throw new SpillDirectoryCleanupException(e);
         }
         releaseDeletedChannels();
-        try {
-            // Writer, compaction and global-index resources are already quiescent. This exact pass
-            // can safely release disappeared raw files as well as charging any residual files.
-            accountant.reconcile(true);
-        } catch (IOException reconciliationFailure) {
-            if (cleanupFailure != null) {
-                reconciliationFailure.addSuppressed(cleanupFailure);
-            }
-            throw reconciliationFailure;
-        }
-        if (cleanupFailure != null) {
-            throw new SpillDirectoryCleanupException(cleanupFailure);
-        }
-    }
-
-    void reconcileIfDue() throws IOException {
-        if (delegate == null) {
-            return;
-        }
-        long now = nanoTime.getAsLong();
-        while (true) {
-            long previous = lastRawFileReconcileNanos.get();
-            if (previous != Long.MIN_VALUE
-                    && now - previous < rawFileReconcileIntervalNanos) {
-                return;
-            }
-            if (lastRawFileReconcileNanos.compareAndSet(previous, now)) {
-                try {
-                    reconcileNow(false);
-                } catch (IOException e) {
-                    lastRawFileReconcileNanos.compareAndSet(now, previous);
-                    throw e;
-                }
-                return;
-            }
-        }
-    }
-
-    void reconcileNow(boolean allowRelease) throws IOException {
-        releaseDeletedChannels();
-        accountant.reconcile(allowRelease);
     }
 
     private boolean releaseDeletedChannels() {
@@ -295,11 +238,6 @@ final class DorisIOManager implements IOManager {
         public void release(String path, long bytes) {
             PaimonJniWriter.updatePaimonSpillAccounting(
                     nativeSpillSession, path, -bytes, 0, 0);
-        }
-
-        @Override
-        public void reconcile(boolean allowRelease) throws IOException {
-            PaimonJniWriter.reconcilePaimonSpill(nativeSpillSession, allowRelease);
         }
     }
 

--- a/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/DorisIOManager.java
+++ b/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/DorisIOManager.java
@@ -23,177 +23,153 @@ import org.apache.paimon.disk.FileIOChannel;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.memory.Buffer;
 
-import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.channels.FileChannel;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
-/** Paimon IOManager adapter which charges temporary channel I/O to Doris spill management. */
+/** Paimon IOManager adapter which charges temporary channel I/O to one Doris spill session. */
 final class DorisIOManager implements IOManager {
     interface SpillAccountant {
-        void reserve(String path, long bytes) throws IOException;
+        String getSpillDirectory() throws IOException;
 
-        void rollback(String path, long bytes);
+        void reserve(long bytes) throws IOException;
 
-        void commitWrite(String path, long bytes);
+        void rollback(long bytes);
 
-        void recordRead(String path, long bytes);
+        void commitWrite(long bytes);
 
-        void release(String path, long bytes);
+        void recordRead(long bytes);
+
+        void release(long bytes);
     }
 
-    private final IOManager delegate;
     private final SpillAccountant accountant;
-    private final Map<String, Long> channelBytes = new ConcurrentHashMap<>();
-    private final Map<String, Integer> activeChannelWriters = new ConcurrentHashMap<>();
+    private volatile IOManager delegate;
 
-    static DorisIOManager create(String[] tempDirs, long nativeSpillDirectory) {
-        return new DorisIOManager(
-                IOManager.create(tempDirs), new NativeSpillAccountant(nativeSpillDirectory));
+    static DorisIOManager create(long nativeSpillSession) {
+        return new DorisIOManager(new NativeSpillAccountant(nativeSpillSession));
+    }
+
+    DorisIOManager(SpillAccountant accountant) {
+        this.accountant = accountant;
     }
 
     DorisIOManager(IOManager delegate, SpillAccountant accountant) {
-        this.delegate = delegate;
         this.accountant = accountant;
+        this.delegate = delegate;
+    }
+
+    private IOManager delegate() throws IOException {
+        if (delegate == null) {
+            synchronized (this) {
+                if (delegate == null) {
+                    String spillDirectory = accountant.getSpillDirectory();
+                    if (spillDirectory == null || spillDirectory.isEmpty()) {
+                        throw new IOException("Doris spill manager returned no available directory");
+                    }
+                    delegate = IOManager.create(spillDirectory);
+                }
+            }
+        }
+        return delegate;
+    }
+
+    private IOManager uncheckedDelegate() {
+        try {
+            return delegate();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to initialize the Doris spill directory", e);
+        }
     }
 
     @Override
     public FileIOChannel.ID createChannel() {
-        return delegate.createChannel();
+        return uncheckedDelegate().createChannel();
     }
 
     @Override
     public FileIOChannel.ID createChannel(String prefix) {
-        return delegate.createChannel(prefix);
+        return uncheckedDelegate().createChannel(prefix);
     }
 
     @Override
     public String[] tempDirs() {
-        return delegate.tempDirs();
+        return uncheckedDelegate().tempDirs();
     }
 
     @Override
     public String pickTempDir() {
-        return delegate.pickTempDir();
+        return uncheckedDelegate().pickTempDir();
     }
 
     @Override
     public FileIOChannel.Enumerator createChannelEnumerator() {
-        return delegate.createChannelEnumerator();
+        return uncheckedDelegate().createChannelEnumerator();
     }
 
     @Override
     public BufferFileWriter createBufferFileWriter(FileIOChannel.ID channelID) throws IOException {
-        // Paimon ExternalBuffer.reset() deletes old channel files directly instead of calling the
-        // IOManager deletion methods. Reconcile once per writer instead of scanning all historical
-        // channels before every block written by the same writer.
-        releaseDeletedChannels();
-        return new AccountingBufferFileWriter(delegate.createBufferFileWriter(channelID), this);
+        return new AccountingBufferFileWriter(delegate().createBufferFileWriter(channelID), this);
     }
 
     @Override
     public BufferFileReader createBufferFileReader(FileIOChannel.ID channelID) throws IOException {
-        return new AccountingBufferFileReader(delegate.createBufferFileReader(channelID), this);
+        return new AccountingBufferFileReader(delegate().createBufferFileReader(channelID), this);
     }
 
     @Override
     public void close() throws Exception {
-        try {
-            delegate.close();
-        } finally {
-            releaseDeletedChannels();
+        IOManager initializedDelegate = delegate;
+        if (initializedDelegate != null) {
+            initializedDelegate.close();
         }
     }
 
-    private boolean releaseDeletedChannels() {
-        boolean releasedAny = false;
-        for (Map.Entry<String, Long> entry : channelBytes.entrySet()) {
-            if (!activeChannelWriters.containsKey(entry.getKey())
-                    && !new File(entry.getKey()).exists()
-                    && channelBytes.remove(entry.getKey(), entry.getValue())) {
-                accountant.release(entry.getKey(), entry.getValue());
-                releasedAny = true;
-            }
-        }
-        return releasedAny;
+    private static long channelSize(FileIOChannel.ID channelID) {
+        return channelID.getPathFile().isFile() ? channelID.getPathFile().length() : 0;
     }
 
-    private void reserveWrite(FileIOChannel.ID channelID, long bytes) throws IOException {
-        String path = channelID.getPath();
-        activeChannelWriters.merge(path, 1, Integer::sum);
-        boolean accounted = false;
-        boolean tracked = false;
-        try {
-            try {
-                accountant.reserve(path, bytes);
-            } catch (IOException reserveFailure) {
-                // A different ExternalBuffer may have directly deleted an old channel after this
-                // writer was created. Retry only when reconciliation actually released capacity.
-                if (!releaseDeletedChannels()) {
-                    throw reserveFailure;
-                }
-                accountant.reserve(path, bytes);
-            }
-            accounted = true;
-            channelBytes.merge(path, bytes, Long::sum);
-            tracked = true;
-        } finally {
-            if (!tracked) {
-                if (accounted) {
-                    accountant.rollback(path, bytes);
-                }
-                finishWrite(channelID);
-            }
-        }
-    }
-
-    private void finishWrite(FileIOChannel.ID channelID) {
-        activeChannelWriters.computeIfPresent(channelID.getPath(), (ignored, writers) ->
-                writers == 1 ? null : writers - 1);
-    }
-
-    private void releaseChannel(FileIOChannel.ID channelID) {
-        Long released = channelBytes.remove(channelID.getPath());
-        if (released != null) {
-            accountant.release(channelID.getPath(), released);
+    private void releaseIfDeleted(FileIOChannel.ID channelID, long bytes) {
+        if (bytes > 0 && !channelID.getPathFile().exists()) {
+            accountant.release(bytes);
         }
     }
 
     private static final class NativeSpillAccountant implements SpillAccountant {
-        private final long nativeSpillDirectory;
+        private final long nativeSpillSession;
 
-        private NativeSpillAccountant(long nativeSpillDirectory) {
-            this.nativeSpillDirectory = nativeSpillDirectory;
+        private NativeSpillAccountant(long nativeSpillSession) {
+            this.nativeSpillSession = nativeSpillSession;
         }
 
         @Override
-        public void reserve(String path, long bytes) throws IOException {
-            PaimonJniWriter.reservePaimonSpill(nativeSpillDirectory, path, bytes);
+        public String getSpillDirectory() throws IOException {
+            return PaimonJniWriter.getPaimonSpillDirectory(nativeSpillSession);
         }
 
         @Override
-        public void rollback(String path, long bytes) {
-            PaimonJniWriter.updatePaimonSpillAccounting(
-                    nativeSpillDirectory, path, -bytes, 0, 0);
+        public void reserve(long bytes) throws IOException {
+            PaimonJniWriter.reservePaimonSpill(nativeSpillSession, bytes);
         }
 
         @Override
-        public void commitWrite(String path, long bytes) {
-            PaimonJniWriter.updatePaimonSpillAccounting(
-                    nativeSpillDirectory, path, 0, bytes, 0);
+        public void rollback(long bytes) {
+            PaimonJniWriter.updatePaimonSpillAccounting(nativeSpillSession, -bytes, 0, 0);
         }
 
         @Override
-        public void recordRead(String path, long bytes) {
-            PaimonJniWriter.updatePaimonSpillAccounting(
-                    nativeSpillDirectory, path, 0, 0, bytes);
+        public void commitWrite(long bytes) {
+            PaimonJniWriter.updatePaimonSpillAccounting(nativeSpillSession, 0, bytes, 0);
         }
 
         @Override
-        public void release(String path, long bytes) {
-            PaimonJniWriter.updatePaimonSpillAccounting(
-                    nativeSpillDirectory, path, -bytes, 0, 0);
+        public void recordRead(long bytes) {
+            PaimonJniWriter.updatePaimonSpillAccounting(nativeSpillSession, 0, 0, bytes);
+        }
+
+        @Override
+        public void release(long bytes) {
+            PaimonJniWriter.updatePaimonSpillAccounting(nativeSpillSession, -bytes, 0, 0);
         }
     }
 
@@ -209,12 +185,20 @@ final class DorisIOManager implements IOManager {
         @Override
         public void writeBlock(Buffer buffer) throws IOException {
             long bytes = Integer.BYTES + buffer.getSize();
-            manager.reserveWrite(getChannelID(), bytes);
+            manager.accountant.reserve(bytes);
             try {
                 delegate.writeBlock(buffer);
-                manager.accountant.commitWrite(getChannelID().getPath(), bytes);
-            } finally {
-                manager.finishWrite(getChannelID());
+                manager.accountant.commitWrite(bytes);
+            } catch (IOException | RuntimeException writeFailure) {
+                try {
+                    delegate.closeAndDelete();
+                } catch (IOException | RuntimeException cleanupFailure) {
+                    writeFailure.addSuppressed(cleanupFailure);
+                }
+                if (!getChannelID().getPathFile().exists()) {
+                    manager.accountant.rollback(bytes);
+                }
+                throw writeFailure;
             }
         }
 
@@ -240,9 +224,11 @@ final class DorisIOManager implements IOManager {
 
         @Override
         public void deleteChannel() {
-            delegate.deleteChannel();
-            if (!getChannelID().getPathFile().exists()) {
-                manager.releaseChannel(getChannelID());
+            long bytes = channelSize(getChannelID());
+            try {
+                delegate.deleteChannel();
+            } finally {
+                manager.releaseIfDeleted(getChannelID(), bytes);
             }
         }
 
@@ -253,9 +239,11 @@ final class DorisIOManager implements IOManager {
 
         @Override
         public void closeAndDelete() throws IOException {
-            delegate.closeAndDelete();
-            if (!getChannelID().getPathFile().exists()) {
-                manager.releaseChannel(getChannelID());
+            long bytes = channelSize(getChannelID());
+            try {
+                delegate.closeAndDelete();
+            } finally {
+                manager.releaseIfDeleted(getChannelID(), bytes);
             }
         }
     }
@@ -273,8 +261,7 @@ final class DorisIOManager implements IOManager {
         public void readInto(Buffer buffer) throws IOException {
             long position = delegate.getNioFileChannel().position();
             delegate.readInto(buffer);
-            manager.accountant.recordRead(
-                    getChannelID().getPath(), delegate.getNioFileChannel().position() - position);
+            manager.accountant.recordRead(delegate.getNioFileChannel().position() - position);
         }
 
         @Override
@@ -304,9 +291,11 @@ final class DorisIOManager implements IOManager {
 
         @Override
         public void deleteChannel() {
-            delegate.deleteChannel();
-            if (!getChannelID().getPathFile().exists()) {
-                manager.releaseChannel(getChannelID());
+            long bytes = channelSize(getChannelID());
+            try {
+                delegate.deleteChannel();
+            } finally {
+                manager.releaseIfDeleted(getChannelID(), bytes);
             }
         }
 
@@ -317,9 +306,11 @@ final class DorisIOManager implements IOManager {
 
         @Override
         public void closeAndDelete() throws IOException {
-            delegate.closeAndDelete();
-            if (!getChannelID().getPathFile().exists()) {
-                manager.releaseChannel(getChannelID());
+            long bytes = channelSize(getChannelID());
+            try {
+                delegate.closeAndDelete();
+            } finally {
+                manager.releaseIfDeleted(getChannelID(), bytes);
             }
         }
     }

--- a/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/PaimonJniWriter.java
+++ b/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/PaimonJniWriter.java
@@ -32,7 +32,6 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.crosspartition.IndexBootstrap;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.index.BucketAssigner;
 import org.apache.paimon.index.HashBucketAssigner;
 import org.apache.paimon.index.SimpleHashBucketAssigner;
@@ -104,7 +103,7 @@ public class PaimonJniWriter {
     private PaimonWriteSchema writeSchema;
     private FileStoreTable table;
     private TableWriteImpl<?> writer;
-    private IOManager ioManager;
+    private DorisIOManager ioManager;
     private ExecutorService compactionExecutor;
     private long commitIdentifier;
     private String commitUser;
@@ -233,6 +232,10 @@ public class PaimonJniWriter {
                         VectorSchemaRoot root = Data.importVectorSchemaRoot(
                                 allocator, array, schema, dictionaries)) {
                     writeBatch(root);
+                    // Some Paimon writers (lookup stores, global indexes and clustering indexes)
+                    // write raw files below IOManager paths. Account their observed growth before
+                    // returning control to the native pipeline.
+                    ioManager.reconcile();
                     return null;
                 } catch (Throwable t) {
                     throw new RuntimeException("PaimonJniWriter C Data write failed", t);
@@ -550,6 +553,7 @@ public class PaimonJniWriter {
         List<CommitMessage> messages = commitIdentifier > 0
                 ? writer.prepareCommit(true, commitIdentifier)
                 : writer.prepareCommit();
+        ioManager.reconcile();
         preparedCommitMessages = new ArrayList<>(messages);
         return messages;
     }
@@ -579,21 +583,31 @@ public class PaimonJniWriter {
             throw new IllegalStateException(
                     "A previous Paimon SDK close failed; native memory cannot be released safely");
         }
-        Exception failure = closeResource(writer, null);
+        Exception lifecycleFailure = closeResource(writer, null);
         Exception compactionFailure = closeCompactionExecutor();
         if (compactionFailure != null) {
-            failure = appendFailure(failure, compactionFailure);
+            lifecycleFailure = appendFailure(lifecycleFailure, compactionFailure);
             // The task may still reference Doris-backed memory and spill files. Leave all dependent
             // Java resources reachable and open; the native backend will retain their handles.
             sdkCloseFailed = true;
-            throw failure;
+            throw lifecycleFailure;
         }
-        failure = closeResource(globalIndexAssigner, failure);
-        failure = closeResource(ioManager, failure);
+        lifecycleFailure = closeResource(globalIndexAssigner, lifecycleFailure);
+        Exception cleanupFailure = closeResource(ioManager, null);
         clearWriterState();
-        if (failure != null) {
+        if (lifecycleFailure != null) {
+            if (cleanupFailure != null) {
+                lifecycleFailure.addSuppressed(cleanupFailure);
+            }
             sdkCloseFailed = true;
-            throw failure;
+            throw lifecycleFailure;
+        }
+        if (cleanupFailure != null) {
+            // The QueryContext owns the parent spill directory and its GC retry path. Failure to
+            // eagerly remove Paimon's nested directory is not evidence that Java tasks still hold
+            // native memory, so it must not fence every later Paimon writer on this BE.
+            LOG.warn("Failed to eagerly clean a Paimon spill directory; Doris spill GC will retry",
+                    cleanupFailure);
         }
     }
 
@@ -681,14 +695,17 @@ public class PaimonJniWriter {
 
     static native ByteBuffer allocatePaimonMemoryPage(long nativeMemoryManager, int bytes);
 
-    static native String getPaimonSpillDirectory(long nativeSpillSession)
+    static native String[] getPaimonSpillDirectories(long nativeSpillSession)
             throws IOException;
 
-    static native void reservePaimonSpill(long nativeSpillSession, long bytes)
+    static native void reservePaimonSpill(long nativeSpillSession, String path, long bytes)
             throws IOException;
 
     static native void updatePaimonSpillAccounting(
-            long nativeSpillSession, long currentBytesDelta, long writeBytes, long readBytes);
+            long nativeSpillSession, String path,
+            long currentBytesDelta, long writeBytes, long readBytes);
+
+    static native void reconcilePaimonSpill(long nativeSpillSession) throws IOException;
 
     private static class PartitionBucket {
         private final BinaryRow partition;

--- a/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/PaimonJniWriter.java
+++ b/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/PaimonJniWriter.java
@@ -150,13 +150,13 @@ public class PaimonJniWriter {
      * @param timeZone       normalized Doris session timezone used for Paimon LTZ values
      * @param nativePageMemoryLimitBytes maximum Doris-managed Paimon page memory
      * @param nativeMemoryManager opaque BE manager used to allocate tracked native pages
-     * @param nativeSpillDirectory opaque managed spill session used for capacity and I/O accounting
+     * @param nativeSpillSession opaque managed spill session used for capacity and I/O accounting
      */
     public void open(String serializedTable, Map<String, String> hadoopConfig,
                      String[] columnNames, long transactionId, String commitUser,
                      boolean overwrite, boolean changelogWrite, String timeZone,
                      long nativePageMemoryLimitBytes, long nativeMemoryManager,
-                     long nativeSpillDirectory) throws Exception {
+                     long nativeSpillSession) throws Exception {
         try (ThreadClassLoaderContext ignored = new ThreadClassLoaderContext(classLoader)) {
             if (nativePageMemoryLimitBytes <= 0) {
                 throw new IllegalArgumentException(
@@ -195,7 +195,7 @@ public class PaimonJniWriter {
                             coreOptions,
                             nativePageMemoryLimitBytes,
                             nativeMemoryManager,
-                            nativeSpillDirectory);
+                            nativeSpillSession);
                     return null;
                 } catch (Throwable t) {
                     try {
@@ -318,7 +318,7 @@ public class PaimonJniWriter {
 
     private void openFileStoreWriter(FileStoreTable table, String commitUser, boolean overwrite,
             CoreOptions coreOptions, long nativePageMemoryLimitBytes,
-            long nativeMemoryManager, long nativeSpillDirectory) throws Exception {
+            long nativeMemoryManager, long nativeSpillSession) throws Exception {
         writer = table.newWrite(commitUser);
         compactionExecutor = Executors.newSingleThreadExecutor(
                 new ExecutorThreadFactory("doris-paimon-compaction"));
@@ -327,7 +327,7 @@ public class PaimonJniWriter {
             writer.withIgnorePreviousFiles(true);
         }
         openMemoryResources(table, coreOptions, nativePageMemoryLimitBytes,
-                nativeMemoryManager, nativeSpillDirectory);
+                nativeMemoryManager, nativeSpillSession);
         openDynamicBucketAssigner(table, commitUser, overwrite, coreOptions);
     }
 
@@ -350,7 +350,7 @@ public class PaimonJniWriter {
             CoreOptions coreOptions,
             long nativePageMemoryLimitBytes,
             long nativeMemoryManager,
-            long nativeSpillDirectory) throws Exception {
+            long nativeSpillSession) throws Exception {
         int pageSize = coreOptions.pageSize();
         long writeBufferSize = coreOptions.writeBufferSize();
         // Paimon creates merge-tree bucket writers lazily on the first write. Their
@@ -367,25 +367,12 @@ public class PaimonJniWriter {
         LOG.info("Paimon writer uses Doris-managed memory pool: limit={} bytes, pageSize={}",
                 memoryPoolFactory.totalBufferSize(), pageSize);
 
-        if (!coreOptions.writeBufferSpillable()) {
-            return;
-        }
-
-        if (nativeSpillDirectory == 0) {
-            throw new IllegalArgumentException(
-                    "PaimonJniWriter requires a managed spill directory when spill is enabled");
-        }
-        String[] spillDirectories = createPaimonSpillDirectories(nativeSpillDirectory);
-        if (spillDirectories == null || spillDirectories.length == 0) {
-            throw new IOException("Doris spill manager returned no available directories");
-        }
         // All Paimon temporary files, including lookup and clustering files written directly by
-        // Paimon, live below the query-scoped Doris spill directory and share its cleanup lease.
-        // DorisIOManager additionally accounts buffer-channel I/O, which is the part exposed by
-        // Paimon's IOManager callbacks.
-        ioManager = DorisIOManager.create(spillDirectories, nativeSpillDirectory);
+        // Paimon, use the same Doris-managed directory. DorisIOManager requests that directory only
+        // on its first actual use, so a memory-only writer does not depend on spill storage.
+        ioManager = DorisIOManager.create(nativeSpillSession);
         writer.withIOManager(ioManager);
-        LOG.info("Paimon writer spill enabled: dirs={}", String.join(",", spillDirectories));
+        LOG.info("Paimon writer uses a lazy Doris-managed spill session");
     }
 
     static long validateAndGetMemoryPoolLimit(long writeBufferSize,
@@ -694,15 +681,14 @@ public class PaimonJniWriter {
 
     static native ByteBuffer allocatePaimonMemoryPage(long nativeMemoryManager, int bytes);
 
-    static native String[] createPaimonSpillDirectories(long nativeSpillDirectory)
+    static native String getPaimonSpillDirectory(long nativeSpillSession)
             throws IOException;
 
-    static native void reservePaimonSpill(long nativeSpillDirectory, String path, long bytes)
+    static native void reservePaimonSpill(long nativeSpillSession, long bytes)
             throws IOException;
 
     static native void updatePaimonSpillAccounting(
-            long nativeSpillDirectory, String path, long currentBytesDelta,
-            long writeBytes, long readBytes);
+            long nativeSpillSession, long currentBytesDelta, long writeBytes, long readBytes);
 
     private static class PartitionBucket {
         private final BinaryRow partition;

--- a/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/PaimonJniWriter.java
+++ b/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/PaimonJniWriter.java
@@ -33,7 +33,6 @@ import org.apache.paimon.crosspartition.IndexBootstrap;
 import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.disk.IOManager;
-import org.apache.paimon.disk.IOManagerImpl;
 import org.apache.paimon.index.BucketAssigner;
 import org.apache.paimon.index.HashBucketAssigner;
 import org.apache.paimon.index.SimpleHashBucketAssigner;
@@ -46,12 +45,12 @@ import org.apache.paimon.table.sink.PartitionKeyExtractor;
 import org.apache.paimon.table.sink.RowPartitionKeyExtractor;
 import org.apache.paimon.table.sink.SinkRecord;
 import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.utils.ExecutorThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,6 +60,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * JNI entry point for Paimon write operations.
@@ -90,6 +92,7 @@ public class PaimonJniWriter {
     private static final Logger LOG = LoggerFactory.getLogger(PaimonJniWriter.class);
     private static final int APPEND_ONLY_WRITER_MIN_PAGES = 1;
     private static final int MERGE_TREE_WRITER_MIN_PAGES = 3;
+    private static final long COMPACTION_CLOSE_TIMEOUT_SECONDS = 60;
 
     private final ClassLoader classLoader;
     private final PaimonCommitCodec commitCodec = new PaimonCommitCodec();
@@ -102,6 +105,7 @@ public class PaimonJniWriter {
     private FileStoreTable table;
     private TableWriteImpl<?> writer;
     private IOManager ioManager;
+    private ExecutorService compactionExecutor;
     private long commitIdentifier;
     private String commitUser;
     private BucketMode bucketMode;
@@ -144,14 +148,15 @@ public class PaimonJniWriter {
      * @param overwrite      whether this is an overwrite write
      * @param changelogWrite whether the first input column contains a row change operation
      * @param timeZone       normalized Doris session timezone used for Paimon LTZ values
-     * @param spillDirectories Doris storage-root scoped directories for Paimon write-buffer spill
      * @param nativePageMemoryLimitBytes maximum Doris-managed Paimon page memory
      * @param nativeMemoryManager opaque BE manager used to allocate tracked native pages
+     * @param nativeSpillDirectory opaque managed spill session used for capacity and I/O accounting
      */
     public void open(String serializedTable, Map<String, String> hadoopConfig,
                      String[] columnNames, long transactionId, String commitUser,
-                     boolean overwrite, boolean changelogWrite, String timeZone, String spillDirectories,
-                     long nativePageMemoryLimitBytes, long nativeMemoryManager) throws Exception {
+                     boolean overwrite, boolean changelogWrite, String timeZone,
+                     long nativePageMemoryLimitBytes, long nativeMemoryManager,
+                     long nativeSpillDirectory) throws Exception {
         try (ThreadClassLoaderContext ignored = new ThreadClassLoaderContext(classLoader)) {
             if (nativePageMemoryLimitBytes <= 0) {
                 throw new IllegalArgumentException(
@@ -187,10 +192,10 @@ public class PaimonJniWriter {
                             table,
                             commitUser,
                             overwrite,
-                            spillDirectories,
                             coreOptions,
                             nativePageMemoryLimitBytes,
-                            nativeMemoryManager);
+                            nativeMemoryManager,
+                            nativeSpillDirectory);
                     return null;
                 } catch (Throwable t) {
                     try {
@@ -312,14 +317,17 @@ public class PaimonJniWriter {
     // ────────────────────────────────────────────────────────────
 
     private void openFileStoreWriter(FileStoreTable table, String commitUser, boolean overwrite,
-            String spillDirectories, CoreOptions coreOptions, long nativePageMemoryLimitBytes,
-            long nativeMemoryManager) throws Exception {
+            CoreOptions coreOptions, long nativePageMemoryLimitBytes,
+            long nativeMemoryManager, long nativeSpillDirectory) throws Exception {
         writer = table.newWrite(commitUser);
+        compactionExecutor = Executors.newSingleThreadExecutor(
+                new ExecutorThreadFactory("doris-paimon-compaction"));
+        writer.withCompactExecutor(compactionExecutor);
         if (overwrite) {
             writer.withIgnorePreviousFiles(true);
         }
-        openMemoryResources(table, coreOptions, spillDirectories, nativePageMemoryLimitBytes,
-                nativeMemoryManager);
+        openMemoryResources(table, coreOptions, nativePageMemoryLimitBytes,
+                nativeMemoryManager, nativeSpillDirectory);
         openDynamicBucketAssigner(table, commitUser, overwrite, coreOptions);
     }
 
@@ -340,9 +348,9 @@ public class PaimonJniWriter {
     private void openMemoryResources(
             FileStoreTable table,
             CoreOptions coreOptions,
-            String spillDirectories,
             long nativePageMemoryLimitBytes,
-            long nativeMemoryManager) throws Exception {
+            long nativeMemoryManager,
+            long nativeSpillDirectory) throws Exception {
         int pageSize = coreOptions.pageSize();
         long writeBufferSize = coreOptions.writeBufferSize();
         // Paimon creates merge-tree bucket writers lazily on the first write. Their
@@ -363,13 +371,21 @@ public class PaimonJniWriter {
             return;
         }
 
-        String[] splitDirectories = IOManagerImpl.splitPaths(spillDirectories);
-        for (String directory : splitDirectories) {
-            Files.createDirectories(Paths.get(directory));
+        if (nativeSpillDirectory == 0) {
+            throw new IllegalArgumentException(
+                    "PaimonJniWriter requires a managed spill directory when spill is enabled");
         }
-        ioManager = IOManager.create(splitDirectories);
+        String[] spillDirectories = createPaimonSpillDirectories(nativeSpillDirectory);
+        if (spillDirectories == null || spillDirectories.length == 0) {
+            throw new IOException("Doris spill manager returned no available directories");
+        }
+        // All Paimon temporary files, including lookup and clustering files written directly by
+        // Paimon, live below the query-scoped Doris spill directory and share its cleanup lease.
+        // DorisIOManager additionally accounts buffer-channel I/O, which is the part exposed by
+        // Paimon's IOManager callbacks.
+        ioManager = DorisIOManager.create(spillDirectories, nativeSpillDirectory);
         writer.withIOManager(ioManager);
-        LOG.info("Paimon writer spill enabled: dirs={}", spillDirectories);
+        LOG.info("Paimon writer spill enabled: dirs={}", String.join(",", spillDirectories));
     }
 
     static long validateAndGetMemoryPoolLimit(long writeBufferSize,
@@ -577,6 +593,14 @@ public class PaimonJniWriter {
                     "A previous Paimon SDK close failed; native memory cannot be released safely");
         }
         Exception failure = closeResource(writer, null);
+        Exception compactionFailure = closeCompactionExecutor();
+        if (compactionFailure != null) {
+            failure = appendFailure(failure, compactionFailure);
+            // The task may still reference Doris-backed memory and spill files. Leave all dependent
+            // Java resources reachable and open; the native backend will retain their handles.
+            sdkCloseFailed = true;
+            throw failure;
+        }
         failure = closeResource(globalIndexAssigner, failure);
         failure = closeResource(ioManager, failure);
         clearWriterState();
@@ -598,6 +622,35 @@ public class PaimonJniWriter {
             }
             previousFailure.addSuppressed(closeFailure);
         }
+        return previousFailure;
+    }
+
+    private Exception closeCompactionExecutor() {
+        if (compactionExecutor == null) {
+            return null;
+        }
+        ExecutorService executor = compactionExecutor;
+        compactionExecutor = null;
+        executor.shutdownNow();
+        try {
+            if (!executor.awaitTermination(COMPACTION_CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                IllegalStateException failure = new IllegalStateException(
+                        "Paimon compaction did not stop within "
+                                + COMPACTION_CLOSE_TIMEOUT_SECONDS + " seconds");
+                return failure;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return e;
+        }
+        return null;
+    }
+
+    private static Exception appendFailure(Exception previousFailure, Exception failure) {
+        if (previousFailure == null) {
+            return failure;
+        }
+        previousFailure.addSuppressed(failure);
         return previousFailure;
     }
 
@@ -640,6 +693,16 @@ public class PaimonJniWriter {
     // ────────────────────────────────────────────────────────────
 
     static native ByteBuffer allocatePaimonMemoryPage(long nativeMemoryManager, int bytes);
+
+    static native String[] createPaimonSpillDirectories(long nativeSpillDirectory)
+            throws IOException;
+
+    static native void reservePaimonSpill(long nativeSpillDirectory, String path, long bytes)
+            throws IOException;
+
+    static native void updatePaimonSpillAccounting(
+            long nativeSpillDirectory, String path, long currentBytesDelta,
+            long writeBytes, long readBytes);
 
     private static class PartitionBucket {
         private final BinaryRow partition;

--- a/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/PaimonJniWriter.java
+++ b/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/PaimonJniWriter.java
@@ -232,10 +232,6 @@ public class PaimonJniWriter {
                         VectorSchemaRoot root = Data.importVectorSchemaRoot(
                                 allocator, array, schema, dictionaries)) {
                     writeBatch(root);
-                    // Some Paimon writers (lookup stores, global indexes and clustering indexes)
-                    // write raw files below IOManager paths. Observe their growth periodically
-                    // without turning every Doris block into a recursive filesystem scan.
-                    ioManager.reconcileIfDue();
                     return null;
                 } catch (Throwable t) {
                     throw new RuntimeException("PaimonJniWriter C Data write failed", t);
@@ -553,7 +549,6 @@ public class PaimonJniWriter {
         List<CommitMessage> messages = commitIdentifier > 0
                 ? writer.prepareCommit(true, commitIdentifier)
                 : writer.prepareCommit();
-        ioManager.reconcileNow(false);
         preparedCommitMessages = new ArrayList<>(messages);
         return messages;
     }
@@ -709,9 +704,6 @@ public class PaimonJniWriter {
     static native void updatePaimonSpillAccounting(
             long nativeSpillSession, String path,
             long currentBytesDelta, long writeBytes, long readBytes);
-
-    static native void reconcilePaimonSpill(
-            long nativeSpillSession, boolean allowRelease) throws IOException;
 
     private static class PartitionBucket {
         private final BinaryRow partition;

--- a/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/PaimonJniWriter.java
+++ b/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/PaimonJniWriter.java
@@ -233,9 +233,9 @@ public class PaimonJniWriter {
                                 allocator, array, schema, dictionaries)) {
                     writeBatch(root);
                     // Some Paimon writers (lookup stores, global indexes and clustering indexes)
-                    // write raw files below IOManager paths. Account their observed growth before
-                    // returning control to the native pipeline.
-                    ioManager.reconcile();
+                    // write raw files below IOManager paths. Observe their growth periodically
+                    // without turning every Doris block into a recursive filesystem scan.
+                    ioManager.reconcileIfDue();
                     return null;
                 } catch (Throwable t) {
                     throw new RuntimeException("PaimonJniWriter C Data write failed", t);
@@ -553,7 +553,7 @@ public class PaimonJniWriter {
         List<CommitMessage> messages = commitIdentifier > 0
                 ? writer.prepareCommit(true, commitIdentifier)
                 : writer.prepareCommit();
-        ioManager.reconcile();
+        ioManager.reconcileNow(false);
         preparedCommitMessages = new ArrayList<>(messages);
         return messages;
     }
@@ -594,15 +594,20 @@ public class PaimonJniWriter {
         }
         lifecycleFailure = closeResource(globalIndexAssigner, lifecycleFailure);
         Exception cleanupFailure = closeResource(ioManager, null);
+        boolean physicalCleanupFailure =
+                cleanupFailure instanceof DorisIOManager.SpillDirectoryCleanupException;
+        if (cleanupFailure != null && !physicalCleanupFailure) {
+            lifecycleFailure = appendFailure(lifecycleFailure, cleanupFailure);
+        }
         clearWriterState();
         if (lifecycleFailure != null) {
-            if (cleanupFailure != null) {
+            if (physicalCleanupFailure) {
                 lifecycleFailure.addSuppressed(cleanupFailure);
             }
             sdkCloseFailed = true;
             throw lifecycleFailure;
         }
-        if (cleanupFailure != null) {
+        if (physicalCleanupFailure) {
             // The QueryContext owns the parent spill directory and its GC retry path. Failure to
             // eagerly remove Paimon's nested directory is not evidence that Java tasks still hold
             // native memory, so it must not fence every later Paimon writer on this BE.
@@ -705,7 +710,8 @@ public class PaimonJniWriter {
             long nativeSpillSession, String path,
             long currentBytesDelta, long writeBytes, long readBytes);
 
-    static native void reconcilePaimonSpill(long nativeSpillSession) throws IOException;
+    static native void reconcilePaimonSpill(
+            long nativeSpillSession, boolean allowRelease) throws IOException;
 
     private static class PartitionBucket {
         private final BinaryRow partition;

--- a/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/DorisIOManagerTest.java
+++ b/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/DorisIOManagerTest.java
@@ -37,13 +37,17 @@ public class DorisIOManagerTest {
     private Path tempDir;
 
     @Test
-    public void testSpillWriteReadAndDeleteAccounting() throws Exception {
-        RecordingSpillAccountant accountant = new RecordingSpillAccountant();
+    public void testSpillDirectoryIsLazyAndVisibleIoIsAccounted() throws Exception {
         Path managedSpillPath = tempDir.resolve("query/paimon");
+        RecordingSpillAccountant accountant = new RecordingSpillAccountant(managedSpillPath);
         Assertions.assertFalse(Files.exists(managedSpillPath));
-        try (DorisIOManager manager = new DorisIOManager(
-                IOManager.create(managedSpillPath.toString()), accountant)) {
+
+        try (DorisIOManager manager = new DorisIOManager(accountant)) {
+            Assertions.assertEquals(0, accountant.directoryRequests);
+            Assertions.assertFalse(Files.exists(managedSpillPath));
+
             FileIOChannel.ID channel = manager.createChannel();
+            Assertions.assertEquals(1, accountant.directoryRequests);
             Assertions.assertTrue(Files.isDirectory(managedSpillPath));
             Buffer buffer = Buffer.create(MemorySegment.wrap(new byte[16]), 16);
 
@@ -66,23 +70,66 @@ public class DorisIOManagerTest {
     }
 
     @Test
-    public void testManagerCloseReleasesUndeletedChannels() throws Exception {
-        RecordingSpillAccountant accountant = new RecordingSpillAccountant();
-        DorisIOManager manager = new DorisIOManager(IOManager.create(tempDir.toString()), accountant);
-        FileIOChannel.ID channel = manager.createChannel();
-        BufferFileWriter writer = manager.createBufferFileWriter(channel);
-        writer.writeBlock(Buffer.create(MemorySegment.wrap(new byte[8]), 8));
-        writer.close();
+    public void testCloseBeforeUseDoesNotRequestSpillDirectory() throws Exception {
+        Path managedSpillPath = tempDir.resolve("query/paimon");
+        RecordingSpillAccountant accountant = new RecordingSpillAccountant(managedSpillPath);
 
-        manager.close();
+        new DorisIOManager(accountant).close();
 
-        Assertions.assertEquals(0, accountant.currentBytes);
-        Assertions.assertEquals(12, accountant.releasedBytes);
+        Assertions.assertEquals(0, accountant.directoryRequests);
+        Assertions.assertFalse(Files.exists(managedSpillPath));
+    }
+
+    @Test
+    public void testDirectDeletionIsConservativelyAccountedUntilSessionEnds() throws Exception {
+        RecordingSpillAccountant accountant = new RecordingSpillAccountant(tempDir);
+        try (DorisIOManager manager = new DorisIOManager(accountant)) {
+            FileIOChannel.ID deletedChannel = manager.createChannel();
+            BufferFileWriter firstWriter = manager.createBufferFileWriter(deletedChannel);
+            firstWriter.writeBlock(Buffer.create(MemorySegment.wrap(new byte[8]), 8));
+            firstWriter.close();
+            Assertions.assertTrue(deletedChannel.getPathFile().delete());
+
+            FileIOChannel.ID nextChannel = manager.createChannel();
+            BufferFileWriter nextWriter = manager.createBufferFileWriter(nextChannel);
+            nextWriter.writeBlock(Buffer.create(MemorySegment.wrap(new byte[4]), 4));
+            nextWriter.close();
+
+            Assertions.assertEquals(20, accountant.reservedBytes);
+            Assertions.assertEquals(20, accountant.currentBytes);
+            Assertions.assertEquals(0, accountant.releasedBytes);
+        }
+    }
+
+    @Test
+    public void testWriteFailureRollsBackWhenChannelIsDeleted() throws Exception {
+        RecordingSpillAccountant accountant = new RecordingSpillAccountant(tempDir);
+        IOManager delegate = IOManager.create(tempDir.toString());
+        FileIOChannel.ID channel = delegate.createChannel();
+        BufferFileWriter closedWriter = delegate.createBufferFileWriter(channel);
+        closedWriter.close();
+        IOManager failingWriteManager = new IOManagerImpl(tempDir.toString()) {
+            @Override
+            public BufferFileWriter createBufferFileWriter(FileIOChannel.ID ignored) {
+                return closedWriter;
+            }
+        };
+
+        try (DorisIOManager manager = new DorisIOManager(failingWriteManager, accountant)) {
+            BufferFileWriter writer = manager.createBufferFileWriter(channel);
+            Assertions.assertThrows(IOException.class,
+                    () -> writer.writeBlock(Buffer.create(MemorySegment.wrap(new byte[8]), 8)));
+            Assertions.assertFalse(channel.getPathFile().exists());
+            Assertions.assertEquals(12, accountant.reservedBytes);
+            Assertions.assertEquals(0, accountant.currentBytes);
+        } finally {
+            delegate.close();
+        }
     }
 
     @Test
     public void testManagerCloseFailureKeepsExistingChannelAccounted() throws Exception {
-        RecordingSpillAccountant accountant = new RecordingSpillAccountant();
+        RecordingSpillAccountant accountant = new RecordingSpillAccountant(tempDir);
         IOManager failingCloseManager = new IOManagerImpl(tempDir.toString()) {
             @Override
             public void close() throws Exception {
@@ -98,103 +145,54 @@ public class DorisIOManagerTest {
         Assertions.assertThrows(IOException.class, manager::close);
         Assertions.assertTrue(channel.getPathFile().exists());
         Assertions.assertEquals(12, accountant.currentBytes);
-        Assertions.assertEquals(0, accountant.releasedBytes);
 
         writer.deleteChannel();
         Assertions.assertEquals(0, accountant.currentBytes);
         Assertions.assertEquals(12, accountant.releasedBytes);
     }
 
-    @Test
-    public void testNextReservationReleasesDirectlyDeletedChannel() throws Exception {
-        RecordingSpillAccountant accountant = new RecordingSpillAccountant();
-        try (DorisIOManager manager = new DorisIOManager(
-                IOManager.create(tempDir.toString()), accountant)) {
-            FileIOChannel.ID deletedChannel = manager.createChannel();
-            BufferFileWriter firstWriter = manager.createBufferFileWriter(deletedChannel);
-            firstWriter.writeBlock(Buffer.create(MemorySegment.wrap(new byte[8]), 8));
-            firstWriter.close();
-            Assertions.assertTrue(deletedChannel.getPathFile().delete());
-
-            FileIOChannel.ID nextChannel = manager.createChannel();
-            BufferFileWriter nextWriter = manager.createBufferFileWriter(nextChannel);
-            nextWriter.writeBlock(Buffer.create(MemorySegment.wrap(new byte[4]), 4));
-            nextWriter.close();
-
-            Assertions.assertEquals(20, accountant.reservedBytes);
-            Assertions.assertEquals(8, accountant.currentBytes);
-            Assertions.assertEquals(12, accountant.releasedBytes);
-        }
-    }
-
-    @Test
-    public void testFailedReservationReconcilesDirectDeletionAndRetries() throws Exception {
-        RecordingSpillAccountant accountant = new RecordingSpillAccountant(16);
-        try (DorisIOManager manager = new DorisIOManager(
-                IOManager.create(tempDir.toString()), accountant)) {
-            FileIOChannel.ID oldChannel = manager.createChannel();
-            BufferFileWriter oldWriter = manager.createBufferFileWriter(oldChannel);
-            oldWriter.writeBlock(Buffer.create(MemorySegment.wrap(new byte[8]), 8));
-            oldWriter.close();
-
-            FileIOChannel.ID nextChannel = manager.createChannel();
-            BufferFileWriter nextWriter = manager.createBufferFileWriter(nextChannel);
-            Assertions.assertTrue(oldChannel.getPathFile().delete());
-
-            nextWriter.writeBlock(Buffer.create(MemorySegment.wrap(new byte[4]), 4));
-            nextWriter.close();
-
-            Assertions.assertEquals(3, accountant.reserveAttempts);
-            Assertions.assertEquals(20, accountant.reservedBytes);
-            Assertions.assertEquals(8, accountant.currentBytes);
-            Assertions.assertEquals(12, accountant.releasedBytes);
-        }
-    }
-
     private static final class RecordingSpillAccountant implements DorisIOManager.SpillAccountant {
-        private final long limitBytes;
-        private long reserveAttempts;
+        private final Path spillDirectory;
+        private long directoryRequests;
         private long reservedBytes;
         private long currentBytes;
         private long writtenBytes;
         private long readBytes;
         private long releasedBytes;
 
-        private RecordingSpillAccountant() {
-            this(Long.MAX_VALUE);
-        }
-
-        private RecordingSpillAccountant(long limitBytes) {
-            this.limitBytes = limitBytes;
+        private RecordingSpillAccountant(Path spillDirectory) {
+            this.spillDirectory = spillDirectory;
         }
 
         @Override
-        public void reserve(String path, long bytes) throws IOException {
-            reserveAttempts++;
-            if (currentBytes + bytes > limitBytes) {
-                throw new IOException("spill capacity exceeded");
-            }
+        public String getSpillDirectory() {
+            directoryRequests++;
+            return spillDirectory.toString();
+        }
+
+        @Override
+        public void reserve(long bytes) {
             reservedBytes += bytes;
             currentBytes += bytes;
         }
 
         @Override
-        public void rollback(String path, long bytes) {
+        public void rollback(long bytes) {
             currentBytes -= bytes;
         }
 
         @Override
-        public void commitWrite(String path, long bytes) {
+        public void commitWrite(long bytes) {
             writtenBytes += bytes;
         }
 
         @Override
-        public void recordRead(String path, long bytes) {
+        public void recordRead(long bytes) {
             readBytes += bytes;
         }
 
         @Override
-        public void release(String path, long bytes) {
+        public void release(long bytes) {
             releasedBytes += bytes;
             currentBytes -= bytes;
         }

--- a/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/DorisIOManagerTest.java
+++ b/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/DorisIOManagerTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.atomic.AtomicLong;
 
 public class DorisIOManagerTest {
     @TempDir
@@ -167,42 +166,10 @@ public class DorisIOManagerTest {
                 DorisIOManager.SpillDirectoryCleanupException.class, manager::close);
         Assertions.assertTrue(channel.getPathFile().exists());
         Assertions.assertEquals(12, accountant.currentBytes);
-        Assertions.assertEquals(1, accountant.reconcileCalls);
-        Assertions.assertTrue(accountant.lastAllowRelease);
 
         writer.deleteChannel();
         Assertions.assertEquals(0, accountant.currentBytes);
         Assertions.assertEquals(12, accountant.releasedBytes);
-    }
-
-    @Test
-    public void testRawFileReconciliationIsRateLimitedAndFinalPassIsExact() throws Exception {
-        RecordingSpillAccountant accountant = new RecordingSpillAccountant(tempDir);
-        IOManager delegate = IOManager.create(tempDir.toString());
-        AtomicLong nanoTime = new AtomicLong(10);
-        DorisIOManager manager =
-                new DorisIOManager(delegate, accountant, nanoTime::get, 100);
-        try {
-            for (int i = 0; i < 100; i++) {
-                Files.writeString(tempDir.resolve("raw-" + i), "data-" + i);
-                manager.reconcileIfDue();
-            }
-            Assertions.assertEquals(1, accountant.reconcileCalls);
-            Assertions.assertFalse(accountant.lastAllowRelease);
-
-            nanoTime.addAndGet(100);
-            manager.reconcileIfDue();
-            Assertions.assertEquals(2, accountant.reconcileCalls);
-            Assertions.assertFalse(accountant.lastAllowRelease);
-
-            manager.close();
-            Assertions.assertEquals(3, accountant.reconcileCalls);
-            Assertions.assertTrue(accountant.lastAllowRelease);
-        } finally {
-            if (accountant.reconcileCalls < 3) {
-                delegate.close();
-            }
-        }
     }
 
     private static final class RecordingSpillAccountant implements DorisIOManager.SpillAccountant {
@@ -213,8 +180,6 @@ public class DorisIOManagerTest {
         private long writtenBytes;
         private long readBytes;
         private long releasedBytes;
-        private int reconcileCalls;
-        private boolean lastAllowRelease;
 
         private RecordingSpillAccountant(Path... spillDirectories) {
             this.spillDirectories = spillDirectories;
@@ -253,12 +218,6 @@ public class DorisIOManagerTest {
         public void release(String path, long bytes) {
             releasedBytes += bytes;
             currentBytes -= bytes;
-        }
-
-        @Override
-        public void reconcile(boolean allowRelease) {
-            reconcileCalls++;
-            lastAllowRelease = allowRelease;
         }
     }
 }

--- a/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/DorisIOManagerTest.java
+++ b/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/DorisIOManagerTest.java
@@ -81,7 +81,7 @@ public class DorisIOManagerTest {
     }
 
     @Test
-    public void testDirectDeletionIsConservativelyAccountedUntilSessionEnds() throws Exception {
+    public void testDirectDeletionIsReleasedBeforeNextWriter() throws Exception {
         RecordingSpillAccountant accountant = new RecordingSpillAccountant(tempDir);
         try (DorisIOManager manager = new DorisIOManager(accountant)) {
             FileIOChannel.ID deletedChannel = manager.createChannel();
@@ -96,8 +96,28 @@ public class DorisIOManagerTest {
             nextWriter.close();
 
             Assertions.assertEquals(20, accountant.reservedBytes);
-            Assertions.assertEquals(20, accountant.currentBytes);
-            Assertions.assertEquals(0, accountant.releasedBytes);
+            Assertions.assertEquals(8, accountant.currentBytes);
+            Assertions.assertEquals(12, accountant.releasedBytes);
+        }
+    }
+
+    @Test
+    public void testAllManagedSpillDirectoriesArePassedToPaimon() throws Exception {
+        Path first = tempDir.resolve("spill-a");
+        Path second = tempDir.resolve("spill-b");
+        RecordingSpillAccountant accountant = new RecordingSpillAccountant(first, second);
+
+        try (DorisIOManager manager = new DorisIOManager(accountant)) {
+            boolean usedFirst = false;
+            boolean usedSecond = false;
+            for (int i = 0; i < 4; i++) {
+                Path channel = manager.createChannel().getPathFile().toPath();
+                usedFirst |= channel.startsWith(first);
+                usedSecond |= channel.startsWith(second);
+            }
+            Assertions.assertTrue(usedFirst);
+            Assertions.assertTrue(usedSecond);
+            Assertions.assertEquals(1, accountant.directoryRequests);
         }
     }
 
@@ -152,7 +172,7 @@ public class DorisIOManagerTest {
     }
 
     private static final class RecordingSpillAccountant implements DorisIOManager.SpillAccountant {
-        private final Path spillDirectory;
+        private final Path[] spillDirectories;
         private long directoryRequests;
         private long reservedBytes;
         private long currentBytes;
@@ -160,41 +180,47 @@ public class DorisIOManagerTest {
         private long readBytes;
         private long releasedBytes;
 
-        private RecordingSpillAccountant(Path spillDirectory) {
-            this.spillDirectory = spillDirectory;
+        private RecordingSpillAccountant(Path... spillDirectories) {
+            this.spillDirectories = spillDirectories;
         }
 
         @Override
-        public String getSpillDirectory() {
+        public String[] getSpillDirectories() {
             directoryRequests++;
-            return spillDirectory.toString();
+            return java.util.Arrays.stream(spillDirectories)
+                    .map(Path::toString)
+                    .toArray(String[]::new);
         }
 
         @Override
-        public void reserve(long bytes) {
+        public void reserve(String path, long bytes) {
             reservedBytes += bytes;
             currentBytes += bytes;
         }
 
         @Override
-        public void rollback(long bytes) {
+        public void rollback(String path, long bytes) {
             currentBytes -= bytes;
         }
 
         @Override
-        public void commitWrite(long bytes) {
+        public void commitWrite(String path, long bytes) {
             writtenBytes += bytes;
         }
 
         @Override
-        public void recordRead(long bytes) {
+        public void recordRead(String path, long bytes) {
             readBytes += bytes;
         }
 
         @Override
-        public void release(long bytes) {
+        public void release(String path, long bytes) {
             releasedBytes += bytes;
             currentBytes -= bytes;
+        }
+
+        @Override
+        public void reconcile() {
         }
     }
 }

--- a/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/DorisIOManagerTest.java
+++ b/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/DorisIOManagerTest.java
@@ -1,0 +1,202 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.paimon;
+
+import org.apache.paimon.disk.BufferFileReader;
+import org.apache.paimon.disk.BufferFileWriter;
+import org.apache.paimon.disk.FileIOChannel;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.disk.IOManagerImpl;
+import org.apache.paimon.memory.Buffer;
+import org.apache.paimon.memory.MemorySegment;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class DorisIOManagerTest {
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    public void testSpillWriteReadAndDeleteAccounting() throws Exception {
+        RecordingSpillAccountant accountant = new RecordingSpillAccountant();
+        Path managedSpillPath = tempDir.resolve("query/paimon");
+        Assertions.assertFalse(Files.exists(managedSpillPath));
+        try (DorisIOManager manager = new DorisIOManager(
+                IOManager.create(managedSpillPath.toString()), accountant)) {
+            FileIOChannel.ID channel = manager.createChannel();
+            Assertions.assertTrue(Files.isDirectory(managedSpillPath));
+            Buffer buffer = Buffer.create(MemorySegment.wrap(new byte[16]), 16);
+
+            BufferFileWriter writer = manager.createBufferFileWriter(channel);
+            writer.writeBlock(buffer);
+            writer.close();
+
+            Assertions.assertEquals(20, accountant.reservedBytes);
+            Assertions.assertEquals(20, accountant.currentBytes);
+            Assertions.assertEquals(20, accountant.writtenBytes);
+
+            BufferFileReader reader = manager.createBufferFileReader(channel);
+            reader.readInto(Buffer.create(MemorySegment.wrap(new byte[16]), 0));
+            Assertions.assertEquals(20, accountant.readBytes);
+            reader.closeAndDelete();
+
+            Assertions.assertEquals(0, accountant.currentBytes);
+            Assertions.assertEquals(20, accountant.releasedBytes);
+        }
+    }
+
+    @Test
+    public void testManagerCloseReleasesUndeletedChannels() throws Exception {
+        RecordingSpillAccountant accountant = new RecordingSpillAccountant();
+        DorisIOManager manager = new DorisIOManager(IOManager.create(tempDir.toString()), accountant);
+        FileIOChannel.ID channel = manager.createChannel();
+        BufferFileWriter writer = manager.createBufferFileWriter(channel);
+        writer.writeBlock(Buffer.create(MemorySegment.wrap(new byte[8]), 8));
+        writer.close();
+
+        manager.close();
+
+        Assertions.assertEquals(0, accountant.currentBytes);
+        Assertions.assertEquals(12, accountant.releasedBytes);
+    }
+
+    @Test
+    public void testManagerCloseFailureKeepsExistingChannelAccounted() throws Exception {
+        RecordingSpillAccountant accountant = new RecordingSpillAccountant();
+        IOManager failingCloseManager = new IOManagerImpl(tempDir.toString()) {
+            @Override
+            public void close() throws Exception {
+                throw new IOException("injected close failure");
+            }
+        };
+        DorisIOManager manager = new DorisIOManager(failingCloseManager, accountant);
+        FileIOChannel.ID channel = manager.createChannel();
+        BufferFileWriter writer = manager.createBufferFileWriter(channel);
+        writer.writeBlock(Buffer.create(MemorySegment.wrap(new byte[8]), 8));
+        writer.close();
+
+        Assertions.assertThrows(IOException.class, manager::close);
+        Assertions.assertTrue(channel.getPathFile().exists());
+        Assertions.assertEquals(12, accountant.currentBytes);
+        Assertions.assertEquals(0, accountant.releasedBytes);
+
+        writer.deleteChannel();
+        Assertions.assertEquals(0, accountant.currentBytes);
+        Assertions.assertEquals(12, accountant.releasedBytes);
+    }
+
+    @Test
+    public void testNextReservationReleasesDirectlyDeletedChannel() throws Exception {
+        RecordingSpillAccountant accountant = new RecordingSpillAccountant();
+        try (DorisIOManager manager = new DorisIOManager(
+                IOManager.create(tempDir.toString()), accountant)) {
+            FileIOChannel.ID deletedChannel = manager.createChannel();
+            BufferFileWriter firstWriter = manager.createBufferFileWriter(deletedChannel);
+            firstWriter.writeBlock(Buffer.create(MemorySegment.wrap(new byte[8]), 8));
+            firstWriter.close();
+            Assertions.assertTrue(deletedChannel.getPathFile().delete());
+
+            FileIOChannel.ID nextChannel = manager.createChannel();
+            BufferFileWriter nextWriter = manager.createBufferFileWriter(nextChannel);
+            nextWriter.writeBlock(Buffer.create(MemorySegment.wrap(new byte[4]), 4));
+            nextWriter.close();
+
+            Assertions.assertEquals(20, accountant.reservedBytes);
+            Assertions.assertEquals(8, accountant.currentBytes);
+            Assertions.assertEquals(12, accountant.releasedBytes);
+        }
+    }
+
+    @Test
+    public void testFailedReservationReconcilesDirectDeletionAndRetries() throws Exception {
+        RecordingSpillAccountant accountant = new RecordingSpillAccountant(16);
+        try (DorisIOManager manager = new DorisIOManager(
+                IOManager.create(tempDir.toString()), accountant)) {
+            FileIOChannel.ID oldChannel = manager.createChannel();
+            BufferFileWriter oldWriter = manager.createBufferFileWriter(oldChannel);
+            oldWriter.writeBlock(Buffer.create(MemorySegment.wrap(new byte[8]), 8));
+            oldWriter.close();
+
+            FileIOChannel.ID nextChannel = manager.createChannel();
+            BufferFileWriter nextWriter = manager.createBufferFileWriter(nextChannel);
+            Assertions.assertTrue(oldChannel.getPathFile().delete());
+
+            nextWriter.writeBlock(Buffer.create(MemorySegment.wrap(new byte[4]), 4));
+            nextWriter.close();
+
+            Assertions.assertEquals(3, accountant.reserveAttempts);
+            Assertions.assertEquals(20, accountant.reservedBytes);
+            Assertions.assertEquals(8, accountant.currentBytes);
+            Assertions.assertEquals(12, accountant.releasedBytes);
+        }
+    }
+
+    private static final class RecordingSpillAccountant implements DorisIOManager.SpillAccountant {
+        private final long limitBytes;
+        private long reserveAttempts;
+        private long reservedBytes;
+        private long currentBytes;
+        private long writtenBytes;
+        private long readBytes;
+        private long releasedBytes;
+
+        private RecordingSpillAccountant() {
+            this(Long.MAX_VALUE);
+        }
+
+        private RecordingSpillAccountant(long limitBytes) {
+            this.limitBytes = limitBytes;
+        }
+
+        @Override
+        public void reserve(String path, long bytes) throws IOException {
+            reserveAttempts++;
+            if (currentBytes + bytes > limitBytes) {
+                throw new IOException("spill capacity exceeded");
+            }
+            reservedBytes += bytes;
+            currentBytes += bytes;
+        }
+
+        @Override
+        public void rollback(String path, long bytes) {
+            currentBytes -= bytes;
+        }
+
+        @Override
+        public void commitWrite(String path, long bytes) {
+            writtenBytes += bytes;
+        }
+
+        @Override
+        public void recordRead(String path, long bytes) {
+            readBytes += bytes;
+        }
+
+        @Override
+        public void release(String path, long bytes) {
+            releasedBytes += bytes;
+            currentBytes -= bytes;
+        }
+    }
+}

--- a/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/DorisIOManagerTest.java
+++ b/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/DorisIOManagerTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class DorisIOManagerTest {
     @TempDir
@@ -162,13 +163,46 @@ public class DorisIOManagerTest {
         writer.writeBlock(Buffer.create(MemorySegment.wrap(new byte[8]), 8));
         writer.close();
 
-        Assertions.assertThrows(IOException.class, manager::close);
+        Assertions.assertThrows(
+                DorisIOManager.SpillDirectoryCleanupException.class, manager::close);
         Assertions.assertTrue(channel.getPathFile().exists());
         Assertions.assertEquals(12, accountant.currentBytes);
+        Assertions.assertEquals(1, accountant.reconcileCalls);
+        Assertions.assertTrue(accountant.lastAllowRelease);
 
         writer.deleteChannel();
         Assertions.assertEquals(0, accountant.currentBytes);
         Assertions.assertEquals(12, accountant.releasedBytes);
+    }
+
+    @Test
+    public void testRawFileReconciliationIsRateLimitedAndFinalPassIsExact() throws Exception {
+        RecordingSpillAccountant accountant = new RecordingSpillAccountant(tempDir);
+        IOManager delegate = IOManager.create(tempDir.toString());
+        AtomicLong nanoTime = new AtomicLong(10);
+        DorisIOManager manager =
+                new DorisIOManager(delegate, accountant, nanoTime::get, 100);
+        try {
+            for (int i = 0; i < 100; i++) {
+                Files.writeString(tempDir.resolve("raw-" + i), "data-" + i);
+                manager.reconcileIfDue();
+            }
+            Assertions.assertEquals(1, accountant.reconcileCalls);
+            Assertions.assertFalse(accountant.lastAllowRelease);
+
+            nanoTime.addAndGet(100);
+            manager.reconcileIfDue();
+            Assertions.assertEquals(2, accountant.reconcileCalls);
+            Assertions.assertFalse(accountant.lastAllowRelease);
+
+            manager.close();
+            Assertions.assertEquals(3, accountant.reconcileCalls);
+            Assertions.assertTrue(accountant.lastAllowRelease);
+        } finally {
+            if (accountant.reconcileCalls < 3) {
+                delegate.close();
+            }
+        }
     }
 
     private static final class RecordingSpillAccountant implements DorisIOManager.SpillAccountant {
@@ -179,6 +213,8 @@ public class DorisIOManagerTest {
         private long writtenBytes;
         private long readBytes;
         private long releasedBytes;
+        private int reconcileCalls;
+        private boolean lastAllowRelease;
 
         private RecordingSpillAccountant(Path... spillDirectories) {
             this.spillDirectories = spillDirectories;
@@ -220,7 +256,9 @@ public class DorisIOManagerTest {
         }
 
         @Override
-        public void reconcile() {
+        public void reconcile(boolean allowRelease) {
+            reconcileCalls++;
+            lastAllowRelease = allowRelease;
         }
     }
 }

--- a/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/PaimonJniWriterTest.java
+++ b/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/PaimonJniWriterTest.java
@@ -17,8 +17,12 @@
 
 package org.apache.doris.paimon;
 
+import org.apache.paimon.disk.BufferFileWriter;
+import org.apache.paimon.disk.FileIOChannel;
 import org.apache.paimon.disk.IOManager;
 import org.apache.paimon.disk.IOManagerImpl;
+import org.apache.paimon.memory.Buffer;
+import org.apache.paimon.memory.MemorySegment;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -33,6 +37,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class PaimonJniWriterTest {
     @TempDir
@@ -169,6 +175,8 @@ public class PaimonJniWriterTest {
                 throw new IOException("injected cleanup failure");
             }
         };
+        AtomicLong currentBytes = new AtomicLong();
+        AtomicBoolean finalReconcile = new AtomicBoolean();
         DorisIOManager.SpillAccountant accountant = new DorisIOManager.SpillAccountant() {
             @Override
             public String[] getSpillDirectories() {
@@ -177,10 +185,12 @@ public class PaimonJniWriterTest {
 
             @Override
             public void reserve(String path, long bytes) {
+                currentBytes.addAndGet(bytes);
             }
 
             @Override
             public void rollback(String path, long bytes) {
+                currentBytes.addAndGet(-bytes);
             }
 
             @Override
@@ -193,18 +203,32 @@ public class PaimonJniWriterTest {
 
             @Override
             public void release(String path, long bytes) {
+                currentBytes.addAndGet(-bytes);
             }
 
             @Override
-            public void reconcile() {
+            public void reconcile(boolean allowRelease) {
+                finalReconcile.set(allowRelease);
             }
         };
+        DorisIOManager ioManager = new DorisIOManager(failingCloseManager, accountant);
+        FileIOChannel.ID channel = ioManager.createChannel();
+        BufferFileWriter spillWriter = ioManager.createBufferFileWriter(channel);
+        spillWriter.writeBlock(Buffer.create(MemorySegment.wrap(new byte[8]), 8));
+        spillWriter.close();
+        Assertions.assertEquals(12, currentBytes.get());
+
         PaimonJniWriter writer = new PaimonJniWriter();
         Field ioManagerField = PaimonJniWriter.class.getDeclaredField("ioManager");
         ioManagerField.setAccessible(true);
-        ioManagerField.set(writer, new DorisIOManager(failingCloseManager, accountant));
+        ioManagerField.set(writer, ioManager);
 
         Assertions.assertDoesNotThrow(writer::close);
+        Assertions.assertTrue(finalReconcile.get());
+        Assertions.assertTrue(channel.getPathFile().exists());
+        Assertions.assertEquals(12, currentBytes.get());
         Assertions.assertDoesNotThrow(writer::close);
+        spillWriter.deleteChannel();
+        Assertions.assertEquals(0, currentBytes.get());
     }
 }

--- a/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/PaimonJniWriterTest.java
+++ b/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/PaimonJniWriterTest.java
@@ -37,7 +37,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class PaimonJniWriterTest {
@@ -176,7 +175,6 @@ public class PaimonJniWriterTest {
             }
         };
         AtomicLong currentBytes = new AtomicLong();
-        AtomicBoolean finalReconcile = new AtomicBoolean();
         DorisIOManager.SpillAccountant accountant = new DorisIOManager.SpillAccountant() {
             @Override
             public String[] getSpillDirectories() {
@@ -205,11 +203,6 @@ public class PaimonJniWriterTest {
             public void release(String path, long bytes) {
                 currentBytes.addAndGet(-bytes);
             }
-
-            @Override
-            public void reconcile(boolean allowRelease) {
-                finalReconcile.set(allowRelease);
-            }
         };
         DorisIOManager ioManager = new DorisIOManager(failingCloseManager, accountant);
         FileIOChannel.ID channel = ioManager.createChannel();
@@ -224,7 +217,6 @@ public class PaimonJniWriterTest {
         ioManagerField.set(writer, ioManager);
 
         Assertions.assertDoesNotThrow(writer::close);
-        Assertions.assertTrue(finalReconcile.get());
         Assertions.assertTrue(channel.getPathFile().exists());
         Assertions.assertEquals(12, currentBytes.get());
         Assertions.assertDoesNotThrow(writer::close);

--- a/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/PaimonJniWriterTest.java
+++ b/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/PaimonJniWriterTest.java
@@ -17,12 +17,17 @@
 
 package org.apache.doris.paimon;
 
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.disk.IOManagerImpl;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -30,6 +35,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 public class PaimonJniWriterTest {
+    @TempDir
+    private Path tempDir;
 
     @Test
     public void testManagedMemoryPoolRequiresAtLeastOnePage() {
@@ -152,5 +159,52 @@ public class PaimonJniWriterTest {
         } finally {
             executor.shutdownNow();
         }
+    }
+
+    @Test
+    public void testSpillDirectoryCleanupFailureDoesNotFenceWriter() throws Exception {
+        IOManager failingCloseManager = new IOManagerImpl(tempDir.toString()) {
+            @Override
+            public void close() throws Exception {
+                throw new IOException("injected cleanup failure");
+            }
+        };
+        DorisIOManager.SpillAccountant accountant = new DorisIOManager.SpillAccountant() {
+            @Override
+            public String[] getSpillDirectories() {
+                return new String[] {tempDir.toString()};
+            }
+
+            @Override
+            public void reserve(String path, long bytes) {
+            }
+
+            @Override
+            public void rollback(String path, long bytes) {
+            }
+
+            @Override
+            public void commitWrite(String path, long bytes) {
+            }
+
+            @Override
+            public void recordRead(String path, long bytes) {
+            }
+
+            @Override
+            public void release(String path, long bytes) {
+            }
+
+            @Override
+            public void reconcile() {
+            }
+        };
+        PaimonJniWriter writer = new PaimonJniWriter();
+        Field ioManagerField = PaimonJniWriter.class.getDeclaredField("ioManager");
+        ioManagerField.setAccessible(true);
+        ioManagerField.set(writer, new DorisIOManager(failingCloseManager, accountant));
+
+        Assertions.assertDoesNotThrow(writer::close);
+        Assertions.assertDoesNotThrow(writer::close);
     }
 }

--- a/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/PaimonJniWriterTest.java
+++ b/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/PaimonJniWriterTest.java
@@ -20,9 +20,14 @@ package org.apache.doris.paimon;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 public class PaimonJniWriterTest {
 
@@ -65,8 +70,7 @@ public class PaimonJniWriterTest {
         try {
             Assertions.assertThrows(Exception.class, () -> writer.open(
                     "not-a-serialized-table", Collections.emptyMap(), new String[0],
-                    1L, "test-user", false, false, "UTC", System.getProperty("java.io.tmpdir"),
-                    64L * 1024 * 1024, 1L));
+                    1L, "test-user", false, false, "UTC", 64L * 1024 * 1024, 1L, 1L));
             Assertions.assertSame(testClassLoader, thread.getContextClassLoader());
         } finally {
             try {
@@ -116,6 +120,37 @@ public class PaimonJniWriterTest {
         } finally {
             thread.setContextClassLoader(originalClassLoader);
             testClassLoader.close();
+        }
+    }
+
+    @Test
+    public void testCloseWaitsForCompactionExecutor() throws Exception {
+        PaimonJniWriter writer = new PaimonJniWriter();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch stopped = new CountDownLatch(1);
+        try {
+            executor.execute(() -> {
+                started.countDown();
+                try {
+                    new CountDownLatch(1).await();
+                } catch (InterruptedException ignored) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    stopped.countDown();
+                }
+            });
+            Assertions.assertTrue(started.await(10, TimeUnit.SECONDS));
+
+            Field executorField = PaimonJniWriter.class.getDeclaredField("compactionExecutor");
+            executorField.setAccessible(true);
+            executorField.set(writer, executor);
+
+            writer.close();
+            Assertions.assertTrue(stopped.await(10, TimeUnit.SECONDS));
+            Assertions.assertTrue(executor.isTerminated());
+        } finally {
+            executor.shutdownNow();
         }
     }
 }

--- a/regression-test/suites/external_table_p0/paimon/write/test_paimon_write_external_paths.groovy
+++ b/regression-test/suites/external_table_p0/paimon/write/test_paimon_write_external_paths.groovy
@@ -46,6 +46,19 @@ suite("test_paimon_write_external_paths", "p0,external,paimon") {
             'data-file.external-paths.strategy' = 'round-robin'
         );
 
+        DROP TABLE IF EXISTS paimon.${dbName}.t_round_robin_roll;
+        CREATE TABLE paimon.${dbName}.t_round_robin_roll (
+            id INT, payload STRING
+        ) USING paimon
+        TBLPROPERTIES (
+            'primary-key' = 'id',
+            'bucket' = '1',
+            'write-only' = 'true',
+            'target-file-size' = '1 kb',
+            'data-file.external-paths' = '${pathRoot}/round-roll-a,${pathRoot}/round-roll-b',
+            'data-file.external-paths.strategy' = 'round-robin'
+        );
+
         DROP TABLE IF EXISTS paimon.${dbName}.t_weight_robin;
         CREATE TABLE paimon.${dbName}.t_weight_robin (
             id INT, payload STRING
@@ -127,11 +140,6 @@ suite("test_paimon_write_external_paths", "p0,external,paimon") {
         sql """INSERT INTO t_round_robin VALUES ('p1', 2, 'two')"""
         sql """INSERT INTO t_round_robin VALUES ('p2', 3, 'three')"""
         sql """INSERT INTO t_round_robin VALUES ('p2', 4, 'four')"""
-        sql """
-            INSERT INTO t_round_robin
-            SELECT 'p-bulk', CAST(number + 100 AS INT), repeat('x', 2048)
-            FROM numbers("number" = "16")
-        """
         def oldRoundFiles = dataFiles("t_round_robin")
         assertFalse(oldRoundFiles.isEmpty())
         // Each lifecycle randomly initializes its round-robin position, so independent
@@ -142,6 +150,33 @@ suite("test_paimon_write_external_paths", "p0,external,paimon") {
         })
         assertDorisSparkRows("external_round_robin_initial", "t_round_robin",
                 "pt, id, length(payload)", "ORDER BY pt, id")
+
+        // Isolate the round-robin oracle from the independent writers above. One fixed bucket and
+        // one pipeline task keep all rows in a single Paimon writer. Paimon checks file rolling
+        // every 1000 rows; 4000 deterministic high-entropy rows leave enough margin to roll
+        // repeatedly and therefore visit both roots regardless of its random start.
+        sql """SET parallel_pipeline_task_num = 1"""
+        try {
+            sql """
+                INSERT INTO t_round_robin_roll
+                SELECT CAST(number AS INT),
+                        concat(md5(CAST(number AS STRING)),
+                               md5(CAST(number + 100000 AS STRING)))
+                FROM numbers("number" = "4000")
+            """
+        } finally {
+            sql """SET parallel_pipeline_task_num = 0"""
+        }
+        def rolledFiles = dataFiles("t_round_robin_roll")
+        assertTrue(rolledFiles.size() >= 2)
+        assertTrue(rolledFiles.every {
+            it.startsWith("${pathRoot}/round-roll-a/") ||
+                    it.startsWith("${pathRoot}/round-roll-b/")
+        })
+        assertTrue(rolledFiles.any { it.startsWith("${pathRoot}/round-roll-a/") })
+        assertTrue(rolledFiles.any { it.startsWith("${pathRoot}/round-roll-b/") })
+        assertDorisSparkRows("external_round_robin_roll", "t_round_robin_roll",
+                "count(*), sum(id), min(length(payload)), max(length(payload))", "")
 
         spark_paimon """
             ALTER TABLE paimon.${dbName}.t_round_robin SET TBLPROPERTIES (

--- a/regression-test/suites/external_table_p0/paimon/write/test_paimon_write_thread_lifecycle.groovy
+++ b/regression-test/suites/external_table_p0/paimon/write/test_paimon_write_thread_lifecycle.groovy
@@ -135,19 +135,21 @@ suite("test_paimon_write_thread_lifecycle", "p0,external,paimon,nonConcurrent") 
                 (sql """SELECT COUNT(*) FROM t_thread_lifecycle""")[0][0] as long)
 
         backendEndpoints.keySet().each { backendId ->
-            // The warmup initializes the shared writer pool and SDK classes before the baseline.
-            // Every later minimum must remain near that baseline; comparing only two post-write
-            // phases would miss the old bounded attach leak after it filled the scheduler pool.
-            jvmPhases.eachWithIndex { counts, phase ->
-                assertTrue(counts[backendId] <= jvmBefore[backendId] + 2,
-                        "JVM threads exceeded warmed baseline on backend ${backendId}, phase "
-                                + "${phase + 1}: baseline=${jvmBefore[backendId]}, phases="
+            // The first full phase may expand a shared worker pool. Treat its settled count as
+            // the steady-state baseline and verify that subsequent equal workloads do not keep
+            // growing the JVM or process thread count.
+            def steadyJvmBaseline = jvmPhases[0][backendId]
+            def steadyProcessBaseline = processPhases[0][backendId]
+            jvmPhases.drop(1).eachWithIndex { counts, phase ->
+                assertTrue(counts[backendId] <= steadyJvmBaseline + 2,
+                        "JVM threads kept growing on backend ${backendId}, phase ${phase + 2}: "
+                                + "steadyBaseline=${steadyJvmBaseline}, phases="
                                 + jvmPhases.collect { sample -> sample[backendId] })
             }
-            processPhases.eachWithIndex { counts, phase ->
-                assertTrue(counts[backendId] <= processBefore[backendId] + 4,
-                        "Process threads exceeded warmed baseline on backend ${backendId}, phase "
-                                + "${phase + 1}: baseline=${processBefore[backendId]}, phases="
+            processPhases.drop(1).eachWithIndex { counts, phase ->
+                assertTrue(counts[backendId] <= steadyProcessBaseline + 4,
+                        "Process threads kept growing on backend ${backendId}, phase ${phase + 2}: "
+                                + "steadyBaseline=${steadyProcessBaseline}, phases="
                                 + processPhases.collect { sample -> sample[backendId] })
             }
         }

--- a/regression-test/suites/external_table_p0/paimon/write/test_paimon_write_thread_lifecycle.groovy
+++ b/regression-test/suites/external_table_p0/paimon/write/test_paimon_write_thread_lifecycle.groovy
@@ -135,21 +135,27 @@ suite("test_paimon_write_thread_lifecycle", "p0,external,paimon,nonConcurrent") 
                 (sql """SELECT COUNT(*) FROM t_thread_lifecycle""")[0][0] as long)
 
         backendEndpoints.keySet().each { backendId ->
-            // Warm-up now performs the same workload as every measured phase, so compare every
-            // phase with the actual pre-phase baseline. A bounded per-writer leak can no longer be
-            // hidden by using phase one as the oracle.
-            jvmPhases.eachWithIndex { counts, phase ->
-                assertTrue(counts[backendId] <= jvmBefore[backendId] + 2,
-                        "JVM threads grew after warm-up on backend ${backendId}, phase ${phase + 1}: "
-                                + "baseline=${jvmBefore[backendId]}, phases="
-                                + jvmPhases.collect { sample -> sample[backendId] })
-            }
-            processPhases.eachWithIndex { counts, phase ->
-                assertTrue(counts[backendId] <= processBefore[backendId] + 4,
-                        "Process threads grew after warm-up on backend ${backendId}, phase ${phase + 1}: "
-                                + "baseline=${processBefore[backendId]}, phases="
-                                + processPhases.collect { sample -> sample[backendId] })
-            }
+            // Warm-up performs the same workload as every measured phase. Judge persistent growth
+            // from the actual pre-phase baseline and phase low-water marks instead of failing on
+            // an isolated background-thread spike: a leaked thread cannot disappear in a later
+            // phase, while an unrelated transient thread can.
+            def jvmCounts = jvmPhases.collect { sample -> sample[backendId] as long }
+            def processCounts = processPhases.collect { sample -> sample[backendId] as long }
+            def earlyJvmFloor = jvmCounts.take(2).min()
+            def lateJvmFloor = jvmCounts.drop(2).min()
+            def earlyProcessFloor = processCounts.take(2).min()
+            def lateProcessFloor = processCounts.drop(2).min()
+
+            assertTrue(jvmCounts.min() <= jvmBefore[backendId] + 2,
+                    "JVM threads never returned to the warm-up baseline on backend ${backendId}: "
+                            + "baseline=${jvmBefore[backendId]}, phases=${jvmCounts}")
+            assertTrue(lateJvmFloor <= earlyJvmFloor + 2,
+                    "JVM threads kept growing on backend ${backendId}: phases=${jvmCounts}")
+            assertTrue(processCounts.min() <= processBefore[backendId] + 4,
+                    "Process threads never returned to the warm-up baseline on backend ${backendId}: "
+                            + "baseline=${processBefore[backendId]}, phases=${processCounts}")
+            assertTrue(lateProcessFloor <= earlyProcessFloor + 4,
+                    "Process threads kept growing on backend ${backendId}: phases=${processCounts}")
         }
     } finally {
         sql """drop catalog if exists ${catalogName}"""

--- a/regression-test/suites/external_table_p0/paimon/write/test_paimon_write_thread_lifecycle.groovy
+++ b/regression-test/suites/external_table_p0/paimon/write/test_paimon_write_thread_lifecycle.groovy
@@ -97,7 +97,7 @@ suite("test_paimon_write_thread_lifecycle", "p0,external,paimon,nonConcurrent") 
     try {
         // Warm all writer and metrics paths before taking the baseline. This keeps
         // one-time JVM attachment and SDK class initialization out of the leak oracle.
-        for (int round = 0; round < 2; round++) {
+        for (int round = 0; round < 12; round++) {
             sql """
                 INSERT INTO t_thread_lifecycle
                 SELECT number + ${round * 1000}, repeat('w', 32)
@@ -123,7 +123,7 @@ suite("test_paimon_write_thread_lifecycle", "p0,external,paimon,nonConcurrent") 
         def jvmPhases = []
         def processPhases = []
         for (int phase = 0; phase < 4; phase++) {
-            writePhase(2 + phase * 12)
+            writePhase(12 + phase * 12)
             sleep(5000)
             jvmPhases.add(minimumThreadCounts(jvmThreadCounts))
             processPhases.add(minimumThreadCounts(processThreadCounts))
@@ -131,25 +131,23 @@ suite("test_paimon_write_thread_lifecycle", "p0,external,paimon,nonConcurrent") 
                     + "process=${processPhases[-1]}")
         }
 
-        assertEquals(50000L,
+        assertEquals(60000L,
                 (sql """SELECT COUNT(*) FROM t_thread_lifecycle""")[0][0] as long)
 
         backendEndpoints.keySet().each { backendId ->
-            // The first full phase may expand a shared worker pool. Treat its settled count as
-            // the steady-state baseline and verify that subsequent equal workloads do not keep
-            // growing the JVM or process thread count.
-            def steadyJvmBaseline = jvmPhases[0][backendId]
-            def steadyProcessBaseline = processPhases[0][backendId]
-            jvmPhases.drop(1).eachWithIndex { counts, phase ->
-                assertTrue(counts[backendId] <= steadyJvmBaseline + 2,
-                        "JVM threads kept growing on backend ${backendId}, phase ${phase + 2}: "
-                                + "steadyBaseline=${steadyJvmBaseline}, phases="
+            // Warm-up now performs the same workload as every measured phase, so compare every
+            // phase with the actual pre-phase baseline. A bounded per-writer leak can no longer be
+            // hidden by using phase one as the oracle.
+            jvmPhases.eachWithIndex { counts, phase ->
+                assertTrue(counts[backendId] <= jvmBefore[backendId] + 2,
+                        "JVM threads grew after warm-up on backend ${backendId}, phase ${phase + 1}: "
+                                + "baseline=${jvmBefore[backendId]}, phases="
                                 + jvmPhases.collect { sample -> sample[backendId] })
             }
-            processPhases.drop(1).eachWithIndex { counts, phase ->
-                assertTrue(counts[backendId] <= steadyProcessBaseline + 4,
-                        "Process threads kept growing on backend ${backendId}, phase ${phase + 2}: "
-                                + "steadyBaseline=${steadyProcessBaseline}, phases="
+            processPhases.eachWithIndex { counts, phase ->
+                assertTrue(counts[backendId] <= processBefore[backendId] + 4,
+                        "Process threads grew after warm-up on backend ${backendId}, phase ${phase + 1}: "
+                                + "baseline=${processBefore[backendId]}, phases="
                                 + processPhases.collect { sample -> sample[backendId] })
             }
         }

--- a/regression-test/suites/external_table_p0/paimon/write/test_paimon_write_thread_lifecycle.groovy
+++ b/regression-test/suites/external_table_p0/paimon/write/test_paimon_write_thread_lifecycle.groovy
@@ -18,17 +18,10 @@
 // Http is a framework utility class, not an injected Suite DSL property.
 import org.apache.doris.regression.util.Http
 
-suite("test_paimon_write_thread_lifecycle", "p0,external,paimon") {
+suite("test_paimon_write_thread_lifecycle", "p0,external,paimon,nonConcurrent") {
     String enabled = context.config.otherConfigs.get("enablePaimonTest")
     if (enabled == null || !enabled.equalsIgnoreCase("true")) {
         logger.info("disable paimon test.")
-        return
-    }
-
-    // Keep the reproducer opt-in until attached JNI writer threads are released.
-    String knownBugTestEnabled = context.config.otherConfigs.get("enablePaimonKnownBugTest")
-    if (knownBugTestEnabled == null || !knownBugTestEnabled.equalsIgnoreCase("true")) {
-        logger.info("skip isolated Paimon known-bug thread regression")
         return
     }
 
@@ -142,11 +135,21 @@ suite("test_paimon_write_thread_lifecycle", "p0,external,paimon") {
                 (sql """SELECT COUNT(*) FROM t_thread_lifecycle""")[0][0] as long)
 
         backendEndpoints.keySet().each { backendId ->
-            // Equal steady-state phases must reuse or detach JNI writer threads.
-            // Comparing later phases excludes the cold shared writer-pool expansion.
-            assertTrue(jvmPhases[-1][backendId] <= jvmPhases[0][backendId] + 4,
-                    "JVM threads kept growing on backend ${backendId}: phases="
-                            + jvmPhases.collect { counts -> counts[backendId] })
+            // The warmup initializes the shared writer pool and SDK classes before the baseline.
+            // Every later minimum must remain near that baseline; comparing only two post-write
+            // phases would miss the old bounded attach leak after it filled the scheduler pool.
+            jvmPhases.eachWithIndex { counts, phase ->
+                assertTrue(counts[backendId] <= jvmBefore[backendId] + 2,
+                        "JVM threads exceeded warmed baseline on backend ${backendId}, phase "
+                                + "${phase + 1}: baseline=${jvmBefore[backendId]}, phases="
+                                + jvmPhases.collect { sample -> sample[backendId] })
+            }
+            processPhases.eachWithIndex { counts, phase ->
+                assertTrue(counts[backendId] <= processBefore[backendId] + 4,
+                        "Process threads exceeded warmed baseline on backend ${backendId}, phase "
+                                + "${phase + 1}: baseline=${processBefore[backendId]}, phases="
+                                + processPhases.collect { sample -> sample[backendId] })
+            }
         }
     } finally {
         sql """drop catalog if exists ${catalogName}"""


### PR DESCRIPTION
### What problem does this PR solve?

Paimon JNI writers can create write-buffer, lookup, and clustering temporary files while background compaction tasks are still running. Previously, those files were not owned by Doris query spill lifecycle, and native callbacks or memory could be released before all Java tasks had stopped.

This PR fixes the lifecycle and spill-management issues:

- Places each Paimon writer's temporary directory lazily under one Doris-managed, query-scoped spill root, following the same root selection, capacity check, usage accounting, and query cleanup model as internal spill.
- Accounts Paimon buffer-channel writes through Doris spill callbacks and protects the query spill directory with a lease while asynchronous SDK work may still access it.
- Stops and joins Paimon compaction work before releasing JNI resources, native memory, or spill callbacks; if task termination cannot be confirmed, dependent resources remain retained.
- Uses scoped JNI references on writer open and error paths and avoids leaking native thread attachments.
- Adds deterministic coverage for managed spill paths, cleanup retry, disabled-spill behavior, and writer thread lifecycle.