### PR TITLE
[improvement](agg) Narrow has_null scan to frame range in window aggr…

### DIFF
--- a/be/src/exprs/aggregate/aggregate_function_null.h
+++ b/be/src/exprs/aggregate/aggregate_function_null.h
@@ -468,9 +468,15 @@ public:
         // Only scan the frame range for nulls (O(frame)), not the whole buffered
         // column (O(n)). Scanning the whole column per row makes the analytic
         // sliding-window path O(n * buffer) when nulls are sparse/absent.
-        bool has_null = current_frame_start < current_frame_end
-                                ? column->has_null(current_frame_start, current_frame_end)
-                                : false;
+        // _remove_unused_rows() erases physical rows and subtracts the removed
+        // count from the frame coordinates, so the frame can extend past either
+        // end of the retained column. Intersect the scan with the physical
+        // interval [0, column->size()) and skip empty ranges so has_null() only
+        // touches buffered rows.
+        auto column_size = static_cast<int64_t>(column->size());
+        int64_t scan_begin = std::max<int64_t>(current_frame_start, 0);
+        int64_t scan_end = std::min<int64_t>(current_frame_end, column_size);
+        bool has_null = scan_begin < scan_end ? column->has_null(scan_begin, scan_end) : false;
         if (has_null) {
             for (size_t i = current_frame_start; i < current_frame_end; ++i) {
                 this->add(place, columns, i, arena);
@@ -511,8 +517,15 @@ public:
         // Scan only [frame_start-1, frame_end) covering the incremental step's
         // outgoing (frame_start-1) and incoming (frame_end-1) positions, instead
         // of has_null() over the whole buffered column (avoids O(n * buffer)).
-        if (!column->has_null(std::max<int64_t>(frame_start - 1, partition_start),
-                              current_frame_end)) {
+        // _remove_unused_rows() shifts coordinates around the retained column, so
+        // intersect the scan with the physical interval [0, column->size()) and
+        // skip empty ranges so has_null() only touches buffered rows.
+        auto column_size = static_cast<int64_t>(column->size());
+        int64_t scan_begin =
+                std::max<int64_t>(std::max<int64_t>(frame_start - 1, partition_start), 0);
+        int64_t scan_end = std::min<int64_t>(current_frame_end, column_size);
+        bool range_has_null = scan_begin < scan_end && column->has_null(scan_begin, scan_end);
+        if (!range_has_null) {
             if (*could_use_previous_result) {
                 this->nested_function->execute_function_with_incremental(
                         partition_start, partition_end, frame_start, frame_end,

--- a/be/src/exprs/aggregate/aggregate_function_null.h
+++ b/be/src/exprs/aggregate/aggregate_function_null.h
@@ -465,7 +465,12 @@ public:
         }
         const auto* column =
                 assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
-        bool has_null = column->has_null();
+        // Only scan the frame range for nulls (O(frame)), not the whole buffered
+        // column (O(n)). Scanning the whole column per row makes the analytic
+        // sliding-window path O(n * buffer) when nulls are sparse/absent.
+        bool has_null = current_frame_start < current_frame_end
+                                ? column->has_null(current_frame_start, current_frame_end)
+                                : false;
         if (has_null) {
             for (size_t i = current_frame_start; i < current_frame_end; ++i) {
                 this->add(place, columns, i, arena);
@@ -503,7 +508,11 @@ public:
                 assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
         const IColumn* nested_column = &column->get_nested_column();
 
-        if (!column->has_null()) {
+        // Scan only [frame_start-1, frame_end) covering the incremental step's
+        // outgoing (frame_start-1) and incoming (frame_end-1) positions, instead
+        // of has_null() over the whole buffered column (avoids O(n * buffer)).
+        if (!column->has_null(std::max<int64_t>(frame_start - 1, partition_start),
+                              current_frame_end)) {
             if (*could_use_previous_result) {
                 this->nested_function->execute_function_with_incremental(
                         partition_start, partition_end, frame_start, frame_end,

--- a/be/src/exprs/aggregate/aggregate_function_null_v2.h
+++ b/be/src/exprs/aggregate/aggregate_function_null_v2.h
@@ -532,7 +532,15 @@ public:
         }
         const auto* column =
                 assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
-        bool has_null = column->has_null();
+        // Only scan the physical frame range for nulls (O(frame)), not the whole
+        // buffered column (O(n)). _remove_unused_rows() shifts frame coordinates
+        // around the retained column, so the frame can extend past either end.
+        // Intersect the scan with the physical interval [0, column->size()) and
+        // skip empty ranges so has_null() only touches buffered rows.
+        auto column_size = static_cast<int64_t>(column->size());
+        int64_t scan_begin = std::max<int64_t>(current_frame_start, 0);
+        int64_t scan_end = std::min<int64_t>(current_frame_end, column_size);
+        bool has_null = scan_begin < scan_end ? column->has_null(scan_begin, scan_end) : false;
         if (has_null) {
             for (size_t i = current_frame_start; i < current_frame_end; ++i) {
                 this->add(place, columns, i, arena);
@@ -570,7 +578,18 @@ public:
                 assert_cast<const ColumnNullable*, TypeCheckOnRelease::DISABLE>(columns[0]);
         const IColumn* nested_column = &column->get_nested_column();
 
-        if (!column->has_null()) {
+        // Scan only [frame_start-1, frame_end) covering the incremental step's
+        // outgoing (frame_start-1) and incoming (frame_end-1) positions, instead
+        // of has_null() over the whole buffered column (avoids O(n * buffer)).
+        // _remove_unused_rows() shifts coordinates around the retained column, so
+        // intersect the scan with the physical interval [0, column->size()) and
+        // skip empty ranges so has_null() only touches buffered rows.
+        auto column_size = static_cast<int64_t>(column->size());
+        int64_t scan_begin =
+                std::max<int64_t>(std::max<int64_t>(frame_start - 1, partition_start), 0);
+        int64_t scan_end = std::min<int64_t>(current_frame_end, column_size);
+        bool range_has_null = scan_begin < scan_end && column->has_null(scan_begin, scan_end);
+        if (!range_has_null) {
             if (*could_use_previous_result) {
                 this->nested_function->execute_function_with_incremental(
                         partition_start, partition_end, frame_start, frame_end,

--- a/be/test/exprs/aggregate/agg_function_null_window_test.cpp
+++ b/be/test/exprs/aggregate/agg_function_null_window_test.cpp
@@ -16,12 +16,19 @@
 // under the License.
 
 // Regression tests for the optimization that narrowed the has_null() scan in
-// AggregateFunctionNullUnaryInline::add_range_single_place and
-// ::execute_function_with_incremental from the whole buffered column (O(n))
-// down to just the frame range that is actually touched (O(frame)).
-// These tests pin down that the narrower range check still finds every null
-// that matters, including nulls that sit outside the checked sub-range but
-// inside the full column, and nulls that sit exactly on a frame boundary.
+// the Nullable window-function wrappers' add_range_single_place and
+// execute_function_with_incremental from the whole buffered column (O(n)) down
+// to just the physical frame range that is actually touched (O(frame)). Every
+// case runs against both wrapper variants: V1 (AggregateFunctionNullUnaryInline,
+// "Nullable(...)") and V2 (AggregateFunctionNullUnaryInlineV2, "NullableV2(...)",
+// selected by enable_aggregate_function_null_v2, the FE default).
+//
+// The narrowed scan must still find every null that matters, and it must clamp
+// its begin to physical index 0: AnalyticSinkLocalState::_remove_unused_rows()
+// erases physical rows and subtracts the removed count from the frame/partition
+// coordinates, so frame_start/partition_start can be negative while the retained
+// column starts at index 0. Without the clamp, has_null(begin, end) computes
+// data() + begin with a negative begin and reads before the buffer (ASAN).
 
 #include <gtest/gtest.h>
 
@@ -58,12 +65,27 @@ ColumnPtr build_nullable_int32_column(const std::vector<int32_t>& values,
     return ColumnNullable::create(std::move(data_column), std::move(null_map));
 }
 
-AggregateFunctionPtr create_window_sum() {
+AggregateFunctionPtr create_window_sum(bool enable_aggregate_function_null_v2) {
     AggregateFunctionSimpleFactory factory;
     register_aggregate_function_sum(factory);
     DataTypes data_types = {make_nullable(std::make_shared<DataTypeInt32>())};
     return factory.get("sum", data_types, nullptr, true, -1,
-                       {.is_window_function = true, .column_names = {}});
+                       {.is_window_function = true,
+                        .enable_aggregate_function_null_v2 = enable_aggregate_function_null_v2,
+                        .column_names = {}});
+}
+
+// Runs `body` against both the V1 and V2 null wrappers, tagging each run with
+// SCOPED_TRACE and pinning the dispatched wrapper name so a regression that only
+// affects one variant is attributed to the right one.
+template <typename Body>
+void for_each_null_wrapper(Body body) {
+    for (bool enable_v2 : {false, true}) {
+        SCOPED_TRACE(enable_v2 ? "NullableV2" : "Nullable");
+        auto agg_function = create_window_sum(enable_v2);
+        ASSERT_EQ(agg_function->get_name(), enable_v2 ? "NullableV2(sum)" : "Nullable(sum)");
+        body(agg_function);
+    }
 }
 
 int64_t naive_sum_skip_null(const std::vector<int32_t>& values,
@@ -92,6 +114,15 @@ int64_t read_sum_result(const AggregateFunctionPtr& agg_function, AggregateDataP
     return assert_cast<const ColumnInt64&>(result_column->get_nested_column()).get_element(0);
 }
 
+bool sum_result_is_null(const AggregateFunctionPtr& agg_function, AggregateDataPtr place) {
+    auto result_nested = ColumnInt64::create();
+    auto result_null_map = ColumnUInt8::create();
+    auto result_column =
+            ColumnNullable::create(std::move(result_nested), std::move(result_null_map));
+    agg_function->insert_result_into(place, *result_column);
+    return result_column->get_null_map_data().back() != 0;
+}
+
 } // namespace
 
 // The whole column has a null, but it sits *outside* the queried frame.
@@ -106,22 +137,23 @@ TEST(AggFunctionNullWindowTest, AddRangeSinglePlaceIgnoresNullOutsideFrame) {
     auto column = build_nullable_int32_column(values, null_positions);
     const IColumn* columns[1] = {column.get()};
 
-    auto agg_function = create_window_sum();
-    std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
-    AggregateDataPtr place = memory.get();
-    agg_function->create(place);
-    Arena arena;
+    for_each_null_wrapper([&](const AggregateFunctionPtr& agg_function) {
+        std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+        AggregateDataPtr place = memory.get();
+        agg_function->create(place);
+        Arena arena;
 
-    UInt8 use_null_result = 0;
-    UInt8 could_use_previous_result = 0;
-    // frame [0, 3) does not touch the null at index 3.
-    agg_function->add_range_single_place(0, 5, 0, 3, place, columns, arena, &use_null_result,
-                                         &could_use_previous_result);
+        UInt8 use_null_result = 0;
+        UInt8 could_use_previous_result = 0;
+        // frame [0, 3) does not touch the null at index 3.
+        agg_function->add_range_single_place(0, 5, 0, 3, place, columns, arena, &use_null_result,
+                                             &could_use_previous_result);
 
-    EXPECT_FALSE(use_null_result);
-    EXPECT_EQ(read_sum_result(agg_function, place),
-              naive_sum_skip_null(values, null_positions, 0, 3));
-    agg_function->destroy(place);
+        EXPECT_FALSE(use_null_result);
+        EXPECT_EQ(read_sum_result(agg_function, place),
+                  naive_sum_skip_null(values, null_positions, 0, 3));
+        agg_function->destroy(place);
+    });
 }
 
 // The frame itself contains a null in the middle; the narrowed has_null()
@@ -133,22 +165,23 @@ TEST(AggFunctionNullWindowTest, AddRangeSinglePlaceSkipsNullInsideFrame) {
     auto column = build_nullable_int32_column(values, null_positions);
     const IColumn* columns[1] = {column.get()};
 
-    auto agg_function = create_window_sum();
-    std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
-    AggregateDataPtr place = memory.get();
-    agg_function->create(place);
-    Arena arena;
+    for_each_null_wrapper([&](const AggregateFunctionPtr& agg_function) {
+        std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+        AggregateDataPtr place = memory.get();
+        agg_function->create(place);
+        Arena arena;
 
-    UInt8 use_null_result = 0;
-    UInt8 could_use_previous_result = 0;
-    // frame [2, 5) covers index 3, which is NULL.
-    agg_function->add_range_single_place(0, 5, 2, 5, place, columns, arena, &use_null_result,
-                                         &could_use_previous_result);
+        UInt8 use_null_result = 0;
+        UInt8 could_use_previous_result = 0;
+        // frame [2, 5) covers index 3, which is NULL.
+        agg_function->add_range_single_place(0, 5, 2, 5, place, columns, arena, &use_null_result,
+                                             &could_use_previous_result);
 
-    EXPECT_FALSE(use_null_result);
-    EXPECT_EQ(read_sum_result(agg_function, place),
-              naive_sum_skip_null(values, null_positions, 2, 5));
-    agg_function->destroy(place);
+        EXPECT_FALSE(use_null_result);
+        EXPECT_EQ(read_sum_result(agg_function, place),
+                  naive_sum_skip_null(values, null_positions, 2, 5));
+        agg_function->destroy(place);
+    });
 }
 
 // A null sitting exactly at the first position of the frame must still be
@@ -159,33 +192,34 @@ TEST(AggFunctionNullWindowTest, AddRangeSinglePlaceDetectsNullAtFrameStart) {
     auto column = build_nullable_int32_column(values, null_positions);
     const IColumn* columns[1] = {column.get()};
 
-    auto agg_function = create_window_sum();
-    std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
-    AggregateDataPtr place = memory.get();
-    agg_function->create(place);
-    Arena arena;
+    for_each_null_wrapper([&](const AggregateFunctionPtr& agg_function) {
+        std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+        AggregateDataPtr place = memory.get();
+        agg_function->create(place);
+        Arena arena;
 
-    UInt8 use_null_result = 0;
-    UInt8 could_use_previous_result = 0;
-    // frame [0, 2) starts exactly at the NULL row.
-    agg_function->add_range_single_place(0, 5, 0, 2, place, columns, arena, &use_null_result,
-                                         &could_use_previous_result);
+        UInt8 use_null_result = 0;
+        UInt8 could_use_previous_result = 0;
+        // frame [0, 2) starts exactly at the NULL row.
+        agg_function->add_range_single_place(0, 5, 0, 2, place, columns, arena, &use_null_result,
+                                             &could_use_previous_result);
 
-    EXPECT_FALSE(use_null_result);
-    EXPECT_EQ(read_sum_result(agg_function, place),
-              naive_sum_skip_null(values, null_positions, 0, 2));
-    agg_function->destroy(place);
+        EXPECT_FALSE(use_null_result);
+        EXPECT_EQ(read_sum_result(agg_function, place),
+                  naive_sum_skip_null(values, null_positions, 0, 2));
+        agg_function->destroy(place);
+    });
 }
 
 // End-to-end simulation of the analytic sink's sliding-window driver
 // (see AnalyticSinkLocalState::_execute_for_function), which always passes
 // previous_is_nul=false, end_is_nul=false, has_null=false into
 // execute_function_with_incremental and lets the Nullable wrapper compute
-// null-awareness itself from the null map. This exercises the widened
-// has_null(frame_start - 1, current_frame_end) check added by the fix,
-// which must cover both the outgoing (frame_start - 1) and incoming
-// (frame_end - 1) positions as the frame slides across scattered nulls,
-// including nulls landing exactly on those boundary positions.
+// null-awareness itself from the null map. This exercises the narrowed
+// has_null(frame_start - 1, current_frame_end) check, which must cover both
+// the outgoing (frame_start - 1) and incoming (frame_end - 1) positions as the
+// frame slides across scattered nulls, including nulls landing exactly on those
+// boundary positions.
 TEST(AggFunctionNullWindowTest, ExecuteFunctionWithIncrementalSlidingWindowMatchesNaive) {
     std::vector<int32_t> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
     // Nulls scattered so that, as a size-3 window slides, they land at the
@@ -194,49 +228,143 @@ TEST(AggFunctionNullWindowTest, ExecuteFunctionWithIncrementalSlidingWindowMatch
     auto column = build_nullable_int32_column(values, null_positions);
     const IColumn* columns[1] = {column.get()};
 
-    auto agg_function = create_window_sum();
-    std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
-    AggregateDataPtr place = memory.get();
-    agg_function->create(place);
-    Arena arena;
-
     const int64_t partition_start = 0;
     const auto partition_end = static_cast<int64_t>(values.size());
     const int64_t window_size = 3;
 
-    UInt8 use_null_result = 0;
-    UInt8 could_use_previous_result = 0;
+    for_each_null_wrapper([&](const AggregateFunctionPtr& agg_function) {
+        std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+        AggregateDataPtr place = memory.get();
+        agg_function->create(place);
+        Arena arena;
 
-    for (int64_t frame_start = 0; frame_start + window_size <= partition_end; ++frame_start) {
-        int64_t frame_end = frame_start + window_size;
-        agg_function->execute_function_with_incremental(
-                partition_start, partition_end, frame_start, frame_end, place, columns, arena,
-                /*previous_is_nul*/ false, /*end_is_nul*/ false, /*has_null*/ false,
-                &use_null_result, &could_use_previous_result);
+        UInt8 use_null_result = 0;
+        UInt8 could_use_previous_result = 0;
 
-        int64_t expected = naive_sum_skip_null(values, null_positions, frame_start, frame_end);
-        bool expect_null = false;
-        {
-            std::vector<uint8_t> is_null(values.size(), 0);
-            for (auto pos : null_positions) {
-                is_null[pos] = 1;
-            }
-            expect_null = true;
-            for (int64_t i = frame_start; i < frame_end; ++i) {
-                if (!is_null[i]) {
-                    expect_null = false;
-                    break;
+        for (int64_t frame_start = 0; frame_start + window_size <= partition_end; ++frame_start) {
+            int64_t frame_end = frame_start + window_size;
+            agg_function->execute_function_with_incremental(
+                    partition_start, partition_end, frame_start, frame_end, place, columns, arena,
+                    /*previous_is_nul*/ false, /*end_is_nul*/ false, /*has_null*/ false,
+                    &use_null_result, &could_use_previous_result);
+
+            int64_t expected = naive_sum_skip_null(values, null_positions, frame_start, frame_end);
+            bool expect_null = true;
+            {
+                std::vector<uint8_t> is_null(values.size(), 0);
+                for (auto pos : null_positions) {
+                    is_null[pos] = 1;
+                }
+                for (int64_t i = frame_start; i < frame_end; ++i) {
+                    if (!is_null[i]) {
+                        expect_null = false;
+                        break;
+                    }
                 }
             }
-        }
-        ASSERT_EQ(use_null_result, expect_null)
-                << "frame [" << frame_start << ", " << frame_end << ")";
-        if (!use_null_result) {
-            EXPECT_EQ(read_sum_result(agg_function, place), expected)
+            ASSERT_EQ(use_null_result, expect_null)
                     << "frame [" << frame_start << ", " << frame_end << ")";
+            if (!use_null_result) {
+                EXPECT_EQ(read_sum_result(agg_function, place), expected)
+                        << "frame [" << frame_start << ", " << frame_end << ")";
+            }
         }
-    }
-    agg_function->destroy(place);
+        agg_function->destroy(place);
+    });
+}
+
+// _remove_unused_rows() erases physical rows and subtracts the removed count
+// from the frame/partition coordinates, so a frame can carry a negative
+// current_frame_start while the retained column starts at physical index 0.
+// Here the two logically-preceding rows (-2, -1) were erased and only physical
+// rows 0 and 1 remain in the frame, both NULL, so SUM over the frame is SQL
+// NULL. The old V1 scan called has_null(current_frame_start = -2, 2), reading
+// null_map[-2] before the buffer (caught by ASAN); the clamped scan begins at
+// physical 0.
+TEST(AggFunctionNullWindowTest, AddRangeSinglePlaceClampsNegativeFrameStart) {
+    std::vector<int32_t> values = {0, 0, 30, 40, 50};
+    std::vector<size_t> null_positions = {0, 1}; // the only present frame rows are NULL
+    auto column = build_nullable_int32_column(values, null_positions);
+    const IColumn* columns[1] = {column.get()};
+
+    for_each_null_wrapper([&](const AggregateFunctionPtr& agg_function) {
+        std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+        AggregateDataPtr place = memory.get();
+        agg_function->create(place);
+        Arena arena;
+
+        UInt8 use_null_result = 0;
+        UInt8 could_use_previous_result = 0;
+        // partition_start=-2, frame [-2, 2): physical rows 0 and 1 remain, both NULL.
+        agg_function->add_range_single_place(-2, 3, -2, 2, place, columns, arena, &use_null_result,
+                                             &could_use_previous_result);
+
+        EXPECT_TRUE(sum_result_is_null(agg_function, place));
+        agg_function->destroy(place);
+    });
+}
+
+// Sliding-window incremental step after row removal shifted partition_start
+// negative while the frame itself, [0, 3), is fully present and null-free.
+// The old V1 scan called has_null(frame_start - 1 = -1, ...), reading
+// null_map[-1] before the buffer (ASAN); the clamped scan begins at physical 0
+// and the fast nested path yields the plain sum.
+TEST(AggFunctionNullWindowTest, ExecuteFunctionWithIncrementalClampsNegativePartitionStart) {
+    std::vector<int32_t> values = {10, 20, 30, 40, 50, 60};
+    std::vector<size_t> null_positions = {};
+    auto column = build_nullable_int32_column(values, null_positions);
+    const IColumn* columns[1] = {column.get()};
+
+    for_each_null_wrapper([&](const AggregateFunctionPtr& agg_function) {
+        std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+        AggregateDataPtr place = memory.get();
+        agg_function->create(place);
+        Arena arena;
+
+        UInt8 use_null_result = 0;
+        UInt8 could_use_previous_result = 0;
+        agg_function->execute_function_with_incremental(
+                -3, 6, 0, 3, place, columns, arena, /*previous_is_nul*/ false,
+                /*end_is_nul*/ false, /*has_null*/ false, &use_null_result,
+                &could_use_previous_result);
+
+        EXPECT_FALSE(use_null_result);
+        EXPECT_EQ(read_sum_result(agg_function, place),
+                  naive_sum_skip_null(values, null_positions, 0, 3));
+        agg_function->destroy(place);
+    });
+}
+
+// Same negative-partition_start setup, but the frame contains a null. With
+// could_use_previous_result=false the wrapper recurses into
+// add_range_single_place, whose per-row path skips the null. The old V1
+// incremental scan called has_null(frame_start - 1 = -1, ...) first, reading
+// before the buffer (ASAN), before it could ever recurse.
+TEST(AggFunctionNullWindowTest,
+     ExecuteFunctionWithIncrementalClampsNegativePartitionStartWithNull) {
+    std::vector<int32_t> values = {10, 20, 30, 40, 50, 60};
+    std::vector<size_t> null_positions = {1}; // value 20 is NULL, inside frame [0, 3)
+    auto column = build_nullable_int32_column(values, null_positions);
+    const IColumn* columns[1] = {column.get()};
+
+    for_each_null_wrapper([&](const AggregateFunctionPtr& agg_function) {
+        std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+        AggregateDataPtr place = memory.get();
+        agg_function->create(place);
+        Arena arena;
+
+        UInt8 use_null_result = 0;
+        UInt8 could_use_previous_result = 0;
+        agg_function->execute_function_with_incremental(
+                -3, 6, 0, 3, place, columns, arena, /*previous_is_nul*/ false,
+                /*end_is_nul*/ false, /*has_null*/ false, &use_null_result,
+                &could_use_previous_result);
+
+        EXPECT_FALSE(use_null_result);
+        EXPECT_EQ(read_sum_result(agg_function, place),
+                  naive_sum_skip_null(values, null_positions, 0, 3));
+        agg_function->destroy(place);
+    });
 }
 
 } // namespace doris

--- a/be/test/exprs/aggregate/agg_function_null_window_test.cpp
+++ b/be/test/exprs/aggregate/agg_function_null_window_test.cpp
@@ -1,0 +1,242 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Regression tests for the optimization that narrowed the has_null() scan in
+// AggregateFunctionNullUnaryInline::add_range_single_place and
+// ::execute_function_with_incremental from the whole buffered column (O(n))
+// down to just the frame range that is actually touched (O(frame)).
+// These tests pin down that the narrower range check still finds every null
+// that matters, including nulls that sit outside the checked sub-range but
+// inside the full column, and nulls that sit exactly on a frame boundary.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "core/column/column_nullable.h"
+#include "core/column/column_vector.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_number.h"
+#include "core/data_type/primitive_type.h"
+#include "exprs/aggregate/aggregate_function.h"
+#include "exprs/aggregate/aggregate_function_simple_factory.h"
+
+namespace doris {
+
+void register_aggregate_function_sum(AggregateFunctionSimpleFactory& factory);
+
+namespace {
+
+// Builds a nullable Int32 column, marking `null_positions` as NULL.
+ColumnPtr build_nullable_int32_column(const std::vector<int32_t>& values,
+                                      const std::vector<size_t>& null_positions) {
+    auto data_column = ColumnInt32::create();
+    auto null_map = ColumnUInt8::create();
+    std::vector<uint8_t> is_null(values.size(), 0);
+    for (auto pos : null_positions) {
+        is_null[pos] = 1;
+    }
+    for (size_t i = 0; i < values.size(); ++i) {
+        data_column->insert_value(values[i]);
+        null_map->insert_value(is_null[i]);
+    }
+    return ColumnNullable::create(std::move(data_column), std::move(null_map));
+}
+
+AggregateFunctionPtr create_window_sum() {
+    AggregateFunctionSimpleFactory factory;
+    register_aggregate_function_sum(factory);
+    DataTypes data_types = {make_nullable(std::make_shared<DataTypeInt32>())};
+    return factory.get("sum", data_types, nullptr, true, -1,
+                       {.is_window_function = true, .column_names = {}});
+}
+
+int64_t naive_sum_skip_null(const std::vector<int32_t>& values,
+                            const std::vector<size_t>& null_positions, int64_t begin, int64_t end) {
+    std::vector<uint8_t> is_null(values.size(), 0);
+    for (auto pos : null_positions) {
+        is_null[pos] = 1;
+    }
+    int64_t sum = 0;
+    for (int64_t i = begin; i < end; ++i) {
+        if (!is_null[i]) {
+            sum += values[i];
+        }
+    }
+    return sum;
+}
+
+int64_t read_sum_result(const AggregateFunctionPtr& agg_function, AggregateDataPtr place) {
+    auto nested_data_type = std::make_shared<DataTypeInt64>();
+    auto result_nested = ColumnInt64::create();
+    auto result_null_map = ColumnUInt8::create();
+    auto result_column =
+            ColumnNullable::create(std::move(result_nested), std::move(result_null_map));
+    agg_function->insert_result_into(place, *result_column);
+    EXPECT_EQ(result_column->get_null_map_data().back(), 0);
+    return assert_cast<const ColumnInt64&>(result_column->get_nested_column()).get_element(0);
+}
+
+} // namespace
+
+// The whole column has a null, but it sits *outside* the queried frame.
+// Before the fix, has_null() scanned the entire buffered column and always
+// took the slow per-row `add()` path whenever any null existed anywhere.
+// After the fix, has_null(begin, end) is scoped to the frame, so a frame
+// with no null in range should take the fast nested add_range_single_place
+// path and still produce the same (correct) sum.
+TEST(AggFunctionNullWindowTest, AddRangeSinglePlaceIgnoresNullOutsideFrame) {
+    std::vector<int32_t> values = {10, 20, 30, 40, 50};
+    std::vector<size_t> null_positions = {3}; // value 40 is NULL
+    auto column = build_nullable_int32_column(values, null_positions);
+    const IColumn* columns[1] = {column.get()};
+
+    auto agg_function = create_window_sum();
+    std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+    AggregateDataPtr place = memory.get();
+    agg_function->create(place);
+    Arena arena;
+
+    UInt8 use_null_result = 0;
+    UInt8 could_use_previous_result = 0;
+    // frame [0, 3) does not touch the null at index 3.
+    agg_function->add_range_single_place(0, 5, 0, 3, place, columns, arena, &use_null_result,
+                                         &could_use_previous_result);
+
+    EXPECT_FALSE(use_null_result);
+    EXPECT_EQ(read_sum_result(agg_function, place),
+              naive_sum_skip_null(values, null_positions, 0, 3));
+    agg_function->destroy(place);
+}
+
+// The frame itself contains a null in the middle; the narrowed has_null()
+// check must still detect it and fall back to the per-row add() path that
+// correctly skips the null.
+TEST(AggFunctionNullWindowTest, AddRangeSinglePlaceSkipsNullInsideFrame) {
+    std::vector<int32_t> values = {10, 20, 30, 40, 50};
+    std::vector<size_t> null_positions = {3}; // value 40 is NULL
+    auto column = build_nullable_int32_column(values, null_positions);
+    const IColumn* columns[1] = {column.get()};
+
+    auto agg_function = create_window_sum();
+    std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+    AggregateDataPtr place = memory.get();
+    agg_function->create(place);
+    Arena arena;
+
+    UInt8 use_null_result = 0;
+    UInt8 could_use_previous_result = 0;
+    // frame [2, 5) covers index 3, which is NULL.
+    agg_function->add_range_single_place(0, 5, 2, 5, place, columns, arena, &use_null_result,
+                                         &could_use_previous_result);
+
+    EXPECT_FALSE(use_null_result);
+    EXPECT_EQ(read_sum_result(agg_function, place),
+              naive_sum_skip_null(values, null_positions, 2, 5));
+    agg_function->destroy(place);
+}
+
+// A null sitting exactly at the first position of the frame must still be
+// detected (guards against an off-by-one in the narrowed begin index).
+TEST(AggFunctionNullWindowTest, AddRangeSinglePlaceDetectsNullAtFrameStart) {
+    std::vector<int32_t> values = {1, 2, 3, 4, 5};
+    std::vector<size_t> null_positions = {0};
+    auto column = build_nullable_int32_column(values, null_positions);
+    const IColumn* columns[1] = {column.get()};
+
+    auto agg_function = create_window_sum();
+    std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+    AggregateDataPtr place = memory.get();
+    agg_function->create(place);
+    Arena arena;
+
+    UInt8 use_null_result = 0;
+    UInt8 could_use_previous_result = 0;
+    // frame [0, 2) starts exactly at the NULL row.
+    agg_function->add_range_single_place(0, 5, 0, 2, place, columns, arena, &use_null_result,
+                                         &could_use_previous_result);
+
+    EXPECT_FALSE(use_null_result);
+    EXPECT_EQ(read_sum_result(agg_function, place),
+              naive_sum_skip_null(values, null_positions, 0, 2));
+    agg_function->destroy(place);
+}
+
+// End-to-end simulation of the analytic sink's sliding-window driver
+// (see AnalyticSinkLocalState::_execute_for_function), which always passes
+// previous_is_nul=false, end_is_nul=false, has_null=false into
+// execute_function_with_incremental and lets the Nullable wrapper compute
+// null-awareness itself from the null map. This exercises the widened
+// has_null(frame_start - 1, current_frame_end) check added by the fix,
+// which must cover both the outgoing (frame_start - 1) and incoming
+// (frame_end - 1) positions as the frame slides across scattered nulls,
+// including nulls landing exactly on those boundary positions.
+TEST(AggFunctionNullWindowTest, ExecuteFunctionWithIncrementalSlidingWindowMatchesNaive) {
+    std::vector<int32_t> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    // Nulls scattered so that, as a size-3 window slides, they land at the
+    // outgoing position, the incoming position, and mid-frame at various steps.
+    std::vector<size_t> null_positions = {2, 5, 6, 9};
+    auto column = build_nullable_int32_column(values, null_positions);
+    const IColumn* columns[1] = {column.get()};
+
+    auto agg_function = create_window_sum();
+    std::unique_ptr<char[]> memory(new char[agg_function->size_of_data()]);
+    AggregateDataPtr place = memory.get();
+    agg_function->create(place);
+    Arena arena;
+
+    const int64_t partition_start = 0;
+    const auto partition_end = static_cast<int64_t>(values.size());
+    const int64_t window_size = 3;
+
+    UInt8 use_null_result = 0;
+    UInt8 could_use_previous_result = 0;
+
+    for (int64_t frame_start = 0; frame_start + window_size <= partition_end; ++frame_start) {
+        int64_t frame_end = frame_start + window_size;
+        agg_function->execute_function_with_incremental(
+                partition_start, partition_end, frame_start, frame_end, place, columns, arena,
+                /*previous_is_nul*/ false, /*end_is_nul*/ false, /*has_null*/ false,
+                &use_null_result, &could_use_previous_result);
+
+        int64_t expected = naive_sum_skip_null(values, null_positions, frame_start, frame_end);
+        bool expect_null = false;
+        {
+            std::vector<uint8_t> is_null(values.size(), 0);
+            for (auto pos : null_positions) {
+                is_null[pos] = 1;
+            }
+            expect_null = true;
+            for (int64_t i = frame_start; i < frame_end; ++i) {
+                if (!is_null[i]) {
+                    expect_null = false;
+                    break;
+                }
+            }
+        }
+        ASSERT_EQ(use_null_result, expect_null)
+                << "frame [" << frame_start << ", " << frame_end << ")";
+        if (!use_null_result) {
+            EXPECT_EQ(read_sum_result(agg_function, place), expected)
+                    << "frame [" << frame_start << ", " << frame_end << ")";
+        }
+    }
+    agg_function->destroy(place);
+}
+
+} // namespace doris


### PR DESCRIPTION
…egate

### What problem does this PR solve?

Issue Number: close #<TBD>

Problem Summary: The Nullable wrapper for window/analytic aggregate functions called ColumnNullable::has_null() over the ENTIRE buffered column on every row in AggregateFunctionNullUnaryInline::add_range_single_place and ::execute_function_with_incremental. For an analytic sliding window this makes the per-row null check O(n) and the whole scan O(n * buffer), even when nulls are sparse or absent. This narrows the scan to only the frame range that is actually touched: [current_frame_start, current_frame_end) for add_range_single_place, and [frame_start-1, current_frame_end) for the incremental path (covering the outgoing frame_start-1 and incoming frame_end-1 boundary positions). Result is correct and unchanged; the per-row check drops from O(n) to O(frame).

### Release note

None

### Check List (For Author)

- Test: Unit Test (be/test/exprs/aggregate/agg_function_null_window_test.cpp)
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
```bash
# Step 1 — build no-null tables of increasing size (nullable type, all values non-null)
for N in 2000000 4000000 8000000; do
  mysql -h127.0.0.1 -P9030 -uroot -e "
    DROP TABLE IF EXISTS d4_repro.nn_$N;
    CREATE TABLE d4_repro.nn_$N (
      vender_id INT, monitor_day INT, roll_diff_amount DOUBLE NULL
    ) DUPLICATE KEY(vender_id)
      DISTRIBUTED BY HASH(vender_id) BUCKETS 8
      PROPERTIES('replication_num'='1');
    INSERT INTO d4_repro.nn_$N
      SELECT cast(number % 400000 AS int),   -- ~400k partitions (small partitions, matches prod)
             cast(number % 30 AS int),
             cast(number % 100000 AS double)  -- NEVER null
      FROM numbers('number'='$N');"
done

# Step 2 — time the window query single-threaded; per-row = wall / N
for N in 2000000 4000000 8000000; do
  Q="SELECT count(a+s) FROM (
       SELECT vender_id,
         avg(roll_diff_amount)    OVER (PARTITION BY vender_id ORDER BY monitor_day
                                        ROWS BETWEEN 7 PRECEDING AND 1 PRECEDING) a,
         stddev(roll_diff_amount) OVER (PARTITION BY vender_id ORDER BY monitor_day
                                        ROWS BETWEEN 7 PRECEDING AND 1 PRECEDING) s
       FROM d4_repro.nn_$N) t"
  start=$(date +%s.%N)
  mysql -h127.0.0.1 -P9030 -uroot -e "set parallel_pipeline_task_num=1; ${Q}" >/dev/null 2>&1
  end=$(date +%s.%N)
  el=$(echo "$end - $start" | bc)
  perrow=$(echo "scale=3; $el * 1000000 / $N" | bc)
  echo "N=$N  wall=${el}s  per-row=${perrow}us"
done
```
Evaluation Results(single-thread, no NULLs)

| N | before fix | after fix | speedup |
|---|---|---|---|
| 2,000,000 | 16.05 µs/row (32.1 s) | 0.39 µs/row (0.78 s) | ~41x |
| 4,000,000 | 17.51 µs/row (70.0 s) | 0.35 µs/row (1.40 s) | ~50x |
| 8,000,000 | **>120 s (timeout)** | 0.32 µs/row (2.56 s) | ~50x+ |


    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

### APPENDIX
flame graph in our prod env. In our real prod case, the SQL wall time dropped from `3min27sec` to `15.981s`: 
<img width="1915" height="906" alt="image" src="https://github.com/user-attachments/assets/4bf2096c-e483-4e6a-ad90-9050faa064b3" />


