### PR TITLE
[fix](fe) Reject unsupported casts during constant folding

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -36,6 +36,7 @@ import org.apache.doris.nereids.rules.expression.ExpressionRewriteContext;
 import org.apache.doris.nereids.rules.expression.ExpressionRuleType;
 import org.apache.doris.nereids.rules.expression.ExpressionTraverseListener;
 import org.apache.doris.nereids.rules.expression.ExpressionTraverseListenerFactory;
+import org.apache.doris.nereids.rules.expression.check.CheckCast;
 import org.apache.doris.nereids.trees.expressions.AggregateExpression;
 import org.apache.doris.nereids.trees.expressions.And;
 import org.apache.doris.nereids.trees.expressions.BinaryArithmetic;
@@ -501,6 +502,9 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         }
         Expression child = cast.child();
         DataType dataType = cast.getDataType();
+        if (!CheckCast.check(child.getDataType(), dataType, SessionVariable.enableStrictCast())) {
+            return cast;
+        }
         // todo: process other null case
         if (child.isNullLiteral()) {
             return new NullLiteral(dataType);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -503,7 +503,8 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         Expression child = cast.child();
         DataType dataType = cast.getDataType();
         if (!CheckCast.check(child.getDataType(), dataType, SessionVariable.enableStrictCast())) {
-            return cast;
+            throw new AnalysisException("cannot cast " + child.getDataType().toSql()
+                    + " to " + dataType.toSql());
         }
         // todo: process other null case
         if (child.isNullLiteral()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -123,6 +123,7 @@ import org.apache.doris.nereids.types.DecimalV3Type;
 import org.apache.doris.nereids.types.DoubleType;
 import org.apache.doris.nereids.types.FloatType;
 import org.apache.doris.nereids.types.IntegerType;
+import org.apache.doris.nereids.types.TimeStampTzType;
 import org.apache.doris.nereids.types.TinyIntType;
 import org.apache.doris.nereids.types.VarcharType;
 import org.apache.doris.nereids.util.MemoTestUtils;
@@ -276,6 +277,9 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
         Expression rewritten = executor.rewrite(c, context);
         Literal expected = Literal.of((byte) 1);
         Assertions.assertEquals(rewritten, expected);
+
+        Cast unsupportedCast = new Cast(new BigIntLiteral(20240229112233L), TimeStampTzType.of(6));
+        Assertions.assertEquals(unsupportedCast, executor.rewrite(unsupportedCast, context));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -279,7 +279,9 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
         Assertions.assertEquals(rewritten, expected);
 
         Cast unsupportedCast = new Cast(new BigIntLiteral(20240229112233L), TimeStampTzType.of(6));
-        Assertions.assertEquals(unsupportedCast, executor.rewrite(unsupportedCast, context));
+        AnalysisException exception = Assertions.assertThrows(
+                AnalysisException.class, () -> executor.rewrite(unsupportedCast, context));
+        Assertions.assertEquals("cannot cast BIGINT to TIMESTAMPTZ(6)", exception.getMessage());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/check/CheckCastTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/check/CheckCastTest.java
@@ -42,6 +42,7 @@ import org.apache.doris.nereids.types.SmallIntType;
 import org.apache.doris.nereids.types.StringType;
 import org.apache.doris.nereids.types.StructField;
 import org.apache.doris.nereids.types.StructType;
+import org.apache.doris.nereids.types.TimeStampTzType;
 import org.apache.doris.nereids.types.TimeV2Type;
 import org.apache.doris.nereids.types.TinyIntType;
 import org.apache.doris.nereids.types.VarcharType;
@@ -63,6 +64,12 @@ public class CheckCastTest {
 
         Assertions.assertTrue(CheckCast.check(v1Source, v1SameProperties, true));
         Assertions.assertTrue(CheckCast.check(v1Source, v1DifferentProperties, true));
+    }
+
+    @Test
+    public void testCastFromBigIntToTimeStampTz() {
+        Assertions.assertFalse(CheckCast.check(BigIntType.INSTANCE, TimeStampTzType.of(6), true));
+        Assertions.assertFalse(CheckCast.check(BigIntType.INSTANCE, TimeStampTzType.of(6), false));
     }
 
     @Test

--- a/regression-test/suites/datatype_p0/timestamptz/test_timestamptz_cast.groovy
+++ b/regression-test/suites/datatype_p0/timestamptz/test_timestamptz_cast.groovy
@@ -27,6 +27,10 @@ suite("test_timestamptz_cast") {
     qt_cast_from_string1 """
     select cast("2020-01-01 23:59:59.999999+08:00" as timestamptz(5));
     """
+    test {
+        sql """select cast(cast(20240229112233 as bigint) as timestamptz(6));"""
+        exception "cannot cast BIGINT to TIMESTAMPTZ(6)"
+    }
     sql " set debug_skip_fold_constant = true; "
     qt_cast_from_string2 """
     select cast("2020-01-01 00:00:00.123456+08:00" as timestamptz(5));


### PR DESCRIPTION
Problem Summary: FE constant folding could evaluate an unsupported `BIGINT` to `TIMESTAMPTZ` cast before cast validation, producing an incorrect timestamp. This change validates constant casts first and throws an analysis error for unsupported type combinations.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

