### PR TITLE
[refactor](be) Encapsulate cached constant columns

### DIFF
--- a/be/src/core/column/column.cpp
+++ b/be/src/core/column/column.cpp
@@ -28,6 +28,16 @@
 
 namespace doris {
 
+ColumnPtrWrapper::ColumnPtrWrapper(ColumnPtr column) {
+    DORIS_CHECK(column.get() != nullptr);
+    if (const auto* const_column = check_and_get_column<ColumnConst>(column.get())) {
+        _column_ptr = const_column->get_data_column_ptr();
+    } else {
+        _column_ptr = std::move(column);
+    }
+    DORIS_CHECK_EQ(_column_ptr->size(), 1);
+}
+
 std::string IColumn::dump_structure() const {
     std::stringstream res;
     res << get_name() << "(size = " << size();

--- a/be/src/core/column/column.h
+++ b/be/src/core/column/column.h
@@ -900,11 +900,17 @@ bool is_column_const(const IColumn& column);
 bool is_column_nullable(const IColumn& column);
 } // namespace doris
 
-// Wrap `ColumnPtr` because `ColumnPtr` can't be used in forward declaration.
+// Store the single-row data column of a constant expression because `ColumnPtr` can't be used in
+// forward declarations. A ColumnConst input is unwrapped without copying.
 namespace doris {
-struct ColumnPtrWrapper {
-    ColumnPtr column_ptr;
+class ColumnPtrWrapper {
+public:
+    explicit ColumnPtrWrapper(ColumnPtr column);
 
-    ColumnPtrWrapper(ColumnPtr col) : column_ptr(std::move(col)) {}
+    const IColumn& column() const { return *_column_ptr; }
+    const ColumnPtr& column_ptr() const { return _column_ptr; }
+
+private:
+    ColumnPtr _column_ptr;
 };
 } // namespace doris

--- a/be/src/exec/operator/file_scan_operator.cpp
+++ b/be/src/exec/operator/file_scan_operator.cpp
@@ -44,9 +44,7 @@ PushDownType FileScanLocalState::_should_push_down_binary_predicate(
     if (children[1]->is_constant()) {
         std::shared_ptr<ColumnPtrWrapper> const_col_wrapper;
         THROW_IF_ERROR(children[1]->get_const_col(expr_ctx, &const_col_wrapper));
-        const auto* const_column =
-                assert_cast<const ColumnConst*>(const_col_wrapper->column_ptr.get());
-        constant_val = const_column->operator[](0);
+        constant_val = const_col_wrapper->column()[0];
         return PushDownType::PARTIAL_ACCEPTABLE;
     } else {
         // only handle constant value

--- a/be/src/exec/operator/mock_scan_operator.h
+++ b/be/src/exec/operator/mock_scan_operator.h
@@ -63,9 +63,7 @@ private:
         if (children[1]->is_constant()) {
             std::shared_ptr<ColumnPtrWrapper> const_col_wrapper;
             THROW_IF_ERROR(children[1]->get_const_col(expr_ctx, &const_col_wrapper));
-            const auto* const_column =
-                    assert_cast<const ColumnConst*>(const_col_wrapper->column_ptr.get());
-            constant_val = const_column->operator[](0);
+            constant_val = const_col_wrapper->column()[0];
             return PushDownType::ACCEPTABLE;
         } else {
             // only handle constant value

--- a/be/src/exec/operator/olap_scan_operator.cpp
+++ b/be/src/exec/operator/olap_scan_operator.cpp
@@ -113,9 +113,7 @@ PushDownType OlapScanLocalState::_should_push_down_binary_predicate(
     if (children[1]->is_constant()) {
         std::shared_ptr<ColumnPtrWrapper> const_col_wrapper;
         THROW_IF_ERROR(children[1]->get_const_col(expr_ctx, &const_col_wrapper));
-        const auto* const_column =
-                assert_cast<const ColumnConst*>(const_col_wrapper->column_ptr.get());
-        constant_val = const_column->operator[](0);
+        constant_val = const_col_wrapper->column()[0];
         return PushDownType::ACCEPTABLE;
     } else {
         // only handle constant value
@@ -547,13 +545,7 @@ Status OlapScanLocalState::_should_push_down_function_filter(VectorizedFnCall* f
             DCHECK(is_string_type(children[1 - i]->data_type()->get_primitive_type()));
             std::shared_ptr<ColumnPtrWrapper> const_col_wrapper;
             RETURN_IF_ERROR(children[1 - i]->get_const_col(expr_ctx, &const_col_wrapper));
-            if (const auto* const_column =
-                        check_and_get_column<ColumnConst>(const_col_wrapper->column_ptr.get())) {
-                *constant_str = const_column->get_data_at(0);
-            } else {
-                pdt = PushDownType::UNACCEPTABLE;
-                return Status::OK();
-            }
+            *constant_str = const_col_wrapper->column().get_data_at(0);
         }
     }
     *fn_ctx = func_cxt;

--- a/be/src/exec/operator/scan_operator.cpp
+++ b/be/src/exec/operator/scan_operator.cpp
@@ -651,41 +651,11 @@ Status ScanLocalStateBase::_eval_const_conjuncts(VExprContext* expr_ctx, PushDow
     if (vexpr->is_constant()) {
         std::shared_ptr<ColumnPtrWrapper> const_col_wrapper;
         RETURN_IF_ERROR(vexpr->get_const_col(expr_ctx, &const_col_wrapper));
-        if (const auto* const_column =
-                    check_and_get_column<ColumnConst>(const_col_wrapper->column_ptr.get())) {
-            constant_val = const_column->get_data_at(0).data;
-            if (constant_val == nullptr || !*reinterpret_cast<const bool*>(constant_val)) {
-                *pdt = PushDownType::ACCEPTABLE;
-                _eos = true;
-                _scan_dependency->set_ready();
-            }
-        } else if (const auto* bool_column =
-                           check_and_get_column<ColumnUInt8>(const_col_wrapper->column_ptr.get())) {
-            // TODO: If `vexpr->is_constant()` is true, a const column is expected here.
-            //  But now we still don't cover all predicates for const expression.
-            //  For example, for query `SELECT col FROM tbl WHERE 'PROMOTION' LIKE 'AAA%'`,
-            //  predicate `like` will return a ColumnVector<UInt8> which contains a single value.
-            LOG(WARNING) << "VExpr[" << vexpr->debug_string()
-                         << "] should return a const column but actually is "
-                         << const_col_wrapper->column_ptr->get_name();
-            DCHECK_EQ(bool_column->size(), 1);
-            /// TODO: There is a DCHECK here, but an additional check is still needed. It should return an error code.
-            if (bool_column->size() == 1) {
-                constant_val = bool_column->get_data_at(0).data;
-                if (constant_val == nullptr || !*reinterpret_cast<const bool*>(constant_val)) {
-                    *pdt = PushDownType::ACCEPTABLE;
-                    _eos = true;
-                    _scan_dependency->set_ready();
-                }
-            } else {
-                LOG(WARNING) << "Constant predicate in scan node should return a bool column with "
-                                "`size == 1` but actually is "
-                             << bool_column->size();
-            }
-        } else {
-            LOG(WARNING) << "VExpr[" << vexpr->debug_string()
-                         << "] should return a const column but actually is "
-                         << const_col_wrapper->column_ptr->get_name();
+        constant_val = const_col_wrapper->column().get_data_at(0).data;
+        if (constant_val == nullptr || !*reinterpret_cast<const bool*>(constant_val)) {
+            *pdt = PushDownType::ACCEPTABLE;
+            _eos = true;
+            _scan_dependency->set_ready();
         }
     }
     return Status::OK();

--- a/be/src/exprs/function/array/function_array_index.h
+++ b/be/src/exprs/function/array/function_array_index.h
@@ -120,7 +120,7 @@ public:
         std::shared_ptr<ParamValue> state = std::make_shared<ParamValue>();
         Field field;
         if (context->get_constant_col(1)) {
-            context->get_constant_col(1)->column_ptr->get(0, field);
+            context->get_constant_col(1)->column().get(0, field);
             state->value = field;
             state->type = context->get_arg_type(1)->get_primitive_type();
             context->set_function_state(scope, state);

--- a/be/src/exprs/function/function_collection_in.h
+++ b/be/src/exprs/function/function_collection_in.h
@@ -112,7 +112,7 @@ public:
             const auto& const_column_ptr = context->get_constant_col(i);
             // Types like struct, array, and map only support constant expressions.
             DCHECK(const_column_ptr != nullptr);
-            const auto& [col, _] = unpack_if_const(const_column_ptr->column_ptr);
+            const auto& col = const_column_ptr->column_ptr();
             if (const auto* null_col = check_and_get_column<ColumnNullable>(col.get())) {
                 if (null_col->has_null()) {
                     state->null_in_set = true;

--- a/be/src/exprs/function/function_convert_tz.cpp
+++ b/be/src/exprs/function/function_convert_tz.cpp
@@ -110,8 +110,8 @@ public:
     void init_convert_tz_state(std::shared_ptr<ConvertTzState> state,
                                const ColumnPtrWrapper* const_from_tz,
                                const ColumnPtrWrapper* const_to_tz) {
-        auto const_data_from_tz = const_from_tz->column_ptr->get_data_at(0);
-        auto const_data_to_tz = const_to_tz->column_ptr->get_data_at(0);
+        auto const_data_from_tz = const_from_tz->column().get_data_at(0);
+        auto const_data_to_tz = const_to_tz->column().get_data_at(0);
 
         // from_tz and to_tz must both be non-null.
         if (const_data_from_tz.data == nullptr || const_data_to_tz.data == nullptr) {

--- a/be/src/exprs/function/function_datetime_string_to_string.h
+++ b/be/src/exprs/function/function_datetime_string_to_string.h
@@ -108,7 +108,7 @@ public:
                     "The second parameter of the function {} must be a constant.", get_name());
         }
 
-        auto string_vale = column_string->column_ptr->get_data_at(0);
+        auto string_vale = column_string->column().get_data_at(0);
         if (string_vale.data == nullptr) {
             // func(col , null);
             state->is_valid = false;

--- a/be/src/exprs/function/function_dict_get.cpp
+++ b/be/src/exprs/function/function_dict_get.cpp
@@ -71,7 +71,7 @@ public:
                                                                 dict_fn->version_id);
         if (!dict) {
             std::string dict_name =
-                    context->get_constant_col(0)->column_ptr->get_data_at(0).to_string();
+                    context->get_constant_col(0)->column().get_data_at(0).to_string();
             throw doris::Exception(ErrorCode::INVALID_ARGUMENT,
                                    "can not find dict name : {} , dict_id : {} , version_id : {}  ",
                                    dict_name, dict_fn->dictionary_id, dict_fn->version_id);

--- a/be/src/exprs/function/function_dict_get_many.cpp
+++ b/be/src/exprs/function/function_dict_get_many.cpp
@@ -76,7 +76,7 @@ public:
                                                                 dict_fn->version_id);
         if (!dict) {
             std::string dict_name =
-                    context->get_constant_col(0)->column_ptr->get_data_at(0).to_string();
+                    context->get_constant_col(0)->column().get_data_at(0).to_string();
             throw doris::Exception(ErrorCode::INVALID_ARGUMENT,
                                    "can not find dict name : {} , dict_id : {} , version_id : {}  ",
                                    dict_name, dict_fn->dictionary_id, dict_fn->version_id);

--- a/be/src/exprs/function/function_jsonb.cpp
+++ b/be/src/exprs/function/function_jsonb.cpp
@@ -149,11 +149,11 @@ public:
                 if (state) {
                     if (context->get_num_args() == 2) {
                         if (context->is_col_constant(1)) {
-                            const auto default_value_col = context->get_constant_col(1)->column_ptr;
-                            if (default_value_col->is_null_at(0)) {
+                            const auto& default_value_col = context->get_constant_col(1)->column();
+                            if (default_value_col.is_null_at(0)) {
                                 state->default_is_null = true;
                             } else {
-                                const auto& default_value = default_value_col->get_data_at(0);
+                                const auto& default_value = default_value_col.get_data_at(0);
 
                                 state->default_value = default_value;
                                 state->has_const_default_value = true;
@@ -2531,8 +2531,8 @@ public:
         if (context->is_col_constant(2)) {
             std::shared_ptr<LikeState> state = std::make_shared<LikeState>();
             state->is_like_pattern = true;
-            const auto pattern_col = context->get_constant_col(2)->column_ptr;
-            const auto& pattern = pattern_col->get_data_at(0);
+            const auto& pattern_col = context->get_constant_col(2)->column();
+            const auto& pattern = pattern_col.get_data_at(0);
             RETURN_IF_ERROR(
                     FunctionLike::construct_like_const_state(context, pattern, state, false));
             context->set_function_state(scope, state);

--- a/be/src/exprs/function/function_other_types_to_date.cpp
+++ b/be/src/exprs/function/function_other_types_to_date.cpp
@@ -484,7 +484,7 @@ struct DateTrunc {
                     "date_trunc function of time unit argument must be constant.");
         }
         const auto& data_str =
-                context->get_constant_col(DateArgIsFirst ? 1 : 0)->column_ptr->get_data_at(0);
+                context->get_constant_col(DateArgIsFirst ? 1 : 0)->column().get_data_at(0);
         std::string lower_str(data_str.data, data_str.size);
         std::transform(lower_str.begin(), lower_str.end(), lower_str.begin(),
                        [](unsigned char c) { return std::tolower(c); });

--- a/be/src/exprs/function/function_regexp.cpp
+++ b/be/src/exprs/function/function_regexp.cpp
@@ -265,8 +265,8 @@ public:
         if (scope == FunctionContext::THREAD_LOCAL) {
             if (context->is_col_constant(1)) {
                 DCHECK(!context->get_function_state(scope));
-                const auto pattern_col = context->get_constant_col(1)->column_ptr;
-                const auto& pattern = pattern_col->get_data_at(0);
+                const auto& pattern_col = context->get_constant_col(1)->column();
+                const auto& pattern = pattern_col.get_data_at(0);
                 if (pattern.size == 0) {
                     return Status::OK();
                 }
@@ -344,8 +344,8 @@ public:
         if (scope == FunctionContext::THREAD_LOCAL) {
             if (context->is_col_constant(1)) {
                 DCHECK(!context->get_function_state(scope));
-                const auto pattern_col = context->get_constant_col(1)->column_ptr;
-                const auto& pattern = pattern_col->get_data_at(0);
+                const auto& pattern_col = context->get_constant_col(1)->column();
+                const auto& pattern = pattern_col.get_data_at(0);
                 if (pattern.size == 0) {
                     return Status::OK();
                 }
@@ -356,8 +356,8 @@ public:
                 if constexpr (std::is_same_v<FourParamTypes, ParamTypes>) {
                     DCHECK_EQ(context->get_num_args(), 4);
                     DCHECK(context->is_col_constant(3));
-                    const auto options_col = context->get_constant_col(3)->column_ptr;
-                    options_value = options_col->get_data_at(0);
+                    const auto& options_col = context->get_constant_col(3)->column();
+                    options_value = options_col.get_data_at(0);
                 }
 
                 bool st = StringFunctions::compile_regex(pattern, &error_str, StringRef(),
@@ -820,9 +820,9 @@ public:
         if (scope == FunctionContext::THREAD_LOCAL) {
             if (context->is_col_constant(Impl::PATTERN_ARG_IDX)) {
                 DCHECK(!context->get_function_state(scope));
-                const auto pattern_col =
-                        context->get_constant_col(Impl::PATTERN_ARG_IDX)->column_ptr;
-                const auto& pattern = pattern_col->get_data_at(0);
+                const auto& pattern_col =
+                        context->get_constant_col(Impl::PATTERN_ARG_IDX)->column();
+                const auto& pattern = pattern_col.get_data_at(0);
                 if (pattern.size == 0) {
                     return Status::OK();
                 }

--- a/be/src/exprs/function/function_string_concat.h
+++ b/be/src/exprs/function/function_string_concat.h
@@ -87,7 +87,7 @@ public:
                 state->use_state = false;
                 return IFunction::open(context, scope);
             }
-            auto string_vale = column_string->column_ptr->get_data_at(0);
+            auto string_vale = column_string->column().get_data_at(0);
             if (string_vale.data == nullptr) {
                 // For concat(col, null), it is handled by default_implementation_for_nulls
                 state->use_state = false;

--- a/be/src/exprs/function/function_string_misc.cpp
+++ b/be/src/exprs/function/function_string_misc.cpp
@@ -411,7 +411,7 @@ public:
             return Status::InvalidArgument(
                     "character argument to convert function must be constant.");
         }
-        const auto& character_data = context->get_constant_col(1)->column_ptr->get_data_at(0);
+        const auto& character_data = context->get_constant_col(1)->column().get_data_at(0);
         if (!iequal(character_data.to_string(), "gbk")) {
             return Status::RuntimeError(
                     "Illegal second argument column of function convert. now only support "
@@ -1535,7 +1535,7 @@ public:
         }
 
         auto* const_col = context->get_constant_col(1);
-        auto mode_ref = const_col->column_ptr->get_data_at(0);
+        auto mode_ref = const_col->column().get_data_at(0);
         std::string lower_mode = doris::to_lower(std::string(doris::trim(mode_ref.to_string())));
 
         UErrorCode status = U_ZERO_ERROR;

--- a/be/src/exprs/function/in.h
+++ b/be/src/exprs/function/in.h
@@ -92,7 +92,7 @@ public:
         for (int i = 1; i < context->get_num_args(); ++i) {
             const auto& const_column_ptr = context->get_constant_col(i);
             if (const_column_ptr != nullptr) {
-                auto const_data = const_column_ptr->column_ptr->get_data_at(0);
+                auto const_data = const_column_ptr->column().get_data_at(0);
                 if (const_data.data != nullptr) {
                     sz++;
                 }
@@ -123,7 +123,7 @@ public:
         for (int i = 1; i < context->get_num_args(); ++i) {
             const auto& const_column_ptr = context->get_constant_col(i);
             if (const_column_ptr != nullptr) {
-                auto const_data = const_column_ptr->column_ptr->get_data_at(0);
+                auto const_data = const_column_ptr->column().get_data_at(0);
                 state->hybrid_set->insert((void*)const_data.data, const_data.size);
             } else {
                 state->use_set = false;

--- a/be/src/exprs/function/like.cpp
+++ b/be/src/exprs/function/like.cpp
@@ -978,8 +978,8 @@ Status FunctionLike::open(FunctionContext* context, FunctionContext::FunctionSta
     state->scalar_function = like_fn_scalar;
     if (context->is_col_constant(2)) {
         state->has_custom_escape = true;
-        const auto escape_col = context->get_constant_col(2)->column_ptr;
-        const auto& escape = escape_col->get_data_at(0);
+        const auto& escape_col = context->get_constant_col(2)->column();
+        const auto& escape = escape_col.get_data_at(0);
         if (escape.size != 1) {
             return Status::InternalError("Escape character must be a single character, got: {}",
                                          escape.to_string());
@@ -987,8 +987,8 @@ Status FunctionLike::open(FunctionContext* context, FunctionContext::FunctionSta
         state->escape_char = escape.data[0];
     }
     if (context->is_col_constant(1)) {
-        const auto pattern_col = context->get_constant_col(1)->column_ptr;
-        const auto& pattern = pattern_col->get_data_at(0);
+        const auto& pattern_col = context->get_constant_col(1)->column();
+        const auto& pattern = pattern_col.get_data_at(0);
         RETURN_IF_ERROR(construct_like_const_state(context, pattern, state));
     }
     context->set_function_state(scope, state);
@@ -1007,8 +1007,8 @@ Status FunctionRegexpLike::open(FunctionContext* context,
     state->function = regexp_fn;
     state->scalar_function = regexp_fn_scalar;
     if (context->is_col_constant(1)) {
-        const auto pattern_col = context->get_constant_col(1)->column_ptr;
-        const auto& pattern = pattern_col->get_data_at(0);
+        const auto& pattern_col = context->get_constant_col(1)->column();
+        const auto& pattern = pattern_col.get_data_at(0);
 
         std::string pattern_str = pattern.to_string();
         std::string search_string;

--- a/be/src/exprs/function/random.cpp
+++ b/be/src/exprs/function/random.cpp
@@ -72,9 +72,8 @@ public:
                     return Status::InvalidArgument("The param of rand function must be literal");
                 }
                 uint32_t seed = 0;
-                if (!context->get_constant_col(0)->column_ptr->is_null_at(0)) {
-                    seed = (uint32_t)(*context->get_constant_col(0)->column_ptr)[0]
-                                   .get<TYPE_BIGINT>();
+                if (!context->get_constant_col(0)->column().is_null_at(0)) {
+                    seed = (uint32_t)context->get_constant_col(0)->column()[0].get<TYPE_BIGINT>();
                 }
                 generator->seed(seed);
             } else if (context->get_num_args() == 2) {

--- a/be/src/exprs/function_context.h
+++ b/be/src/exprs/function_context.h
@@ -30,7 +30,7 @@
 
 namespace doris {
 
-struct ColumnPtrWrapper;
+class ColumnPtrWrapper;
 struct StringRef;
 class RuntimeState;
 

--- a/be/src/exprs/vexpr.cpp
+++ b/be/src/exprs/vexpr.cpp
@@ -905,7 +905,7 @@ uint64_t VExpr::get_digest(uint64_t seed) const {
 }
 
 ColumnPtr VExpr::get_result_from_const(size_t count) const {
-    return ColumnConst::create(_constant_col->column_ptr, count);
+    return ColumnConst::create(_constant_col->column_ptr(), count);
 }
 
 Status VExpr::_evaluate_inverted_index(VExprContext* context, const FunctionBasePtr& function,

--- a/be/src/exprs/vmatch_predicate.cpp
+++ b/be/src/exprs/vmatch_predicate.cpp
@@ -131,9 +131,6 @@ Status VMatchPredicate::open(RuntimeState* state, VExprContext* context,
     if (scope == FunctionContext::THREAD_LOCAL || scope == FunctionContext::FRAGMENT_LOCAL) {
         context->fn_context(_fn_context_index)->set_function_state(scope, _analyzer_ctx);
     }
-    if (scope == FunctionContext::FRAGMENT_LOCAL) {
-        RETURN_IF_ERROR(VExpr::get_const_col(context, nullptr));
-    }
     _open_finished = true;
     return Status::OK();
 }

--- a/be/src/storage/index/ann/ann_topn_runtime.cpp
+++ b/be/src/storage/index/ann/ann_topn_runtime.cpp
@@ -27,7 +27,6 @@
 #include "common/status.h"
 #include "core/column/column.h"
 #include "core/column/column_array.h"
-#include "core/column/column_const.h"
 #include "core/column/column_nullable.h"
 #include "core/column/column_vector.h"
 #include "core/data_type/primitive_type.h"
@@ -56,11 +55,7 @@ Result<ColumnFloat32::Ptr> extract_query_vector(std::shared_ptr<VExpr> arg_expr)
                                                    st.to_string()));
     }
 
-    // Unwrap ColumnConst without copy to get the underlying single-row column
-    IColumn::Ptr col_ptr = column_wrapper->column_ptr;
-    if (const auto* const_col = check_and_get_column<ColumnConst>(*col_ptr)) {
-        col_ptr = const_col->get_data_column_ptr();
-    }
+    IColumn::Ptr col_ptr = column_wrapper->column_ptr();
 
     // The expected runtime column layout for the literal is:
     // Nullable(ColumnArray(Nullable(ColumnFloat32))) with exactly 1 row (one array literal)

--- a/be/test/core/column/column_const_test.cpp
+++ b/be/test/core/column/column_const_test.cpp
@@ -42,6 +42,26 @@ TEST(ColumnConstTest, TestCreate) {
     EXPECT_TRUE(!is_column_const(column_const2->get_data_column()));
 }
 
+TEST(ColumnPtrWrapperTest, StoresSingleRowDataColumn) {
+    auto data_column = ColumnHelper::create_column<DataTypeInt64>({7});
+
+    ColumnPtrWrapper data_wrapper(data_column);
+    EXPECT_EQ(data_wrapper.column_ptr().get(), data_column.get());
+    EXPECT_EQ(data_wrapper.column().get_int(0), 7);
+    EXPECT_FALSE(is_column_const(data_wrapper.column()));
+
+    auto const_column = ColumnConst::create(data_column, 3);
+    ColumnPtrWrapper const_wrapper(std::move(const_column));
+    EXPECT_EQ(const_wrapper.column_ptr().get(), data_column.get());
+    EXPECT_EQ(const_wrapper.column().get_int(0), 7);
+    EXPECT_FALSE(is_column_const(const_wrapper.column()));
+}
+
+TEST(ColumnPtrWrapperTest, RejectsNonConstMultiRowColumn) {
+    auto column = ColumnHelper::create_column<DataTypeInt64>({7, 8});
+    EXPECT_DEATH(static_cast<void>(ColumnPtrWrapper(column)), "");
+}
+
 TEST(ColumnConstTest, IsExclusiveChecksNestedColumn) {
     auto column_data = ColumnHelper::create_column<DataTypeInt64>({7});
     auto column_const = ColumnConst::create(column_data, 3);

--- a/be/test/core/column/column_const_test.cpp
+++ b/be/test/core/column/column_const_test.cpp
@@ -59,7 +59,11 @@ TEST(ColumnPtrWrapperTest, StoresSingleRowDataColumn) {
 
 TEST(ColumnPtrWrapperTest, RejectsNonConstMultiRowColumn) {
     auto column = ColumnHelper::create_column<DataTypeInt64>({7, 8});
-    EXPECT_DEATH(static_cast<void>(ColumnPtrWrapper(column)), "");
+#ifdef NDEBUG
+    EXPECT_THROW(static_cast<void>(ColumnPtrWrapper(column)), Exception);
+#elif DCHECK_IS_ON()
+    EXPECT_DEATH(static_cast<void>(ColumnPtrWrapper(column)), "Check failed");
+#endif
 }
 
 TEST(ColumnConstTest, IsExclusiveChecksNestedColumn) {

--- a/be/test/exec/operator/scan_normalize_predicate_test.cpp
+++ b/be/test/exec/operator/scan_normalize_predicate_test.cpp
@@ -119,53 +119,6 @@ TEST_F(ScanNormalizePredicate, test_eval_const_conjuncts2) {
     EXPECT_TRUE(local_state->_eos);
 }
 
-TEST_F(ScanNormalizePredicate, test_eval_const_conjuncts3) {
-    // case
-    // Predicate false and xxx and xxx ....
-    // The returned column is not a constant column, but the size is not equal to 1
-    auto local_state = std::make_shared<MockScanLocalState>(state.get(), op.get());
-
-    auto fn_eq = MockFnCall::create("eq");
-    fn_eq->_mock_is_constant = true;
-    fn_eq->set_const_expr_col(ColumnHelper::create_column<DataTypeBool>({false, false}));
-    EXPECT_TRUE(fn_eq->is_constant());
-
-    auto ctx = VExprContext::create_shared(fn_eq);
-    ctx->_prepared = true;
-    ctx->_opened = true;
-
-    VExprSPtr new_root;
-    auto conjunct_expr_root = ctx;
-    // There is a DCHECK in the code to ensure size must be equal to 1, wait for this part of the code to be removed later
-    // auto st = local_state->_normalize_predicate(
-    //                                             conjunct_expr_root.get(), new_root);
-    // EXPECT_FALSE(st.ok());
-    // std::cout << st.msg() << std::endl;
-}
-
-TEST_F(ScanNormalizePredicate, test_eval_const_conjuncts4) {
-    // case
-    // Predicate false and xxx and xxx ....
-    // The returned column is neither a constant column nor a boolean column
-    auto local_state = std::make_shared<MockScanLocalState>(state.get(), op.get());
-
-    auto fn_eq = MockFnCall::create("eq");
-    fn_eq->_mock_is_constant = true;
-    fn_eq->set_const_expr_col(ColumnHelper::create_column<DataTypeInt32>({false, false}));
-    EXPECT_TRUE(fn_eq->is_constant());
-
-    auto ctx = VExprContext::create_shared(fn_eq);
-    ctx->_prepared = true;
-    ctx->_opened = true;
-
-    VExprSPtr new_root;
-    auto conjunct_expr_root = ctx;
-    auto st = local_state->_normalize_predicate(conjunct_expr_root.get(),
-                                                conjunct_expr_root->root(), new_root);
-    EXPECT_TRUE(st.ok());
-    std::cout << st.msg() << std::endl;
-}
-
 TEST_F(ScanNormalizePredicate, test_is_predicate_acting_on_slot1) {
     auto local_state = std::make_shared<MockScanLocalState>(state.get(), op.get());
 

--- a/be/test/testutil/mock/mock_fn_call.cpp
+++ b/be/test/testutil/mock/mock_fn_call.cpp
@@ -30,8 +30,8 @@ TEST(MockFnCallTest, test) {
     fn->set_const_expr_col(ColumnHelper::create_column<DataTypeInt64>({1}));
     std::shared_ptr<ColumnPtrWrapper> column_wrapper;
     EXPECT_TRUE(fn->get_const_col(nullptr, &column_wrapper));
-    EXPECT_EQ(column_wrapper->column_ptr->size(), 1);
-    EXPECT_EQ(column_wrapper->column_ptr->get_int(0), 1);
+    EXPECT_EQ(column_wrapper->column().size(), 1);
+    EXPECT_EQ(column_wrapper->column().get_int(0), 1);
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Cached constant expressions could expose either a `ColumnConst` or a single-row data column, forcing callers to inspect the physical column type. This change makes `ColumnPtrWrapper` store a private, single-row data column, unwraps `ColumnConst` without copying, and creates `ColumnConst` only when broadcasting the cached value. It also removes redundant constant evaluation from `VMatchPredicate::open()`.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

