### PR TITLE
[fix](be) Preserve seconds in TIMESTAMPTZ offsets

### DIFF
--- a/be/src/core/value/timestamptz_value.cpp
+++ b/be/src/core/value/timestamptz_value.cpp
@@ -44,6 +44,7 @@ std::string TimestampTzValue::to_string(const cctz::time_zone& tz, int scale) co
     int abs_offset = std::abs(time_offset);
     int offset_hours = abs_offset / 3600;
     int offset_mins = (abs_offset % 3600) / 60;
+    int offset_secs = abs_offset % 60;
 
     /// TODO: We could directly use datetime's to_string here. In the future,
     /// when we support a function like 'show datetime with timezone',
@@ -65,6 +66,11 @@ std::string TimestampTzValue::to_string(const cctz::time_zone& tz, int scale) co
     buffer[len++] = ':';
     buffer[len++] = static_cast<char>('0' + offset_mins / 10);
     buffer[len++] = '0' + offset_mins % 10;
+    if (offset_secs != 0) {
+        buffer[len++] = ':';
+        buffer[len++] = static_cast<char>('0' + offset_secs / 10);
+        buffer[len++] = '0' + offset_secs % 10;
+    }
     return {buffer, static_cast<size_t>(len)};
 }
 

--- a/be/src/core/value/timestamptz_value.h
+++ b/be/src/core/value/timestamptz_value.h
@@ -60,7 +60,7 @@ public:
     // Returns an integer value for storage in a column
     underlying_value to_date_int_val() const { return _utc_dt.to_date_int_val(); }
 
-    // Outputs a string representation with timezone information in the format +03:00
+    // Outputs a string representation with timezone information in the format +03:00[:SS]
     std::string to_string(const cctz::time_zone& local_time_zone, int scale = 6) const;
 
     // Parses a string, CastParameters can control whether strict mode is used

--- a/be/test/core/data_type/data_type_timestamptz_test.cpp
+++ b/be/test/core/data_type/data_type_timestamptz_test.cpp
@@ -113,6 +113,24 @@ TEST_F(DataTypeTimeStampTzTest, test_to_string_negative_sub_hour_offset) {
     EXPECT_EQ(value.to_string(time_zone), "2023-12-31 23:45:00.000000-00:30");
 }
 
+TEST_F(DataTypeTimeStampTzTest, test_to_string_second_offset_round_trip) {
+    TimestampTzValue value = make_timestamptz(1900, 1, 1, 0, 0, 0, 0);
+
+    cctz::time_zone shanghai;
+    ASSERT_TRUE(cctz::load_time_zone("Asia/Shanghai", &shanghai));
+    auto rendered = value.to_string(shanghai, 0);
+    EXPECT_EQ(rendered, "1900-01-01 08:05:43+08:05:43");
+
+    DataTypeSerDe::FormatOptions options;
+    options.timezone = &shanghai;
+    auto column = type->create_column();
+    ASSERT_TRUE(serder->from_string(StringRef {rendered}, *column, options).ok());
+    EXPECT_EQ(assert_cast<ColumnTimeStampTz&>(*column).get_data()[0], value);
+
+    auto negative_second_offset = cctz::fixed_time_zone(std::chrono::seconds(-1845));
+    EXPECT_EQ(value.to_string(negative_second_offset, 0), "1899-12-31 23:29:15-00:30:45");
+}
+
 TEST_F(DataTypeTimeStampTzTest, test_sort) {
     MockRuntimeState _state;
     RuntimeProfile _profile {"test"};


### PR DESCRIPTION
Problem Summary: Historical time zones can have UTC offsets with second precision. For example, `Asia/Shanghai` used `+08:05:43` in 1900. TIMESTAMPTZ string formatting previously emitted only the hour and minute components, producing `+08:05` and losing 43 seconds. As a result, the rendered value could not be converted back to the same TIMESTAMPTZ value.

Root cause: `TimestampTzValue::to_string()` obtained the complete offset in seconds from cctz but formatted only `HH:MM`. This change appends `:SS` when the offset contains a non-zero seconds component. Minute-aligned offsets retain the existing `HH:MM` output format.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

