### PR TITLE
Fix ICU locale lock contention in LOWER/UPPER/INITCAP

### DIFF
--- a/be/src/exprs/function/function_string.cpp
+++ b/be/src/exprs/function/function_string.cpp
@@ -18,6 +18,7 @@
 #include <ctype.h>
 #include <math.h>
 #include <re2/stringpiece.h>
+#include <unicode/locid.h>
 #include <unicode/schriter.h>
 #include <unicode/uchar.h>
 #include <unicode/unistr.h>
@@ -593,7 +594,7 @@ struct TransferImpl {
         icu::StringPiece sp;
         sp.set(data, size);
         icu::UnicodeString unicode_str = icu::UnicodeString::fromUTF8(sp);
-        unicode_str.toUpper();
+        unicode_str.toUpper(icu::Locale::getRoot());
         unicode_str.toUTF8String(result);
     }
 
@@ -601,7 +602,7 @@ struct TransferImpl {
         icu::StringPiece sp;
         sp.set(data, size);
         icu::UnicodeString unicode_str = icu::UnicodeString::fromUTF8(sp);
-        unicode_str.toLower();
+        unicode_str.toLower(icu::Locale::getRoot());
         unicode_str.toUTF8String(result);
     }
 };
@@ -683,7 +684,7 @@ struct InitcapImpl {
         icu::StringPiece sp;
         sp.set(data, size);
         icu::UnicodeString unicode_str = icu::UnicodeString::fromUTF8(sp);
-        unicode_str.toLower();
+        unicode_str.toLower(icu::Locale::getRoot());
         icu::UnicodeString output_str;
         bool need_capitalize = true;
         icu::StringCharacterIterator iter(unicode_str);


### PR DESCRIPTION
## Problem

ICU's `UnicodeString::toLower()` / `toUpper()` with no explicit `Locale` argument internally calls `locale_get_default_69()`, which acquires a global mutex. Under concurrent multi-threaded LOWER/UPPER/INITCAP evaluation on UTF-8 data, this mutex becomes a severe CPU bottleneck.

Production flame graph evidence shows **82% of CPU wasted on a spinlock** inside ICU's default-locale lookup — not on actual case conversion or string matching.

## Root Cause

`TransferImpl::to_upper_utf8`, `TransferImpl::to_lower_utf8`, and `InitcapImpl::to_initcap_utf8` in `be/src/exprs/function/function_string.cpp` all call `unicode_str.toUpper()` / `unicode_str.toLower()` without an explicit `Locale` parameter. ICU internally resolves the default locale via `locale_get_default_69()`, which takes a global mutex.

## Fix

Pass `icu::Locale::getRoot()` explicitly to all three call sites:

```cpp
// Before:
unicode_str.toUpper();   // → locale_get_default_9() → global mutex
unicode_str.toLower();   // → locale_get_default_9() → global mutex

// After:
unicode_str.toUpper(icu::Locale::getRoot());   // direct, no mutex
unicode_str.toLower(icu::Locale::getRoot());   // direct, no mutex
```

**Changes:** 1 file, +4/-3 lines

## Benefits

1. **Eliminates lock contention** — bypasses `locale_get_default_69()` entirely
2. **Deterministic results** — case conversion now uses ICU root locale regardless of process environment
3. **Fixes Turkish locale correctness bug** — under `tr_TR` default locale, `I` maps to `ı` (dotless i) instead of `i`, producing incorrect results

## References

- Fixes #66439