### PR TITLE
[fix](build) Fix the BE unit-test and benchmark build on macOS arm64

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -766,7 +766,15 @@ endif ()
 
 # Add sanitize static link flags
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG" OR "${CMAKE_BUILD_TYPE}" STREQUAL "RELEASE")
-    set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} ${MALLOCLIB})
+    if (OS_MACOSX AND ARCH_ARM AND MAKE_TEST)
+        # doris_be_test's Debug .text exceeds arm64's +/-128MB BL reach and
+        # Apple's linker emits no branch islands for tcmalloc's prebuilt
+        # archive ("fixup error ... B/BL out of range"). Tests don't need a
+        # custom allocator; fall back to system malloc here. ASAN builds never
+        # linked ${MALLOCLIB} anyway, which is why they never hit this.
+    else()
+        set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} ${MALLOCLIB})
+    endif()
 elseif ("${CMAKE_BUILD_TYPE}" STREQUAL "ASAN" OR "${CMAKE_BUILD_TYPE}" STREQUAL "ASAN_UT")
     set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} ${ASAN_LIBS})
     if (OS_LINUX)

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -766,12 +766,15 @@ endif ()
 
 # Add sanitize static link flags
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG" OR "${CMAKE_BUILD_TYPE}" STREQUAL "RELEASE")
-    if (OS_MACOSX AND ARCH_ARM AND MAKE_TEST)
-        # doris_be_test's Debug .text exceeds arm64's +/-128MB BL reach and
-        # Apple's linker emits no branch islands for tcmalloc's prebuilt
-        # archive ("fixup error ... B/BL out of range"). Tests don't need a
-        # custom allocator; fall back to system malloc here. ASAN builds never
-        # linked ${MALLOCLIB} anyway, which is why they never hit this.
+    if (OS_MACOSX AND ARCH_ARM AND (MAKE_TEST OR BUILD_BENCHMARK))
+        # doris_be_test's and benchmark_test's .text exceeds arm64's +/-128MB
+        # BL reach (BE_TEST/BE_BENCHMARK macros inflate it further) and Apple's
+        # linker emits no branch islands for tcmalloc's prebuilt archive
+        # ("fixup error ... B/BL out of range"). Tests and benchmarks don't
+        # need a custom allocator; fall back to system malloc here. ASAN
+        # builds never linked ${MALLOCLIB} anyway, which is why they never
+        # hit this. gperftools_stubs.cpp supplies the few symbols still
+        # referenced unconditionally.
     else()
         set(DORIS_LINK_LIBS ${DORIS_LINK_LIBS} ${MALLOCLIB})
     endif()
@@ -1032,7 +1035,10 @@ if (BUILD_BENCHMARK)
     if (NOT ${CMAKE_BUILD_TYPE} STREQUAL "RELEASE")
         message(FATAL_ERROR "Benchmark should be built with RELEASE build type, current build type is ${CMAKE_BUILD_TYPE}")
     endif()
-    add_executable(benchmark_test ${BASE_DIR}/benchmark/benchmark_main.cpp)
+    add_executable(benchmark_test ${BASE_DIR}/benchmark/benchmark_main.cpp
+        # No-ops everywhere except macOS/arm64, where benchmark_test links
+        # without tcmalloc (see the MALLOCLIB branch above).
+        ${BASE_DIR}/test/testutil/gperftools_stubs.cpp)
     set_target_properties(benchmark_test PROPERTIES COMPILE_FLAGS "-fno-access-control")
     target_link_libraries(benchmark_test ${DORIS_LINK_LIBS})
     message(STATUS "Add benchmark to build")

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -45,10 +45,13 @@ endif ()
 
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
     set (OS_LINUX 1)
-    add_definitions(-D OS_LINUX)
+    # No space after -D: "-D OS_LINUX" becomes two argv entries in some
+    # generators, and the dangling "-D" then swallows the next flag
+    # (doris_be_test lost its -fno-access-control this way).
+    add_definitions(-DOS_LINUX)
 elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
     set (OS_MACOSX 1)
-    add_definitions(-D OS_MACOSX)
+    add_definitions(-DOS_MACOSX)
 endif ()
 
 if (OS_MACOSX)

