### PR TITLE
branch-4.1: [fix](mtmv) reuse Gson instance in MTMVTask.getTvfInfo to avoid Master FE CPU spike

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/job/extensions/mtmv/MTMVTask.java
@@ -97,6 +97,8 @@ public class MTMVTask extends AbstractTask {
     private static final Logger LOG = LogManager.getLogger(MTMVTask.class);
     public static final int DEFAULT_REFRESH_PARTITION_NUM = 1;
 
+    private static final Gson GSON = new Gson();
+
     public static final ImmutableList<Column> SCHEMA = ImmutableList.of(
             new Column("TaskId", ScalarType.createStringType()),
             new Column("JobId", ScalarType.createStringType()),
@@ -544,16 +546,16 @@ public class MTMVTask extends AbstractTask {
                 (super.getFinishTimeMs() == null || super.getFinishTimeMs() == 0) ? FeConstants.null_string
                         : String.valueOf(super.getFinishTimeMs() - super.getStartTimeMs())));
         trow.addToColumnValue(new TCell()
-                .setStringVal(taskContext == null ? FeConstants.null_string : new Gson().toJson(taskContext)));
+                .setStringVal(taskContext == null ? FeConstants.null_string : GSON.toJson(taskContext)));
         trow.addToColumnValue(
                 new TCell().setStringVal(refreshMode == null ? FeConstants.null_string : refreshMode.toString()));
         trow.addToColumnValue(
                 new TCell().setStringVal(
-                        needRefreshPartitions == null ? FeConstants.null_string : new Gson().toJson(
+                        needRefreshPartitions == null ? FeConstants.null_string : GSON.toJson(
                                 needRefreshPartitions)));
         trow.addToColumnValue(
                 new TCell().setStringVal(
-                        completedPartitions == null ? FeConstants.null_string : new Gson().toJson(
+                        completedPartitions == null ? FeConstants.null_string : GSON.toJson(
                                 completedPartitions)));
         trow.addToColumnValue(
                 new TCell().setStringVal(getProgress()));


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #66792

防止在集群有大量物化视图刷新任务的场景下，`tasks('type'='mv')` TVF 调用 将 Master Cpu 打满:
复用Gson对象可以防止getAdapter的重复调用

200个刷新任务（包括pending）+ 30s 一次的`tasks('type'='mv')` TVF 调用，32cFE效果就可能达到如下

<img width="1511" height="924" alt="Clipboard_Screenshot_1786726026" src="https://github.com/user-attachments/assets/5b6acd49-844c-4cf8-a248-3def8db0ad42" />
<img width="508" height="258" alt="Clipboard_Screenshot_1786727546" src="https://github.com/user-attachments/assets/2917730f-1e30-4633-8298-bbbf156439eb" />


Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

