### PR TITLE
[fix](cloud) Restore idempotent injection config after test

### DIFF
--- a/cloud/test/meta_service_http_test.cpp
+++ b/cloud/test/meta_service_http_test.cpp
@@ -3256,10 +3256,12 @@ TEST(MetaServiceHttpTest, VirtualClusterTest) {
 }
 
 TEST(MetaServiceHttpTest, ShortGetTabletStatsDebugStringTest) {
+    const bool previous_injection_enabled = config::enable_idempotent_request_injection;
     config::enable_idempotent_request_injection = true;
     auto sp = SyncPoint::get_instance();
     sp->enable_processing();
     DORIS_CLOUD_DEFER {
+        config::enable_idempotent_request_injection = previous_injection_enabled;
         sp->disable_processing();
     };
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #56061

Problem Summary: `MetaServiceHttpTest.ShortGetTabletStatsDebugStringTest` enables the mutable global config `enable_idempotent_request_injection` but does not restore it. Cloud Meta Service tests run in the same process, so later tests inherit chaos injection and unexpectedly schedule delayed request replays. In an ASan run, a later `UpdateTabletRequest` replay executed after its test-owned service proxy had been destroyed and caused the test binary to abort. This change saves the previous config value and restores it in the existing deferred cleanup, isolating the test from subsequent cases.

### Release note

None

### Check List (For Author)

- Test
    - [x] Unit Test
        - `./run-cloud-ut.sh --run --filter=meta_service_test:MetaServiceHttpTest.ShortGetTabletStatsDebugStringTest -j100`
        - `./run_all_tests.sh --test meta_service_test --filter 'MetaServiceHttpTest.ShortGetTabletStatsDebugStringTest:MetaServiceOperationLogTest.UpdateVersionedTabletMeta'`
        - `build-support/check-format.sh`
        - `git diff --check`

- Behavior changed:
    - [x] No. This only restores test configuration after the test finishes.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
