### PR TITLE
[feature](cache) Add session variable to keep INSERT source scans in the normal file cache queue

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
@@ -500,8 +500,15 @@ public class NereidsCoordinator extends Coordinator {
     private void setForInsert(long jobId) {
         JobProcessor jobProc = new LoadProcessor(this.coordinatorContext, jobId);
         this.coordinatorContext.setJobProcessor(jobProc);
-        // Set this field to true to avoid data entering the normal cache LRU queue
-        this.coordinatorContext.queryOptions.setDisableFileCache(true);
+        // Set this field to true to avoid data entering the normal cache LRU queue.
+        // enable_file_cache_for_insert_source opts OUT of that protection: recurring
+        // INSERT ... SELECT / CTAS whose source working set is shared with interactive
+        // queries (and re-read every cycle) benefits from normal-queue retention.
+        boolean keepInsertSourceInCache = this.coordinatorContext.connectContext != null
+                && this.coordinatorContext.connectContext.getSessionVariable().enableFileCacheForInsertSource;
+        if (!keepInsertSourceInCache) {
+            this.coordinatorContext.queryOptions.setDisableFileCache(true);
+        }
         this.coordinatorContext.queryOptions.setNewVersionUnixTimestamp(true);
         this.coordinatorContext.queryOptions.setNewVersionPercentile(true);
         this.coordinatorContext.queryOptions.setNewVersionBitmapOpCount(true);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -97,6 +97,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String MAX_SCANNERS_CONCURRENCY = "max_scanners_concurrency";
     public static final String MAX_FILE_SCANNERS_CONCURRENCY = "max_file_scanners_concurrency";
     public static final String ENABLE_FILE_SCANNER_V2 = "enable_file_scanner_v2";
+    public static final String ENABLE_FILE_CACHE_FOR_INSERT_SOURCE = "enable_file_cache_for_insert_source";
     public static final String MIN_SCANNERS_CONCURRENCY = "min_scanners_concurrency";
     public static final String MIN_FILE_SCANNERS_CONCURRENCY = "min_file_scanners_concurrency";
     public static final String MIN_SCAN_SCHEDULER_CONCURRENCY = "min_scan_scheduler_concurrency";
@@ -1161,6 +1162,15 @@ public class SessionVariable implements Serializable, Writable {
     @VarAttrDef.VarAttr(name = ENABLE_FILE_SCANNER_V2, needForward = true, fuzzy = true, description = "When enabled, "
             + "FileScanNode uses FileScannerV2 for supported query scans. Enabled by default.")
     public boolean enableFileScannerV2 = true;
+
+    @VarAttrDef.VarAttr(name = ENABLE_FILE_CACHE_FOR_INSERT_SOURCE, needForward = true, description = {
+            "开启后 INSERT ... SELECT / CTAS 的源表扫描使用普通文件缓存队列（不再强制 disposable 队列）。"
+                    + "适用于源扫描工作集与交互查询共享、且周期性重复读取的 ETL 场景。默认关闭（保持原有行为）",
+            "When enabled, source scans of INSERT ... SELECT / CTAS use the normal file cache queue "
+                    + "instead of being forced onto the disposable queue. Useful for recurring ETL whose "
+                    + "source working set is shared with interactive queries and re-read every cycle. "
+                    + "Disabled by default (preserves existing behavior)."})
+    public boolean enableFileCacheForInsertSource = false;
 
     @VarAttrDef.VarAttr(name = LOCAL_EXCHANGE_FREE_BLOCKS_LIMIT)
     public int localExchangeFreeBlocksLimit = 4;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

`NereidsCoordinator.setForInsert()` unconditionally sets `disableFileCache(true)`, so the source scan of every `INSERT ... SELECT` / CTAS is classified into the **disposable** file cache queue (the comment explains the intent: keep one-shot load scans from polluting the normal LRU).

That one-shot assumption doesn't hold for a common warehouse shape: recurring ETL. Hourly dbt-style builds re-read the same source tables (in our case Iceberg external tables) every cycle — but because the disposable queue is capped at 5% of the cache and hits never promote, those scans re-fetch from remote storage every hour, forever, no matter how large the file cache is.

This PR adds an opt-in session variable, `enable_file_cache_for_insert_source` (default **false** — existing behavior is unchanged byte-for-byte). When enabled, the insert source scan uses the normal cache queue. The broker-load constructor path is deliberately untouched (no ConnectContext, genuinely one-shot).

Design notes: we considered conditioning on the *target* catalog instead of a variable, but the pollution question is a property of the **source scan's reuse pattern**, not the target — a variable lets the operator state that intent directly. Automatic frequency-based promotion between queues would be the ideal long-term answer; that's out of scope here.

Measured in production (recurring hourly ETL over Iceberg external tables, 280GB file cache per BE): after enabling, the ETL account's remote-read rate dropped ~8x within hours (23.5 GB/h -> 3 GB/h), byte-level cache hit rate rose from 64% to 78% and climbing, and fleet block hit-ratio gained ~5pp.

### Release note

New session variable `enable_file_cache_for_insert_source` (default false): when enabled, source scans of INSERT ... SELECT / CTAS use the normal file cache queue instead of the disposable queue.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
      Behavior is opt-in and default-off (existing behavior byte-identical). Manually verified in a production deployment: with the variable enabled, insert source scans populate the normal queue (`normal_queue_cache_size` growth, disposable evict flatline in BE bvars) and remote reads drop as described above.

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [x] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->
      Will add the session variable to the docs site once the approach is confirmed by reviewers.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
