### PR TITLE
[fix](parquet) Support deeply shredded Variant schemas

### DIFF
--- a/be/src/format_v2/parquet/native_schema_desc.h
+++ b/be/src/format_v2/parquet/native_schema_desc.h
@@ -38,7 +38,10 @@ namespace doris::format::parquet {
 
 // Constant for unassigned column IDs
 constexpr uint64_t NATIVE_UNASSIGNED_COLUMN_ID = UINT64_MAX;
-constexpr size_t MAX_NATIVE_SCHEMA_DEPTH = 100;
+// Paimon and Iceberg cap automatic Variant shredding at 50 logical levels, but each nested array
+// can add three Parquet groups. 192 also covers Doris's nine enclosing nested-type levels while
+// keeping footer recursion bounded for untrusted files.
+constexpr size_t MAX_NATIVE_SCHEMA_DEPTH = 192;
 
 struct NativeFieldSchema {
     std::string name;

--- a/be/test/format_v2/parquet/parquet_schema_test.cpp
+++ b/be/test/format_v2/parquet/parquet_schema_test.cpp
@@ -1018,12 +1018,107 @@ std::vector<tparquet::SchemaElement> nested_native_schema(size_t depth) {
     return schema;
 }
 
+constexpr size_t PAIMON_DEFAULT_VARIANT_SHREDDING_DEPTH = 50;
+
+std::vector<tparquet::SchemaElement> paimon_shredded_object_schema(size_t logical_depth) {
+    auto schema = unshredded_variant_schema();
+    schema[1].__isset.logicalType = false;
+    schema[1].__set_num_children(3);
+    schema[3].__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+
+    tparquet::SchemaElement typed_object;
+    typed_object.__set_name("typed_value");
+    typed_object.__set_num_children(1);
+    typed_object.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+    schema.push_back(std::move(typed_object));
+
+    for (size_t level = 0; level < logical_depth; ++level) {
+        tparquet::SchemaElement field_wrapper;
+        field_wrapper.__set_name("field" + std::to_string(level));
+        field_wrapper.__set_num_children(2);
+        field_wrapper.__set_repetition_type(tparquet::FieldRepetitionType::REQUIRED);
+        schema.push_back(std::move(field_wrapper));
+
+        tparquet::SchemaElement value;
+        value.__set_name("value");
+        value.__set_type(tparquet::Type::BYTE_ARRAY);
+        value.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+        schema.push_back(std::move(value));
+
+        tparquet::SchemaElement typed_value;
+        typed_value.__set_name("typed_value");
+        typed_value.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+        if (level + 1 == logical_depth) {
+            typed_value.__set_type(tparquet::Type::INT32);
+        } else {
+            typed_value.__set_num_children(1);
+        }
+        schema.push_back(std::move(typed_value));
+    }
+    return schema;
+}
+
+std::vector<tparquet::SchemaElement> paimon_shredded_array_schema(size_t logical_depth) {
+    auto schema = unshredded_variant_schema();
+    schema[1].__isset.logicalType = false;
+    schema[1].__set_num_children(3);
+    schema[3].__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+
+    for (size_t level = 0; level < logical_depth; ++level) {
+        tparquet::SchemaElement typed_array;
+        typed_array.__set_name("typed_value");
+        typed_array.__set_num_children(1);
+        typed_array.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+        typed_array.__set_converted_type(tparquet::ConvertedType::LIST);
+        schema.push_back(std::move(typed_array));
+
+        tparquet::SchemaElement list;
+        list.__set_name("list");
+        list.__set_num_children(1);
+        list.__set_repetition_type(tparquet::FieldRepetitionType::REPEATED);
+        schema.push_back(std::move(list));
+
+        tparquet::SchemaElement element;
+        element.__set_name("element");
+        element.__set_num_children(2);
+        element.__set_repetition_type(tparquet::FieldRepetitionType::REQUIRED);
+        schema.push_back(std::move(element));
+
+        tparquet::SchemaElement value;
+        value.__set_name("value");
+        value.__set_type(tparquet::Type::BYTE_ARRAY);
+        value.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+        schema.push_back(std::move(value));
+    }
+
+    tparquet::SchemaElement typed_value;
+    typed_value.__set_name("typed_value");
+    typed_value.__set_type(tparquet::Type::INT32);
+    typed_value.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+    schema.push_back(std::move(typed_value));
+    return schema;
+}
+
 TEST(ParquetSchemaTest, NativeSchemaBoundsRecursiveDepth) {
     NativeFieldDescriptor accepted;
     EXPECT_TRUE(accepted.parse_from_thrift(nested_native_schema(MAX_NATIVE_SCHEMA_DEPTH)).ok());
     NativeFieldDescriptor rejected;
     EXPECT_FALSE(
             rejected.parse_from_thrift(nested_native_schema(MAX_NATIVE_SCHEMA_DEPTH + 1)).ok());
+}
+
+TEST(ParquetSchemaTest, NativeSchemaAcceptsPaimonDefaultShreddedObjectDepth) {
+    NativeFieldDescriptor descriptor;
+    auto status = descriptor.parse_from_thrift(
+            paimon_shredded_object_schema(PAIMON_DEFAULT_VARIANT_SHREDDING_DEPTH));
+    EXPECT_TRUE(status.ok()) << status;
+}
+
+TEST(ParquetSchemaTest, NativeSchemaAcceptsPaimonDefaultShreddedArrayDepth) {
+    NativeFieldDescriptor descriptor;
+    auto status = descriptor.parse_from_thrift(
+            paimon_shredded_array_schema(PAIMON_DEFAULT_VARIANT_SHREDDING_DEPTH));
+    EXPECT_TRUE(status.ok()) << status;
 }
 
 TEST(ParquetSchemaTest, NativeListTupleCompatibilityRequiresEnclosingListName) {

--- a/regression-test/data/external_table_p0/iceberg/test_iceberg_variant_read.out
+++ b/regression-test/data/external_table_p0/iceberg/test_iceberg_variant_read.out
@@ -131,6 +131,9 @@ true	5	170	4.17
 -- !variant_nested_projection --
 1	first	{"deep":{"name":"inside"},"x":11}	{"kind":"open","score":101}	{"enabled":true,"score":1001}
 2	second	\N	null	{"enabled":false,"score":2002}
+3	doris-nested	{"kind":"struct","n":3}	null	\N
+4	empty	{}	\N	\N
+5	\N	\N	\N	\N
 
 -- !variant_nested_filter --
 1
@@ -138,6 +141,9 @@ true	5	170	4.17
 -- !variant_nested_expressions --
 1	11	inside	open	\N	true	1002
 2	\N	\N	\N	202	false	2003
+3	\N	\N	\N	\N	\N	\N
+4	\N	\N	\N	\N	\N	\N
+5	\N	\N	\N	\N	\N	\N
 
 -- !variant_evolution_renamed_snapshot --
 1	initial	10	v1

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_partition_evolution_runtime_filter.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_partition_evolution_runtime_filter.groovy
@@ -70,16 +70,28 @@ suite("test_iceberg_partition_evolution_runtime_filter",
             ${queryBody}
             order by f.id
         """)
-        // Scanner counters can arrive after the profile list first reports COMPLETE.
-        String profile = profileAction.getProfileBySql(
-                token,
-                ["RuntimeFilterPartitionPrunedRangeNum"],
-                30000L,
-                500L)
-        long fileRangesPruned = profileCounterValues(
-                profile, "RuntimeFilterPartitionPrunedRangeNum").sum(0L)
-        long partitionsPruned = profileCounterValues(
-                profile, "PartitionsPrunedByRuntimeFilter").sum(0L)
+        // Partial profiles already contain zero-valued counters, so wait for actual pruning.
+        String profile = ""
+        long fileRangesPruned = 0L
+        long partitionsPruned = 0L
+        long profileDeadline = System.currentTimeMillis() + 30000L
+        while (System.currentTimeMillis() <= profileDeadline) {
+            profile = profileAction.getProfileBySql(
+                    token,
+                    ["RuntimeFilterPartitionPrunedRangeNum"],
+                    30000L,
+                    500L)
+            fileRangesPruned = profileCounterValues(
+                    profile, "RuntimeFilterPartitionPrunedRangeNum").sum(0L)
+            partitionsPruned = profileCounterValues(
+                    profile, "PartitionsPrunedByRuntimeFilter").sum(0L)
+            if (fileRangesPruned + partitionsPruned > 0L) {
+                break
+            }
+            if (System.currentTimeMillis() < profileDeadline) {
+                sleep(500L)
+            }
+        }
         assertTrue(fileRangesPruned + partitionsPruned > 0L,
                 "Runtime filter did not prune any evolved Iceberg partition/file range; "
                         + profile.take(2000).replaceAll("\\s+", " "))

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_variant_read.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_variant_read.groovy
@@ -897,43 +897,51 @@ public class AppendVariantEqualityDelete {
                         ARRAY(), MAP()),
                 (5, NULL, NULL, NULL)
         """
+        // Spark caches Iceberg snapshots, so refresh after a Doris commit before cross-engine reads.
+        spark_iceberg """REFRESH TABLE demo.${dbName}.variant_nested"""
 
-        List<List<Object>> sparkNestedVariantValues = spark_iceberg """
+        List<List<Object>> sparkNestedContainers = spark_iceberg """
             SELECT id,
                    info.label,
                    variant_get(info.payload, '\$.kind', 'string'),
                    variant_get(info.payload, '\$.n', 'int'),
-                   to_json(events[0]),
-                   events[1] IS NULL,
-                   to_json(events[2]),
-                   to_json(events[3]),
-                   variant_get(attrs['object'], '\$.kind', 'string'),
-                   variant_get(attrs['object'], '\$.n', 'int'),
-                   to_json(attrs['json_null']),
-                   attrs['sql_null'] IS NULL
-            FROM demo.${dbName}.variant_nested
-            WHERE id = 3
-        """
-        assertEquals([[
-                "3", "doris-nested", "struct", "3", "null", "true", '"null"', "{}",
-                "map", "30", "null", "true"
-        ]], sparkNestedVariantValues.collect { row ->
-            row.collect { value -> value == null ? null : value.toString().toLowerCase() }
-        })
-
-        List<List<Object>> sparkNestedContainers = spark_iceberg """
-            SELECT id,
-                   info IS NULL,
+                   info.payload IS NULL,
                    events IS NULL, size(events),
                    attrs IS NULL, size(attrs)
             FROM demo.${dbName}.variant_nested
-            WHERE id IN (4, 5)
+            WHERE id IN (3, 4, 5)
             ORDER BY id
         """
         assertEquals([
-                ["4", "false", "false", "0", "false", "0"],
-                ["5", "true", "true", null, "true", null]
+                ["3", "doris-nested", "struct", "3", "false", "false", "4", "false", "3"],
+                ["4", "empty", null, null, "false", "false", "0", "false", "0"],
+                ["5", null, null, null, "true", "true", null, "true", null]
         ], sparkNestedContainers.collect { row ->
+            row.collect { value -> value == null ? null : value.toString().toLowerCase() }
+        })
+
+        // Iceberg 1.10.1 cannot materialize Variant values from ArrayData/MapData in Spark 4.
+        // Doris still validates every nested value written to the shared Parquet files.
+        List<List<Object>> dorisNestedVariantValues = sql """
+            SELECT id,
+                   CAST(info.payload['kind'] AS STRING),
+                   CAST(info.payload['n'] AS INT),
+                   VARIANT_TYPE(events[1]),
+                   events[2] IS NULL,
+                   VARIANT_TYPE(events[3]),
+                   CAST(events[3] AS STRING),
+                   VARIANT_TYPE(events[4]),
+                   CAST(attrs['object']['kind'] AS STRING),
+                   CAST(attrs['object']['n'] AS INT),
+                   VARIANT_TYPE(attrs['json_null']),
+                   attrs['sql_null'] IS NULL
+            FROM variant_nested
+            WHERE id = 3
+        """
+        assertEquals([[
+                "3", "struct", "3", "null", "true", "string", "null", "object",
+                "map", "30", "null", "true"
+        ]], dorisNestedVariantValues.collect { row ->
             row.collect { value -> value == null ? null : value.toString().toLowerCase() }
         })
 
@@ -966,19 +974,32 @@ public class AppendVariantEqualityDelete {
                     )
                 )
         """
-        List<List<Object>> sparkDeepVariantRows = spark_iceberg """
+        spark_iceberg """REFRESH TABLE demo.${dbName}.variant_nested_deep"""
+        List<List<Object>> sparkDeepContainerRows = spark_iceberg """
             SELECT id,
                    deep.level1[0]['outer'].note,
-                   variant_get(deep.level1[0]['outer'].payload,
-                           '\$.level2.level3.value', 'string'),
-                   deep.level1[0]['outer'].payload IS NULL
+                   size(deep.level1)
             FROM demo.${dbName}.variant_nested_deep
+            ORDER BY id
+        """
+        assertEquals([
+                ["1", "from-doris", "1"],
+                ["2", "sql-null", "1"]
+        ], sparkDeepContainerRows.collect { row ->
+            row.collect { value -> value == null ? null : value.toString().toLowerCase() }
+        })
+        List<List<Object>> dorisDeepVariantRows = sql """
+            SELECT id,
+                   deep.level1[1]['outer'].note,
+                   CAST(deep.level1[1]['outer'].payload['level2']['level3']['value'] AS STRING),
+                   deep.level1[1]['outer'].payload IS NULL
+            FROM variant_nested_deep
             ORDER BY id
         """
         assertEquals([
                 ["1", "from-doris", "deep-ok", "false"],
                 ["2", "sql-null", null, "true"]
-        ], sparkDeepVariantRows.collect { row ->
+        ], dorisDeepVariantRows.collect { row ->
             row.collect { value -> value == null ? null : value.toString().toLowerCase() }
         })
 
@@ -1000,6 +1021,7 @@ public class AppendVariantEqualityDelete {
             WHEN MATCHED THEN UPDATE SET `operation` = s.payload
             WHEN NOT MATCHED THEN INSERT (id, `operation`) VALUES (s.id, s.payload)
         """
+        spark_iceberg """REFRESH TABLE demo.${dbName}.variant_operation_column"""
         List<List<Object>> sparkOperationRows = spark_iceberg """
             SELECT id,
                    variant_get(`operation`, '\$.stage', 'string'),
@@ -1065,6 +1087,7 @@ public class AppendVariantEqualityDelete {
             WHEN MATCHED THEN UPDATE SET payload = t.payload
             WHEN NOT MATCHED THEN INSERT (id, payload) VALUES (s.id, 1)
         """
+        spark_iceberg """REFRESH TABLE demo.${dbName}.variant_doris_write"""
         List<List<Object>> sparkUnchangedMergeVariant = spark_iceberg """
             SELECT variant_get(payload, '\$.name', 'string'),
                    variant_get(payload, '\$.n', 'int'),
@@ -1100,9 +1123,10 @@ public class AppendVariantEqualityDelete {
                     DISTRIBUTED BY HASH(id) BUCKETS 1
                     PROPERTIES ("replication_num" = "1")
                 """
+                // Let the sink build the parameterized legacy Variant used by the target column.
                 sql """
                     INSERT INTO internal.${internalVariantDbName}.variant_source VALUES
-                        (1, PARSE_TO_VARIANT('{"name":"legacy"}'))
+                        (1, '{"name":"legacy"}')
                 """
 
                 sql """DROP TABLE IF EXISTS variant_doris_legacy_write"""
@@ -1127,19 +1151,21 @@ public class AppendVariantEqualityDelete {
                 """
                 assertEquals("0", sparkLegacyVariantRows[0][0].toString())
 
+                // Legacy execution rejects nested Variant containers before Iceberg sink analysis.
                 test {
                     sql """
                         INSERT INTO variant_nested_legacy_guard
                         SELECT id, ARRAY(payload)
                         FROM internal.${internalVariantDbName}.variant_source
                     """
-                    exception "Writing legacy Doris VARIANT to Iceberg VARIANT column 'events[]' is not supported"
+                    exception "array does not support jsonb/variant type"
                 }
                 List<List<Object>> sparkLegacyNestedRows = spark_iceberg """
                     SELECT COUNT(*) FROM demo.${dbName}.variant_nested_legacy_guard
                 """
                 assertEquals("0", sparkLegacyNestedRows[0][0].toString())
 
+                // MERGE materializes the compute-only target before sink-specific validation.
                 test {
                     sql """
                         MERGE INTO variant_operation_column t
@@ -1147,7 +1173,7 @@ public class AppendVariantEqualityDelete {
                         ON t.id = s.id
                         WHEN MATCHED THEN UPDATE SET `operation` = s.payload
                     """
-                    exception "Writing legacy Doris VARIANT to Iceberg VARIANT column 'operation' is not supported"
+                    exception "Cast between legacy Variant and compute-only Variant V2 is not supported"
                 }
                 List<List<Object>> sparkOperationAfterRejectedMerge = spark_iceberg """
                     SELECT variant_get(`operation`, '\$.stage', 'string')

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_variant_read.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_variant_read.groovy
@@ -725,11 +725,15 @@ public class AppendVariantEqualityDelete {
             FROM numbers("number" = "100000")
         """
         spark_iceberg """REFRESH TABLE demo.${dbName}.variant_doris_multi_row_group"""
+        // Iceberg allocates IDs to all top-level fields before nested fields; payload is 5, not 4.
+        int nestedPayloadFieldId = 5
         List<List<Object>> sparkDorisMultiRowGroupFiles = spark_iceberg """
             SELECT file_format, record_count,
-                   value_counts[4], null_value_counts[4],
-                   column_sizes[4] IS NULL,
-                   lower_bounds[4] IS NULL, upper_bounds[4] IS NULL
+                   value_counts[${nestedPayloadFieldId}],
+                   null_value_counts[${nestedPayloadFieldId}],
+                   column_sizes[${nestedPayloadFieldId}] IS NULL,
+                   lower_bounds[${nestedPayloadFieldId}] IS NULL,
+                   upper_bounds[${nestedPayloadFieldId}] IS NULL
             FROM demo.${dbName}.variant_doris_multi_row_group.files
             WHERE content = 0
         """

--- a/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_variant_select.groovy
+++ b/regression-test/suites/external_table_p0/remote_doris/test_remote_doris_variant_select.groovy
@@ -111,9 +111,9 @@ suite("test_remote_doris_variant_select", "p0,external,doris,external_docker,ext
         sql """
             select * from `${catalog_arrow_name}`.`${db_name}`.`test_remote_doris_variant_select_t` order by id
         """
-        // check exception message contains
-        exception "External Variant is supported only for Parquet files in FileScannerV2; "
-                + "file format ARROW is not supported"
+        // Keep the concatenation inside one DSL argument; a leading '+' starts a unary expression.
+        exception("External Variant is supported only for Parquet files in FileScannerV2; "
+                + "file format ARROW is not supported")
     }
 
     qt_sql """


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: DORIS-27899

Problem Summary:

The native Parquet schema validator rejected every group deeper than 100. That bound is below the physical depth produced by standard automatic Variant shredding:

- Paimon 1.4.2 defaults `variant.shredding.maxSchemaDepth` to 50 ([source](https://github.com/apache/paimon/blob/release-1.4.2/paimon-api/src/main/java/org/apache/paimon/CoreOptions.java#L418-L424)).
- Iceberg also caps automatic shredding at 50 logical levels ([source](https://github.com/apache/iceberg/blob/35889387c8c6ff0a3f57d17a304709dc1b7d9340/parquet/src/main/java/org/apache/iceberg/parquet/VariantShreddingAnalyzer.java#L79-L80)).
- An object level adds a field wrapper and a `typed_value` wrapper, so 50 levels can reach group depth 101.
- A nested array level adds `typed_value (LIST)`, repeated `list`, and `element` groups, so 50 levels can reach group depth 151.

This PR raises the bound to 192. The value covers the 151-level nested-array case plus Doris's maximum nine enclosing logical type levels ([source](https://github.com/apache/doris/blob/branch-4.1/fe/fe-common/src/main/java/org/apache/doris/catalog/Type.java#L52)), where list/map encodings may add up to three physical groups per level, and leaves a small compatibility margin.

The limit remains a fixed reader-side safety bound. It is intentionally derived from the physical Parquet schema instead of a Paimon table option: the option controls schema inference, is not guaranteed to be present in the file footer, and explicit or third-party writers can produce the same layout. Validation still happens before recursive parsing or schema-driven allocation, and schemas deeper than 192 remain rejected.

Two unit tests construct Paimon-style object and nested-array schemas at the default 50-level shredding depth. The existing boundary test also verifies that depth 192 is accepted and depth 193 is rejected.

### Release note

Fix native Parquet reads of deeply shredded Variant schemas generated by standard writers.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. Native Parquet readers now accept valid group nesting up to 192 instead of 100.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
