### PR TITLE
[fix](cloud) Unify Nereids command restrictions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/InternalSchemaInitializer.java
@@ -270,7 +270,7 @@ public class InternalSchemaInitializer extends Thread {
 
                             ops.add(new ModifyPartitionOp(Lists.newArrayList(tbl.getPartitionNames()), props, false));
                             AlterTableCommand alterTableCommand = new AlterTableCommand(tableNameInfo, ops);
-                            alterTableCommand.run(ConnectContext.get(), null);
+                            alterTableCommand.execute(ConnectContext.get(), null);
                         }
                     } finally {
                         tbl.writeUnlock();

--- a/fe/fe-core/src/main/java/org/apache/doris/dictionary/DictionaryManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/dictionary/DictionaryManager.java
@@ -482,7 +482,7 @@ public class DictionaryManager extends MasterDaemon implements Writable {
             // avoid to generate EmptySetNode making us not able to get base table version.
             ctx.getSessionVariable().setVarOnce(SessionVariable.DISABLE_NEREIDS_RULES,
                     "OLAP_SCAN_PARTITION_PRUNE,PRUNE_EMPTY_PARTITION");
-            command.run(ctx, executor);
+            command.execute(ctx, executor);
         } catch (Exception e) {
             // wait next shedule.
             dictionary.trySetStatus(oldStatus);

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJob.java
@@ -312,7 +312,7 @@ public class StreamingInsertJob extends AbstractJob<StreamingJobSchedulerTask, M
             String srcTable = entry.getKey();
             CreateTableCommand createTblCmd = entry.getValue();
             if (!db.isTableExist(createTblCmd.getCreateTableInfo().getTableName())) {
-                createTblCmd.run(ConnectContext.get(), null);
+                createTblCmd.execute(ConnectContext.get(), null);
             }
             // Use the upstream table name so CDC monitors the correct source table.
             syncTbls.add(srcTable);

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertTask.java
@@ -122,7 +122,7 @@ public class StreamingInsertTask extends AbstractStreamingTask {
         log.info("start to run streaming insert task, label {}, offset is {}", labelName, runningOffset.toString());
         String errMsg = null;
         try {
-            taskCommand.run(ctx, stmtExecutor);
+            taskCommand.execute(ctx, stmtExecutor);
             if (ctx.getState().getStateType() == QueryState.MysqlStateType.OK) {
                 return;
             } else {

--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
@@ -345,7 +345,7 @@ public class MTMVTask extends AbstractTask {
             ctx.setExecutor(executor);
             ctx.setQueryId(queryId);
             ctx.getState().setNereids(true);
-            command.run(ctx, executor);
+            command.execute(ctx, executor);
             if (getStatus() == TaskStatus.CANCELED) {
                 // Throwing an exception to interrupt subsequent partition update tasks
                 throw new JobException("task is CANCELED");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCancelRebalanceDiskCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCancelRebalanceDiskCommand.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.util.NetUtils;
@@ -42,7 +41,7 @@ import java.util.Map;
 /**
  * admin cancel rebalance disk
  */
-public class AdminCancelRebalanceDiskCommand extends Command implements NoForward {
+public class AdminCancelRebalanceDiskCommand extends Command implements NoForward, CloudUnsupportedCommand {
     private static final Logger LOG = LogManager.getLogger(AdminCancelRebalanceDiskCommand.class);
     private List<String> backends;
 
@@ -93,12 +92,6 @@ public class AdminCancelRebalanceDiskCommand extends Command implements NoForwar
             }
         }
         return needRebalanceDiskBackends;
-    }
-
-    @Override
-    protected void checkSupportedInCloudMode(ConnectContext ctx) throws DdlException {
-        LOG.info("AdminCancelRebalanceDiskCommand not supported in cloud mode");
-        throw new DdlException("Unsupported operation");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCancelRepairTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCancelRepairTableCommand.java
@@ -21,7 +21,6 @@ import org.apache.doris.analysis.StmtType;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.info.PartitionNamesInfo;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.util.Util;
@@ -33,8 +32,6 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 
 import com.google.common.collect.Lists;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Objects;
@@ -42,8 +39,7 @@ import java.util.Objects;
 /**
  * AdminCancelRepairTableCommand
  */
-public class AdminCancelRepairTableCommand extends Command implements ForwardWithSync {
-    private static final Logger LOG = LogManager.getLogger(AdminCancelRepairTableCommand.class);
+public class AdminCancelRepairTableCommand extends Command implements ForwardWithSync, CloudUnsupportedCommand {
     private final TableRefInfo tableRefInfo;
     private List<String> partitions = Lists.newArrayList();
 
@@ -92,12 +88,6 @@ public class AdminCancelRepairTableCommand extends Command implements ForwardWit
             }
             partitions.addAll(partitionNamesInfo.getPartitionNames());
         }
-    }
-
-    @Override
-    protected void checkSupportedInCloudMode(ConnectContext ctx) throws DdlException {
-        LOG.info("AdminCancelRepairTableCommand not supported in cloud mode");
-        throw new DdlException("denied");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCheckTabletsCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCheckTabletsCommand.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.util.PropertyAnalyzer;
@@ -30,8 +29,6 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
@@ -40,8 +37,7 @@ import java.util.Objects;
 /**
  * drop user command
  */
-public class AdminCheckTabletsCommand extends Command implements ForwardNoSync {
-    private static final Logger LOG = LogManager.getLogger(AdminCheckTabletsCommand.class);
+public class AdminCheckTabletsCommand extends Command implements ForwardNoSync, CloudUnsupportedCommand {
     private final List<Long> tabletIds;
     private final Map<String, String> properties;
 
@@ -94,12 +90,6 @@ public class AdminCheckTabletsCommand extends Command implements ForwardNoSync {
         if (Objects.requireNonNull(checkType) == CheckType.CONSISTENCY) {
             Env.getCurrentEnv().getConsistencyChecker().addTabletsToCheck(tabletIds);
         }
-    }
-
-    @Override
-    protected void checkSupportedInCloudMode(ConnectContext ctx) throws DdlException {
-        LOG.info("AdminCheckTabletsCommand not supported in cloud mode");
-        throw new DdlException("Unsupported operation");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCleanTrashCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminCleanTrashCommand.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.util.NetUtils;
@@ -45,7 +44,7 @@ import java.util.Map;
 /**
  * admin clean trash
  */
-public class AdminCleanTrashCommand extends Command implements NoForward {
+public class AdminCleanTrashCommand extends Command implements NoForward, CloudUnsupportedCommand {
     private static final Logger LOG = LogManager.getLogger(AdminCleanTrashCommand.class);
     private List<String> backendsQuery;
 
@@ -105,12 +104,6 @@ public class AdminCleanTrashCommand extends Command implements NoForward {
             LOG.info("clean trash in be {}, beId {}", backend.getHost(), backend.getId());
         }
         AgentTaskExecutor.submit(batchTask);
-    }
-
-    @Override
-    protected void checkSupportedInCloudMode(ConnectContext ctx) throws DdlException {
-        LOG.info("AdminCleanTrashCommand not supported in cloud mode");
-        throw new DdlException("Unsupported operation");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminRebalanceDiskCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminRebalanceDiskCommand.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.util.NetUtils;
@@ -42,7 +41,7 @@ import java.util.Map;
 /**
  * admin rebalance disk
  */
-public class AdminRebalanceDiskCommand extends Command implements NoForward {
+public class AdminRebalanceDiskCommand extends Command implements NoForward, CloudUnsupportedCommand {
     private static final Logger LOG = LogManager.getLogger(AdminRebalanceDiskCommand.class);
     private final long timeoutS = 24 * 3600; // default 24 hours
     private List<String> backends;
@@ -94,12 +93,6 @@ public class AdminRebalanceDiskCommand extends Command implements NoForward {
             }
         }
         return needRebalanceDiskBackends;
-    }
-
-    @Override
-    protected void checkSupportedInCloudMode(ConnectContext ctx) throws DdlException {
-        LOG.info("AdminRebalanceDiskCommand not supported in cloud mode");
-        throw new DdlException("Unsupported operation");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminRepairTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminRepairTableCommand.java
@@ -21,7 +21,6 @@ import org.apache.doris.analysis.StmtType;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.info.PartitionNamesInfo;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.util.Util;
@@ -33,8 +32,6 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 
 import com.google.common.collect.Lists;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Objects;
@@ -42,8 +39,7 @@ import java.util.Objects;
 /**
  * AdminRepairTableCommand
  */
-public class AdminRepairTableCommand extends Command implements ForwardWithSync {
-    private static final Logger LOG = LogManager.getLogger(AdminRepairTableCommand.class);
+public class AdminRepairTableCommand extends Command implements ForwardWithSync, CloudUnsupportedCommand {
     private final TableRefInfo tableRefInfo;
     private List<String> partitions = Lists.newArrayList();
 
@@ -97,12 +93,6 @@ public class AdminRepairTableCommand extends Command implements ForwardWithSync 
             partitions.addAll(partitionNamesInfo.getPartitionNames());
         }
         timeoutS = 4 * 3600; // default 4 hours
-    }
-
-    @Override
-    protected void checkSupportedInCloudMode(ConnectContext ctx) throws DdlException {
-        LOG.info("AdminRepairTableCommand not supported in cloud mode");
-        throw new DdlException("denied");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminSetFrontendConfigCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminSetFrontendConfigCommand.java
@@ -20,13 +20,10 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.analysis.RedirectStatus;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.Config;
 import org.apache.doris.common.ConfigBase;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.UserException;
-import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -42,7 +39,7 @@ import java.util.Map;
 /**
  * admin set frontend config ("key" = "value");
  */
-public class AdminSetFrontendConfigCommand extends Command implements Redirect {
+public class AdminSetFrontendConfigCommand extends Command implements Redirect, CloudRootOnlyCommand {
     private boolean applyToAll;
     private NodeType type;
     private Map<String, String> configs;
@@ -96,10 +93,6 @@ public class AdminSetFrontendConfigCommand extends Command implements Redirect {
             throw new AnalysisException("Only support setting Frontend configs now");
         }
 
-        if (Config.isCloudMode()
-                && !ConnectContext.get().getCurrentUserIdentity().getUser().equals(Auth.ROOT_USER)) {
-            throw new DdlException("Unsupported operation");
-        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminSetPartitionVersionCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminSetPartitionVersionCommand.java
@@ -20,7 +20,6 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.info.TableNameInfo;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.util.PropertyAnalyzer;
@@ -37,7 +36,7 @@ import java.util.Map;
  * admin set table {table_name} partition version properties ("key" = "value");
  * key and value may be : "partition_id" = "10075", "visible_version" = "100");
  */
-public class AdminSetPartitionVersionCommand extends Command implements ForwardWithSync {
+public class AdminSetPartitionVersionCommand extends Command implements ForwardWithSync, CloudUnsupportedCommand {
     private long partitionId = -1;
     private long visibleVersion = -1;
     private final TableNameInfo tableName;
@@ -101,8 +100,4 @@ public class AdminSetPartitionVersionCommand extends Command implements ForwardW
         }
     }
 
-    @Override
-    protected void checkSupportedInCloudMode(ConnectContext ctx) throws DdlException {
-        throw new DdlException("Unsupported operation");
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminSetReplicaStatusCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminSetReplicaStatusCommand.java
@@ -21,7 +21,6 @@ import org.apache.doris.analysis.StmtType;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -29,9 +28,6 @@ import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
 import java.util.Objects;
@@ -43,8 +39,7 @@ import java.util.Objects;
  *      "backend_id" = "10001"
  *      "status" = "drop"/"bad"/"ok"
  */
-public class AdminSetReplicaStatusCommand extends Command implements ForwardWithSync {
-    private static final Logger LOG = LogManager.getLogger(AdminSetReplicaStatusCommand.class);
+public class AdminSetReplicaStatusCommand extends Command implements ForwardWithSync, CloudUnsupportedCommand {
     private static final String TABLET_ID = "tablet_id";
     private static final String BACKEND_ID = "backend_id";
     private static final String STATUS = "status";
@@ -117,12 +112,6 @@ public class AdminSetReplicaStatusCommand extends Command implements ForwardWith
         if (tabletId == -1 || backendId == -1 || status == null) {
             throw new AnalysisException("Should add following properties: TABLET_ID, BACKEND_ID and STATUS");
         }
-    }
-
-    @Override
-    protected void checkSupportedInCloudMode(ConnectContext ctx) throws DdlException {
-        LOG.info("AdminSetReplicaStatusCommand not supported in cloud mode");
-        throw new DdlException("denied");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminSetReplicaVersionCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AdminSetReplicaVersionCommand.java
@@ -19,7 +19,6 @@ package org.apache.doris.nereids.trees.plans.commands;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -40,7 +39,7 @@ import java.util.Map;
  *      "last_success_version" = "100",
  *      "last_failed_version" = "-1",
  */
-public class AdminSetReplicaVersionCommand extends Command implements ForwardWithSync {
+public class AdminSetReplicaVersionCommand extends Command implements ForwardWithSync, CloudUnsupportedCommand {
     public static final String TABLET_ID = "tablet_id";
     public static final String BACKEND_ID = "backend_id";
     public static final String VERSION = "version";
@@ -131,11 +130,6 @@ public class AdminSetReplicaVersionCommand extends Command implements ForwardWit
             throw new AnalysisException("Should add following properties: TABLET_ID, BACKEND_ID, "
                 + "VERSION, LAST_SUCCESS_VERSION, LAST_FAILED_VERSION");
         }
-    }
-
-    @Override
-    protected void checkSupportedInCloudMode(ConnectContext ctx) throws DdlException {
-        throw new DdlException("Unsupported operation");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterResourceCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterResourceCommand.java
@@ -33,7 +33,7 @@ import java.util.Map;
 /**
  * Command for ALTER RESOURCE in Nereids.
  */
-public class AlterResourceCommand extends AlterCommand implements NeedAuditEncryption {
+public class AlterResourceCommand extends AlterCommand implements NeedAuditEncryption, CloudUnsupportedCommand {
     private static final String TYPE = "type";
     private final String resourceName;
     private final Map<String, String> properties;
@@ -86,4 +86,3 @@ public class AlterResourceCommand extends AlterCommand implements NeedAuditEncry
         return true;
     }
 }
-

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterStoragePolicyCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/AlterStoragePolicyCommand.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 /**
  * Command to execute ALTER STORAGE POLICY in the Nereids planner.
  */
-public class AlterStoragePolicyCommand extends AlterCommand {
+public class AlterStoragePolicyCommand extends AlterCommand implements CloudUnsupportedCommand {
     private final String policyName;
     private final Map<String, String> properties;
 
@@ -97,4 +97,3 @@ public class AlterStoragePolicyCommand extends AlterCommand {
         return visitor.visitAlterStoragePolicyCommand(this, context);
     }
 }
-

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/BackupCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/BackupCommand.java
@@ -21,7 +21,6 @@ import org.apache.doris.analysis.StmtType;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.datasource.InternalCatalog;
@@ -46,7 +45,7 @@ import java.util.Objects;
 /**
  * BackupCommand
  */
-public class BackupCommand extends Command implements ForwardWithSync {
+public class BackupCommand extends Command implements ForwardWithSync, CloudUnsupportedCommand {
     public static final String PROP_CONTENT = "content";
     private static final Logger LOG = LogManager.getLogger(BackupCommand.class);
     private static final String PROP_TIMEOUT = "timeout";
@@ -264,9 +263,4 @@ public class BackupCommand extends Command implements ForwardWithSync {
         return StmtType.BACKUP;
     }
 
-    @Override
-    protected void checkSupportedInCloudMode(ConnectContext ctx) throws DdlException {
-        LOG.info("BackupCommand not supported in cloud mode");
-        throw new DdlException("denied");
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CancelDecommissionBackendCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CancelDecommissionBackendCommand.java
@@ -20,7 +20,6 @@ package org.apache.doris.nereids.trees.plans.commands;
 import org.apache.doris.analysis.StmtType;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -32,8 +31,6 @@ import org.apache.doris.system.SystemInfoService;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Objects;
@@ -41,8 +38,7 @@ import java.util.Objects;
 /**
  * CancelDecommissionBackendCommand
  */
-public class CancelDecommissionBackendCommand extends CancelCommand {
-    private static final Logger LOG = LogManager.getLogger(CancelDecommissionBackendCommand.class);
+public class CancelDecommissionBackendCommand extends CancelCommand implements CloudUnsupportedCommand {
     private final List<String> params;
     private final List<SystemInfoService.HostInfo> hostInfos;
     private final List<String> ids;
@@ -117,12 +113,6 @@ public class CancelDecommissionBackendCommand extends CancelCommand {
             }
         }
         return sb.toString();
-    }
-
-    @Override
-    protected void checkSupportedInCloudMode(ConnectContext ctx) throws DdlException {
-        LOG.info("CancelDecommissionBackendCommand not supported in cloud mode");
-        throw new DdlException("Unsupported operation");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CloudRestrictedCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CloudRestrictedCommand.java
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands;
+
+/**
+ * A command whose availability is restricted in cloud mode.
+ */
+public interface CloudRestrictedCommand {
+    CloudRestrictionPolicy cloudRestrictionPolicy();
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CloudRestrictionPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CloudRestrictionPolicy.java
@@ -1,0 +1,54 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands;
+
+import org.apache.doris.common.DdlException;
+import org.apache.doris.mysql.privilege.Auth;
+import org.apache.doris.qe.ConnectContext;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Shared cloud-mode restriction policies for Nereids commands.
+ */
+public enum CloudRestrictionPolicy {
+    UNSUPPORTED {
+        @Override
+        void validate(ConnectContext ctx, Command command) throws DdlException {
+            reject(command);
+        }
+    },
+    ROOT_ONLY {
+        @Override
+        void validate(ConnectContext ctx, Command command) throws DdlException {
+            if (!Auth.ROOT_USER.equals(ctx.getCurrentUserIdentity().getUser())) {
+                reject(command);
+            }
+        }
+    };
+
+    private static final Logger LOG = LogManager.getLogger(CloudRestrictionPolicy.class);
+
+    abstract void validate(ConnectContext ctx, Command command) throws DdlException;
+
+    private static void reject(Command command) throws DdlException {
+        LOG.info("{} is not supported in cloud mode", command.getClass().getSimpleName());
+        throw new DdlException("Unsupported operation");
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CloudRootOnlyCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CloudRootOnlyCommand.java
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands;
+
+/**
+ * A command that only the root user can execute in cloud mode.
+ */
+public interface CloudRootOnlyCommand extends CloudRestrictedCommand {
+    @Override
+    default CloudRestrictionPolicy cloudRestrictionPolicy() {
+        return CloudRestrictionPolicy.ROOT_ONLY;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CloudUnsupportedCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CloudUnsupportedCommand.java
@@ -1,0 +1,28 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands;
+
+/**
+ * A command that is not supported in cloud mode.
+ */
+public interface CloudUnsupportedCommand extends CloudRestrictedCommand {
+    @Override
+    default CloudRestrictionPolicy cloudRestrictionPolicy() {
+        return CloudRestrictionPolicy.UNSUPPORTED;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/Command.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/Command.java
@@ -51,6 +51,32 @@ public abstract class Command extends AbstractPlan implements LogicalPlan, Block
 
     public abstract void run(ConnectContext ctx, StmtExecutor executor) throws Exception;
 
+    /**
+     * Execute this command through the shared command lifecycle.
+     */
+    public final void execute(ConnectContext ctx, StmtExecutor executor) throws Exception {
+        Throwable failure = null;
+        try {
+            before(ctx);
+            run(ctx, executor);
+        } catch (Exception | Error e) {
+            failure = e;
+            throw e;
+        } finally {
+            after(ctx, failure);
+        }
+    }
+
+    private void before(ConnectContext ctx) throws DdlException {
+        if (Config.isCloudMode() && this instanceof CloudRestrictedCommand) {
+            ((CloudRestrictedCommand) this).cloudRestrictionPolicy().validate(ctx, this);
+        }
+    }
+
+    private void after(ConnectContext ctx, Throwable failure) {
+        // Reserved for shared cleanup, auditing, or metrics. It must not hide the original failure.
+    }
+
     @Override
     public Optional<GroupExpression> getGroupExpression() {
         throw new RuntimeException("Command do not implement getGroupExpression");
@@ -121,18 +147,6 @@ public abstract class Command extends AbstractPlan implements LogicalPlan, Block
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
         throw new RuntimeException("Command do not implement withGroupExpression");
     }
-
-    public void verifyCommandSupported(ConnectContext ctx) throws DdlException {
-        // check command has been supported in cloud mode
-        if (Config.isCloudMode()) {
-            checkSupportedInCloudMode(ctx);
-        }
-    }
-
-    // check if the command is supported in cloud mode
-    // see checkStmtSupported() in fe/fe-core/src/main/java/org/apache/doris/qe/ShowExecutor.java
-    // override this method if the command is not supported in cloud mode
-    protected void checkSupportedInCloudMode(ConnectContext ctx) throws DdlException {}
 
     // For prepare statement only, used to get the result set metadata in prepare stage.
     // Subclass need to override this to return correct metadata.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateTableCommand.java
@@ -133,7 +133,7 @@ public class CreateTableCommand extends Command implements NeedAuditEncryption, 
             if (!FeConstants.runningUnitTest) {
                 insertCommand = new InsertIntoTableCommand(sinkQuery, Optional.empty(),
                         Optional.empty(), Optional.empty(), true, Optional.empty());
-                insertCommand.run(ctx, executor);
+                insertCommand.execute(ctx, executor);
                 if (ctx.getState().getStateType() == MysqlStateType.OK) {
                     LineageUtils.submitLineageEventIfNeeded(executor, insertCommand.getLineagePlan(),
                             insertCommand.getLogicalQuery(), getClass());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateTableLikeCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateTableLikeCommand.java
@@ -115,7 +115,7 @@ public class CreateTableLikeCommand extends Command implements ForwardWithSync {
                 createTableCommand = new CreateTableCommand(createTableCommand.getCtasQuery(),
                     createTableInfo.withTableNameAndIfNotExists(createTableLikeInfo.getTableName(),
                             createTableLikeInfo.isIfNotExists()));
-                createTableCommand.run(ctx, executor);
+                createTableCommand.execute(ctx, executor);
             } finally {
                 ctx.setSkipAuth(false);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
@@ -201,7 +201,7 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
         } catch (Exception e) {
             try {
                 new DeleteFromUsingCommand(nameParts, tableAlias, isTempPart, partitions,
-                        logicalQuery, Optional.empty(), false).run(ctx, executor);
+                        logicalQuery, Optional.empty(), false).execute(ctx, executor);
                 return;
             } catch (Exception e2) {
                 LOG.warn("delete from command failed", e2);
@@ -214,7 +214,7 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
         if (olapTable.getKeysType() == KeysType.UNIQUE_KEYS && olapTable.getEnableUniqueKeyMergeOnWrite()
                 && !olapTable.getEnableMowLightDelete()) {
             new DeleteFromUsingCommand(nameParts, tableAlias, isTempPart, partitions, logicalQuery,
-                    Optional.empty(), false).run(ctx, executor);
+                    Optional.empty(), false).execute(ctx, executor);
             return;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromUsingCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromUsingCommand.java
@@ -57,7 +57,7 @@ public class DeleteFromUsingCommand extends DeleteFromCommand implements Support
         }
         // NOTE: delete from using command is executed as insert command, so txn insert can support it
         new InsertIntoTableCommand(completeQueryPlan(ctx, logicalQuery), Optional.empty(), Optional.empty(),
-                Optional.empty(), true, Optional.empty()).run(ctx, executor);
+                Optional.empty(), true, Optional.empty()).execute(ctx, executor);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowReplicaDistributionCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowReplicaDistributionCommand.java
@@ -28,7 +28,6 @@ import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.info.TableRefInfo;
-import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.nereids.trees.plans.PlanType;
 import org.apache.doris.nereids.trees.plans.visitor.PlanVisitor;
@@ -38,22 +37,19 @@ import org.apache.doris.qe.ShowResultSetMetaData;
 import org.apache.doris.qe.StmtExecutor;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
 /**
  * show replica distribution command
  */
-public class ShowReplicaDistributionCommand extends ShowCommand {
+public class ShowReplicaDistributionCommand extends ShowCommand implements CloudRootOnlyCommand {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("BackendId").add("ReplicaNum").add("ReplicaSize")
             .add("NumGraph").add("NumPercent")
             .add("SizeGraph").add("SizePercent")
             .add("CloudClusterName").add("CloudClusterId")
             .build();
-    private static final Logger LOG = LogManager.getLogger(ShowReplicaDistributionCommand.class);
     private final TableRefInfo tableRefInfo;
 
     /**
@@ -106,11 +102,4 @@ public class ShowReplicaDistributionCommand extends ShowCommand {
         }
     }
 
-    @Override
-    protected void checkSupportedInCloudMode(ConnectContext ctx) throws DdlException {
-        if (!ctx.getCurrentUserIdentity().getUser().equals(Auth.ROOT_USER)) {
-            LOG.info("ShowReplicaDistributionCommand not supported in cloud mode");
-            throw new DdlException("Unsupported operation");
-        }
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowTabletStorageFormatCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowTabletStorageFormatCommand.java
@@ -21,7 +21,6 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.AnalysisException;
-import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.mysql.privilege.PrivPredicate;
@@ -36,8 +35,6 @@ import org.apache.doris.task.AgentClient;
 import org.apache.doris.thrift.TCheckStorageFormatResult;
 
 import com.google.common.collect.Lists;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,8 +42,7 @@ import java.util.List;
 /**
  * show tablet storage format command
  */
-public class ShowTabletStorageFormatCommand extends ShowCommand {
-    public static final Logger LOG = LogManager.getLogger(ShowTabletStorageFormatCommand.class);
+public class ShowTabletStorageFormatCommand extends ShowCommand implements CloudUnsupportedCommand {
     private final boolean verbose;
 
     /**
@@ -121,9 +117,4 @@ public class ShowTabletStorageFormatCommand extends ShowCommand {
         return visitor.visitShowTabletStorageFormatCommand(this, context);
     }
 
-    @Override
-    protected void checkSupportedInCloudMode(ConnectContext ctx) throws DdlException {
-        LOG.info("show tablet storage format not supported in cloud mode");
-        throw new DdlException("Unsupported operation");
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/UpdateCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/UpdateCommand.java
@@ -117,7 +117,7 @@ public class UpdateCommand extends Command implements ForwardWithSync, Explainab
 
         // NOTE: update command is executed as insert command, so txn insert can support it
         new InsertIntoTableCommand(completeQueryPlan(ctx, logicalQuery), Optional.empty(), Optional.empty(),
-                Optional.empty(), true, Optional.empty()).run(ctx, executor);
+                Optional.empty(), true, Optional.empty()).execute(ctx, executor);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertOverwriteTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertOverwriteTableCommand.java
@@ -356,7 +356,7 @@ public class InsertOverwriteTableCommand extends Command implements NeedAuditEnc
             ConnectContext ctx, StmtExecutor executor) throws Exception {
         InsertIntoTableCommand insertCommand = new InsertIntoTableCommand(logicalQuery, labelName,
                 Optional.of(insertCtx), Optional.empty(), false, branchName);
-        insertCommand.run(ctx, executor);
+        insertCommand.execute(ctx, executor);
         if (ctx.getState().getStateType() == MysqlStateType.ERR) {
             String errMsg = Strings.emptyToNull(ctx.getState().getErrorMessage());
             LOG.warn("InsertInto state error:{}", errMsg);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/merge/MergeIntoCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/merge/MergeIntoCommand.java
@@ -141,7 +141,7 @@ public class MergeIntoCommand extends Command implements ForwardWithSync, Explai
             return;
         }
         new InsertIntoTableCommand(completeQueryPlan(ctx), Optional.empty(), Optional.empty(),
-                Optional.empty(), true, Optional.empty()).run(ctx, executor);
+                Optional.empty(), true, Optional.empty()).execute(ctx, executor);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -841,8 +841,7 @@ public class StmtExecutor {
             // t3: observer fe receive editlog creating the table from the master fe
             syncJournalIfNeeded(context);
             try {
-                ((Command) logicalPlan).verifyCommandSupported(context);
-                ((Command) logicalPlan).run(context, this);
+                ((Command) logicalPlan).execute(context, this);
             } catch (QueryStateException e) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Command({}) process failed.", getStmtForLogging(originStmt.originStmt), e);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminSetReplicaVersionCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/AdminSetReplicaVersionCommandTest.java
@@ -159,7 +159,7 @@ public class AdminSetReplicaVersionCommandTest extends TestWithFeService {
             AdminSetReplicaVersionCommand command = new AdminSetReplicaVersionCommand(properties);
 
             DdlException ex = Assertions.assertThrows(DdlException.class,
-                    () -> command.verifyCommandSupported(connectContext));
+                    () -> command.execute(connectContext, null));
             Assertions.assertTrue(ex.getMessage().contains("Unsupported operation"));
         } finally {
             Config.deploy_mode = originDeployMode;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CloudRestrictedCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CloudRestrictedCommandTest.java
@@ -1,0 +1,191 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands;
+
+import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.StmtExecutor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class CloudRestrictedCommandTest {
+    private String originalDeployMode;
+    private String originalCloudUniqueId;
+
+    @BeforeEach
+    public void saveCloudConfig() {
+        originalDeployMode = Config.deploy_mode;
+        originalCloudUniqueId = Config.cloud_unique_id;
+    }
+
+    @AfterEach
+    public void restoreCloudConfig() {
+        Config.deploy_mode = originalDeployMode;
+        Config.cloud_unique_id = originalCloudUniqueId;
+    }
+
+    @Test
+    public void testUnsupportedCommandIsRejectedBeforeRunForEveryUser() {
+        setCloudMode();
+        for (UserIdentity userIdentity : Arrays.asList(UserIdentity.ADMIN, UserIdentity.ROOT)) {
+            RecordingUnsupportedCommand command = new RecordingUnsupportedCommand();
+            DdlException exception = Assertions.assertThrows(DdlException.class,
+                    () -> command.execute(contextFor(userIdentity), null));
+            Assertions.assertEquals("Unsupported operation", exception.getDetailMessage());
+            Assertions.assertFalse(command.isRunInvoked());
+        }
+    }
+
+    @Test
+    public void testUnsupportedCommandRunsOutsideCloudMode() {
+        setNonCloudMode();
+        RecordingUnsupportedCommand command = new RecordingUnsupportedCommand();
+
+        Assertions.assertDoesNotThrow(() -> command.execute(contextFor(UserIdentity.ADMIN), null));
+        Assertions.assertTrue(command.isRunInvoked());
+    }
+
+    @Test
+    public void testRootOnlyCommandRejectsAdminAndAllowsRootInCloudMode() {
+        setCloudMode();
+        RecordingRootOnlyCommand adminCommand = new RecordingRootOnlyCommand();
+        DdlException exception = Assertions.assertThrows(DdlException.class,
+                () -> adminCommand.execute(contextFor(UserIdentity.ADMIN), null));
+        Assertions.assertEquals("Unsupported operation", exception.getDetailMessage());
+        Assertions.assertFalse(adminCommand.isRunInvoked());
+
+        RecordingRootOnlyCommand rootCommand = new RecordingRootOnlyCommand();
+        Assertions.assertDoesNotThrow(() -> rootCommand.execute(contextFor(UserIdentity.ROOT), null));
+        Assertions.assertTrue(rootCommand.isRunInvoked());
+    }
+
+    @Test
+    public void testRootOnlyCommandRunsForAdminOutsideCloudMode() {
+        setNonCloudMode();
+        RecordingRootOnlyCommand command = new RecordingRootOnlyCommand();
+
+        Assertions.assertDoesNotThrow(() -> command.execute(contextFor(UserIdentity.ADMIN), null));
+        Assertions.assertTrue(command.isRunInvoked());
+    }
+
+    @Test
+    public void testUnrestrictedCommandRunsInCloudMode() {
+        setCloudMode();
+        RecordingCommand command = new RecordingCommand();
+
+        Assertions.assertDoesNotThrow(() -> command.execute(contextFor(UserIdentity.ADMIN), null));
+        Assertions.assertTrue(command.isRunInvoked());
+    }
+
+    @Test
+    public void testExecutePreservesCommandFailure() {
+        setNonCloudMode();
+        RecordingCommand command = new RecordingCommand();
+        RuntimeException expected = new RuntimeException("command failed");
+        command.setFailure(expected);
+
+        RuntimeException actual = Assertions.assertThrows(RuntimeException.class,
+                () -> command.execute(contextFor(UserIdentity.ADMIN), null));
+        Assertions.assertSame(expected, actual);
+        Assertions.assertTrue(command.isRunInvoked());
+    }
+
+    @Test
+    public void testCloudRestrictionDeclarations() {
+        List<Class<? extends Command>> unsupportedCommands = Arrays.asList(
+                AdminCancelRebalanceDiskCommand.class,
+                AdminCancelRepairTableCommand.class,
+                AdminCheckTabletsCommand.class,
+                AdminCleanTrashCommand.class,
+                AdminRebalanceDiskCommand.class,
+                AdminRepairTableCommand.class,
+                AdminSetPartitionVersionCommand.class,
+                AdminSetReplicaStatusCommand.class,
+                AdminSetReplicaVersionCommand.class,
+                AlterResourceCommand.class,
+                AlterStoragePolicyCommand.class,
+                BackupCommand.class,
+                CancelDecommissionBackendCommand.class,
+                ShowTabletStorageFormatCommand.class);
+        for (Class<? extends Command> commandClass : unsupportedCommands) {
+            Assertions.assertTrue(CloudUnsupportedCommand.class.isAssignableFrom(commandClass),
+                    commandClass.getSimpleName());
+        }
+
+        List<Class<? extends Command>> rootOnlyCommands = Arrays.asList(
+                AdminSetFrontendConfigCommand.class,
+                ShowReplicaDistributionCommand.class);
+        for (Class<? extends Command> commandClass : rootOnlyCommands) {
+            Assertions.assertTrue(CloudRootOnlyCommand.class.isAssignableFrom(commandClass),
+                    commandClass.getSimpleName());
+        }
+
+        Assertions.assertFalse(CloudRestrictedCommand.class.isAssignableFrom(AdminCompactTableCommand.class));
+    }
+
+    private static ConnectContext contextFor(UserIdentity userIdentity) {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setCurrentUserIdentity(userIdentity);
+        return ctx;
+    }
+
+    private static void setCloudMode() {
+        Config.deploy_mode = "cloud";
+        Config.cloud_unique_id = "";
+    }
+
+    private static void setNonCloudMode() {
+        Config.deploy_mode = "";
+        Config.cloud_unique_id = "";
+    }
+
+    private static class RecordingCommand extends EmptyCommand {
+        private boolean runInvoked;
+        private RuntimeException failure;
+
+        @Override
+        public void run(ConnectContext ctx, StmtExecutor executor) {
+            runInvoked = true;
+            if (failure != null) {
+                throw failure;
+            }
+        }
+
+        public boolean isRunInvoked() {
+            return runInvoked;
+        }
+
+        public void setFailure(RuntimeException failure) {
+            this.failure = failure;
+        }
+    }
+
+    private static class RecordingUnsupportedCommand extends RecordingCommand implements CloudUnsupportedCommand {
+    }
+
+    private static class RecordingRootOnlyCommand extends RecordingCommand implements CloudRootOnlyCommand {
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CloudUnsupportedCommandSqlTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CloudUnsupportedCommandSqlTest.java
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands;
+
+import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.common.Config;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class CloudUnsupportedCommandSqlTest extends TestWithFeService {
+    private static final List<String> UNSUPPORTED_SQL = Arrays.asList(
+            "ALTER RESOURCE missing_cloud_resource PROPERTIES (\"s3.connection.maximum\" = \"100\")",
+            "ALTER STORAGE POLICY missing_cloud_policy PROPERTIES (\"cooldown_ttl\" = \"86400\")");
+
+    @Test
+    public void testMissingCloudRestrictionsThroughSqlEntry() {
+        String originalDeployMode = Config.deploy_mode;
+        String originalCloudUniqueId = Config.cloud_unique_id;
+        UserIdentity originalUserIdentity = connectContext.getCurrentUserIdentity();
+        try {
+            Config.deploy_mode = "cloud";
+            Config.cloud_unique_id = "";
+
+            for (UserIdentity userIdentity : Arrays.asList(UserIdentity.ADMIN, UserIdentity.ROOT)) {
+                connectContext.setCurrentUserIdentity(userIdentity);
+                for (String sql : UNSUPPORTED_SQL) {
+                    IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class,
+                            () -> executeSql(sql));
+                    Assertions.assertEquals("errCode = 2, detailMessage = Unsupported operation",
+                            exception.getMessage());
+                }
+            }
+        } finally {
+            connectContext.setCurrentUserIdentity(originalUserIdentity);
+            Config.deploy_mode = originalDeployMode;
+            Config.cloud_unique_id = originalCloudUniqueId;
+        }
+    }
+}

--- a/regression-test/suites/cloud_p0/auth/test_cloud_command_restrictions.groovy
+++ b/regression-test/suites/cloud_p0/auth/test_cloud_command_restrictions.groovy
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_cloud_command_restrictions", "cloud_auth") {
+    if (!isCloudMode()) {
+        return
+    }
+
+    def user = "test_cloud_command_restrictions_admin"
+    def password = "Cloud12345"
+    sql "DROP USER IF EXISTS ${user}"
+    sql "CREATE USER ${user} IDENTIFIED BY '${password}' DEFAULT ROLE 'admin'"
+
+    def cloudUnsupportedStatements = [
+            "ADMIN CANCEL REBALANCE DISK",
+            "ADMIN CANCEL REPAIR TABLE cloud_restriction_db.missing_cloud_table",
+            "ADMIN CHECK TABLET (10000) PROPERTIES (\"type\" = \"consistency\")",
+            "ADMIN CLEAN TRASH",
+            "ADMIN REBALANCE DISK",
+            "ADMIN REPAIR TABLE cloud_restriction_db.missing_cloud_table",
+            "ADMIN SET TABLE cloud_restriction_db.missing_cloud_table PARTITION VERSION "
+                    + "PROPERTIES (\"partition_id\" = \"1\", \"visible_version\" = \"2\")",
+            "ADMIN SET REPLICA STATUS PROPERTIES (\"tablet_id\" = \"1\", \"backend_id\" = \"2\", "
+                    + "\"status\" = \"ok\")",
+            "ADMIN SET REPLICA VERSION PROPERTIES (\"tablet_id\" = \"1\", \"backend_id\" = \"2\", "
+                    + "\"version\" = \"3\")",
+            "ALTER RESOURCE missing_cloud_resource PROPERTIES (\"s3.connection.maximum\" = \"100\")",
+            "ALTER STORAGE POLICY missing_cloud_policy PROPERTIES (\"cooldown_ttl\" = \"86400\")",
+            "BACKUP SNAPSHOT cloud_restriction_db.cloud_restriction_snapshot "
+                    + "TO cloud_restriction_repository",
+            "CANCEL DECOMMISSION BACKEND '127.0.0.1:9050'",
+            "SHOW TABLET STORAGE FORMAT"
+    ]
+
+    def cloudRootOnlyStatements = [
+            "ADMIN SET FRONTEND CONFIG (\"enable_udf_in_load\" = \"true\")",
+            "ADMIN SHOW REPLICA DISTRIBUTION FROM cloud_restriction_db.missing_cloud_table"
+    ]
+
+    connect(user, password, context.config.jdbcUrl) {
+        cloudUnsupportedStatements.each { statement ->
+            test {
+                sql statement
+                exception "Unsupported operation"
+            }
+        }
+        cloudRootOnlyStatements.each { statement ->
+            test {
+                sql statement
+                exception "Unsupported operation"
+            }
+        }
+    }
+
+    cloudUnsupportedStatements.each { statement ->
+        test {
+            sql statement
+            exception "Unsupported operation"
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

Cloud-mode restrictions for Nereids commands were implemented as scattered overrides, and every caller had to remember to invoke a separate verification method before `run()`. This made the restrictions easy to bypass and left `ALTER RESOURCE` and `ALTER STORAGE POLICY` unprotected after their migration to Nereids commands.

This PR:

- adds a shared `Command.execute()` lifecycle (`before -> run -> after`) and routes production command invocations through it;
- declares cloud restrictions with reusable `CloudUnsupportedCommand` and `CloudRootOnlyCommand` marker interfaces;
- applies hard cloud-mode rejection to the unsupported admin, backup, resource, and storage-policy commands;
- keeps `ADMIN SET FRONTEND CONFIG` and `ADMIN SHOW REPLICA DISTRIBUTION` root-only in cloud mode;
- deliberately keeps `ADMIN COMPACT TABLE` supported;
- adds lifecycle/mapping tests, SQL-entry tests, and a `cloud_p0` regression suite covering both ordinary admin and root users.

### Release note

Fix cloud-mode validation for unsupported Nereids commands and centralize command restriction enforcement.

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

FE unit tests passed (17 tests):

- `CloudRestrictedCommandTest`
- `CloudUnsupportedCommandSqlTest`
- `AdminSetFrontendConfigCommandTest`
- `AdminSetReplicaVersionCommandTest`

FE-only compilation passed. The new `cloud_p0` regression suite was added but was not run locally.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Cloud mode now consistently rejects the declared unsupported commands before command-specific validation or execution. `ALTER RESOURCE` and `ALTER STORAGE POLICY` are newly covered.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
