### PR TITLE
[feat](load) support cross-AZ minimum success replica quorum on load commit

### DIFF
--- a/be/src/exec/sink/load_stream_stub.cpp
+++ b/be/src/exec/sink/load_stream_stub.cpp
@@ -63,6 +63,9 @@ int LoadStreamReplyHandler::on_received_messages(brpc::StreamId id, butil::IOBuf
 
         if (response.eos()) {
             stub->_is_eos.store(true);
+            if (response.final_tablet_result_fanout()) {
+                stub->_final_tablet_result_fanout.store(true);
+            }
         }
 
         Status st = Status::create<false>(response.status());

--- a/be/src/exec/sink/load_stream_stub.cpp
+++ b/be/src/exec/sink/load_stream_stub.cpp
@@ -170,7 +170,8 @@ Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
                             const NodeInfo& node_info, int64_t txn_id,
                             const OlapTableSchemaParam& schema,
                             const std::vector<PTabletID>& tablets_for_schema, int total_streams,
-                            int64_t idle_timeout_ms, bool enable_profile) {
+                            int64_t idle_timeout_ms, bool enable_profile,
+                            bool need_final_tablet_result) {
     std::unique_lock<bthread::Mutex> lock(_open_mutex);
     if (_is_init.load()) {
         return _status;
@@ -203,6 +204,9 @@ Status LoadStreamStub::open(BrpcClientCache<PBackendService_Stub>* client_cache,
         return _status;
     }
     request.set_idle_timeout_ms(idle_timeout_ms);
+    if (need_final_tablet_result) {
+        request.set_need_final_tablet_result(true);
+    }
     schema.to_protobuf(request.mutable_schema());
     for (auto& tablet : tablets_for_schema) {
         *request.add_tablets() = tablet;
@@ -591,7 +595,8 @@ Status LoadStreamStubs::open(BrpcClientCache<PBackendService_Stub>* client_cache
                              const NodeInfo& node_info, int64_t txn_id,
                              const OlapTableSchemaParam& schema,
                              const std::vector<PTabletID>& tablets_for_schema, int total_streams,
-                             int64_t idle_timeout_ms, bool enable_profile) {
+                             int64_t idle_timeout_ms, bool enable_profile,
+                             bool need_final_tablet_result) {
     bool get_schema = true;
     auto status = Status::OK();
     bool first_stream = true;
@@ -599,10 +604,11 @@ Status LoadStreamStubs::open(BrpcClientCache<PBackendService_Stub>* client_cache
         Status st;
         if (get_schema) {
             st = stream->open(client_cache, node_info, txn_id, schema, tablets_for_schema,
-                              total_streams, idle_timeout_ms, enable_profile);
+                              total_streams, idle_timeout_ms, enable_profile,
+                              need_final_tablet_result);
         } else {
             st = stream->open(client_cache, node_info, txn_id, schema, {}, total_streams,
-                              idle_timeout_ms, enable_profile);
+                              idle_timeout_ms, enable_profile, need_final_tablet_result);
         }
         // Simulate one stream open failure within LoadStreamStubs.
         // This causes the successfully opened streams to be cancelled,

--- a/be/src/exec/sink/load_stream_stub.h
+++ b/be/src/exec/sink/load_stream_stub.h
@@ -144,7 +144,8 @@ public:
     Status open(BrpcClientCache<PBackendService_Stub>* client_cache, const NodeInfo& node_info,
                 int64_t txn_id, const OlapTableSchemaParam& schema,
                 const std::vector<PTabletID>& tablets_for_schema, int total_streams,
-                int64_t idle_timeout_ms, bool enable_profile);
+                int64_t idle_timeout_ms, bool enable_profile,
+                bool need_final_tablet_result = false);
 
 // for mock this class in UT
 #ifdef BE_TEST
@@ -331,7 +332,8 @@ public:
     Status open(BrpcClientCache<PBackendService_Stub>* client_cache, const NodeInfo& node_info,
                 int64_t txn_id, const OlapTableSchemaParam& schema,
                 const std::vector<PTabletID>& tablets_for_schema, int total_streams,
-                int64_t idle_timeout_ms, bool enable_profile);
+                int64_t idle_timeout_ms, bool enable_profile,
+                bool need_final_tablet_result = false);
 
     bool is_incremental() const { return _is_incremental; }
 

--- a/be/src/exec/sink/load_stream_stub.h
+++ b/be/src/exec/sink/load_stream_stub.h
@@ -256,6 +256,8 @@ public:
                                  _cancel_st.to_string_no_stack());
     }
 
+    bool final_tablet_result_fanout() const { return _final_tablet_result_fanout.load(); }
+
     int64_t get_and_reset_load_back_pressure_version_wait_time_ms() {
         return _load_back_pressure_version_wait_time_ms.exchange(0);
     }
@@ -303,6 +305,7 @@ protected:
     bthread::Mutex _failed_tablets_mutex;
     std::vector<int64_t> _success_tablets;
     std::unordered_map<int64_t, Status> _failed_tablets;
+    std::atomic<bool> _final_tablet_result_fanout = false;
 
     bool _is_incremental = false;
     std::shared_ptr<CloseWaitNotifier> _close_wait_notifier;
@@ -365,6 +368,15 @@ public:
             std::copy(v.begin(), v.end(), std::inserter(s, s.end()));
         }
         return s;
