### PR TITLE
branch-4.0: [fix](fe) Select S3 storage for cloud plugin downloads

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/plugin/CloudPluginDownloader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/plugin/CloudPluginDownloader.java
@@ -33,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -153,15 +154,22 @@ public class CloudPluginDownloader {
         props.put("s3.bucket", objInfo.getBucket());
 
         // Auto-detect storage type (S3, COS, OSS, etc.)
-        StorageProperties storageProps;
+        AbstractS3CompatibleProperties storageProps;
         try {
-            storageProps = StorageProperties.createAll(props).stream()
-                    .findFirst()
-                    .orElseThrow(() -> new RuntimeException("Failed to create storage properties"));
+            storageProps = selectS3CompatibleProperties(StorageProperties.createAll(props));
         } catch (UserException e) {
             throw new RuntimeException(e);
         }
 
-        return new S3ObjStorage((AbstractS3CompatibleProperties) storageProps);
+        return new S3ObjStorage(storageProps);
+    }
+
+    static AbstractS3CompatibleProperties selectS3CompatibleProperties(
+            List<StorageProperties> storageProperties) {
+        return storageProperties.stream()
+                .filter(AbstractS3CompatibleProperties.class::isInstance)
+                .map(AbstractS3CompatibleProperties.class::cast)
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Failed to create S3-compatible storage properties"));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/plugin/CloudPluginDownloaderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/plugin/CloudPluginDownloaderTest.java
@@ -19,7 +19,18 @@ package org.apache.doris.common.plugin;
 
 import org.apache.doris.cloud.proto.Cloud;
 import org.apache.doris.cloud.rpc.MetaServiceProxy;
+import org.apache.doris.common.UserException;
 import org.apache.doris.common.plugin.CloudPluginDownloader.PluginType;
+import org.apache.doris.datasource.property.storage.AbstractS3CompatibleProperties;
+import org.apache.doris.datasource.property.storage.COSProperties;
+import org.apache.doris.datasource.property.storage.GCSProperties;
+import org.apache.doris.datasource.property.storage.HdfsProperties;
+import org.apache.doris.datasource.property.storage.MinioProperties;
+import org.apache.doris.datasource.property.storage.OBSProperties;
+import org.apache.doris.datasource.property.storage.OSSProperties;
+import org.apache.doris.datasource.property.storage.OzoneProperties;
+import org.apache.doris.datasource.property.storage.S3Properties;
+import org.apache.doris.datasource.property.storage.StorageProperties;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,7 +38,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Unit tests for CloudPluginDownloader using package-private methods for direct white-box testing.
@@ -158,6 +173,47 @@ public class CloudPluginDownloaderTest {
         Mockito.when(mockObjInfo.getBucket()).thenReturn("test-bucket");
         String specialResult = CloudPluginDownloader.buildS3Path(mockObjInfo, PluginType.JAVA_UDF, "test-udf@v1.0.jar");
         Assertions.assertEquals("s3://test-bucket/plugins/java_udf/test-udf@v1.0.jar", specialResult);
+    }
+
+    @Test
+    void testSelectS3CompatiblePropertiesAfterDefaultHdfs() throws UserException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("s3.endpoint", "s3.us-west-2.amazonaws.com");
+        properties.put("s3.region", "us-west-2");
+
+        List<StorageProperties> storageProperties = StorageProperties.createAll(properties);
+
+        Assertions.assertEquals(HdfsProperties.class, storageProperties.get(0).getClass());
+        Assertions.assertEquals(S3Properties.class,
+                CloudPluginDownloader.selectS3CompatibleProperties(storageProperties).getClass());
+    }
+
+    @Test
+    void testSelectEveryS3CompatiblePropertiesType() {
+        List<Class<? extends AbstractS3CompatibleProperties>> compatibleTypes = Arrays.asList(
+                S3Properties.class,
+                OSSProperties.class,
+                OBSProperties.class,
+                COSProperties.class,
+                GCSProperties.class,
+                MinioProperties.class,
+                OzoneProperties.class);
+        StorageProperties hdfsProperties = Mockito.mock(HdfsProperties.class);
+
+        for (Class<? extends AbstractS3CompatibleProperties> compatibleType : compatibleTypes) {
+            AbstractS3CompatibleProperties expected = Mockito.mock(compatibleType);
+            Assertions.assertSame(expected, CloudPluginDownloader.selectS3CompatibleProperties(
+                    Arrays.asList(hdfsProperties, expected)));
+        }
+    }
+
+    @Test
+    void testSelectS3CompatiblePropertiesFailsWithoutCompatibleStorage() {
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class,
+                () -> CloudPluginDownloader.selectS3CompatibleProperties(
+                        Collections.singletonList(Mockito.mock(HdfsProperties.class))));
+
+        Assertions.assertEquals("Failed to create S3-compatible storage properties", exception.getMessage());
     }
 
     // ============== Enum Tests ==============


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None


Problem Summary: In Cloud SaaS mode, a JDBC catalog or Java UDF using a bare jar name downloads the file from the instance object store. `StorageProperties.createAll()` now prepends a default HDFS entry, while `CloudPluginDownloader` selected the first entry and cast it to `AbstractS3CompatibleProperties`. The cast therefore failed with `ClassCastException` before the download. This change selects the first explicitly S3-compatible property by type and fails clearly if none exists. Tests cover default-HDFS ordering, all current S3-compatible property implementations, and the missing-compatible-storage path.

### Release note

Fix automatic JDBC driver and Java UDF jar downloads from Cloud SaaS object storage when the plugin is referenced by a bare file name.

### Check List (For Author)

- Test: Unit Test (environment blocked)
    - `MAVEN_OPTS="-Xmx4g -XX:MaxMetaspaceSize=1g" FE_UT_PARALLEL=1 ./run-fe-ut.sh --run org.apache.doris.common.plugin.CloudPluginDownloaderTest` completed Checkstyle, FE main compilation, and test compilation. All 9 tests were blocked in the existing Mockito setup because Byte Buddy cannot self-attach in the execution sandbox; there were no assertion failures.
- Behavior changed: Yes (Cloud SaaS plugin downloads select S3-compatible storage instead of the prepended default HDFS entry)
- Does this need documentation: No
