### PR TITLE
[feat](iceberg) HDFS lazy open + iceberg delete file file_size propagation

### DIFF
--- a/be/src/exec/scan/file_scanner.cpp
+++ b/be/src/exec/scan/file_scanner.cpp
@@ -580,8 +580,14 @@ Status FileScanner::_get_block_wrapped(RuntimeState* state, Block* block, bool* 
 
             // Read next block.
             // Some of column in block may not be filled (column not exist in file)
-            RETURN_IF_ERROR(
-                    _cur_reader->get_next_block(_src_block_ptr, &read_rows, &_cur_reader_eof));
+            Status st = _cur_reader->get_next_block(_src_block_ptr, &read_rows, &_cur_reader_eof);
+            // Lazy open may surface NOT_FOUND on the first read; skip as above.
+            if (st.is<ErrorCode::NOT_FOUND>() && config::ignore_not_found_file_in_external_table) {
+                _cur_reader_eof = true;
+                COUNTER_UPDATE(_not_found_file_counter, 1);
+                continue;
+            }
+            RETURN_IF_ERROR(st);
         }
         // use read_rows instead of _src_block_ptr->rows(), because the first column of _src_block_ptr
         // may not be filled after calling `get_next_block()`, so _src_block_ptr->rows() may return wrong result.

--- a/be/src/format/table/iceberg_delete_file_reader_helper.cpp
+++ b/be/src/format/table/iceberg_delete_file_reader_helper.cpp
@@ -236,12 +236,13 @@ TFileScanRangeParams build_iceberg_delete_scan_range_params(
     return params;
 }
 