+    }
+
+    bool final_tablet_result_fanout() const {
+        for (auto& stream : _streams) {
+            if (stream->final_tablet_result_fanout()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     std::unordered_map<int64_t, Status> failed_tablets() {

--- a/be/src/exec/sink/writer/vtablet_writer.cpp
+++ b/be/src/exec/sink/writer/vtablet_writer.cpp
@@ -506,12 +506,24 @@ bool IndexChannel::_quorum_success(const std::unordered_set<int64_t>& unfinished
             if (tablet == nullptr) {
                 continue;
             }
+            std::unordered_set<int64_t> successful_node_ids;
+            {
+                std::lock_guard<std::mutex> l(_fail_lock);
+                const auto failed_it = _failed_channels.find(tablet_id);
+                for (int64_t node_id : tablet->node_ids) {
+                    if (finished_node_ids.contains(node_id) &&
+                        (failed_it == _failed_channels.end() ||
+                         !failed_it->second.contains(node_id))) {
+                        successful_node_ids.insert(node_id);
+                    }
+                }
+            }
             const auto gap_it = _parent->_tablet_version_gap_backends.find(tablet_id);
             const auto* version_gap_node_ids = gap_it == _parent->_tablet_version_gap_backends.end()
                                                        ? nullptr
                                                        : &gap_it->second;
             if (!_parent->_nodes_info->is_cross_az_quorum_success(
-                        table_sink.cross_az_succ_quorum, tablet->node_ids, finished_node_ids,
+                        table_sink.cross_az_succ_quorum, tablet->node_ids, successful_node_ids,
                         version_gap_node_ids)) {
                 return false;
             }

--- a/be/src/exec/sink/writer/vtablet_writer.cpp
+++ b/be/src/exec/sink/writer/vtablet_writer.cpp
@@ -492,6 +492,32 @@ bool IndexChannel::_quorum_success(const std::unordered_set<int64_t>& unfinished
         }
     }
 
+    const auto& table_sink = _parent->_t_sink.olap_table_sink;
+    if (table_sink.__isset.cross_az_succ_quorum) {
+        std::unordered_set<int64_t> finished_node_ids;
+        for (const auto& [node_id, node_channel] : _node_channels) {
+            if (!unfinished_node_channel_ids.contains(node_id) &&
+                node_channel->check_status().ok()) {
+                finished_node_ids.insert(node_id);
+            }
+        }
+        for (int64_t tablet_id : need_finish_tablets) {
+            const auto* tablet = _parent->_location->find_tablet(tablet_id);
+            if (tablet == nullptr) {
+                continue;
+            }
+            const auto gap_it = _parent->_tablet_version_gap_backends.find(tablet_id);
+            const auto* version_gap_node_ids = gap_it == _parent->_tablet_version_gap_backends.end()
+                                                       ? nullptr
+                                                       : &gap_it->second;
+            if (!_parent->_nodes_info->is_cross_az_quorum_success(
+                        table_sink.cross_az_succ_quorum, tablet->node_ids, finished_node_ids,
+                        version_gap_node_ids)) {
+                return false;
+            }
+        }
+    }
+
     return true;
 }
 

--- a/be/src/exec/sink/writer/vtablet_writer.cpp
+++ b/be/src/exec/sink/writer/vtablet_writer.cpp
@@ -382,7 +382,8 @@ Status IndexChannel::close_wait(
         int64_t close_wait_version = this->close_wait_version();
         RETURN_IF_ERROR(check_each_node_channel_close(
                 &unfinished_node_channel_ids, node_add_batch_counter_map, writer_stats, status));
-        bool quorum_success = _quorum_success(unfinished_node_channel_ids, need_finish_tablets);
+        bool quorum_success = _quorum_success(unfinished_node_channel_ids, need_finish_tablets,
+                                              need_wait_after_quorum_success);
         if (unfinished_node_channel_ids.empty() || quorum_success) {
             LOG(INFO) << "quorum_success: " << quorum_success
                       << ", is all finished: " << unfinished_node_channel_ids.empty()
@@ -460,7 +461,8 @@ Status IndexChannel::check_each_node_channel_close(
 }
 
 bool IndexChannel::_quorum_success(const std::unordered_set<int64_t>& unfinished_node_channel_ids,
-                                   const std::unordered_set<int64_t>& need_finish_tablets) {
+                                   const std::unordered_set<int64_t>& need_finish_tablets,
+                                   bool check_cross_az) {
     if (!config::enable_quorum_success_write) {
         return false;
     }
@@ -493,29 +495,20 @@ bool IndexChannel::_quorum_success(const std::unordered_set<int64_t>& unfinished
     }
 
     const auto& table_sink = _parent->_t_sink.olap_table_sink;
-    if (table_sink.__isset.cross_az_succ_quorum) {
-        std::unordered_set<int64_t> finished_node_ids;
-        for (const auto& [node_id, node_channel] : _node_channels) {
-            if (!unfinished_node_channel_ids.contains(node_id) &&
-                node_channel->check_status().ok()) {
-                finished_node_ids.insert(node_id);
-            }
-        }
+    if (check_cross_az && table_sink.__isset.cross_az_succ_quorum) {
         for (int64_t tablet_id : need_finish_tablets) {
             const auto* tablet = _parent->_location->find_tablet(tablet_id);
             if (tablet == nullptr) {
                 continue;
             }
             std::unordered_set<int64_t> successful_node_ids;
-            {
-                std::lock_guard<std::mutex> l(_fail_lock);
-                const auto failed_it = _failed_channels.find(tablet_id);
-                for (int64_t node_id : tablet->node_ids) {
-                    if (finished_node_ids.contains(node_id) &&
-                        (failed_it == _failed_channels.end() ||
-                         !failed_it->second.contains(node_id))) {
-                        successful_node_ids.insert(node_id);
-                    }
+            for (int64_t node_id : tablet->node_ids) {
+                const auto node_channel = _node_channels.find(node_id);
+                if (node_channel != _node_channels.end() &&
+                    !unfinished_node_channel_ids.contains(node_id) &&
+                    node_channel->second->check_status().ok() &&
+                    node_channel->second->is_tablet_successful(tablet_id)) {
+                    successful_node_ids.insert(node_id);
                 }
             }
             const auto gap_it = _parent->_tablet_version_gap_backends.find(tablet_id);
@@ -1286,6 +1279,12 @@ void VNodeChannel::_add_block_success_callback(const PTabletWriterAddBlockResult
                         continue;
                     }
                 });
+                if (_parent->_t_sink.olap_table_sink.__isset.cross_az_succ_quorum) {
+                    _successful_tablet_ids.insert(tablet.tablet_id());
+                }
+                if (result.final_tablet_result_fanout()) {
+                    continue;
+                }
                 TTabletCommitInfo commit_info;
                 commit_info.tabletId = tablet.tablet_id();
                 commit_info.backendId = _node_id;
@@ -1506,6 +1505,9 @@ void VNodeChannel::mark_close(bool hang_wait) {
         }
         _cur_add_block_request->set_eos(true);
         _cur_add_block_request->set_hang_wait(hang_wait);
+        if (_parent->_t_sink.olap_table_sink.__isset.cross_az_succ_quorum) {
+            _cur_add_block_request->set_need_final_tablet_result(true);
+        }
         auto tmp_add_block_request =
                 std::make_shared<PTabletWriterAddBlockRequest>(*_cur_add_block_request);
         // when prepare to close, add block to queue so that try_send_pending_block thread will send it.

--- a/be/src/exec/sink/writer/vtablet_writer.h
+++ b/be/src/exec/sink/writer/vtablet_writer.h
@@ -335,6 +335,10 @@ public:
 
     int64_t write_bytes() const { return _write_bytes.load(); }
 
+    bool is_tablet_successful(int64_t tablet_id) const {
+        return _successful_tablet_ids.contains(tablet_id);
+    }
+
 protected:
     // make a real open request for relative BE's load channel.
     void _open_internal(bool is_incremental);
@@ -404,6 +408,7 @@ protected:
     // this local tablet id instead of failing on an empty tablet_ids list.
     std::unordered_map<int64_t, int64_t> _adaptive_partition_compat_tablets;
     std::vector<TTabletCommitInfo> _tablet_commit_infos;
+    std::unordered_set<int64_t> _successful_tablet_ids;
 
     AddBatchCounter _add_batch_counter;
     std::atomic<int64_t> _serialize_batch_ns {0};
@@ -588,7 +593,8 @@ private:
     int _load_required_replicas_num(int64_t tablet_id);
 
     bool _quorum_success(const std::unordered_set<int64_t>& unfinished_node_channel_ids,
-                         const std::unordered_set<int64_t>& need_finish_tablets);
+                         const std::unordered_set<int64_t>& need_finish_tablets,
+                         bool check_cross_az = true);
 
     int64_t _calc_max_wait_time_ms(const std::unordered_set<int64_t>& unfinished_node_channel_ids);
 

--- a/be/src/exec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/exec/sink/writer/vtablet_writer_v2.cpp
@@ -908,7 +908,9 @@ bool VTabletWriterV2::_quorum_success(
     }
 
     // 1. calculate finished tablets replica num
+    const auto& table_sink = _t_sink.olap_table_sink;
     std::unordered_set<int64_t> finished_dst_ids;
+    std::unordered_map<int64_t, std::unordered_set<int64_t>> successful_dst_ids_by_tablet;
     std::unordered_map<int64_t, int64_t> finished_tablets_replica;
     for (const auto& [dst_id, streams] : streams_for_node) {
         bool finished = true;
@@ -922,6 +924,11 @@ bool VTabletWriterV2::_quorum_success(
         }
         if (finished) {
             finished_dst_ids.insert(dst_id);
+            if (table_sink.__isset.cross_az_succ_quorum) {
+                for (int64_t tablet_id : streams->success_tablets()) {
+                    successful_dst_ids_by_tablet[tablet_id].insert(dst_id);
+                }
+            }
         }
     }
     for (const auto& [dst_id, _] : streams_for_node) {
@@ -945,7 +952,6 @@ bool VTabletWriterV2::_quorum_success(
             return false;
         }
     }
-    const auto& table_sink = _t_sink.olap_table_sink;
     if (table_sink.__isset.cross_az_succ_quorum) {
         for (int64_t tablet_id : need_finish_tablets) {
             const auto* tablet = _location->find_tablet(tablet_id);
@@ -955,9 +961,9 @@ bool VTabletWriterV2::_quorum_success(
             const auto gap_it = _tablet_version_gap_backends.find(tablet_id);
             const auto* version_gap_node_ids =
                     gap_it == _tablet_version_gap_backends.end() ? nullptr : &gap_it->second;
-            if (!_nodes_info->is_cross_az_quorum_success(table_sink.cross_az_succ_quorum,
-                                                         tablet->node_ids, finished_dst_ids,
-                                                         version_gap_node_ids)) {
+            if (!_nodes_info->is_cross_az_quorum_success(
+                        table_sink.cross_az_succ_quorum, tablet->node_ids,
+                        successful_dst_ids_by_tablet[tablet_id], version_gap_node_ids)) {
                 return false;
             }
         }

--- a/be/src/exec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/exec/sink/writer/vtablet_writer_v2.cpp
@@ -1111,11 +1111,15 @@ Status VTabletWriterV2::_create_commit_info(std::vector<TTabletCommitInfo>& tabl
             failed_reason[tablet_id] = reason;
             num_failed_tablets++;
         }
+        const bool final_result_fanout = _t_sink.olap_table_sink.__isset.cross_az_succ_quorum &&
+                                         streams.final_tablet_result_fanout();
         for (auto tablet_id : streams.success_tablets()) {
-            TTabletCommitInfo commit_info;
-            commit_info.tabletId = tablet_id;
-            commit_info.backendId = dst_id;
-            tablet_commit_infos.emplace_back(std::move(commit_info));
+            if (!final_result_fanout) {
+                TTabletCommitInfo commit_info;
+                commit_info.tabletId = tablet_id;
+                commit_info.backendId = dst_id;
+                tablet_commit_infos.emplace_back(std::move(commit_info));
+            }
             // Only count non-gap backends toward success
             auto gap_it = _tablet_version_gap_backends.find(tablet_id);
             if (gap_it == _tablet_version_gap_backends.end() ||

--- a/be/src/exec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/exec/sink/writer/vtablet_writer_v2.cpp
@@ -945,6 +945,23 @@ bool VTabletWriterV2::_quorum_success(
             return false;
         }
     }
+    const auto& table_sink = _t_sink.olap_table_sink;
+    if (table_sink.__isset.cross_az_succ_quorum) {
+        for (int64_t tablet_id : need_finish_tablets) {
+            const auto* tablet = _location->find_tablet(tablet_id);
+            if (tablet == nullptr) {
+                continue;
+            }
+            const auto gap_it = _tablet_version_gap_backends.find(tablet_id);
+            const auto* version_gap_node_ids =
+                    gap_it == _tablet_version_gap_backends.end() ? nullptr : &gap_it->second;
+            if (!_nodes_info->is_cross_az_quorum_success(table_sink.cross_az_succ_quorum,
+                                                         tablet->node_ids, finished_dst_ids,
+                                                         version_gap_node_ids)) {
+                return false;
+            }
+        }
+    }
     return true;
 }
 

--- a/be/src/exec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/exec/sink/writer/vtablet_writer_v2.cpp
@@ -320,7 +320,8 @@ Status VTabletWriterV2::_open_streams_to_backend(int64_t dst_id, LoadStreamStubs
                     { tablets_for_schema.clear(); });
     auto st = streams.open(_state->exec_env()->brpc_streaming_client_cache(), *node_info, _txn_id,
                            *_schema, tablets_for_schema, _total_streams, idle_timeout_ms,
-                           _state->enable_profile());
+                           _state->enable_profile(),
+                           _t_sink.olap_table_sink.__isset.cross_az_succ_quorum);
     if (!st.ok()) {
         LOG(WARNING) << "failed to open stream to backend " << dst_id
                      << ", load_id=" << print_id(_load_id) << ", err=" << st;
@@ -850,7 +851,8 @@ Status VTabletWriterV2::_close_wait(
         int64_t close_wait_version = _load_stream_map->close_wait_version();
         RETURN_IF_ERROR(_check_timeout());
         RETURN_IF_ERROR(_check_streams_finish(unfinished_streams, status, streams_for_node));
-        bool quorum_success = _quorum_success(unfinished_streams, need_finish_tablets);
+        bool quorum_success = _quorum_success(unfinished_streams, need_finish_tablets,
+                                              need_wait_after_quorum_success);
         if (quorum_success || unfinished_streams.empty()) {
             LOG(INFO) << "quorum_success: " << quorum_success
                       << ", is all finished: " << unfinished_streams.empty()
@@ -898,7 +900,7 @@ Status VTabletWriterV2::_close_wait(
 
 bool VTabletWriterV2::_quorum_success(
         const std::unordered_set<std::shared_ptr<LoadStreamStub>>& unfinished_streams,
-        const std::unordered_set<int64_t>& need_finish_tablets) {
+        const std::unordered_set<int64_t>& need_finish_tablets, bool final_close_stage) {
     if (!config::enable_quorum_success_write) {
         return false;
     }
@@ -924,7 +926,7 @@ bool VTabletWriterV2::_quorum_success(
         }
         if (finished) {
             finished_dst_ids.insert(dst_id);
-            if (table_sink.__isset.cross_az_succ_quorum) {
+            if (final_close_stage && table_sink.__isset.cross_az_succ_quorum) {
                 for (int64_t tablet_id : streams->success_tablets()) {
                     successful_dst_ids_by_tablet[tablet_id].insert(dst_id);
                 }
@@ -952,7 +954,7 @@ bool VTabletWriterV2::_quorum_success(
             return false;
         }
     }
-    if (table_sink.__isset.cross_az_succ_quorum) {
+    if (final_close_stage && table_sink.__isset.cross_az_succ_quorum) {
         for (int64_t tablet_id : need_finish_tablets) {
             const auto* tablet = _location->find_tablet(tablet_id);
             if (tablet == nullptr) {

--- a/be/src/exec/sink/writer/vtablet_writer_v2.h
+++ b/be/src/exec/sink/writer/vtablet_writer_v2.h
@@ -153,7 +153,7 @@ private:
 
     bool _quorum_success(
             const std::unordered_set<std::shared_ptr<LoadStreamStub>>& unfinished_streams,
-            const std::unordered_set<int64_t>& need_finish_tablets);
+            const std::unordered_set<int64_t>& need_finish_tablets, bool final_close_stage = true);
 
     int _load_required_replicas_num(int64_t tablet_id);
 

--- a/be/src/load/channel/load_channel.cpp
+++ b/be/src/load/channel/load_channel.cpp
@@ -291,6 +291,9 @@ Status LoadChannel::_handle_eos(BaseTabletsChannel* channel,
 void LoadChannel::_reserve_final_tablet_result(int64_t index_id) {
     std::lock_guard<std::mutex> lock(_final_tablet_result_lock);
     _need_final_tablet_result.store(true);
+    if (_cancelled.load() && _final_tablet_result_cancel_status.ok()) {
+        _final_tablet_result_cancel_status = Status::Cancelled("Load channel cancelled");
+    }
     _final_tablet_results.try_emplace(index_id);
 }
 

--- a/be/src/load/channel/load_channel.cpp
+++ b/be/src/load/channel/load_channel.cpp
@@ -21,6 +21,8 @@
 #include <glog/logging.h>
 #include <google/protobuf/stubs/callback.h>
 
+#include <algorithm>
+
 #include "cloud/cloud_tablets_channel.h"
 #include "cloud/config.h"
 #include "common/logging.h"
@@ -432,7 +434,13 @@ bool LoadChannel::is_finished() {
         return false;
     }
     std::lock_guard<std::mutex> l(_lock);
-    return _tablets_channels.empty();
+    if (!_tablets_channels.empty() || !need_final_tablet_result()) {
+        return _tablets_channels.empty();
+    }
+    std::lock_guard<std::mutex> result_lock(_final_tablet_result_lock);
+    return std::ranges::all_of(_final_tablet_results, [](const auto& result) {
+        return result.second.tablet_result != nullptr;
+    });
 }
 
 bool LoadChannel::copy_final_tablet_results(std::unordered_map<int64_t, FinalTabletResult>* results,

--- a/be/src/load/channel/load_channel.cpp
+++ b/be/src/load/channel/load_channel.cpp
@@ -19,6 +19,7 @@
 
 #include <gen_cpp/internal_service.pb.h>
 #include <glog/logging.h>
+#include <google/protobuf/stubs/callback.h>
 
 #include "cloud/cloud_tablets_channel.h"
 #include "cloud/config.h"
@@ -36,6 +37,14 @@
 namespace doris {
 
 bvar::Adder<int64_t> g_loadchannel_cnt("loadchannel_cnt");
+
+static void copy_final_tablet_result(PTabletWriterAddBlockResult* response,
+                                     const PTabletWriterAddBlockResult& result, bool fanout) {
+    response->mutable_status()->CopyFrom(result.status());
+    response->mutable_tablet_vec()->CopyFrom(result.tablet_vec());
+    response->mutable_tablet_errors()->CopyFrom(result.tablet_errors());
+    response->set_final_tablet_result_fanout(fanout);
+}
 
 LoadChannel::LoadChannel(const UniqueId& load_id, int64_t timeout_s, bool is_high_priority,
                          std::string sender_ip, int64_t backend_id, bool enable_profile,
@@ -79,6 +88,7 @@ LoadChannel::LoadChannel(const UniqueId& load_id, int64_t timeout_s, bool is_hig
 }
 
 LoadChannel::~LoadChannel() {
+    _cancel_final_tablet_result_waiters(Status::Cancelled("Load channel removed"));
     g_loadchannel_cnt << -1;
     std::stringstream rows_str;
     for (const auto& entry : _tablets_channels_rows) {
@@ -179,7 +189,8 @@ Status LoadChannel::_get_tablets_channel(std::shared_ptr<BaseTabletsChannel>& ch
 }
 
 Status LoadChannel::add_batch(const PTabletWriterAddBlockRequest& request,
-                              PTabletWriterAddBlockResult* response) {
+                              PTabletWriterAddBlockResult* response,
+                              google::protobuf::Closure** done) {
     DBUG_EXECUTE_IF("LoadChannel.add_batch.failed",
                     { return Status::InternalError("fault injection"); });
     SCOPED_TIMER(_add_batch_timer);
@@ -193,6 +204,9 @@ Status LoadChannel::add_batch(const PTabletWriterAddBlockRequest& request,
     bool is_finished = false;
     Status st = _get_tablets_channel(channel, is_finished, index_id);
     if (!st.ok() || is_finished) {
+        if (st.ok() && request.eos() && request.need_final_tablet_result()) {
+            _defer_or_copy_final_tablet_result(index_id, request.sender_id(), response, done);
+        }
         return st;
     }
 
@@ -207,8 +221,19 @@ Status LoadChannel::add_batch(const PTabletWriterAddBlockRequest& request,
     // 3. handle eos
     // if channel is incremental, maybe hang on close until all close request arrived.
     if (request.has_eos() && request.eos()) {
-        st = _handle_eos(channel.get(), request, response);
+        bool finished = false;
+        st = _handle_eos(channel.get(), request, response, &finished);
         _report_profile(response);
+        if (finished && need_final_tablet_result()) {
+            st.to_protobuf(response->mutable_status());
+            _publish_final_tablet_result(index_id, request.sender_id(), *response);
+            if (request.need_final_tablet_result()) {
+                _defer_or_copy_final_tablet_result(index_id, request.sender_id(), response, done);
+            }
+        } else if (request.need_final_tablet_result() && st.ok()) {
+            st.to_protobuf(response->mutable_status());
+            _defer_or_copy_final_tablet_result(index_id, request.sender_id(), response, done);
+        }
         if (!st.ok()) {
             return st;
         }
@@ -221,17 +246,18 @@ Status LoadChannel::add_batch(const PTabletWriterAddBlockRequest& request,
 
 Status LoadChannel::_handle_eos(BaseTabletsChannel* channel,
                                 const PTabletWriterAddBlockRequest& request,
-                                PTabletWriterAddBlockResult* response) {
+                                PTabletWriterAddBlockResult* response, bool* finished) {
     if (_enable_profile) {
         _self_profile->add_info_string("EosHost", fmt::format("{}", request.backend_id()));
     }
-    bool finished = false;
     auto index_id = request.index_id();
 
-    RETURN_IF_ERROR(channel->close(this, request, response, &finished));
+    RETURN_IF_ERROR(channel->close(this, request, response, finished));
 
     // for init node, we close waiting(hang on) all close request and let them return together.
-    if (request.has_hang_wait() && request.hang_wait()) {
+    // Cross-AZ final-result fan-out replaces this busy-wait barrier and completes after the final
+    // tablets-channel close result is published.
+    if (request.has_hang_wait() && request.hang_wait() && !request.need_final_tablet_result()) {
         DCHECK(!channel->is_incremental_channel());
         VLOG_DEBUG << fmt::format("txn {}: reciever index {} close waiting by sender {}", _txn_id,
                                   request.index_id(), request.sender_id());
@@ -247,7 +273,7 @@ Status LoadChannel::_handle_eos(BaseTabletsChannel* channel,
         }
     }
 
-    if (finished) {
+    if (*finished) {
         std::lock_guard<std::mutex> l(_lock);
         {
             std::lock_guard<std::mutex> lt(_tablets_channels_lock);
@@ -260,6 +286,108 @@ Status LoadChannel::_handle_eos(BaseTabletsChannel* channel,
         _finished_channel_ids.emplace(index_id);
     }
     return Status::OK();
+}
+
+void LoadChannel::_reserve_final_tablet_result(int64_t index_id) {
+    std::lock_guard<std::mutex> lock(_final_tablet_result_lock);
+    _need_final_tablet_result.store(true);
+    _final_tablet_results.try_emplace(index_id);
+}
+
+void LoadChannel::_defer_or_copy_final_tablet_result(int64_t index_id, int32_t sender_id,
+                                                     PTabletWriterAddBlockResult* response,
+                                                     google::protobuf::Closure** done) {
+    std::shared_ptr<PTabletWriterAddBlockResult> tablet_result;
+    bool fanout = false;
+    {
+        std::lock_guard<std::mutex> lock(_final_tablet_result_lock);
+        _need_final_tablet_result.store(true);
+        auto& state = _final_tablet_results[index_id];
+        if (state.tablet_result != nullptr) {
+            tablet_result = state.tablet_result;
+            fanout = sender_id != state.owner_sender_id;
+        } else if (!_final_tablet_result_cancel_status.ok()) {
+            state.tablet_result = std::make_shared<PTabletWriterAddBlockResult>();
+            _final_tablet_result_cancel_status.to_protobuf(state.tablet_result->mutable_status());
+            tablet_result = state.tablet_result;
+        } else {
+            DORIS_CHECK(done != nullptr && *done != nullptr);
+            for (const auto& error : response->tablet_errors()) {
+                state.tablet_errors.try_emplace(error.tablet_id(), error);
+            }
+            state.waiters.push_back({response, *done});
+            *done = nullptr;
+            return;
+        }
+    }
+    copy_final_tablet_result(response, *tablet_result, fanout);
+}
+
+void LoadChannel::_publish_final_tablet_result(int64_t index_id, int32_t sender_id,
+                                               const PTabletWriterAddBlockResult& result) {
+    std::shared_ptr<PTabletWriterAddBlockResult> tablet_result;
+    std::vector<FinalTabletResultWaiter> waiters;
+    {
+        std::lock_guard<std::mutex> lock(_final_tablet_result_lock);
+        _need_final_tablet_result.store(true);
+        auto state_it = _final_tablet_results.find(index_id);
+        if (state_it == _final_tablet_results.end()) {
+            state_it = _final_tablet_results.emplace(index_id, FinalTabletResultState()).first;
+        }
+        auto& state = state_it->second;
+        if (state.tablet_result != nullptr) {
+            return;
+        }
+        state.tablet_result = std::make_shared<PTabletWriterAddBlockResult>();
+        state.owner_sender_id = sender_id;
+        if (_final_tablet_result_cancel_status.ok()) {
+            state.tablet_result->mutable_status()->CopyFrom(result.status());
+            state.tablet_result->mutable_tablet_vec()->CopyFrom(result.tablet_vec());
+            for (const auto& error : result.tablet_errors()) {
+                state.tablet_errors.try_emplace(error.tablet_id(), error);
+            }
+            for (const auto& [_, error] : state.tablet_errors) {
+                state.tablet_result->add_tablet_errors()->CopyFrom(error);
+            }
+        } else {
+            _final_tablet_result_cancel_status.to_protobuf(state.tablet_result->mutable_status());
+        }
+        tablet_result = state.tablet_result;
+        waiters.swap(state.waiters);
+    }
+    for (auto& waiter : waiters) {
+        copy_final_tablet_result(waiter.response, *tablet_result, true);
+        waiter.done->Run();
+    }
+}
+
+void LoadChannel::_cancel_final_tablet_result_waiters(const Status& reason) {
+    if (!_need_final_tablet_result.load()) {
+        return;
+    }
+    std::vector<std::pair<std::shared_ptr<PTabletWriterAddBlockResult>,
+                          std::vector<FinalTabletResultWaiter>>>
+            completions;
+    {
+        std::lock_guard<std::mutex> lock(_final_tablet_result_lock);
+        if (_final_tablet_result_cancel_status.ok()) {
+            _final_tablet_result_cancel_status = reason;
+        }
+        for (auto& [_, state] : _final_tablet_results) {
+            if (state.tablet_result != nullptr) {
+                continue;
+            }
+            state.tablet_result = std::make_shared<PTabletWriterAddBlockResult>();
+            _final_tablet_result_cancel_status.to_protobuf(state.tablet_result->mutable_status());
+            completions.emplace_back(state.tablet_result, std::move(state.waiters));
+        }
+    }
+    for (auto& [result, waiters] : completions) {
+        for (auto& waiter : waiters) {
+            copy_final_tablet_result(waiter.response, *result, false);
+            waiter.done->Run();
+        }
+    }
 }
 
 void LoadChannel::_report_profile(PTabletWriterAddBlockResult* response) {
@@ -304,11 +432,38 @@ bool LoadChannel::is_finished() {
     return _tablets_channels.empty();
 }
 
-Status LoadChannel::cancel() {
+bool LoadChannel::copy_final_tablet_results(std::unordered_map<int64_t, FinalTabletResult>* results,
+                                            size_t max_bytes, bool* oversized,
+                                            size_t* result_bytes) const {
+    std::lock_guard<std::mutex> lock(_final_tablet_result_lock);
+    results->clear();
+    *oversized = false;
+    *result_bytes = 0;
+    for (const auto& [_, state] : _final_tablet_results) {
+        if (state.tablet_result == nullptr) {
+            return false;
+        }
+        const size_t bytes = state.tablet_result->SpaceUsedLong();
+        if (bytes > max_bytes - *result_bytes) {
+            *oversized = true;
+            return true;
+        }
+        *result_bytes += bytes;
+    }
+    for (const auto& [index_id, state] : _final_tablet_results) {
+        results->emplace(index_id, FinalTabletResult {*state.tablet_result, state.owner_sender_id});
+    }
+    return true;
+}
+
+Status LoadChannel::cancel(const Status& reason) {
     _cancelled.store(true);
-    std::lock_guard<std::mutex> l(_lock);
-    for (auto& it : _tablets_channels) {
-        static_cast<void>(it.second->cancel());
+    _cancel_final_tablet_result_waiters(reason);
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        for (auto& it : _tablets_channels) {
+            static_cast<void>(it.second->cancel());
+        }
     }
     return Status::OK();
 }

--- a/be/src/load/channel/load_channel.h
+++ b/be/src/load/channel/load_channel.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <gen_cpp/internal_service.pb.h>
+
 #include <atomic>
 #include <cstdint>
 #include <memory>
@@ -26,6 +28,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include "common/status.h"
 #include "runtime/runtime_profile.h"
@@ -33,18 +36,24 @@
 #include "runtime/workload_management/resource_context.h"
 #include "util/uid_util.h"
 
+namespace google::protobuf {
+class Closure;
+}
+
 namespace doris {
 
-class PTabletWriterOpenRequest;
-class PTabletWriterAddBlockRequest;
-class PTabletWriterAddBlockResult;
-class OpenPartitionRequest;
 class BaseTabletsChannel;
+class LoadChannelMgr;
 
 // A LoadChannel manages tablets channels for all indexes
 // corresponding to a certain load job
 class LoadChannel {
 public:
+    struct FinalTabletResult {
+        PTabletWriterAddBlockResult result;
+        int32_t owner_sender_id = -1;
+    };
+
     LoadChannel(const UniqueId& load_id, int64_t timeout_s, bool is_high_priority,
                 std::string sender_ip, int64_t backend_id, bool enable_profile, int64_t wg_id);
     ~LoadChannel();
@@ -54,12 +63,17 @@ public:
 
     // this batch must belong to a index in one transaction
     Status add_batch(const PTabletWriterAddBlockRequest& request,
-                     PTabletWriterAddBlockResult* response);
+                     PTabletWriterAddBlockResult* response,
+                     google::protobuf::Closure** done = nullptr);
 
     // return true if this load channel has been opened and all tablets channels are closed then.
     bool is_finished();
 
-    Status cancel();
+    bool need_final_tablet_result() const { return _need_final_tablet_result.load(); }
+    bool copy_final_tablet_results(std::unordered_map<int64_t, FinalTabletResult>* results,
+                                   size_t max_bytes, bool* oversized, size_t* result_bytes) const;
+
+    Status cancel(const Status& reason = Status::Cancelled("Load channel cancelled"));
 
     time_t last_updated_time() const { return _last_updated_time.load(); }
 
@@ -81,13 +95,24 @@ protected:
                                 int64_t index_id);
 
     Status _handle_eos(BaseTabletsChannel* channel, const PTabletWriterAddBlockRequest& request,
-                       PTabletWriterAddBlockResult* response);
+                       PTabletWriterAddBlockResult* response, bool* finished);
+
+    void _defer_or_copy_final_tablet_result(int64_t index_id, int32_t sender_id,
+                                            PTabletWriterAddBlockResult* response,
+                                            google::protobuf::Closure** done);
+    void _publish_final_tablet_result(int64_t index_id, int32_t sender_id,
+                                      const PTabletWriterAddBlockResult& result);
+    void _cancel_final_tablet_result_waiters(const Status& reason);
 
     void _init_profile();
     // thread safety
     void _report_profile(PTabletWriterAddBlockResult* response);
 
 private:
+    friend class LoadChannelMgr;
+
+    void _reserve_final_tablet_result(int64_t index_id);
+
     UniqueId _load_id;
     int64_t _txn_id = 0;
 
@@ -131,6 +156,21 @@ private:
     int64_t _backend_id;
 
     bool _enable_profile;
+
+    struct FinalTabletResultWaiter {
+        PTabletWriterAddBlockResult* response = nullptr;
+        google::protobuf::Closure* done = nullptr;
+    };
+    struct FinalTabletResultState {
+        std::shared_ptr<PTabletWriterAddBlockResult> tablet_result;
+        int32_t owner_sender_id = -1;
+        std::vector<FinalTabletResultWaiter> waiters;
+        std::unordered_map<int64_t, PTabletError> tablet_errors;
+    };
+    mutable std::mutex _final_tablet_result_lock;
+    std::atomic<bool> _need_final_tablet_result {false};
+    std::unordered_map<int64_t, FinalTabletResultState> _final_tablet_results;
+    Status _final_tablet_result_cancel_status;
 };
 
 inline std::ostream& operator<<(std::ostream& os, LoadChannel& load_channel) {

--- a/be/src/load/channel/load_channel_mgr.cpp
+++ b/be/src/load/channel/load_channel_mgr.cpp
@@ -238,7 +238,6 @@ Status LoadChannelMgr::add_batch(const PTabletWriterAddBlockRequest& request,
 
 void LoadChannelMgr::_finish_load_channel(const UniqueId load_id,
                                           const std::shared_ptr<LoadChannel>& channel) {
-    VLOG_NOTICE << "removing load channel " << load_id << " because it's finished";
     const std::string cache_key = load_id.to_string();
     bool need_final_tablet_result = false;
     {
@@ -267,7 +266,6 @@ void LoadChannelMgr::_finish_load_channel(const UniqueId load_id,
             _finishing_load_channels.erase(load_id);
         }
     });
-
     std::unique_ptr<FinalTabletResultCache::CacheValue> cache_value;
     DBUG_EXECUTE_IF("LoadChannelMgr.finish.before_copy", DBUG_RUN_CALLBACK());
     size_t cache_size = 0;
@@ -276,18 +274,17 @@ void LoadChannelMgr::_finish_load_channel(const UniqueId load_id,
     size_t result_bytes = 0;
     const size_t cache_overhead =
             sizeof(FinalTabletResultCache::CacheValue) + sizeof(LRUHandle) - 1 + cache_key.size();
-    const bool ready = channel->copy_final_tablet_results(
+    DORIS_CHECK(channel->copy_final_tablet_results(
             &final_tablet_results, FinalTabletResultCache::MAX_BYTES - cache_overhead, &oversized,
-            &result_bytes);
-    if (ready && !oversized && !final_tablet_results.empty()) {
+            &result_bytes));
+    if (!oversized && !final_tablet_results.empty()) {
         cache_value = std::make_unique<FinalTabletResultCache::CacheValue>();
         cache_value->_results = std::move(final_tablet_results);
         cache_size = sizeof(FinalTabletResultCache::CacheValue) + result_bytes;
-    } else if (!ready || oversized) {
+    } else if (oversized) {
         LOG(WARNING) << "Skip caching final tablet result for load " << load_id
-                     << ", ready=" << ready << ", oversized=" << oversized;
+                     << ", oversized=" << oversized;
     }
-
     Cache::Handle* result_handle = nullptr;
     Defer release_result_handle([this, &result_handle] {
         if (result_handle != nullptr) {
@@ -300,7 +297,6 @@ void LoadChannelMgr::_finish_load_channel(const UniqueId load_id,
                                                            cache_size);
         cache_value.release();
     }
-
     bool published = false;
     {
         std::lock_guard<std::mutex> l(_lock);

--- a/be/src/load/channel/load_channel_mgr.cpp
+++ b/be/src/load/channel/load_channel_mgr.cpp
@@ -35,6 +35,7 @@
 #include "common/metrics/metrics.h"
 #include "load/channel/load_channel.h"
 #include "runtime/exec_env.h"
+#include "util/debug_points.h"
 #include "util/thread.h"
 
 namespace doris {
@@ -141,7 +142,7 @@ Status LoadChannelMgr::_get_load_channel(std::shared_ptr<LoadChannel>& channel, 
                                 _final_tablet_result_cache->lookup(load_id.to_string());
                         if (result_handle == nullptr) {
                             LOG(WARNING) << "Final tablet result is unavailable for retried load "
-                                         << load_id;
+                                         << load_id << ", sender_id=" << request.sender_id();
                             is_eof = true;
                             return Status::OK();
                         }
@@ -152,7 +153,8 @@ Status LoadChannelMgr::_get_load_channel(std::shared_ptr<LoadChannel>& channel, 
                         if (result == result_cache_value->_results.end()) {
                             _final_tablet_result_cache->release(result_handle);
                             LOG(WARNING) << "Final tablet result is unavailable for retried load "
-                                         << load_id << ", index_id=" << request.index_id();
+                                         << load_id << ", index_id=" << request.index_id()
+                                         << ", sender_id=" << request.sender_id();
                             is_eof = true;
                             return Status::OK();
                         }
@@ -234,9 +236,11 @@ void LoadChannelMgr::_finish_load_channel(const UniqueId load_id,
         need_final_tablet_result = channel->need_final_tablet_result();
         if (!need_final_tablet_result) {
             _load_channels.erase(channel_it);
-            auto* handle = _load_state_channels->insert(cache_key, nullptr, 1, 1);
-            _load_state_channels->release(handle);
         }
+        // Cross-AZ retains the active channel for the lock-free copy, but publishes success now
+        // so cancel cannot remove the only retry tombstone during that window.
+        auto* handle = _load_state_channels->insert(cache_key, nullptr, 1, 1);
+        _load_state_channels->release(handle);
     }
     if (!need_final_tablet_result) {
         VLOG_CRITICAL << "removed load channel " << load_id;
@@ -244,6 +248,7 @@ void LoadChannelMgr::_finish_load_channel(const UniqueId load_id,
     }
 
     std::unique_ptr<FinalTabletResultCache::CacheValue> cache_value;
+    DBUG_EXECUTE_IF("LoadChannelMgr.finish.before_copy", DBUG_RUN_CALLBACK());
     size_t cache_size = 0;
     std::unordered_map<int64_t, LoadChannel::FinalTabletResult> final_tablet_results;
     bool oversized = false;

--- a/be/src/load/channel/load_channel_mgr.cpp
+++ b/be/src/load/channel/load_channel_mgr.cpp
@@ -75,6 +75,7 @@ void LoadChannelMgr::stop() {
 
 Status LoadChannelMgr::init(int64_t process_mem_limit) {
     _load_state_channels = std::make_unique<LoadStateChannelCache>(1024);
+    _final_tablet_result_cache = std::make_unique<FinalTabletResultCache>();
     RETURN_IF_ERROR(_start_bg_worker());
     return Status::OK();
 }
@@ -112,7 +113,8 @@ Status LoadChannelMgr::open(const PTabletWriterOpenRequest& params) {
 
 Status LoadChannelMgr::_get_load_channel(std::shared_ptr<LoadChannel>& channel, bool& is_eof,
                                          const UniqueId& load_id,
-                                         const PTabletWriterAddBlockRequest& request) {
+                                         const PTabletWriterAddBlockRequest& request,
+                                         PTabletWriterAddBlockResult* response) {
     is_eof = false;
     std::lock_guard<std::mutex> l(_lock);
     auto it = _load_channels.find(load_id);
@@ -121,7 +123,8 @@ Status LoadChannelMgr::_get_load_channel(std::shared_ptr<LoadChannel>& channel, 
         if (handle != nullptr) {
             // load is cancelled
             if (auto* value = _load_state_channels->value(handle); value != nullptr) {
-                const auto& cancel_reason = reinterpret_cast<CacheValue*>(value)->_cancel_reason;
+                const auto* cache_value = reinterpret_cast<CacheValue*>(value);
+                const auto& cancel_reason = cache_value->_cancel_reason;
                 _load_state_channels->release(handle);
                 if (!cancel_reason.empty()) {
                     LOG(INFO) << fmt::format(
@@ -133,6 +136,31 @@ Status LoadChannelMgr::_get_load_channel(std::shared_ptr<LoadChannel>& channel, 
                 // load is success, success only when eos be true
                 _load_state_channels->release(handle);
                 if (request.has_eos() && request.eos()) {
+                    if (request.need_final_tablet_result()) {
+                        auto* result_handle =
+                                _final_tablet_result_cache->lookup(load_id.to_string());
+                        if (result_handle == nullptr) {
+                            LOG(WARNING) << "Final tablet result is unavailable for retried load "
+                                         << load_id;
+                            is_eof = true;
+                            return Status::OK();
+                        }
+                        const auto* result_cache_value =
+                                reinterpret_cast<FinalTabletResultCache::CacheValue*>(
+                                        _final_tablet_result_cache->value(result_handle));
+                        const auto result = result_cache_value->_results.find(request.index_id());
+                        if (result == result_cache_value->_results.end()) {
+                            _final_tablet_result_cache->release(result_handle);
+                            LOG(WARNING) << "Final tablet result is unavailable for retried load "
+                                         << load_id << ", index_id=" << request.index_id();
+                            is_eof = true;
+                            return Status::OK();
+                        }
+                        response->CopyFrom(result->second.result);
+                        response->set_final_tablet_result_fanout(request.sender_id() !=
+                                                                 result->second.owner_sender_id);
+                        _final_tablet_result_cache->release(result_handle);
+                    }
                     is_eof = true;
                     return Status::OK();
                 }
@@ -145,16 +173,20 @@ Status LoadChannelMgr::_get_load_channel(std::shared_ptr<LoadChannel>& channel, 
                 load_id.to_string());
     }
     channel = it->second;
+    if (request.eos() && request.need_final_tablet_result()) {
+        channel->_reserve_final_tablet_result(request.index_id());
+    }
     return Status::OK();
 }
 
 Status LoadChannelMgr::add_batch(const PTabletWriterAddBlockRequest& request,
-                                 PTabletWriterAddBlockResult* response) {
+                                 PTabletWriterAddBlockResult* response,
+                                 google::protobuf::Closure** done) {
     UniqueId load_id(request.id());
     // 1. get load channel
     std::shared_ptr<LoadChannel> channel;
     bool is_eof;
-    auto status = _get_load_channel(channel, is_eof, load_id, request);
+    auto status = _get_load_channel(channel, is_eof, load_id, request, response);
     if (!status.ok() || is_eof) {
         return status;
     }
@@ -175,27 +207,76 @@ Status LoadChannelMgr::add_batch(const PTabletWriterAddBlockRequest& request,
     // 3. add batch to load channel
     // batch may not exist in request(eg: eos request without batch),
     // this case will be handled in load channel's add batch method.
-    Status st = channel->add_batch(request, response);
+    Status st = channel->add_batch(request, response, done);
     if (UNLIKELY(!st.ok())) {
-        RETURN_IF_ERROR(channel->cancel());
+        RETURN_IF_ERROR(channel->cancel(st));
         return st;
     }
 
     // 4. handle finish
     if (channel->is_finished()) {
-        _finish_load_channel(load_id);
+        _finish_load_channel(load_id, channel);
     }
     return Status::OK();
 }
 
-void LoadChannelMgr::_finish_load_channel(const UniqueId load_id) {
+void LoadChannelMgr::_finish_load_channel(const UniqueId load_id,
+                                          const std::shared_ptr<LoadChannel>& channel) {
     VLOG_NOTICE << "removing load channel " << load_id << " because it's finished";
+    const std::string cache_key = load_id.to_string();
+    bool need_final_tablet_result = false;
     {
         std::lock_guard<std::mutex> l(_lock);
-        if (_load_channels.contains(load_id)) {
-            _load_channels.erase(load_id);
+        const auto channel_it = _load_channels.find(load_id);
+        if (channel_it == _load_channels.end() || channel_it->second != channel) {
+            return;
         }
-        auto* handle = _load_state_channels->insert(load_id.to_string(), nullptr, 1, 1);
+        need_final_tablet_result = channel->need_final_tablet_result();
+        if (!need_final_tablet_result) {
+            _load_channels.erase(channel_it);
+            auto* handle = _load_state_channels->insert(cache_key, nullptr, 1, 1);
+            _load_state_channels->release(handle);
+        }
+    }
+    if (!need_final_tablet_result) {
+        VLOG_CRITICAL << "removed load channel " << load_id;
+        return;
+    }
+
+    std::unique_ptr<FinalTabletResultCache::CacheValue> cache_value;
+    size_t cache_size = 0;
+    std::unordered_map<int64_t, LoadChannel::FinalTabletResult> final_tablet_results;
+    bool oversized = false;
+    size_t result_bytes = 0;
+    const size_t cache_overhead =
+            sizeof(FinalTabletResultCache::CacheValue) + sizeof(LRUHandle) - 1 + cache_key.size();
+    const bool ready = channel->copy_final_tablet_results(
+            &final_tablet_results, FinalTabletResultCache::MAX_BYTES - cache_overhead, &oversized,
+            &result_bytes);
+    if (ready && !oversized && !final_tablet_results.empty()) {
+        cache_value = std::make_unique<FinalTabletResultCache::CacheValue>();
+        cache_value->_results = std::move(final_tablet_results);
+        cache_size = sizeof(FinalTabletResultCache::CacheValue) + result_bytes;
+    } else if (!ready || oversized) {
+        LOG(WARNING) << "Skip caching final tablet result for load " << load_id
+                     << ", ready=" << ready << ", oversized=" << oversized;
+    }
+
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        const auto channel_it = _load_channels.find(load_id);
+        if (channel_it == _load_channels.end() || channel_it->second != channel) {
+            return;
+        }
+        _load_channels.erase(channel_it);
+        _final_tablet_result_cache->erase(cache_key);
+        if (cache_value != nullptr) {
+            auto* result_handle = _final_tablet_result_cache->insert(cache_key, cache_value.get(),
+                                                                     cache_size, cache_size);
+            cache_value.release();
+            _final_tablet_result_cache->release(result_handle);
+        }
+        auto* handle = _load_state_channels->insert(cache_key, nullptr, 1, 1);
         _load_state_channels->release(handle);
     }
     VLOG_CRITICAL << "removed load channel " << load_id;
@@ -231,7 +312,10 @@ Status LoadChannelMgr::cancel(const PTabletWriterCancelRequest& params) {
     }
 
     if (cancelled_channel != nullptr) {
-        RETURN_IF_ERROR(cancelled_channel->cancel());
+        const Status reason = params.has_cancel_reason()
+                                      ? Status::Cancelled(params.cancel_reason())
+                                      : Status::Cancelled("Load channel cancelled");
+        RETURN_IF_ERROR(cancelled_channel->cancel(reason));
         LOG(INFO) << "load channel has been cancelled: " << load_id;
     }
 
@@ -279,7 +363,7 @@ Status LoadChannelMgr::_start_load_channels_clean() {
     // otherwise some object may be invalid before trying to visit it.
     // eg: MemTracker in load channel
     for (auto& channel : need_delete_channels) {
-        RETURN_IF_ERROR(channel->cancel());
+        RETURN_IF_ERROR(channel->cancel(Status::TimedOut("Load channel timed out")));
         LOG(INFO) << "load channel has been safely deleted: " << channel->load_id()
                   << ", timeout(s): " << channel->timeout();
     }

--- a/be/src/load/channel/load_channel_mgr.cpp
+++ b/be/src/load/channel/load_channel_mgr.cpp
@@ -36,6 +36,7 @@
 #include "load/channel/load_channel.h"
 #include "runtime/exec_env.h"
 #include "util/debug_points.h"
+#include "util/defer_op.h"
 #include "util/thread.h"
 
 namespace doris {
@@ -112,12 +113,36 @@ Status LoadChannelMgr::open(const PTabletWriterOpenRequest& params) {
     return Status::OK();
 }
 
+Status LoadChannelMgr::_copy_cached_final_tablet_result(const UniqueId& load_id,
+                                                        const PTabletWriterAddBlockRequest& request,
+                                                        Cache::Handle* result_handle,
+                                                        PTabletWriterAddBlockResult* response) {
+    DORIS_CHECK(result_handle != nullptr);
+    Defer release_result_handle(
+            [this, result_handle] { _final_tablet_result_cache->release(result_handle); });
+    const auto* result_cache_value = reinterpret_cast<FinalTabletResultCache::CacheValue*>(
+            _final_tablet_result_cache->value(result_handle));
+    const auto result = result_cache_value->_results.find(request.index_id());
+    if (result == result_cache_value->_results.end()) {
+        LOG(WARNING) << "Final tablet result is unavailable for retried load " << load_id
+                     << ", index_id=" << request.index_id()
+                     << ", sender_id=" << request.sender_id();
+        return Status::InternalError<false>(
+                "Final tablet result is unavailable for retried load {}, index_id={}, sender_id={}",
+                load_id.to_string(), request.index_id(), request.sender_id());
+    }
+    DBUG_EXECUTE_IF("LoadChannelMgr.get.before_copy", DBUG_RUN_CALLBACK());
+    response->CopyFrom(result->second.result);
+    response->set_final_tablet_result_fanout(request.sender_id() != result->second.owner_sender_id);
+    return Status::OK();
+}
+
 Status LoadChannelMgr::_get_load_channel(std::shared_ptr<LoadChannel>& channel, bool& is_eof,
                                          const UniqueId& load_id,
                                          const PTabletWriterAddBlockRequest& request,
                                          PTabletWriterAddBlockResult* response) {
     is_eof = false;
-    std::lock_guard<std::mutex> l(_lock);
+    std::unique_lock<std::mutex> l(_lock);
     auto it = _load_channels.find(load_id);
     if (it == _load_channels.end()) {
         Cache::Handle* handle = _load_state_channels->lookup(load_id.to_string());
@@ -143,25 +168,14 @@ Status LoadChannelMgr::_get_load_channel(std::shared_ptr<LoadChannel>& channel, 
                         if (result_handle == nullptr) {
                             LOG(WARNING) << "Final tablet result is unavailable for retried load "
                                          << load_id << ", sender_id=" << request.sender_id();
-                            is_eof = true;
-                            return Status::OK();
+                            return Status::InternalError<false>(
+                                    "Final tablet result is unavailable for retried load {}, "
+                                    "index_id={}, sender_id={}",
+                                    load_id.to_string(), request.index_id(), request.sender_id());
                         }
-                        const auto* result_cache_value =
-                                reinterpret_cast<FinalTabletResultCache::CacheValue*>(
-                                        _final_tablet_result_cache->value(result_handle));
-                        const auto result = result_cache_value->_results.find(request.index_id());
-                        if (result == result_cache_value->_results.end()) {
-                            _final_tablet_result_cache->release(result_handle);
-                            LOG(WARNING) << "Final tablet result is unavailable for retried load "
-                                         << load_id << ", index_id=" << request.index_id()
-                                         << ", sender_id=" << request.sender_id();
-                            is_eof = true;
-                            return Status::OK();
-                        }
-                        response->CopyFrom(result->second.result);
-                        response->set_final_tablet_result_fanout(request.sender_id() !=
-                                                                 result->second.owner_sender_id);
-                        _final_tablet_result_cache->release(result_handle);
+                        l.unlock();
+                        RETURN_IF_ERROR(_copy_cached_final_tablet_result(load_id, request,
+                                                                         result_handle, response));
                     }
                     is_eof = true;
                     return Status::OK();
@@ -236,16 +250,23 @@ void LoadChannelMgr::_finish_load_channel(const UniqueId load_id,
         need_final_tablet_result = channel->need_final_tablet_result();
         if (!need_final_tablet_result) {
             _load_channels.erase(channel_it);
+            auto* handle = _load_state_channels->insert(cache_key, nullptr, 1, 1);
+            _load_state_channels->release(handle);
+        } else if (!_finishing_load_channels.emplace(load_id).second) {
+            return;
         }
-        // Cross-AZ retains the active channel for the lock-free copy, but publishes success now
-        // so cancel cannot remove the only retry tombstone during that window.
-        auto* handle = _load_state_channels->insert(cache_key, nullptr, 1, 1);
-        _load_state_channels->release(handle);
     }
     if (!need_final_tablet_result) {
         VLOG_CRITICAL << "removed load channel " << load_id;
         return;
     }
+    bool finishing_registered = true;
+    Defer clear_finishing([this, load_id, &finishing_registered] {
+        if (finishing_registered) {
+            std::lock_guard<std::mutex> l(_lock);
+            _finishing_load_channels.erase(load_id);
+        }
+    });
 
     std::unique_ptr<FinalTabletResultCache::CacheValue> cache_value;
     DBUG_EXECUTE_IF("LoadChannelMgr.finish.before_copy", DBUG_RUN_CALLBACK());
@@ -267,22 +288,35 @@ void LoadChannelMgr::_finish_load_channel(const UniqueId load_id,
                      << ", ready=" << ready << ", oversized=" << oversized;
     }
 
+    Cache::Handle* result_handle = nullptr;
+    Defer release_result_handle([this, &result_handle] {
+        if (result_handle != nullptr) {
+            _final_tablet_result_cache->release(result_handle);
+        }
+    });
+    _final_tablet_result_cache->erase(cache_key);
+    if (cache_value != nullptr) {
+        result_handle = _final_tablet_result_cache->insert(cache_key, cache_value.get(), cache_size,
+                                                           cache_size);
+        cache_value.release();
+    }
+
+    bool published = false;
     {
         std::lock_guard<std::mutex> l(_lock);
         const auto channel_it = _load_channels.find(load_id);
-        if (channel_it == _load_channels.end() || channel_it->second != channel) {
-            return;
+        if (channel_it != _load_channels.end() && channel_it->second == channel) {
+            _load_channels.erase(channel_it);
+            auto* handle = _load_state_channels->insert(cache_key, nullptr, 1, 1);
+            _load_state_channels->release(handle);
+            published = true;
         }
-        _load_channels.erase(channel_it);
+        _finishing_load_channels.erase(load_id);
+        finishing_registered = false;
+    }
+    if (!published) {
         _final_tablet_result_cache->erase(cache_key);
-        if (cache_value != nullptr) {
-            auto* result_handle = _final_tablet_result_cache->insert(cache_key, cache_value.get(),
-                                                                     cache_size, cache_size);
-            cache_value.release();
-            _final_tablet_result_cache->release(result_handle);
-        }
-        auto* handle = _load_state_channels->insert(cache_key, nullptr, 1, 1);
-        _load_state_channels->release(handle);
+        return;
     }
     VLOG_CRITICAL << "removed load channel " << load_id;
 }
@@ -292,27 +326,34 @@ Status LoadChannelMgr::cancel(const PTabletWriterCancelRequest& params) {
     std::shared_ptr<LoadChannel> cancelled_channel;
     {
         std::lock_guard<std::mutex> l(_lock);
-        if (_load_channels.contains(load_id)) {
-            cancelled_channel = _load_channels[load_id];
-            _load_channels.erase(load_id);
+        const bool finish_in_progress =
+                !_finishing_load_channels.empty() && _finishing_load_channels.contains(load_id);
+        // Once final-result publication starts, finish wins so a success marker can never outlive
+        // its reproducible result because of a concurrent cancel.
+        if (const auto channel_it = _load_channels.find(load_id);
+            !finish_in_progress && channel_it != _load_channels.end()) {
+            cancelled_channel = channel_it->second;
+            _load_channels.erase(channel_it);
         }
-        // We just need to record the first cancel msg
-        auto* existing_handle = _load_state_channels->lookup(load_id.to_string());
-        if (existing_handle == nullptr) {
-            if (params.has_cancel_reason() && !params.cancel_reason().empty()) {
-                std::unique_ptr<CacheValue> cancel_reason_ptr = std::make_unique<CacheValue>();
-                cancel_reason_ptr->_cancel_reason = params.cancel_reason();
-                size_t cache_capacity =
-                        cancel_reason_ptr->_cancel_reason.capacity() + sizeof(CacheValue);
-                auto* handle = _load_state_channels->insert(
-                        load_id.to_string(), cancel_reason_ptr.get(), 1, cache_capacity);
-                cancel_reason_ptr.release();
-                _load_state_channels->release(handle);
-                LOG(INFO) << fmt::format("load_id = {}, record_error reason = {}",
-                                         print_id(load_id), params.cancel_reason());
+        if (!finish_in_progress) {
+            // We just need to record the first cancel msg
+            auto* existing_handle = _load_state_channels->lookup(load_id.to_string());
+            if (existing_handle == nullptr) {
+                if (params.has_cancel_reason() && !params.cancel_reason().empty()) {
+                    std::unique_ptr<CacheValue> cancel_reason_ptr = std::make_unique<CacheValue>();
+                    cancel_reason_ptr->_cancel_reason = params.cancel_reason();
+                    size_t cache_capacity =
+                            cancel_reason_ptr->_cancel_reason.capacity() + sizeof(CacheValue);
+                    auto* handle = _load_state_channels->insert(
+                            load_id.to_string(), cancel_reason_ptr.get(), 1, cache_capacity);
+                    cancel_reason_ptr.release();
+                    _load_state_channels->release(handle);
+                    LOG(INFO) << fmt::format("load_id = {}, record_error reason = {}",
+                                             print_id(load_id), params.cancel_reason());
+                }
+            } else {
+                _load_state_channels->release(existing_handle);
             }
-        } else {
-            _load_state_channels->release(existing_handle);
         }
     }
 
@@ -350,6 +391,9 @@ Status LoadChannelMgr::_start_load_channels_clean() {
         std::lock_guard<std::mutex> l(_lock);
         int i = 0;
         for (auto& kv : _load_channels) {
+            if (!_finishing_load_channels.empty() && _finishing_load_channels.contains(kv.first)) {
+                continue;
+            }
             VLOG_CRITICAL << "load channel[" << i++ << "]: " << *(kv.second);
             time_t last_updated_time = kv.second->last_updated_time();
             if (difftime(now, last_updated_time) >= kv.second->timeout()) {

--- a/be/src/load/channel/load_channel_mgr.h
+++ b/be/src/load/channel/load_channel_mgr.h
@@ -39,6 +39,10 @@
 #include "util/lru_cache.h"
 #include "util/uid_util.h"
 
+namespace google::protobuf {
+class Closure;
+}
+
 namespace doris {
 
 class PTabletWriterCancelRequest;
@@ -57,7 +61,8 @@ public:
     Status open(const PTabletWriterOpenRequest& request);
 
     Status add_batch(const PTabletWriterAddBlockRequest& request,
-                     PTabletWriterAddBlockResult* response);
+                     PTabletWriterAddBlockResult* response,
+                     google::protobuf::Closure** done = nullptr);
 
     // cancel all tablet stream for 'load_id' load
     Status cancel(const PTabletWriterCancelRequest& request);
@@ -76,9 +81,10 @@ public:
 
 private:
     Status _get_load_channel(std::shared_ptr<LoadChannel>& channel, bool& is_eof,
-                             const UniqueId& load_id, const PTabletWriterAddBlockRequest& request);
+                             const UniqueId& load_id, const PTabletWriterAddBlockRequest& request,
+                             PTabletWriterAddBlockResult* response);
 
-    void _finish_load_channel(UniqueId load_id);
+    void _finish_load_channel(UniqueId load_id, const std::shared_ptr<LoadChannel>& channel);
 
     Status _start_bg_worker();
 
@@ -98,6 +104,23 @@ private:
 
     using CacheValue = LoadStateChannelCache::CacheValue;
 
+    class FinalTabletResultCache : public LRUCachePolicy {
+    public:
+        static constexpr size_t MAX_ENTRIES = 1024;
+        static constexpr size_t MAX_BYTES = 64 * 1024 * 1024;
+
+        class CacheValue : public LRUCacheValueBase {
+        public:
+            std::unordered_map<int64_t, LoadChannel::FinalTabletResult> _results;
+        };
+
+        FinalTabletResultCache()
+                : LRUCachePolicy(CachePolicy::CacheType::LOAD_FINAL_TABLET_RESULT_CACHE, MAX_BYTES,
+                                 LRUCacheType::SIZE, /*sweep time*/ -1, /*num shards*/ 1,
+                                 /*element capacity*/ MAX_ENTRIES, /*enable prune */ true,
+                                 /*is lru k*/ false) {}
+    };
+
 protected:
     // lock protect the load channel map
     std::mutex _lock;
@@ -105,6 +128,7 @@ protected:
     std::unordered_map<UniqueId, std::shared_ptr<LoadChannel>> _load_channels;
     // load id window, remember the recently initiated load id, regardless of whether they succeed or fail
     std::unique_ptr<LoadStateChannelCache> _load_state_channels;
+    std::unique_ptr<FinalTabletResultCache> _final_tablet_result_cache;
 
     MemTableMemoryLimiter* _memtable_memory_limiter = nullptr;
 

--- a/be/src/load/channel/load_channel_mgr.h
+++ b/be/src/load/channel/load_channel_mgr.h
@@ -18,14 +18,15 @@
 #pragma once
 
 #include <gen_cpp/internal_service.pb.h>
-#include <stdint.h>
 
 #include <condition_variable>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include "common/compiler_util.h" // IWYU pragma: keep
@@ -80,6 +81,11 @@ public:
     }
 
 private:
+    Status _copy_cached_final_tablet_result(const UniqueId& load_id,
+                                            const PTabletWriterAddBlockRequest& request,
+                                            Cache::Handle* result_handle,
+                                            PTabletWriterAddBlockResult* response);
+
     Status _get_load_channel(std::shared_ptr<LoadChannel>& channel, bool& is_eof,
                              const UniqueId& load_id, const PTabletWriterAddBlockRequest& request,
                              PTabletWriterAddBlockResult* response);
@@ -126,6 +132,8 @@ protected:
     std::mutex _lock;
     // load id -> load channel
     std::unordered_map<UniqueId, std::shared_ptr<LoadChannel>> _load_channels;
+    // Cross-AZ loads publishing final results outside _lock.
+    std::unordered_set<UniqueId> _finishing_load_channels;
     // load id window, remember the recently initiated load id, regardless of whether they succeed or fail
     std::unique_ptr<LoadStateChannelCache> _load_state_channels;
     std::unique_ptr<FinalTabletResultCache> _final_tablet_result_cache;

--- a/be/src/load/channel/load_stream.cpp
+++ b/be/src/load/channel/load_stream.cpp
@@ -491,38 +491,80 @@ Status LoadStream::init(const POpenLoadStreamRequest* request) {
         _index_streams_map[index.id()] = std::make_shared<IndexStream>(
                 _load_id, index.id(), _txn_id, _schema, _load_stream_mgr, _profile.get());
     }
+    _need_final_tablet_result = request->need_final_tablet_result();
     LOG(INFO) << "succeed to init load stream " << *this;
     return Status::OK();
 }
 
-bool LoadStream::close(int64_t src_id, const std::vector<PTabletID>& tablets_to_commit,
-                       std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablets) {
+LoadStream::CloseLoadResult LoadStream::_close_load(StreamId stream, const PStreamHeader& header) {
+    CloseLoadResult result;
+    const int64_t src_id = header.src_id();
     std::lock_guard<bthread::Mutex> lock_guard(_lock);
     SCOPED_TIMER(_close_wait_timer);
 
     // we do nothing until recv CLOSE_LOAD from all stream to ensure all data are handled before ack
-    _open_streams[src_id]--;
-    if (_open_streams[src_id] == 0) {
+    auto& source_streams = _open_streams[src_id];
+    source_streams--;
+    const bool last_stream_from_source = source_streams == 0;
+    if (last_stream_from_source) {
         _open_streams.erase(src_id);
     }
     _close_load_cnt++;
     LOG(INFO) << "received CLOSE_LOAD from sender " << src_id << ", remaining "
               << _total_streams - _close_load_cnt << " senders, " << *this;
 
-    _tablets_to_commit.insert(_tablets_to_commit.end(), tablets_to_commit.begin(),
-                              tablets_to_commit.end());
+    _tablets_to_commit.insert(_tablets_to_commit.end(), header.tablets().begin(),
+                              header.tablets().end());
 
-    if (_close_load_cnt < _total_streams) {
-        // do not return commit info if there is remaining streams.
-        return false;
+    const bool all_closed = _close_load_cnt == _total_streams;
+    const bool waits_for_incremental_streams =
+            header.has_num_incremental_streams() && header.num_incremental_streams() > 0;
+
+    if (_need_final_tablet_result) {
+        // Retain one stream per source so every source receives the global tablet outcome.
+        // Additional physical streams only need an empty EOS.
+        const auto [_, is_representative] =
+                _final_result_stream_by_source.try_emplace(src_id, stream);
+        if (is_representative) {
+            result.report_current_stream = false;
+        } else {
+            result.report_final_result_on_current_stream = false;
+            if (waits_for_incremental_streams) {
+                _closing_stream_ids.push_back(stream);
+            } else {
+                result.close_current_stream = true;
+            }
+        }
+    } else if (waits_for_incremental_streams) {
+        _closing_stream_ids.push_back(stream);
+    } else {
+        result.close_current_stream = true;
+    }
+
+    if (!all_closed) {
+        return result;
     }
 
     for (auto& [_, index_stream] : _index_streams_map) {
-        index_stream->close(_tablets_to_commit, success_tablet_ids, failed_tablets);
+        index_stream->close(_tablets_to_commit, &result.success_tablet_ids, &result.failed_tablets);
     }
-    LOG(INFO) << "close load " << *this << ", success_tablet_num=" << success_tablet_ids->size()
-              << ", failed_tablet_num=" << failed_tablets->size();
-    return true;
+    LOG(INFO) << "close load " << *this
+              << ", success_tablet_num=" << result.success_tablet_ids.size()
+              << ", failed_tablet_num=" << result.failed_tablets.size();
+
+    result.streams_to_report.reserve(_final_result_stream_by_source.size());
+    result.streams_to_close.reserve(_closing_stream_ids.size() +
+                                    _final_result_stream_by_source.size());
+    for (const auto& [_, final_result_stream] : _final_result_stream_by_source) {
+        result.streams_to_report.push_back(final_result_stream);
+        result.streams_to_close.push_back(final_result_stream);
+    }
+    _final_result_stream_by_source.clear();
+
+    result.streams_to_close.insert(result.streams_to_close.end(), _closing_stream_ids.begin(),
+                                   _closing_stream_ids.end());
+    _closing_stream_ids.clear();
+    return result;
 }
 
 void LoadStream::_report_result(StreamId stream, const Status& status,
@@ -759,27 +801,24 @@ void LoadStream::_dispatch(StreamId id, const PStreamHeader& hdr, butil::IOBuf* 
     } break;
     case PStreamHeader::CLOSE_LOAD: {
         DBUG_EXECUTE_IF("LoadStream.close_load.block", DBUG_BLOCK);
-        std::vector<int64_t> success_tablet_ids;
-        FailedTablets failed_tablets;
-        std::vector<PTabletID> tablets_to_commit(hdr.tablets().begin(), hdr.tablets().end());
-        bool all_closed =
-                close(hdr.src_id(), tablets_to_commit, &success_tablet_ids, &failed_tablets);
-        _report_result(id, Status::OK(), success_tablet_ids, failed_tablets, true);
-        std::lock_guard<bthread::Mutex> lock_guard(_lock);
-        // if incremental stream, we need to wait for all non-incremental streams to be closed
-        // before closing incremental streams. We need a fencing mechanism to avoid use after closing
-        // across different be.
-        if (hdr.has_num_incremental_streams() && hdr.num_incremental_streams() > 0) {
-            _closing_stream_ids.push_back(id);
-        } else {
+        auto result = _close_load(id, hdr);
+        if (result.report_current_stream) {
+            if (result.report_final_result_on_current_stream) {
+                _report_result(id, Status::OK(), result.success_tablet_ids, result.failed_tablets,
+                               true);
+            } else {
+                _report_result(id, Status::OK(), {}, {}, true);
+            }
+        }
+        for (auto stream : result.streams_to_report) {
+            _report_result(stream, Status::OK(), result.success_tablet_ids, result.failed_tablets,
+                           true);
+        }
+        if (result.close_current_stream) {
             brpc::StreamClose(id);
         }
-
-        if (all_closed) {
-            for (auto& closing_id : _closing_stream_ids) {
-                brpc::StreamClose(closing_id);
-            }
-            _closing_stream_ids.clear();
+        for (auto stream : result.streams_to_close) {
+            brpc::StreamClose(stream);
         }
     } break;
     case PStreamHeader::GET_SCHEMA: {

--- a/be/src/load/channel/load_stream.cpp
+++ b/be/src/load/channel/load_stream.cpp
@@ -555,9 +555,13 @@ LoadStream::CloseLoadResult LoadStream::_close_load(StreamId stream, const PStre
     result.streams_to_report.reserve(_final_result_stream_by_source.size());
     result.streams_to_close.reserve(_closing_stream_ids.size() +
                                     _final_result_stream_by_source.size());
-    for (const auto& [_, final_result_stream] : _final_result_stream_by_source) {
-        result.streams_to_report.push_back(final_result_stream);
-        result.streams_to_close.push_back(final_result_stream);
+    if (_need_final_tablet_result) {
+        const StreamId owner_stream = _final_result_stream_by_source.at(src_id);
+        for (const auto& [_, final_result_stream] : _final_result_stream_by_source) {
+            result.streams_to_report.push_back(
+                    {final_result_stream, final_result_stream != owner_stream});
+            result.streams_to_close.push_back(final_result_stream);
+        }
     }
     _final_result_stream_by_source.clear();
 
@@ -569,12 +573,16 @@ LoadStream::CloseLoadResult LoadStream::_close_load(StreamId stream, const PStre
 
 void LoadStream::_report_result(StreamId stream, const Status& status,
                                 const std::vector<int64_t>& success_tablet_ids,
-                                const FailedTablets& failed_tablets, bool eos) {
+                                const FailedTablets& failed_tablets, bool eos,
+                                bool final_tablet_result_fanout) {
     LOG(INFO) << "report result " << *this << ", success tablet num " << success_tablet_ids.size()
               << ", failed tablet num " << failed_tablets.size();
     butil::IOBuf buf;
     PLoadStreamResponse response;
     response.set_eos(eos);
+    if (final_tablet_result_fanout) {
+        response.set_final_tablet_result_fanout(true);
+    }
     status.to_protobuf(response.mutable_status());
     for (auto& id : success_tablet_ids) {
         response.add_success_tablet_ids(id);
@@ -810,9 +818,9 @@ void LoadStream::_dispatch(StreamId id, const PStreamHeader& hdr, butil::IOBuf* 
                 _report_result(id, Status::OK(), {}, {}, true);
             }
         }
-        for (auto stream : result.streams_to_report) {
-            _report_result(stream, Status::OK(), result.success_tablet_ids, result.failed_tablets,
-                           true);
+        for (const auto& stream : result.streams_to_report) {
+            _report_result(stream.id, Status::OK(), result.success_tablet_ids,
+                           result.failed_tablets, true, stream.fanout);
         }
         if (result.close_current_stream) {
             brpc::StreamClose(id);

--- a/be/src/load/channel/load_stream.h
+++ b/be/src/load/channel/load_stream.h
@@ -148,9 +148,14 @@ public:
 
 private:
     struct CloseLoadResult {
+        struct FinalResultStream {
+            StreamId id;
+            bool fanout;
+        };
+
         std::vector<int64_t> success_tablet_ids;
         FailedTablets failed_tablets;
-        std::vector<StreamId> streams_to_report;
+        std::vector<FinalResultStream> streams_to_report;
         std::vector<StreamId> streams_to_close;
         bool report_current_stream = true;
         bool report_final_result_on_current_stream = true;
@@ -164,7 +169,8 @@ private:
 
     void _report_result(StreamId stream, const Status& status,
                         const std::vector<int64_t>& success_tablet_ids,
-                        const FailedTablets& failed_tablets, bool eos);
+                        const FailedTablets& failed_tablets, bool eos,
+                        bool final_tablet_result_fanout = false);
     void _report_schema(StreamId stream, const PStreamHeader& hdr);
     void _report_tablet_load_info(StreamId stream, int64_t index_id);
     void _collect_tablet_load_info_from_tablets(

--- a/be/src/load/channel/load_stream.h
+++ b/be/src/load/channel/load_stream.h
@@ -24,6 +24,7 @@
 #include <mutex>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "brpc/stream.h"
 #include "butil/iobuf.h"
@@ -128,17 +129,15 @@ public:
 
     Status init(const POpenLoadStreamRequest* request);
 
-    void add_source(int64_t src_id) {
+    void add_source(int64_t src_id, bool need_final_tablet_result) {
         std::lock_guard lock_guard(_lock);
+        // Mixed-version source BEs may omit the flag; enable fan-out if any source requests it.
+        _need_final_tablet_result |= need_final_tablet_result;
         _open_streams[src_id]++;
         if (_is_incremental) {
             _total_streams++;
         }
     }
-
-    // return true if all streams are closed, otherwise return false
-    bool close(int64_t src_id, const std::vector<PTabletID>& tablets_to_commit,
-               std::vector<int64_t>* success_tablet_ids, FailedTablets* failed_tablet_ids);
 
     // callbacks called by brpc
     int on_received_messages(StreamId id, butil::IOBuf* const messages[], size_t size) override;
@@ -148,9 +147,20 @@ public:
     friend std::ostream& operator<<(std::ostream& ostr, const LoadStream& load_stream);
 
 private:
+    struct CloseLoadResult {
+        std::vector<int64_t> success_tablet_ids;
+        FailedTablets failed_tablets;
+        std::vector<StreamId> streams_to_report;
+        std::vector<StreamId> streams_to_close;
+        bool report_current_stream = true;
+        bool report_final_result_on_current_stream = true;
+        bool close_current_stream = false;
+    };
+
     void _parse_header(butil::IOBuf* const message, PStreamHeader& hdr);
     void _dispatch(StreamId id, const PStreamHeader& hdr, butil::IOBuf* data);
     Status _append_data(const PStreamHeader& header, butil::IOBuf* data);
+    CloseLoadResult _close_load(StreamId stream, const PStreamHeader& header);
 
     void _report_result(StreamId stream, const Status& status,
                         const std::vector<int64_t>& success_tablet_ids,
@@ -191,6 +201,8 @@ private:
     std::shared_ptr<ResourceContext> _resource_ctx;
     std::vector<int64_t> _closing_stream_ids;
     bool _is_incremental = false;
+    bool _need_final_tablet_result = false;
+    std::unordered_map<int64_t, StreamId> _final_result_stream_by_source;
 };
 
 using LoadStreamPtr = std::unique_ptr<LoadStream>;

--- a/be/src/load/channel/load_stream_mgr.cpp
+++ b/be/src/load/channel/load_stream_mgr.cpp
@@ -59,7 +59,7 @@ Status LoadStreamMgr::open_load_stream(const POpenLoadStreamRequest* request,
             load_stream = p.get();
             _load_streams_map[load_id] = std::move(p);
         }
-        load_stream->add_source(request->src_id());
+        load_stream->add_source(request->src_id(), request->need_final_tablet_result());
     }
     return Status::OK();
 }

--- a/be/src/runtime/memory/cache_policy.h
+++ b/be/src/runtime/memory/cache_policy.h
@@ -58,6 +58,7 @@ public:
         CONDITION_CACHE = 23,
         ANN_INDEX_IVF_LIST_CACHE = 24,
         ANN_INDEX_RESULT_CACHE = 25,
+        LOAD_FINAL_TABLET_RESULT_CACHE = 26,
     };
 
     static std::string type_string(CacheType type) {
@@ -86,6 +87,8 @@ public:
             return "MowTabletVersionCache";
         case CacheType::LOAD_STATE_CHANNEL_CACHE:
             return "LoadStateChannelCache ";
+        case CacheType::LOAD_FINAL_TABLET_RESULT_CACHE:
+            return "LoadFinalTabletResultCache";
         case CacheType::COMMON_OBJ_LRU_CACHE:
             return "CommonObjLRUCache";
         case CacheType::FOR_UT_CACHE_SIZE:
@@ -132,6 +135,7 @@ public:
             {"MowDeleteBitmapAggCache", CacheType::DELETE_BITMAP_AGG_CACHE},
             {"MowTabletVersionCache", CacheType::TABLET_VERSION_CACHE},
             {"LoadStateChannelCache ", CacheType::LOAD_STATE_CHANNEL_CACHE},
+            {"LoadFinalTabletResultCache", CacheType::LOAD_FINAL_TABLET_RESULT_CACHE},
             {"CommonObjLRUCache", CacheType::COMMON_OBJ_LRU_CACHE},
             {"ForUTCacheSize", CacheType::FOR_UT_CACHE_SIZE},
             {"TabletSchemaCache", CacheType::TABLET_SCHEMA_CACHE},

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -516,21 +516,28 @@ void PInternalService::tablet_writer_add_block(google::protobuf::RpcController* 
                                                PTabletWriterAddBlockResult* response,
                                                google::protobuf::Closure* done) {
     int64_t submit_task_time_ns = MonotonicNanos();
-    bool ret = _heavy_work_pool.try_offer([request, response, done, submit_task_time_ns, this]() {
+    bool ret = _heavy_work_pool.try_offer([request, response, done, submit_task_time_ns,
+                                           this]() mutable {
         int64_t wait_execution_time_ns = MonotonicNanos() - submit_task_time_ns;
-        brpc::ClosureGuard closure_guard(done);
         int64_t execution_time_ns = 0;
+        brpc::ClosureGuard closure_guard(done);
         {
             SCOPED_RAW_TIMER(&execution_time_ns);
             signal::SignalTaskIdKeeper keeper(request->id());
-            auto st = _exec_env->load_channel_mgr()->add_batch(*request, response);
+            auto st = _exec_env->load_channel_mgr()->add_batch(*request, response, &done);
+            if (done == nullptr) {
+                closure_guard.release();
+                return;
+            }
             if (!st.ok()) {
                 LOG(WARNING) << "tablet writer add block failed, message=" << st
                              << ", id=" << request->id() << ", index_id=" << request->index_id()
                              << ", sender_id=" << request->sender_id()
                              << ", backend id=" << request->backend_id();
             }
-            st.to_protobuf(response->mutable_status());
+            if (!st.ok() || !response->has_status()) {
+                st.to_protobuf(response->mutable_status());
+            }
         }
         response->set_execution_time_us(execution_time_ns / NANOS_PER_MICRO);
         response->set_wait_execution_time_us(wait_execution_time_ns / NANOS_PER_MICRO);

--- a/be/src/storage/tablet_info.cpp
+++ b/be/src/storage/tablet_info.cpp
@@ -60,6 +60,36 @@
 
 namespace doris {
 
+bool DorisNodesInfo::is_cross_az_quorum_success(
+        const std::map<std::string, int32_t>& cross_az_succ_quorum,
+        const std::vector<int64_t>& tablet_node_ids,
+        const std::unordered_set<int64_t>& finished_node_ids,
+        const std::unordered_set<int64_t>* version_gap_node_ids) const {
+    for (const auto& [az, configured_min] : cross_az_succ_quorum) {
+        int replica_num_in_az = 0;
+        int succ_in_az = 0;
+        for (int64_t node_id : tablet_node_ids) {
+            const auto* node = find_node(node_id);
+            if (node == nullptr || node->location != az) {
+                continue;
+            }
+            ++replica_num_in_az;
+            if (finished_node_ids.contains(node_id) &&
+                (version_gap_node_ids == nullptr || !version_gap_node_ids->contains(node_id))) {
+                ++succ_in_az;
+            }
+        }
+        const int required_in_az = std::min(configured_min, replica_num_in_az);
+        if (required_in_az == 0) {
+            continue;
+        }
+        if (succ_in_az < required_in_az) {
+            return false;
+        }
+    }
+    return true;
+}
+
 const OlapTableIndexSchema* OlapTableSchemaParam::row_binlog_index_schema(int64_t index_id) const {
     for (auto* schema : _row_binlog_index_schemas) {
         if (schema->index_id == index_id) {

--- a/be/src/storage/tablet_info.h
+++ b/be/src/storage/tablet_info.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -443,6 +444,7 @@ struct NodeInfo {
     int64_t option;
     std::string host;
     int32_t brpc_port;
+    std::string location;
 
     NodeInfo() = default;
 
@@ -450,7 +452,8 @@ struct NodeInfo {
             : id(tnode.id),
               option(tnode.option),
               host(tnode.host),
-              brpc_port(tnode.async_internal_port) {}
+              brpc_port(tnode.async_internal_port),
+              location(tnode.__isset.location ? tnode.location : "") {}
 };
 
 class DorisNodesInfo {
@@ -474,6 +477,11 @@ public:
         }
         return nullptr;
     }
+
+    bool is_cross_az_quorum_success(const std::map<std::string, int32_t>& cross_az_succ_quorum,
+                                    const std::vector<int64_t>& tablet_node_ids,
+                                    const std::unordered_set<int64_t>& finished_node_ids,
+                                    const std::unordered_set<int64_t>* version_gap_node_ids) const;
 
     void add_nodes(const std::vector<TNodeInfo>& t_nodes) {
         for (const auto& node : t_nodes) {

--- a/be/test/exec/sink/vtablet_writer_v2_test.cpp
+++ b/be/test/exec/sink/vtablet_writer_v2_test.cpp
@@ -520,4 +520,54 @@ TEST_F(TestVTabletWriterV2, quorum_excludes_streams_not_closing_in_current_stage
     ASSERT_TRUE(writer->_quorum_success(unfinished_streams, need_finish_tablets));
 }
 
+TEST_F(TestVTabletWriterV2, quorum_waits_for_cross_az_success) {
+    UniqueId load_id;
+    auto load_stream_map = std::make_shared<LoadStreamMap>(load_id, src_id, 1, 1, nullptr);
+    auto streams_1 = load_stream_map->get_or_create(1001);
+    auto streams_2 = load_stream_map->get_or_create(1002);
+    auto streams_3 = load_stream_map->get_or_create(1003);
+    for (const auto& streams : {streams_1, streams_2, streams_3}) {
+        streams->streams().front()->_is_closing.store(true);
+    }
+
+    TPaloNodesInfo t_nodes;
+    for (const auto& [node_id, location] : std::vector<std::pair<int64_t, std::string>> {
+                 {1001, "az1"}, {1002, "az1"}, {1003, "az2"}}) {
+        TNodeInfo node;
+        node.__set_id(node_id);
+        node.__set_location(location);
+        t_nodes.nodes.push_back(node);
+    }
+    DorisNodesInfo nodes_info(t_nodes);
+
+    TOlapTableLocationParam t_location;
+    TTabletLocation tablet;
+    tablet.__set_tablet_id(1);
+    tablet.__set_node_ids({1001, 1002, 1003});
+    t_location.tablets.push_back(tablet);
+    OlapTableLocationParam location(t_location);
+
+    auto writer = create_vtablet_writer();
+    writer->_load_stream_map = load_stream_map;
+    writer->_nodes_info = &nodes_info;
+    writer->_location = &location;
+    for (int64_t node_id : {1001, 1002, 1003}) {
+        writer->_tablets_by_node[node_id].insert(1);
+    }
+
+    std::unordered_set<std::shared_ptr<LoadStreamStub>> unfinished_streams {
+            streams_3->streams().front()};
+    std::unordered_set<int64_t> need_finish_tablets {1};
+    ASSERT_TRUE(writer->_quorum_success(unfinished_streams, need_finish_tablets));
+
+    writer->_t_sink.olap_table_sink.__set_cross_az_succ_quorum({{"az1", 2}, {"az2", 2}});
+    ASSERT_FALSE(writer->_quorum_success(unfinished_streams, need_finish_tablets));
+
+    unfinished_streams.clear();
+    ASSERT_TRUE(writer->_quorum_success(unfinished_streams, need_finish_tablets));
+
+    writer->_tablet_version_gap_backends[1].insert(1003);
+    ASSERT_FALSE(writer->_quorum_success(unfinished_streams, need_finish_tablets));
+}
+
 } // namespace doris

--- a/be/test/exec/sink/vtablet_writer_v2_test.cpp
+++ b/be/test/exec/sink/vtablet_writer_v2_test.cpp
@@ -316,6 +316,24 @@ TEST_F(TestVTabletWriterV2, one_replica) {
     ASSERT_EQ(tablet_commit_infos.size(), 2);
 }
 
+TEST_F(TestVTabletWriterV2, final_result_fanout_does_not_duplicate_commit_info) {
+    UniqueId load_id;
+    auto load_stream_map = std::make_shared<LoadStreamMap>(load_id, src_id, 1, 1, nullptr);
+    add_stream(load_stream_map, 1001, {1}, {{1, Status::InternalError("other replica failed")}});
+    auto stream = load_stream_map->at(1001)->streams().front();
+    stream->_final_tablet_result_fanout.store(true);
+
+    auto writer = create_vtablet_writer(1);
+    writer->_t_sink.olap_table_sink.__set_cross_az_succ_quorum({{"az1", 1}});
+    std::vector<TTabletCommitInfo> tablet_commit_infos;
+    ASSERT_TRUE(writer->_create_commit_info(tablet_commit_infos, load_stream_map).ok());
+    EXPECT_TRUE(tablet_commit_infos.empty());
+
+    stream->_final_tablet_result_fanout.store(false);
+    ASSERT_TRUE(writer->_create_commit_info(tablet_commit_infos, load_stream_map).ok());
+    ASSERT_EQ(tablet_commit_infos.size(), 1);
+}
+
 TEST_F(TestVTabletWriterV2, one_replica_fail) {
     UniqueId load_id;
     std::vector<TTabletCommitInfo> tablet_commit_infos;

--- a/be/test/exec/sink/vtablet_writer_v2_test.cpp
+++ b/be/test/exec/sink/vtablet_writer_v2_test.cpp
@@ -572,7 +572,7 @@ TEST_F(TestVTabletWriterV2, quorum_waits_for_cross_az_success) {
     ASSERT_FALSE(writer->_quorum_success(unfinished_streams, need_finish_tablets));
 }
 
-TEST_F(TestVTabletWriterV2, v1_quorum_waits_for_cross_az_tablet_success) {
+TEST_F(TestVTabletWriterV2, v1_quorum_checks_cross_az_only_in_final_close_stage) {
     TDataSink t_sink;
     t_sink.__isset.olap_table_sink = true;
     t_sink.olap_table_sink.num_replicas = 5;
@@ -605,6 +605,9 @@ TEST_F(TestVTabletWriterV2, v1_quorum_waits_for_cross_az_tablet_success) {
     for (int64_t node_id : {1001, 1002, 1003, 1004, 1005}) {
         auto node_channel = std::make_shared<VNodeChannel>(writer.get(), &index_channel, node_id);
         node_channel->_eos_is_produced = true;
+        if (node_id != 1004) {
+            node_channel->_successful_tablet_ids.insert(1);
+        }
         index_channel._node_channels[node_id] = node_channel;
         index_channel._tablets_by_channel[node_id].insert(1);
     }
@@ -612,10 +615,54 @@ TEST_F(TestVTabletWriterV2, v1_quorum_waits_for_cross_az_tablet_success) {
 
     std::unordered_set<int64_t> unfinished_node_channel_ids {1005};
     std::unordered_set<int64_t> need_finish_tablets {1};
-    ASSERT_FALSE(index_channel._quorum_success(unfinished_node_channel_ids, need_finish_tablets));
+
+    // Initial channels already have an ordinary majority (1001, 1002, 1003), so the first
+    // auto-partition close stage can finish without waiting for the incremental AZ replica.
+    ASSERT_TRUE(
+            index_channel._quorum_success(unfinished_node_channel_ids, need_finish_tablets, false));
+
+    // The final close stage must additionally enforce the cross-AZ policy. Node 1004 failed and
+    // node 1005 has not finished, so az2 does not have a successful replica yet.
+    ASSERT_FALSE(
+            index_channel._quorum_success(unfinished_node_channel_ids, need_finish_tablets, true));
 
     unfinished_node_channel_ids.clear();
-    ASSERT_TRUE(index_channel._quorum_success(unfinished_node_channel_ids, need_finish_tablets));
+    ASSERT_TRUE(
+            index_channel._quorum_success(unfinished_node_channel_ids, need_finish_tablets, true));
+}
+
+TEST_F(TestVTabletWriterV2, v1_final_result_fanout_does_not_duplicate_commit_info) {
+    TDataSink t_sink;
+    t_sink.__isset.olap_table_sink = true;
+    t_sink.olap_table_sink.__set_cross_az_succ_quorum({{"az1", 1}});
+    VExprContextSPtrs output_exprs;
+    VTabletWriter writer(t_sink, output_exprs, nullptr, nullptr);
+    IndexChannel index_channel(&writer, 1, nullptr);
+    VNodeChannel node_channel(&writer, &index_channel, 1001);
+    MockRuntimeState state;
+    node_channel._state = &state;
+
+    PTabletWriterAddBlockResult result;
+    Status::OK().to_protobuf(result.mutable_status());
+    auto* tablet = result.add_tablet_vec();
+    tablet->set_tablet_id(1);
+    tablet->set_received_rows(10);
+    tablet->set_num_rows_filtered(1);
+    result.set_final_tablet_result_fanout(true);
+    WriteBlockCallbackContext ctx;
+    ctx._is_last_rpc = true;
+
+    node_channel._add_block_success_callback(result, ctx);
+    EXPECT_TRUE(node_channel._successful_tablet_ids.contains(1));
+    EXPECT_TRUE(node_channel._tablet_commit_infos.empty());
+    EXPECT_TRUE(node_channel._tablets_received_rows.empty());
+    EXPECT_TRUE(node_channel._tablets_filtered_rows.empty());
+
+    result.set_final_tablet_result_fanout(false);
+    node_channel._add_block_success_callback(result, ctx);
+    EXPECT_EQ(node_channel._tablet_commit_infos.size(), 1);
+    EXPECT_EQ(node_channel._tablets_received_rows.size(), 1);
+    EXPECT_EQ(node_channel._tablets_filtered_rows.size(), 1);
 }
 
 TEST_F(TestVTabletWriterV2, v2_quorum_waits_for_cross_az_tablet_success) {
@@ -669,6 +716,66 @@ TEST_F(TestVTabletWriterV2, v2_quorum_waits_for_cross_az_tablet_success) {
     streams_5->select_one_stream()->add_success_tablet(1);
     unfinished_streams.clear();
     ASSERT_TRUE(writer->_quorum_success(unfinished_streams, need_finish_tablets));
+}
+
+TEST_F(TestVTabletWriterV2, v2_quorum_checks_cross_az_only_in_final_close_stage) {
+    UniqueId load_id;
+    auto load_stream_map = std::make_shared<LoadStreamMap>(load_id, src_id, 1, 1, nullptr);
+    auto streams_1 = load_stream_map->get_or_create(1001);
+    auto streams_2 = load_stream_map->get_or_create(1002);
+    auto streams_3 = load_stream_map->get_or_create(1003);
+    auto streams_4 = load_stream_map->get_or_create(1004);
+    auto streams_5 = load_stream_map->get_or_create(1005);
+    for (const auto& streams : {streams_1, streams_2, streams_3, streams_4, streams_5}) {
+        streams->mark_open();
+        streams->streams().front()->_is_closing.store(true);
+    }
+    for (const auto& streams : {streams_1, streams_2, streams_3}) {
+        streams->select_one_stream()->add_success_tablet(1);
+    }
+    streams_4->select_one_stream()->add_failed_tablet(1, Status::InternalError("test"));
+
+    TPaloNodesInfo t_nodes;
+    for (const auto& [node_id, location] : std::vector<std::pair<int64_t, std::string>> {
+                 {1001, "az1"}, {1002, "az1"}, {1003, "az1"}, {1004, "az2"}, {1005, "az2"}}) {
+        TNodeInfo node;
+        node.__set_id(node_id);
+        node.__set_location(location);
+        t_nodes.nodes.push_back(node);
+    }
+    DorisNodesInfo nodes_info(t_nodes);
+
+    TOlapTableLocationParam t_location;
+    TTabletLocation tablet;
+    tablet.__set_tablet_id(1);
+    tablet.__set_node_ids({1001, 1002, 1003, 1004, 1005});
+    t_location.tablets.push_back(tablet);
+    OlapTableLocationParam location(t_location);
+
+    auto writer = create_vtablet_writer(5);
+    writer->_load_stream_map = load_stream_map;
+    writer->_nodes_info = &nodes_info;
+    writer->_location = &location;
+    writer->_t_sink.olap_table_sink.__set_cross_az_succ_quorum({{"az2", 1}});
+    for (int64_t node_id : {1001, 1002, 1003, 1004, 1005}) {
+        writer->_tablets_by_node[node_id].insert(1);
+    }
+
+    std::unordered_set<std::shared_ptr<LoadStreamStub>> unfinished_streams {
+            streams_5->streams().front()};
+    std::unordered_set<int64_t> need_finish_tablets {1};
+
+    // The first auto-partition close stage is only a lifecycle fence. Its ordinary majority is
+    // already complete, so the unfinished incremental stream in az2 must not block it.
+    ASSERT_TRUE(writer->_quorum_success(unfinished_streams, need_finish_tablets, false));
+
+    // The final stage makes the load decision and must enforce the AZ policy. Node 1004 failed
+    // and node 1005 is unfinished, so az2 has no successful replica yet.
+    ASSERT_FALSE(writer->_quorum_success(unfinished_streams, need_finish_tablets, true));
+
+    streams_5->select_one_stream()->add_success_tablet(1);
+    unfinished_streams.clear();
+    ASSERT_TRUE(writer->_quorum_success(unfinished_streams, need_finish_tablets, true));
 }
 
 } // namespace doris

--- a/be/test/exec/sink/vtablet_writer_v2_test.cpp
+++ b/be/test/exec/sink/vtablet_writer_v2_test.cpp
@@ -31,6 +31,7 @@
 #include "exec/sink/load_stream_map_pool.h"
 #include "exec/sink/load_stream_stub.h"
 #include "exec/sink/sink_test_utils.h"
+#include "exec/sink/writer/vtablet_writer.h"
 #include "io/fs/local_file_system.h"
 #include "load/memtable/memtable_memory_limiter.h"
 #include "runtime/exec_env.h"
@@ -527,6 +528,7 @@ TEST_F(TestVTabletWriterV2, quorum_waits_for_cross_az_success) {
     auto streams_2 = load_stream_map->get_or_create(1002);
     auto streams_3 = load_stream_map->get_or_create(1003);
     for (const auto& streams : {streams_1, streams_2, streams_3}) {
+        streams->streams().front()->add_success_tablet(1);
         streams->streams().front()->_is_closing.store(true);
     }
 
@@ -568,6 +570,105 @@ TEST_F(TestVTabletWriterV2, quorum_waits_for_cross_az_success) {
 
     writer->_tablet_version_gap_backends[1].insert(1003);
     ASSERT_FALSE(writer->_quorum_success(unfinished_streams, need_finish_tablets));
+}
+
+TEST_F(TestVTabletWriterV2, v1_quorum_waits_for_cross_az_tablet_success) {
+    TDataSink t_sink;
+    t_sink.__isset.olap_table_sink = true;
+    t_sink.olap_table_sink.num_replicas = 5;
+    t_sink.olap_table_sink.__set_cross_az_succ_quorum({{"az2", 1}});
+    VExprContextSPtrs output_exprs;
+    auto writer = std::make_unique<VTabletWriter>(t_sink, output_exprs, nullptr, nullptr);
+    writer->_num_replicas = 5;
+    writer->_tablet_replica_info[1] = {5, 3};
+
+    TPaloNodesInfo t_nodes;
+    for (const auto& [node_id, location] : std::vector<std::pair<int64_t, std::string>> {
+                 {1001, "az1"}, {1002, "az1"}, {1003, "az1"}, {1004, "az2"}, {1005, "az2"}}) {
+        TNodeInfo node;
+        node.__set_id(node_id);
+        node.__set_location(location);
+        t_nodes.nodes.push_back(node);
+    }
+    DorisNodesInfo nodes_info(t_nodes);
+    writer->_nodes_info = &nodes_info;
+
+    TOlapTableLocationParam t_location;
+    TTabletLocation tablet;
+    tablet.__set_tablet_id(1);
+    tablet.__set_node_ids({1001, 1002, 1003, 1004, 1005});
+    t_location.tablets.push_back(tablet);
+    OlapTableLocationParam location(t_location);
+    writer->_location = &location;
+
+    IndexChannel index_channel(writer.get(), 1, nullptr);
+    for (int64_t node_id : {1001, 1002, 1003, 1004, 1005}) {
+        auto node_channel = std::make_shared<VNodeChannel>(writer.get(), &index_channel, node_id);
+        node_channel->_eos_is_produced = true;
+        index_channel._node_channels[node_id] = node_channel;
+        index_channel._tablets_by_channel[node_id].insert(1);
+    }
+    index_channel.mark_as_failed(index_channel._node_channels[1004].get(), "test", 1);
+
+    std::unordered_set<int64_t> unfinished_node_channel_ids {1005};
+    std::unordered_set<int64_t> need_finish_tablets {1};
+    ASSERT_FALSE(index_channel._quorum_success(unfinished_node_channel_ids, need_finish_tablets));
+
+    unfinished_node_channel_ids.clear();
+    ASSERT_TRUE(index_channel._quorum_success(unfinished_node_channel_ids, need_finish_tablets));
+}
+
+TEST_F(TestVTabletWriterV2, v2_quorum_waits_for_cross_az_tablet_success) {
+    UniqueId load_id;
+    auto load_stream_map = std::make_shared<LoadStreamMap>(load_id, src_id, 1, 1, nullptr);
+    auto streams_1 = load_stream_map->get_or_create(1001);
+    auto streams_2 = load_stream_map->get_or_create(1002);
+    auto streams_3 = load_stream_map->get_or_create(1003);
+    auto streams_4 = load_stream_map->get_or_create(1004);
+    auto streams_5 = load_stream_map->get_or_create(1005);
+    for (const auto& streams : {streams_1, streams_2, streams_3, streams_4, streams_5}) {
+        streams->mark_open();
+        streams->streams().front()->_is_closing.store(true);
+    }
+    for (const auto& streams : {streams_1, streams_2, streams_3}) {
+        streams->select_one_stream()->add_success_tablet(1);
+    }
+    streams_4->select_one_stream()->add_failed_tablet(1, Status::InternalError("test"));
+
+    TPaloNodesInfo t_nodes;
+    for (const auto& [node_id, location] : std::vector<std::pair<int64_t, std::string>> {
+                 {1001, "az1"}, {1002, "az1"}, {1003, "az1"}, {1004, "az2"}, {1005, "az2"}}) {
+        TNodeInfo node;
+        node.__set_id(node_id);
+        node.__set_location(location);
+        t_nodes.nodes.push_back(node);
+    }
+    DorisNodesInfo nodes_info(t_nodes);
+
+    TOlapTableLocationParam t_location;
+    TTabletLocation tablet;
+    tablet.__set_tablet_id(1);
+    tablet.__set_node_ids({1001, 1002, 1003, 1004, 1005});
+    t_location.tablets.push_back(tablet);
+    OlapTableLocationParam location(t_location);
+
+    auto writer = create_vtablet_writer(5);
+    writer->_load_stream_map = load_stream_map;
+    writer->_nodes_info = &nodes_info;
+    writer->_location = &location;
+    writer->_t_sink.olap_table_sink.__set_cross_az_succ_quorum({{"az2", 1}});
+    for (int64_t node_id : {1001, 1002, 1003, 1004, 1005}) {
+        writer->_tablets_by_node[node_id].insert(1);
+    }
+
+    std::unordered_set<std::shared_ptr<LoadStreamStub>> unfinished_streams {
+            streams_5->streams().front()};
+    std::unordered_set<int64_t> need_finish_tablets {1};
+    ASSERT_FALSE(writer->_quorum_success(unfinished_streams, need_finish_tablets));
+
+    streams_5->select_one_stream()->add_success_tablet(1);
+    unfinished_streams.clear();
+    ASSERT_TRUE(writer->_quorum_success(unfinished_streams, need_finish_tablets));
 }
 
 } // namespace doris

--- a/be/test/load/load_channel_test.cpp
+++ b/be/test/load/load_channel_test.cpp
@@ -24,6 +24,7 @@
 #include "load/channel/load_channel_mgr.h"
 #include "runtime/exec_env.h"
 #include "runtime/fragment_mgr.h"
+#include "util/debug_points.h"
 
 namespace doris {
 
@@ -134,6 +135,53 @@ TEST_F(LoadChannelFinalTabletResultTest, CancelCompletesDeferredRpcOnce) {
     ASSERT_TRUE(channel.cancel(Status::Cancelled("second cancellation")).ok());
     EXPECT_EQ(closure.runs, 1);
     EXPECT_TRUE(Status::create(response.status()).is<ErrorCode::CANCELLED>());
+}
+
+TEST_F(LoadChannelFinalTabletResultTest, CancelBeforeReserveDoesNotParkRpc) {
+    LoadChannel channel(UniqueId(3, 5), 60, false, "test", -1, false, -1);
+    ASSERT_TRUE(channel.cancel(Status::Cancelled("early cancellation")).ok());
+
+    PTabletWriterAddBlockResult response;
+    Status::OK().to_protobuf(response.mutable_status());
+    CountingClosure closure;
+    google::protobuf::Closure* done = &closure;
+    channel._reserve_final_tablet_result(10);
+    channel._defer_or_copy_final_tablet_result(10, 1, &response, &done);
+
+    EXPECT_EQ(done, &closure);
+    EXPECT_TRUE(Status::create(response.status()).is<ErrorCode::CANCELLED>());
+}
+
+TEST_F(LoadChannelFinalTabletResultTest, FinishPublishesTombstoneBeforeCopy) {
+    LoadChannelMgr manager;
+    manager._load_state_channels = std::make_unique<LoadChannelMgr::LoadStateChannelCache>(1024);
+    manager._final_tablet_result_cache = std::make_unique<LoadChannelMgr::FinalTabletResultCache>();
+    UniqueId load_id(6, 7);
+    auto channel = std::make_shared<LoadChannel>(load_id, 60, false, "test", -1, false, -1);
+    PTabletWriterAddBlockResult final_response;
+    Status::OK().to_protobuf(final_response.mutable_status());
+    channel->_publish_final_tablet_result(10, 1, final_response);
+    manager._load_channels.emplace(load_id, channel);
+
+    bool cancelled_during_copy = false;
+    const bool old_enable_debug_points = config::enable_debug_points;
+    config::enable_debug_points = true;
+    DebugPoints::instance()->add_with_callback(
+            "LoadChannelMgr.finish.before_copy", std::function<void()>([&] {
+                cancelled_during_copy = true;
+                PTabletWriterCancelRequest request;
+                request.mutable_id()->CopyFrom(load_id.to_proto());
+                ASSERT_TRUE(manager.cancel(request).ok());
+            }));
+    manager._finish_load_channel(load_id, channel);
+    DebugPoints::instance()->remove("LoadChannelMgr.finish.before_copy");
+    config::enable_debug_points = old_enable_debug_points;
+
+    EXPECT_TRUE(cancelled_during_copy);
+    auto* handle = manager._load_state_channels->lookup(load_id.to_string());
+    ASSERT_NE(handle, nullptr);
+    manager._load_state_channels->release(handle);
+    manager.stop();
 }
 
 TEST_F(LoadChannelFinalTabletResultTest, ManagerReservesResultBeforeReturningChannel) {

--- a/be/test/load/load_channel_test.cpp
+++ b/be/test/load/load_channel_test.cpp
@@ -1,0 +1,246 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "load/channel/load_channel.h"
+
+#include <gen_cpp/internal_service.pb.h>
+#include <google/protobuf/stubs/callback.h>
+#include <gtest/gtest.h>
+
+#include "load/channel/load_channel_mgr.h"
+#include "runtime/exec_env.h"
+#include "runtime/fragment_mgr.h"
+
+namespace doris {
+
+class LoadChannelFinalTabletResultTest : public testing::Test {
+protected:
+    void SetUp() override {
+        _exec_env = ExecEnv::GetInstance();
+        _previous_fragment_mgr = _exec_env->_fragment_mgr;
+        if (_previous_fragment_mgr == nullptr) {
+            _fragment_mgr = std::make_unique<FragmentMgr>(_exec_env);
+            _exec_env->_fragment_mgr = _fragment_mgr.get();
+        }
+    }
+
+    void TearDown() override {
+        if (_fragment_mgr != nullptr) {
+            _fragment_mgr->stop();
+            _exec_env->_fragment_mgr = _previous_fragment_mgr;
+        }
+    }
+
+    class CountingClosure final : public google::protobuf::Closure {
+    public:
+        void Run() override { ++runs; }
+
+        int runs = 0;
+    };
+
+    ExecEnv* _exec_env = nullptr;
+    FragmentMgr* _previous_fragment_mgr = nullptr;
+    std::unique_ptr<FragmentMgr> _fragment_mgr;
+};
+
+TEST_F(LoadChannelFinalTabletResultTest, PublishCompletesDeferredRpcOnce) {
+    LoadChannel channel(UniqueId(1, 2), 60, false, "test", -1, false, -1);
+    PTabletWriterAddBlockResult deferred_response;
+    Status::OK().to_protobuf(deferred_response.mutable_status());
+    auto* deferred_error = deferred_response.add_tablet_errors();
+    deferred_error->set_tablet_id(102);
+    deferred_error->set_msg("early failure");
+    CountingClosure closure;
+    google::protobuf::Closure* done = &closure;
+
+    channel._defer_or_copy_final_tablet_result(10, 1, &deferred_response, &done);
+    EXPECT_EQ(done, nullptr);
+    EXPECT_EQ(closure.runs, 0);
+    std::unordered_map<int64_t, LoadChannel::FinalTabletResult> final_results;
+    bool oversized = false;
+    size_t result_bytes = 0;
+    EXPECT_FALSE(
+            channel.copy_final_tablet_results(&final_results, 1024, &oversized, &result_bytes));
+
+    PTabletWriterAddBlockResult final_response;
+    Status::OK().to_protobuf(final_response.mutable_status());
+    auto* tablet = final_response.add_tablet_vec();
+    tablet->set_tablet_id(100);
+    tablet->set_schema_hash(0);
+    auto* error = final_response.add_tablet_errors();
+    error->set_tablet_id(101);
+    error->set_msg("failed");
+
+    channel._publish_final_tablet_result(10, 2, final_response);
+    EXPECT_EQ(closure.runs, 1);
+    EXPECT_TRUE(Status::create(deferred_response.status()).ok());
+    ASSERT_EQ(deferred_response.tablet_vec_size(), 1);
+    EXPECT_EQ(deferred_response.tablet_vec(0).tablet_id(), 100);
+    EXPECT_TRUE(deferred_response.final_tablet_result_fanout());
+    ASSERT_EQ(deferred_response.tablet_errors_size(), 2);
+    std::unordered_set<int64_t> error_tablet_ids;
+    for (const auto& tablet_error : deferred_response.tablet_errors()) {
+        error_tablet_ids.insert(tablet_error.tablet_id());
+    }
+    EXPECT_EQ(error_tablet_ids, (std::unordered_set<int64_t> {101, 102}));
+
+    PTabletWriterAddBlockResult final_rpc_response = final_response;
+    CountingClosure final_closure;
+    google::protobuf::Closure* final_done = &final_closure;
+    channel._defer_or_copy_final_tablet_result(10, 2, &final_rpc_response, &final_done);
+    EXPECT_EQ(final_done, &final_closure);
+    EXPECT_EQ(final_closure.runs, 0);
+    EXPECT_EQ(final_rpc_response.tablet_errors_size(), 2);
+    EXPECT_FALSE(final_rpc_response.final_tablet_result_fanout());
+
+    channel._publish_final_tablet_result(10, 2, final_response);
+    EXPECT_EQ(closure.runs, 1);
+    EXPECT_TRUE(channel.copy_final_tablet_results(&final_results, 1024, &oversized, &result_bytes));
+    EXPECT_FALSE(oversized);
+    EXPECT_EQ(final_results.at(10).owner_sender_id, 2);
+    EXPECT_TRUE(channel.copy_final_tablet_results(&final_results, 0, &oversized, &result_bytes));
+    EXPECT_TRUE(oversized);
+}
+
+TEST_F(LoadChannelFinalTabletResultTest, CancelCompletesDeferredRpcOnce) {
+    LoadChannel channel(UniqueId(3, 4), 60, false, "test", -1, false, -1);
+    PTabletWriterAddBlockResult response;
+    Status::OK().to_protobuf(response.mutable_status());
+    CountingClosure closure;
+    google::protobuf::Closure* done = &closure;
+
+    channel._defer_or_copy_final_tablet_result(10, 1, &response, &done);
+    ASSERT_TRUE(channel.cancel(Status::Cancelled("test cancellation")).ok());
+    EXPECT_EQ(closure.runs, 1);
+    EXPECT_TRUE(Status::create(response.status()).is<ErrorCode::CANCELLED>());
+
+    PTabletWriterAddBlockResult late_result;
+    Status::OK().to_protobuf(late_result.mutable_status());
+    channel._publish_final_tablet_result(10, 2, late_result);
+    ASSERT_TRUE(channel.cancel(Status::Cancelled("second cancellation")).ok());
+    EXPECT_EQ(closure.runs, 1);
+    EXPECT_TRUE(Status::create(response.status()).is<ErrorCode::CANCELLED>());
+}
+
+TEST_F(LoadChannelFinalTabletResultTest, ManagerReservesResultBeforeReturningChannel) {
+    LoadChannelMgr manager;
+    UniqueId load_id(5, 6);
+    auto channel = std::make_shared<LoadChannel>(load_id, 60, false, "test", -1, false, -1);
+    manager._load_channels.emplace(load_id, channel);
+    PTabletWriterAddBlockRequest request;
+    request.set_index_id(10);
+    request.set_eos(true);
+    request.set_need_final_tablet_result(true);
+    std::shared_ptr<LoadChannel> returned_channel;
+    bool is_eof = false;
+    PTabletWriterAddBlockResult response;
+
+    ASSERT_TRUE(
+            manager._get_load_channel(returned_channel, is_eof, load_id, request, &response).ok());
+    EXPECT_EQ(returned_channel, channel);
+    EXPECT_FALSE(is_eof);
+    EXPECT_TRUE(channel->need_final_tablet_result());
+    std::unordered_map<int64_t, LoadChannel::FinalTabletResult> final_results;
+    bool oversized = false;
+    size_t result_bytes = 0;
+    EXPECT_FALSE(
+            channel->copy_final_tablet_results(&final_results, 1024, &oversized, &result_bytes));
+    manager.stop();
+}
+
+TEST_F(LoadChannelFinalTabletResultTest, OrdinaryLoadDoesNotTouchFinalResultCache) {
+    LoadChannelMgr manager;
+    manager._load_state_channels = std::make_unique<LoadChannelMgr::LoadStateChannelCache>(1024);
+    manager._final_tablet_result_cache = std::make_unique<LoadChannelMgr::FinalTabletResultCache>();
+
+    UniqueId load_id(7, 8);
+    auto channel = std::make_shared<LoadChannel>(load_id, 60, false, "test", -1, false, -1);
+    manager._load_channels.emplace(load_id, channel);
+    auto cache_value = std::make_unique<LoadChannelMgr::FinalTabletResultCache::CacheValue>();
+    auto* inserted = manager._final_tablet_result_cache->insert(
+            load_id.to_string(), cache_value.get(), sizeof(*cache_value), sizeof(*cache_value));
+    cache_value.release();
+    manager._final_tablet_result_cache->release(inserted);
+
+    manager._finish_load_channel(load_id, channel);
+
+    auto* cached = manager._final_tablet_result_cache->lookup(load_id.to_string());
+    ASSERT_NE(cached, nullptr);
+    manager._final_tablet_result_cache->release(cached);
+    manager.stop();
+}
+
+TEST_F(LoadChannelFinalTabletResultTest, RetryReadsFinalResultFromSuccessCache) {
+    LoadChannelMgr manager;
+    manager._load_state_channels = std::make_unique<LoadChannelMgr::LoadStateChannelCache>(1024);
+    manager._final_tablet_result_cache = std::make_unique<LoadChannelMgr::FinalTabletResultCache>();
+
+    UniqueId load_id(7, 8);
+    auto channel = std::make_shared<LoadChannel>(load_id, 60, false, "test", -1, false, -1);
+    PTabletWriterAddBlockResult final_response;
+    Status::OK().to_protobuf(final_response.mutable_status());
+    auto* tablet = final_response.add_tablet_vec();
+    tablet->set_tablet_id(100);
+    tablet->set_schema_hash(0);
+    final_response.add_tablet_errors()->set_tablet_id(101);
+    channel->_publish_final_tablet_result(10, 2, final_response);
+    manager._load_channels.emplace(load_id, channel);
+
+    manager._finish_load_channel(load_id, channel);
+
+    PTabletWriterAddBlockRequest retry;
+    retry.mutable_id()->CopyFrom(load_id.to_proto());
+    retry.set_index_id(10);
+    retry.set_eos(true);
+    retry.set_sender_id(2);
+    retry.set_need_final_tablet_result(true);
+    PTabletWriterAddBlockResult retry_response;
+    Status retry_status = manager.add_batch(retry, &retry_response);
+
+    retry.set_index_id(11);
+    PTabletWriterAddBlockResult unavailable_response;
+    Status unavailable_status = manager.add_batch(retry, &unavailable_response);
+
+    retry.set_need_final_tablet_result(false);
+    PTabletWriterAddBlockResult legacy_retry_response;
+    Status legacy_retry_status = manager.add_batch(retry, &legacy_retry_response);
+
+    ASSERT_TRUE(retry_status.ok());
+    EXPECT_TRUE(unavailable_status.ok());
+    EXPECT_TRUE(legacy_retry_status.ok());
+    EXPECT_TRUE(Status::create(retry_response.status()).ok());
+    ASSERT_EQ(retry_response.tablet_vec_size(), 1);
+    EXPECT_EQ(retry_response.tablet_vec(0).tablet_id(), 100);
+    ASSERT_EQ(retry_response.tablet_errors_size(), 1);
+    EXPECT_EQ(retry_response.tablet_errors(0).tablet_id(), 101);
+    EXPECT_FALSE(retry_response.final_tablet_result_fanout());
+
+    retry.set_index_id(10);
+    retry.set_sender_id(1);
+    retry.set_need_final_tablet_result(true);
+    PTabletWriterAddBlockResult fanout_retry_response;
+    ASSERT_TRUE(manager.add_batch(retry, &fanout_retry_response).ok());
+    EXPECT_TRUE(fanout_retry_response.final_tablet_result_fanout());
+
+    manager._final_tablet_result_cache->erase(load_id.to_string());
+    PTabletWriterAddBlockResult uncached_retry_response;
+    ASSERT_TRUE(manager.add_batch(retry, &uncached_retry_response).ok());
+    EXPECT_EQ(uncached_retry_response.tablet_vec_size(), 0);
+    manager.stop();
+}
+
+} // namespace doris

--- a/be/test/load/load_channel_test.cpp
+++ b/be/test/load/load_channel_test.cpp
@@ -193,6 +193,40 @@ TEST_F(LoadChannelFinalTabletResultTest, FinishPreservesResultAcrossConcurrentCa
     manager.stop();
 }
 
+TEST_F(LoadChannelFinalTabletResultTest, FinishedWaitsForPendingFinalTabletResult) {
+    LoadChannelMgr manager;
+    manager._load_state_channels = std::make_unique<LoadChannelMgr::LoadStateChannelCache>(1024);
+    manager._final_tablet_result_cache = std::make_unique<LoadChannelMgr::FinalTabletResultCache>();
+    UniqueId load_id(7, 8);
+    auto channel = std::make_shared<LoadChannel>(load_id, 60, false, "test", -1, false, -1);
+    channel->_opened = true;
+    channel->_reserve_final_tablet_result(10);
+    manager._load_channels.emplace(load_id, channel);
+
+    EXPECT_FALSE(channel->is_finished());
+    EXPECT_TRUE(manager._load_channels.contains(load_id));
+    EXPECT_EQ(manager._load_state_channels->lookup(load_id.to_string()), nullptr);
+
+    PTabletWriterAddBlockResult final_response;
+    Status::OK().to_protobuf(final_response.mutable_status());
+    final_response.add_tablet_vec()->set_tablet_id(100);
+    channel->_publish_final_tablet_result(10, 1, final_response);
+    EXPECT_TRUE(channel->is_finished());
+    manager._finish_load_channel(load_id, channel);
+
+    PTabletWriterAddBlockRequest retry;
+    retry.mutable_id()->CopyFrom(load_id.to_proto());
+    retry.set_index_id(10);
+    retry.set_eos(true);
+    retry.set_sender_id(1);
+    retry.set_need_final_tablet_result(true);
+    PTabletWriterAddBlockResult retry_response;
+    ASSERT_TRUE(manager.add_batch(retry, &retry_response).ok());
+    ASSERT_EQ(retry_response.tablet_vec_size(), 1);
+    EXPECT_EQ(retry_response.tablet_vec(0).tablet_id(), 100);
+    manager.stop();
+}
+
 TEST_F(LoadChannelFinalTabletResultTest, ManagerReservesResultBeforeReturningChannel) {
     LoadChannelMgr manager;
     UniqueId load_id(5, 6);

--- a/be/test/load/load_channel_test.cpp
+++ b/be/test/load/load_channel_test.cpp
@@ -152,14 +152,16 @@ TEST_F(LoadChannelFinalTabletResultTest, CancelBeforeReserveDoesNotParkRpc) {
     EXPECT_TRUE(Status::create(response.status()).is<ErrorCode::CANCELLED>());
 }
 
-TEST_F(LoadChannelFinalTabletResultTest, FinishPublishesTombstoneBeforeCopy) {
+TEST_F(LoadChannelFinalTabletResultTest, FinishPreservesResultAcrossConcurrentCancel) {
     LoadChannelMgr manager;
     manager._load_state_channels = std::make_unique<LoadChannelMgr::LoadStateChannelCache>(1024);
     manager._final_tablet_result_cache = std::make_unique<LoadChannelMgr::FinalTabletResultCache>();
     UniqueId load_id(6, 7);
     auto channel = std::make_shared<LoadChannel>(load_id, 60, false, "test", -1, false, -1);
+    channel->_opened = true;
     PTabletWriterAddBlockResult final_response;
     Status::OK().to_protobuf(final_response.mutable_status());
+    final_response.add_tablet_vec()->set_tablet_id(100);
     channel->_publish_final_tablet_result(10, 1, final_response);
     manager._load_channels.emplace(load_id, channel);
 
@@ -178,9 +180,16 @@ TEST_F(LoadChannelFinalTabletResultTest, FinishPublishesTombstoneBeforeCopy) {
     config::enable_debug_points = old_enable_debug_points;
 
     EXPECT_TRUE(cancelled_during_copy);
-    auto* handle = manager._load_state_channels->lookup(load_id.to_string());
-    ASSERT_NE(handle, nullptr);
-    manager._load_state_channels->release(handle);
+    PTabletWriterAddBlockRequest retry;
+    retry.mutable_id()->CopyFrom(load_id.to_proto());
+    retry.set_index_id(10);
+    retry.set_eos(true);
+    retry.set_sender_id(1);
+    retry.set_need_final_tablet_result(true);
+    PTabletWriterAddBlockResult retry_response;
+    ASSERT_TRUE(manager.add_batch(retry, &retry_response).ok());
+    ASSERT_EQ(retry_response.tablet_vec_size(), 1);
+    EXPECT_EQ(retry_response.tablet_vec(0).tablet_id(), 100);
     manager.stop();
 }
 
@@ -268,7 +277,7 @@ TEST_F(LoadChannelFinalTabletResultTest, RetryReadsFinalResultFromSuccessCache) 
     Status legacy_retry_status = manager.add_batch(retry, &legacy_retry_response);
 
     ASSERT_TRUE(retry_status.ok());
-    EXPECT_TRUE(unavailable_status.ok());
+    EXPECT_FALSE(unavailable_status.ok());
     EXPECT_TRUE(legacy_retry_status.ok());
     EXPECT_TRUE(Status::create(retry_response.status()).ok());
     ASSERT_EQ(retry_response.tablet_vec_size(), 1);
@@ -286,8 +295,45 @@ TEST_F(LoadChannelFinalTabletResultTest, RetryReadsFinalResultFromSuccessCache) 
 
     manager._final_tablet_result_cache->erase(load_id.to_string());
     PTabletWriterAddBlockResult uncached_retry_response;
-    ASSERT_TRUE(manager.add_batch(retry, &uncached_retry_response).ok());
-    EXPECT_EQ(uncached_retry_response.tablet_vec_size(), 0);
+    EXPECT_FALSE(manager.add_batch(retry, &uncached_retry_response).ok());
+    manager.stop();
+}
+
+TEST_F(LoadChannelFinalTabletResultTest, RetryCopiesFinalResultWithoutManagerLock) {
+    LoadChannelMgr manager;
+    manager._load_state_channels = std::make_unique<LoadChannelMgr::LoadStateChannelCache>(1024);
+    manager._final_tablet_result_cache = std::make_unique<LoadChannelMgr::FinalTabletResultCache>();
+    UniqueId load_id(8, 9);
+    auto* success = manager._load_state_channels->insert(load_id.to_string(), nullptr, 1, 1);
+    manager._load_state_channels->release(success);
+    auto cache_value = std::make_unique<LoadChannelMgr::FinalTabletResultCache::CacheValue>();
+    Status::OK().to_protobuf(cache_value->_results[10].result.mutable_status());
+    auto* cached = manager._final_tablet_result_cache->insert(
+            load_id.to_string(), cache_value.get(), sizeof(*cache_value), sizeof(*cache_value));
+    cache_value.release();
+    manager._final_tablet_result_cache->release(cached);
+
+    bool manager_lock_available = false;
+    const bool old_enable_debug_points = config::enable_debug_points;
+    config::enable_debug_points = true;
+    DebugPoints::instance()->add_with_callback(
+            "LoadChannelMgr.get.before_copy", std::function<void()>([&] {
+                manager_lock_available = manager._lock.try_lock();
+                if (manager_lock_available) {
+                    manager._lock.unlock();
+                }
+            }));
+    PTabletWriterAddBlockRequest retry;
+    retry.mutable_id()->CopyFrom(load_id.to_proto());
+    retry.set_index_id(10);
+    retry.set_eos(true);
+    retry.set_need_final_tablet_result(true);
+    PTabletWriterAddBlockResult response;
+    EXPECT_TRUE(manager.add_batch(retry, &response).ok());
+    DebugPoints::instance()->remove("LoadChannelMgr.get.before_copy");
+    config::enable_debug_points = old_enable_debug_points;
+
+    EXPECT_TRUE(manager_lock_available);
     manager.stop();
 }
 

--- a/be/test/runtime/load_stream_test.cpp
+++ b/be/test/runtime/load_stream_test.cpp
@@ -307,6 +307,7 @@ struct ResponseStat {
     struct TabletOutcome {
         std::vector<int64_t> success_tablet_ids;
         std::vector<int64_t> failed_tablet_ids;
+        bool final_tablet_result_fanout = false;
     };
 
     std::atomic<int32_t> num {0};
@@ -349,6 +350,7 @@ public:
                         stat.failed_tablet_ids.push_back(tablet.id());
                         outcome.failed_tablet_ids.push_back(tablet.id());
                     }
+                    outcome.final_tablet_result_fanout = response.final_tablet_result_fanout();
                     stat.tablet_outcomes.push_back(std::move(outcome));
                     stat.num++;
                 };
@@ -1367,6 +1369,20 @@ TEST_F(LoadStreamMgrTest,
 
     EXPECT_EQ(final_outcome_count(0), 1);
     EXPECT_EQ(final_outcome_count(1), 1);
+
+    int owner_count = 0;
+    int fanout_count = 0;
+    for (int source = 0; source < kSourceCount; ++source) {
+        for (int stream = 0; stream < kStreamsPerSource; ++stream) {
+            for (const auto& outcome : clients[source][stream].tablet_outcomes()) {
+                if (outcome.success_tablet_ids == std::vector<int64_t> {NORMAL_TABLET_ID}) {
+                    outcome.final_tablet_result_fanout ? ++fanout_count : ++owner_count;
+                }
+            }
+        }
+    }
+    EXPECT_EQ(owner_count, 1);
+    EXPECT_EQ(fanout_count, 1);
 }
 
 TEST_F(LoadStreamMgrTest, two_client_one_close_before_the_other_open) {

--- a/be/test/runtime/load_stream_test.cpp
+++ b/be/test/runtime/load_stream_test.cpp
@@ -304,9 +304,15 @@ static void create_tablet_request(int64_t tablet_id, int32_t schema_hash,
 }
 
 struct ResponseStat {
-    std::atomic<int32_t> num;
+    struct TabletOutcome {
+        std::vector<int64_t> success_tablet_ids;
+        std::vector<int64_t> failed_tablet_ids;
+    };
+
+    std::atomic<int32_t> num {0};
     std::vector<int64_t> success_tablet_ids;
     std::vector<int64_t> failed_tablet_ids;
+    std::vector<TabletOutcome> tablet_outcomes;
 };
 bthread::Mutex g_stat_lock;
 static ResponseStat g_response_stat;
@@ -316,12 +322,15 @@ void reset_response_stat() {
     g_response_stat.num = 0;
     g_response_stat.success_tablet_ids.clear();
     g_response_stat.failed_tablet_ids.clear();
+    g_response_stat.tablet_outcomes.clear();
 }
 
 class LoadStreamMgrTest : public testing::Test {
 public:
     class Handler : public brpc::StreamInputHandler {
     public:
+        explicit Handler(ResponseStat* response_stat = nullptr) : _response_stat(response_stat) {}
+
         int on_received_messages(StreamId id, butil::IOBuf* const messages[],
                                  size_t size) override {
             for (size_t i = 0; i < size; i++) {
@@ -330,19 +339,32 @@ public:
                 response.ParseFromZeroCopyStream(&wrapper);
                 LOG(INFO) << "response " << response.DebugString();
                 std::lock_guard lock_guard(g_stat_lock);
-                for (auto& id : response.success_tablet_ids()) {
-                    g_response_stat.success_tablet_ids.push_back(id);
+                auto record_response = [&](ResponseStat& stat) {
+                    ResponseStat::TabletOutcome outcome;
+                    for (auto tablet_id : response.success_tablet_ids()) {
+                        stat.success_tablet_ids.push_back(tablet_id);
+                        outcome.success_tablet_ids.push_back(tablet_id);
+                    }
+                    for (const auto& tablet : response.failed_tablets()) {
+                        stat.failed_tablet_ids.push_back(tablet.id());
+                        outcome.failed_tablet_ids.push_back(tablet.id());
+                    }
+                    stat.tablet_outcomes.push_back(std::move(outcome));
+                    stat.num++;
+                };
+                record_response(g_response_stat);
+                if (_response_stat != nullptr) {
+                    record_response(*_response_stat);
                 }
-                for (auto& tablet : response.failed_tablets()) {
-                    g_response_stat.failed_tablet_ids.push_back(tablet.id());
-                }
-                g_response_stat.num++;
             }
 
             return 0;
         }
         void on_idle_timeout(StreamId id) override { std::cerr << "on_idle_timeout" << std::endl; }
         void on_closed(StreamId id) override { std::cerr << "on_closed" << std::endl; }
+
+    private:
+        ResponseStat* _response_stat;
     };
 
     class StreamService : public PBackendService {
@@ -405,7 +427,7 @@ public:
 
     class MockSinkClient {
     public:
-        MockSinkClient() = default;
+        MockSinkClient() : _handler(&_response_stat) {}
         ~MockSinkClient() { disconnect(); }
 
         class MockClosure : public google::protobuf::Closure {
@@ -420,7 +442,8 @@ public:
             std::function<void()> _cb;
         };
 
-        Status connect_stream(int64_t sender_id = NORMAL_SENDER_ID, int total_streams = 1) {
+        Status connect_stream(int64_t sender_id = NORMAL_SENDER_ID, int total_streams = 1,
+                              bool need_final_tablet_result = false) {
             brpc::Channel channel;
             std::cerr << "connect_stream" << std::endl;
             // Initialize the channel, NULL means using default options.
@@ -454,6 +477,9 @@ public:
             request.set_txn_id(NORMAL_TXN_ID);
             request.set_src_id(sender_id);
             request.set_total_streams(total_streams);
+            if (need_final_tablet_result) {
+                request.set_need_final_tablet_result(true);
+            }
             auto ptablet = request.add_tablets();
             ptablet->set_tablet_id(NORMAL_TABLET_ID);
             ptablet->set_index_id(NORMAL_INDEX_ID);
@@ -484,10 +510,16 @@ public:
 
         Status close() { return Status::OK(); }
 
+        std::vector<ResponseStat::TabletOutcome> tablet_outcomes() const {
+            std::lock_guard lock_guard(g_stat_lock);
+            return _response_stat.tablet_outcomes;
+        }
+
     private:
         brpc::StreamId _stream;
         brpc::Controller _cntl;
         brpc::StreamOptions _stream_options;
+        ResponseStat _response_stat;
         Handler _handler;
     };
 
@@ -1277,6 +1309,64 @@ TEST_F(LoadStreamMgrTest, two_client_one_index_one_tablet_three_segment) {
     // server will close stream on CLOSE_LOAD
     wait_for_close();
     EXPECT_EQ(_load_stream_mgr->get_load_stream_num(), 0);
+}
+
+TEST_F(LoadStreamMgrTest,
+       multiple_sources_receive_same_final_outcome_with_multiple_physical_streams) {
+    constexpr int kSourceCount = 2;
+    constexpr int kStreamsPerSource = 2;
+    constexpr int kTotalStreams = kSourceCount * kStreamsPerSource;
+    MockSinkClient clients[kSourceCount][kStreamsPerSource];
+
+    for (int source = 0; source < kSourceCount; ++source) {
+        for (int stream = 0; stream < kStreamsPerSource; ++stream) {
+            ASSERT_TRUE(clients[source][stream].connect_stream(source, kTotalStreams, true).ok());
+        }
+    }
+    reset_response_stat();
+
+    std::string data = "success tablet data";
+    write_one_tablet(clients[0][0], NORMAL_LOAD_ID, 0, NORMAL_INDEX_ID, NORMAL_TABLET_ID, 0, 0,
+                     data, true);
+
+    PTabletID success_tablet;
+    success_tablet.set_partition_id(NORMAL_PARTITION_ID);
+    success_tablet.set_index_id(NORMAL_INDEX_ID);
+    success_tablet.set_tablet_id(NORMAL_TABLET_ID);
+    success_tablet.set_num_segments(1);
+    PTabletID failed_tablet {success_tablet};
+    failed_tablet.set_tablet_id(NORMAL_TABLET_ID + 1);
+
+    // Close both physical streams of source 0 before source 1. The final tablet result is not
+    // available yet, but source 0 must retain a representative stream to receive it later.
+    close_load(clients[0][0], {success_tablet, failed_tablet}, 0);
+    close_load(clients[0][1], {}, 0);
+    wait_for_ack(1);
+    EXPECT_EQ(g_response_stat.num.load(), 1);
+
+    close_load(clients[1][0], {}, 1);
+    close_load(clients[1][1], {}, 1);
+    wait_for_ack(kTotalStreams);
+    EXPECT_EQ(g_response_stat.num.load(), kTotalStreams);
+
+    wait_for_close();
+    ASSERT_EQ(_load_stream_mgr->get_load_stream_num(), 0);
+
+    auto final_outcome_count = [&](int source) {
+        int count = 0;
+        for (int stream = 0; stream < kStreamsPerSource; ++stream) {
+            for (const auto& outcome : clients[source][stream].tablet_outcomes()) {
+                if (outcome.success_tablet_ids == std::vector<int64_t> {NORMAL_TABLET_ID} &&
+                    outcome.failed_tablet_ids == std::vector<int64_t> {NORMAL_TABLET_ID + 1}) {
+                    ++count;
+                }
+            }
+        }
+        return count;
+    };
+
+    EXPECT_EQ(final_outcome_count(0), 1);
+    EXPECT_EQ(final_outcome_count(1), 1);
 }
 
 TEST_F(LoadStreamMgrTest, two_client_one_close_before_the_other_open) {

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -17,9 +17,18 @@
 
 package org.apache.doris.common;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 public class Config extends ConfigBase {
+    private static final Logger LOG = LogManager.getLogger(Config.class);
+    // ConfigBase replaces the array on every update, so its identity is the cache version.
+    private static volatile String[] cachedCrossAzSuccQuorumConfig;
+    private static volatile Map<String, Integer> cachedCrossAzSuccQuorum = Map.of();
 
     @ConfField(description = "The path of the user-defined configuration file, used to store fe_custom.conf. "
             + "Configurations in this file will override those in fe.conf")
@@ -540,6 +549,40 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, masterOnly = true, description = "Minimum number of successfully written replicas for "
             + "a load job.")
     public static short min_load_replica_num = -1;
+
+    @ConfField(mutable = true, masterOnly = true, description = "Minimum number of successfully written replicas "
+            + "required in each availability zone for a load job.")
+    public static String[] cross_az_succ_quorum = {};
+
+    public static Map<String, Integer> getCrossAzSuccQuorum() {
+        String[] config = cross_az_succ_quorum;
+        if (config == cachedCrossAzSuccQuorumConfig) {
+            return cachedCrossAzSuccQuorum;
+        }
+        synchronized (Config.class) {
+            config = cross_az_succ_quorum;
+            if (config == cachedCrossAzSuccQuorumConfig) {
+                return cachedCrossAzSuccQuorum;
+            }
+            Map<String, Integer> parsedConfig = new HashMap<>();
+            for (String item : config) {
+                String[] parts = item.split(":", -1);
+                try {
+                    int configuredMin = Integer.parseInt(parts.length == 2 ? parts[1].trim() : "");
+                    if (parts[0].trim().isEmpty() || configuredMin < 0) {
+                        throw new NumberFormatException();
+                    }
+                    parsedConfig.put(parts[0].trim(), configuredMin);
+                } catch (NumberFormatException e) {
+                    LOG.warn("Invalid cross_az_succ_quorum item '{}', ignored. Expected format "
+                            + "az:min_success_replicas with a non-negative integer.", item);
+                }
+            }
+            cachedCrossAzSuccQuorum = parsedConfig;
+            cachedCrossAzSuccQuorumConfig = config;
+            return parsedConfig;
+        }
+    }
 
     @ConfField(description = "The interval of the load job scheduler, in seconds.")
     public static int load_checker_interval_second = 5;

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -551,7 +551,8 @@ public class Config extends ConfigBase {
     public static short min_load_replica_num = -1;
 
     @ConfField(mutable = true, masterOnly = true, description = "Minimum number of successfully written replicas "
-            + "required in each availability zone for a load job.")
+            + "required in each availability zone for a load job. Enable only after all BEs are upgraded because "
+            + "older receivers do not fan out final tablet results.")
     public static volatile String[] cross_az_succ_quorum = {};
 
     public static Map<String, Integer> getCrossAzSuccQuorum() {

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -552,7 +552,7 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true, masterOnly = true, description = "Minimum number of successfully written replicas "
             + "required in each availability zone for a load job.")
-    public static String[] cross_az_succ_quorum = {};
+    public static volatile String[] cross_az_succ_quorum = {};
 
     public static Map<String, Integer> getCrossAzSuccQuorum() {
         String[] config = cross_az_succ_quorum;

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -238,7 +238,7 @@ public class OlapTableSink extends DataSink {
         tSink.setSchema(tOlapTableSchemaParam);
         tSink.setPartition(tOlapTablePartitionParam);
         tSink.setLocation(tOlapTableLocationParam);
-        tSink.setNodesInfo(createPaloNodesInfo());
+        setNodesInfo(tSink);
 
         if (!olapInsertCtx.isAllowAutoPartition()) {
             setAutoPartition(false);
@@ -293,7 +293,7 @@ public class OlapTableSink extends DataSink {
         tSink.setSchema(tOlapTableSchemaParam);
         tSink.setPartition(tOlapTablePartitionParam);
         tSink.setLocation(tOlapTableLocationParam);
-        tSink.setNodesInfo(createPaloNodesInfo());
+        setNodesInfo(tSink);
     }
 
     public TOlapTableSchemaParam getOlapTableSchemaParam() {
@@ -1324,9 +1324,24 @@ public class OlapTableSink extends DataSink {
             if (backend == null) {
                 continue;
             }
-            nodesInfo.addToNodes(new TNodeInfo(backend.getId(), 0, backend.getHost(), backend.getBrpcPort()));
+            nodesInfo.addToNodes(createNodeInfo(backend));
         }
         return nodesInfo;
+    }
+
+    public static TNodeInfo createNodeInfo(Backend backend) {
+        TNodeInfo nodeInfo = new TNodeInfo(backend.getId(), 0, backend.getHost(), backend.getBrpcPort());
+        if (Config.cross_az_succ_quorum.length > 0) {
+            nodeInfo.setLocation(backend.getLocationTag().value);
+        }
+        return nodeInfo;
+    }
+
+    private void setNodesInfo(TOlapTableSink tSink) {
+        tSink.setNodesInfo(createPaloNodesInfo());
+        if (Config.cross_az_succ_quorum.length > 0) {
+            tSink.setCrossAzSuccQuorum(Config.getCrossAzSuccQuorum());
+        }
     }
 
     protected TDataSinkType getDataSinkType() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/RemoteOlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/RemoteOlapTableSink.java
@@ -24,7 +24,6 @@ import org.apache.doris.system.Backend;
 import org.apache.doris.thrift.TDataSink;
 import org.apache.doris.thrift.TDataSinkType;
 import org.apache.doris.thrift.TNetworkAddress;
-import org.apache.doris.thrift.TNodeInfo;
 import org.apache.doris.thrift.TPaloNodesInfo;
 
 import com.google.common.collect.ImmutableMap;
@@ -61,7 +60,7 @@ public class RemoteOlapTableSink extends OlapTableSink {
             if (backend == null) {
                 continue;
             }
-            nodesInfo.addToNodes(new TNodeInfo(backend.getId(), 0, backend.getHost(), backend.getBrpcPort()));
+            nodesInfo.addToNodes(createNodeInfo(backend));
         }
         return nodesInfo;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -4860,7 +4860,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         SystemInfoService systemInfoService = Env.getCurrentSystemInfo();
         for (Long id : systemInfoService.getAllBackendByCurrentCluster(false)) {
             Backend backend = systemInfoService.getBackend(id);
-            nodeInfos.add(new TNodeInfo(backend.getId(), 0, backend.getHost(), backend.getBrpcPort()));
+            nodeInfos.add(OlapTableSink.createNodeInfo(backend));
         }
         result.setNodes(nodeInfos);
         result.setStatus(new TStatus(TStatusCode.OK));
@@ -5198,7 +5198,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         SystemInfoService systemInfoService = Env.getCurrentSystemInfo();
         for (Long id : systemInfoService.getAllBackendByCurrentCluster(false)) {
             Backend backend = systemInfoService.getBackend(id);
-            nodeInfos.add(new TNodeInfo(backend.getId(), 0, backend.getHost(), backend.getBrpcPort()));
+            nodeInfos.add(OlapTableSink.createNodeInfo(backend));
         }
         result.setNodes(nodeInfos);
 

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -639,10 +639,12 @@ public class DatabaseTransactionMgr {
                                     Backend backend = env.getCurrentSystemInfo().getBackend(backendId);
                                     return backend == null ? "" : backend.getLocationTag().value;
                                 });
-                                boolean canLoad = replica.getState().canLoad()
+                                boolean canLoad = env.getCurrentSystemInfo().checkBackendAlive(tabletBackend)
+                                        && !replica.isBad()
+                                        && (replica.getState().canLoad()
                                         || (replica.getState() == Replica.ReplicaState.DECOMMISSION
                                         && replica.getPostWatermarkTxnId() < 0
-                                        && replica.getLastFailedVersion() < 0);
+                                        && replica.getLastFailedVersion() < 0));
                                 if (canLoad) {
                                     loadReplicaNumByAz.merge(backendLocationTags.get(tabletBackend), 1, Integer::sum);
                                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -61,6 +61,7 @@ import org.apache.doris.persist.EditLog;
 import org.apache.doris.persist.OperationType;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.statistics.AnalysisManager;
+import org.apache.doris.system.Backend;
 import org.apache.doris.task.AgentBatchTask;
 import org.apache.doris.task.AgentTaskExecutor;
 import org.apache.doris.task.ClearTransactionTask;
@@ -494,6 +495,8 @@ public class DatabaseTransactionMgr {
         TabletInvertedIndex tabletInvertedIndex = env.getTabletInvertedIndex();
         Map<Long, Set<Long>> tabletToBackends = new HashMap<>();
         Map<Long, Table> idToTable = new HashMap<>();
+        Map<String, Integer> crossAzSuccQuorum = Config.getCrossAzSuccQuorum();
+        Map<Long, String> backendLocationTags = crossAzSuccQuorum.isEmpty() ? Map.of() : new HashMap<>();
         for (int i = 0; i < tableList.size(); i++) {
             idToTable.put(tableList.get(i).getId(), tableList.get(i));
         }
@@ -622,6 +625,12 @@ public class DatabaseTransactionMgr {
                         // save the error replica ids for current tablet
                         // this param is used for log
                         for (long tabletBackend : tabletBackends) {
+                            if (!crossAzSuccQuorum.isEmpty()) {
+                                backendLocationTags.computeIfAbsent(tabletBackend, backendId -> {
+                                    Backend backend = env.getCurrentSystemInfo().getBackend(backendId);
+                                    return backend == null ? "" : backend.getLocationTag().value;
+                                });
+                            }
                             Replica replica = tabletInvertedIndex.getReplica(tabletId, tabletBackend);
                             if (replica == null) {
                                 throw new TransactionCommitFailedException("could not find replica for tablet ["
@@ -669,6 +678,41 @@ public class DatabaseTransactionMgr {
                             LOG.info(errMsg);
 
                             throw new TabletQuorumFailedException(transactionId, errMsg);
+                        }
+
+                        for (Entry<String, Integer> entry : crossAzSuccQuorum.entrySet()) {
+                            String az = entry.getKey();
+                            int replicaNumInAz = 0;
+                            for (long backendId : tabletBackends) {
+                                if (az.equals(backendLocationTags.get(backendId))) {
+                                    replicaNumInAz++;
+                                }
+                            }
+                            int requiredInAz = Math.min(entry.getValue(), replicaNumInAz);
+                            if (requiredInAz == 0) {
+                                continue;
+                            }
+
+                            int succInAz = 0;
+                            for (Replica replica : tabletSuccReplicas) {
+                                if (az.equals(backendLocationTags.get(replica.getBackendIdWithoutException()))) {
+                                    succInAz++;
+                                }
+                            }
+                            if (succInAz < requiredInAz) {
+                                String writeDetail = getTabletWriteDetail(tabletSuccReplicas,
+                                        tabletWriteFailedReplicas, tabletVersionFailedReplicas);
+                                String errMsg = String.format("Failed to commit txn %s, cause tablet %s cross AZ "
+                                                + "success quorum failed for %s: required %s successful replicas, "
+                                                + "but only %s succeeded. table %s, partition: [ id=%s, commit "
+                                                + "version %s, visible version %s ], this tablet detail: %s. "
+                                                + "Please try again later.",
+                                        transactionId, tablet.getId(), az, requiredInAz, succInAz, tableId,
+                                        partition.getId(), partition.getCommittedVersion(),
+                                        partition.getVisibleVersion(), writeDetail);
+                                LOG.info(errMsg);
+                                throw new TabletQuorumFailedException(transactionId, errMsg);
+                            }
                         }
                     }
                 }

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/DatabaseTransactionMgr.java
@@ -497,6 +497,7 @@ public class DatabaseTransactionMgr {
         Map<Long, Table> idToTable = new HashMap<>();
         Map<String, Integer> crossAzSuccQuorum = Config.getCrossAzSuccQuorum();
         Map<Long, String> backendLocationTags = crossAzSuccQuorum.isEmpty() ? Map.of() : new HashMap<>();
+        Map<String, Integer> loadReplicaNumByAz = crossAzSuccQuorum.isEmpty() ? Map.of() : new HashMap<>();
         for (int i = 0; i < tableList.size(); i++) {
             idToTable.put(tableList.get(i).getId(), tableList.get(i));
         }
@@ -618,6 +619,9 @@ public class DatabaseTransactionMgr {
                         tabletSuccReplicas.clear();
                         tabletWriteFailedReplicas.clear();
                         tabletVersionFailedReplicas.clear();
+                        if (!crossAzSuccQuorum.isEmpty()) {
+                            loadReplicaNumByAz.clear();
+                        }
                         long tabletId = tablet.getId();
                         Set<Long> tabletBackends = tablet.getBackendIds();
                         totalInvolvedBackends.addAll(tabletBackends);
@@ -625,16 +629,23 @@ public class DatabaseTransactionMgr {
                         // save the error replica ids for current tablet
                         // this param is used for log
                         for (long tabletBackend : tabletBackends) {
+                            Replica replica = tabletInvertedIndex.getReplica(tabletId, tabletBackend);
+                            if (replica == null) {
+                                throw new TransactionCommitFailedException("could not find replica for tablet ["
+                                        + tabletId + "], backend [" + tabletBackend + "]");
+                            }
                             if (!crossAzSuccQuorum.isEmpty()) {
                                 backendLocationTags.computeIfAbsent(tabletBackend, backendId -> {
                                     Backend backend = env.getCurrentSystemInfo().getBackend(backendId);
                                     return backend == null ? "" : backend.getLocationTag().value;
                                 });
-                            }
-                            Replica replica = tabletInvertedIndex.getReplica(tabletId, tabletBackend);
-                            if (replica == null) {
-                                throw new TransactionCommitFailedException("could not find replica for tablet ["
-                                        + tabletId + "], backend [" + tabletBackend + "]");
+                                boolean canLoad = replica.getState().canLoad()
+                                        || (replica.getState() == Replica.ReplicaState.DECOMMISSION
+                                        && replica.getPostWatermarkTxnId() < 0
+                                        && replica.getLastFailedVersion() < 0);
+                                if (canLoad) {
+                                    loadReplicaNumByAz.merge(backendLocationTags.get(tabletBackend), 1, Integer::sum);
+                                }
                             }
 
                             // if the tablet have no replica's to commit or the tablet is a rolling up tablet,
@@ -682,12 +693,7 @@ public class DatabaseTransactionMgr {
 
                         for (Entry<String, Integer> entry : crossAzSuccQuorum.entrySet()) {
                             String az = entry.getKey();
-                            int replicaNumInAz = 0;
-                            for (long backendId : tabletBackends) {
-                                if (az.equals(backendLocationTags.get(backendId))) {
-                                    replicaNumInAz++;
-                                }
-                            }
+                            int replicaNumInAz = loadReplicaNumByAz.getOrDefault(az, 0);
                             int requiredInAz = Math.min(entry.getValue(), replicaNumInAz);
                             if (requiredInAz == 0) {
                                 continue;

--- a/fe/fe-core/src/test/java/org/apache/doris/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/transaction/DatabaseTransactionMgrTest.java
@@ -313,8 +313,58 @@ public class DatabaseTransactionMgrTest {
                         transactionId, commitInfos, null);
                 Assert.assertFalse(appender.contains(Level.WARN, "Invalid cross_az_succ_quorum item"));
             }
+
         } finally {
             Config.cross_az_succ_quorum = originalCrossAzSuccQuorum;
+            backend1.setTagMap(backend1TagMap);
+            backend2.setTagMap(backend2TagMap);
+            backend3.setTagMap(backend3TagMap);
+        }
+    }
+
+    @Test
+    public void testCrossAzSuccessQuorumIgnoresDeadAndBadReplicas() throws UserException {
+        FakeEnv.setEnv(masterEnv);
+        String[] originalCrossAzSuccQuorum = Config.cross_az_succ_quorum;
+        Backend backend1 = masterEnv.getCurrentSystemInfo().getBackend(CatalogTestUtil.testBackendId1);
+        Backend backend2 = masterEnv.getCurrentSystemInfo().getBackend(CatalogTestUtil.testBackendId2);
+        Backend backend3 = masterEnv.getCurrentSystemInfo().getBackend(CatalogTestUtil.testBackendId3);
+        Map<String, String> backend1TagMap = ImmutableMap.copyOf(backend1.getTagMap());
+        Map<String, String> backend2TagMap = ImmutableMap.copyOf(backend2.getTagMap());
+        Map<String, String> backend3TagMap = ImmutableMap.copyOf(backend3.getTagMap());
+        backend1.setTagMap(ImmutableMap.of(Tag.TYPE_LOCATION, "az1"));
+        backend2.setTagMap(ImmutableMap.of(Tag.TYPE_LOCATION, "az1"));
+        backend3.setTagMap(ImmutableMap.of(Tag.TYPE_LOCATION, "az2"));
+        OlapTable table = (OlapTable) masterEnv.getInternalCatalog()
+                .getDbOrMetaException(CatalogTestUtil.testDbId1)
+                .getTableOrMetaException(CatalogTestUtil.testTableId1);
+        Replica backend2Replica = table.getPartition(CatalogTestUtil.testPartitionId1)
+                .getIndex(CatalogTestUtil.testIndexId1).getTablet(CatalogTestUtil.testTabletId1)
+                .getReplicaByBackendId(CatalogTestUtil.testBackendId2);
+
+        try {
+            Config.cross_az_succ_quorum = new String[] {"az1:2"};
+            List<TabletCommitInfo> commitInfos = GlobalTransactionMgrTest.generateTabletCommitInfos(
+                    CatalogTestUtil.testTabletId1,
+                    Lists.newArrayList(CatalogTestUtil.testBackendId1, CatalogTestUtil.testBackendId3));
+            backend2.setAlive(false);
+            long transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
+                    Lists.newArrayList(CatalogTestUtil.testTableId1), "cross_az_quorum_ignore_dead", transactionSource,
+                    LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+            masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(table),
+                    transactionId, commitInfos, null);
+            backend2.setAlive(true);
+
+            backend2Replica.setBad(true);
+            transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
+                    Lists.newArrayList(CatalogTestUtil.testTableId1), "cross_az_quorum_ignore_bad", transactionSource,
+                    LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+            masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(table),
+                    transactionId, commitInfos, null);
+        } finally {
+            Config.cross_az_succ_quorum = originalCrossAzSuccQuorum;
+            backend2.setAlive(true);
+            backend2Replica.setBad(false);
             backend1.setTagMap(backend1TagMap);
             backend2.setTagMap(backend2TagMap);
             backend3.setTagMap(backend3TagMap);

--- a/fe/fe-core/src/test/java/org/apache/doris/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/transaction/DatabaseTransactionMgrTest.java
@@ -22,8 +22,11 @@ import org.apache.doris.catalog.CatalogTestUtil;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.FakeEditLog;
 import org.apache.doris.catalog.FakeEnv;
+import org.apache.doris.catalog.LocalReplica;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeMetaVersion;
@@ -311,6 +314,62 @@ public class DatabaseTransactionMgrTest {
                 Assert.assertFalse(appender.contains(Level.WARN, "Invalid cross_az_succ_quorum item"));
             }
         } finally {
+            Config.cross_az_succ_quorum = originalCrossAzSuccQuorum;
+            backend1.setTagMap(backend1TagMap);
+            backend2.setTagMap(backend2TagMap);
+            backend3.setTagMap(backend3TagMap);
+        }
+    }
+
+    @Test
+    public void testCrossAzSuccessQuorumIgnoresTransientCloneWithThreeReplicas() throws UserException {
+        FakeEnv.setEnv(masterEnv);
+        String[] originalCrossAzSuccQuorum = Config.cross_az_succ_quorum;
+        Backend backend1 = masterEnv.getCurrentSystemInfo().getBackend(CatalogTestUtil.testBackendId1);
+        Backend backend2 = masterEnv.getCurrentSystemInfo().getBackend(CatalogTestUtil.testBackendId2);
+        Backend backend3 = masterEnv.getCurrentSystemInfo().getBackend(CatalogTestUtil.testBackendId3);
+        Map<String, String> backend1TagMap = ImmutableMap.copyOf(backend1.getTagMap());
+        Map<String, String> backend2TagMap = ImmutableMap.copyOf(backend2.getTagMap());
+        Map<String, String> backend3TagMap = ImmutableMap.copyOf(backend3.getTagMap());
+        backend1.setTagMap(ImmutableMap.of(Tag.TYPE_LOCATION, "az1"));
+        backend2.setTagMap(ImmutableMap.of(Tag.TYPE_LOCATION, "az2"));
+        backend3.setTagMap(ImmutableMap.of(Tag.TYPE_LOCATION, "az2"));
+
+        long cloneBackendId = CatalogTestUtil.testBackendId3 + 100;
+        Backend cloneBackend = CatalogTestUtil.createBackend(cloneBackendId, "clone-host", 123, 124, 125);
+        cloneBackend.setTagMap(ImmutableMap.of(Tag.TYPE_LOCATION, "az1"));
+        masterEnv.getCurrentSystemInfo().addBackend(cloneBackend);
+
+        OlapTable table = (OlapTable) masterEnv.getInternalCatalog()
+                .getDbOrMetaException(CatalogTestUtil.testDbId1)
+                .getTableOrMetaException(CatalogTestUtil.testTableId1);
+        Tablet tablet = table.getPartition(CatalogTestUtil.testPartitionId1)
+                .getIndex(CatalogTestUtil.testIndexId1).getTablet(CatalogTestUtil.testTabletId1);
+        Replica cloneReplica = new LocalReplica(CatalogTestUtil.testReplicaId3 + 100,
+                cloneBackendId, Replica.ReplicaState.CLONE,
+                CatalogTestUtil.testStartVersion, CatalogTestUtil.testSchemaHash1);
+        tablet.addReplica(cloneReplica);
+
+        try {
+            Assert.assertEquals(3, table.getPartitionInfo()
+                    .getReplicaAllocation(CatalogTestUtil.testPartitionId1).getTotalReplicaNum());
+            Assert.assertEquals(4, tablet.getReplicas().size());
+            Assert.assertEquals(Replica.ReplicaState.CLONE,
+                    tablet.getReplicaByBackendId(cloneBackendId).getState());
+
+            Config.cross_az_succ_quorum = new String[] {"az1:2"};
+            long transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
+                    Lists.newArrayList(CatalogTestUtil.testTableId1), "cross_az_quorum_ignore_rf3_clone",
+                    transactionSource, LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+            List<TabletCommitInfo> commitInfos = GlobalTransactionMgrTest.generateTabletCommitInfos(
+                    CatalogTestUtil.testTabletId1,
+                    Lists.newArrayList(CatalogTestUtil.testBackendId1, CatalogTestUtil.testBackendId2));
+
+            masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(table),
+                    transactionId, commitInfos, null);
+        } finally {
+            tablet.deleteReplica(cloneReplica);
+            masterEnv.getCurrentSystemInfo().dropBackend(cloneBackendId);
             Config.cross_az_succ_quorum = originalCrossAzSuccQuorum;
             backend1.setTagMap(backend1TagMap);
             backend2.setTagMap(backend2TagMap);

--- a/fe/fe-core/src/test/java/org/apache/doris/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/transaction/DatabaseTransactionMgrTest.java
@@ -31,14 +31,19 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.meta.MetaContext;
+import org.apache.doris.mysql.authenticate.TestLogAppender;
+import org.apache.doris.resource.Tag;
+import org.apache.doris.system.Backend;
 import org.apache.doris.task.PublishVersionTask;
 import org.apache.doris.thrift.TPartitionVersionInfo;
 import org.apache.doris.transaction.GlobalTransactionMgrTest.SubTransactionInfo;
 import org.apache.doris.transaction.TransactionState.LoadJobSourceType;
 import org.apache.doris.tso.TSOService;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
@@ -232,6 +237,85 @@ public class DatabaseTransactionMgrTest {
         TransactionState transactionState2 = masterDbTransMgr.getTransactionState(txnId2);
         Assert.assertEquals(txnId2.longValue(), transactionState2.getTransactionId());
         Assert.assertEquals(TransactionStatus.PREPARE, transactionState2.getTransactionStatus());
+    }
+
+    @Test
+    public void testCrossAzSuccessQuorum() throws UserException {
+        FakeEnv.setEnv(masterEnv);
+        String[] originalCrossAzSuccQuorum = Config.cross_az_succ_quorum;
+        Backend backend1 = masterEnv.getCurrentSystemInfo().getBackend(CatalogTestUtil.testBackendId1);
+        Backend backend2 = masterEnv.getCurrentSystemInfo().getBackend(CatalogTestUtil.testBackendId2);
+        Backend backend3 = masterEnv.getCurrentSystemInfo().getBackend(CatalogTestUtil.testBackendId3);
+        Map<String, String> backend1TagMap = ImmutableMap.copyOf(backend1.getTagMap());
+        Map<String, String> backend2TagMap = ImmutableMap.copyOf(backend2.getTagMap());
+        Map<String, String> backend3TagMap = ImmutableMap.copyOf(backend3.getTagMap());
+        backend1.setTagMap(ImmutableMap.of(Tag.TYPE_LOCATION, "az1"));
+        backend2.setTagMap(ImmutableMap.of(Tag.TYPE_LOCATION, "az1"));
+        backend3.setTagMap(ImmutableMap.of(Tag.TYPE_LOCATION, "az2"));
+        Table table = masterEnv.getInternalCatalog().getDbOrMetaException(CatalogTestUtil.testDbId1)
+                .getTableOrMetaException(CatalogTestUtil.testTableId1);
+
+        try {
+            Config.cross_az_succ_quorum = new String[] {"az1:2", "az2:1"};
+            Assert.assertEquals(ImmutableMap.of("az1", 2, "az2", 1), Config.getCrossAzSuccQuorum());
+            long transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
+                    Lists.newArrayList(CatalogTestUtil.testTableId1), "cross_az_quorum_failure", transactionSource,
+                    LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+            List<TabletCommitInfo> commitInfos = GlobalTransactionMgrTest.generateTabletCommitInfos(
+                    CatalogTestUtil.testTabletId1,
+                    Lists.newArrayList(CatalogTestUtil.testBackendId2, CatalogTestUtil.testBackendId3));
+            try {
+                masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(table),
+                        transactionId, commitInfos, null);
+                Assert.fail();
+            } catch (TabletQuorumFailedException e) {
+                Assert.assertTrue(e.getMessage().contains("cross AZ success quorum failed for az1"));
+            }
+
+            transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
+                    Lists.newArrayList(CatalogTestUtil.testTableId1), "cross_az_quorum_az2_failure", transactionSource,
+                    LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+            commitInfos = GlobalTransactionMgrTest.generateTabletCommitInfos(CatalogTestUtil.testTabletId1,
+                    Lists.newArrayList(CatalogTestUtil.testBackendId1, CatalogTestUtil.testBackendId2));
+            try {
+                masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(table),
+                        transactionId, commitInfos, null);
+                Assert.fail();
+            } catch (TabletQuorumFailedException e) {
+                Assert.assertTrue(e.getMessage().contains("cross AZ success quorum failed for az2"));
+            }
+
+            backend2.setTagMap(ImmutableMap.of(Tag.TYPE_LOCATION, "az2"));
+            transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
+                    Lists.newArrayList(CatalogTestUtil.testTableId1), "cross_az_quorum_clamp", transactionSource,
+                    LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+            commitInfos = GlobalTransactionMgrTest.generateTabletCommitInfos(CatalogTestUtil.testTabletId1,
+                    Lists.newArrayList(CatalogTestUtil.testBackendId1, CatalogTestUtil.testBackendId2));
+            masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(table),
+                    transactionId, commitInfos, null);
+
+            // Invalid items are ignored. The parse result is cached, so only the first commit after
+            // a config change may warn; later commits on the hot path must stay silent.
+            Config.cross_az_succ_quorum = new String[] {"invalid", "az1:not-a-number"};
+            transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
+                    Lists.newArrayList(CatalogTestUtil.testTableId1), "cross_az_quorum_invalid_0",
+                    transactionSource, LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+            masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(table),
+                    transactionId, commitInfos, null);
+            try (TestLogAppender appender = TestLogAppender.attach(Config.class, Level.WARN)) {
+                transactionId = masterTransMgr.beginTransaction(CatalogTestUtil.testDbId1,
+                        Lists.newArrayList(CatalogTestUtil.testTableId1), "cross_az_quorum_invalid_1",
+                        transactionSource, LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
+                masterTransMgr.commitTransactionWithoutLock(CatalogTestUtil.testDbId1, Lists.newArrayList(table),
+                        transactionId, commitInfos, null);
+                Assert.assertFalse(appender.contains(Level.WARN, "Invalid cross_az_succ_quorum item"));
+            }
+        } finally {
+            Config.cross_az_succ_quorum = originalCrossAzSuccQuorum;
+            backend1.setTagMap(backend1TagMap);
+            backend2.setTagMap(backend2TagMap);
+            backend3.setTagMap(backend3TagMap);
+        }
     }
 
     @Test

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -192,6 +192,7 @@ message PTabletWriterAddBlockRequest {
     // Per-row row-binlog LSNs allocated by olap table sink. The order is the same
     // as rows in block/tablet_ids.
     repeated int64 row_binlog_lsns = 17;
+    optional bool need_final_tablet_result = 18 [default = false];
 };
 
 message PSlaveTabletNodes {
@@ -224,6 +225,7 @@ message PTabletWriterAddBlockResult {
     repeated PTabletError tablet_errors = 6;
     map<int64, PSuccessSlaveTabletNodeIds> success_slave_tablet_node_ids = 7;
     optional bytes load_channel_profile = 8;
+    optional bool final_tablet_result_fanout = 9 [default = false];
 
     // For cloud
     optional int64 build_rowset_latency_ms = 1000;
@@ -1017,6 +1019,7 @@ message POpenLoadStreamRequest {
     optional bool enable_profile = 6 [default = false];
     optional int64 total_streams = 7;
     optional int64 idle_timeout_ms = 8;
+    optional bool need_final_tablet_result = 9 [default = false];
 }
 
 message PTabletSchemaWithIndex {

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -1047,6 +1047,7 @@ message PLoadStreamResponse {
     repeated PTabletSchemaWithIndex tablet_schemas = 5;
     optional bool eos = 6;
     repeated PTabletLoadRowsetInfo tablet_load_rowset_num_infos = 7;
+    optional bool final_tablet_result_fanout = 8 [default = false];
 }
 
 message PStreamHeader {

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -319,6 +319,7 @@ struct TOlapTableSink {
     // initial partition list is empty, so auto-partition tables whose first partitions arrive at
     // runtime still enter the correct mode from the start.
     25: optional bool enable_adaptive_random_bucket
+    26: optional map<string, i32> cross_az_succ_quorum
 }
 
 struct THiveLocationParams {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -390,6 +390,7 @@ struct TNodeInfo {
     3: required string host
     // used to transfer data between nodes
     4: required i32 async_internal_port
+    5: optional string location
 }
 
 struct TPaloNodesInfo {

--- a/regression-test/suites/load_p0/cross_az_quorum/test_cross_az_succ_quorum.groovy
+++ b/regression-test/suites/load_p0/cross_az_quorum/test_cross_az_succ_quorum.groovy
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import org.apache.doris.regression.util.NodeType
+import org.awaitility.Awaitility
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+suite('test_cross_az_succ_quorum', 'docker') {
+    def options = new ClusterOptions()
+    options.feConfigs += ['disable_tablet_scheduler=true']
+    options.beConfigs += ['quorum_success_min_wait_seconds=1']
+    options.enableDebugPoints()
+    options.cloudMode = false
+
+    docker(options) {
+        def backends = sql_return_maparray('SHOW BACKENDS')
+        assertEquals(3, backends.size())
+        sql """ALTER SYSTEM MODIFY BACKEND '${backends[0].BackendId}' SET ('tag.location' = 'az1')"""
+        sql """ALTER SYSTEM MODIFY BACKEND '${backends[1].BackendId}' SET ('tag.location' = 'az1')"""
+        sql """ALTER SYSTEM MODIFY BACKEND '${backends[2].BackendId}' SET ('tag.location' = 'az2')"""
+
+        // tag.location doubles as the compute group name, and WorkloadGroupChecker only creates the
+        // `normal` workload group for a newly seen compute group every workload_group_check_interval_ms
+        // (2s by default). Loading before that fails with "Can not find workload group normal in
+        // compute group az1", so wait for it rather than turning workload groups off -- production
+        // runs with them on.
+        Awaitility.await().atMost(60, SECONDS).pollInterval(1, SECONDS).until({
+            def normals = sql_return_maparray('SHOW WORKLOAD GROUPS')
+                    .findAll { it.Name == 'normal' }
+                    .collect { it.compute_group } as Set
+            normals.containsAll(['az1', 'az2'])
+        })
+
+        sql 'DROP TABLE IF EXISTS cross_az_quorum_table'
+        sql '''
+            CREATE TABLE cross_az_quorum_table (k INT)
+            DISTRIBUTED BY HASH(k) BUCKETS 1
+            PROPERTIES ('replication_allocation' = 'tag.location.az1: 2, tag.location.az2: 1')
+        '''
+
+        def injectName = 'TxnManager.prepare_txn.random_failed'
+        GetDebugPoint().enableDebugPoint(backends[0].Host, backends[0].HttpPort as int,
+                NodeType.BE, injectName, [percent: 1.0])
+
+        // The default empty config preserves the normal two-of-three quorum behavior.
+        sql 'INSERT INTO cross_az_quorum_table VALUES (1)'
+
+        setFeConfig('cross_az_succ_quorum', 'az1:2,az2:1')
+        test {
+            sql 'INSERT INTO cross_az_quorum_table VALUES (2)'
+            exception 'cross AZ success quorum failed for az1'
+        }
+
+        setFeConfig('cross_az_succ_quorum', '')
+        sql 'INSERT INTO cross_az_quorum_table VALUES (3)'
+        GetDebugPoint().disableDebugPoint(backends[0].Host, backends[0].HttpPort as int,
+                NodeType.BE, injectName)
+
+        // Losing all successful replicas in one AZ still leaves a normal two-of-three quorum.
+        sql 'DROP TABLE IF EXISTS cross_az_quorum_az2_table'
+        sql '''
+            CREATE TABLE cross_az_quorum_az2_table (k INT)
+            DISTRIBUTED BY HASH(k) BUCKETS 1
+            PROPERTIES ('replication_allocation' = 'tag.location.az1: 2, tag.location.az2: 1')
+        '''
+        GetDebugPoint().enableDebugPoint(backends[2].Host, backends[2].HttpPort as int,
+                NodeType.BE, injectName, [percent: 1.0])
+        sql 'INSERT INTO cross_az_quorum_az2_table VALUES (1)'
+        setFeConfig('cross_az_succ_quorum', 'az1:2,az2:1')
+        test {
+            sql 'INSERT INTO cross_az_quorum_az2_table VALUES (2)'
+            exception 'cross AZ success quorum failed for az2'
+        }
+        setFeConfig('cross_az_succ_quorum', '')
+        GetDebugPoint().disableDebugPoint(backends[2].Host, backends[2].HttpPort as int,
+                NodeType.BE, injectName)
+
+        // A slow remote AZ must remain in the first close-wait stage instead of being dropped
+        // after the two local replicas reach the ordinary quorum.
+        // Use a fresh table: the tables above already committed a version while their az2 replica
+        // was failing, so that replica carries a version gap and, with the tablet scheduler
+        // disabled, is never repaired -- it could never count as a success again.
+        sql 'DROP TABLE IF EXISTS cross_az_quorum_slow_table'
+        sql '''
+            CREATE TABLE cross_az_quorum_slow_table (k INT)
+            DISTRIBUTED BY HASH(k) BUCKETS 1
+            PROPERTIES ('replication_allocation' = 'tag.location.az1: 2, tag.location.az2: 1')
+        '''
+        setFeConfig('cross_az_succ_quorum', 'az1:2,az2:1')
+        GetDebugPoint().enableDebugPoint(backends[2].Host, backends[2].HttpPort as int,
+                NodeType.BE, 'TxnManager.prepare_txn.wait', [duration: 3000])
+        sql 'INSERT INTO cross_az_quorum_slow_table VALUES (1)'
+        GetDebugPoint().disableDebugPoint(backends[2].Host, backends[2].HttpPort as int,
+                NodeType.BE, 'TxnManager.prepare_txn.wait')
+        setFeConfig('cross_az_succ_quorum', '')
+
+        sql 'DROP TABLE IF EXISTS cross_az_quorum_clamp_table'
+        sql '''
+            CREATE TABLE cross_az_quorum_clamp_table (k INT)
+            DISTRIBUTED BY HASH(k) BUCKETS 1
+            PROPERTIES ('replication_allocation' = 'tag.location.az1: 1')
+        '''
+        setFeConfig('cross_az_succ_quorum', 'az1:2')
+        sql 'INSERT INTO cross_az_quorum_clamp_table VALUES (1)'
+
+        // Invalid entries are ignored and must never break the commit path.
+        setFeConfig('cross_az_succ_quorum', 'invalid,az1:not-a-number')
+        sql 'INSERT INTO cross_az_quorum_clamp_table VALUES (2)'
+        setFeConfig('cross_az_succ_quorum', '')
+    }
+}

--- a/regression-test/suites/load_p0/cross_az_quorum/test_cross_az_succ_quorum_min_load_replica.groovy
+++ b/regression-test/suites/load_p0/cross_az_quorum/test_cross_az_succ_quorum_min_load_replica.groovy
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import org.apache.doris.regression.util.NodeType
+import org.awaitility.Awaitility
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+// min_load_replica_num lowers how many successful replicas a commit needs, which makes it easier
+// for the surviving replicas to all sit in one AZ. cross_az_succ_quorum is the guard for exactly
+// that combination: the two conditions stack, the AZ requirement never relaxes the replica count.
+suite('test_cross_az_succ_quorum_min_load_replica', 'docker') {
+    def options = new ClusterOptions()
+    // 5 backends so the table can hold 5 replicas: the default quorum is then 3 and lowering it
+    // to 2 actually changes the outcome. With 3 az1 and 2 az2 backends every backend holds exactly
+    // one replica of the single tablet, which keeps the fault injection deterministic.
+    options.beNum = 5
+    options.feConfigs += ['disable_tablet_scheduler=true']
+    options.enableDebugPoints()
+    options.cloudMode = false
+
+    docker(options) {
+        def backends = sql_return_maparray('SHOW BACKENDS')
+        assertEquals(5, backends.size())
+        def az1Backends = backends[0..2]
+        def az2Backends = backends[3..4]
+        az1Backends.each {
+            sql """ALTER SYSTEM MODIFY BACKEND '${it.BackendId}' SET ('tag.location' = 'az1')"""
+        }
+        az2Backends.each {
+            sql """ALTER SYSTEM MODIFY BACKEND '${it.BackendId}' SET ('tag.location' = 'az2')"""
+        }
+
+        // tag.location doubles as the compute group name; wait for WorkloadGroupChecker to create
+        // the `normal` workload group for the new compute groups before loading.
+        Awaitility.await().atMost(60, SECONDS).pollInterval(1, SECONDS).until({
+            def normals = sql_return_maparray('SHOW WORKLOAD GROUPS')
+                    .findAll { it.Name == 'normal' }
+                    .collect { it.compute_group } as Set
+            normals.containsAll(['az1', 'az2'])
+        })
+
+        def injectName = 'TxnManager.prepare_txn.random_failed'
+        def enableInject = { List bes ->
+            bes.each {
+                GetDebugPoint().enableDebugPoint(it.Host, it.HttpPort as int, NodeType.BE,
+                        injectName, [percent: 1.0])
+            }
+        }
+        def disableInject = { List bes ->
+            bes.each {
+                GetDebugPoint().disableDebugPoint(it.Host, it.HttpPort as int, NodeType.BE, injectName)
+            }
+        }
+
+        // Fail both az2 replicas and one az1 replica: 2 successful replicas left, both in az1.
+        // Below the default quorum of 3, but enough for the lowered min_load_replica_num of 2.
+        def singleAzFailures = az2Backends + [az1Backends[0]]
+        // Fail two az1 replicas and one az2 replica: 2 successful replicas left, one per AZ.
+        def crossAzFailures = [az1Backends[0], az1Backends[1], az2Backends[0]]
+
+        def createTable = { String name ->
+            sql "DROP TABLE IF EXISTS ${name}"
+            sql """
+                CREATE TABLE ${name} (k INT)
+                DISTRIBUTED BY HASH(k) BUCKETS 1
+                PROPERTIES ('replication_allocation' = 'tag.location.az1: 3, tag.location.az2: 2')
+            """
+            sql """ALTER TABLE ${name} SET ("min_load_replica_num" = "2")"""
+        }
+
+        // Without cross_az_succ_quorum the lowered quorum accepts a commit whose successful
+        // replicas all live in az1 -- the silent durability risk this feature exists to remove.
+        enableInject(singleAzFailures)
+        createTable('cross_az_min_load_baseline')
+        sql 'INSERT INTO cross_az_min_load_baseline VALUES (1)'
+
+        // Same load, same lowered quorum, but now the AZ coverage requirement rejects it.
+        createTable('cross_az_min_load_guarded')
+        setFeConfig('cross_az_succ_quorum', 'az1:1,az2:1')
+        test {
+            sql 'INSERT INTO cross_az_min_load_guarded VALUES (1)'
+            exception 'cross AZ success quorum failed for az2'
+        }
+        disableInject(singleAzFailures)
+
+        // Still only 2 successful replicas and the same lowered quorum, but this time they are
+        // spread over both AZs, so the commit is accepted: the AZ requirement constrains where the
+        // successful replicas sit, it does not simply reject every degraded load.
+        enableInject(crossAzFailures)
+        createTable('cross_az_min_load_spread')
+        sql 'INSERT INTO cross_az_min_load_spread VALUES (1)'
+        disableInject(crossAzFailures)
+
+        setFeConfig('cross_az_succ_quorum', '')
+    }
+}


### PR DESCRIPTION
Add a cluster-level FE config `cross_az_succ_quorum` (format `az1:2,az2:1`, empty by default) requiring, per tablet, a minimum number of successfully written replicas in each availability zone before a load transaction may commit. It only tightens the existing commit condition, never relaxes it; the default empty value keeps today's behavior unchanged and costs nothing on the commit path.

The requirement of each AZ is clamped to the replicas the tablet actually has there:

    required_in_az = min(configured, replica_num_in_az)

A tablet with no replica in a configured AZ (single-AZ tables, backends without a location tag) is therefore skipped, and a table whose replica distribution cannot reach the configured value degrades instead of becoming permanently unloadable. This mirrors how `min_load_replica_num` is clamped in OlapTable#getLoadRequiredReplicaNum.

FE enforces it in DatabaseTransactionMgr#checkCommitStatus, the single choke point shared by the 2PC pre-commit, ordinary commit and sub-transaction commit paths.

BE's quorum success write is made AZ aware as well. Without that, a merely slow replica is dropped from the reported success set once the ordinary majority is reached; in a cross-AZ deployment the systematically slowest replica is the remote-AZ one, so the FE check would reject healthy loads. Two optional thrift fields carry what BE needs -- `TNodeInfo.location` and `TOlapTableSink.cross_az_succ_quorum` -- both sent only when the config is non-empty, so an old BE simply ignores them and falls back to the FE-only check. BE applies the identical clamp in
DorisNodesInfo#is_cross_az_quorum_success, shared by the v1 and v2 tablet writers. Replicas with a version gap are excluded from the success count on both sides.

Applies to the integrated storage-compute mode only; cloud mode commits through CloudGlobalTransactionMgr and never reaches this check.

Do not enable cross_az_succ_quorum until all potential coordinator BEs have been upgraded.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

