### PR TITLE
[fix](build) drop the unique_ptr NSDMI that breaks gcc builds of the per-db scanners

### DIFF
--- a/be/src/information_schema/schema_per_db_scanner.h
+++ b/be/src/information_schema/schema_per_db_scanner.h
@@ -65,7 +65,10 @@ private:
     TGetDbsResult _db_result;
     int _row_idx = 0;
     int _total_rows = 0;
-    std::unique_ptr<Block> _fetched_block = nullptr;
+    // Left without an `= nullptr` initializer on purpose: a default member initializer makes
+    // GCC instantiate `~unique_ptr<Block>()` in every translation unit that includes this
+    // header, and that needs Block to be complete. Default construction gives the same null.
+    std::unique_ptr<Block> _fetched_block;
     int _rpc_timeout_ms = 3000;
 };
 


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #66732, #66712

Problem Summary:

`schema_per_db_scanner.h` gives its `unique_ptr` member a default member initializer:

```cpp
std::unique_ptr<Block> _fetched_block = nullptr;
```

That initializer makes gcc instantiate `~unique_ptr<Block>()` in **every** translation unit that
includes the header, and the instantiation needs `Block` to be a complete type. None of the seven
`SchemaPerDbScanner` subclasses include `core/block/block.h`, so each of them fails to compile with
g++ 15:

```
In instantiation of 'void std::default_delete<_Tp>::operator()(_Tp*) const [with _Tp = doris::Block]':
bits/unique_ptr.h:399:17:   required from 'std::unique_ptr<_Tp, _Dp>::~unique_ptr() [with _Tp = doris::Block]'
schema_per_db_scanner.h:68:45:   required from here
   68 |     std::unique_ptr<Block> _fetched_block = nullptr;
      |                                             ^~~~~~~
bits/unique_ptr.h:91:23: error: invalid application of 'sizeof' to incomplete type 'doris::Block'
```

Declaring the destructor out of line -- which the header already does -- does not help: the default
member initializer is what marks `~unique_ptr<Block>()` as used. clang does not instantiate the
destructor there, which is why only the gcc build reports it. `SchemaScanner::_data_block` has the
same type and the same forward-declared `Block` and is fine, because it has no initializer.

Dropping the `= nullptr` leaves the member null just the same, and costs nothing at build time --
the alternative, including `core/block/block.h` from the header, would pull that closure into seven
more translation units.

Note that the failure is currently masked on master: since #66712 turned `ENABLE_UNITY_BUILD` on by
default, all of `information_schema` is merged into a single unity TU, and
`schema_per_db_scanner.cpp` in that TU includes `core/block/block.h`, so `Block` ends up complete for
its neighbours. Building with `ENABLE_UNITY_BUILD=OFF` still fails, as does any file that later opts
out via `SKIP_UNITY_BUILD_INCLUSION`.

### Release note

None

### Check List (For Author)

- Test
    - [x] No need to test or manual test. Explain why:
        - [x] This is a refactor/code format and no logic has been changed.

  Verified as a build fix instead: reproduced the exact diagnostic with g++ 15.2 on a reduced case
  and confirmed it compiles clean after removing the initializer, then re-checked the real
  translation units (`schema_key_column_usage_scanner.cpp`, `schema_partitions_scanner.cpp`,
  `schema_table_options_scanner.cpp`, `schema_per_db_scanner.cpp`) against the edited header.

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