-TFileRangeDesc build_iceberg_delete_file_range(const std::string& path) {
+TFileRangeDesc build_iceberg_delete_file_range(const std::string& path, int64_t file_size) {
     TFileRangeDesc range;
     range.path = path;
     range.start_offset = 0;
     range.size = -1;
-    range.file_size = -1;
+    // thrift optional defaults to 0 when unset; treat 0 as unknown (-1)
+    range.file_size = (file_size <= 0) ? -1 : file_size;
     return range;
 }
 
@@ -276,7 +277,7 @@ Status read_iceberg_position_delete_file(const TIcebergDeleteFileDesc& delete_fi
         return Status::InvalidArgument("invalid position delete reader options");
     }
 
-    TFileRangeDesc delete_range = build_iceberg_delete_file_range(delete_file.path);
+    TFileRangeDesc delete_range = build_iceberg_delete_file_range(delete_file.path, delete_file.file_size);
     if (options.fs_name != nullptr && !options.fs_name->empty()) {
         delete_range.__set_fs_name(*options.fs_name);
     }
@@ -348,7 +349,7 @@ Status read_iceberg_deletion_vector(const TIcebergDeleteFileDesc& delete_file,
     DBUG_EXECUTE_IF("IcebergDeleteFileReader.read_deletion_vector.should_stop",
                     { return Status::EndOfFile("stop read."); });
 
-    TFileRangeDesc delete_range = build_iceberg_delete_file_range(delete_file.path);
+    TFileRangeDesc delete_range = build_iceberg_delete_file_range(delete_file.path, delete_file.file_size);
     if (options.fs_name != nullptr && !options.fs_name->empty()) {
         delete_range.__set_fs_name(*options.fs_name);
     }

--- a/be/src/format/table/iceberg_delete_file_reader_helper.cpp
+++ b/be/src/format/table/iceberg_delete_file_reader_helper.cpp
@@ -241,8 +241,7 @@ TFileRangeDesc build_iceberg_delete_file_range(const std::string& path, int64_t 
     range.path = path;
     range.start_offset = 0;
     range.size = -1;
-    // thrift optional defaults to 0 when unset; treat 0 as unknown (-1)
-    range.file_size = (file_size <= 0) ? -1 : file_size;
+    range.file_size = file_size;
     return range;
 }
 
@@ -277,8 +276,9 @@ Status read_iceberg_position_delete_file(const TIcebergDeleteFileDesc& delete_fi
         return Status::InvalidArgument("invalid position delete reader options");
     }
 
-    TFileRangeDesc delete_range =
-            build_iceberg_delete_file_range(delete_file.path, delete_file.file_size);
+    TFileRangeDesc delete_range = build_iceberg_delete_file_range(
+            delete_file.path,
+            delete_file.__isset.file_size ? delete_file.file_size : -1);
     if (options.fs_name != nullptr && !options.fs_name->empty()) {
         delete_range.__set_fs_name(*options.fs_name);
     }
@@ -350,8 +350,9 @@ Status read_iceberg_deletion_vector(const TIcebergDeleteFileDesc& delete_file,
     DBUG_EXECUTE_IF("IcebergDeleteFileReader.read_deletion_vector.should_stop",
                     { return Status::EndOfFile("stop read."); });
 
-    TFileRangeDesc delete_range =
-            build_iceberg_delete_file_range(delete_file.path, delete_file.file_size);
+    TFileRangeDesc delete_range = build_iceberg_delete_file_range(
+            delete_file.path,
+            delete_file.__isset.file_size ? delete_file.file_size : -1);
     if (options.fs_name != nullptr && !options.fs_name->empty()) {
         delete_range.__set_fs_name(*options.fs_name);
     }

--- a/be/src/format/table/iceberg_delete_file_reader_helper.cpp
+++ b/be/src/format/table/iceberg_delete_file_reader_helper.cpp
@@ -277,8 +277,7 @@ Status read_iceberg_position_delete_file(const TIcebergDeleteFileDesc& delete_fi
     }
 
     TFileRangeDesc delete_range = build_iceberg_delete_file_range(
-            delete_file.path,
-            delete_file.__isset.file_size ? delete_file.file_size : -1);
+            delete_file.path, delete_file.__isset.file_size ? delete_file.file_size : -1);
     if (options.fs_name != nullptr && !options.fs_name->empty()) {
         delete_range.__set_fs_name(*options.fs_name);
     }
@@ -351,8 +350,7 @@ Status read_iceberg_deletion_vector(const TIcebergDeleteFileDesc& delete_file,
                     { return Status::EndOfFile("stop read."); });
 
     TFileRangeDesc delete_range = build_iceberg_delete_file_range(
-            delete_file.path,
-            delete_file.__isset.file_size ? delete_file.file_size : -1);
+            delete_file.path, delete_file.__isset.file_size ? delete_file.file_size : -1);
     if (options.fs_name != nullptr && !options.fs_name->empty()) {
         delete_range.__set_fs_name(*options.fs_name);
     }

--- a/be/src/format/table/iceberg_delete_file_reader_helper.cpp
+++ b/be/src/format/table/iceberg_delete_file_reader_helper.cpp
@@ -277,7 +277,8 @@ Status read_iceberg_position_delete_file(const TIcebergDeleteFileDesc& delete_fi
         return Status::InvalidArgument("invalid position delete reader options");
     }
 
-    TFileRangeDesc delete_range = build_iceberg_delete_file_range(delete_file.path, delete_file.file_size);
+    TFileRangeDesc delete_range =
+            build_iceberg_delete_file_range(delete_file.path, delete_file.file_size);
     if (options.fs_name != nullptr && !options.fs_name->empty()) {
         delete_range.__set_fs_name(*options.fs_name);
     }
@@ -349,7 +350,8 @@ Status read_iceberg_deletion_vector(const TIcebergDeleteFileDesc& delete_file,
     DBUG_EXECUTE_IF("IcebergDeleteFileReader.read_deletion_vector.should_stop",
                     { return Status::EndOfFile("stop read."); });
 
-    TFileRangeDesc delete_range = build_iceberg_delete_file_range(delete_file.path, delete_file.file_size);
+    TFileRangeDesc delete_range =
+            build_iceberg_delete_file_range(delete_file.path, delete_file.file_size);
     if (options.fs_name != nullptr && !options.fs_name->empty()) {
         delete_range.__set_fs_name(*options.fs_name);
     }

--- a/be/src/format/table/iceberg_delete_file_reader_helper.h
+++ b/be/src/format/table/iceberg_delete_file_reader_helper.h
@@ -67,7 +67,7 @@ TFileScanRangeParams build_iceberg_delete_scan_range_params(
         const std::map<std::string, std::string>& hadoop_conf, TFileType::type file_type,
         const std::vector<TNetworkAddress>& broker_addresses);
 
-TFileRangeDesc build_iceberg_delete_file_range(const std::string& path);
+TFileRangeDesc build_iceberg_delete_file_range(const std::string& path, int64_t file_size);
 
 bool is_iceberg_deletion_vector(const TIcebergDeleteFileDesc& delete_file);
 

--- a/be/src/format/table/iceberg_reader_mixin.h
+++ b/be/src/format/table/iceberg_reader_mixin.h
@@ -848,7 +848,7 @@ Status IcebergReaderMixin<BaseReader>::_read_equality_delete_file(
     delete_desc.path = delete_file.path;
     delete_desc.start_offset = 0;
     delete_desc.size = -1;
-    delete_desc.file_size = -1;
+    delete_desc.file_size = delete_file.__isset.file_size ? delete_file.file_size : -1;
 
     std::unique_ptr<GenericReader> reader = _create_equality_reader(delete_desc);
     RETURN_IF_ERROR(reader->init_schema_reader());

--- a/be/src/format/table/iceberg_reader_mixin.h
+++ b/be/src/format/table/iceberg_reader_mixin.h
@@ -143,6 +143,10 @@ public:
         return _position_delete_base(data_file_path, delete_files);
     }
 
+    Status TEST_read_equality_delete_file(const TIcebergDeleteFileDesc& delete_file) {
+        return _read_equality_delete_file(delete_file);
+    }
+
     void TEST_set_column_name_to_block_index(
             std::unordered_map<std::string, uint32_t>* column_name_to_block_index) {
         this->col_name_to_block_idx_ref() = column_name_to_block_index;
@@ -1290,7 +1294,8 @@ Status IcebergReaderMixin<BaseReader>::_position_delete_base(
                     delete_file_range.path = delete_file.path;
                     delete_file_range.start_offset = 0;
                     delete_file_range.size = -1;
-                    delete_file_range.file_size = -1;
+                    delete_file_range.file_size =
+                            delete_file.__isset.file_size ? delete_file.file_size : -1;
                     create_status =
                             _read_position_delete_file(&delete_file_range, position_delete.get());
                     if (!create_status) {

--- a/be/src/format_v2/orc/orc_reader.cpp
+++ b/be/src/format_v2/orc/orc_reader.cpp
@@ -945,8 +945,15 @@ Status OrcReader::init(RuntimeState* state) {
         if (is_orc_stop(_io_ctx.get(), e)) {
             return Status::EndOfFile("stop");
         }
+        // invoker maybe just skip Status.NotFound and continue
+        // so we need distinguish between it and other kinds of errors
+        const std::string err_msg = e.what();
+        if (err_msg.find("No such file or directory") != std::string::npos ||
+            err_msg.find("NoSuchKey") != std::string::npos) {
+            return Status::NotFound(err_msg);
+        }
         return Status::InternalError("Failed to open ORC file {}: {}", _file_description->path,
-                                     e.what());
+                                     err_msg);
     }
     return Status::OK();
 }

--- a/be/src/format_v2/table/iceberg_reader.cpp
+++ b/be/src/format_v2/table/iceberg_reader.cpp
@@ -1596,8 +1596,7 @@ Status IcebergTableReader::_create_delete_file_reader(const TIcebergDeleteFileDe
                                     delete_file.file_format);
     }
     auto delete_range = build_iceberg_delete_file_range(
-            delete_file.path,
-            delete_file.__isset.file_size ? delete_file.file_size : -1);
+            delete_file.path, delete_file.__isset.file_size ? delete_file.file_size : -1);
     if (_current_task != nullptr && _current_task->data_file != nullptr &&
         !_current_task->data_file->fs_name.empty()) {
         delete_range.__set_fs_name(_current_task->data_file->fs_name);

--- a/be/src/format_v2/table/iceberg_reader.cpp
+++ b/be/src/format_v2/table/iceberg_reader.cpp
@@ -1239,7 +1239,7 @@ Status IcebergTableReader::_parse_deletion_vector_file(const TTableFormatFileDes
     desc->path = deletion_vector->path;
     desc->start_offset = deletion_vector->content_offset;
     desc->size = static_cast<int64_t>(bytes_read);
-    desc->file_size = deletion_vector->file_size;
+    desc->file_size = deletion_vector->__isset.file_size ? deletion_vector->file_size : -1;
     desc->format = DeleteFileDesc::Format::ICEBERG;
     *has_delete_file = true;
     return Status::OK();
@@ -1595,7 +1595,9 @@ Status IcebergTableReader::_create_delete_file_reader(const TIcebergDeleteFileDe
         return Status::NotSupported("Unsupported Iceberg delete file format {}",
                                     delete_file.file_format);
     }
-    auto delete_range = build_iceberg_delete_file_range(delete_file.path, delete_file.file_size);
+    auto delete_range = build_iceberg_delete_file_range(
+            delete_file.path,
+            delete_file.__isset.file_size ? delete_file.file_size : -1);
     if (_current_task != nullptr && _current_task->data_file != nullptr &&
         !_current_task->data_file->fs_name.empty()) {
         delete_range.__set_fs_name(_current_task->data_file->fs_name);

--- a/be/src/format_v2/table/iceberg_reader.cpp
+++ b/be/src/format_v2/table/iceberg_reader.cpp
@@ -1239,7 +1239,7 @@ Status IcebergTableReader::_parse_deletion_vector_file(const TTableFormatFileDes
     desc->path = deletion_vector->path;
     desc->start_offset = deletion_vector->content_offset;
     desc->size = static_cast<int64_t>(bytes_read);
-    desc->file_size = -1;
+    desc->file_size = deletion_vector->file_size;
     desc->format = DeleteFileDesc::Format::ICEBERG;
     *has_delete_file = true;
     return Status::OK();
@@ -1595,7 +1595,7 @@ Status IcebergTableReader::_create_delete_file_reader(const TIcebergDeleteFileDe
         return Status::NotSupported("Unsupported Iceberg delete file format {}",
                                     delete_file.file_format);
     }
-    auto delete_range = build_iceberg_delete_file_range(delete_file.path);
+    auto delete_range = build_iceberg_delete_file_range(delete_file.path, delete_file.file_size);
     if (_current_task != nullptr && _current_task->data_file != nullptr &&
         !_current_task->data_file->fs_name.empty()) {
         delete_range.__set_fs_name(_current_task->data_file->fs_name);

--- a/be/src/io/fs/file_handle_cache.cpp
+++ b/be/src/io/fs/file_handle_cache.cpp
@@ -27,6 +27,8 @@
 
 #include "common/cast_set.h"
 #include "io/fs/err_utils.h"
+#include "io/hdfs_util.h"
+#include "util/bvar_helper.h"
 #include "util/hash_util.hpp"
 #include "util/time.h"
 namespace doris::io {
@@ -34,6 +36,7 @@ namespace doris::io {
 HdfsFileHandle::~HdfsFileHandle() {
     if (_hdfs_file != nullptr && _fs != nullptr) {
         VLOG_FILE << "hdfsCloseFile() fid=" << _hdfs_file;
+        SCOPED_BVAR_LATENCY(hdfs_bvar::hdfs_close_latency);
         hdfsCloseFile(_fs, _hdfs_file); // TODO: check return code
     }
     _fs = nullptr;
@@ -57,6 +60,7 @@ Status HdfsFileHandle::init(int64_t file_size) {
 Status HdfsFileHandle::ensure_open() {
     std::call_once(_open_once, [this]() {
         VLOG_DEBUG << "lazy open hdfs file: " << _fname;
+        SCOPED_BVAR_LATENCY(hdfs_bvar::hdfs_open_latency);
         _hdfs_file = hdfsOpenFile(_fs, _fname.c_str(), O_RDONLY, 0, 0, 0);
     });
     if (_hdfs_file == nullptr) {

--- a/be/src/io/fs/file_handle_cache.cpp
+++ b/be/src/io/fs/file_handle_cache.cpp
@@ -51,15 +51,13 @@ Status HdfsFileHandle::init(int64_t file_size) {
     _file_size = file_size;
     if (_file_size <= 0) {
         SCOPED_BVAR_LATENCY(hdfs_bvar::hdfs_get_path_info_latency);
-        auto* file_info = SYNC_POINT_HOOK_RETURN_VALUE(
-                hdfsGetPathInfo(_fs, _fname.c_str()),
-                "HdfsFileHandle::init::hdfsGetPathInfo");
+        auto* file_info = SYNC_POINT_HOOK_RETURN_VALUE(hdfsGetPathInfo(_fs, _fname.c_str()),
+                                                       "HdfsFileHandle::init::hdfsGetPathInfo");
         if (file_info == nullptr) {
             return Status::InternalError("failed to get file size of {}: {}", _fname, hdfs_error());
         }
         _file_size = file_info->mSize;
-        TEST_SYNC_POINT_RETURN_WITH_VALUE("HdfsFileHandle::init::hdfsFreeFileInfo",
-                                          Status::OK());
+        TEST_SYNC_POINT_RETURN_WITH_VALUE("HdfsFileHandle::init::hdfsFreeFileInfo", Status::OK());
         hdfsFreeFileInfo(file_info, 1);
     }
     return Status::OK();
@@ -69,9 +67,9 @@ Status HdfsFileHandle::ensure_open() {
     std::call_once(_open_once, [this]() {
         VLOG_DEBUG << "lazy open hdfs file: " << _fname;
         SCOPED_BVAR_LATENCY(hdfs_bvar::hdfs_open_latency);
-        _hdfs_file = SYNC_POINT_HOOK_RETURN_VALUE(
-                hdfsOpenFile(_fs, _fname.c_str(), O_RDONLY, 0, 0, 0),
-                "HdfsFileHandle::ensure_open::hdfsOpenFile");
+        _hdfs_file =
+                SYNC_POINT_HOOK_RETURN_VALUE(hdfsOpenFile(_fs, _fname.c_str(), O_RDONLY, 0, 0, 0),
+                                             "HdfsFileHandle::ensure_open::hdfsOpenFile");
         if (_hdfs_file != nullptr) {
             DorisMetrics::instance()->hdfs_file_open_reading->increment(1);
             DorisMetrics::instance()->hdfs_file_reader_total->increment(1);

--- a/be/src/io/fs/file_handle_cache.cpp
+++ b/be/src/io/fs/file_handle_cache.cpp
@@ -27,6 +27,7 @@
 
 #include "common/cast_set.h"
 #include "common/metrics/doris_metrics.h"
+#include "cpp/sync_point.h"
 #include "io/fs/err_utils.h"
 #include "io/hdfs_util.h"
 #include "util/bvar_helper.h"
@@ -38,7 +39,8 @@ HdfsFileHandle::~HdfsFileHandle() {
     if (_hdfs_file != nullptr && _fs != nullptr) {
         VLOG_FILE << "hdfsCloseFile() fid=" << _hdfs_file;
         SCOPED_BVAR_LATENCY(hdfs_bvar::hdfs_close_latency);
-        hdfsCloseFile(_fs, _hdfs_file); // TODO: check return code
+        SYNC_POINT_HOOK_RETURN_VALUE(hdfsCloseFile(_fs, _hdfs_file),
+                                     "HdfsFileHandle::close::hdfsCloseFile");
         DorisMetrics::instance()->hdfs_file_open_reading->increment(-1);
     }
     _fs = nullptr;
@@ -48,13 +50,16 @@ HdfsFileHandle::~HdfsFileHandle() {
 Status HdfsFileHandle::init(int64_t file_size) {
     _file_size = file_size;
     if (_file_size <= 0) {
-        // file_size unknown, fetch via hdfsGetPathInfo (no need to hdfsOpenFile)
         SCOPED_BVAR_LATENCY(hdfs_bvar::hdfs_get_path_info_latency);
-        hdfsFileInfo* file_info = hdfsGetPathInfo(_fs, _fname.c_str());
+        auto* file_info = SYNC_POINT_HOOK_RETURN_VALUE(
+                hdfsGetPathInfo(_fs, _fname.c_str()),
+                "HdfsFileHandle::init::hdfsGetPathInfo");
         if (file_info == nullptr) {
             return Status::InternalError("failed to get file size of {}: {}", _fname, hdfs_error());
         }
         _file_size = file_info->mSize;
+        TEST_SYNC_POINT_RETURN_WITH_VALUE("HdfsFileHandle::init::hdfsFreeFileInfo",
+                                          Status::OK());
         hdfsFreeFileInfo(file_info, 1);
     }
     return Status::OK();
@@ -64,14 +69,17 @@ Status HdfsFileHandle::ensure_open() {
     std::call_once(_open_once, [this]() {
         VLOG_DEBUG << "lazy open hdfs file: " << _fname;
         SCOPED_BVAR_LATENCY(hdfs_bvar::hdfs_open_latency);
-        _hdfs_file = hdfsOpenFile(_fs, _fname.c_str(), O_RDONLY, 0, 0, 0);
+        _hdfs_file = SYNC_POINT_HOOK_RETURN_VALUE(
+                hdfsOpenFile(_fs, _fname.c_str(), O_RDONLY, 0, 0, 0),
+                "HdfsFileHandle::ensure_open::hdfsOpenFile");
         if (_hdfs_file != nullptr) {
             DorisMetrics::instance()->hdfs_file_open_reading->increment(1);
             DorisMetrics::instance()->hdfs_file_reader_total->increment(1);
         }
     });
     if (_hdfs_file == nullptr) {
-        std::string _err_msg = hdfs_error();
+        std::string _err_msg = SYNC_POINT_HOOK_RETURN_VALUE(
+                hdfs_error(), "HdfsFileHandle::ensure_open::hdfs_error");
         if (_err_msg.find("No such file or directory") != std::string::npos) {
             return Status::NotFound(_err_msg);
         }

--- a/be/src/io/fs/file_handle_cache.cpp
+++ b/be/src/io/fs/file_handle_cache.cpp
@@ -71,19 +71,21 @@ Status HdfsFileHandle::ensure_open() {
                 SYNC_POINT_HOOK_RETURN_VALUE(hdfsOpenFile(_fs, _fname.c_str(), O_RDONLY, 0, 0, 0),
                                              "HdfsFileHandle::ensure_open::hdfsOpenFile");
         if (_hdfs_file != nullptr) {
+            _open_status = Status::OK();
             DorisMetrics::instance()->hdfs_file_open_reading->increment(1);
             DorisMetrics::instance()->hdfs_file_reader_total->increment(1);
+        } else {
+            // Capture error inside the opening thread (libhdfs last-error is thread-local).
+            std::string _err_msg = SYNC_POINT_HOOK_RETURN_VALUE(
+                    hdfs_error(), "HdfsFileHandle::ensure_open::hdfs_error");
+            if (_err_msg.find("No such file or directory") != std::string::npos) {
+                _open_status = Status::NotFound(_err_msg);
+            } else {
+                _open_status = Status::InternalError("failed to open {}: {}", _fname, _err_msg);
+            }
         }
     });
-    if (_hdfs_file == nullptr) {
-        std::string _err_msg = SYNC_POINT_HOOK_RETURN_VALUE(
-                hdfs_error(), "HdfsFileHandle::ensure_open::hdfs_error");
-        if (_err_msg.find("No such file or directory") != std::string::npos) {
-            return Status::NotFound(_err_msg);
-        }
-        return Status::InternalError("failed to open {}: {}", _fname, _err_msg);
-    }
-    return Status::OK();
+    return _open_status;
 }
 
 CachedHdfsFileHandle::CachedHdfsFileHandle(const hdfsFS& fs, const std::string& fname,

--- a/be/src/io/fs/file_handle_cache.cpp
+++ b/be/src/io/fs/file_handle_cache.cpp
@@ -122,12 +122,14 @@ FileHandleCache::Accessor::~Accessor() {
     if (_cache_accessor.get()) {
         auto* handle = get();
         if (handle->file() == nullptr) {
-            // Not opened (lazy open), no resources to release
-            release();
+            // Not opened or open failed (call_once won't retry), destroy to avoid cache pollution
+            destroy();
             return;
         }
 #ifdef USE_HADOOP_HDFS
-        if (hdfsUnbufferFile(handle->file()) != 0) {
+        int unbuffer_ret = SYNC_POINT_HOOK_RETURN_VALUE(hdfsUnbufferFile(handle->file()),
+                                                        "HdfsFileHandle::close::hdfsUnbufferFile");
+        if (unbuffer_ret != 0) {
             VLOG_FILE << "FS does not support file handle unbuffering, closing file="
                       << _cache_accessor.get_key()->second.first;
             destroy();

--- a/be/src/io/fs/file_handle_cache.cpp
+++ b/be/src/io/fs/file_handle_cache.cpp
@@ -26,6 +26,7 @@
 #include <tuple>
 
 #include "common/cast_set.h"
+#include "common/metrics/doris_metrics.h"
 #include "io/fs/err_utils.h"
 #include "io/hdfs_util.h"
 #include "util/bvar_helper.h"
@@ -38,6 +39,7 @@ HdfsFileHandle::~HdfsFileHandle() {
         VLOG_FILE << "hdfsCloseFile() fid=" << _hdfs_file;
         SCOPED_BVAR_LATENCY(hdfs_bvar::hdfs_close_latency);
         hdfsCloseFile(_fs, _hdfs_file); // TODO: check return code
+        DorisMetrics::instance()->hdfs_file_open_reading->increment(-1);
     }
     _fs = nullptr;
     _hdfs_file = nullptr;
@@ -62,6 +64,10 @@ Status HdfsFileHandle::ensure_open() {
         VLOG_DEBUG << "lazy open hdfs file: " << _fname;
         SCOPED_BVAR_LATENCY(hdfs_bvar::hdfs_open_latency);
         _hdfs_file = hdfsOpenFile(_fs, _fname.c_str(), O_RDONLY, 0, 0, 0);
+        if (_hdfs_file != nullptr) {
+            DorisMetrics::instance()->hdfs_file_open_reading->increment(1);
+            DorisMetrics::instance()->hdfs_file_reader_total->increment(1);
+        }
     });
     if (_hdfs_file == nullptr) {
         std::string _err_msg = hdfs_error();

--- a/be/src/io/fs/file_handle_cache.cpp
+++ b/be/src/io/fs/file_handle_cache.cpp
@@ -49,6 +49,7 @@ Status HdfsFileHandle::init(int64_t file_size) {
     _file_size = file_size;
     if (_file_size <= 0) {
         // file_size unknown, fetch via hdfsGetPathInfo (no need to hdfsOpenFile)
+        SCOPED_BVAR_LATENCY(hdfs_bvar::hdfs_get_path_info_latency);
         hdfsFileInfo* file_info = hdfsGetPathInfo(_fs, _fname.c_str());
         if (file_info == nullptr) {
             return Status::InternalError("failed to get file size of {}: {}", _fname, hdfs_error());

--- a/be/src/io/fs/file_handle_cache.cpp
+++ b/be/src/io/fs/file_handle_cache.cpp
@@ -41,25 +41,30 @@ HdfsFileHandle::~HdfsFileHandle() {
 }
 
 Status HdfsFileHandle::init(int64_t file_size) {
-    _hdfs_file = hdfsOpenFile(_fs, _fname.c_str(), O_RDONLY, 0, 0, 0);
-    if (_hdfs_file == nullptr) {
-        std::string _err_msg = hdfs_error();
-        // invoker maybe just skip Status.NotFound and continue
-        // so we need distinguish between it and other kinds of errors
-        if (_err_msg.find("No such file or directory") != std::string::npos) {
-            return Status::NotFound(_err_msg);
-        }
-        return Status::InternalError("failed to open {}: {}", _fname, _err_msg);
-    }
-
     _file_size = file_size;
     if (_file_size <= 0) {
+        // file_size unknown, fetch via hdfsGetPathInfo (no need to hdfsOpenFile)
         hdfsFileInfo* file_info = hdfsGetPathInfo(_fs, _fname.c_str());
         if (file_info == nullptr) {
             return Status::InternalError("failed to get file size of {}: {}", _fname, hdfs_error());
         }
         _file_size = file_info->mSize;
         hdfsFreeFileInfo(file_info, 1);
+    }
+    return Status::OK();
+}
+
+Status HdfsFileHandle::ensure_open() {
+    std::call_once(_open_once, [this]() {
+        VLOG_DEBUG << "lazy open hdfs file: " << _fname;
+        _hdfs_file = hdfsOpenFile(_fs, _fname.c_str(), O_RDONLY, 0, 0, 0);
+    });
+    if (_hdfs_file == nullptr) {
+        std::string _err_msg = hdfs_error();
+        if (_err_msg.find("No such file or directory") != std::string::npos) {
+            return Status::NotFound(_err_msg);
+        }
+        return Status::InternalError("failed to open {}: {}", _fname, _err_msg);
     }
     return Status::OK();
 }
@@ -98,8 +103,14 @@ void FileHandleCache::Accessor::destroy() {
 
 FileHandleCache::Accessor::~Accessor() {
     if (_cache_accessor.get()) {
+        auto* handle = get();
+        if (handle->file() == nullptr) {
+            // Not opened (lazy open), no resources to release
+            release();
+            return;
+        }
 #ifdef USE_HADOOP_HDFS
-        if (hdfsUnbufferFile(get()->file()) != 0) {
+        if (hdfsUnbufferFile(handle->file()) != 0) {
             VLOG_FILE << "FS does not support file handle unbuffering, closing file="
                       << _cache_accessor.get_key()->second.first;
             destroy();

--- a/be/src/io/fs/file_handle_cache.cpp
+++ b/be/src/io/fs/file_handle_cache.cpp
@@ -54,10 +54,16 @@ Status HdfsFileHandle::init(int64_t file_size) {
         auto* file_info = SYNC_POINT_HOOK_RETURN_VALUE(hdfsGetPathInfo(_fs, _fname.c_str()),
                                                        "HdfsFileHandle::init::hdfsGetPathInfo");
         if (file_info == nullptr) {
-            return Status::InternalError("failed to get file size of {}: {}", _fname, hdfs_error());
+            std::string err_msg =
+                    SYNC_POINT_HOOK_RETURN_VALUE(hdfs_error(), "HdfsFileHandle::init::hdfs_error");
+            // invoker maybe just skip Status.NotFound and continue
+            // so we need distinguish between it and other kinds of errors
+            if (err_msg.find("No such file or directory") != std::string::npos) {
+                return Status::NotFound(err_msg);
+            }
+            return Status::InternalError("failed to get file size of {}: {}", _fname, err_msg);
         }
         _file_size = file_info->mSize;
-        TEST_SYNC_POINT_RETURN_WITH_VALUE("HdfsFileHandle::init::hdfsFreeFileInfo", Status::OK());
         hdfsFreeFileInfo(file_info, 1);
     }
     return Status::OK();

--- a/be/src/io/fs/file_handle_cache.h
+++ b/be/src/io/fs/file_handle_cache.h
@@ -72,6 +72,7 @@ private:
     int64_t _mtime;
     int64_t _file_size = -1;
     std::once_flag _open_once;
+    Status _open_status;
 };
 
 /// CachedHdfsFileHandles are owned by the file handle cache and are used for no

--- a/be/src/io/fs/file_handle_cache.h
+++ b/be/src/io/fs/file_handle_cache.h
@@ -26,6 +26,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 
@@ -49,8 +50,11 @@ public:
     /// Destructor will close the file handle
     ~HdfsFileHandle();
 
-    /// Init opens the file handle
+    /// Init only sets file_size (from param or hdfsGetPathInfo), does NOT open the file.
     Status init(int64_t file_size);
+
+    /// Lazily opens the file handle on first read. Thread-safe via std::call_once.
+    Status ensure_open();
 
     hdfsFS fs() const { return _fs; }
     hdfsFile file() const { return _hdfs_file; }
@@ -66,7 +70,8 @@ private:
     const std::string _fname;
     hdfsFile _hdfs_file = nullptr;
     int64_t _mtime;
-    int64_t _file_size;
+    int64_t _file_size = -1;
+    std::once_flag _open_once;
 };
 
 /// CachedHdfsFileHandles are owned by the file handle cache and are used for no

--- a/be/src/io/fs/hdfs_file_reader.cpp
+++ b/be/src/io/fs/hdfs_file_reader.cpp
@@ -138,8 +138,8 @@ Status HdfsFileReader::do_read_at_impl(size_t offset, Slice result, size_t* byte
         tSize loop_read;
         {
             SCOPED_BVAR_LATENCY(hdfs_bvar::hdfs_read_latency);
-            loop_read = hdfsPread(_handle->fs(), _handle->file(), offset + has_read,
-                                  to + has_read, to_read);
+            loop_read = hdfsPread(_handle->fs(), _handle->file(), offset + has_read, to + has_read,
+                                  to_read);
         }
         {
             [[maybe_unused]] Status error_ret;

--- a/be/src/io/fs/hdfs_file_reader.cpp
+++ b/be/src/io/fs/hdfs_file_reader.cpp
@@ -34,6 +34,7 @@
 #include "runtime/workload_management/io_throttle.h"
 #include "runtime/workload_management/resource_context.h"
 #include "service/backend_options.h"
+#include "util/bvar_helper.h"
 
 namespace doris::io {
 
@@ -134,8 +135,12 @@ Status HdfsFileReader::do_read_at_impl(size_t offset, Slice result, size_t* byte
         int64_t max_to_read = bytes_req - has_read;
         tSize to_read = static_cast<tSize>(
                 std::min(max_to_read, static_cast<int64_t>(std::numeric_limits<tSize>::max())));
-        tSize loop_read = hdfsPread(_handle->fs(), _handle->file(), offset + has_read,
-                                    to + has_read, to_read);
+        tSize loop_read;
+        {
+            SCOPED_BVAR_LATENCY(hdfs_bvar::hdfs_read_latency);
+            loop_read = hdfsPread(_handle->fs(), _handle->file(), offset + has_read,
+                                  to + has_read, to_read);
+        }
         {
             [[maybe_unused]] Status error_ret;
             TEST_INJECTION_POINT_RETURN_WITH_VALUE("HdfsFileReader:read_error", error_ret);
@@ -200,8 +205,12 @@ Status HdfsFileReader::do_read_at_impl(size_t offset, Slice result, size_t* byte
 
     size_t has_read = 0;
     while (has_read < bytes_req) {
-        int64_t loop_read = hdfsRead(_handle->fs(), _handle->file(), to + has_read,
-                                     static_cast<int32_t>(bytes_req - has_read));
+        int64_t loop_read;
+        {
+            SCOPED_BVAR_LATENCY(hdfs_bvar::hdfs_read_latency);
+            loop_read = hdfsRead(_handle->fs(), _handle->file(), to + has_read,
+                                 static_cast<int32_t>(bytes_req - has_read));
+        }
         if (loop_read < 0) {
             // invoker maybe just skip Status.NotFound and continue
             // so we need distinguish between it and other kinds of errors

--- a/be/src/io/fs/hdfs_file_reader.cpp
+++ b/be/src/io/fs/hdfs_file_reader.cpp
@@ -87,6 +87,10 @@ Status HdfsFileReader::close() {
 
 Status HdfsFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                                     const IOContext* io_ctx) {
+    if (_handle == nullptr) [[unlikely]] {
+        return Status::InternalError("cached hdfs file handle has been destroyed: {}",
+                                     _path.native());
+    }
     RETURN_IF_ERROR(_handle->ensure_open());
     auto st = do_read_at_impl(offset, result, bytes_read, io_ctx);
     if (!st.ok()) {

--- a/be/src/io/fs/hdfs_file_reader.cpp
+++ b/be/src/io/fs/hdfs_file_reader.cpp
@@ -93,6 +93,7 @@ Status HdfsFileReader::close() {
 
 Status HdfsFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                                     const IOContext* io_ctx) {
+    RETURN_IF_ERROR(_handle->ensure_open());
     auto st = do_read_at_impl(offset, result, bytes_read, io_ctx);
     if (!st.ok()) {
         _handle = nullptr;

--- a/be/src/io/fs/hdfs_file_reader.cpp
+++ b/be/src/io/fs/hdfs_file_reader.cpp
@@ -25,7 +25,6 @@
 #include "bvar/latency_recorder.h"
 #include "bvar/reducer.h"
 #include "common/compiler_util.h" // IWYU pragma: keep
-#include "common/metrics/doris_metrics.h"
 #include "cpp/sync_point.h"
 #include "io/fs/err_utils.h"
 #include "io/hdfs_util.h"
@@ -75,9 +74,6 @@ HdfsFileReader::HdfsFileReader(Path path, std::string fs_name, FileHandleCache::
           _accessor(std::move(accessor)),
           _mtime(mtime) {
     _handle = _accessor.get();
-
-    DorisMetrics::instance()->hdfs_file_open_reading->increment(1);
-    DorisMetrics::instance()->hdfs_file_reader_total->increment(1);
 }
 
 HdfsFileReader::~HdfsFileReader() {
@@ -85,10 +81,7 @@ HdfsFileReader::~HdfsFileReader() {
 }
 
 Status HdfsFileReader::close() {
-    bool expected = false;
-    if (_closed.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
-        DorisMetrics::instance()->hdfs_file_open_reading->increment(-1);
-    }
+    _closed = true;
     return Status::OK();
 }
 

--- a/be/src/io/fs/hdfs_file_reader.cpp
+++ b/be/src/io/fs/hdfs_file_reader.cpp
@@ -87,6 +87,9 @@ Status HdfsFileReader::close() {
 
 Status HdfsFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                                     const IOContext* io_ctx) {
+    if (closed()) [[unlikely]] {
+        return Status::InternalError("read closed file: {}", _path.native());
+    }
     if (_handle == nullptr) [[unlikely]] {
         return Status::InternalError("cached hdfs file handle has been destroyed: {}",
                                      _path.native());
@@ -103,15 +106,6 @@ Status HdfsFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_r
 #ifdef USE_HADOOP_HDFS
 Status HdfsFileReader::do_read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                                        const IOContext* /*io_ctx*/) {
-    if (closed()) [[unlikely]] {
-        return Status::InternalError("read closed file: {}", _path.native());
-    }
-
-    if (_handle == nullptr) [[unlikely]] {
-        return Status::InternalError("cached hdfs file handle has been destroyed: {}",
-                                     _path.native());
-    }
-
     if (offset > _handle->file_size()) {
         return Status::IOError("offset exceeds file size(offset: {}, file size: {}, path: {})",
                                offset, _handle->file_size(), _path.native());
@@ -169,10 +163,6 @@ Status HdfsFileReader::do_read_at_impl(size_t offset, Slice result, size_t* byte
 // TODO: rethink here to see if there are some difference between hdfsPread() and hdfsRead()
 Status HdfsFileReader::do_read_at_impl(size_t offset, Slice result, size_t* bytes_read,
                                        const IOContext* /*io_ctx*/) {
-    if (closed()) [[unlikely]] {
-        return Status::InternalError("read closed file: ", _path.native());
-    }
-
     if (offset > _handle->file_size()) {
         return Status::IOError("offset exceeds file size(offset: {}, file size: {}, path: {})",
                                offset, _handle->file_size(), _path.native());

--- a/be/src/io/fs/hdfs_file_system.cpp
+++ b/be/src/io/fs/hdfs_file_system.cpp
@@ -185,6 +185,7 @@ Status HdfsFileSystem::exists_impl(const Path& path, bool* res) const {
 Status HdfsFileSystem::file_size_impl(const Path& path, int64_t* file_size) const {
     CHECK_HDFS_HANDLER(_fs_handler);
     Path real_path = convert_path(path, _fs_name);
+    SCOPED_BVAR_LATENCY(hdfs_bvar::hdfs_get_path_info_latency);
     hdfsFileInfo* file_info = hdfsGetPathInfo(_fs_handler->hdfs_fs, real_path.string().c_str());
     if (file_info == nullptr) {
         return Status::IOError("failed to get file size of {}: {}", path.native(), hdfs_error());

--- a/be/src/io/fs/hdfs_file_system.cpp
+++ b/be/src/io/fs/hdfs_file_system.cpp
@@ -228,6 +228,7 @@ Status HdfsFileSystem::list_impl(const Path& path, bool only_file, std::vector<F
 }
 
 Status HdfsFileSystem::rename_impl(const Path& orig_name, const Path& new_name) {
+    CHECK_HDFS_HANDLER(_fs_handler);
     Path normal_orig_name = convert_path(orig_name, _fs_name);
     Path normal_new_name = convert_path(new_name, _fs_name);
     int ret = hdfsRename(_fs_handler->hdfs_fs, normal_orig_name.c_str(), normal_new_name.c_str());

--- a/be/src/io/fs/hdfs_file_system.cpp
+++ b/be/src/io/fs/hdfs_file_system.cpp
@@ -40,6 +40,7 @@
 #include "io/hdfs_builder.h"
 #include "io/hdfs_util.h"
 #include "runtime/exec_env.h"
+#include "util/bvar_helper.h"
 #include "util/obj_lru_cache.h"
 #include "util/slice.h"
 
@@ -117,7 +118,11 @@ Status HdfsFileSystem::open_file_internal(const Path& file, FileReaderSPtr* read
 Status HdfsFileSystem::create_directory_impl(const Path& dir, bool failed_if_exists) {
     CHECK_HDFS_HANDLER(_fs_handler);
     Path real_path = convert_path(dir, _fs_name);
-    int res = hdfsCreateDirectory(_fs_handler->hdfs_fs, real_path.string().c_str());
+    int res;
+    {
+        SCOPED_BVAR_LATENCY(hdfs_bvar::hdfs_create_dir_latency);
+        res = hdfsCreateDirectory(_fs_handler->hdfs_fs, real_path.string().c_str());
+    }
     if (res == -1) {
         return Status::IOError("failed to create directory {}: {}", dir.native(), hdfs_error());
     }

--- a/be/src/io/fs/hdfs_file_system.h
+++ b/be/src/io/fs/hdfs_file_system.h
@@ -82,6 +82,7 @@ private:
 
 private:
     friend class HdfsFileWriter;
+    friend class HdfsFileSystemTest;
     HdfsFileSystem(const THdfsParams& hdfs_params, std::string fs_name, std::string id,
                    std::string root_path);
     const THdfsParams& _hdfs_params; // Only used in init, so we can use reference here

--- a/be/src/io/fs/hdfs_file_system.h
+++ b/be/src/io/fs/hdfs_file_system.h
@@ -82,7 +82,6 @@ private:
 
 private:
     friend class HdfsFileWriter;
-    friend class HdfsFileSystemTest;
     HdfsFileSystem(const THdfsParams& hdfs_params, std::string fs_name, std::string id,
                    std::string root_path);
     const THdfsParams& _hdfs_params; // Only used in init, so we can use reference here

--- a/be/src/io/fs/local_file_reader.cpp
+++ b/be/src/io/fs/local_file_reader.cpp
@@ -176,7 +176,7 @@ Status LocalFileReader::read_at_impl(size_t offset, Slice result, size_t* bytes_
             if ((sub_path.empty() && _path.filename().compare(kTestFilePath)) ||
                 (!sub_path.empty() && _path.native().find(sub_path) != std::string::npos)) {
                 res = -1;
-                errno = EIO;
+                errno = dp->param<int>("errno", EIO);
                 LOG(WARNING) << Status::IOError("debug read io error: {}", _path.native());
             }
         });

--- a/be/src/io/fs/s3_file_reader.cpp
+++ b/be/src/io/fs/s3_file_reader.cpp
@@ -68,18 +68,12 @@ Result<FileReaderSPtr> S3FileReader::create(std::shared_ptr<const ObjClientHolde
                                             std::string bucket, std::string key, int64_t file_size,
                                             RuntimeProfile* profile) {
     if (file_size < 0) {
-        VLOG_DEBUG
-                << "S3FileReader: file_size not provided by FE, falling back to HeadObject: bucket="
-                << bucket << ", key=" << key;
         auto res = client->object_file_size(bucket, key);
         if (!res.has_value()) {
             return ResultError(std::move(res.error()));
         }
 
         file_size = res.value();
-    } else {
-        VLOG_DEBUG << "S3FileReader: file_size provided by FE: bucket=" << bucket << ", key=" << key
-                   << ", file_size=" << file_size;
     }
 
     return std::make_shared<S3FileReader>(std::move(client), std::move(bucket), std::move(key),

--- a/be/src/io/fs/s3_file_reader.cpp
+++ b/be/src/io/fs/s3_file_reader.cpp
@@ -68,8 +68,9 @@ Result<FileReaderSPtr> S3FileReader::create(std::shared_ptr<const ObjClientHolde
                                             std::string bucket, std::string key, int64_t file_size,
                                             RuntimeProfile* profile) {
     if (file_size < 0) {
-        VLOG_DEBUG << "S3FileReader: file_size not provided by FE, falling back to HeadObject: bucket="
-                   << bucket << ", key=" << key;
+        VLOG_DEBUG
+                << "S3FileReader: file_size not provided by FE, falling back to HeadObject: bucket="
+                << bucket << ", key=" << key;
         auto res = client->object_file_size(bucket, key);
         if (!res.has_value()) {
             return ResultError(std::move(res.error()));

--- a/be/src/io/fs/s3_file_reader.cpp
+++ b/be/src/io/fs/s3_file_reader.cpp
@@ -68,12 +68,17 @@ Result<FileReaderSPtr> S3FileReader::create(std::shared_ptr<const ObjClientHolde
                                             std::string bucket, std::string key, int64_t file_size,
                                             RuntimeProfile* profile) {
     if (file_size < 0) {
+        VLOG_DEBUG << "S3FileReader: file_size not provided by FE, falling back to HeadObject: bucket="
+                   << bucket << ", key=" << key;
         auto res = client->object_file_size(bucket, key);
         if (!res.has_value()) {
             return ResultError(std::move(res.error()));
         }
 
         file_size = res.value();
+    } else {
+        VLOG_DEBUG << "S3FileReader: file_size provided by FE: bucket=" << bucket << ", key=" << key
+                   << ", file_size=" << file_size;
     }
 
     return std::make_shared<S3FileReader>(std::move(client), std::move(bucket), std::move(key),

--- a/be/src/io/hdfs_util.cpp
+++ b/be/src/io/hdfs_util.cpp
@@ -41,6 +41,7 @@ bvar::LatencyRecorder hdfs_close_latency("hdfs_close");
 bvar::LatencyRecorder hdfs_flush_latency("hdfs_flush");
 bvar::LatencyRecorder hdfs_hflush_latency("hdfs_hflush");
 bvar::LatencyRecorder hdfs_hsync_latency("hdfs_hsync");
+bvar::LatencyRecorder hdfs_get_path_info_latency("hdfs_get_path_info");
 }; // namespace hdfs_bvar
 
 Path convert_path(const Path& path, const std::string& namenode) {

--- a/be/src/io/hdfs_util.h
+++ b/be/src/io/hdfs_util.h
@@ -80,6 +80,7 @@ extern bvar::LatencyRecorder hdfs_close_latency;
 extern bvar::LatencyRecorder hdfs_flush_latency;
 extern bvar::LatencyRecorder hdfs_hflush_latency;
 extern bvar::LatencyRecorder hdfs_hsync_latency;
+extern bvar::LatencyRecorder hdfs_get_path_info_latency;
 }; // namespace hdfs_bvar
 
 // if the format of path is hdfs://ip:port/path, replace it to /path.

--- a/be/src/storage/index/index_file_reader.cpp
+++ b/be/src/storage/index/index_file_reader.cpp
@@ -133,6 +133,11 @@ Status IndexFileReader::_init_from(int32_t read_buffer_size, const io::IOContext
                         index_file_full_path, err.what());
             }
         }
+        // Lazy open can surface a missing file as a read error; keep NotFound distinguishable
+        if (err.number() == CL_ERR_FileNotFound) {
+            return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>(
+                    "inverted index file {} is not found.", index_file_full_path);
+        }
         return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                 "CLuceneError occur when init idx file {}, error msg: {}", index_file_full_path,
                 err.what());
@@ -318,6 +323,11 @@ Result<std::unique_ptr<DorisCompoundReader, DirectoryDeleter>> IndexFileReader::
             // 3. read file in DorisCompoundReader
             compound_reader.reset(new DorisCompoundReader(index_input, _read_buffer_size));
         } catch (CLuceneError& err) {
+            // Lazy open can surface a missing file as a read error; keep NotFound distinguishable
+            if (err.number() == CL_ERR_FileNotFound) {
+                return ResultError(Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>(
+                        "inverted index file {} is not found.", index_file_path));
+            }
             return ResultError(Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                     "CLuceneError occur when open idx file {}, error msg: {}", index_file_path,
                     err.what()));

--- a/be/src/storage/index/inverted/inverted_index_fs_directory.cpp
+++ b/be/src/storage/index/inverted/inverted_index_fs_directory.cpp
@@ -241,7 +241,11 @@ void DorisFSDirectory::FSIndexInput::readInternal(uint8_t* b, const int32_t len)
                     "DorisFSDirectory::FSIndexInput::readInternal_reader_read_at_error");
         })
         if (!st.ok()) {
-            _CLTHROWA(CL_ERR_IO, "read past EOF");
+            // Carry NotFound across the CLucene boundary so index callers can downgrade
+            if (st.is<ErrorCode::NOT_FOUND>()) {
+                _CLTHROWA(CL_ERR_FileNotFound, st.to_string_no_stack().c_str());
+            }
+            _CLTHROWA(CL_ERR_IO, st.to_string_no_stack().c_str());
         }
         bufferLength = len;
         DBUG_EXECUTE_IF("DorisFSDirectory::FSIndexInput::readInternal_bytes_read_error",

--- a/be/src/storage/index/snii/snii_blob_directory.cpp
+++ b/be/src/storage/index/snii/snii_blob_directory.cpp
@@ -84,8 +84,12 @@ protected:
                                         static_cast<size_t>(len));
         }
         if (!status.ok()) {
+            // Lazy open can surface a missing file as a read error; keep NotFound distinguishable
+            if (status.is<ErrorCode::NOT_FOUND>()) {
+                _CLTHROWA(CL_ERR_FileNotFound, status.to_string_no_stack().c_str());
+            }
             // CLuceneError STRDUPs the message; the temporary is safe.
-            _CLTHROWA(CL_ERR_IO, status.to_string().c_str());
+            _CLTHROWA(CL_ERR_IO, status.to_string_no_stack().c_str());
         }
     }
     void seekInternal(const int64_t /*pos*/) override {}

--- a/be/test/exec/scan/vfile_scanner_exception_test.cpp
+++ b/be/test/exec/scan/vfile_scanner_exception_test.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/config.h"
 #include "common/object_pool.h"
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
@@ -31,13 +32,17 @@
 #include "exec/scan/file_scanner.h"
 #include "exec/scan/split_source_connector.h"
 #include "format_v2/table/hive_reader.h"
+#include "io/fs/hdfs/hdfs_mgr.h"
 #include "io/fs/local_file_system.h"
+#include "io/hdfs_util.h"
 #include "load/group_commit/wal/wal_manager.h"
 #include "runtime/cluster_info.h"
 #include "runtime/descriptors.h"
+#include "runtime/exec_env.h"
 #include "runtime/memory/mem_tracker.h"
 #include "runtime/runtime_state.h"
 #include "runtime/user_function_cache.h"
+#include "util/defer_op.h"
 
 namespace doris {
 class TestSplitSourceConnectorStub : public SplitSourceConnector {
@@ -65,6 +70,47 @@ public:
     TFileScanRangeParams* get_params() override { return &_scan_range.params; }
 };
 
+// Returns a fake HDFS handler so reader construction never touches the network.
+class FakeHdfsMgr final : public io::HdfsMgr {
+public:
+    Status _create_hdfs_fs_impl(const THdfsParams& hdfs_params, const std::string& fs_name,
+                                std::shared_ptr<io::HdfsHandler>* fs_handler) override {
+        *fs_handler = std::make_shared<io::HdfsHandler>(
+                reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1)), false, "", "", fs_name);
+        return Status::OK();
+    }
+};
+
+// Registers a SyncPoint callback that returns a fixed value.
+template <typename T>
+static void set_mock_return(const std::string& point, T value, SyncPoint::CallbackGuard* guard) {
+    SyncPoint::get_instance()->set_call_back(
+            point,
+            [value = std::move(value)](auto&& args) {
+                auto* ret = try_any_cast_ret<T>(args);
+                ret->first = std::move(value);
+                ret->second = true;
+            },
+            guard);
+}
+
+// Injects a read-stage NOT_FOUND through the HDFS lazy-open sync points.
+struct HdfsNotFoundGuard {
+    SyncPoint::CallbackGuard open_guard;
+    SyncPoint::CallbackGuard err_guard;
+    SyncPoint::CallbackGuard close_guard;
+    HdfsNotFoundGuard() {
+        auto* sp = SyncPoint::get_instance();
+        sp->enable_processing();
+        set_mock_return<hdfsFile>("HdfsFileHandle::ensure_open::hdfsOpenFile", nullptr,
+                                  &open_guard);
+        set_mock_return<std::string>("HdfsFileHandle::ensure_open::hdfs_error",
+                                     "No such file or directory", &err_guard);
+        set_mock_return<int>("HdfsFileHandle::close::hdfsCloseFile", 0, &close_guard);
+    }
+    ~HdfsNotFoundGuard() { SyncPoint::get_instance()->disable_processing(); }
+};
+
 class VfileScannerExceptionTest : public testing::Test {
 public:
     VfileScannerExceptionTest()
@@ -78,17 +124,26 @@ public:
     }
     void init();
     void generate_scanner(std::shared_ptr<FileScanner>& scanner);
+    // Fake HDFS CSV range with known size, so open is deferred to the first read.
+    void prepare_hdfs_csv_range();
 
     void TearDown() override {
         WARN_IF_ERROR(_scan_node->close(&_runtime_state), "fail to close scan_node")
+        // Avoid leaving a dangling _hdfs_mgr after _fake_hdfs_mgr is destroyed.
+        ExecEnv::GetInstance()->_hdfs_mgr = _old_hdfs_mgr;
     }
 
 protected:
-    virtual void SetUp() override {}
+    void SetUp() override {
+        _old_hdfs_mgr = ExecEnv::GetInstance()->_hdfs_mgr;
+        ExecEnv::GetInstance()->_hdfs_mgr = &_fake_hdfs_mgr;
+    }
 
 private:
     void _init_desc_table();
 
+    FakeHdfsMgr _fake_hdfs_mgr;
+    io::HdfsMgr* _old_hdfs_mgr = nullptr;
     ExecEnv* _env = nullptr;
     int64_t _backend_id = 1001;
     std::string _label_1 = "test1";
@@ -286,6 +341,34 @@ void VfileScannerExceptionTest::generate_scanner(std::shared_ptr<FileScanner>& s
     WARN_IF_ERROR(scanner->init(&_runtime_state, _conjuncts), "fail to prepare scanner");
 }
 
+void VfileScannerExceptionTest::prepare_hdfs_csv_range() {
+    _range_desc.path = "hdfs://fake-nn:8020/not_found/data.csv";
+    _range_desc.start_offset = 0;
+    _range_desc.size = 100;
+    _range_desc.__set_file_size(100);
+    _ranges[0] = _range_desc;
+    _scan_range.ranges = _ranges;
+    auto& params = _scan_range.params;
+    params.format_type = TFileFormatType::FORMAT_CSV_PLAIN;
+    params.file_type = TFileType::FILE_HDFS;
+    params.hdfs_params.__set_fs_name("hdfs://fake-nn:8020");
+    params.__isset.file_attributes = true;
+    params.file_attributes.__isset.text_params = true;
+    params.file_attributes.text_params.column_separator = ",";
+    params.file_attributes.text_params.line_delimiter = "\n";
+    params.__isset.column_idxs = true;
+    params.column_idxs = {0, 1, 2};
+    params.__set_num_of_columns_from_file(3);
+    params.__isset.required_slots = true;
+    params.required_slots.clear();
+    for (int32_t slot_id = 1; slot_id <= 3; ++slot_id) {
+        TFileScanSlotInfo slot_info;
+        slot_info.__set_slot_id(slot_id);
+        slot_info.__set_is_file_slot(true);
+        params.required_slots.push_back(slot_info);
+    }
+}
+
 TEST_F(VfileScannerExceptionTest, failure_case) {
     std::shared_ptr<FileScanner> scanner = nullptr;
     generate_scanner(scanner);
@@ -337,6 +420,52 @@ TEST_F(VfileScannerExceptionTest, process_late_arrival_conjuncts_retain) {
     ASSERT_EQ(scanner->_conjuncts.size(), 1);
     // And push_down_conjuncts should be cloned/assigned successfully
     ASSERT_EQ(scanner->_push_down_conjuncts.size(), 1);
+
+    WARN_IF_ERROR(scanner->close(&_runtime_state), "fail to close scanner");
+}
+
+// A lazy-open NOT_FOUND on the first HDFS read must be skipped and counted, not fail the scan.
+TEST_F(VfileScannerExceptionTest, read_stage_not_found_skipped_when_enabled) {
+    HdfsNotFoundGuard guard;
+    const bool old_ignore = config::ignore_not_found_file_in_external_table;
+    config::ignore_not_found_file_in_external_table = true;
+    Defer restore_ignore {[&]() { config::ignore_not_found_file_in_external_table = old_ignore; }};
+
+    prepare_hdfs_csv_range();
+    std::shared_ptr<FileScanner> scanner = nullptr;
+    generate_scanner(scanner);
+
+    std::unique_ptr<Block> block(new Block());
+    bool eof = false;
+    auto st = scanner->get_block(&_runtime_state, block.get(), &eof);
+    EXPECT_TRUE(st.ok()) << st;
+    EXPECT_TRUE(eof);
+    EXPECT_EQ(block->rows(), 0);
+
+    auto* local_state = &(_runtime_state.get_local_state(0)->cast<FileScanLocalState>());
+    auto* counter = local_state->scanner_profile()->get_counter("NotFoundFileNum");
+    ASSERT_NE(counter, nullptr);
+    EXPECT_EQ(counter->value(), 1);
+
+    WARN_IF_ERROR(scanner->close(&_runtime_state), "fail to close scanner");
+}
+
+// With the skip config off, a lazy-open NOT_FOUND must surface as an error, not be wrapped.
+TEST_F(VfileScannerExceptionTest, read_stage_not_found_errors_when_disabled) {
+    HdfsNotFoundGuard guard;
+    const bool old_ignore = config::ignore_not_found_file_in_external_table;
+    config::ignore_not_found_file_in_external_table = false;
+    Defer restore_ignore {[&]() { config::ignore_not_found_file_in_external_table = old_ignore; }};
+
+    prepare_hdfs_csv_range();
+    std::shared_ptr<FileScanner> scanner = nullptr;
+    generate_scanner(scanner);
+
+    std::unique_ptr<Block> block(new Block());
+    bool eof = false;
+    auto st = scanner->get_block(&_runtime_state, block.get(), &eof);
+    EXPECT_FALSE(st.ok());
+    EXPECT_TRUE(st.is<ErrorCode::NOT_FOUND>()) << st;
 
     WARN_IF_ERROR(scanner->close(&_runtime_state), "fail to close scanner");
 }

--- a/be/test/format/table/iceberg/iceberg_delete_file_reader_helper_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_delete_file_reader_helper_test.cpp
@@ -397,7 +397,8 @@ TEST(IcebergDeleteFileReaderHelperTest, DeletionVectorReaderValidatesOpenedFileR
         DeletionVectorReader oversized_reader(&state, &profile, scan_params, oversized_range,
                                               &io_context.io_ctx);
         const auto oversized_status = oversized_reader.open();
-        EXPECT_TRUE(oversized_status.template is<ErrorCode::DATA_QUALITY_ERROR>()) << oversized_status;
+        EXPECT_TRUE(oversized_status.template is<ErrorCode::DATA_QUALITY_ERROR>())
+                << oversized_status;
         EXPECT_NE(oversized_status.to_string().find("range exceeds file size"), std::string::npos);
         EXPECT_NE(oversized_status.to_string().find(dv_path), std::string::npos);
     }

--- a/be/test/format/table/iceberg/iceberg_delete_file_reader_helper_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_delete_file_reader_helper_test.cpp
@@ -219,6 +219,9 @@ TEST(IcebergDeleteFileReaderHelperTest, BuildDeleteFileRange) {
     EXPECT_EQ(range.start_offset, 0);
     EXPECT_EQ(range.size, -1);
     EXPECT_EQ(range.file_size, -1);
+
+    auto range2 = build_iceberg_delete_file_range("s3://bucket/delete.parquet", 1024);
+    EXPECT_EQ(range2.file_size, 1024);
 }
 
 TEST(IcebergDeleteFileReaderHelperTest, IsDeletionVector) {

--- a/be/test/format/table/iceberg/iceberg_delete_file_reader_helper_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_delete_file_reader_helper_test.cpp
@@ -214,7 +214,7 @@ IcebergDeleteFileReaderOptions delete_reader_options(RuntimeState* runtime_state
 } // namespace
 
 TEST(IcebergDeleteFileReaderHelperTest, BuildDeleteFileRange) {
-    auto range = build_iceberg_delete_file_range("s3://bucket/delete.parquet");
+    auto range = build_iceberg_delete_file_range("s3://bucket/delete.parquet", -1);
     EXPECT_EQ(range.path, "s3://bucket/delete.parquet");
     EXPECT_EQ(range.start_offset, 0);
     EXPECT_EQ(range.size, -1);
@@ -384,7 +384,7 @@ TEST(IcebergDeleteFileReaderHelperTest, DeletionVectorReaderValidatesOpenedFileR
     IcebergDeleteFileIOContext io_context(&state);
 
     {
-        TFileRangeDesc exact_range = build_iceberg_delete_file_range(dv_path);
+        TFileRangeDesc exact_range = build_iceberg_delete_file_range(dv_path, -1);
         exact_range.start_offset = 4;
         exact_range.size = dv_size - exact_range.start_offset;
         DeletionVectorReader exact_reader(&state, &profile, scan_params, exact_range,
@@ -397,7 +397,7 @@ TEST(IcebergDeleteFileReaderHelperTest, DeletionVectorReaderValidatesOpenedFileR
         DeletionVectorReader oversized_reader(&state, &profile, scan_params, oversized_range,
                                               &io_context.io_ctx);
         const auto oversized_status = oversized_reader.open();
-        EXPECT_TRUE(oversized_status.is<ErrorCode::DATA_QUALITY_ERROR>()) << oversized_status;
+        EXPECT_TRUE(oversized_status.template is<ErrorCode::DATA_QUALITY_ERROR>()) << oversized_status;
         EXPECT_NE(oversized_status.to_string().find("range exceeds file size"), std::string::npos);
         EXPECT_NE(oversized_status.to_string().find(dv_path), std::string::npos);
     }
@@ -613,6 +613,8 @@ TEST(IcebergDeleteFileReaderHelperTest, ReadMixedEncodingParquetPositionDeleteFi
     delete_file.path = kMixedPositionDeleteFile;
     delete_file.file_format = TFileFormatType::FORMAT_PARQUET;
     delete_file.__isset.file_format = true;
+    delete_file.__isset.file_size = true;
+    delete_file.file_size = -1;
 
     IcebergDeleteFileReaderOptions options;
     options.state = &runtime_state;

--- a/be/test/format/table/iceberg/iceberg_delete_file_reader_helper_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_delete_file_reader_helper_test.cpp
@@ -395,13 +395,21 @@ TEST(IcebergDeleteFileReaderHelperTest, DeletionVectorReaderValidatesOpenedFileR
         const auto exact_status = exact_reader.open();
         EXPECT_TRUE(exact_status.ok()) << exact_status;
 
+        // Manifest-style range: exact file_size provided by the FE instead of -1.
+        TFileRangeDesc manifest_range = build_iceberg_delete_file_range(dv_path, dv_size);
+        manifest_range.start_offset = 4;
+        manifest_range.size = dv_size - manifest_range.start_offset;
+        DeletionVectorReader manifest_reader(&state, &profile, scan_params, manifest_range,
+                                             &io_context.io_ctx);
+        const auto manifest_status = manifest_reader.open();
+        EXPECT_TRUE(manifest_status.ok()) << manifest_status;
+
         TFileRangeDesc oversized_range = exact_range;
         oversized_range.size = MAX_ICEBERG_DELETION_VECTOR_BYTES;
         DeletionVectorReader oversized_reader(&state, &profile, scan_params, oversized_range,
                                               &io_context.io_ctx);
         const auto oversized_status = oversized_reader.open();
-        EXPECT_TRUE(oversized_status.template is<ErrorCode::DATA_QUALITY_ERROR>())
-                << oversized_status;
+        EXPECT_TRUE(oversized_status.is<ErrorCode::DATA_QUALITY_ERROR>()) << oversized_status;
         EXPECT_NE(oversized_status.to_string().find("range exceeds file size"), std::string::npos);
         EXPECT_NE(oversized_status.to_string().find(dv_path), std::string::npos);
     }
@@ -617,8 +625,6 @@ TEST(IcebergDeleteFileReaderHelperTest, ReadMixedEncodingParquetPositionDeleteFi
     delete_file.path = kMixedPositionDeleteFile;
     delete_file.file_format = TFileFormatType::FORMAT_PARQUET;
     delete_file.__isset.file_format = true;
-    delete_file.__isset.file_size = true;
-    delete_file.file_size = -1;
 
     IcebergDeleteFileReaderOptions options;
     options.state = &runtime_state;

--- a/be/test/format/table/iceberg/iceberg_reader_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_reader_test.cpp
@@ -1718,6 +1718,79 @@ TEST_F(IcebergReaderTest, v1_position_delete_read_error_releases_cache_entry) {
     EXPECT_NE(status.to_string().find(delete_file.path), std::string::npos);
 }
 
+// An inflated size breaks footer reads, proving the v1 position-delete path consumes the FE file_size.
+TEST_F(IcebergReaderTest, v1_position_delete_consumes_delete_file_size) {
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
+    TFileScanRangeParams scan_params;
+    scan_params.__set_file_type(TFileType::FILE_LOCAL);
+    scan_params.__set_format_type(TFileFormatType::FORMAT_PARQUET);
+
+    TFileRangeDesc scan_range;
+    scan_range.__set_fs_name("");
+    scan_range.__set_path("data.parquet");
+    scan_range.__set_start_offset(0);
+    scan_range.__set_size(0);
+
+    RuntimeProfile profile("test_profile");
+    cctz::time_zone ctz;
+    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    io::IOContext io_ctx;
+    ShardedKVCache kv_cache(8);
+
+    IcebergParquetReader iceberg_reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz,
+                                        &io_ctx, &runtime_state, cache.get());
+
+    TIcebergDeleteFileDesc delete_file;
+    delete_file.__set_content(IcebergReaderMixin<ParquetReader>::POSITION_DELETE);
+    delete_file.__set_path(mixed_position_delete_file());
+    delete_file.__set_file_size(1 << 30); // wrong on purpose: must reach the reader
+
+    const auto status =
+            iceberg_reader.TEST_position_delete_base("file:///tmp/data.parquet", {delete_file});
+
+    ASSERT_FALSE(status.ok());
+}
+
+// An inflated size must break the read, proving the v1 equality-delete path consumes the FE file_size.
+TEST_F(IcebergReaderTest, v1_equality_delete_consumes_delete_file_size) {
+    const auto test_dir = std::filesystem::temp_directory_path() / "doris_v1_eq_delete_size_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+    const auto delete_file_path = (test_dir / "equality-delete.parquet").string();
+    write_iceberg_int_equality_delete_parquet_file(delete_file_path, "id", 0, 2);
+
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
+    TFileScanRangeParams scan_params;
+    scan_params.__set_file_type(TFileType::FILE_LOCAL);
+    scan_params.__set_format_type(TFileFormatType::FORMAT_PARQUET);
+
+    TFileRangeDesc scan_range;
+    scan_range.__set_fs_name("");
+    scan_range.__set_path("data.parquet");
+    scan_range.__set_start_offset(0);
+    scan_range.__set_size(0);
+
+    RuntimeProfile profile("test_profile");
+    cctz::time_zone ctz;
+    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    io::IOContext io_ctx;
+    ShardedKVCache kv_cache(8);
+
+    IcebergParquetReader iceberg_reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz,
+                                        &io_ctx, &runtime_state, cache.get());
+
+    TIcebergDeleteFileDesc delete_file;
+    delete_file.__set_content(IcebergReaderMixin<ParquetReader>::EQUALITY_DELETE);
+    delete_file.__set_path(delete_file_path);
+    delete_file.__set_field_ids({0});
+    delete_file.__set_file_format(TFileFormatType::FORMAT_PARQUET);
+    delete_file.__set_file_size(1 << 30); // wrong on purpose: must reach the reader
+
+    const auto status = iceberg_reader.TEST_read_equality_delete_file(delete_file);
+
+    ASSERT_FALSE(status.ok());
+}
+
 TEST_F(IcebergReaderTest, v1_rejects_missing_required_field_without_initial_default) {
     schema::external::TField field;
     field.__set_name("required_added");

--- a/be/test/format_v2/orc/orc_file_input_stream_test.cpp
+++ b/be/test/format_v2/orc/orc_file_input_stream_test.cpp
@@ -75,6 +75,25 @@ private:
     io::Path _path = "/tmp/orc_v2_input_stream";
 };
 
+// FileReader whose reads always fail with NotFound, mimicking a missing HDFS file under lazy open.
+class NotFoundFileReader final : public io::FileReader {
+public:
+    Status close() override { return Status::OK(); }
+    const io::Path& path() const override { return _path; }
+    size_t size() const override { return 4096; }
+    bool closed() const override { return false; }
+    int64_t mtime() const override { return 0; }
+
+protected:
+    Status read_at_impl(size_t offset, Slice result, size_t* bytes_read,
+                        const io::IOContext* io_ctx) override {
+        return Status::NotFound("failed to open /test/missing.orc: No such file or directory");
+    }
+
+private:
+    io::Path _path = "/test/missing.orc";
+};
+
 class TestStreamInformation final : public ::orc::StreamInformation {
 public:
     TestStreamInformation(TestStream stream, uint64_t offset) : _stream(stream), _offset(offset) {}
@@ -371,6 +390,20 @@ TEST(OrcFileInputStreamTest, MergedIoChildrenStayIsolatedInBothInitializationOrd
         EXPECT_EQ(generic_request_io->value(), 0);
         ASSERT_NE(profile.get_counter("OrcMergedRequestIO"), nullptr);
         EXPECT_EQ(profile.get_counter("OrcMergedRequestIO")->value(), 1);
+    }
+}
+
+// A failed read must carry the status text so the ORC reader can restore NotFound (parity with v1).
+TEST(OrcFileInputStreamTest, ReadFailureCarriesNotFoundText) {
+    auto reader = std::make_shared<NotFoundFileReader>();
+    OrcFileInputStream input("missing.orc", reader, nullptr, nullptr, {});
+    std::array<char, 16> buf {};
+    try {
+        input.read(buf.data(), buf.size(), 0);
+        FAIL() << "expected orc::ParseError";
+    } catch (const ::orc::ParseError& e) {
+        const std::string msg = e.what();
+        EXPECT_NE(msg.find("No such file or directory"), std::string::npos);
     }
 }
 

--- a/be/test/format_v2/orc/orc_reader_test.cpp
+++ b/be/test/format_v2/orc/orc_reader_test.cpp
@@ -18,6 +18,7 @@
 #include "format_v2/orc/orc_reader.h"
 
 #include <cctz/time_zone.h>
+#include <errno.h>
 #include <gtest/gtest.h>
 #include <unistd.h>
 
@@ -4730,6 +4731,39 @@ TEST_F(NewOrcReaderTest, AggregatePushdownReturnsCountFromFileMetadata) {
     ASSERT_TRUE(status.ok()) << status;
     EXPECT_EQ(aggregate_result.count, ROW_COUNT);
     EXPECT_TRUE(aggregate_result.columns.empty());
+}
+
+// Only ENOENT-style errors map to NotFound so FileScannerV2 does not silently skip unhealthy splits.
+TEST_F(NewOrcReaderTest, InitKeepsInternalErrorForDirectory) {
+    auto system_properties = std::make_shared<io::FileSystemProperties>();
+    system_properties->system_type = TFileType::FILE_LOCAL;
+    auto file_description = std::make_unique<io::FileDescription>();
+    file_description->path = _test_dir; // open() on a directory succeeds, read fails with EISDIR
+    file_description->file_size = 4096;
+    format::orc::OrcReader reader(system_properties, file_description, nullptr, nullptr,
+                                  std::nullopt);
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    auto st = reader.init(&state);
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is<ErrorCode::INTERNAL_ERROR>()) << st;
+}
+
+// ENOENT injected at the file layer surfaces as NotFound so FileScannerV2 can skip the split.
+TEST_F(NewOrcReaderTest, InitRestoresNotFoundFromReadFailure) {
+    const auto old_enable = config::enable_debug_points;
+    config::enable_debug_points = true;
+    const std::string point = "LocalFileReader::read_at_impl.io_error";
+    DebugPoints::instance()->add_with_params(point, {{"errno", std::to_string(ENOENT)}});
+
+    auto reader = create_reader();
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    auto st = reader->init(&state);
+
+    DebugPoints::instance()->remove(point);
+    config::enable_debug_points = old_enable;
+
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is<ErrorCode::NOT_FOUND>()) << st;
 }
 
 TEST_F(NewOrcReaderTest, AggregatePushdownCountUsesOnlySplitStripes) {

--- a/be/test/format_v2/table/iceberg_reader_test.cpp
+++ b/be/test/format_v2/table/iceberg_reader_test.cpp
@@ -1297,7 +1297,10 @@ TIcebergDeleteFileDesc make_iceberg_equality_delete_file(
     delete_file.__set_path(path);
     delete_file.__set_field_ids(field_ids);
     delete_file.__set_file_format(file_format);
-    delete_file.__set_file_size(file_size);
+    // Default callers emulate an old FE that sends no file_size.
+    if (file_size >= 0) {
+        delete_file.__set_file_size(file_size);
+    }
     return delete_file;
 }
 
@@ -5454,22 +5457,19 @@ TEST(IcebergV2ReaderTest, IcebergEqualityDeleteFileSizePropagatedToReader) {
                             })
                         .ok());
 
+    // A truncated size must break the read; a correct size is indistinguishable from the stat fallback.
     auto split_options = build_split_options(file_path);
     split_options.cache = &cache;
     split_options.current_range.__set_table_format_params(make_iceberg_table_format_desc(
-            file_path,
-            {make_iceberg_equality_delete_file(
-                    delete_file_path, {0}, TFileFormatType::FORMAT_PARQUET, delete_file_size)}));
-    ASSERT_TRUE(reader.prepare_split(split_options).ok());
+            file_path, {make_iceberg_equality_delete_file(delete_file_path, {0},
+                                                          TFileFormatType::FORMAT_PARQUET,
+                                                          delete_file_size - 16)}));
 
+    const bool prepare_ok = reader.prepare_split(split_options).ok();
     Block block = build_table_block(projected_columns);
     bool eos = false;
-    ASSERT_TRUE(reader.get_block(&block, &eos).ok());
-    ASSERT_FALSE(eos);
-    ASSERT_EQ(block.rows(), 2);
-    const auto& id_column = assert_cast<const ColumnInt32&>(expect_not_null_table_column(block, 0));
-    EXPECT_EQ(id_column.get_element(0), 1);
-    EXPECT_EQ(id_column.get_element(1), 3);
+    const bool read_ok = prepare_ok && reader.get_block(&block, &eos).ok();
+    ASSERT_FALSE(read_ok) << "truncated file_size must fail the delete-file read";
 
     ASSERT_TRUE(reader.close().ok());
     std::filesystem::remove_all(test_dir);

--- a/be/test/format_v2/table/iceberg_reader_test.cpp
+++ b/be/test/format_v2/table/iceberg_reader_test.cpp
@@ -1290,14 +1290,14 @@ TIcebergDeleteFileDesc make_iceberg_position_delete_file(const std::string& path
 
 TIcebergDeleteFileDesc make_iceberg_equality_delete_file(
         const std::string& path, const std::vector<int32_t>& field_ids,
-        TFileFormatType::type file_format = TFileFormatType::FORMAT_PARQUET) {
+        TFileFormatType::type file_format = TFileFormatType::FORMAT_PARQUET,
+        int64_t file_size = -1) {
     TIcebergDeleteFileDesc delete_file;
     delete_file.__set_content(2);
     delete_file.__set_path(path);
     delete_file.__set_field_ids(field_ids);
     delete_file.__set_file_format(file_format);
-    // Set file_size to actual file size, simulating FE propagation from iceberg manifest
-    delete_file.__set_file_size(static_cast<int64_t>(std::filesystem::file_size(path)));
+    delete_file.__set_file_size(file_size);
     return delete_file;
 }
 
@@ -5461,7 +5461,9 @@ TEST(IcebergV2ReaderTest, IcebergEqualityDeleteFileSizePropagatedToReader) {
     auto split_options = build_split_options(file_path);
     split_options.cache = &cache;
     split_options.current_range.__set_table_format_params(make_iceberg_table_format_desc(
-            file_path, {make_iceberg_equality_delete_file(delete_file_path, {0})}));
+            file_path, {make_iceberg_equality_delete_file(delete_file_path, {0},
+                                                            TFileFormatType::FORMAT_PARQUET,
+                                                            delete_file_size)}));
     ASSERT_TRUE(reader.prepare_split(split_options).ok());
 
     Block block = build_table_block(projected_columns);

--- a/be/test/format_v2/table/iceberg_reader_test.cpp
+++ b/be/test/format_v2/table/iceberg_reader_test.cpp
@@ -5461,9 +5461,9 @@ TEST(IcebergV2ReaderTest, IcebergEqualityDeleteFileSizePropagatedToReader) {
     auto split_options = build_split_options(file_path);
     split_options.cache = &cache;
     split_options.current_range.__set_table_format_params(make_iceberg_table_format_desc(
-            file_path, {make_iceberg_equality_delete_file(delete_file_path, {0},
-                                                            TFileFormatType::FORMAT_PARQUET,
-                                                            delete_file_size)}));
+            file_path,
+            {make_iceberg_equality_delete_file(
+                    delete_file_path, {0}, TFileFormatType::FORMAT_PARQUET, delete_file_size)}));
     ASSERT_TRUE(reader.prepare_split(split_options).ok());
 
     Block block = build_table_block(projected_columns);

--- a/be/test/format_v2/table/iceberg_reader_test.cpp
+++ b/be/test/format_v2/table/iceberg_reader_test.cpp
@@ -5439,6 +5439,7 @@ TEST(IcebergV2ReaderTest, IcebergEqualityDeleteFileSizePropagatedToReader) {
     std::vector<ColumnDefinition> projected_columns;
     projected_columns.push_back(make_table_column(0, "id", std::make_shared<DataTypeInt32>()));
 
+    RuntimeProfile profile("test_profile");
     RuntimeState state {TQueryOptions(), TQueryGlobals()};
     auto scan_params = make_local_parquet_scan_params();
     io::FileReaderStats file_reader_stats;
@@ -5453,7 +5454,7 @@ TEST(IcebergV2ReaderTest, IcebergEqualityDeleteFileSizePropagatedToReader) {
                                     .scan_params = &scan_params,
                                     .io_ctx = io_ctx,
                                     .runtime_state = &state,
-                                    .scanner_profile = nullptr,
+                                    .scanner_profile = &profile,
                             })
                         .ok());
 
@@ -5495,6 +5496,7 @@ TEST(IcebergV2ReaderTest, IcebergEqualityDeleteFileSizeUnknownFallsBackToStat) {
     std::vector<ColumnDefinition> projected_columns;
     projected_columns.push_back(make_table_column(0, "id", std::make_shared<DataTypeInt32>()));
 
+    RuntimeProfile profile("test_profile");
     RuntimeState state {TQueryOptions(), TQueryGlobals()};
     auto scan_params = make_local_parquet_scan_params();
     io::FileReaderStats file_reader_stats;
@@ -5509,7 +5511,7 @@ TEST(IcebergV2ReaderTest, IcebergEqualityDeleteFileSizeUnknownFallsBackToStat) {
                                     .scan_params = &scan_params,
                                     .io_ctx = io_ctx,
                                     .runtime_state = &state,
-                                    .scanner_profile = nullptr,
+                                    .scanner_profile = &profile,
                             })
                         .ok());
 

--- a/be/test/format_v2/table/iceberg_reader_test.cpp
+++ b/be/test/format_v2/table/iceberg_reader_test.cpp
@@ -1296,6 +1296,8 @@ TIcebergDeleteFileDesc make_iceberg_equality_delete_file(
     delete_file.__set_path(path);
     delete_file.__set_field_ids(field_ids);
     delete_file.__set_file_format(file_format);
+    // Set file_size to actual file size, simulating FE propagation from iceberg manifest
+    delete_file.__set_file_size(static_cast<int64_t>(std::filesystem::file_size(path)));
     return delete_file;
 }
 
@@ -5414,6 +5416,126 @@ TEST(IcebergV2ReaderTest, DataFileIsMarkedImmutableForPageCache) {
     ASSERT_TRUE(reader.init_for_scan_request_test(std::move(projected_columns)).ok());
 
     EXPECT_TRUE(reader.current_data_file_is_immutable());
+}
+
+// E2E: Verify file_size from FE thrift propagates through the full reader chain.
+// Data file: 3 rows (id=1,2,3). Equality delete: delete id=2.
+// With file_size set on TIcebergDeleteFileDesc, the reader should use it
+// instead of falling back to stat, and return correct results (id=1,3).
+TEST(IcebergV2ReaderTest, IcebergEqualityDeleteFileSizePropagatedToReader) {
+    const auto test_dir =
+            std::filesystem::temp_directory_path() / "doris_iceberg_eq_delete_file_size_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+
+    const auto file_path = (test_dir / "split.parquet").string();
+    const auto delete_file_path = (test_dir / "equality-delete.parquet").string();
+    write_int_pair_parquet_file(file_path, {1, 2, 3}, {10, 20, 30}, {"one", "two", "three"});
+    write_iceberg_equality_delete_parquet_file(delete_file_path, 0, 2);
+
+    const auto delete_file_size = static_cast<int64_t>(std::filesystem::file_size(delete_file_path));
+    ASSERT_GT(delete_file_size, 0) << "delete file should not be empty";
+
+    std::vector<ColumnDefinition> projected_columns;
+    projected_columns.push_back(make_table_column(0, "id", std::make_shared<DataTypeInt32>()));
+
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    auto scan_params = make_local_parquet_scan_params();
+    io::FileReaderStats file_reader_stats;
+    io::FileCacheStatistics file_cache_stats;
+    auto io_ctx = make_io_context(&file_reader_stats, &file_cache_stats);
+    ShardedKVCache cache(1);
+    doris::format::iceberg::IcebergTableReader reader;
+    ASSERT_TRUE(reader.init({
+                                    .projected_columns = projected_columns,
+                                    .conjuncts = {},
+                                    .format = FileFormat::PARQUET,
+                                    .scan_params = &scan_params,
+                                    .io_ctx = io_ctx,
+                                    .runtime_state = &state,
+                                    .scanner_profile = nullptr,
+                            })
+                        .ok());
+
+    auto split_options = build_split_options(file_path);
+    split_options.cache = &cache;
+    split_options.current_range.__set_table_format_params(make_iceberg_table_format_desc(
+            file_path, {make_iceberg_equality_delete_file(delete_file_path, {0})}));
+    ASSERT_TRUE(reader.prepare_split(split_options).ok());
+
+    Block block = build_table_block(projected_columns);
+    bool eos = false;
+    ASSERT_TRUE(reader.get_block(&block, &eos).ok());
+    ASSERT_FALSE(eos);
+    ASSERT_EQ(block.rows(), 2);
+    const auto& id_column = assert_cast<const ColumnInt32&>(expect_not_null_table_column(block, 0));
+    EXPECT_EQ(id_column.get_element(0), 1);
+    EXPECT_EQ(id_column.get_element(1), 3);
+
+    ASSERT_TRUE(reader.close().ok());
+    std::filesystem::remove_all(test_dir);
+}
+
+// E2E: Verify that when file_size is not set (thrift optional defaults to 0),
+// build_iceberg_delete_file_range converts 0 to -1, and FileFactory falls back
+// to stat. The reader should still return correct results.
+TEST(IcebergV2ReaderTest, IcebergEqualityDeleteFileSizeUnknownFallsBackToStat) {
+    const auto test_dir =
+            std::filesystem::temp_directory_path() / "doris_iceberg_eq_delete_no_file_size_test";
+    std::filesystem::remove_all(test_dir);
+    std::filesystem::create_directories(test_dir);
+
+    const auto file_path = (test_dir / "split.parquet").string();
+    const auto delete_file_path = (test_dir / "equality-delete.parquet").string();
+    write_int_pair_parquet_file(file_path, {1, 2, 3}, {10, 20, 30}, {"one", "two", "three"});
+    write_iceberg_equality_delete_parquet_file(delete_file_path, 0, 2);
+
+    // Construct delete file WITHOUT file_size (simulating FE not setting it)
+    TIcebergDeleteFileDesc delete_file;
+    delete_file.__set_content(2);
+    delete_file.__set_path(delete_file_path);
+    delete_file.__set_field_ids({0});
+    delete_file.__set_file_format(TFileFormatType::FORMAT_PARQUET);
+    // file_size intentionally not set — thrift defaults to 0
+
+    std::vector<ColumnDefinition> projected_columns;
+    projected_columns.push_back(make_table_column(0, "id", std::make_shared<DataTypeInt32>()));
+
+    RuntimeState state {TQueryOptions(), TQueryGlobals()};
+    auto scan_params = make_local_parquet_scan_params();
+    io::FileReaderStats file_reader_stats;
+    io::FileCacheStatistics file_cache_stats;
+    auto io_ctx = make_io_context(&file_reader_stats, &file_cache_stats);
+    ShardedKVCache cache(1);
+    doris::format::iceberg::IcebergTableReader reader;
+    ASSERT_TRUE(reader.init({
+                                    .projected_columns = projected_columns,
+                                    .conjuncts = {},
+                                    .format = FileFormat::PARQUET,
+                                    .scan_params = &scan_params,
+                                    .io_ctx = io_ctx,
+                                    .runtime_state = &state,
+                                    .scanner_profile = nullptr,
+                            })
+                        .ok());
+
+    auto split_options = build_split_options(file_path);
+    split_options.cache = &cache;
+    split_options.current_range.__set_table_format_params(
+            make_iceberg_table_format_desc(file_path, {delete_file}));
+    ASSERT_TRUE(reader.prepare_split(split_options).ok());
+
+    Block block = build_table_block(projected_columns);
+    bool eos = false;
+    ASSERT_TRUE(reader.get_block(&block, &eos).ok());
+    ASSERT_FALSE(eos);
+    ASSERT_EQ(block.rows(), 2);
+    const auto& id_column = assert_cast<const ColumnInt32&>(expect_not_null_table_column(block, 0));
+    EXPECT_EQ(id_column.get_element(0), 1);
+    EXPECT_EQ(id_column.get_element(1), 3);
+
+    ASSERT_TRUE(reader.close().ok());
+    std::filesystem::remove_all(test_dir);
 }
 
 } // namespace

--- a/be/test/format_v2/table/iceberg_reader_test.cpp
+++ b/be/test/format_v2/table/iceberg_reader_test.cpp
@@ -5433,7 +5433,8 @@ TEST(IcebergV2ReaderTest, IcebergEqualityDeleteFileSizePropagatedToReader) {
     write_int_pair_parquet_file(file_path, {1, 2, 3}, {10, 20, 30}, {"one", "two", "three"});
     write_iceberg_equality_delete_parquet_file(delete_file_path, 0, 2);
 
-    const auto delete_file_size = static_cast<int64_t>(std::filesystem::file_size(delete_file_path));
+    const auto delete_file_size =
+            static_cast<int64_t>(std::filesystem::file_size(delete_file_path));
     ASSERT_GT(delete_file_size, 0) << "delete file should not be empty";
 
     std::vector<ColumnDefinition> projected_columns;

--- a/be/test/format_v2/table/iceberg_reader_test.cpp
+++ b/be/test/format_v2/table/iceberg_reader_test.cpp
@@ -5418,10 +5418,6 @@ TEST(IcebergV2ReaderTest, DataFileIsMarkedImmutableForPageCache) {
     EXPECT_TRUE(reader.current_data_file_is_immutable());
 }
 
-// E2E: Verify file_size from FE thrift propagates through the full reader chain.
-// Data file: 3 rows (id=1,2,3). Equality delete: delete id=2.
-// With file_size set on TIcebergDeleteFileDesc, the reader should use it
-// instead of falling back to stat, and return correct results (id=1,3).
 TEST(IcebergV2ReaderTest, IcebergEqualityDeleteFileSizePropagatedToReader) {
     const auto test_dir =
             std::filesystem::temp_directory_path() / "doris_iceberg_eq_delete_file_size_test";
@@ -5479,9 +5475,6 @@ TEST(IcebergV2ReaderTest, IcebergEqualityDeleteFileSizePropagatedToReader) {
     std::filesystem::remove_all(test_dir);
 }
 
-// E2E: Verify that when file_size is not set (thrift optional defaults to 0),
-// build_iceberg_delete_file_range converts 0 to -1, and FileFactory falls back
-// to stat. The reader should still return correct results.
 TEST(IcebergV2ReaderTest, IcebergEqualityDeleteFileSizeUnknownFallsBackToStat) {
     const auto test_dir =
             std::filesystem::temp_directory_path() / "doris_iceberg_eq_delete_no_file_size_test";
@@ -5493,13 +5486,11 @@ TEST(IcebergV2ReaderTest, IcebergEqualityDeleteFileSizeUnknownFallsBackToStat) {
     write_int_pair_parquet_file(file_path, {1, 2, 3}, {10, 20, 30}, {"one", "two", "three"});
     write_iceberg_equality_delete_parquet_file(delete_file_path, 0, 2);
 
-    // Construct delete file WITHOUT file_size (simulating FE not setting it)
     TIcebergDeleteFileDesc delete_file;
     delete_file.__set_content(2);
     delete_file.__set_path(delete_file_path);
     delete_file.__set_field_ids({0});
     delete_file.__set_file_format(TFileFormatType::FORMAT_PARQUET);
-    // file_size intentionally not set — thrift defaults to 0
 
     std::vector<ColumnDefinition> projected_columns;
     projected_columns.push_back(make_table_column(0, "id", std::make_shared<DataTypeInt32>()));

--- a/be/test/io/fs/file_handle_cache_test.cpp
+++ b/be/test/io/fs/file_handle_cache_test.cpp
@@ -55,17 +55,4 @@ TEST(FileHandleCacheTest, InitWithKnownFileSizeDoesNotOpenFile) {
     EXPECT_EQ(handle.file(), nullptr);
 }
 
-// Verify that build_iceberg_delete_file_range treats file_size <= 0 as unknown (-1).
-// This covers the case where thrift optional file_size defaults to 0.
-TEST(FileHandleCacheTest, BuildDeleteFileRangeTreatsZeroAsUnknown) {
-    auto range_known = build_iceberg_delete_file_range("s3://b/f.parquet", 1024);
-    EXPECT_EQ(range_known.file_size, 1024);
-
-    auto range_zero = build_iceberg_delete_file_range("s3://b/f.parquet", 0);
-    EXPECT_EQ(range_zero.file_size, -1);
-
-    auto range_neg = build_iceberg_delete_file_range("s3://b/f.parquet", -1);
-    EXPECT_EQ(range_neg.file_size, -1);
-}
-
 } // namespace doris::io

--- a/be/test/io/fs/file_handle_cache_test.cpp
+++ b/be/test/io/fs/file_handle_cache_test.cpp
@@ -28,6 +28,7 @@
 
 #include "cpp/sync_point.h"
 #include "format/table/iceberg_delete_file_reader_helper.h"
+#include "gen_cpp/Status_types.h"
 #include "io/fs/hdfs_file_reader.h"
 
 namespace doris::io {

--- a/be/test/io/fs/file_handle_cache_test.cpp
+++ b/be/test/io/fs/file_handle_cache_test.cpp
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <string>
 
+#include "cpp/sync_point.h"
 #include "format/table/iceberg_delete_file_reader_helper.h"
 
 namespace doris::io {
@@ -42,17 +43,170 @@ TEST(FileHandleCacheTest, CacheKeyIncludesHdfsFs) {
                                                           mtime + 1));
 }
 
-// Verify that init() with file_size > 0 does NOT open the file (lazy open).
-// The handle should know file_size but file() should be nullptr.
+// init(file_size>0) does not open the file.
 TEST(FileHandleCacheTest, InitWithKnownFileSizeDoesNotOpenFile) {
     auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
     ExclusiveHdfsFileHandle handle(mock_fs, "/nonexistent/file.parquet", 12345);
     auto st = handle.init(4096);
     ASSERT_TRUE(st.ok()) << st;
-    // file_size should be set from parameter
     EXPECT_EQ(handle.file_size(), 4096);
-    // file() should be nullptr — lazy open means no hdfsOpenFile was called
     EXPECT_EQ(handle.file(), nullptr);
+}
+
+// Destructor is safe when file was never opened.
+TEST(FileHandleCacheTest, DestructorSafeWithoutOpen) {
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    {
+        ExclusiveHdfsFileHandle handle(mock_fs, "/nonexistent/file.parquet", 12345);
+        ASSERT_TRUE(handle.init(4096).ok());
+        EXPECT_EQ(handle.file(), nullptr);
+    }
+}
+
+// Mocks hdfsOpenFile/hdfsCloseFile/hdfsGetPathInfo/hdfsFreeFileInfo via SyncPoint to avoid JNI.
+struct MockHandleGuard {
+    SyncPoint::CallbackGuard open_guard;
+    SyncPoint::CallbackGuard close_guard;
+    SyncPoint::CallbackGuard info_guard;
+    SyncPoint::CallbackGuard free_guard;
+    static inline hdfsFileInfo mock_info;
+    MockHandleGuard(hdfsFile mock_file, int64_t file_size = 4096) {
+        mock_info.mSize = file_size;
+        auto* sp = SyncPoint::get_instance();
+        sp->enable_processing();
+        sp->set_call_back(
+                "HdfsFileHandle::ensure_open::hdfsOpenFile",
+                [mock_file](auto&& args) {
+                    auto* ret = try_any_cast_ret<hdfsFile>(args);
+                    ret->first = mock_file;
+                    ret->second = true;
+                },
+                &open_guard);
+        sp->set_call_back(
+                "HdfsFileHandle::close::hdfsCloseFile",
+                [](auto&& args) {
+                    auto* ret = try_any_cast_ret<int>(args);
+                    ret->first = 0;
+                    ret->second = true;
+                },
+                &close_guard);
+        sp->set_call_back(
+                "HdfsFileHandle::init::hdfsGetPathInfo",
+                [](auto&& args) {
+                    auto* ret = try_any_cast_ret<hdfsFileInfo*>(args);
+                    ret->first = &mock_info;
+                    ret->second = true;
+                },
+                &info_guard);
+        sp->set_call_back(
+                "HdfsFileHandle::init::hdfsFreeFileInfo",
+                [](auto&& args) {
+                    auto* ret = try_any_cast_ret<Status>(args);
+                    ret->first = Status::OK();
+                    ret->second = true;
+                },
+                &free_guard);
+    }
+};
+
+// ensure_open() succeeds via SyncPoint mock.
+TEST(FileHandleCacheTest, EnsureOpenSucceedsWithMock) {
+    MockHandleGuard mg(reinterpret_cast<hdfsFile>(static_cast<uintptr_t>(0xdeadbeef)));
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    ExclusiveHdfsFileHandle handle(mock_fs, "/test/file.parquet", 12345);
+    ASSERT_TRUE(handle.init(4096).ok());
+    EXPECT_EQ(handle.file(), nullptr);
+
+    ASSERT_TRUE(handle.ensure_open().ok());
+    EXPECT_NE(handle.file(), nullptr);
+}
+
+// ensure_open() fails when mock returns nullptr.
+TEST(FileHandleCacheTest, EnsureOpenFailsWithMock) {
+    MockHandleGuard mg(nullptr);
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    ExclusiveHdfsFileHandle handle(mock_fs, "/test/file.parquet", 12345);
+    ASSERT_TRUE(handle.init(4096).ok());
+
+    auto st = handle.ensure_open();
+    ASSERT_FALSE(st.ok());
+    EXPECT_EQ(handle.file(), nullptr);
+}
+
+// ensure_open() is idempotent via call_once.
+TEST(FileHandleCacheTest, EnsureOpenIsIdempotentWithMock) {
+    MockHandleGuard mg(reinterpret_cast<hdfsFile>(static_cast<uintptr_t>(0xdeadbeef)));
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    ExclusiveHdfsFileHandle handle(mock_fs, "/test/file.parquet", 12345);
+    ASSERT_TRUE(handle.init(4096).ok());
+
+    ASSERT_TRUE(handle.ensure_open().ok());
+    ASSERT_TRUE(handle.ensure_open().ok());
+}
+
+// init(-1) fetches file_size via mocked hdfsGetPathInfo.
+TEST(FileHandleCacheTest, InitWithUnknownFileSizeWithMock) {
+    MockHandleGuard mg(nullptr, 8192);
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    ExclusiveHdfsFileHandle handle(mock_fs, "/test/file.parquet", 12345);
+
+    ASSERT_TRUE(handle.init(-1).ok());
+    EXPECT_EQ(handle.file_size(), 8192);
+    EXPECT_EQ(handle.file(), nullptr);
+}
+
+// init(-1) fails when hdfsGetPathInfo returns nullptr.
+TEST(FileHandleCacheTest, InitFailsWhenGetPathInfoReturnsNull) {
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    ExclusiveHdfsFileHandle handle(mock_fs, "/test/file.parquet", 12345);
+
+    auto* sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    SyncPoint::CallbackGuard guard;
+    sp->set_call_back(
+            "HdfsFileHandle::init::hdfsGetPathInfo",
+            [](auto&& args) {
+                auto* ret = try_any_cast_ret<hdfsFileInfo*>(args);
+                ret->first = nullptr;
+                ret->second = true;
+            },
+            &guard);
+
+    auto st = handle.init(-1);
+    ASSERT_FALSE(st.ok());
+    EXPECT_EQ(st.code(), TStatusCode::INTERNAL_ERROR);
+}
+
+// ensure_open() returns NotFound when error contains "No such file or directory".
+TEST(FileHandleCacheTest, EnsureOpenReturnsNotFoundForMissingFile) {
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    ExclusiveHdfsFileHandle handle(mock_fs, "/test/missing.parquet", 12345);
+    ASSERT_TRUE(handle.init(4096).ok());
+
+    auto* sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    SyncPoint::CallbackGuard open_guard;
+    sp->set_call_back(
+            "HdfsFileHandle::ensure_open::hdfsOpenFile",
+            [](auto&& args) {
+                auto* ret = try_any_cast_ret<hdfsFile>(args);
+                ret->first = nullptr;
+                ret->second = true;
+            },
+            &open_guard);
+    SyncPoint::CallbackGuard err_guard;
+    sp->set_call_back(
+            "HdfsFileHandle::ensure_open::hdfs_error",
+            [](auto&& args) {
+                auto* ret = try_any_cast_ret<std::string>(args);
+                ret->first = "No such file or directory";
+                ret->second = true;
+            },
+            &err_guard);
+
+    auto st = handle.ensure_open();
+    ASSERT_FALSE(st.ok());
+    EXPECT_EQ(st.code(), TStatusCode::NOT_FOUND);
 }
 
 } // namespace doris::io

--- a/be/test/io/fs/file_handle_cache_test.cpp
+++ b/be/test/io/fs/file_handle_cache_test.cpp
@@ -256,8 +256,8 @@ TEST(FileHandleCacheTest, ReadAtOpenFailedHandleDestroyedNotCached) {
         FileHandleCache::Accessor accessor;
         get_handle(*cache, mock_fs, fname, mtime, &accessor, &cache_hit);
         EXPECT_FALSE(cache_hit);
-        auto reader = std::make_shared<HdfsFileReader>(Path(fname), "hdfs", std::move(accessor),
-                                                       nullptr, mtime);
+        auto reader =
+                std::make_shared<HdfsFileReader>(Path(fname), "hdfs", std::move(accessor), mtime);
         char buf[16];
         size_t bytes_read = 0;
         auto st = reader->read_at(0, {buf, sizeof(buf)}, &bytes_read, nullptr);
@@ -354,8 +354,7 @@ TEST(FileHandleCacheTest, SecondReadAfterFailureDoesNotCrash) {
     bool cache_hit = false;
     FileHandleCache::Accessor accessor;
     get_handle(*cache, mock_fs, fname, mtime, &accessor, &cache_hit);
-    auto reader = std::make_shared<HdfsFileReader>(Path(fname), "hdfs", std::move(accessor),
-                                                   nullptr, mtime);
+    auto reader = std::make_shared<HdfsFileReader>(Path(fname), "hdfs", std::move(accessor), mtime);
 
     char buf[16];
     size_t bytes_read = 0;

--- a/be/test/io/fs/file_handle_cache_test.cpp
+++ b/be/test/io/fs/file_handle_cache_test.cpp
@@ -22,6 +22,8 @@
 #include <cstdint>
 #include <string>
 
+#include "format/table/iceberg_delete_file_reader_helper.h"
+
 namespace doris::io {
 
 TEST(FileHandleCacheTest, CacheKeyIncludesHdfsFs) {
@@ -38,6 +40,32 @@ TEST(FileHandleCacheTest, CacheKeyIncludesHdfsFs) {
                                                           fname + ".other", mtime));
     EXPECT_FALSE(FileHandleCache::same_cache_key_for_test(first_fs, fname, mtime, first_fs, fname,
                                                           mtime + 1));
+}
+
+// Verify that init() with file_size > 0 does NOT open the file (lazy open).
+// The handle should know file_size but file() should be nullptr.
+TEST(FileHandleCacheTest, InitWithKnownFileSizeDoesNotOpenFile) {
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    ExclusiveHdfsFileHandle handle(mock_fs, "/nonexistent/file.parquet", 12345);
+    auto st = handle.init(4096);
+    ASSERT_TRUE(st.ok()) << st;
+    // file_size should be set from parameter
+    EXPECT_EQ(handle.file_size(), 4096);
+    // file() should be nullptr — lazy open means no hdfsOpenFile was called
+    EXPECT_EQ(handle.file(), nullptr);
+}
+
+// Verify that build_iceberg_delete_file_range treats file_size <= 0 as unknown (-1).
+// This covers the case where thrift optional file_size defaults to 0.
+TEST(FileHandleCacheTest, BuildDeleteFileRangeTreatsZeroAsUnknown) {
+    auto range_known = build_iceberg_delete_file_range("s3://b/f.parquet", 1024);
+    EXPECT_EQ(range_known.file_size, 1024);
+
+    auto range_zero = build_iceberg_delete_file_range("s3://b/f.parquet", 0);
+    EXPECT_EQ(range_zero.file_size, -1);
+
+    auto range_neg = build_iceberg_delete_file_range("s3://b/f.parquet", -1);
+    EXPECT_EQ(range_neg.file_size, -1);
 }
 
 } // namespace doris::io

--- a/be/test/io/fs/file_handle_cache_test.cpp
+++ b/be/test/io/fs/file_handle_cache_test.cpp
@@ -19,8 +19,12 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <cstdint>
 #include <string>
+#include <thread>
+#include <utility>
+#include <vector>
 
 #include "cpp/sync_point.h"
 #include "format/table/iceberg_delete_file_reader_helper.h"
@@ -64,6 +68,19 @@ TEST(FileHandleCacheTest, DestructorSafeWithoutOpen) {
     }
 }
 
+// Register a SyncPoint callback that returns a fixed value.
+template <typename T>
+static void set_mock_return(const std::string& point, T value, SyncPoint::CallbackGuard* guard) {
+    SyncPoint::get_instance()->set_call_back(
+            point,
+            [value = std::move(value)](auto&& args) {
+                auto* ret = try_any_cast_ret<T>(args);
+                ret->first = std::move(value);
+                ret->second = true;
+            },
+            guard);
+}
+
 // Mocks hdfsOpenFile/hdfsCloseFile/hdfsGetPathInfo/hdfsFreeFileInfo/hdfsUnbufferFile via SyncPoint to avoid JNI.
 struct MockHandleGuard {
     SyncPoint::CallbackGuard open_guard;
@@ -76,46 +93,14 @@ struct MockHandleGuard {
         mock_info.mSize = file_size;
         auto* sp = SyncPoint::get_instance();
         sp->enable_processing();
-        sp->set_call_back(
-                "HdfsFileHandle::ensure_open::hdfsOpenFile",
-                [mock_file](auto&& args) {
-                    auto* ret = try_any_cast_ret<hdfsFile>(args);
-                    ret->first = mock_file;
-                    ret->second = true;
-                },
-                &open_guard);
-        sp->set_call_back(
-                "HdfsFileHandle::close::hdfsCloseFile",
-                [](auto&& args) {
-                    auto* ret = try_any_cast_ret<int>(args);
-                    ret->first = 0;
-                    ret->second = true;
-                },
-                &close_guard);
-        sp->set_call_back(
-                "HdfsFileHandle::init::hdfsGetPathInfo",
-                [](auto&& args) {
-                    auto* ret = try_any_cast_ret<hdfsFileInfo*>(args);
-                    ret->first = &mock_info;
-                    ret->second = true;
-                },
-                &info_guard);
-        sp->set_call_back(
-                "HdfsFileHandle::init::hdfsFreeFileInfo",
-                [](auto&& args) {
-                    auto* ret = try_any_cast_ret<Status>(args);
-                    ret->first = Status::OK();
-                    ret->second = true;
-                },
-                &free_guard);
-        sp->set_call_back(
-                "HdfsFileHandle::close::hdfsUnbufferFile",
-                [](auto&& args) {
-                    auto* ret = try_any_cast_ret<int>(args);
-                    ret->first = 0;
-                    ret->second = true;
-                },
-                &unbuffer_guard);
+        set_mock_return<hdfsFile>("HdfsFileHandle::ensure_open::hdfsOpenFile", mock_file,
+                                  &open_guard);
+        set_mock_return<int>("HdfsFileHandle::close::hdfsCloseFile", 0, &close_guard);
+        set_mock_return<hdfsFileInfo*>("HdfsFileHandle::init::hdfsGetPathInfo", &mock_info,
+                                       &info_guard);
+        set_mock_return<Status>("HdfsFileHandle::init::hdfsFreeFileInfo", Status::OK(),
+                                &free_guard);
+        set_mock_return<int>("HdfsFileHandle::close::hdfsUnbufferFile", 0, &unbuffer_guard);
     }
 };
 
@@ -173,14 +158,7 @@ TEST(FileHandleCacheTest, InitFailsWhenGetPathInfoReturnsNull) {
     auto* sp = SyncPoint::get_instance();
     sp->enable_processing();
     SyncPoint::CallbackGuard guard;
-    sp->set_call_back(
-            "HdfsFileHandle::init::hdfsGetPathInfo",
-            [](auto&& args) {
-                auto* ret = try_any_cast_ret<hdfsFileInfo*>(args);
-                ret->first = nullptr;
-                ret->second = true;
-            },
-            &guard);
+    set_mock_return<hdfsFileInfo*>("HdfsFileHandle::init::hdfsGetPathInfo", nullptr, &guard);
 
     auto st = handle.init(-1);
     ASSERT_FALSE(st.ok());
@@ -196,23 +174,10 @@ TEST(FileHandleCacheTest, EnsureOpenReturnsNotFoundForMissingFile) {
     auto* sp = SyncPoint::get_instance();
     sp->enable_processing();
     SyncPoint::CallbackGuard open_guard;
-    sp->set_call_back(
-            "HdfsFileHandle::ensure_open::hdfsOpenFile",
-            [](auto&& args) {
-                auto* ret = try_any_cast_ret<hdfsFile>(args);
-                ret->first = nullptr;
-                ret->second = true;
-            },
-            &open_guard);
+    set_mock_return<hdfsFile>("HdfsFileHandle::ensure_open::hdfsOpenFile", nullptr, &open_guard);
     SyncPoint::CallbackGuard err_guard;
-    sp->set_call_back(
-            "HdfsFileHandle::ensure_open::hdfs_error",
-            [](auto&& args) {
-                auto* ret = try_any_cast_ret<std::string>(args);
-                ret->first = "No such file or directory";
-                ret->second = true;
-            },
-            &err_guard);
+    set_mock_return<std::string>("HdfsFileHandle::ensure_open::hdfs_error",
+                                 "No such file or directory", &err_guard);
 
     auto st = handle.ensure_open();
     ASSERT_FALSE(st.ok());
@@ -302,6 +267,108 @@ TEST(FileHandleCacheTest, ReadAtOpenFailedHandleDestroyedNotCached) {
     FileHandleCache::Accessor accessor2;
     get_handle(*cache, mock_fs, fname, mtime, &accessor2, &cache_hit);
     EXPECT_FALSE(cache_hit);
+}
+
+// Serial ensure_open() preserves Status inside call_once.
+TEST(FileHandleCacheTest, OpenFailurePreservesStatusInsideCallOnce) {
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    ExclusiveHdfsFileHandle handle(mock_fs, "/test/serial_fail.parquet", 12345);
+    ASSERT_TRUE(handle.init(4096).ok());
+
+    auto* sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    SyncPoint::CallbackGuard open_guard;
+    set_mock_return<hdfsFile>("HdfsFileHandle::ensure_open::hdfsOpenFile", nullptr, &open_guard);
+    SyncPoint::CallbackGuard err_guard;
+    set_mock_return<std::string>("HdfsFileHandle::ensure_open::hdfs_error",
+                                 "No such file or directory", &err_guard);
+
+    // First call opens and fails -> NotFound.
+    auto st1 = handle.ensure_open();
+    ASSERT_FALSE(st1.ok());
+    EXPECT_EQ(st1.code(), TStatusCode::NOT_FOUND);
+
+    // Change hdfs_error mock to a different value; _open_status must be preserved.
+    sp->clear_call_back("HdfsFileHandle::ensure_open::hdfs_error");
+    set_mock_return<std::string>("HdfsFileHandle::ensure_open::hdfs_error", "Permission denied",
+                                 &err_guard);
+
+    auto st2 = handle.ensure_open();
+    ASSERT_FALSE(st2.ok());
+    EXPECT_EQ(st2.code(), TStatusCode::NOT_FOUND);
+}
+
+// Concurrent ensure_open() must return the same Status to all callers.
+TEST(FileHandleCacheTest, ConcurrentOpenFailureReturnsSameStatusToAllCallers) {
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    ExclusiveHdfsFileHandle handle(mock_fs, "/test/concurrent_fail.parquet", 12345);
+    ASSERT_TRUE(handle.init(4096).ok());
+
+    auto* sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    SyncPoint::CallbackGuard open_guard;
+    set_mock_return<hdfsFile>("HdfsFileHandle::ensure_open::hdfsOpenFile", nullptr, &open_guard);
+
+    // Simulate libhdfs thread-local last-error: only first call returns real message.
+    std::atomic<int> err_call_count {0};
+    SyncPoint::CallbackGuard err_guard;
+    sp->set_call_back(
+            "HdfsFileHandle::ensure_open::hdfs_error",
+            [&err_call_count](auto&& args) {
+                auto* ret = try_any_cast_ret<std::string>(args);
+                if (err_call_count.fetch_add(1) == 0) {
+                    ret->first = "No such file or directory";
+                } else {
+                    ret->first = "";
+                }
+                ret->second = true;
+            },
+            &err_guard);
+
+    constexpr int kNumThreads = 8;
+    std::vector<std::thread> threads;
+    std::vector<TStatusCode::type> codes(kNumThreads);
+    for (int i = 0; i < kNumThreads; ++i) {
+        threads.emplace_back([&handle, &codes, i]() {
+            auto st = handle.ensure_open();
+            codes[i] = static_cast<TStatusCode::type>(st.code());
+        });
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    for (int i = 0; i < kNumThreads; ++i) {
+        EXPECT_EQ(codes[i], TStatusCode::NOT_FOUND) << "thread " << i << " got code " << codes[i];
+    }
+}
+
+// Second read_at after a failed read must not dereference null _handle.
+TEST(FileHandleCacheTest, SecondReadAfterFailureDoesNotCrash) {
+    MockHandleGuard mg(reinterpret_cast<hdfsFile>(static_cast<uintptr_t>(0xdeadbeef)));
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    auto cache = make_test_cache();
+    const std::string fname = "/test/second_read.parquet";
+    constexpr int64_t mtime = 12345;
+
+    bool cache_hit = false;
+    FileHandleCache::Accessor accessor;
+    get_handle(*cache, mock_fs, fname, mtime, &accessor, &cache_hit);
+    auto reader = std::make_shared<HdfsFileReader>(Path(fname), "hdfs", std::move(accessor),
+                                                   nullptr, mtime);
+
+    char buf[16];
+    size_t bytes_read = 0;
+    // offset > file_size(4096) -> IOError -> read_at_impl sets _handle=nullptr.
+    auto st1 = reader->read_at(5000, {buf, sizeof(buf)}, &bytes_read, nullptr);
+    ASSERT_FALSE(st1.ok());
+    // Confirm error came from do_read_at_impl's offset guard (sets _handle=nullptr).
+    EXPECT_EQ(st1.code(), TStatusCode::IO_ERROR);
+
+    // Second read must not crash; should return InternalError about destroyed handle.
+    auto st2 = reader->read_at(0, {buf, sizeof(buf)}, &bytes_read, nullptr);
+    ASSERT_FALSE(st2.ok());
+    EXPECT_EQ(st2.code(), TStatusCode::INTERNAL_ERROR);
 }
 
 } // namespace doris::io

--- a/be/test/io/fs/file_handle_cache_test.cpp
+++ b/be/test/io/fs/file_handle_cache_test.cpp
@@ -24,6 +24,7 @@
 
 #include "cpp/sync_point.h"
 #include "format/table/iceberg_delete_file_reader_helper.h"
+#include "io/fs/hdfs_file_reader.h"
 
 namespace doris::io {
 
@@ -63,12 +64,13 @@ TEST(FileHandleCacheTest, DestructorSafeWithoutOpen) {
     }
 }
 
-// Mocks hdfsOpenFile/hdfsCloseFile/hdfsGetPathInfo/hdfsFreeFileInfo via SyncPoint to avoid JNI.
+// Mocks hdfsOpenFile/hdfsCloseFile/hdfsGetPathInfo/hdfsFreeFileInfo/hdfsUnbufferFile via SyncPoint to avoid JNI.
 struct MockHandleGuard {
     SyncPoint::CallbackGuard open_guard;
     SyncPoint::CallbackGuard close_guard;
     SyncPoint::CallbackGuard info_guard;
     SyncPoint::CallbackGuard free_guard;
+    SyncPoint::CallbackGuard unbuffer_guard;
     static inline hdfsFileInfo mock_info;
     MockHandleGuard(hdfsFile mock_file, int64_t file_size = 4096) {
         mock_info.mSize = file_size;
@@ -106,6 +108,14 @@ struct MockHandleGuard {
                     ret->second = true;
                 },
                 &free_guard);
+        sp->set_call_back(
+                "HdfsFileHandle::close::hdfsUnbufferFile",
+                [](auto&& args) {
+                    auto* ret = try_any_cast_ret<int>(args);
+                    ret->first = 0;
+                    ret->second = true;
+                },
+                &unbuffer_guard);
     }
 };
 
@@ -207,6 +217,91 @@ TEST(FileHandleCacheTest, EnsureOpenReturnsNotFoundForMissingFile) {
     auto st = handle.ensure_open();
     ASSERT_FALSE(st.ok());
     EXPECT_EQ(st.code(), TStatusCode::NOT_FOUND);
+}
+
+// --- Cache lifecycle tests ---
+
+// Helper: create a FileHandleCache with small capacity for testing.
+static std::unique_ptr<FileHandleCache> make_test_cache() {
+    return std::make_unique<FileHandleCache>(4, 1, 0);
+}
+
+// Helper: get a file handle from cache, asserting success.
+static void get_handle(FileHandleCache& cache, const hdfsFS& fs, const std::string& fname,
+                       int64_t mtime, FileHandleCache::Accessor* accessor, bool* cache_hit) {
+    ASSERT_TRUE(cache.get_file_handle(fs, fname, mtime, 4096, false, accessor, cache_hit).ok());
+}
+
+// ensure_open succeeds → ~Accessor releases (unbuffer OK) → next get_file_handle hits cache.
+TEST(FileHandleCacheTest, OpenedHandleReleasedBackToCache) {
+    MockHandleGuard mg(reinterpret_cast<hdfsFile>(static_cast<uintptr_t>(0xdeadbeef)));
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    auto cache = make_test_cache();
+    const std::string fname = "/test/opened_release.parquet";
+    constexpr int64_t mtime = 12345;
+
+    bool cache_hit = false;
+    {
+        FileHandleCache::Accessor accessor;
+        get_handle(*cache, mock_fs, fname, mtime, &accessor, &cache_hit);
+        EXPECT_FALSE(cache_hit);
+        ASSERT_TRUE(accessor.get()->ensure_open().ok());
+        EXPECT_NE(accessor.get()->file(), nullptr);
+    }
+
+    FileHandleCache::Accessor accessor2;
+    get_handle(*cache, mock_fs, fname, mtime, &accessor2, &cache_hit);
+    EXPECT_TRUE(cache_hit);
+    EXPECT_NE(accessor2.get()->file(), nullptr);
+}
+
+// ensure_open fails → ~Accessor destroys → next get_file_handle misses cache.
+TEST(FileHandleCacheTest, OpenFailedHandleDestroyedNotCached) {
+    MockHandleGuard mg(nullptr);
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    auto cache = make_test_cache();
+    const std::string fname = "/test/open_fail.parquet";
+    constexpr int64_t mtime = 12345;
+
+    bool cache_hit = false;
+    {
+        FileHandleCache::Accessor accessor;
+        get_handle(*cache, mock_fs, fname, mtime, &accessor, &cache_hit);
+        EXPECT_FALSE(cache_hit);
+        auto st = accessor.get()->ensure_open();
+        ASSERT_FALSE(st.ok());
+        EXPECT_EQ(accessor.get()->file(), nullptr);
+    }
+
+    FileHandleCache::Accessor accessor2;
+    get_handle(*cache, mock_fs, fname, mtime, &accessor2, &cache_hit);
+    EXPECT_FALSE(cache_hit);
+}
+
+// read_at triggers ensure_open failure → reader destroyed → ~Accessor destroys → cache miss.
+TEST(FileHandleCacheTest, ReadAtOpenFailedHandleDestroyedNotCached) {
+    MockHandleGuard mg(nullptr);
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    auto cache = make_test_cache();
+    const std::string fname = "/test/read_at_fail.parquet";
+    constexpr int64_t mtime = 12345;
+
+    bool cache_hit = false;
+    {
+        FileHandleCache::Accessor accessor;
+        get_handle(*cache, mock_fs, fname, mtime, &accessor, &cache_hit);
+        EXPECT_FALSE(cache_hit);
+        auto reader = std::make_shared<HdfsFileReader>(Path(fname), "hdfs", std::move(accessor),
+                                                       nullptr, mtime);
+        char buf[16];
+        size_t bytes_read = 0;
+        auto st = reader->read_at(0, {buf, sizeof(buf)}, &bytes_read, nullptr);
+        ASSERT_FALSE(st.ok());
+    }
+
+    FileHandleCache::Accessor accessor2;
+    get_handle(*cache, mock_fs, fname, mtime, &accessor2, &cache_hit);
+    EXPECT_FALSE(cache_hit);
 }
 
 } // namespace doris::io

--- a/be/test/io/fs/file_handle_cache_test.cpp
+++ b/be/test/io/fs/file_handle_cache_test.cpp
@@ -21,13 +21,14 @@
 
 #include <atomic>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <string>
 #include <thread>
 #include <utility>
 #include <vector>
 
 #include "cpp/sync_point.h"
-#include "format/table/iceberg_delete_file_reader_helper.h"
 #include "gen_cpp/Status_types.h"
 #include "io/fs/hdfs_file_reader.h"
 
@@ -82,25 +83,36 @@ static void set_mock_return(const std::string& point, T value, SyncPoint::Callba
             guard);
 }
 
-// Mocks hdfsOpenFile/hdfsCloseFile/hdfsGetPathInfo/hdfsFreeFileInfo/hdfsUnbufferFile via SyncPoint to avoid JNI.
+// Enables SyncPoint processing for the enclosing scope only.
+struct SyncPointProcessingGuard {
+    SyncPointProcessingGuard() { SyncPoint::get_instance()->enable_processing(); }
+    ~SyncPointProcessingGuard() { SyncPoint::get_instance()->disable_processing(); }
+};
+
+// Mocks hdfsOpenFile/hdfsCloseFile/hdfsGetPathInfo/hdfsUnbufferFile via SyncPoint to avoid JNI.
 struct MockHandleGuard {
     SyncPoint::CallbackGuard open_guard;
     SyncPoint::CallbackGuard close_guard;
     SyncPoint::CallbackGuard info_guard;
-    SyncPoint::CallbackGuard free_guard;
     SyncPoint::CallbackGuard unbuffer_guard;
-    static inline hdfsFileInfo mock_info;
+    SyncPointProcessingGuard processing_guard;
     MockHandleGuard(hdfsFile mock_file, int64_t file_size = 4096) {
-        mock_info.mSize = file_size;
         auto* sp = SyncPoint::get_instance();
-        sp->enable_processing();
         set_mock_return<hdfsFile>("HdfsFileHandle::ensure_open::hdfsOpenFile", mock_file,
                                   &open_guard);
         set_mock_return<int>("HdfsFileHandle::close::hdfsCloseFile", 0, &close_guard);
-        set_mock_return<hdfsFileInfo*>("HdfsFileHandle::init::hdfsGetPathInfo", &mock_info,
-                                       &info_guard);
-        set_mock_return<Status>("HdfsFileHandle::init::hdfsFreeFileInfo", Status::OK(),
-                                &free_guard);
+        // Each hit allocates a fresh heap info so init()'s real hdfsFreeFileInfo can free it safely.
+        sp->set_call_back(
+                "HdfsFileHandle::init::hdfsGetPathInfo",
+                [file_size](auto&& args) {
+                    auto* ret = try_any_cast_ret<hdfsFileInfo*>(args);
+                    auto* info = static_cast<hdfsFileInfo*>(calloc(1, sizeof(hdfsFileInfo)));
+                    info->mSize = file_size;
+                    info->mName = strdup("/test/mock-file.parquet");
+                    ret->first = info;
+                    ret->second = true;
+                },
+                &info_guard);
         set_mock_return<int>("HdfsFileHandle::close::hdfsUnbufferFile", 0, &unbuffer_guard);
     }
 };
@@ -156,14 +168,33 @@ TEST(FileHandleCacheTest, InitFailsWhenGetPathInfoReturnsNull) {
     auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
     ExclusiveHdfsFileHandle handle(mock_fs, "/test/file.parquet", 12345);
 
-    auto* sp = SyncPoint::get_instance();
-    sp->enable_processing();
+    SyncPointProcessingGuard sp_guard;
     SyncPoint::CallbackGuard guard;
     set_mock_return<hdfsFileInfo*>("HdfsFileHandle::init::hdfsGetPathInfo", nullptr, &guard);
+    SyncPoint::CallbackGuard err_guard;
+    set_mock_return<std::string>("HdfsFileHandle::init::hdfs_error", "connection refused",
+                                 &err_guard);
 
     auto st = handle.init(-1);
     ASSERT_FALSE(st.ok());
     EXPECT_EQ(st.code(), TStatusCode::INTERNAL_ERROR);
+}
+
+// init(-1) returns NotFound when the file is missing.
+TEST(FileHandleCacheTest, InitReturnsNotFoundForMissingFile) {
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    ExclusiveHdfsFileHandle handle(mock_fs, "/test/missing.parquet", 12345);
+
+    SyncPointProcessingGuard sp_guard;
+    SyncPoint::CallbackGuard guard;
+    set_mock_return<hdfsFileInfo*>("HdfsFileHandle::init::hdfsGetPathInfo", nullptr, &guard);
+    SyncPoint::CallbackGuard err_guard;
+    set_mock_return<std::string>("HdfsFileHandle::init::hdfs_error", "No such file or directory",
+                                 &err_guard);
+
+    auto st = handle.init(-1);
+    ASSERT_FALSE(st.ok());
+    EXPECT_EQ(st.code(), TStatusCode::NOT_FOUND);
 }
 
 // ensure_open() returns NotFound when error contains "No such file or directory".
@@ -172,8 +203,7 @@ TEST(FileHandleCacheTest, EnsureOpenReturnsNotFoundForMissingFile) {
     ExclusiveHdfsFileHandle handle(mock_fs, "/test/missing.parquet", 12345);
     ASSERT_TRUE(handle.init(4096).ok());
 
-    auto* sp = SyncPoint::get_instance();
-    sp->enable_processing();
+    SyncPointProcessingGuard sp_guard;
     SyncPoint::CallbackGuard open_guard;
     set_mock_return<hdfsFile>("HdfsFileHandle::ensure_open::hdfsOpenFile", nullptr, &open_guard);
     SyncPoint::CallbackGuard err_guard;
@@ -276,8 +306,8 @@ TEST(FileHandleCacheTest, OpenFailurePreservesStatusInsideCallOnce) {
     ExclusiveHdfsFileHandle handle(mock_fs, "/test/serial_fail.parquet", 12345);
     ASSERT_TRUE(handle.init(4096).ok());
 
+    SyncPointProcessingGuard sp_guard;
     auto* sp = SyncPoint::get_instance();
-    sp->enable_processing();
     SyncPoint::CallbackGuard open_guard;
     set_mock_return<hdfsFile>("HdfsFileHandle::ensure_open::hdfsOpenFile", nullptr, &open_guard);
     SyncPoint::CallbackGuard err_guard;
@@ -305,8 +335,8 @@ TEST(FileHandleCacheTest, ConcurrentOpenFailureReturnsSameStatusToAllCallers) {
     ExclusiveHdfsFileHandle handle(mock_fs, "/test/concurrent_fail.parquet", 12345);
     ASSERT_TRUE(handle.init(4096).ok());
 
+    SyncPointProcessingGuard sp_guard;
     auto* sp = SyncPoint::get_instance();
-    sp->enable_processing();
     SyncPoint::CallbackGuard open_guard;
     set_mock_return<hdfsFile>("HdfsFileHandle::ensure_open::hdfsOpenFile", nullptr, &open_guard);
 

--- a/be/test/io/fs/file_handle_cache_test.cpp
+++ b/be/test/io/fs/file_handle_cache_test.cpp
@@ -31,6 +31,7 @@
 #include "cpp/sync_point.h"
 #include "gen_cpp/Status_types.h"
 #include "io/fs/hdfs_file_reader.h"
+#include "util/defer_op.h"
 
 namespace doris::io {
 
@@ -83,21 +84,15 @@ static void set_mock_return(const std::string& point, T value, SyncPoint::Callba
             guard);
 }
 
-// Enables SyncPoint processing for the enclosing scope only.
-struct SyncPointProcessingGuard {
-    SyncPointProcessingGuard() { SyncPoint::get_instance()->enable_processing(); }
-    ~SyncPointProcessingGuard() { SyncPoint::get_instance()->disable_processing(); }
-};
-
 // Mocks hdfsOpenFile/hdfsCloseFile/hdfsGetPathInfo/hdfsUnbufferFile via SyncPoint to avoid JNI.
 struct MockHandleGuard {
     SyncPoint::CallbackGuard open_guard;
     SyncPoint::CallbackGuard close_guard;
     SyncPoint::CallbackGuard info_guard;
     SyncPoint::CallbackGuard unbuffer_guard;
-    SyncPointProcessingGuard processing_guard;
     MockHandleGuard(hdfsFile mock_file, int64_t file_size = 4096) {
         auto* sp = SyncPoint::get_instance();
+        sp->enable_processing();
         set_mock_return<hdfsFile>("HdfsFileHandle::ensure_open::hdfsOpenFile", mock_file,
                                   &open_guard);
         set_mock_return<int>("HdfsFileHandle::close::hdfsCloseFile", 0, &close_guard);
@@ -115,6 +110,7 @@ struct MockHandleGuard {
                 &info_guard);
         set_mock_return<int>("HdfsFileHandle::close::hdfsUnbufferFile", 0, &unbuffer_guard);
     }
+    ~MockHandleGuard() { SyncPoint::get_instance()->disable_processing(); }
 };
 
 // ensure_open() succeeds via SyncPoint mock.
@@ -168,7 +164,8 @@ TEST(FileHandleCacheTest, InitFailsWhenGetPathInfoReturnsNull) {
     auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
     ExclusiveHdfsFileHandle handle(mock_fs, "/test/file.parquet", 12345);
 
-    SyncPointProcessingGuard sp_guard;
+    SyncPoint::get_instance()->enable_processing();
+    Defer defer {[&]() { SyncPoint::get_instance()->disable_processing(); }};
     SyncPoint::CallbackGuard guard;
     set_mock_return<hdfsFileInfo*>("HdfsFileHandle::init::hdfsGetPathInfo", nullptr, &guard);
     SyncPoint::CallbackGuard err_guard;
@@ -185,7 +182,8 @@ TEST(FileHandleCacheTest, InitReturnsNotFoundForMissingFile) {
     auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
     ExclusiveHdfsFileHandle handle(mock_fs, "/test/missing.parquet", 12345);
 
-    SyncPointProcessingGuard sp_guard;
+    SyncPoint::get_instance()->enable_processing();
+    Defer defer {[&]() { SyncPoint::get_instance()->disable_processing(); }};
     SyncPoint::CallbackGuard guard;
     set_mock_return<hdfsFileInfo*>("HdfsFileHandle::init::hdfsGetPathInfo", nullptr, &guard);
     SyncPoint::CallbackGuard err_guard;
@@ -203,7 +201,8 @@ TEST(FileHandleCacheTest, EnsureOpenReturnsNotFoundForMissingFile) {
     ExclusiveHdfsFileHandle handle(mock_fs, "/test/missing.parquet", 12345);
     ASSERT_TRUE(handle.init(4096).ok());
 
-    SyncPointProcessingGuard sp_guard;
+    SyncPoint::get_instance()->enable_processing();
+    Defer defer {[&]() { SyncPoint::get_instance()->disable_processing(); }};
     SyncPoint::CallbackGuard open_guard;
     set_mock_return<hdfsFile>("HdfsFileHandle::ensure_open::hdfsOpenFile", nullptr, &open_guard);
     SyncPoint::CallbackGuard err_guard;
@@ -306,8 +305,9 @@ TEST(FileHandleCacheTest, OpenFailurePreservesStatusInsideCallOnce) {
     ExclusiveHdfsFileHandle handle(mock_fs, "/test/serial_fail.parquet", 12345);
     ASSERT_TRUE(handle.init(4096).ok());
 
-    SyncPointProcessingGuard sp_guard;
     auto* sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    Defer defer {[&]() { sp->disable_processing(); }};
     SyncPoint::CallbackGuard open_guard;
     set_mock_return<hdfsFile>("HdfsFileHandle::ensure_open::hdfsOpenFile", nullptr, &open_guard);
     SyncPoint::CallbackGuard err_guard;
@@ -335,8 +335,9 @@ TEST(FileHandleCacheTest, ConcurrentOpenFailureReturnsSameStatusToAllCallers) {
     ExclusiveHdfsFileHandle handle(mock_fs, "/test/concurrent_fail.parquet", 12345);
     ASSERT_TRUE(handle.init(4096).ok());
 
-    SyncPointProcessingGuard sp_guard;
     auto* sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    Defer defer {[&]() { sp->disable_processing(); }};
     SyncPoint::CallbackGuard open_guard;
     set_mock_return<hdfsFile>("HdfsFileHandle::ensure_open::hdfsOpenFile", nullptr, &open_guard);
 

--- a/be/test/io/fs/file_handle_cache_test.cpp
+++ b/be/test/io/fs/file_handle_cache_test.cpp
@@ -375,6 +375,29 @@ TEST(FileHandleCacheTest, ConcurrentOpenFailureReturnsSameStatusToAllCallers) {
     }
 }
 
+// A read after close must fail before lazy open: no hdfsOpenFile call is allowed.
+TEST(FileHandleCacheTest, ReadAfterCloseSkipsLazyOpen) {
+    MockHandleGuard mg(reinterpret_cast<hdfsFile>(static_cast<uintptr_t>(0xdeadbeef)));
+    auto mock_fs = reinterpret_cast<hdfsFS>(static_cast<uintptr_t>(0x1));
+    auto cache = make_test_cache();
+    const std::string fname = "/test/close_before_read.parquet";
+    constexpr int64_t mtime = 12345;
+
+    bool cache_hit = false;
+    FileHandleCache::Accessor accessor;
+    get_handle(*cache, mock_fs, fname, mtime, &accessor, &cache_hit);
+    auto reader = std::make_shared<HdfsFileReader>(Path(fname), "hdfs", std::move(accessor), mtime);
+
+    ASSERT_TRUE(reader->close().ok());
+    char buf[16];
+    size_t bytes_read = 0;
+    auto st = reader->read_at(0, {buf, sizeof(buf)}, &bytes_read, nullptr);
+    ASSERT_FALSE(st.ok());
+    EXPECT_EQ(st.code(), TStatusCode::INTERNAL_ERROR);
+    // "read closed file" proves the closed guard fired before lazy open.
+    EXPECT_NE(st.to_string().find("read closed file"), std::string::npos);
+}
+
 // Second read_at after a failed read must not dereference null _handle.
 TEST(FileHandleCacheTest, SecondReadAfterFailureDoesNotCrash) {
     MockHandleGuard mg(reinterpret_cast<hdfsFile>(static_cast<uintptr_t>(0xdeadbeef)));

--- a/be/test/io/fs/file_handle_cache_test.cpp
+++ b/be/test/io/fs/file_handle_cache_test.cpp
@@ -246,8 +246,14 @@ TEST(FileHandleCacheTest, OpenedHandleReleasedBackToCache) {
 
     FileHandleCache::Accessor accessor2;
     get_handle(*cache, mock_fs, fname, mtime, &accessor2, &cache_hit);
+#ifdef USE_HADOOP_HDFS
     EXPECT_TRUE(cache_hit);
     EXPECT_NE(accessor2.get()->file(), nullptr);
+#else
+    // libhdfs3: ~Accessor() destroys the opened handle, so the next lookup must miss.
+    EXPECT_FALSE(cache_hit);
+    EXPECT_EQ(accessor2.get()->file(), nullptr);
+#endif
 }
 
 // ensure_open fails → ~Accessor destroys → next get_file_handle misses cache.

--- a/be/test/io/fs/hdfs_file_system_test.cpp
+++ b/be/test/io/fs/hdfs_file_system_test.cpp
@@ -161,8 +161,7 @@ TEST(HdfsFileSystemTest, Write) {
 TEST(HdfsFileSystemTest, CreateFailsWhenJavaSupportDisabled) {
     config::enable_java_support = false;
     std::map<std::string, std::string> properties;
-    auto res =
-            io::HdfsFileSystem::create(properties, "hdfs://namenode:8020", "test_id", nullptr, "/");
+    auto res = io::HdfsFileSystem::create(properties, "hdfs://namenode:8020", "test_id", "/");
     EXPECT_FALSE(res.has_value());
     config::enable_java_support = true;
 }
@@ -170,7 +169,7 @@ TEST(HdfsFileSystemTest, CreateFailsWhenJavaSupportDisabled) {
 // open_file_internal returns IOError when _fs_handler is null.
 TEST(HdfsFileSystemTest, OpenFileFailsWithoutHandler) {
     THdfsParams params;
-    io::HdfsFileSystem fs(params, "hdfs://namenode:8020", "test_id", nullptr, "/");
+    io::HdfsFileSystem fs(params, "hdfs://namenode:8020", "test_id", "/");
     io::FileReaderSPtr reader;
     auto st = fs.open_file_internal("/test/file.parquet", &reader, io::FileReaderOptions::DEFAULT);
     ASSERT_FALSE(st.ok());
@@ -180,7 +179,7 @@ TEST(HdfsFileSystemTest, OpenFileFailsWithoutHandler) {
 // file_size_impl returns IOError when _fs_handler is null.
 TEST(HdfsFileSystemTest, FileSizeFailsWithoutHandler) {
     THdfsParams params;
-    io::HdfsFileSystem fs(params, "hdfs://namenode:8020", "test_id", nullptr, "/");
+    io::HdfsFileSystem fs(params, "hdfs://namenode:8020", "test_id", "/");
     int64_t file_size = 0;
     auto st = fs.file_size_impl("/test/file.parquet", &file_size);
     ASSERT_FALSE(st.ok());
@@ -190,7 +189,7 @@ TEST(HdfsFileSystemTest, FileSizeFailsWithoutHandler) {
 // exists_impl returns IOError when _fs_handler is null.
 TEST(HdfsFileSystemTest, ExistsFailsWithoutHandler) {
     THdfsParams params;
-    io::HdfsFileSystem fs(params, "hdfs://namenode:8020", "test_id", nullptr, "/");
+    io::HdfsFileSystem fs(params, "hdfs://namenode:8020", "test_id", "/");
     bool exists = false;
     auto st = fs.exists_impl("/test/file.parquet", &exists);
     ASSERT_FALSE(st.ok());
@@ -200,7 +199,7 @@ TEST(HdfsFileSystemTest, ExistsFailsWithoutHandler) {
 // create_directory_impl returns IOError when _fs_handler is null.
 TEST(HdfsFileSystemTest, CreateDirectoryFailsWithoutHandler) {
     THdfsParams params;
-    io::HdfsFileSystem fs(params, "hdfs://namenode:8020", "test_id", nullptr, "/");
+    io::HdfsFileSystem fs(params, "hdfs://namenode:8020", "test_id", "/");
     auto st = fs.create_directory_impl("/test/dir", false);
     ASSERT_FALSE(st.ok());
     EXPECT_EQ(st.code(), TStatusCode::IO_ERROR);
@@ -209,7 +208,7 @@ TEST(HdfsFileSystemTest, CreateDirectoryFailsWithoutHandler) {
 // rename_impl returns IOError when _fs_handler is null.
 TEST(HdfsFileSystemTest, RenameFailsWithoutHandler) {
     THdfsParams params;
-    io::HdfsFileSystem fs(params, "hdfs://namenode:8020", "test_id", nullptr, "/");
+    io::HdfsFileSystem fs(params, "hdfs://namenode:8020", "test_id", "/");
     auto st = fs.rename_impl("/test/old.parquet", "/test/new.parquet");
     ASSERT_FALSE(st.ok());
     EXPECT_EQ(st.code(), TStatusCode::IO_ERROR);

--- a/be/test/io/fs/hdfs_file_system_test.cpp
+++ b/be/test/io/fs/hdfs_file_system_test.cpp
@@ -25,6 +25,7 @@
 #include "common/config.h"
 #include "cpp/sync_point.h"
 #include "gen_cpp/PlanNodes_types.h"
+#include "gen_cpp/Status_types.h"
 #include "io/fs/file_reader.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/hdfs_file_writer.h"

--- a/be/test/io/fs/hdfs_file_system_test.cpp
+++ b/be/test/io/fs/hdfs_file_system_test.cpp
@@ -15,10 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include "io/fs/hdfs_file_system.h"
+
 #include <gtest/gtest.h>
+
+#include <map>
+#include <string>
 
 #include "common/config.h"
 #include "cpp/sync_point.h"
+#include "gen_cpp/PlanNodes_types.h"
 #include "io/fs/file_reader.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/hdfs_file_writer.h"
@@ -149,6 +155,64 @@ TEST(HdfsFileSystemTest, Write) {
     // TODO(plat1ko): Check cached content
 
     st = local_fs->delete_directory(test_dir);
+}
+
+// create() returns error when java support is disabled.
+TEST(HdfsFileSystemTest, CreateFailsWhenJavaSupportDisabled) {
+    config::enable_java_support = false;
+    std::map<std::string, std::string> properties;
+    auto res =
+            io::HdfsFileSystem::create(properties, "hdfs://namenode:8020", "test_id", nullptr, "/");
+    EXPECT_FALSE(res.has_value());
+    config::enable_java_support = true;
+}
+
+// open_file_internal returns IOError when _fs_handler is null.
+TEST(HdfsFileSystemTest, OpenFileFailsWithoutHandler) {
+    THdfsParams params;
+    io::HdfsFileSystem fs(params, "hdfs://namenode:8020", "test_id", nullptr, "/");
+    io::FileReaderSPtr reader;
+    auto st = fs.open_file_internal("/test/file.parquet", &reader, io::FileReaderOptions::DEFAULT);
+    ASSERT_FALSE(st.ok());
+    EXPECT_EQ(st.code(), TStatusCode::IO_ERROR);
+}
+
+// file_size_impl returns IOError when _fs_handler is null.
+TEST(HdfsFileSystemTest, FileSizeFailsWithoutHandler) {
+    THdfsParams params;
+    io::HdfsFileSystem fs(params, "hdfs://namenode:8020", "test_id", nullptr, "/");
+    int64_t file_size = 0;
+    auto st = fs.file_size_impl("/test/file.parquet", &file_size);
+    ASSERT_FALSE(st.ok());
+    EXPECT_EQ(st.code(), TStatusCode::IO_ERROR);
+}
+
+// exists_impl returns IOError when _fs_handler is null.
+TEST(HdfsFileSystemTest, ExistsFailsWithoutHandler) {
+    THdfsParams params;
+    io::HdfsFileSystem fs(params, "hdfs://namenode:8020", "test_id", nullptr, "/");
+    bool exists = false;
+    auto st = fs.exists_impl("/test/file.parquet", &exists);
+    ASSERT_FALSE(st.ok());
+    EXPECT_EQ(st.code(), TStatusCode::IO_ERROR);
+}
+
+// create_directory_impl returns IOError when _fs_handler is null.
+TEST(HdfsFileSystemTest, CreateDirectoryFailsWithoutHandler) {
+    THdfsParams params;
+    io::HdfsFileSystem fs(params, "hdfs://namenode:8020", "test_id", nullptr, "/");
+    auto st = fs.create_directory_impl("/test/dir", false);
+    ASSERT_FALSE(st.ok());
+    EXPECT_EQ(st.code(), TStatusCode::IO_ERROR);
+}
+
+// rename_impl returns IOError when _fs_handler is null.
+TEST(HdfsFileSystemTest, RenameFailsWithoutHandler) {
+    THdfsParams params;
+    io::HdfsFileSystem fs(params, "hdfs://namenode:8020", "test_id", nullptr, "/");
+    auto st = fs.rename_impl("/test/old.parquet", "/test/new.parquet");
+    ASSERT_FALSE(st.ok());
+    EXPECT_EQ(st.code(), TStatusCode::IO_ERROR);
 }
 
 } // namespace doris

--- a/be/test/io/fs/hdfs_file_system_test.cpp
+++ b/be/test/io/fs/hdfs_file_system_test.cpp
@@ -159,6 +159,8 @@ TEST(HdfsFileSystemTest, Write) {
     st = local_fs->delete_directory(test_dir);
 }
 
+// Guarded: the enable_java_support check is compiled out on libhdfs3 builds.
+#ifdef USE_HADOOP_HDFS
 // create() returns error when java support is disabled.
 TEST(HdfsFileSystemTest, CreateFailsWhenJavaSupportDisabled) {
     const bool old_enable_java_support = config::enable_java_support;
@@ -169,6 +171,7 @@ TEST(HdfsFileSystemTest, CreateFailsWhenJavaSupportDisabled) {
     ASSERT_FALSE(res.has_value());
     EXPECT_NE(res.error().to_string().find("enable_java_support"), std::string::npos);
 }
+#endif
 
 // open_file_internal returns IOError when _fs_handler is null.
 TEST(HdfsFileSystemTest, OpenFileFailsWithoutHandler) {

--- a/be/test/io/fs/hdfs_file_system_test.cpp
+++ b/be/test/io/fs/hdfs_file_system_test.cpp
@@ -30,6 +30,7 @@
 #include "io/fs/file_writer.h"
 #include "io/fs/hdfs_file_writer.h"
 #include "io/fs/local_file_system.h"
+#include "util/defer_op.h"
 
 namespace doris {
 
@@ -160,11 +161,13 @@ TEST(HdfsFileSystemTest, Write) {
 
 // create() returns error when java support is disabled.
 TEST(HdfsFileSystemTest, CreateFailsWhenJavaSupportDisabled) {
+    const bool old_enable_java_support = config::enable_java_support;
     config::enable_java_support = false;
+    Defer defer {[&]() { config::enable_java_support = old_enable_java_support; }};
     std::map<std::string, std::string> properties;
     auto res = io::HdfsFileSystem::create(properties, "hdfs://namenode:8020", "test_id", "/");
-    EXPECT_FALSE(res.has_value());
-    config::enable_java_support = true;
+    ASSERT_FALSE(res.has_value());
+    EXPECT_NE(res.error().to_string().find("enable_java_support"), std::string::npos);
 }
 
 // open_file_internal returns IOError when _fs_handler is null.

--- a/be/test/storage/index/snii/snii_blob_directory_test.cpp
+++ b/be/test/storage/index/snii/snii_blob_directory_test.cpp
@@ -31,8 +31,6 @@
 #include <CLucene/store/IndexInput.h>
 #include <gtest/gtest.h>
 
-#include <errno.h>
-
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>

--- a/be/test/storage/index/snii/snii_blob_directory_test.cpp
+++ b/be/test/storage/index/snii/snii_blob_directory_test.cpp
@@ -31,6 +31,8 @@
 #include <CLucene/store/IndexInput.h>
 #include <gtest/gtest.h>
 
+#include <errno.h>
+
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
@@ -39,10 +41,13 @@
 #include <string>
 #include <vector>
 
+#include "common/config.h"
 #include "common/status.h"
 #include "io/fs/local_file_system.h"
 #include "storage/index/snii/format/metadata_directory.h"
 #include "storage/index/snii/snii_doris_adapter.h"
+#include "util/debug_points.h"
+#include "util/defer_op.h"
 
 using doris::Status;
 using doris::segment_v2::snii_doris::DorisSniiFileReader;
@@ -207,6 +212,39 @@ TEST(SniiBlobDirectory, MissingFileFailsWithoutThrowing) {
     EXPECT_FALSE(fx.dir->openInput("nope", raw, err));
     EXPECT_EQ(nullptr, raw);
     EXPECT_EQ(CL_ERR_IO, err.number());
+}
+
+// A read-stage NotFound must surface as CL_ERR_FileNotFound, not collapse into CL_ERR_IO.
+TEST(SniiBlobDirectory, ReadFailureKeepsNotFoundDistinguishable) {
+    Fixture fx;
+    fx.Build();
+    ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+    const auto old_enable = doris::config::enable_debug_points;
+    doris::config::enable_debug_points = true;
+    const std::string point = "LocalFileReader::read_at_impl.io_error";
+    doris::DebugPoints::instance()->add_with_params(
+            point, {{"errno", std::to_string(ENOENT)}, {"sub_path", "snii_blob_dir_test"}});
+    doris::Defer dp {[&]() {
+        doris::DebugPoints::instance()->remove(point);
+        doris::config::enable_debug_points = old_enable;
+    }};
+
+    lucene::store::IndexInput* raw = nullptr;
+    CLuceneError err;
+    ASSERT_TRUE(fx.dir->openInput("a", raw, err));
+    std::unique_ptr<lucene::store::IndexInput> input(raw);
+
+    std::vector<uint8_t> got(fx.payload_a.size(), 0);
+    bool threw = false;
+    try {
+        input->readBytes(got.data(), static_cast<int32_t>(got.size()));
+    } catch (CLuceneError& e) {
+        threw = true;
+        EXPECT_EQ(CL_ERR_FileNotFound, e.number());
+    }
+    EXPECT_TRUE(threw);
+    input->close();
 }
 
 TEST(SniiBlobDirectory, WriteOperationsThrowUnsupportedAndCloseNeverThrows) {

--- a/be/test/storage/segment/inverted_index_file_reader_test.cpp
+++ b/be/test/storage/segment/inverted_index_file_reader_test.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <CLucene.h>
+#include <errno.h>
 #include <gtest/gtest.h>
 #include <unistd.h>
 
@@ -24,6 +25,7 @@
 #include <string>
 #include <vector>
 
+#include "common/config.h"
 #include "io/fs/local_file_system.h"
 #include "runtime/exec_env.h"
 #include "storage/data_dir.h"
@@ -39,6 +41,7 @@
 #include "storage/options.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet/tablet_schema.h"
+#include "util/debug_points.h"
 
 namespace doris::segment_v2 {
 
@@ -295,6 +298,30 @@ TEST_F(InvertedIndexFileReaderTest, TestUnknownIndexFormatError) {
     // since reading invalid data may trigger CLucene exceptions
     EXPECT_TRUE(status.msg().find("unknown inverted index format") != std::string::npos ||
                 status.msg().find("CLuceneError") != std::string::npos);
+}
+
+// A read-stage NotFound must surface as INVERTED_INDEX_FILE_NOT_FOUND so callers can downgrade.
+TEST_F(InvertedIndexFileReaderTest, TestV2ReadNotFoundReturnsFileNotFound) {
+    std::string index_path = kTestDir + "/read_not_found_index_file";
+    create_invalid_version_file(index_path + ".idx", 1);
+
+    InvertedIndexFileInfo file_info;
+    file_info.set_index_size(1024); // size known: init() skips stat, open succeeds
+
+    IndexFileReader reader(io::global_local_filesystem(), index_path,
+                           InvertedIndexStorageFormatPB::V2, file_info);
+
+    const auto old_enable = config::enable_debug_points;
+    config::enable_debug_points = true;
+    const std::string point = "LocalFileReader::read_at_impl.io_error";
+    DebugPoints::instance()->add_with_params(
+            point, {{"errno", std::to_string(ENOENT)}, {"sub_path", "read_not_found"}});
+    Status status = reader.init(4096);
+    DebugPoints::instance()->remove(point);
+    config::enable_debug_points = old_enable;
+
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code(), ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND);
 }
 
 // Test case for V1 format file not found error

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergScanPlanProvider.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergScanPlanProvider.java
@@ -1746,13 +1746,13 @@ public class IcebergScanPlanProvider implements ConnectorScanPlanProvider {
                 validateDeletionVectorMetadata(
                         delete.path().toString(), delete.fileSizeInBytes(), contentOffset, contentLength);
                 return IcebergScanRange.DeleteFile.deletionVector(path, lowerBound, upperBound,
-                        contentOffset, contentLength);
+                        contentOffset, contentLength, delete.fileSizeInBytes());
             }
             return IcebergScanRange.DeleteFile.positionDelete(path, deleteFileFormat(delete.format()),
-                    lowerBound, upperBound);
+                    lowerBound, upperBound, delete.fileSizeInBytes());
         } else if (content == FileContent.EQUALITY_DELETES) {
             return IcebergScanRange.DeleteFile.equalityDelete(path, deleteFileFormat(delete.format()),
-                    delete.equalityFieldIds());
+                    delete.equalityFieldIds(), delete.fileSizeInBytes());
         }
         // Defensive (legacy parity): delete files are only position or equality; DATA content here is a bug.
         throw new IllegalStateException("Unknown delete content: " + content);

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergScanRange.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergScanRange.java
@@ -631,9 +631,11 @@ public class IcebergScanRange implements ConnectorScanRange {
         // deletion vector only (null otherwise).
         private final Long contentOffset;
         private final Long contentSizeInBytes;
+        private final long fileSize;
 
         private DeleteFile(String path, int content, TFileFormatType fileFormat, Long positionLowerBound,
-                Long positionUpperBound, List<Integer> fieldIds, Long contentOffset, Long contentSizeInBytes) {
+                Long positionUpperBound, List<Integer> fieldIds, Long contentOffset, Long contentSizeInBytes,
+                long fileSize) {
             this.path = path;
             this.content = content;
             this.fileFormat = fileFormat;
@@ -642,13 +644,14 @@ public class IcebergScanRange implements ConnectorScanRange {
             this.fieldIds = fieldIds != null ? Collections.unmodifiableList(new ArrayList<>(fieldIds)) : null;
             this.contentOffset = contentOffset;
             this.contentSizeInBytes = contentSizeInBytes;
+            this.fileSize = fileSize;
         }
 
         /** A position delete file (content 1): row positions to drop, with optional [lower,upper] bounds. */
         public static DeleteFile positionDelete(String path, TFileFormatType fileFormat,
-                Long positionLowerBound, Long positionUpperBound) {
+                Long positionLowerBound, Long positionUpperBound, long fileSize) {
             return new DeleteFile(path, CONTENT_POSITION_DELETE, fileFormat,
-                    positionLowerBound, positionUpperBound, null, null, null);
+                    positionLowerBound, positionUpperBound, null, null, null, fileSize);
         }
 
         /**
@@ -657,14 +660,16 @@ public class IcebergScanRange implements ConnectorScanRange {
          * bounds (legacy {@code DeletionVector extends PositionDelete}); {@code file_format} stays unset.
          */
         public static DeleteFile deletionVector(String path, Long positionLowerBound, Long positionUpperBound,
-                long contentOffset, long contentSizeInBytes) {
+                long contentOffset, long contentSizeInBytes, long fileSize) {
             return new DeleteFile(path, CONTENT_DELETION_VECTOR, null,
-                    positionLowerBound, positionUpperBound, null, contentOffset, contentSizeInBytes);
+                    positionLowerBound, positionUpperBound, null, contentOffset, contentSizeInBytes, fileSize);
         }
 
         /** An equality delete file (content 2): rows equal on {@code fieldIds} are dropped (BE re-projects). */
-        public static DeleteFile equalityDelete(String path, TFileFormatType fileFormat, List<Integer> fieldIds) {
-            return new DeleteFile(path, CONTENT_EQUALITY_DELETE, fileFormat, null, null, fieldIds, null, null);
+        public static DeleteFile equalityDelete(String path, TFileFormatType fileFormat, List<Integer> fieldIds,
+                long fileSize) {
+            return new DeleteFile(path, CONTENT_EQUALITY_DELETE, fileFormat, null, null,
+                    fieldIds, null, null, fileSize);
         }
 
         int getContent() {
@@ -693,6 +698,7 @@ public class IcebergScanRange implements ConnectorScanRange {
                 desc.setContentSizeInBytes(contentSizeInBytes);
             }
             desc.setContent(content);
+            desc.setFileSize(fileSize);
             return desc;
         }
     }

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergScanRange.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergScanRange.java
@@ -348,6 +348,9 @@ public class IcebergScanRange implements ConnectorScanRange {
             deleteFileDesc.setOriginalPath(positionDeleteOriginalPath);
             deleteFileDesc.setFileFormat(positionDeleteFileFormat);
             deleteFileDesc.setContent(positionDeleteContent);
+            if (rangeDesc.isSetFileSize()) {
+                deleteFileDesc.setFileSize(rangeDesc.getFileSize());
+            }
             if (positionDeleteContentOffset != null) {
                 deleteFileDesc.setContentOffset(positionDeleteContentOffset);
             }

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanPlanProviderTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanPlanProviderTest.java
@@ -4295,14 +4295,11 @@ public class IcebergScanPlanProviderTest {
 
     @Test
     public void deleteFileSizePropagatedFromIcebergManifest() {
-        // E2E: iceberg DeleteFile.fileSizeInBytes (482) → IcebergScanPlanProvider →
-        // IcebergScanRange.DeleteFile.fileSize → toThrift → TIcebergDeleteFileDesc.file_size
         Table table = createTable("t_filesize", SCHEMA, PartitionSpec.unpartitioned(),
                 Collections.singletonMap("format-version", "2"));
         table.newAppend()
                 .appendFile(dataFile(table.spec(), "s3://b/db/t_filesize/f1.parquet", 512, null, null))
                 .commit();
-        // Position delete with fileSizeInBytes=128 (rewritableDeleteDescs includes position deletes)
         DeleteFile posDelete = FileMetadata.deleteFileBuilder(table.spec())
                 .ofPositionDeletes()
                 .withPath("s3://b/db/t_filesize/pos-delete.parquet")
@@ -4322,9 +4319,6 @@ public class IcebergScanPlanProviderTest {
         Assertions.assertEquals(1, ranges.size());
         IcebergScanRange range = (IcebergScanRange) ranges.get(0);
 
-        // Use rewritableDeleteDescs() (returns TIcebergDeleteFileDesc via toThrift)
-        // to verify file_size propagated from iceberg manifest → DeleteFile → toThrift.
-        // Note: equality deletes are excluded from rewritableDeleteDescs, so use position delete instead.
         List<TIcebergDeleteFileDesc> descs = range.rewritableDeleteDescs();
         Assertions.assertFalse(descs.isEmpty());
         TIcebergDeleteFileDesc desc = descs.get(0);

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanPlanProviderTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanPlanProviderTest.java
@@ -4292,4 +4292,43 @@ public class IcebergScanPlanProviderTest {
             throw new UnsupportedOperationException();
         }
     }
+
+    @Test
+    public void deleteFileSizePropagatedFromIcebergManifest() {
+        // E2E: iceberg DeleteFile.fileSizeInBytes (482) → IcebergScanPlanProvider →
+        // IcebergScanRange.DeleteFile.fileSize → toThrift → TIcebergDeleteFileDesc.file_size
+        Table table = createTable("t_filesize", SCHEMA, PartitionSpec.unpartitioned(),
+                Collections.singletonMap("format-version", "2"));
+        table.newAppend()
+                .appendFile(dataFile(table.spec(), "s3://b/db/t_filesize/f1.parquet", 512, null, null))
+                .commit();
+        // Position delete with fileSizeInBytes=128 (rewritableDeleteDescs includes position deletes)
+        DeleteFile posDelete = FileMetadata.deleteFileBuilder(table.spec())
+                .ofPositionDeletes()
+                .withPath("s3://b/db/t_filesize/pos-delete.parquet")
+                .withFormat(FileFormat.PARQUET)
+                .withFileSizeInBytes(128L)
+                .withRecordCount(1L)
+                .build();
+        table.newRowDelta().addDeletes(posDelete).commit();
+
+        IcebergScanPlanProvider provider = new IcebergScanPlanProvider(
+                IcebergCatalogProperties.of(Collections.emptyMap()), opsReturning(table));
+        List<ConnectorScanRange> ranges = provider.planScan(
+                new FakeScanSession("UTC", Collections.emptyMap()),
+                ConnectorScanRequest.builder(new IcebergTableHandle("db1", "t_filesize"), Collections.emptyList())
+                        .build());
+
+        Assertions.assertEquals(1, ranges.size());
+        IcebergScanRange range = (IcebergScanRange) ranges.get(0);
+
+        // Use rewritableDeleteDescs() (returns TIcebergDeleteFileDesc via toThrift)
+        // to verify file_size propagated from iceberg manifest → DeleteFile → toThrift.
+        // Note: equality deletes are excluded from rewritableDeleteDescs, so use position delete instead.
+        List<TIcebergDeleteFileDesc> descs = range.rewritableDeleteDescs();
+        Assertions.assertFalse(descs.isEmpty());
+        TIcebergDeleteFileDesc desc = descs.get(0);
+        Assertions.assertTrue(desc.isSetFileSize());
+        Assertions.assertEquals(128L, desc.getFileSize());
+    }
 }

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanPlanProviderTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanPlanProviderTest.java
@@ -4325,4 +4325,79 @@ public class IcebergScanPlanProviderTest {
         Assertions.assertTrue(desc.isSetFileSize());
         Assertions.assertEquals(128L, desc.getFileSize());
     }
+
+    @Test
+    public void deletionVectorFileSizePropagatedFromIcebergManifest() {
+        Table table = createTable("t_dv_filesize", SCHEMA, PartitionSpec.unpartitioned(),
+                Collections.singletonMap("format-version", "3"));
+        table.newAppend()
+                .appendFile(dataFile(table.spec(), "s3://b/db/t_dv_filesize/f1.parquet", 512, null, null))
+                .commit();
+        DeleteFile dvDelete = FileMetadata.deleteFileBuilder(table.spec())
+                .ofPositionDeletes()
+                .withPath("s3://b/db/t_dv_filesize/dv.puffin")
+                .withFormat(FileFormat.PUFFIN)
+                .withFileSizeInBytes(256L)
+                .withRecordCount(1L)
+                .withContentOffset(16L)
+                .withContentSizeInBytes(64L)
+                .withReferencedDataFile("s3://b/db/t_dv_filesize/f1.parquet")
+                .build();
+        table.newRowDelta().addDeletes(dvDelete).commit();
+
+        IcebergScanPlanProvider provider = new IcebergScanPlanProvider(
+                IcebergCatalogProperties.of(Collections.emptyMap()), opsReturning(table));
+        List<ConnectorScanRange> ranges = provider.planScan(
+                new FakeScanSession("UTC", Collections.emptyMap()),
+                ConnectorScanRequest.builder(new IcebergTableHandle("db1", "t_dv_filesize"), Collections.emptyList())
+                        .build());
+
+        Assertions.assertEquals(1, ranges.size());
+        IcebergScanRange range = (IcebergScanRange) ranges.get(0);
+
+        List<TIcebergDeleteFileDesc> descs = range.rewritableDeleteDescs();
+        Assertions.assertFalse(descs.isEmpty());
+        TIcebergDeleteFileDesc desc = descs.get(0);
+        Assertions.assertEquals(3, desc.getContent());
+        Assertions.assertTrue(desc.isSetFileSize());
+        Assertions.assertEquals(256L, desc.getFileSize());
+    }
+
+    @Test
+    public void equalityDeleteFileSizePropagatedFromIcebergManifest() {
+        Table table = createTable("t_eq_filesize", SCHEMA, PartitionSpec.unpartitioned(),
+                Collections.singletonMap("format-version", "2"));
+        table.newAppend()
+                .appendFile(dataFile(table.spec(), "s3://b/db/t_eq_filesize/f1.parquet", 512, null, null))
+                .commit();
+        DeleteFile eqDelete = FileMetadata.deleteFileBuilder(table.spec())
+                .ofEqualityDeletes(1)
+                .withPath("s3://b/db/t_eq_filesize/eq.parquet")
+                .withFormat(FileFormat.PARQUET)
+                .withFileSizeInBytes(96L)
+                .withRecordCount(1L)
+                .build();
+        table.newRowDelta().addDeletes(eqDelete).commit();
+
+        IcebergScanPlanProvider provider = new IcebergScanPlanProvider(
+                IcebergCatalogProperties.of(Collections.emptyMap()), opsReturning(table));
+        List<ConnectorScanRange> ranges = provider.planScan(
+                new FakeScanSession("UTC", Collections.emptyMap()),
+                ConnectorScanRequest.builder(new IcebergTableHandle("db1", "t_eq_filesize"), Collections.emptyList())
+                        .build());
+
+        Assertions.assertEquals(1, ranges.size());
+        IcebergScanRange range = (IcebergScanRange) ranges.get(0);
+
+        // equality deletes are excluded from rewritableDeleteDescs; verify via populateRangeParams
+        TFileRangeDesc rangeDesc = new TFileRangeDesc();
+        TTableFormatFileDesc formatDesc = new TTableFormatFileDesc();
+        range.populateRangeParams(formatDesc, rangeDesc);
+        List<TIcebergDeleteFileDesc> descs = formatDesc.getIcebergParams().getDeleteFiles();
+        Assertions.assertFalse(descs.isEmpty());
+        TIcebergDeleteFileDesc desc = descs.get(0);
+        Assertions.assertEquals(2, desc.getContent());
+        Assertions.assertTrue(desc.isSetFileSize());
+        Assertions.assertEquals(96L, desc.getFileSize());
+    }
 }

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanRangeTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanRangeTest.java
@@ -191,7 +191,7 @@ public class IcebergScanRangeTest {
         // A position delete (content 1) with parquet format + [lower,upper] bounds. MUTATION: dropping the
         // bounds, wrong content id, or wrong format -> red.
         IcebergScanRange.DeleteFile posDelete = IcebergScanRange.DeleteFile.positionDelete(
-                "s3://b/db/t/pos-delete.parquet", TFileFormatType.FORMAT_PARQUET, 10L, 99L);
+                "s3://b/db/t/pos-delete.parquet", TFileFormatType.FORMAT_PARQUET, 10L, 99L, 100L);
         IcebergScanRange range = new IcebergScanRange.Builder()
                 .path("s3://b/db/t/f.parquet").fileFormat("parquet").formatVersion(2)
                 .deleteFiles(Collections.singletonList(posDelete)).build();
@@ -218,7 +218,7 @@ public class IcebergScanRangeTest {
         // No bounds present -> position_lower/upper_bound left UNSET (legacy emits them only when present).
         // MUTATION: defaulting an absent bound to 0 / -1 instead of unset -> red.
         IcebergScanRange.DeleteFile posDelete = IcebergScanRange.DeleteFile.positionDelete(
-                "s3://b/db/t/pos-delete.orc", TFileFormatType.FORMAT_ORC, null, null);
+                "s3://b/db/t/pos-delete.orc", TFileFormatType.FORMAT_ORC, null, null, 100L);
         IcebergScanRange range = new IcebergScanRange.Builder()
                 .path("s3://b/db/t/f.parquet").fileFormat("parquet").formatVersion(2)
                 .deleteFiles(Collections.singletonList(posDelete)).build();
@@ -236,9 +236,9 @@ public class IcebergScanRangeTest {
         // A deletion vector (content 3, PUFFIN): blob content_offset/size set, file_format UNSET, bounds
         // carried (it IS a position delete). An equality delete (content 2): field-ids set, no bounds/blob.
         IcebergScanRange.DeleteFile dv = IcebergScanRange.DeleteFile.deletionVector(
-                "s3://b/db/t/dv.puffin", 5L, 42L, 16L, 64L);
+                "s3://b/db/t/dv.puffin", 5L, 42L, 16L, 64L, 100L);
         IcebergScanRange.DeleteFile eq = IcebergScanRange.DeleteFile.equalityDelete(
-                "s3://b/db/t/eq-delete.parquet", TFileFormatType.FORMAT_PARQUET, Arrays.asList(3, 7));
+                "s3://b/db/t/eq-delete.parquet", TFileFormatType.FORMAT_PARQUET, Arrays.asList(3, 7), 100L);
         IcebergScanRange range = new IcebergScanRange.Builder()
                 .path("s3://b/db/t/f.parquet").fileFormat("parquet").formatVersion(2)
                 .deleteFiles(Arrays.asList(dv, eq)).build();
@@ -467,11 +467,11 @@ public class IcebergScanRangeTest {
         // rewritten, so they MUST be excluded (mirrors legacy deleteFilesDescByReferencedDataFile). MUTATION:
         // including the equality delete -> the BE would treat equality rows as positions / over-delete.
         IcebergScanRange.DeleteFile dv = IcebergScanRange.DeleteFile.deletionVector(
-                "s3://b/db/t/dv.puffin", 5L, 42L, 16L, 64L);
+                "s3://b/db/t/dv.puffin", 5L, 42L, 16L, 64L, 100L);
         IcebergScanRange.DeleteFile pos = IcebergScanRange.DeleteFile.positionDelete(
-                "s3://b/db/t/pos.parquet", TFileFormatType.FORMAT_PARQUET, 1L, 9L);
+                "s3://b/db/t/pos.parquet", TFileFormatType.FORMAT_PARQUET, 1L, 9L, 100L);
         IcebergScanRange.DeleteFile eq = IcebergScanRange.DeleteFile.equalityDelete(
-                "s3://b/db/t/eq.parquet", TFileFormatType.FORMAT_PARQUET, Arrays.asList(3, 7));
+                "s3://b/db/t/eq.parquet", TFileFormatType.FORMAT_PARQUET, Arrays.asList(3, 7), 100L);
         IcebergScanRange range = new IcebergScanRange.Builder()
                 .path("s3://b/db/t/f.parquet").fileFormat("parquet").formatVersion(3)
                 .deleteFiles(Arrays.asList(dv, pos, eq)).build();
@@ -495,10 +495,34 @@ public class IcebergScanRangeTest {
         Assertions.assertTrue(none.rewritableDeleteDescs().isEmpty());
 
         IcebergScanRange.DeleteFile eq = IcebergScanRange.DeleteFile.equalityDelete(
-                "s3://b/db/t/eq.parquet", TFileFormatType.FORMAT_PARQUET, Arrays.asList(3));
+                "s3://b/db/t/eq.parquet", TFileFormatType.FORMAT_PARQUET, Arrays.asList(3), 100L);
         IcebergScanRange onlyEq = new IcebergScanRange.Builder()
                 .path("s3://b/db/t/f.parquet").fileFormat("parquet").formatVersion(3)
                 .deleteFiles(Collections.singletonList(eq)).build();
         Assertions.assertTrue(onlyEq.rewritableDeleteDescs().isEmpty());
+    }
+
+    @Test
+    public void deleteFileToThriftPropagatesFileSize() {
+        // Equality delete
+        IcebergScanRange.DeleteFile eq = IcebergScanRange.DeleteFile.equalityDelete(
+                "s3://b/db/t/eq.parquet", TFileFormatType.FORMAT_PARQUET, Arrays.asList(1), 482L);
+        TIcebergDeleteFileDesc eqDesc = eq.toThrift();
+        Assertions.assertTrue(eqDesc.isSetFileSize());
+        Assertions.assertEquals(482L, eqDesc.getFileSize());
+
+        // Position delete
+        IcebergScanRange.DeleteFile pos = IcebergScanRange.DeleteFile.positionDelete(
+                "s3://b/db/t/pos.parquet", TFileFormatType.FORMAT_PARQUET, 10L, 99L, 735L);
+        TIcebergDeleteFileDesc posDesc = pos.toThrift();
+        Assertions.assertTrue(posDesc.isSetFileSize());
+        Assertions.assertEquals(735L, posDesc.getFileSize());
+
+        // Deletion vector
+        IcebergScanRange.DeleteFile dv = IcebergScanRange.DeleteFile.deletionVector(
+                "s3://b/db/t/dv.puffin", 5L, 42L, 16L, 64L, 1000L);
+        TIcebergDeleteFileDesc dvDesc = dv.toThrift();
+        Assertions.assertTrue(dvDesc.isSetFileSize());
+        Assertions.assertEquals(1000L, dvDesc.getFileSize());
     }
 }

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanRangeTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanRangeTest.java
@@ -207,6 +207,9 @@ public class IcebergScanRangeTest {
         Assertions.assertEquals(10L, d.getPositionLowerBound());
         Assertions.assertTrue(d.isSetPositionUpperBound());
         Assertions.assertEquals(99L, d.getPositionUpperBound());
+        // file_size is propagated from DeleteFile to TIcebergDeleteFileDesc.
+        Assertions.assertTrue(d.isSetFileSize());
+        Assertions.assertEquals(100L, d.getFileSize());
         // A position delete carries neither equality field-ids nor a deletion-vector blob ref.
         Assertions.assertFalse(d.isSetFieldIds());
         Assertions.assertFalse(d.isSetContentOffset());
@@ -255,6 +258,8 @@ public class IcebergScanRangeTest {
         Assertions.assertEquals(64L, dvDesc.getContentSizeInBytes());
         Assertions.assertEquals(5L, dvDesc.getPositionLowerBound());
         Assertions.assertEquals(42L, dvDesc.getPositionUpperBound());
+        Assertions.assertTrue(dvDesc.isSetFileSize());
+        Assertions.assertEquals(100L, dvDesc.getFileSize());
 
         TIcebergDeleteFileDesc eqDesc = deletes.get(1);
         Assertions.assertEquals(2, eqDesc.getContent());
@@ -262,6 +267,8 @@ public class IcebergScanRangeTest {
         Assertions.assertEquals(TFileFormatType.FORMAT_PARQUET, eqDesc.getFileFormat());
         Assertions.assertFalse(eqDesc.isSetContentOffset());
         Assertions.assertFalse(eqDesc.isSetPositionLowerBound());
+        Assertions.assertTrue(eqDesc.isSetFileSize());
+        Assertions.assertEquals(100L, eqDesc.getFileSize());
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanRangeTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergScanRangeTest.java
@@ -453,6 +453,31 @@ public class IcebergScanRangeTest {
         Assertions.assertFalse(rangeDesc.isSetColumnsFromPath());
     }
 
+    @Test
+    public void populateRangeParamsSysTableForwardsDeleteFileSize() {
+        // The sys-table delete descriptor must forward the range's file_size; BE keys on delete_files[0].file_size.
+        IcebergScanRange range = new IcebergScanRange.Builder()
+                .path("/puffin/delete-file.puffin")
+                .positionDeleteSysTableSplit(3, TFileFormatType.FORMAT_PARQUET, "/raw/delete.puffin")
+                .positionDeleteDeletionVector("/data/file.parquet", 4L, 100L)
+                .build();
+
+        TFileRangeDesc rangeDesc = new TFileRangeDesc();
+        rangeDesc.setFileSize(12345L);
+        populate(range, rangeDesc);
+
+        TIcebergFileDesc fd = rangeDesc.getTableFormatParams().getIcebergParams();
+        Assertions.assertTrue(fd.isSetDeleteFiles());
+        Assertions.assertEquals(1, fd.getDeleteFilesSize());
+        Assertions.assertEquals(12345L, fd.getDeleteFiles().get(0).getFileSize());
+
+        // isSet guard: an unset range size must not emit file_size on the delete descriptor.
+        TFileRangeDesc unsetDesc = populate(range, new TFileRangeDesc());
+        Assertions.assertFalse(
+                unsetDesc.getTableFormatParams().getIcebergParams().getDeleteFiles().get(0)
+                        .isSetFileSize());
+    }
+
     // ── commit-bridge supply (S4 part 2): getOriginalPath() key + rewritableDeleteDescs() non-equality filter ──
 
     @Test

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -333,6 +333,7 @@ struct TIcebergDeleteFileDesc {
     9: optional string original_path;
     // Referenced data file path. Required to materialize rows from deletion vectors.
     10: optional string referenced_data_file_path;
+    11: optional i64 file_size;
 }
 
 struct TIcebergFileDesc {

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -436,6 +436,13 @@ if [[ -d "${DORIS_TEST_BINARY_DIR}/util/test_data" ]]; then
 fi
 cp -r "${DORIS_HOME}/be/test/util/test_data" "${DORIS_TEST_BINARY_DIR}/util"/
 
+# prepare exec test_data (iceberg delete file tests use ./be/test/exec/test_data/...)
+mkdir -p "${DORIS_TEST_BINARY_DIR}/be/test/exec"
+if [[ -d "${DORIS_TEST_BINARY_DIR}/be/test/exec/test_data" ]]; then
+    rm -rf "${DORIS_TEST_BINARY_DIR}/be/test/exec/test_data"
+fi
+cp -r "${DORIS_HOME}/be/test/exec/test_data" "${DORIS_TEST_BINARY_DIR}/be/test/exec"/
+
 # prepare ut temp dir
 UT_TMP_DIR="${DORIS_HOME}/ut_dir"
 rm -rf "${UT_TMP_DIR}"

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -436,13 +436,6 @@ if [[ -d "${DORIS_TEST_BINARY_DIR}/util/test_data" ]]; then
 fi
 cp -r "${DORIS_HOME}/be/test/util/test_data" "${DORIS_TEST_BINARY_DIR}/util"/
 
-# prepare exec test_data (iceberg delete file tests use ./be/test/exec/test_data/...)
-mkdir -p "${DORIS_TEST_BINARY_DIR}/be/test/exec"
-if [[ -d "${DORIS_TEST_BINARY_DIR}/be/test/exec/test_data" ]]; then
-    rm -rf "${DORIS_TEST_BINARY_DIR}/be/test/exec/test_data"
-fi
-cp -r "${DORIS_HOME}/be/test/exec/test_data" "${DORIS_TEST_BINARY_DIR}/be/test/exec"/
-
 # prepare ut temp dir
 UT_TMP_DIR="${DORIS_HOME}/ut_dir"
 rm -rf "${UT_TMP_DIR}"


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
    When block cache hits, HdfsFileReader still calls hdfsOpenFile on every construction, wasting NameNode RPCs for data that's never read  from HDFS. 

How To Fix：
1. HdfsFileHandle now lazily opens on first read;
2. FE propagates delete file file_size through thrift to BE;

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

