### PR TITLE
[improvement](release) Make release completion idempotent and confirm every step

### DIFF
--- a/tools/release-tools/04-release-complete.sh
+++ b/tools/release-tools/04-release-complete.sh
@@ -19,8 +19,12 @@
 # Step 04 - publish the passed RC source artifact to the Apache release SVN
 # and generate the [ANNOUNCE] email draft.
 #
-# The release SVN commit is public and requires PMC permission. This script
-# pauses for confirmation before changing SVN, and it never sends email.
+# The release SVN commit is public and requires PMC permission. Every step asks
+# for confirmation before it runs, and this script never sends email.
+#
+# The script is idempotent: it reads the current dev and release SVN state
+# first, skips whatever is already done, and can be re-run safely after a
+# successful publish or after stopping at any confirmation prompt.
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=release.env
@@ -31,6 +35,17 @@ warn() { echo "[WARN] $*"; }
 die()  { echo "[FAIL] $*" >&2; exit 1; }
 confirm() { local a; read -r -p "$1 [y/N] " a; [[ "$a" == y || "$a" == Y ]]; }
 
+# Keep the scratch directory in a global: an EXIT trap fires after the local
+# scope of the function that created it is gone, so a local would expand empty
+# and leak the directory whenever `set -e` aborts mid-run.
+CHECKSUM_DIR=""
+cleanup_checksum_dir() {
+  [[ -n "$CHECKSUM_DIR" ]] || return 0
+  rm -rf "$CHECKSUM_DIR"
+  CHECKSUM_DIR=""
+}
+trap cleanup_checksum_dir EXIT
+
 mail_only=0
 usage() {
   cat <<EOF
@@ -38,6 +53,10 @@ Usage: $0 [--mail-only]
 
 Publishes Apache Doris ${TAG} source artifacts from dev SVN to release SVN as
 Apache Doris ${VERSION}, then writes the [ANNOUNCE] email draft.
+
+Every step asks for confirmation first, and answering anything but y stops the
+run without changing more state. Re-running is safe: already published
+artifacts are detected and left alone.
 
 Options:
   --mail-only   Only write announce-email.txt and announce-email.eml.
@@ -66,8 +85,153 @@ RELEASE_SVN_PARENT_DIR="${RELEASE_SVN_PARENT_DIR:-${RELEASE_SVN_DIR%/*}}"
 DOWNLOAD_PAGE_URL="${DOWNLOAD_PAGE_URL:-https://doris.apache.org/download/}"
 ANNOUNCE_RELEASE_NOTES_URL="${ANNOUNCE_RELEASE_NOTES_URL:-}"
 
+SRC_TAR="${DEV_SVN_DIR}/${PKG_BASE}.tar.gz"
+SRC_ASC="${SRC_TAR}.asc"
+SRC_SHA512="${SRC_TAR}.sha512"
+DST_TAR="${RELEASE_PKG_BASE}.tar.gz"
+DST_ASC="${DST_TAR}.asc"
+DST_SHA512="${DST_TAR}.sha512"
+
 require_tool() {
   command -v "$1" >/dev/null 2>&1 || die "missing tool: $1"
+}
+
+# Every step announces what it is about to do and waits for confirmation, so a
+# run can be stopped at any boundary without leaving half-finished state.
+step_no=0
+step() {
+  local title="$1" line
+  shift
+  step_no=$((step_no + 1))
+  echo
+  echo "== step ${step_no}: ${title} =="
+  for line in "$@"; do
+    echo "     ${line}"
+  done
+  confirm "Proceed with step ${step_no}?" || {
+    warn "stopped before step ${step_no}: ${title}"
+    warn "nothing further was changed; re-run this script to continue."
+    exit 0
+  }
+}
+
+svn_url_exists() { svn info "${svn_auth[@]}" "$1" >/dev/null 2>&1; }
+
+# --- discovered state ------------------------------------------------------
+DEV_DIR_EXISTS=0
+SRC_PRESENT=0             # of SRC_TAR, SRC_ASC, SRC_SHA512
+RELEASE_DIR_EXISTS=0
+RELEASE_PARENT_EXISTS=0
+DST_PRESENT=0             # of DST_TAR, DST_ASC, DST_SHA512
+DST_MISSING=()
+
+discover_svn_state() {
+  local url
+
+  DEV_DIR_EXISTS=0
+  SRC_PRESENT=0
+  RELEASE_DIR_EXISTS=0
+  RELEASE_PARENT_EXISTS=0
+  DST_PRESENT=0
+  DST_MISSING=()
+
+  svn_url_exists "$DEV_SVN_DIR" && DEV_DIR_EXISTS=1
+  for url in "$SRC_TAR" "$SRC_ASC" "$SRC_SHA512"; do
+    svn_url_exists "$url" && SRC_PRESENT=$((SRC_PRESENT + 1))
+  done
+
+  svn_url_exists "$RELEASE_SVN_PARENT_DIR" && RELEASE_PARENT_EXISTS=1
+  svn_url_exists "$RELEASE_SVN_DIR" && RELEASE_DIR_EXISTS=1
+  if [[ "$RELEASE_DIR_EXISTS" -eq 1 ]]; then
+    for url in "$DST_TAR" "$DST_ASC" "$DST_SHA512"; do
+      if svn_url_exists "${RELEASE_SVN_DIR}/${url}"; then
+        DST_PRESENT=$((DST_PRESENT + 1))
+      else
+        DST_MISSING+=("$url")
+      fi
+    done
+  else
+    DST_MISSING=("$DST_TAR" "$DST_ASC" "$DST_SHA512")
+  fi
+
+  echo
+  echo "--- current state ---"
+  echo "dev SVN     ${DEV_SVN_DIR}/"
+  echo "            folder: $([[ "$DEV_DIR_EXISTS" -eq 1 ]] && echo present || echo absent), RC artifacts: ${SRC_PRESENT}/3"
+  echo "release SVN ${RELEASE_SVN_DIR}/"
+  echo "            folder: $([[ "$RELEASE_DIR_EXISTS" -eq 1 ]] && echo present || echo absent), release artifacts: ${DST_PRESENT}/3"
+}
+
+verify_and_build_checksum() {
+  local src_tar_file
+
+  CHECKSUM_DIR="$(mktemp -d)"
+  src_tar_file="${PKG_BASE}.tar.gz"
+  FINAL_SHA512_FILE="${CHECKSUM_DIR}/${DST_SHA512}"
+
+  svn cat "${svn_auth[@]}" "$SRC_TAR" > "${CHECKSUM_DIR}/${src_tar_file}"
+  svn cat "${svn_auth[@]}" "$SRC_SHA512" > "${CHECKSUM_DIR}/${src_tar_file}.sha512"
+  svn cat "${svn_auth[@]}" "$SRC_ASC" > "${CHECKSUM_DIR}/${src_tar_file}.asc"
+  (
+    cd "$CHECKSUM_DIR"
+    sha512sum --check "${src_tar_file}.sha512"
+    gpg --verify "${src_tar_file}.asc" "$src_tar_file"
+    cp "$src_tar_file" "$DST_TAR"
+    sha512sum "$DST_TAR" > "$DST_SHA512"
+    sha512sum --check "$DST_SHA512"
+  )
+  ok "source RC checksum and signature verified: ${src_tar_file}"
+  ok "final sha512 ok: ${DST_SHA512}"
+}
+
+publish_to_release_svn() {
+  local -a svnmucc_ops op_lines
+
+  svnmucc_ops=()
+  op_lines=()
+  if [[ "$RELEASE_PARENT_EXISTS" -eq 0 ]]; then
+    op_lines+=("mkdir ${RELEASE_SVN_PARENT_DIR}")
+    svnmucc_ops+=(mkdir "$RELEASE_SVN_PARENT_DIR")
+  fi
+  if [[ "$RELEASE_DIR_EXISTS" -eq 0 ]]; then
+    op_lines+=("mkdir ${RELEASE_SVN_DIR}")
+    svnmucc_ops+=(mkdir "$RELEASE_SVN_DIR")
+  fi
+  op_lines+=("mv    ${SRC_TAR}")
+  op_lines+=("  ->  ${RELEASE_SVN_DIR}/${DST_TAR}")
+  svnmucc_ops+=(mv "$SRC_TAR" "${RELEASE_SVN_DIR}/${DST_TAR}")
+  op_lines+=("mv    ${SRC_ASC}")
+  op_lines+=("  ->  ${RELEASE_SVN_DIR}/${DST_ASC}")
+  svnmucc_ops+=(mv "$SRC_ASC" "${RELEASE_SVN_DIR}/${DST_ASC}")
+  op_lines+=("put   ${FINAL_SHA512_FILE}")
+  op_lines+=("  ->  ${RELEASE_SVN_DIR}/${DST_SHA512}")
+  svnmucc_ops+=(put "$FINAL_SHA512_FILE" "${RELEASE_SVN_DIR}/${DST_SHA512}")
+  op_lines+=("rm    ${DEV_SVN_DIR}")
+  svnmucc_ops+=(rm "$DEV_SVN_DIR")
+
+  step "Publish to the release SVN and remove the dev RC folder" \
+    "This is public and requires PMC permission." \
+    "All of it lands in one SVN revision:" \
+    "${op_lines[@]}"
+
+  if ! svnmucc "${svnmucc_auth[@]}" -m "Release Doris ${VERSION}" "${svnmucc_ops[@]}"; then
+    die "svnmucc release publish failed"
+  fi
+  cleanup_checksum_dir
+  ok "committed release artifacts: ${RELEASE_SVN_DIR}/"
+  ok "removed dev RC folder: ${DEV_SVN_DIR}/"
+}
+
+remove_dev_rc_folder() {
+  step "Remove the leftover dev RC folder" \
+    "The release artifacts are already published, so the RC folder is stale." \
+    "rm    ${DEV_SVN_DIR}"
+
+  if ! svnmucc "${svnmucc_auth[@]}" -m "Remove ${TAG} after releasing Doris ${VERSION}" \
+      rm "$DEV_SVN_DIR"; then
+    die "svnmucc dev RC removal failed"
+  fi
+  ok "removed dev RC folder: ${DEV_SVN_DIR}/"
 }
 
 write_announce_email() {
@@ -106,7 +270,13 @@ On behalf of the Doris team,
 ${SIGNER_NAME}
 EOF
 
-  printf '%s\n' "$BODY" > "$body_file"
+  # The .txt draft carries the subject line too, so the whole mail can be
+  # copied from one file. The .eml keeps it as a real header below.
+  {
+    echo "Subject: ${subject}"
+    echo
+    printf '%s\n' "$BODY"
+  } > "$body_file"
   {
     echo "To: ${DEV_LIST}"
     echo "Subject: ${subject}"
@@ -125,106 +295,52 @@ EOF
   echo "(Not auto-sent by design - it's a public ASF list.)"
 }
 
-publish_to_release_svn() {
-  local src_tar src_asc src_sha512 dst_tar dst_asc dst_sha512 checksum_dir src_tar_file final_sha512_file release_parent_missing
-  local -a svnmucc_ops
-
+if [[ "$mail_only" -eq 0 ]]; then
   require_tool svn
   require_tool svnmucc
   require_tool gpg
   require_tool sha512sum
 
-  src_tar="${DEV_SVN_DIR}/${PKG_BASE}.tar.gz"
-  src_asc="${src_tar}.asc"
-  src_sha512="${src_tar}.sha512"
-  dst_tar="${RELEASE_PKG_BASE}.tar.gz"
-  dst_asc="${dst_tar}.asc"
-  dst_sha512="${dst_tar}.sha512"
-
   echo "== Apache Doris ${TAG} - complete release =="
   echo "Source dev SVN folder:     ${DEV_SVN_DIR}/"
   echo "Target release SVN folder: ${RELEASE_SVN_DIR}/"
-  echo
-  echo "Source files:"
-  echo "  ${PKG_BASE}.tar.gz"
-  echo "  ${PKG_BASE}.tar.gz.asc"
-  echo "  ${PKG_BASE}.tar.gz.sha512"
-  echo "Target files:"
-  echo "  ${dst_tar}"
-  echo "  ${dst_asc}"
-  echo "  ${dst_sha512}"
-  echo
   warn "Only PMC members can write to the release SVN directory."
 
-  svn info "${svn_auth[@]}" "$src_tar" >/dev/null || die "source artifact not found: $src_tar"
-  svn info "${svn_auth[@]}" "$src_asc" >/dev/null || die "source signature not found: $src_asc"
-  svn info "${svn_auth[@]}" "$src_sha512" >/dev/null || die "source checksum not found: $src_sha512"
-  if svn info "${svn_auth[@]}" "$RELEASE_SVN_DIR" >/dev/null 2>&1; then
-    die "release SVN folder already exists: $RELEASE_SVN_DIR (use --mail-only to regenerate the email)"
-  fi
-  release_parent_missing=0
-  if svn info "${svn_auth[@]}" "$RELEASE_SVN_PARENT_DIR" >/dev/null 2>&1; then
-    ok "release SVN parent exists: ${RELEASE_SVN_PARENT_DIR}"
+  step "Inspect the dev and release SVN state" \
+    "Read-only: svn info on the dev RC folder and the release folder." \
+    "Nothing is changed by this step; it decides what the later steps do."
+  discover_svn_state
+
+  if [[ "$DST_PRESENT" -eq 3 ]]; then
+    ok "release artifacts already published: ${RELEASE_SVN_DIR}/"
+    ok "nothing to publish; this run only cleans up and drafts the email"
+    if [[ "$DEV_DIR_EXISTS" -eq 1 ]]; then
+      remove_dev_rc_folder
+    else
+      ok "dev RC folder already removed: ${DEV_SVN_DIR}/"
+    fi
+  elif [[ "$DST_PRESENT" -eq 0 ]]; then
+    [[ "$SRC_PRESENT" -eq 3 ]] || die "cannot publish: ${SRC_PRESENT}/3 RC artifacts in ${DEV_SVN_DIR}/ and 0/3 published in ${RELEASE_SVN_DIR}/"
+    if [[ "$RELEASE_DIR_EXISTS" -eq 1 ]]; then
+      warn "release folder exists but is empty; it will be reused instead of created"
+    fi
+
+    step "Verify the RC artifacts and build the final checksum" \
+      "Downloads the RC tarball, signature and checksum to a temp directory," \
+      "checks the sha512 and the detached signature that the voters approved," \
+      "then writes ${DST_SHA512} for the RC-free tarball name." \
+      "Local only: no SVN state is changed by this step."
+    verify_and_build_checksum
+
+    publish_to_release_svn
   else
-    release_parent_missing=1
-    warn "release SVN parent will be created: ${RELEASE_SVN_PARENT_DIR}"
+    die "release folder is half-published (${DST_PRESENT}/3): missing ${DST_MISSING[*]} in ${RELEASE_SVN_DIR}/ - fix it by hand, this script only publishes a complete set"
   fi
-
-  checksum_dir="$(mktemp -d)"
-  trap 'rm -rf "$checksum_dir"' EXIT
-
-  src_tar_file="${PKG_BASE}.tar.gz"
-  final_sha512_file="${checksum_dir}/${dst_sha512}"
-  svn cat "${svn_auth[@]}" "$src_tar" > "${checksum_dir}/${src_tar_file}"
-  svn cat "${svn_auth[@]}" "$src_sha512" > "${checksum_dir}/${src_tar_file}.sha512"
-  svn cat "${svn_auth[@]}" "$src_asc" > "${checksum_dir}/${src_tar_file}.asc"
-  (
-    cd "$checksum_dir"
-    sha512sum --check "${src_tar_file}.sha512"
-    gpg --verify "${src_tar_file}.asc" "$src_tar_file"
-    cp "$src_tar_file" "$dst_tar"
-    sha512sum "$dst_tar" > "$dst_sha512"
-    sha512sum --check "$dst_sha512"
-  )
-  ok "source RC checksum and signature verified: ${src_tar_file}"
-  ok "final sha512 ok: ${dst_sha512}"
-
-  echo "--- svnmucc operations ---"
-  svnmucc_ops=()
-  if [[ "$release_parent_missing" -eq 1 ]]; then
-    echo "mkdir ${RELEASE_SVN_PARENT_DIR}"
-    svnmucc_ops+=(mkdir "$RELEASE_SVN_PARENT_DIR")
-  fi
-  echo "mkdir ${RELEASE_SVN_DIR}"
-  svnmucc_ops+=(mkdir "$RELEASE_SVN_DIR")
-  echo "mv    ${src_tar}"
-  echo "  ->  ${RELEASE_SVN_DIR}/${dst_tar}"
-  svnmucc_ops+=(mv "$src_tar" "${RELEASE_SVN_DIR}/${dst_tar}")
-  echo "mv    ${src_asc}"
-  echo "  ->  ${RELEASE_SVN_DIR}/${dst_asc}"
-  svnmucc_ops+=(mv "$src_asc" "${RELEASE_SVN_DIR}/${dst_asc}")
-  echo "put   ${final_sha512_file}"
-  echo "  ->  ${RELEASE_SVN_DIR}/${dst_sha512}"
-  svnmucc_ops+=(put "$final_sha512_file" "${RELEASE_SVN_DIR}/${dst_sha512}")
-  echo "rm    ${DEV_SVN_DIR}"
-  svnmucc_ops+=(rm "$DEV_SVN_DIR")
-  echo
-  echo "Will commit the URL operations above in one SVN revision."
-  confirm "FINAL confirm - publish release SVN and remove dev RC now?" || { warn "stopping before SVN commit."; exit 0; }
-
-  if ! svnmucc "${svnmucc_auth[@]}" -m "Release Doris ${VERSION}" "${svnmucc_ops[@]}"; then
-    die "svnmucc release publish failed"
-  fi
-  rm -rf "$checksum_dir"
-  trap - EXIT
-  ok "committed release artifacts: ${RELEASE_SVN_DIR}/"
-  ok "removed dev RC folder: ${DEV_SVN_DIR}/"
-}
-
-if [[ "$mail_only" -eq 0 ]]; then
-  publish_to_release_svn
 else
   ok "mail-only mode: skipping SVN publish"
 fi
 
+step "Write the [ANNOUNCE] email draft" \
+  "Writes announce-email.txt and announce-email.eml under ${WORK_DIR}." \
+  "Local only: the mail is never sent by this script."
 write_announce_email

--- a/tools/release-tools/README.md
+++ b/tools/release-tools/README.md
@@ -60,7 +60,9 @@ Also make these boundaries clear:
   locally, but the scripts do not upload those binaries.
 - The scripts never send public emails. The RM must review and send the vote,
   result, and announce emails manually.
-- Step 04 writes to the Apache release SVN and requires PMC permission.
+- Step 04 writes to the Apache release SVN and requires PMC permission. It
+  confirms before every step and is safe to re-run: it reads the current SVN
+  state first and skips whatever is already done.
 
 ## Quick start for a new RC
 
@@ -241,17 +243,41 @@ Review the draft and send it manually from the RM's `@apache.org` address to
 Use this script only after the vote has passed and the `[RESULT]` email has
 been sent manually.
 
-It checks the passed RC source artifacts in the dev SVN, verifies the source
-tarball against the RC checksum and detached signature that voters approved,
-regenerates and verifies the final checksum sidecar with the RC-free source
-tarball name, then uses `svnmucc` to create the final release SVN directory,
-move the source tarball and detached signature there, upload the final checksum,
-and remove the dev RC folder in one SVN revision.
+Every step announces what it is about to do and waits for a `y` before running.
+Answering anything else stops the run without changing further state, and the
+run can be continued later by starting the script again.
 
-It then writes:
+The steps are:
 
-- `announce-email.txt`
-- `announce-email.eml`
+1. Inspect the dev and release SVN state. Read-only, and it decides what the
+   later steps do.
+2. Verify the RC artifacts and build the final checksum. It downloads the RC
+   tarball, signature and checksum, checks the sha512 and the detached
+   signature that voters approved, and regenerates the checksum sidecar under
+   the RC-free tarball name. Local only.
+3. Publish to the release SVN. One `svnmucc` revision creates the release
+   directory, moves the source tarball and detached signature there, uploads
+   the final checksum, and removes the dev RC folder.
+4. Write the announce email draft.
+
+The script is idempotent, so it is safe to re-run after a successful publish or
+after stopping at any prompt:
+
+- All three release artifacts already published: the publish steps are skipped.
+  A dev RC folder left behind is removed, and the announce email is drafted.
+- Nothing published yet: the full flow runs. A release directory that exists
+  but is empty is reused instead of being created again.
+- Some but not all release artifacts present: the script refuses to guess and
+  reports exactly which files are missing. `svnmucc` commits all of its
+  operations in one revision, so this state only comes from manual changes.
+
+It writes:
+
+- `announce-email.txt`, starting with a `Subject:` line so the subject and the
+  body can be copied from one file
+- `announce-email.eml`, carrying the same subject as a real mail header
+
+The subject is `[ANNOUNCE] Apache Doris <version> release`.
 
 Before sending the announce email, check that the release is visible on
 `downloads.apache.org`, update and verify the Doris download page, and wait for

--- a/tools/release-tools/tests/test-release-complete-checksum.sh
+++ b/tools/release-tools/tests/test-release-complete-checksum.sh
@@ -161,7 +161,8 @@ export FAKE_MKTEMP_ROOT="$tmp/mktemp-root"
 export FAKE_MKTEMP_LOG="$tmp/mktemp.log"
 mkdir -p "$FAKE_MKTEMP_ROOT"
 
-printf 'y\n' | bash "$tmp/04-release-complete.sh" >/dev/null
+# One y per step: inspect, verify, publish, announce.
+printf 'y\ny\ny\ny\n' | bash "$tmp/04-release-complete.sh" >/dev/null
 
 if grep -q 'mv https://dist.example.test/dev/doris/9.9.9-rc01/apache-doris-9.9.9-rc01-src.tar.gz.sha512' "$FAKE_SVNMUCC_LOG"; then
   echo "release completion must not move the RC checksum sidecar unchanged" >&2
@@ -187,7 +188,7 @@ if [[ -e "$success_checksum_dir" ]]; then
   exit 1
 fi
 
-if FAKE_BAD_SHA512=1 bash "$tmp/04-release-complete.sh" >/dev/null 2>&1; then
+if printf 'y\ny\ny\ny\n' | FAKE_BAD_SHA512=1 bash "$tmp/04-release-complete.sh" >/dev/null 2>&1; then
   echo "release completion unexpectedly succeeded with a bad RC checksum" >&2
   exit 1
 fi

--- a/tools/release-tools/tests/test-release-complete-idempotent.sh
+++ b/tools/release-tools/tests/test-release-complete-idempotent.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+cp "${ROOT}/04-release-complete.sh" "$tmp/"
+cat > "$tmp/release.env" <<'EOF'
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+VERSION="9.9.9"
+RC="rc01"
+TAG="${VERSION}-${RC}"
+PKG_BASE="apache-doris-${TAG}-src"
+RELEASE_PKG_BASE="apache-doris-${VERSION}-src"
+WORK_DIR="${ROOT}/${TAG}"
+DEV_SVN_BASE="https://dist.example.test/dev/doris"
+DEV_SVN_DIR="${DEV_SVN_BASE}/${TAG}"
+RELEASE_SVN_BASE="https://dist.example.test/release/doris"
+RELEASE_SERIES="${VERSION%.*}"
+DOWNLOAD_PAGE_URL="https://doris.example.test/download/"
+ANNOUNCE_RELEASE_NOTES_URL="https://doris.example.test/release-notes"
+RELEASE_NOTES_URL=""
+DEV_LIST="dev@example.test"
+SIGNER_NAME="Release Manager"
+EOF
+
+# The release is already published. FAKE_DEV_DIR_PRESENT decides whether the
+# stale RC folder is still sitting in the dev SVN.
+cat > "$tmp/svn" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+cmd="$1"
+shift
+url="${@: -1}"
+case "$cmd" in
+  info)
+    case "$url" in
+      https://dist.example.test/dev/doris/*)
+        [[ "${FAKE_DEV_DIR_PRESENT:-0}" -eq 1 ]] || exit 1
+        ;;
+      https://dist.example.test/release/doris/9.9|https://dist.example.test/release/doris/9.9/9.9.9|https://dist.example.test/release/doris/9.9/9.9.9/*)
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    echo "unexpected svn command: $cmd $url" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$tmp/svn"
+
+cat > "$tmp/svnmucc" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_SVNMUCC_LOG"
+EOF
+chmod +x "$tmp/svnmucc"
+
+cat > "$tmp/gpg" <<'EOF'
+#!/usr/bin/env bash
+echo "gpg must not run when nothing is published" >&2
+exit 1
+EOF
+chmod +x "$tmp/gpg"
+
+export PATH="$tmp:$PATH"
+export FAKE_SVNMUCC_LOG="$tmp/svnmucc.log"
+
+# --- re-run after a completed release, dev RC folder already gone -----------
+: > "$FAKE_SVNMUCC_LOG"
+out="$(printf 'y\ny\n' | bash "$tmp/04-release-complete.sh" 2>&1)"
+
+if [[ -s "$FAKE_SVNMUCC_LOG" ]]; then
+  echo "a re-run over a completed release must not touch SVN" >&2
+  cat "$FAKE_SVNMUCC_LOG" >&2
+  exit 1
+fi
+if ! grep -qF "release artifacts already published" <<<"$out"; then
+  echo "a re-run must report that the artifacts are already published" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+fi
+[[ -f "$tmp/9.9.9-rc01/announce-email.txt" ]] || {
+  echo "a re-run must still write the announce email draft" >&2
+  exit 1
+}
+if [[ "$(head -1 "$tmp/9.9.9-rc01/announce-email.txt")" != "Subject: [ANNOUNCE] Apache Doris 9.9.9 release" ]]; then
+  echo "announce-email.txt must start with the subject line" >&2
+  head -1 "$tmp/9.9.9-rc01/announce-email.txt" >&2
+  exit 1
+fi
+if ! grep -qxF "Subject: [ANNOUNCE] Apache Doris 9.9.9 release" "$tmp/9.9.9-rc01/announce-email.eml"; then
+  echo "announce-email.eml must carry the subject header" >&2
+  exit 1
+fi
+
+# --- re-run after a completed release, stale dev RC folder left behind ------
+: > "$FAKE_SVNMUCC_LOG"
+rm -rf "$tmp/9.9.9-rc01"
+out="$(printf 'y\ny\ny\n' | FAKE_DEV_DIR_PRESENT=1 bash "$tmp/04-release-complete.sh" 2>&1)"
+
+if ! grep -qF "rm https://dist.example.test/dev/doris/9.9.9-rc01" "$FAKE_SVNMUCC_LOG"; then
+  echo "a stale dev RC folder must be removed on a re-run" >&2
+  cat "$FAKE_SVNMUCC_LOG" >&2
+  exit 1
+fi
+if grep -qE '(mkdir|mv|put) ' "$FAKE_SVNMUCC_LOG"; then
+  echo "a re-run must only remove the stale RC folder, not republish" >&2
+  cat "$FAKE_SVNMUCC_LOG" >&2
+  exit 1
+fi
+[[ -f "$tmp/9.9.9-rc01/announce-email.txt" ]] || {
+  echo "a re-run must still write the announce email draft" >&2
+  exit 1
+}
+
+# --- declining a step stops the run without changing anything ---------------
+: > "$FAKE_SVNMUCC_LOG"
+rm -rf "$tmp/9.9.9-rc01"
+out="$(printf 'y\nn\n' | FAKE_DEV_DIR_PRESENT=1 bash "$tmp/04-release-complete.sh" 2>&1)"
+
+if [[ -s "$FAKE_SVNMUCC_LOG" ]]; then
+  echo "declining a step must not run any SVN operation" >&2
+  cat "$FAKE_SVNMUCC_LOG" >&2
+  exit 1
+fi
+if ! grep -qF "stopped before step" <<<"$out"; then
+  echo "declining a step must say which step was stopped" >&2
+  printf '%s\n' "$out" >&2
+  exit 1
+fi
+if [[ -e "$tmp/9.9.9-rc01/announce-email.txt" ]]; then
+  echo "declining a step must not continue to the later steps" >&2
+  exit 1
+fi


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #65488, #66663

Problem Summary:

Three improvements to `04-release-complete.sh`, found while preparing 4.0.8-rc02.

**1. The script could only ever run once**

The first thing it did after checking the RC artifacts was:

```bash
if svn info "$RELEASE_SVN_DIR" >/dev/null 2>&1; then
  die "release SVN folder already exists: $RELEASE_SVN_DIR (use --mail-only to regenerate the email)"
fi
```

So once the release was published, every re-run died — including a re-run right after the publish succeeded and the announce step failed, which is exactly when the RM wants to continue. `--mail-only` was the documented workaround, but it also skips the checks that would tell the RM whether the publish actually completed.

It now discovers the dev and release SVN state first and converges from there:

- all three release artifacts present: skip the publish steps, remove a dev RC folder that was left behind, draft the email;
- nothing published: run the full flow, reusing a release directory that exists but is empty instead of trying to create it again;
- some but not all release artifacts present: report exactly which files are missing and stop, rather than guessing. `svnmucc` commits all of its operations in one revision, so this state can only come from a manual change and deserves a human.

The dev RC folder removal is also skipped when the folder is already gone, so the `svnmucc rm` cannot fail a re-run.

**2. Every step now asks before it runs**

There used to be exactly one confirmation, right before the `svnmucc` commit. Each step now prints what it is about to do and waits:

```
== step 3: Publish to the release SVN and remove the dev RC folder ==
     This is public and requires PMC permission.
     All of it lands in one SVN revision:
     mkdir https://dist.apache.org/repos/dist/release/doris/4.0/4.0.8
     mv    .../dev/doris/4.0.8-rc02/apache-doris-4.0.8-rc02-src.tar.gz
       ->  .../release/doris/4.0/4.0.8/apache-doris-4.0.8-src.tar.gz
     ...
Proceed with step 3? [y/N]
```

Declining any step stops the run without changing further state and says so, and because the script is idempotent the run can simply be started again later.

**3. The announce draft carries its subject**

`announce-email.txt` now starts with a `Subject:` line matching the header already written into `announce-email.eml`, so the subject and the body can be copied from one file. This mirrors what #66663 does for the vote email.

**Bonus: a directory leak the existing test already caught**

`tests/test-release-complete-checksum.sh` fails on current master:

```
checksum temp directory was not removed after checksum verification failure: /var/folders/.../checksum-dir-32602-11908
```

`checksum_dir` was `local` to `publish_to_release_svn`, while the `trap ... EXIT` referencing it is global. When `set -e` aborted the run the local was already out of scope, so the trap expanded it to an empty string and `rm -rf ""` left the directory behind. It is a script-level variable with a cleanup function now, and the test passes.

### Release note

None

### Check List (For Author)

- Test
    - [x] Unit Test

      `tools/release-tools/tests/test-release-complete-idempotent.sh` (new) drives the script with a fake `svn`/`svnmucc` over an already-published release and asserts three things:

      - dev RC folder already gone: no SVN operation runs at all, the run reports the artifacts as already published, and the announce draft is still written with its `Subject:` line;
      - stale dev RC folder present: the only `svnmucc` operation is the `rm` of that folder — no `mkdir`, `mv` or `put`;
      - a declined step: nothing runs, the run names the step it stopped before, and it does not fall through to the later steps.

      `tools/release-tools/tests/test-release-complete-checksum.sh` (updated) feeds one `y` per step. It covers the leak fix and passed unchanged in every other respect.

      `./tests/run.sh` is fully green on this branch; `test-release-complete-checksum.sh` is red on master.

- Behavior changed:
    - [x] Yes.

      Only for the RM running this script. A re-run over a published release no longer aborts, each step asks for confirmation instead of only the SVN commit, and `announce-email.txt` gains a leading `Subject:` line. No product code is touched.

- Does this need documentation?
    - [x] No. `tools/release-tools/README.md` is updated in this PR.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label

🤖 Generated with [Claude Code](https://claude.com/claude-code)
