### PR TITLE
[test](regression) Wait for index change jobs in multi-index test

### DIFF
--- a/regression-test/suites/inverted_index_p0/test_single_column_multi_index1.groovy
+++ b/regression-test/suites/inverted_index_p0/test_single_column_multi_index1.groovy
@@ -161,9 +161,19 @@ suite("test_single_column_multi_index1", "p0") {
       runMatchQueries()
 
       sql """ DROP INDEX request_text_idx ON ${tableName}; """
-      wait_for_latest_op_on_table_finish(tableName, timeout)
+      if (isCloudMode()) {
+        // Cloud uses a schema change job here; Local uses an asynchronous index change job.
+        wait_for_latest_op_on_table_finish(tableName, timeout)
+      } else {
+        wait_for_build_index_on_partition_finish(tableName, timeout)
+      }
       sql """ DROP INDEX request_keyword_idx ON ${tableName}; """
-      wait_for_latest_op_on_table_finish(tableName, timeout)
+      if (isCloudMode()) {
+        // Cloud uses a schema change job here; Local uses an asynchronous index change job.
+        wait_for_latest_op_on_table_finish(tableName, timeout)
+      } else {
+        wait_for_build_index_on_partition_finish(tableName, timeout)
+      }
 
       runMatchQueries()
     } finally {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #xxx

Related PR: #xxx

Problem Summary:

The multi-index regression test waited for the latest column alter job after dropping an inverted index. Index removal rewrites existing rowsets asynchronously through an index change job, so the column alter state can be finished while old rowsets still retain the dropped index. Wait for the build index job after each `DROP INDEX` statement before running the following queries.

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label