--- a/be/src/common/object_pool.h
+++ b/be/src/common/object_pool.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <mutex>
-#include <ranges>
 #include <vector>
 
 namespace doris {
@@ -53,8 +52,10 @@ public:
         // reverse delete object to make sure the obj can
         // safe access the member object construt early by
         // object pool
-        for (auto& _object : std::ranges::reverse_view(_objects)) {
-            _object.delete_fn(_object.obj);
+        // NOTE: keep <ranges> out of this widely-included header: doris_be_test
+        // builds with -fno-access-control, which libc++'s <ranges> rejects.
+        for (auto it = _objects.rbegin(); it != _objects.rend(); ++it) {
+            it->delete_fn(it->obj);
         }
         _objects.clear();
     }

--- a/be/src/exprs/lambda_function/lambda_execution_context.h
+++ b/be/src/exprs/lambda_function/lambda_execution_context.h
@@ -19,7 +19,6 @@
 
 #include <glog/logging.h>
 
-#include <ranges>
 #include <set>
 #include <string>
 #include <utility>
@@ -79,10 +78,12 @@ public:
 
     ResolveResult resolve_column_position(const std::string& name) const {
         ResolveResult result;
-        for (const auto& frame : std::ranges::reverse_view(_frames)) {
+        for (auto frame_it = _frames.rbegin(); frame_it != _frames.rend(); ++frame_it) {
+            const auto& frame = *frame_it;
             result.searched_named_scope |= frame.bind_by_name;
-            for (const auto& argument_binding :
-                 std::ranges::reverse_view(frame.argument_bindings)) {
+            for (auto binding_it = frame.argument_bindings.rbegin();
+                 binding_it != frame.argument_bindings.rend(); ++binding_it) {
+                const auto& argument_binding = *binding_it;
                 if (argument_binding.name == name) {
                     result.found = true;
                     result.column_position = argument_binding.column_position;
@@ -97,13 +98,13 @@ public:
     }
 
     void collect_visible_binding_column_positions(std::set<int>& column_positions) const {
-        for (const auto& _frame : std::ranges::reverse_view(_frames)) {
-            for (const auto& binding : _frame.argument_bindings) {
+        for (auto frame_it = _frames.rbegin(); frame_it != _frames.rend(); ++frame_it) {
+            for (const auto& binding : frame_it->argument_bindings) {
                 if (binding.column_position >= 0) {
                     column_positions.insert(binding.column_position);
                 }
             }
-            if (!_frame.parent_bindings_visible) {
+            if (!frame_it->parent_bindings_visible) {
                 break;
             }
         }

--- a/be/src/format/table/iceberg_reader_mixin.h
+++ b/be/src/format/table/iceberg_reader_mixin.h
@@ -19,10 +19,10 @@
 
 #include <gen_cpp/ExternalTableSchema_types.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <ranges>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/be/src/storage/index/inverted/query_v2/collect/top_k_collector.h
+++ b/be/src/storage/index/inverted/query_v2/collect/top_k_collector.h
@@ -22,7 +22,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <limits>
-#include <ranges>
 #include <roaring/roaring.hh>
 #include <string>
 #include <vector>

--- a/be/src/storage/index/inverted/query_v2/composite_reader.h
+++ b/be/src/storage/index/inverted/query_v2/composite_reader.h
@@ -33,7 +33,6 @@
 #endif
 
 #include <algorithm>
-#include <ranges>
 #include <unordered_map>
 #include <vector>
 
@@ -66,7 +65,7 @@ public:
     }
 
     void close() {
-        for (auto* reader : std::views::values(_field_readers)) {
+        for (const auto& [_, reader] : _field_readers) {
             reader->close();
         }
     }
@@ -76,7 +75,7 @@ public:
             throw Exception(ErrorCode::INDEX_INVALID_PARAMETERS, "CompositeReader has no readers");
         }
         uint32_t max_doc = 0;
-        for (auto* reader : std::views::values(_field_readers)) {
+        for (const auto& [_, reader] : _field_readers) {
             max_doc = std::max(max_doc, static_cast<uint32_t>(reader->maxDoc()));
         }
         return max_doc;
@@ -85,7 +84,7 @@ public:
     [[nodiscard]] std::vector<lucene::index::IndexReader*> readers() const {
         std::vector<lucene::index::IndexReader*> readers;
         readers.reserve(_field_readers.size());
-        for (auto* reader : std::views::values(_field_readers)) {
+        for (const auto& [_, reader] : _field_readers) {
             readers.push_back(reader);
         }
         return readers;

--- a/be/src/storage/index/inverted/query_v2/wand/block_wand.h
+++ b/be/src/storage/index/inverted/query_v2/wand/block_wand.h
@@ -19,7 +19,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <ranges>
 #include <vector>
 
 #include "storage/index/inverted/query_v2/term_query/term_scorer.h"

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -164,6 +164,10 @@ endif()
 if (APPLE)
     target_link_libraries(doris_be_test ${TEST_LINK_LIBS}
         -Wl,-force_load,$<TARGET_FILE:vector_search_test>)
+    # $<TARGET_FILE:...> inside a link flag does not create a target-level
+    # dependency, so parallel ninja could link doris_be_test before the
+    # archive exists.
+    add_dependencies(doris_be_test vector_search_test)
 else()
     target_link_libraries(doris_be_test ${TEST_LINK_LIBS}
         -Wl,--whole-archive vector_search_test -Wl,--no-whole-archive)

--- a/be/test/exec/scan/file_scanner_v2_test.cpp
+++ b/be/test/exec/scan/file_scanner_v2_test.cpp
@@ -46,14 +46,12 @@
 #include "exprs/vdirect_in_predicate.h"
 #include "exprs/vliteral.h"
 #include "exprs/vslot_ref.h"
+#include "format/table/iceberg_scan_semantics.h"
 #include "format_v2/expr/cast.h"
 #include "testutil/mock/mock_runtime_state.h"
 
 namespace doris {
 namespace {
-
-constexpr int kIcebergPositionDeleteContent = 1;
-constexpr int kIcebergDeletionVectorContent = 3;
 
 TFileRangeDesc range_with_format(std::string table_format, TFileFormatType::type format_type) {
     TFileRangeDesc range;

--- a/be/test/exec/scan/file_scanner_v2_test.cpp
+++ b/be/test/exec/scan/file_scanner_v2_test.cpp
@@ -46,12 +46,14 @@
 #include "exprs/vdirect_in_predicate.h"
 #include "exprs/vliteral.h"
 #include "exprs/vslot_ref.h"
-#include "format/table/iceberg_scan_semantics.h"
 #include "format_v2/expr/cast.h"
 #include "testutil/mock/mock_runtime_state.h"
 
 namespace doris {
 namespace {
+
+constexpr int kIcebergPositionDeleteContent = 1;
+constexpr int kIcebergDeletionVectorContent = 3;
 
 TFileRangeDesc range_with_format(std::string table_format, TFileFormatType::type format_type) {
     TFileRangeDesc range;

--- a/be/test/exprs/expr_zonemap_filter_test.cpp
+++ b/be/test/exprs/expr_zonemap_filter_test.cpp
@@ -61,10 +61,8 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wkeyword-macro"
 #endif
-#define private public
 #include "exprs/vdirect_in_predicate.h"
 #include "exprs/vin_predicate.h"
-#undef private
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif

--- a/be/test/exprs/vsearch_expr_test.cpp
+++ b/be/test/exprs/vsearch_expr_test.cpp
@@ -41,10 +41,8 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wkeyword-macro"
 #endif
-#define private public
 #include "exprs/vslot_ref.h"
 #include "storage/segment/segment.h"
-#undef private
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif

--- a/be/test/io/cache/block_file_cache_test_meta_store.cpp
+++ b/be/test/io/cache/block_file_cache_test_meta_store.cpp
@@ -23,13 +23,8 @@
 #pragma clang diagnostic ignored "-Wkeyword-macro"
 #endif
 
-#include "util/defer_op.h"
-
-#define private public
-#define protected public
 #include "io/cache/block_file_cache_test_common.h"
-#undef private
-#undef protected
+#include "util/defer_op.h"
 
 #if defined(__clang__)
 #pragma clang diagnostic pop

--- a/be/test/io/cache/fs_file_cache_storage_leak_cleaner_test.cpp
+++ b/be/test/io/cache/fs_file_cache_storage_leak_cleaner_test.cpp
@@ -31,17 +31,12 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wkeyword-macro"
 #endif
-#define private public
-#define protected public
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
 #include "io/cache/block_file_cache.h"
-#include "io/cache/fs_file_cache_storage.h"
-#undef private
-#undef protected
-
 #include "io/cache/block_file_cache_test_common.h"
+#include "io/cache/fs_file_cache_storage.h"
 
 namespace doris::io {
 

--- a/be/test/storage/iterator/block_reader_agg_flush_test.cpp
+++ b/be/test/storage/iterator/block_reader_agg_flush_test.cpp
@@ -24,11 +24,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wkeyword-macro"
 #endif
-#define private public
-#define protected public
 #include "storage/iterator/block_reader.h"
-#undef private
-#undef protected
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif

--- a/be/test/storage/iterator/block_reader_batch_max_rows_test.cpp
+++ b/be/test/storage/iterator/block_reader_batch_max_rows_test.cpp
@@ -15,16 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Use #define private public to access private/protected members for testing
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wkeyword-macro"
 #endif
-#define private public
-#define protected public
 #include "storage/iterator/block_reader.h"
-#undef private
-#undef protected
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif

--- a/be/test/storage/iterator/block_reader_change_next_block_test.cpp
+++ b/be/test/storage/iterator/block_reader_change_next_block_test.cpp
@@ -26,12 +26,8 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wkeyword-macro"
 #endif
-#define private public
-#define protected public
 #include "storage/iterator/block_reader.h"
 #include "storage/iterator/vcollect_iterator.h"
-#undef private
-#undef protected
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif

--- a/be/test/storage/segment/segment_iterator_apply_index_expr_test.cpp
+++ b/be/test/storage/segment/segment_iterator_apply_index_expr_test.cpp
@@ -28,15 +28,12 @@
 #include "storage/segment/column_reader.h"
 #include "storage/tablet/tablet_schema.h"
 
-// Use #define private public to access private members for testing
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wkeyword-macro"
 #endif
-#define private public
 #include "storage/segment/segment.h"
 #include "storage/segment/segment_iterator.h"
-#undef private
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif

--- a/be/test/storage/segment/segment_iterator_lazy_pruned_test.cpp
+++ b/be/test/storage/segment/segment_iterator_lazy_pruned_test.cpp
@@ -29,16 +29,13 @@
 #include "storage/segment/column_reader.h"
 #include "storage/tablet/tablet_schema.h"
 
-// Use #define private public to access SegmentIterator::_read_lazy_pruned_columns()
 // and the small amount of state it consumes. This mirrors the existing
 // segment_iterator_* white-box tests.
 #if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wkeyword-macro"
 #endif
-#define private public
 #include "storage/segment/segment_iterator.h"
-#undef private
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif

--- a/be/test/storage/segment/segment_iterator_limit_opt_test.cpp
+++ b/be/test/storage/segment/segment_iterator_limit_opt_test.cpp
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Use #define private public to access private members for white-box testing
 // of SegmentIterator::_can_opt_limit_reads() and its dependent state. Mirrors
 // the convention in segment_iterator_apply_index_expr_test.cpp.
 #include "core/block/block.h"
@@ -31,11 +30,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wkeyword-macro"
 #endif
-#define private public
-#define protected public
 #include "storage/segment/segment_iterator.h"
-#undef private
-#undef protected
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif

--- a/be/test/testutil/gperftools_stubs.cpp
+++ b/be/test/testutil/gperftools_stubs.cpp
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// doris_be_test on macOS/arm64 links against the system allocator instead of
+// tcmalloc: the Debug test binary's .text exceeds arm64's +/-128MB direct
+// branch reach and Apple's linker emits no branch islands for the prebuilt
+// gperftools archive. These no-op definitions satisfy the few gperftools
+// symbols still referenced unconditionally (HeapAction's HTTP handler, which
+// no unit test invokes, and brpc's periodic MallocExtension release hint).
+// Everywhere else the real libtcmalloc.a provides them and this TU is empty.
+
+#if defined(__APPLE__) && defined(__aarch64__)
+
+#include <cstddef>
+
+extern "C" {
+
+char* GetHeapProfile() {
+    return nullptr;
+}
+
+void HeapProfilerStart(const char* /*prefix*/) {}
+
+void HeapProfilerStop() {}
+
+void MallocExtension_ReleaseFreeMemory() {}
+
+} // extern "C"
+
+#endif

--- a/be/test/util/variant/variant_jsonb_parse_test.cpp
+++ b/be/test/util/variant/variant_jsonb_parse_test.cpp
@@ -221,7 +221,7 @@ TEST(VariantJsonbTest, AllJsonbTypesMapToCanonicalVariant) {
     ASSERT_TRUE(writer.writeInt128(power_of_ten_128(20)));
     ASSERT_TRUE(writer.writeFloat(1.5F));
     ASSERT_TRUE(writer.writeDecimal(Decimal32 {123}, 3, 38));
-    ASSERT_TRUE(writer.writeDecimal(Decimal64 {12'345'678'901}, 11, 38));
+    ASSERT_TRUE(writer.writeDecimal(Decimal64 {int64_t(12'345'678'901)}, 11, 38));
     ASSERT_TRUE(writer.writeDecimal(Decimal128V3 {power_of_ten_128(20)}, 21, 6));
     ASSERT_TRUE(writer.writeEndArray());
 

--- a/run-fe-ut.sh
+++ b/run-fe-ut.sh
@@ -68,7 +68,11 @@ fail_on_unparsed_test_failures() {
         if [[ "${failures:-0}" -gt 0 || "${errors:-0}" -gt 0 ]]; then
             broken+=("${report#"${DORIS_HOME}/"} -- failures=${failures:-0} errors=${errors:-0}")
         fi
-    done < <(find "${DORIS_HOME}/fe" -type f -path '*/target/surefire-reports/*.xml')
+        # A here-string, not `done < <(find ...)`: this script is documented and invoked as
+        # `sh run-fe-ut.sh`, and bash in sh/POSIX mode rejects process substitution outright --
+        # a parse error, so the whole script dies before it builds anything. Piping into the
+        # loop instead would put the body in a subshell and throw `broken` away.
+    done <<<"$(find "${DORIS_HOME}/fe" -type f -path '*/target/surefire-reports/*.xml')"
 
     if [[ "${#broken[@]}" -ne 0 ]]; then
         echo ""


### PR DESCRIPTION
> Part of the BE build-time optimization series tracked in #66715.
>
> Split out of **https://github.com/apache/doris/pull/66510**. That PR carries the
> whole BE build-time batch and its end-to-end measurements — **please refer to
> #66510 for the complete benefit numbers**. This PR is the standalone,
> pre-existing engineering-debt part of it: it has no textual or semantic
> dependency on the rest and can be reviewed and merged on its own.

### What problem does this PR solve?

Related PR: #66510

Problem Summary:

`sh run-be-ut.sh` and `BUILD_BENCHMARK=ON` do not build at all on macOS arm64,
and digging into it surfaced a bug that affects **every** platform.

#### 1. `-fno-access-control` has never reached `doris_be_test` (all platforms)

`add_definitions(-D OS_LINUX)` / `(-D OS_MACOSX)` passes `-D` and the macro name
as two separate argv entries. On the `doris_be_test` target the flag-injection
order leaves the dangling `-D` immediately before the target's `COMPILE_FLAGS`,
so clang parses `-D -fno-access-control` as a (rejected) macro definition and
only warns `macro name must be an identifier`. **The test target has been
compiled without `-fno-access-control` all along.**

Ten tests compensated with `#define private public`, which breaks any TU whose
include graph reaches libc++'s `<ranges>`: a macro cannot rewrite a class's
*default*-private region, so `lazy_split_view`'s member declarations come out
`redeclared with public access`. simdjson pulls `<ranges>` in via
`segment_iterator.h`, which is why this kept resurfacing.
`e27d10362ac` attributed that failure to `<ranges>`; the actual cause is the
swallowed flag, and this PR corrects that attribution.

Fix: write `-DOS_LINUX` / `-DOS_MACOSX` so the flag survives, and delete the
`private`/`protected` `=public` defines from the ten tests — white-box access
now comes from the (finally effective) `-fno-access-control`, which coexists
with `<ranges>` fine.

#### 2. Three macOS arm64 link failures in `doris_be_test`

- **tcmalloc branch out of range.** The Debug test binary's `.text` exceeds
  arm64's ±128MB direct-branch reach, and Apple's linker emits no branch islands
  for the prebuilt `libtcmalloc.a`
  (`fixup error (kind=arm64_b26) ... B/BL out of range`). `-Og` no longer keeps
  it under the limit. Stop linking `${MALLOCLIB}` into macOS-arm `MAKE_TEST`
  builds — unit tests do not need a custom allocator, and ASAN builds never
  linked it anyway (which is why they never hit this).
- **Unconditionally referenced gperftools symbols.** `HeapAction`'s HTTP handler
  and brpc's `MallocExtension_ReleaseFreeMemory` hint get no-op stubs, compiled
  only under `__APPLE__ && __aarch64__`.
- **Parallel link race.** The APPLE branch links `vector_search_test` through
  `-Wl,-force_load,$<TARGET_FILE:...>`, which creates no target-level dependency,
  so a parallel ninja could reach `doris_be_test`'s link step before the archive
  exists (`library libvector_search_test.a not found`). Added the missing
  `add_dependencies`.

`BUILD_BENCHMARK` inflates `.text` past the same ±128MB BL reach, so the
system-malloc fallback and the stub TU are extended to `benchmark_test` too.

#### 3. Six BE headers drop `<ranges>`

Src-side follow-up to `e27d10362ac`'s test-side cleanup. These headers only used
range algorithms that `<algorithm>` already provides
(`std::ranges::sort` / `is_sorted` / `find_if` / `any_of` / `nth_element` /
`max_element`) or trivially rewritable views (`reverse_view` → `rbegin`/`rend`
loop, `views::values` → structured-binding loop). `object_pool.h` alone is
included by hundreds of TUs and was paying for the whole `<ranges>` header for
one reverse loop. **This is the one hunk here with a real compile-time payoff.**

#### 4. Two test portability fixes, one shell fix

- `file_scanner_v2_test` kept a local anonymous-namespace copy of
  `kIcebergPositionDeleteContent` / `kIcebergDeletionVectorContent` after
  `iceberg_scan_semantics.h` began exporting the same names into `namespace
  doris`, making unqualified references ambiguous.
- `variant_jsonb_parse_test` constructed `Decimal64` from a bare `long long`
  literal, ambiguous on macOS where `int64_t` is `long long` vs Linux's `long`
  (same family as `e3724df7cb8`).
- `sh run-fe-ut.sh` — the invocation the script's own usage text documents — died
  at parse time with ``syntax error near unexpected token `<' `` before building
  anything: `/bin/sh` is bash, and bash in POSIX mode rejects process
  substitution at parse time, so `done < <(find ...)` took the whole script down.
  Regressed in `82646c38c00`. Replaced with a here-string (not a pipe, which
  would put the loop body in a subshell and discard `broken`).

### Release note

None

### Check List (For Author)

- Test
    - [x] Unit Test — this PR is what makes `doris_be_test` build and link on
      macOS arm64 in the first place; the existing suites are the test. The ten
      tests that lost `#define private public` still compile and pass, now
      relying on the (finally effective) `-fno-access-control`.
    - [x] Manual test
        - `BUILD_TYPE_UT=Debug sh run-be-ut.sh -j8 --run` builds and links on
          macOS 26.5 arm64 / llvm 20 (it did not before this PR).
        - `sh run-fe-ut.sh` reaches and passes fe-core's `test-compile`
          (1333 test sources, 62 modules, zero errors). The parse fix was
          verified under `sh` against the real function: a nested-module report
          with failures returns 1 and lists only that module, a clean report
          returns 0 with a quoted `failures="7"` inside a stack trace correctly
          ignored, and no reports at all returns 0 — the empty input being the
          case the here-string could have broken.

- Behavior changed:
    - [x] No. Build/test-tooling only; no runtime code path is touched. The
      `<ranges>` → `<algorithm>` rewrites are behavior-preserving
      (`std::ranges::*` algorithms live in `<algorithm>`; the two view rewrites
      iterate the same elements in the same order).

- Does this need documentation?
    - [x] No.

### Proactive disclosure

- The tcmalloc opt-out is deliberately scoped to `OS_MACOSX AND ARCH_ARM AND
  (MAKE_TEST OR BUILD_BENCHMARK)`. Linux CI, and macOS `doris_be` itself, keep
  linking `${MALLOCLIB}` exactly as before — this cannot change allocator
  behavior for any shipped binary.
- Verified on macOS arm64 only for the link fixes (they are macOS-arm-specific by
  construction). Items 1, 3 and 4 are cross-platform and want a look from the
  Linux CI lines: item 1 changes how `OS_LINUX` is defined for **every** target,
  and while `-DOS_LINUX` is strictly more correct than `-D OS_LINUX`, it also
  means `-fno-access-control` starts being honoured on Linux `doris_be_test` too.

