### PR TITLE
[fix](fe) Reject unsafe Iceberg column drops

### DIFF
--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergCatalogOps.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergCatalogOps.java
@@ -458,9 +458,7 @@ public interface IcebergCatalogOps {
 
         @Override
         public void dropColumn(String dbName, String tableName, String columnName) {
-            UpdateSchema updateSchema = loadTable(dbName, tableName).updateSchema();
-            updateSchema.deleteColumn(columnName);
-            updateSchema.commit();
+            IcebergNestedColumnEvolution.dropTopLevelColumn(loadTable(dbName, tableName), columnName);
         }
 
         @Override

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolution.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolution.java
@@ -28,12 +28,18 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.UpdateSchema;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -60,6 +66,8 @@ import java.util.TreeSet;
  * {@link #validateNoCaseInsensitiveTopLevelCollisions} and {@link #renameTopLevelColumn}.</p>
  */
 public final class IcebergNestedColumnEvolution {
+
+    private static final String REST_DROP_FENCE_PREFIX = "_doris_schema_drop_fence_";
 
     private IcebergNestedColumnEvolution() {
     }
@@ -113,12 +121,9 @@ public final class IcebergNestedColumnEvolution {
                 table.name(), path, nested, loaded, loadedSubtreeIds, base);
         validateNotUsedByRetainedPartitionSpec(base, resolvedPath);
 
-        // Iceberg REST has no requirement for the partition-spec ID namespace. Allowing its server-side rebase
-        // could therefore add a spec that references this field after validation and corrupt the replacement
-        // schema; fail closed until the protocol can express that invariant.
         if (isRestTableOperations(operations)) {
-            throw new DorisConnectorException(
-                    "Cannot safely drop a column from an Iceberg REST table: " + table.name());
+            commitRestDropWithSpecFence(operations, table.name(), base, resolvedPath);
+            return;
         }
 
         // Use Iceberg's standard commit so column-scoped writer properties and name mappings are transformed.
@@ -127,10 +132,94 @@ public final class IcebergNestedColumnEvolution {
                 .deleteColumn(resolvedPath.getFullPath()).commit();
     }
 
+    private static void commitRestDropWithSpecFence(
+            TableOperations operations, String tableName, TableMetadata base, ResolvedColumnPath resolvedPath) {
+        if (base.formatVersion() < 2) {
+            throw new DorisConnectorException(
+                    "Cannot safely drop a column from a format-v1 Iceberg REST table: " + tableName);
+        }
+
+        Set<Integer> droppedFieldIds = fieldSubtreeIds(resolvedPath);
+        String fenceSource = findRestFenceSource(base, droppedFieldIds);
+        if (fenceSource == null) {
+            throw new DorisConnectorException(
+                    "Cannot safely fence a column drop in Iceberg REST table: " + tableName);
+        }
+        String fenceName = newRestFenceName(base);
+
+        // Validation proved that no retained spec references the drop target, so any concurrent new reference
+        // must allocate a partition field ID. Adding a distinct void field makes REST assert that ID counter.
+        CapturingTableOperations schemaCapture = new CapturingTableOperations(operations, base);
+        new BaseTable(schemaCapture, tableName).updateSchema()
+                .deleteColumn(resolvedPath.getFullPath()).commit();
+
+        CapturingTableOperations fenceCapture = new CapturingTableOperations(operations, base);
+        new BaseTable(fenceCapture, tableName).updateSpec()
+                .addField(fenceName, Expressions.transform(fenceSource, Transforms.alwaysNull()))
+                .addNonDefaultSpec().commit();
+
+        TableMetadata.Builder combined = TableMetadata.buildFrom(base);
+        schemaCapture.committed().changes().forEach(update -> update.applyTo(combined));
+        fenceCapture.committed().changes().forEach(update -> update.applyTo(combined));
+        // The durable fence must stay in metadata: removing its client-predicted spec ID could delete a
+        // concurrently added spec after REST renumbers the fence during server-side rebase.
+        operations.commit(base, combined.build());
+    }
+
+    private static String findRestFenceSource(TableMetadata metadata, Set<Integer> droppedFieldIds) {
+        LinkedHashSet<Integer> candidates = new LinkedHashSet<>();
+        metadata.specs().forEach(spec -> spec.fields().forEach(field -> candidates.add(field.sourceId())));
+        candidates.addAll(metadata.schema().identifierFieldIds());
+        collectStructPrimitiveFieldIds(metadata.schema().asStruct(), droppedFieldIds, candidates);
+
+        return candidates.stream()
+                .filter(id -> !droppedFieldIds.contains(id))
+                .filter(id -> metadata.schema().findField(id) != null)
+                .filter(id -> metadata.spec().fields().stream()
+                        .noneMatch(field -> field.sourceId() == id && field.transform().isVoid()))
+                .map(metadata.schema()::findColumnName)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static void collectStructPrimitiveFieldIds(
+            Types.StructType struct, Set<Integer> droppedFieldIds, Set<Integer> candidates) {
+        for (NestedField field : struct.fields()) {
+            if (droppedFieldIds.contains(field.fieldId())) {
+                continue;
+            }
+            if (field.type().isPrimitiveType()) {
+                candidates.add(field.fieldId());
+            } else if (field.type().isStructType()) {
+                collectStructPrimitiveFieldIds(field.type().asStructType(), droppedFieldIds, candidates);
+            }
+        }
+    }
+
+    private static String newRestFenceName(TableMetadata metadata) {
+        int suffix = metadata.lastAssignedPartitionId() + 1;
+        String candidate = REST_DROP_FENCE_PREFIX + suffix;
+        while (hasFieldOrPartitionName(metadata, candidate)) {
+            candidate = REST_DROP_FENCE_PREFIX + ++suffix;
+        }
+        return candidate;
+    }
+
+    private static boolean hasFieldOrPartitionName(TableMetadata metadata, String candidate) {
+        boolean fieldNameExists = TypeUtil.indexById(metadata.schema().asStruct()).values().stream()
+                .anyMatch(field -> field.name().equalsIgnoreCase(candidate));
+        return fieldNameExists || metadata.specs().stream().flatMap(spec -> spec.fields().stream())
+                .anyMatch(field -> field.name().equalsIgnoreCase(candidate));
+    }
+
     private static ResolvedColumnPath validatePinnedDropIdentity(
             String tableName, ConnectorColumnPath path, boolean nested, TableMetadata loaded,
             Set<Integer> loadedSubtreeIds, TableMetadata refreshed) {
-        if (!Objects.equals(loaded.uuid(), refreshed.uuid())) {
+        if (!Objects.equals(loaded.uuid(), refreshed.uuid())
+                || (loaded.uuid() == null && loaded != refreshed)) {
+            // UUID-less legacy metadata has no generation identity, so only the exact refreshed object can be
+            // trusted; accepting a different object could retarget the DROP to a recreated table.
             throw concurrentDropTargetChange(tableName, path);
         }
         try {
@@ -169,20 +258,74 @@ public final class IcebergNestedColumnEvolution {
 
     private static void validateNotUsedByRetainedPartitionSpec(
             TableMetadata metadata, ResolvedColumnPath columnPath) {
-        int currentSpecId = metadata.spec().specId();
         Set<Integer> droppedFieldIds = TypeUtil.indexById(
                 Types.StructType.of(columnPath.getField())).keySet();
-        // Historical specs resolve partition types by source field ID against the current schema, so deleting
-        // a referenced source field or any ancestor leaves those specs unreadable. Format-v1 also retains a
-        // void field in the current spec after removal, so it must remain part of this source-ID check.
+        // Every retained spec resolves partition types by source field ID against the current schema. Checking
+        // the current spec too establishes that a later REST fence can detect any newly introduced reference.
         boolean usedByRetainedSpec = metadata.specs().stream()
                 .anyMatch(spec -> spec.fields().stream().anyMatch(field ->
-                        droppedFieldIds.contains(field.sourceId())
-                                && (spec.specId() != currentSpecId || field.transform().isVoid())));
+                        droppedFieldIds.contains(field.sourceId())));
         if (usedByRetainedSpec) {
             throw new DorisConnectorException(
-                    "Cannot drop column which is used by an old partition spec or retained format-v1 void field: "
+                    "Cannot drop column which is used by an old partition spec or current retained partition spec: "
                             + columnPath.getFullPath());
+        }
+    }
+
+    private static final class CapturingTableOperations implements TableOperations {
+        private final TableOperations delegate;
+        private TableMetadata current;
+        private TableMetadata committed;
+
+        private CapturingTableOperations(TableOperations delegate, TableMetadata base) {
+            this.delegate = delegate;
+            this.current = base;
+        }
+
+        private TableMetadata committed() {
+            if (committed == null) {
+                throw new IllegalStateException("Iceberg metadata update did not commit to the capture");
+            }
+            return committed;
+        }
+
+        @Override
+        public TableMetadata current() {
+            return current;
+        }
+
+        @Override
+        public TableMetadata refresh() {
+            return current;
+        }
+
+        @Override
+        public void commit(TableMetadata base, TableMetadata metadata) {
+            if (base != current) {
+                throw new IllegalStateException("Iceberg metadata capture committed from an unexpected base");
+            }
+            current = metadata;
+            committed = metadata;
+        }
+
+        @Override
+        public FileIO io() {
+            return delegate.io();
+        }
+
+        @Override
+        public EncryptionManager encryption() {
+            return delegate.encryption();
+        }
+
+        @Override
+        public String metadataFileLocation(String fileName) {
+            return delegate.metadataFileLocation(fileName);
+        }
+
+        @Override
+        public LocationProvider locationProvider() {
+            return delegate.locationProvider();
         }
     }
 

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolution.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolution.java
@@ -21,13 +21,22 @@ import org.apache.doris.connector.spi.DorisConnectorException;
 import org.apache.doris.connector.spi.ddl.ConnectorColumnPath;
 import org.apache.doris.connector.spi.ddl.ConnectorColumnPosition;
 
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateSchema;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.util.Tasks;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,8 +56,8 @@ import java.util.TreeSet;
  * {@link IcebergColumnChange}), so this class only ever touches iceberg + neutral SPI types — never a Doris type.
  * Every failure is raised as a {@link DorisConnectorException} (the caller maps it to a {@code DdlException}).</p>
  *
- * <p><b>No partial commit:</b> every {@code UpdateSchema.commit()} is the final statement of each entry point, so
- * any validation/resolution throw aborts the whole change before anything is committed (legacy parity).</p>
+ * <p><b>No partial commit:</b> every entry point validates before its single metadata commit, so any
+ * validation/resolution throw aborts the whole change before anything is committed (legacy parity).</p>
  *
  * <p>The TOP-LEVEL (flat) column ops stay on {@link IcebergCatalogOps}, but they share this class's name
  * resolution and validators — iceberg matches field names case-SENSITIVELY while Doris column names are
@@ -87,36 +96,74 @@ public final class IcebergNestedColumnEvolution {
 
     /** Drops the nested field at {@code path}; its parent must resolve to a struct that contains the leaf. */
     public static void dropColumn(Table table, ConnectorColumnPath path) {
-        ResolvedColumnPath resolvedPath = validateNestedStructFieldPath(table.schema(), path, "drop");
-        validateNotUsedByOldPartitionSpec(table, resolvedPath);
-        UpdateSchema updateSchema = table.updateSchema();
-        updateSchema.deleteColumn(resolvedPath.getFullPath());
-        updateSchema.commit();
+        dropColumnWithPartitionSpecFence(table, path, true);
     }
 
     static void dropTopLevelColumn(Table table, String columnName) {
-        ResolvedColumnPath resolvedPath = resolveColumnPath(
-                table.schema(), ConnectorColumnPath.of(columnName), "drop");
-        validateNotUsedByOldPartitionSpec(table, resolvedPath);
-        UpdateSchema updateSchema = table.updateSchema();
-        updateSchema.deleteColumn(resolvedPath.getFullPath());
-        updateSchema.commit();
+        dropColumnWithPartitionSpecFence(table, ConnectorColumnPath.of(columnName), false);
     }
 
-    private static void validateNotUsedByOldPartitionSpec(Table table, ResolvedColumnPath columnPath) {
-        int currentSpecId = table.spec().specId();
+    private static void dropColumnWithPartitionSpecFence(
+            Table table, ConnectorColumnPath path, boolean nested) {
+        TableOperations operations = ((HasTableOperations) table).operations();
+        TableMetadata initial = operations.refresh();
+        // A commit conflict must rerun resolution and retained-spec validation against refreshed metadata.
+        Tasks.foreach(operations)
+                .retry(initial.propertyAsInt(
+                        TableProperties.COMMIT_NUM_RETRIES, TableProperties.COMMIT_NUM_RETRIES_DEFAULT))
+                .exponentialBackoff(
+                        initial.propertyAsInt(TableProperties.COMMIT_MIN_RETRY_WAIT_MS,
+                                TableProperties.COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+                        initial.propertyAsInt(TableProperties.COMMIT_MAX_RETRY_WAIT_MS,
+                                TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+                        initial.propertyAsInt(TableProperties.COMMIT_TOTAL_RETRY_TIME_MS,
+                                TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
+                        2.0)
+                .onlyRetryOn(CommitFailedException.class)
+                .run(ops -> commitDropAttempt(ops, table.name(), path, nested));
+    }
+
+    private static void commitDropAttempt(
+            TableOperations operations, String tableName, ConnectorColumnPath path, boolean nested) {
+        TableMetadata base = operations.refresh();
+        ResolvedColumnPath resolvedPath = nested
+                ? validateNestedStructFieldPath(base.schema(), path, "drop")
+                : resolveColumnPath(base.schema(), path, "drop");
+        validateNotUsedByRetainedPartitionSpec(base, resolvedPath);
+
+        Table attemptTable = new BaseTable(operations.temp(base), tableName);
+        Schema updatedSchema = attemptTable.updateSchema()
+                .deleteColumn(resolvedPath.getFullPath()).apply();
+        int fenceSpecId = base.specs().stream().mapToInt(PartitionSpec::specId).max().orElse(-1) + 1;
+        String fenceFieldName = "_doris_schema_drop_fence_" + (base.lastAssignedPartitionId() + 1);
+        PartitionSpec fenceSpec = PartitionSpec.builderFor(base.schema())
+                .withSpecId(fenceSpecId)
+                .alwaysNull(resolvedPath.getFullPath(), fenceFieldName)
+                .build();
+        TableMetadata.Builder builder = TableMetadata.buildFrom(base).addPartitionSpec(fenceSpec);
+        new MetadataUpdate.RemovePartitionSpecs(Set.of(fenceSpecId)).applyTo(builder);
+        builder.setCurrentSchema(updatedSchema, base.lastColumnId());
+        // The transient spec leaves no readable metadata behind, but forces REST commits to assert the
+        // last partition-field ID so a concurrent non-default spec cannot be silently rebased past validation.
+        operations.commit(base, builder.build());
+    }
+
+    private static void validateNotUsedByRetainedPartitionSpec(
+            TableMetadata metadata, ResolvedColumnPath columnPath) {
+        int currentSpecId = metadata.spec().specId();
         Set<Integer> droppedFieldIds = TypeUtil.indexById(
                 Types.StructType.of(columnPath.getField())).keySet();
         // Historical specs resolve partition types by source field ID against the current schema, so deleting
-        // a referenced source field or any ancestor leaves those specs unreadable even after the field is
-        // removed from the current spec. Index the full subtree because deleting a struct also deletes its fields.
-        boolean usedByOldSpec = table.specs().values().stream()
-                .filter(spec -> spec.specId() != currentSpecId)
-                .flatMap(spec -> spec.fields().stream())
-                .anyMatch(field -> droppedFieldIds.contains(field.sourceId()));
-        if (usedByOldSpec) {
+        // a referenced source field or any ancestor leaves those specs unreadable. Format-v1 also retains a
+        // void field in the current spec after removal, so it must remain part of this source-ID check.
+        boolean usedByRetainedSpec = metadata.specs().stream()
+                .anyMatch(spec -> spec.fields().stream().anyMatch(field ->
+                        droppedFieldIds.contains(field.sourceId())
+                                && (spec.specId() != currentSpecId || field.transform().isVoid())));
+        if (usedByRetainedSpec) {
             throw new DorisConnectorException(
-                    "Cannot drop column which is used by an old partition spec: " + columnPath.getFullPath());
+                    "Cannot drop column which is used by an old partition spec or retained format-v1 void field: "
+                            + columnPath.getFullPath());
         }
     }
 

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolution.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolution.java
@@ -88,9 +88,36 @@ public final class IcebergNestedColumnEvolution {
     /** Drops the nested field at {@code path}; its parent must resolve to a struct that contains the leaf. */
     public static void dropColumn(Table table, ConnectorColumnPath path) {
         ResolvedColumnPath resolvedPath = validateNestedStructFieldPath(table.schema(), path, "drop");
+        validateNotUsedByOldPartitionSpec(table, resolvedPath);
         UpdateSchema updateSchema = table.updateSchema();
         updateSchema.deleteColumn(resolvedPath.getFullPath());
         updateSchema.commit();
+    }
+
+    static void dropTopLevelColumn(Table table, String columnName) {
+        ResolvedColumnPath resolvedPath = resolveColumnPath(
+                table.schema(), ConnectorColumnPath.of(columnName), "drop");
+        validateNotUsedByOldPartitionSpec(table, resolvedPath);
+        UpdateSchema updateSchema = table.updateSchema();
+        updateSchema.deleteColumn(resolvedPath.getFullPath());
+        updateSchema.commit();
+    }
+
+    private static void validateNotUsedByOldPartitionSpec(Table table, ResolvedColumnPath columnPath) {
+        int currentSpecId = table.spec().specId();
+        Set<Integer> droppedFieldIds = TypeUtil.indexById(
+                Types.StructType.of(columnPath.getField())).keySet();
+        // Historical specs resolve partition types by source field ID against the current schema, so deleting
+        // a referenced source field or any ancestor leaves those specs unreadable even after the field is
+        // removed from the current spec. Index the full subtree because deleting a struct also deletes its fields.
+        boolean usedByOldSpec = table.specs().values().stream()
+                .filter(spec -> spec.specId() != currentSpecId)
+                .flatMap(spec -> spec.fields().stream())
+                .anyMatch(field -> droppedFieldIds.contains(field.sourceId()));
+        if (usedByOldSpec) {
+            throw new DorisConnectorException(
+                    "Cannot drop column which is used by an old partition spec: " + columnPath.getFullPath());
+        }
     }
 
     /**

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolution.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolution.java
@@ -23,20 +23,15 @@ import org.apache.doris.connector.spi.ddl.ConnectorColumnPosition;
 
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.HasTableOperations;
-import org.apache.iceberg.MetadataUpdate;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateSchema;
-import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
-import org.apache.iceberg.util.Tasks;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -96,56 +91,80 @@ public final class IcebergNestedColumnEvolution {
 
     /** Drops the nested field at {@code path}; its parent must resolve to a struct that contains the leaf. */
     public static void dropColumn(Table table, ConnectorColumnPath path) {
-        dropColumnWithPartitionSpecFence(table, path, true);
+        dropColumnSafely(table, path, true);
     }
 
     static void dropTopLevelColumn(Table table, String columnName) {
-        dropColumnWithPartitionSpecFence(table, ConnectorColumnPath.of(columnName), false);
+        dropColumnSafely(table, ConnectorColumnPath.of(columnName), false);
     }
 
-    private static void dropColumnWithPartitionSpecFence(
+    private static void dropColumnSafely(
             Table table, ConnectorColumnPath path, boolean nested) {
         TableOperations operations = ((HasTableOperations) table).operations();
-        TableMetadata initial = operations.refresh();
-        // A commit conflict must rerun resolution and retained-spec validation against refreshed metadata.
-        Tasks.foreach(operations)
-                .retry(initial.propertyAsInt(
-                        TableProperties.COMMIT_NUM_RETRIES, TableProperties.COMMIT_NUM_RETRIES_DEFAULT))
-                .exponentialBackoff(
-                        initial.propertyAsInt(TableProperties.COMMIT_MIN_RETRY_WAIT_MS,
-                                TableProperties.COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-                        initial.propertyAsInt(TableProperties.COMMIT_MAX_RETRY_WAIT_MS,
-                                TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-                        initial.propertyAsInt(TableProperties.COMMIT_TOTAL_RETRY_TIME_MS,
-                                TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-                        2.0)
-                .onlyRetryOn(CommitFailedException.class)
-                .run(ops -> commitDropAttempt(ops, table.name(), path, nested));
-    }
+        TableMetadata loaded = operations.current();
+        if (loaded == null) {
+            throw new DorisConnectorException("Cannot drop column from an unloaded Iceberg table: " + table.name());
+        }
+        ResolvedColumnPath loadedPath = resolveDropPath(loaded.schema(), path, nested);
+        Set<Integer> loadedSubtreeIds = fieldSubtreeIds(loadedPath);
 
-    private static void commitDropAttempt(
-            TableOperations operations, String tableName, ConnectorColumnPath path, boolean nested) {
         TableMetadata base = operations.refresh();
-        ResolvedColumnPath resolvedPath = nested
-                ? validateNestedStructFieldPath(base.schema(), path, "drop")
-                : resolveColumnPath(base.schema(), path, "drop");
+        ResolvedColumnPath resolvedPath = validatePinnedDropIdentity(
+                table.name(), path, nested, loaded, loadedSubtreeIds, base);
         validateNotUsedByRetainedPartitionSpec(base, resolvedPath);
 
-        Table attemptTable = new BaseTable(operations.temp(base), tableName);
-        Schema updatedSchema = attemptTable.updateSchema()
-                .deleteColumn(resolvedPath.getFullPath()).apply();
-        int fenceSpecId = base.specs().stream().mapToInt(PartitionSpec::specId).max().orElse(-1) + 1;
-        String fenceFieldName = "_doris_schema_drop_fence_" + (base.lastAssignedPartitionId() + 1);
-        PartitionSpec fenceSpec = PartitionSpec.builderFor(base.schema())
-                .withSpecId(fenceSpecId)
-                .alwaysNull(resolvedPath.getFullPath(), fenceFieldName)
-                .build();
-        TableMetadata.Builder builder = TableMetadata.buildFrom(base).addPartitionSpec(fenceSpec);
-        new MetadataUpdate.RemovePartitionSpecs(Set.of(fenceSpecId)).applyTo(builder);
-        builder.setCurrentSchema(updatedSchema, base.lastColumnId());
-        // The transient spec leaves no readable metadata behind, but forces REST commits to assert the
-        // last partition-field ID so a concurrent non-default spec cannot be silently rebased past validation.
-        operations.commit(base, builder.build());
+        // Iceberg REST has no requirement for the partition-spec ID namespace. Allowing its server-side rebase
+        // could therefore add a spec that references this field after validation and corrupt the replacement
+        // schema; fail closed until the protocol can express that invariant.
+        if (isRestTableOperations(operations)) {
+            throw new DorisConnectorException(
+                    "Cannot safely drop a column from an Iceberg REST table: " + table.name());
+        }
+
+        // Use Iceberg's standard commit so column-scoped writer properties and name mappings are transformed.
+        // Direct catalogs atomically reject any metadata change after the refresh through their metadata CAS.
+        new BaseTable(operations, table.name()).updateSchema()
+                .deleteColumn(resolvedPath.getFullPath()).commit();
+    }
+
+    private static ResolvedColumnPath validatePinnedDropIdentity(
+            String tableName, ConnectorColumnPath path, boolean nested, TableMetadata loaded,
+            Set<Integer> loadedSubtreeIds, TableMetadata refreshed) {
+        if (!Objects.equals(loaded.uuid(), refreshed.uuid())) {
+            throw concurrentDropTargetChange(tableName, path);
+        }
+        try {
+            ResolvedColumnPath refreshedPath = resolveDropPath(refreshed.schema(), path, nested);
+            // A parent DROP pins every descendant ID as well as the parent ID, preventing a same-path subtree
+            // replacement from turning an old request into deletion of a newly created object.
+            if (!loadedSubtreeIds.equals(fieldSubtreeIds(refreshedPath))) {
+                throw concurrentDropTargetChange(tableName, path);
+            }
+            return refreshedPath;
+        } catch (DorisConnectorException e) {
+            throw concurrentDropTargetChange(tableName, path);
+        }
+    }
+
+    private static ResolvedColumnPath resolveDropPath(
+            Schema schema, ConnectorColumnPath path, boolean nested) {
+        return nested
+                ? validateNestedStructFieldPath(schema, path, "drop")
+                : resolveColumnPath(schema, path, "drop");
+    }
+
+    private static Set<Integer> fieldSubtreeIds(ResolvedColumnPath path) {
+        return new TreeSet<>(TypeUtil.indexById(Types.StructType.of(path.getField())).keySet());
+    }
+
+    private static DorisConnectorException concurrentDropTargetChange(
+            String tableName, ConnectorColumnPath path) {
+        return new DorisConnectorException("Iceberg table or drop target changed concurrently: "
+                + tableName + "." + path.getFullPath());
+    }
+
+    private static boolean isRestTableOperations(TableOperations operations) {
+        return "RESTTableOperations".equalsIgnoreCase(operations.getClass().getSimpleName());
     }
 
     private static void validateNotUsedByRetainedPartitionSpec(

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/CatalogBackedIcebergCatalogOpsColumnEvolutionTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/CatalogBackedIcebergCatalogOpsColumnEvolutionTest.java
@@ -23,8 +23,11 @@ import org.apache.doris.connector.spi.ConnectorType;
 import org.apache.doris.connector.spi.DorisConnectorException;
 import org.apache.doris.connector.spi.ddl.ConnectorColumnPosition;
 
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -122,6 +125,26 @@ public class CatalogBackedIcebergCatalogOpsColumnEvolutionTest {
     public void testDropColumn() {
         ops.dropColumn("db1", "t1", "val");
         Assertions.assertNull(reload().findField("val"));
+    }
+
+    @Test
+    public void testDropColumnUsedByHistoricalPartitionSpecFailsLoud() {
+        Table table = ops.loadTable("db1", "t1");
+        table.updateSpec().addField("val").commit();
+        String partitionName = table.spec().fields().get(0).name();
+        DataFile dataFile = DataFiles.builder(table.spec())
+                .withPath("file:/warehouse/t1/data.parquet")
+                .withFileSizeInBytes(1)
+                .withRecordCount(1)
+                .withPartitionPath(partitionName + "=1")
+                .build();
+        table.newAppend().appendFile(dataFile).commit();
+        table.updateSpec().removeField(partitionName).commit();
+
+        DorisConnectorException ex = Assertions.assertThrows(DorisConnectorException.class,
+                () -> ops.dropColumn("db1", "t1", "val"));
+        Assertions.assertTrue(ex.getMessage().contains("used by an old partition spec"), ex.getMessage());
+        Assertions.assertNotNull(reload().findField("val"));
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolutionTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolutionTest.java
@@ -23,8 +23,11 @@ import org.apache.doris.connector.spi.DorisConnectorException;
 import org.apache.doris.connector.spi.ddl.ConnectorColumnPath;
 import org.apache.doris.connector.spi.ddl.ConnectorColumnPosition;
 
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -265,6 +268,48 @@ public class IcebergNestedColumnEvolutionTest {
         Types.StructType s = reload("d_drop").findField("s").type().asStructType();
         Assertions.assertNull(s.field("a"));
         Assertions.assertNotNull(s.field("x"));
+    }
+
+    @Test
+    public void testDropNestedFieldUsedByHistoricalPartitionSpecFailsLoud() {
+        createTable("d_old_spec", flatNestedSchema());
+        Table table = ops.loadTable("db1", "d_old_spec");
+        table.updateSpec().addField("s.a").commit();
+        String partitionName = table.spec().fields().get(0).name();
+        DataFile dataFile = DataFiles.builder(table.spec())
+                .withPath("file:/warehouse/d_old_spec/data.parquet")
+                .withFileSizeInBytes(1)
+                .withRecordCount(1)
+                .withPartitionPath(partitionName + "=1")
+                .build();
+        table.newAppend().appendFile(dataFile).commit();
+        table.updateSpec().removeField(partitionName).commit();
+
+        DorisConnectorException ex = Assertions.assertThrows(DorisConnectorException.class,
+                () -> ops.dropNestedColumn("db1", "d_old_spec", path("s", "a")));
+        Assertions.assertTrue(ex.getMessage().contains("used by an old partition spec"), ex.getMessage());
+        Assertions.assertNotNull(reload("d_old_spec").findField("s.a"));
+    }
+
+    @Test
+    public void testDropParentOfHistoricalPartitionFieldFailsLoud() {
+        createTable("d_old_spec_parent", flatNestedSchema());
+        Table table = ops.loadTable("db1", "d_old_spec_parent");
+        table.updateSpec().addField("s.a").commit();
+        String partitionName = table.spec().fields().get(0).name();
+        DataFile dataFile = DataFiles.builder(table.spec())
+                .withPath("file:/warehouse/d_old_spec_parent/data.parquet")
+                .withFileSizeInBytes(1)
+                .withRecordCount(1)
+                .withPartitionPath(partitionName + "=1")
+                .build();
+        table.newAppend().appendFile(dataFile).commit();
+        table.updateSpec().removeField(partitionName).commit();
+
+        DorisConnectorException ex = Assertions.assertThrows(DorisConnectorException.class,
+                () -> ops.dropColumn("db1", "d_old_spec_parent", "s"));
+        Assertions.assertTrue(ex.getMessage().contains("used by an old partition spec"), ex.getMessage());
+        Assertions.assertNotNull(reload("d_old_spec_parent").findField("s"));
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolutionTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolutionTest.java
@@ -342,33 +342,125 @@ public class IcebergNestedColumnEvolutionTest {
     }
 
     @Test
-    public void testDropRetriesAfterConcurrentNonDefaultSpecAddition() {
+    public void testDropRejectsRestSpecRebaseBeforeCommit() {
         createTable("d_concurrent_spec", flatNestedSchema());
         Table original = ops.loadTable("db1", "d_concurrent_spec");
-        ConcurrentSpecTableOperations concurrentOps = new ConcurrentSpecTableOperations(
+        RestTableOperations concurrentOps = new RestTableOperations(
                 ((HasTableOperations) original).operations(), "s.a");
         Table racedTable = new BaseTable(concurrentOps, original.name());
 
-        assertFailsLoud(() -> IcebergNestedColumnEvolution.dropColumn(
-                racedTable, path("s", "a")), "partition spec");
-
-        Assertions.assertTrue(concurrentOps.sawLastAssignedPartitionIdRequirement,
-                "schema drop must fence REST rebases on partition-spec generation");
-        Assertions.assertEquals(1, concurrentOps.commitAttempts,
-                "the retry must refresh and reject the new spec before a second commit");
+        assertFailsLoud(() -> IcebergNestedColumnEvolution.dropColumn(racedTable, path("s", "a")),
+                "REST");
+        Assertions.assertEquals(0, concurrentOps.commitAttempts,
+                "REST cannot atomically fence the spec-ID namespace, so DROP must fail before commit");
         original.refresh();
         Assertions.assertNotNull(original.schema().findField("s.a"));
     }
 
-    /** Injects a non-default spec, then applies the same requirements a REST server validates on rebase. */
-    private static final class ConcurrentSpecTableOperations implements TableOperations {
+    @Test
+    public void testDropAllowsSchemaContainingOldSyntheticFenceName() {
+        Schema schema = new Schema(
+                Types.NestedField.optional(1, "_doris_schema_drop_fence_1000", Types.StringType.get()),
+                Types.NestedField.optional(2, "drop_me", Types.IntegerType.get()));
+        createTable("d_fence_name", schema);
+
+        ops.dropColumn("db1", "d_fence_name", "drop_me");
+
+        Schema updated = reload("d_fence_name");
+        Assertions.assertNotNull(updated.findField("_doris_schema_drop_fence_1000"));
+        Assertions.assertNull(updated.findField("drop_me"));
+    }
+
+    @Test
+    public void testFormatV1DropPreservesFirstPartitionFieldId() {
+        createTable("d_v1_first_partition", flatNestedSchema(), PartitionSpec.unpartitioned(),
+                Collections.singletonMap(TableProperties.FORMAT_VERSION, "1"));
+
+        ops.dropNestedColumn("db1", "d_v1_first_partition", path("s", "a"));
+        Table table = ops.loadTable("db1", "d_v1_first_partition");
+        Assertions.assertDoesNotThrow(() -> table.updateSpec().addField("s.x").commit());
+        Assertions.assertEquals(1000, table.spec().fields().get(0).fieldId());
+    }
+
+    @Test
+    public void testDropRemovesColumnScopedWriterProperties() {
+        createTable("d_column_props", flatNestedSchema());
+        Table table = ops.loadTable("db1", "d_column_props");
+        String metricsKey = TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "s.a";
+        String bloomKey = TableProperties.PARQUET_BLOOM_FILTER_COLUMN_ENABLED_PREFIX + "s.a";
+        String statsKey = TableProperties.PARQUET_COLUMN_STATS_ENABLED_PREFIX + "s.a";
+        table.updateProperties()
+                .set(metricsKey, "full")
+                .set(bloomKey, "true")
+                .set(statsKey, "true")
+                .commit();
+
+        ops.dropNestedColumn("db1", "d_column_props", path("s", "a"));
+
+        Map<String, String> properties = ops.loadTable("db1", "d_column_props").properties();
+        Assertions.assertFalse(properties.containsKey(metricsKey));
+        Assertions.assertFalse(properties.containsKey(bloomKey));
+        Assertions.assertFalse(properties.containsKey(statsKey));
+    }
+
+    @Test
+    public void testDropRejectsTableReplacementDuringInitialRefresh() {
+        createTable("d_original_identity", flatNestedSchema());
+        createTable("d_replacement_identity", flatNestedSchema());
+        Table original = ops.loadTable("db1", "d_original_identity");
+        Table replacement = ops.loadTable("db1", "d_replacement_identity");
+        RefreshingTableOperations refreshing = new RefreshingTableOperations(
+                ((HasTableOperations) original).operations().current(),
+                ((HasTableOperations) replacement).operations().current(),
+                ((HasTableOperations) original).operations());
+
+        assertFailsLoud(() -> IcebergNestedColumnEvolution.dropColumn(
+                new BaseTable(refreshing, original.name()), path("s", "a")), "changed concurrently");
+        Assertions.assertEquals(0, refreshing.commitAttempts);
+    }
+
+    @Test
+    public void testDropRejectsSamePathFieldReplacementDuringRefresh() {
+        createTable("d_field_identity", flatNestedSchema());
+        Table table = ops.loadTable("db1", "d_field_identity");
+        TableOperations delegate = ((HasTableOperations) table).operations();
+        TableMetadata loaded = delegate.current();
+        int originalFieldId = loaded.schema().findField("s.a").fieldId();
+        table.updateSchema().deleteColumn("s.a").commit();
+        table.updateSchema().addColumn("s", "a", Types.IntegerType.get()).commit();
+        TableMetadata replacement = delegate.refresh();
+        Assertions.assertNotEquals(originalFieldId, replacement.schema().findField("s.a").fieldId());
+        RefreshingTableOperations refreshing = new RefreshingTableOperations(loaded, replacement, delegate);
+
+        assertFailsLoud(() -> IcebergNestedColumnEvolution.dropColumn(
+                new BaseTable(refreshing, table.name()), path("s", "a")), "changed concurrently");
+        Assertions.assertEquals(0, refreshing.commitAttempts);
+    }
+
+    @Test
+    public void testDropParentRejectsSubtreeReplacementDuringRefresh() {
+        createTable("d_subtree_identity", flatNestedSchema());
+        Table table = ops.loadTable("db1", "d_subtree_identity");
+        TableOperations delegate = ((HasTableOperations) table).operations();
+        TableMetadata loaded = delegate.current();
+        table.updateSchema().deleteColumn("s.a").commit();
+        table.updateSchema().addColumn("s", "a", Types.IntegerType.get()).commit();
+        RefreshingTableOperations refreshing = new RefreshingTableOperations(
+                loaded, delegate.refresh(), delegate);
+
+        assertFailsLoud(() -> IcebergNestedColumnEvolution.dropTopLevelColumn(
+                new BaseTable(refreshing, table.name()), "s"), "changed concurrently");
+        Assertions.assertEquals(0, refreshing.commitAttempts);
+    }
+
+    /** Simulates the REST spec rebase that cannot assert the spec-ID namespace. */
+    private static final class RestTableOperations implements TableOperations {
         private final TableOperations delegate;
         private final String sourceColumn;
         private boolean injectConcurrentSpec = true;
-        private boolean sawLastAssignedPartitionIdRequirement;
         private int commitAttempts;
 
-        private ConcurrentSpecTableOperations(TableOperations delegate, String sourceColumn) {
+        private RestTableOperations(TableOperations delegate, String sourceColumn) {
             this.delegate = delegate;
             this.sourceColumn = sourceColumn;
         }
@@ -392,8 +484,6 @@ public class IcebergNestedColumnEvolutionTest {
             }
             injectConcurrentSpec = false;
             List<UpdateRequirement> requirements = UpdateRequirements.forUpdateTable(base, metadata.changes());
-            sawLastAssignedPartitionIdRequirement = requirements.stream()
-                    .anyMatch(UpdateRequirement.AssertLastAssignedPartitionId.class::isInstance);
 
             int newSpecId = base.specs().stream().mapToInt(PartitionSpec::specId).max().orElse(-1) + 1;
             PartitionSpec concurrentSpec = PartitionSpec.builderFor(base.schema())
@@ -405,6 +495,57 @@ public class IcebergNestedColumnEvolutionTest {
                 requirement.validate(rebased);
             }
             throw new CommitFailedException("Schema drop did not detect a concurrent partition spec");
+        }
+
+        @Override
+        public FileIO io() {
+            return delegate.io();
+        }
+
+        @Override
+        public EncryptionManager encryption() {
+            return delegate.encryption();
+        }
+
+        @Override
+        public String metadataFileLocation(String fileName) {
+            return delegate.metadataFileLocation(fileName);
+        }
+
+        @Override
+        public LocationProvider locationProvider() {
+            return delegate.locationProvider();
+        }
+    }
+
+    private static final class RefreshingTableOperations implements TableOperations {
+        private final TableMetadata loaded;
+        private final TableMetadata refreshed;
+        private final TableOperations delegate;
+        private boolean didRefresh;
+        private int commitAttempts;
+
+        private RefreshingTableOperations(
+                TableMetadata loaded, TableMetadata refreshed, TableOperations delegate) {
+            this.loaded = loaded;
+            this.refreshed = refreshed;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public TableMetadata current() {
+            return didRefresh ? refreshed : loaded;
+        }
+
+        @Override
+        public TableMetadata refresh() {
+            didRefresh = true;
+            return refreshed;
+        }
+
+        @Override
+        public void commit(TableMetadata base, TableMetadata metadata) {
+            commitAttempts++;
         }
 
         @Override

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolutionTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolutionTest.java
@@ -23,12 +23,26 @@ import org.apache.doris.connector.spi.DorisConnectorException;
 import org.apache.doris.connector.spi.ddl.ConnectorColumnPath;
 import org.apache.doris.connector.spi.ddl.ConnectorColumnPosition;
 
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.MetadataTableUtils;
+import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.UpdateRequirement;
+import org.apache.iceberg.UpdateRequirements;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterEach;
@@ -39,6 +53,8 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -80,6 +96,11 @@ public class IcebergNestedColumnEvolutionTest {
     private void createTable(String table, Schema schema) {
         ops.createTable("db1", table, schema, PartitionSpec.unpartitioned(), null,
                 IcebergSchemaBuilder.buildTableProperties(Collections.emptyMap()));
+    }
+
+    private void createTable(String table, Schema schema, PartitionSpec spec, Map<String, String> properties) {
+        ops.createTable("db1", table, schema, spec, null,
+                IcebergSchemaBuilder.buildTableProperties(properties));
     }
 
     private Schema reload(String table) {
@@ -289,6 +310,122 @@ public class IcebergNestedColumnEvolutionTest {
                 () -> ops.dropNestedColumn("db1", "d_old_spec", path("s", "a")));
         Assertions.assertTrue(ex.getMessage().contains("used by an old partition spec"), ex.getMessage());
         Assertions.assertNotNull(reload("d_old_spec").findField("s.a"));
+    }
+
+    @Test
+    public void testDropNestedFieldUsedByCurrentFormatV1VoidSpecFailsLoud() {
+        Schema schema = flatNestedSchema();
+        PartitionSpec initialSpec = PartitionSpec.builderFor(schema).identity("s.a").build();
+        createTable("d_v1_void", schema, initialSpec,
+                Collections.singletonMap(TableProperties.FORMAT_VERSION, "1"));
+        Table table = ops.loadTable("db1", "d_v1_void");
+        int oldSpecId = table.spec().specId();
+        table.updateSpec().removeField(table.spec().fields().get(0).name()).commit();
+
+        // Simulate metadata cleanup so only the v1 current void field retains the source ID. Ignoring the
+        // current spec would let schema deletion corrupt metadata-table schema construction.
+        table.refresh();
+        TableOperations tableOps = ((HasTableOperations) table).operations();
+        TableMetadata base = tableOps.current();
+        TableMetadata.Builder builder = TableMetadata.buildFrom(base);
+        new MetadataUpdate.RemovePartitionSpecs(Set.of(oldSpecId)).applyTo(builder);
+        tableOps.commit(base, builder.build());
+        table.refresh();
+
+        Assertions.assertTrue(table.spec().fields().get(0).transform().isVoid());
+        Assertions.assertEquals(1, table.specs().size());
+        assertFailsLoud(() -> ops.dropNestedColumn("db1", "d_v1_void", path("s", "a")),
+                "partition spec");
+        Assertions.assertNotNull(reload("d_v1_void").findField("s.a"));
+        Assertions.assertDoesNotThrow(() -> MetadataTableUtils.createMetadataTableInstance(
+                ops.loadTable("db1", "d_v1_void"), MetadataTableType.POSITION_DELETES).schema());
+    }
+
+    @Test
+    public void testDropRetriesAfterConcurrentNonDefaultSpecAddition() {
+        createTable("d_concurrent_spec", flatNestedSchema());
+        Table original = ops.loadTable("db1", "d_concurrent_spec");
+        ConcurrentSpecTableOperations concurrentOps = new ConcurrentSpecTableOperations(
+                ((HasTableOperations) original).operations(), "s.a");
+        Table racedTable = new BaseTable(concurrentOps, original.name());
+
+        assertFailsLoud(() -> IcebergNestedColumnEvolution.dropColumn(
+                racedTable, path("s", "a")), "partition spec");
+
+        Assertions.assertTrue(concurrentOps.sawLastAssignedPartitionIdRequirement,
+                "schema drop must fence REST rebases on partition-spec generation");
+        Assertions.assertEquals(1, concurrentOps.commitAttempts,
+                "the retry must refresh and reject the new spec before a second commit");
+        original.refresh();
+        Assertions.assertNotNull(original.schema().findField("s.a"));
+    }
+
+    /** Injects a non-default spec, then applies the same requirements a REST server validates on rebase. */
+    private static final class ConcurrentSpecTableOperations implements TableOperations {
+        private final TableOperations delegate;
+        private final String sourceColumn;
+        private boolean injectConcurrentSpec = true;
+        private boolean sawLastAssignedPartitionIdRequirement;
+        private int commitAttempts;
+
+        private ConcurrentSpecTableOperations(TableOperations delegate, String sourceColumn) {
+            this.delegate = delegate;
+            this.sourceColumn = sourceColumn;
+        }
+
+        @Override
+        public TableMetadata current() {
+            return delegate.current();
+        }
+
+        @Override
+        public TableMetadata refresh() {
+            return delegate.refresh();
+        }
+
+        @Override
+        public void commit(TableMetadata base, TableMetadata metadata) {
+            commitAttempts++;
+            if (!injectConcurrentSpec) {
+                delegate.commit(base, metadata);
+                return;
+            }
+            injectConcurrentSpec = false;
+            List<UpdateRequirement> requirements = UpdateRequirements.forUpdateTable(base, metadata.changes());
+            sawLastAssignedPartitionIdRequirement = requirements.stream()
+                    .anyMatch(UpdateRequirement.AssertLastAssignedPartitionId.class::isInstance);
+
+            int newSpecId = base.specs().stream().mapToInt(PartitionSpec::specId).max().orElse(-1) + 1;
+            PartitionSpec concurrentSpec = PartitionSpec.builderFor(base.schema())
+                    .withSpecId(newSpecId).identity(sourceColumn).build();
+            TableMetadata.Builder concurrent = TableMetadata.buildFrom(base).addPartitionSpec(concurrentSpec);
+            delegate.commit(base, concurrent.build());
+            TableMetadata rebased = delegate.refresh();
+            for (UpdateRequirement requirement : requirements) {
+                requirement.validate(rebased);
+            }
+            throw new CommitFailedException("Schema drop did not detect a concurrent partition spec");
+        }
+
+        @Override
+        public FileIO io() {
+            return delegate.io();
+        }
+
+        @Override
+        public EncryptionManager encryption() {
+            return delegate.encryption();
+        }
+
+        @Override
+        public String metadataFileLocation(String fileName) {
+            return delegate.metadataFileLocation(fileName);
+        }
+
+        @Override
+        public LocationProvider locationProvider() {
+            return delegate.locationProvider();
+        }
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolutionTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergNestedColumnEvolutionTest.java
@@ -342,19 +342,76 @@ public class IcebergNestedColumnEvolutionTest {
     }
 
     @Test
-    public void testDropRejectsRestSpecRebaseBeforeCommit() {
-        createTable("d_concurrent_spec", flatNestedSchema());
+    public void testRestDropSurvivesSpecIdRebaseWithoutRemovingConcurrentSpec() {
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "id", Types.LongType.get()),
+                Types.NestedField.optional(2, "drop_me", Types.IntegerType.get()));
+        createTable("d_concurrent_spec", schema,
+                PartitionSpec.builderFor(schema).identity("id").build(), Collections.emptyMap());
         Table original = ops.loadTable("db1", "d_concurrent_spec");
+        String metricsKey = TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "drop_me";
+        original.updateProperties().set(metricsKey, "full").commit();
         RestTableOperations concurrentOps = new RestTableOperations(
-                ((HasTableOperations) original).operations(), "s.a");
+                ((HasTableOperations) original).operations(), null);
         Table racedTable = new BaseTable(concurrentOps, original.name());
 
-        assertFailsLoud(() -> IcebergNestedColumnEvolution.dropColumn(racedTable, path("s", "a")),
-                "REST");
-        Assertions.assertEquals(0, concurrentOps.commitAttempts,
-                "REST cannot atomically fence the spec-ID namespace, so DROP must fail before commit");
+        IcebergNestedColumnEvolution.dropTopLevelColumn(racedTable, "drop_me");
+
+        Assertions.assertEquals(1, concurrentOps.commitAttempts);
+        Assertions.assertTrue(concurrentOps.requirements.stream()
+                .anyMatch(UpdateRequirement.AssertLastAssignedPartitionId.class::isInstance));
+        Assertions.assertFalse(concurrentOps.clientChanges.stream()
+                .anyMatch(MetadataUpdate.RemovePartitionSpecs.class::isInstance));
         original.refresh();
-        Assertions.assertNotNull(original.schema().findField("s.a"));
+        Assertions.assertNull(original.schema().findField("drop_me"));
+        Assertions.assertFalse(original.properties().containsKey(metricsKey),
+                "the REST path must preserve SchemaUpdate's column-property cleanup");
+        Assertions.assertEquals(3, original.specs().size(),
+                "both the rebased concurrent spec and the durable fence must be retained");
+        Assertions.assertTrue(original.specs().values().stream().anyMatch(PartitionSpec::isUnpartitioned));
+        Assertions.assertTrue(original.specs().values().stream().flatMap(spec -> spec.fields().stream())
+                .anyMatch(field -> field.name().startsWith("_doris_schema_drop_fence_")
+                        && field.sourceId() == schema.findField("id").fieldId()
+                        && field.transform().isVoid()));
+    }
+
+    @Test
+    public void testRestDropRejectsConcurrentSpecUsingDropTarget() {
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "id", Types.LongType.get()),
+                Types.NestedField.optional(2, "drop_me", Types.IntegerType.get()));
+        createTable("d_target_spec_race", schema);
+        Table original = ops.loadTable("db1", "d_target_spec_race");
+        RestTableOperations concurrentOps = new RestTableOperations(
+                ((HasTableOperations) original).operations(), "drop_me");
+        Table racedTable = new BaseTable(concurrentOps, original.name());
+
+        Assertions.assertThrows(CommitFailedException.class,
+                () -> IcebergNestedColumnEvolution.dropTopLevelColumn(racedTable, "drop_me"));
+
+        Assertions.assertEquals(1, concurrentOps.commitAttempts);
+        original.refresh();
+        Assertions.assertNotNull(original.schema().findField("drop_me"));
+        Assertions.assertTrue(original.specs().values().stream().flatMap(spec -> spec.fields().stream())
+                .anyMatch(field -> field.sourceId() == schema.findField("drop_me").fieldId()));
+    }
+
+    @Test
+    public void testRestFormatV1DropFailsBeforeCommit() {
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "id", Types.LongType.get()),
+                Types.NestedField.optional(2, "drop_me", Types.IntegerType.get()));
+        createTable("d_rest_v1", schema, PartitionSpec.unpartitioned(),
+                Collections.singletonMap(TableProperties.FORMAT_VERSION, "1"));
+        Table original = ops.loadTable("db1", "d_rest_v1");
+        RestTableOperations concurrentOps = new RestTableOperations(
+                ((HasTableOperations) original).operations(), null);
+
+        assertFailsLoud(() -> IcebergNestedColumnEvolution.dropTopLevelColumn(
+                new BaseTable(concurrentOps, original.name()), "drop_me"), "format-v1");
+
+        Assertions.assertEquals(0, concurrentOps.commitAttempts);
+        Assertions.assertNotNull(original.schema().findField("drop_me"));
     }
 
     @Test
@@ -363,12 +420,18 @@ public class IcebergNestedColumnEvolutionTest {
                 Types.NestedField.optional(1, "_doris_schema_drop_fence_1000", Types.StringType.get()),
                 Types.NestedField.optional(2, "drop_me", Types.IntegerType.get()));
         createTable("d_fence_name", schema);
+        Table original = ops.loadTable("db1", "d_fence_name");
+        RestTableOperations restOps = new RestTableOperations(
+                ((HasTableOperations) original).operations(), null);
 
-        ops.dropColumn("db1", "d_fence_name", "drop_me");
+        IcebergNestedColumnEvolution.dropTopLevelColumn(
+                new BaseTable(restOps, original.name()), "drop_me");
 
-        Schema updated = reload("d_fence_name");
-        Assertions.assertNotNull(updated.findField("_doris_schema_drop_fence_1000"));
-        Assertions.assertNull(updated.findField("drop_me"));
+        original.refresh();
+        Assertions.assertNotNull(original.schema().findField("_doris_schema_drop_fence_1000"));
+        Assertions.assertNull(original.schema().findField("drop_me"));
+        Assertions.assertTrue(original.specs().values().stream().flatMap(spec -> spec.fields().stream())
+                .anyMatch(field -> field.name().equals("_doris_schema_drop_fence_1001")));
     }
 
     @Test
@@ -453,12 +516,14 @@ public class IcebergNestedColumnEvolutionTest {
         Assertions.assertEquals(0, refreshing.commitAttempts);
     }
 
-    /** Simulates the REST spec rebase that cannot assert the spec-ID namespace. */
+    /** Simulates REST applying the client updates after a concurrent partition-spec commit. */
     private static final class RestTableOperations implements TableOperations {
         private final TableOperations delegate;
         private final String sourceColumn;
         private boolean injectConcurrentSpec = true;
         private int commitAttempts;
+        private List<UpdateRequirement> requirements = Collections.emptyList();
+        private List<MetadataUpdate> clientChanges = Collections.emptyList();
 
         private RestTableOperations(TableOperations delegate, String sourceColumn) {
             this.delegate = delegate;
@@ -483,18 +548,24 @@ public class IcebergNestedColumnEvolutionTest {
                 return;
             }
             injectConcurrentSpec = false;
-            List<UpdateRequirement> requirements = UpdateRequirements.forUpdateTable(base, metadata.changes());
+            clientChanges = metadata.changes();
+            requirements = UpdateRequirements.forUpdateTable(base, clientChanges);
 
             int newSpecId = base.specs().stream().mapToInt(PartitionSpec::specId).max().orElse(-1) + 1;
-            PartitionSpec concurrentSpec = PartitionSpec.builderFor(base.schema())
-                    .withSpecId(newSpecId).identity(sourceColumn).build();
+            PartitionSpec concurrentSpec = sourceColumn == null
+                    ? PartitionSpec.builderFor(base.schema()).withSpecId(newSpecId).build()
+                    : PartitionSpec.builderFor(base.schema()).withSpecId(newSpecId).identity(sourceColumn).build();
             TableMetadata.Builder concurrent = TableMetadata.buildFrom(base).addPartitionSpec(concurrentSpec);
             delegate.commit(base, concurrent.build());
             TableMetadata rebased = delegate.refresh();
             for (UpdateRequirement requirement : requirements) {
                 requirement.validate(rebased);
             }
-            throw new CommitFailedException("Schema drop did not detect a concurrent partition spec");
+            TableMetadata.Builder rebasedUpdate = TableMetadata.buildFrom(rebased);
+            for (MetadataUpdate update : clientChanges) {
+                update.applyTo(rebasedUpdate);
+            }
+            delegate.commit(rebased, rebasedUpdate.build());
         }
 
         @Override


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Dropping an Iceberg column can leave historical partition specs referencing a field ID that no longer exists in the current schema, which makes historical metadata unreadable. The same failure occurs when dropping a struct ancestor of a referenced nested field. Resolve top-level and nested drop targets before committing the schema update, then reject the drop when any historical partition spec references the target field or a field in its subtree.

### Release note

Iceberg column drops now fail explicitly when the column, or a nested field beneath it, is referenced by a historical partition spec.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. Invalid Iceberg column drops are rejected before corrupting historical partition metadata.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
