### PR TITLE
[fix](cloud) Remove flaky idempotent injection debug test

### DIFF
--- a/cloud/test/meta_service_http_test.cpp
+++ b/cloud/test/meta_service_http_test.cpp
@@ -3255,38 +3255,6 @@ TEST(MetaServiceHttpTest, VirtualClusterTest) {
     } // namespace doris::cloud
 }
 
-TEST(MetaServiceHttpTest, ShortGetTabletStatsDebugStringTest) {
-    config::enable_idempotent_request_injection = true;
-    auto sp = SyncPoint::get_instance();
-    sp->enable_processing();
-    DORIS_CLOUD_DEFER {
-        sp->disable_processing();
-    };
-
-    HttpContext ctx(true);
-    auto& meta_service = ctx.meta_service_;
-    constexpr auto table_id = 10001, index_id = 11001, partition_id = 12001;
-    int64_t tablet_id = 10001;
-    GetTabletStatsRequest req;
-    GetTabletStatsResponse res;
-
-    brpc::Controller cntl;
-    for (size_t i = 0; i < 50; i++) {
-        auto* idx = req.add_tablet_idx();
-        idx->set_table_id(table_id);
-        idx->set_index_id(index_id);
-        idx->set_partition_id(partition_id);
-        idx->set_tablet_id(tablet_id + i);
-    }
-
-    meta_service->get_tablet_stats(&cntl, &req, &res, nullptr);
-
-    sp->set_call_back("idempotent_injection_short_debug_string_for_get_stats", [](auto&& args) {
-        GetTabletStatsRequest debug_req = *try_any_cast<GetTabletStatsRequest*>(args.back());
-        ASSERT_EQ(10, debug_req.tablet_idx_size());
-    });
-}
-
 TEST(MetaServiceHttpTest, FixTabletIndexDbId) {
     HttpContext ctx(true);
     auto& meta_service = ctx.meta_service_;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: https://github.com/apache/doris/pull/56061

Problem Summary: ShortGetTabletStatsDebugStringTest enables the global idempotent request injection configuration but does not restore it after completion. Because meta_service_http_test.cpp and meta_service_test.cpp are linked into the same test binary, later tests may create delayed background bthreads. 

Those tasks capture MetaServiceProxy through a raw this pointer and can access impl_ after the proxy is destroyed, causing intermittent heap-use-after-free, heap-buffer-overflow, or SEGV failures. Remove the test to prevent this test-binary-wide configuration pollution and the resulting flaky failures.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

