### PR TITLE
[fix](streaming-job) Encode CDC stream load records as UTF-8

### DIFF
--- a/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/service/PipelineCoordinator.java
+++ b/fs_brokers/cdc_client/src/main/java/org/apache/doris/cdcclient/service/PipelineCoordinator.java
@@ -621,7 +621,8 @@ public class PipelineCoordinator {
                         String dorisTable = targetTableMappings.getOrDefault(table, table);
                         for (String record : result.getRecords()) {
                             scannedRows++;
-                            batchStreamLoad.writeRecord(targetDb, dorisTable, record.getBytes());
+                            batchStreamLoad.writeRecord(
+                                    targetDb, dorisTable, record.getBytes(StandardCharsets.UTF_8));
                         }
                         // Mark last message as data (not heartbeat)
                         lastMessageIsHeartbeat = false;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

CDC streaming jobs encoded JSON records with `String.getBytes()`, so the stream-load payload depended on the CDC Client JVM default charset. On JVMs using a non-UTF-8 default charset, characters such as Chinese text and emoji were replaced with question marks before reaching Doris. Encode records explicitly as UTF-8, matching the existing CDC fetch path and the stream-load JSON contract.

Before the change, `MySqlCharsetITCase` running with `-Dfile.encoding=US-ASCII` failed with `expected: "测试数据😀" but was: "?????"`. After the change, the same test passes without requiring the CDC Client JVM default charset to be UTF-8.

### Release note

Fix CDC streaming jobs corrupting non-ASCII text when the CDC Client JVM uses a non-UTF-8 default charset.

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

  ```shell
  mvn -Dtest=MySqlCharsetITCase "-Dtest.add.opens=--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.math=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED -Dfile.encoding=US-ASCII" test
  ```

- Behavior changed:
    - [ ] No.
    - [x] Yes. CDC stream-load records are always encoded as UTF-8.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
