### PR TITLE
[fix](mtmv) Avoid invalid slot cast in MV null-reject compensation

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/AbstractMaterializedViewRule.java
@@ -969,7 +969,9 @@ public abstract class AbstractMaterializedViewRule implements ExplorationRuleFac
         for (Set<Slot> requireNullableSlots : requireNoNullableViewSlot) {
             shuttledRequireNoNullableViewSlot.add(
                     ExpressionUtils.shuttleExpressionWithLineage(new ArrayList<>(requireNullableSlots),
-                                    viewStructInfo.getTopPlan()).stream().map(Slot.class::cast)
+                                    viewStructInfo.getTopPlan()).stream()
+                            .filter(Slot.class::isInstance)
+                            .map(Slot.class::cast)
                             .collect(Collectors.toSet()));
         }
         return shuttledRequireNoNullableViewSlot;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MvExplorationSuiteTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MvExplorationSuiteTest.java
@@ -926,6 +926,53 @@ public class MvExplorationSuiteTest extends SqlTestBase {
                 .anyMatch(expression -> isNotNullOnSlot(expression, "o_orderdate")));
     }
 
+    @Test
+    void testNullRejectCompensationWithCastJoinConditionFallsBack() {
+        connectContext.getSessionVariable().setDisableNereidsRules("INFER_PREDICATES,PRUNE_EMPTY_PARTITION");
+        CascadesContext queryContext = createCascadesContext(
+                "select lineitem.l_orderkey, orders.o_orderkey, orders.o_orderdate from lineitem "
+                        + "inner join orders on cast(lineitem.l_orderkey as bigint) "
+                        + "= cast(orders.o_orderkey as bigint)",
+                connectContext
+        );
+        Plan queryPlan = PlanChecker.from(queryContext)
+                .analyze()
+                .rewrite()
+                .applyExploration(RuleSet.BUSHY_TREE_JOIN_REORDER)
+                .getAllPlan().get(0).child(0);
+
+        CascadesContext viewContext = createCascadesContext(
+                "select lineitem.l_orderkey, orders.o_orderkey, orders.o_orderdate from lineitem "
+                        + "left outer join orders on cast(lineitem.l_orderkey as bigint) "
+                        + "= cast(orders.o_orderkey as bigint)",
+                connectContext
+        );
+        Plan viewPlan = PlanChecker.from(viewContext)
+                .analyze()
+                .rewrite()
+                .applyExploration(RuleSet.BUSHY_TREE_JOIN_REORDER)
+                .getAllPlan().get(0).child(0);
+
+        StructInfo queryStructInfo = StructInfo.of(queryPlan, queryPlan, queryContext);
+        StructInfo viewStructInfo = StructInfo.of(viewPlan, viewPlan, viewContext);
+        RelationMapping relationMapping = RelationMapping.generate(
+                queryStructInfo.getRelations(), viewStructInfo.getRelations(), 8).get(0);
+        SlotMapping queryToView = SlotMapping.generate(relationMapping);
+        SlotMapping viewToQuery = queryToView.inverse();
+        LogicalCompatibilityContext compatibilityContext = LogicalCompatibilityContext.from(
+                relationMapping, viewToQuery, queryStructInfo, viewStructInfo);
+        ComparisonResult comparisonResult = StructInfo.isGraphLogicalEquals(
+                queryStructInfo, viewStructInfo, compatibilityContext);
+
+        Assertions.assertFalse(comparisonResult.isInvalid());
+        Assertions.assertFalse(comparisonResult.getViewNoNullableSlot().isEmpty());
+
+        SplitPredicate compensatePredicates = Assertions.assertDoesNotThrow(
+                () -> TEST_RULE.predicatesCompensateForTest(
+                        queryStructInfo, viewStructInfo, viewToQuery, comparisonResult, queryContext));
+        Assertions.assertTrue(compensatePredicates.isInvalid());
+    }
+
     private static boolean isNotNullOnSlot(Expression expression, String slotName) {
         if (!(expression instanceof Not) || ((Not) expression).isGeneratedIsNotNull()
                 || !(((Not) expression).child() instanceof IsNull)) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #43539, #62492, #63268

Problem Summary:

When an INNER JOIN query is matched against a LEFT OUTER JOIN materialized
view, the rewrite must prove that the nullable side is null-rejected. The MV
rule shuttles the nullable-side output Slots through the view plan lineage to
normalize Project and Alias outputs before selecting an `IS NOT NULL`
compensation Slot.

**Root cause:** `AbstractMaterializedViewRule.getShuttledRequireNoNullableViewSlots()`
assumed that `ExpressionUtils.shuttleExpressionWithLineage()` always returns
`Slot` values and unconditionally used `Slot.class::cast`. The API returns
general `Expression` values. Expression JOIN keys such as CAST equality can
introduce helper projections whose lineage expands to `Cast`, causing a
`ClassCastException` during MV rewrite. The unsafe assumption was introduced
by #43539. PR #62492 added INNER JoinEdge null-reject inference, and #63268
materialized that evidence as compensation, making this path more readily
reachable.

**Change summary:**

| File | Change |
|------|--------|
| `AbstractMaterializedViewRule.java` | Keep only actual `Slot` lineage values before converting the stream. |
| `MvExplorationSuiteTest.java` | Cover CAST equality JOIN compensation and verify that it falls back without throwing. |

**Current limitation:** This is a conservative crash fix, not transparent
rewrite support for CAST or arbitrary derived expressions. If no usable Slot
remains after lineage expansion, the existing proof checks return invalid and
the MV rewrite safely falls back to base tables. The CAST JOIN case covered by
the test therefore still does not use the MV. Using an expression's input Slots
as compensation evidence is not generally sound because functions and casts
can change nullability semantics; supporting such expressions requires an
explicit nullability-preserving proof.

### Release note

Fixed an internal `ClassCastException` during materialized view rewrite for
expression-based join keys. Unsupported derived-expression lineage now falls
back safely.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No. Unsupported expression lineage still falls back; this change removes the internal exception.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
