### PR TITLE
[fix](cloud) commit_restore_job misused blob_put instead of commit

### DIFF
--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -1986,7 +1986,7 @@ void MetaServiceImpl::commit_restore_job(::google::protobuf::RpcController* cont
 
             if (txn0->approximate_bytes() + key.size() * 3 + val.size() >
                 config::max_txn_commit_byte) {
-                cloud::blob_put(txn0.get(), key, val, 0);
+                err = txn0->commit();
                 if (err != TxnErrorCode::TXN_OK) {
                     code = cast_as<ErrCategory::COMMIT>(err);
                     msg = fmt::format(

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -11604,6 +11604,10 @@ TEST(MetaServiceTest, RestoreJobTest) {
     brpc::Controller cntl;
     RestoreJobRequest req;
     RestoreJobResponse res;
+    int64_t max_txn_commit_byte = config::max_txn_commit_byte;
+    DORIS_CLOUD_DEFER {
+        config::max_txn_commit_byte = max_txn_commit_byte;
+    };
 
     // ------------Test prepare restore job------------
     // invalid args prepare restore job
@@ -11767,6 +11771,7 @@ TEST(MetaServiceTest, RestoreJobTest) {
         res.Clear();
     }
     // normal commit restore job
+    config::max_txn_commit_byte = 1;
     for (int store_version = 0; store_version < 4; store_version++) {
         reset_meta_service();
         ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
@@ -11910,6 +11915,7 @@ TEST(MetaServiceTest, RestoreJobTest) {
         req.Clear();
         res.Clear();
     }
+    config::max_txn_commit_byte = max_txn_commit_byte;
     // large commit restore job request with 10000 rowset meta
     {
         reset_meta_service();


### PR DESCRIPTION
`commit_restore_job` misused `blob_put` instead of `commit` when the V2 delete bitmap transaction exceeded the configured size.