### PR TITLE
[fix](compaction) Use row count for cumulative task classification

### DIFF
--- a/be/src/storage/compaction/compaction.cpp
+++ b/be/src/storage/compaction/compaction.cpp
@@ -1669,9 +1669,7 @@ int64_t CompactionMixin::calc_input_rowsets_total_size() const {
 int64_t CompactionMixin::calc_input_rowsets_row_num() const {
     int64_t input_rowsets_row_num = 0;
     for (const auto& rowset : _input_rowsets) {
-        const auto& rowset_meta = rowset->rowset_meta();
-        auto total_size = rowset_meta->total_disk_size();
-        input_rowsets_row_num += total_size;
+        input_rowsets_row_num += rowset->num_rows();
     }
     return input_rowsets_row_num;
 }

--- a/be/test/storage/compaction/cumulative_compaction_test.cpp
+++ b/be/test/storage/compaction/cumulative_compaction_test.cpp
@@ -66,6 +66,29 @@ static RowsetSharedPtr create_rowset(Version version, int num_segments, bool ove
     return rowset;
 }
 
+class TestableCumulativeCompactionMixin : public CompactionMixin {
+public:
+    TestableCumulativeCompactionMixin(StorageEngine& engine, TabletSharedPtr tablet)
+            : CompactionMixin(engine, tablet, "TestableCumulativeCompactionMixin") {}
+
+    void set_input_rowsets(const std::vector<RowsetSharedPtr>& rowsets) {
+        _input_rowsets = rowsets;
+    }
+
+    Status prepare_compact() override { return Status::OK(); }
+
+    Status execute_compact() override { return Status::OK(); }
+
+    ReaderType compaction_type() const override { return ReaderType::READER_CUMULATIVE_COMPACTION; }
+
+    std::string_view compaction_name() const override { return "testable cumulative compaction"; }
+
+protected:
+    Status construct_output_rowset_writer(RowsetWriterContext&) override { return Status::OK(); }
+
+    Status update_delete_bitmap() override { return Status::OK(); }
+};
+
 TEST_F(CumulativeCompactionTest, TestConsecutiveVersion) {
     EngineOptions options;
     StorageEngine storage_engine(options);
@@ -292,6 +315,41 @@ TEST_F(CumulativeCompactionTest, TestShouldDelayLargeTask) {
     storage_engine._cumu_compaction_thread_pool_used_threads = 3;
     storage_engine._cumu_compaction_thread_pool_small_tasks_running = 0;
     EXPECT_EQ(storage_engine._should_delay_large_task(), true);
+}
+
+TEST_F(CumulativeCompactionTest, TestCalcInputRowsetsRowNumUsesRowCount) {
+    EngineOptions options;
+    StorageEngine storage_engine(options);
+
+    TabletMetaSharedPtr tablet_meta;
+    tablet_meta.reset(new TabletMeta(1, 2, 15673, 15674, 4, 5, TTabletSchema(), 6, {{7, 8}},
+                                     UniqueId(9, 10), TTabletType::TABLET_TYPE_DISK,
+                                     TCompressionType::LZ4F));
+    TabletSharedPtr tablet(
+            new Tablet(storage_engine, tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+
+    TestableCumulativeCompactionMixin compaction(storage_engine, tablet);
+
+    std::vector<RowsetSharedPtr> rowsets;
+    auto rowset1 = create_rowset({1, 1}, 1, false, 1024);
+    ASSERT_NE(rowset1, nullptr);
+    rowset1->rowset_meta()->set_num_rows(10);
+    rowsets.push_back(rowset1);
+
+    auto rowset2 = create_rowset({2, 2}, 1, false, 2048);
+    ASSERT_NE(rowset2, nullptr);
+    rowset2->rowset_meta()->set_num_rows(20);
+    rowsets.push_back(rowset2);
+
+    auto rowset3 = create_rowset({3, 3}, 1, false, 4096);
+    ASSERT_NE(rowset3, nullptr);
+    rowset3->rowset_meta()->set_num_rows(30);
+    rowsets.push_back(rowset3);
+
+    compaction.set_input_rowsets(rowsets);
+
+    EXPECT_EQ(compaction.calc_input_rowsets_row_num(), 60);
+    EXPECT_EQ(compaction.calc_input_rowsets_total_size(), 7168);
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

`CompactionMixin::calc_input_rowsets_row_num()` calculated input rowset disk size instead of row count. As a result, cumulative compaction task classification compared bytes with `large_cumu_compaction_task_row_num_threshold`, which could incorrectly treat compactions with small row count but disk size over the threshold value as large tasks.

This PR fixes the calculation to sum `rowset->num_rows()` and adds a BE unit test to verify row-count calculation is independent from total-size calculation.

### Release note

None

### Check List (For Author)

- Test
  - [ ] Regression test
  - [✅] Unit Test
  - [ ] Manual test
  - [ ] No need to test or manual test.


- Behavior changed:
  - [✅] No.
  - [ ] Yes.

- Does this need documentation?
  - [✅] No.
  - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label