### PR TITLE
[chore](be) Reserve BE exec version 13 for external sink hash routing

### DIFF
--- a/be/src/agent/be_exec_version_manager.cpp
+++ b/be/src/agent/be_exec_version_manager.cpp
@@ -128,8 +128,11 @@ void BeExecVersionManager::check_function_compatibility(int current_be_exec_vers
 //   a. enforce Iceberg SQL MERGE cardinality only when every executing BE supports it.
 // 12: start from master
 //   a. support Variant columns and delete-only writer omission in Iceberg SQL MERGE.
+// 13: start from master
+//   a. support strict ownership hash routing for external table sink writers.
+//   b. support Paimon default fixed-bucket routing in the external sink exchange.
 
-const int BeExecVersionManager::max_be_exec_version = 12;
+const int BeExecVersionManager::max_be_exec_version = 13;
 const int BeExecVersionManager::min_be_exec_version = 0;
 std::map<std::string, std::set<int>> BeExecVersionManager::_function_change_map {};
 std::set<std::string> BeExecVersionManager::_function_restrict_map;

--- a/be/src/agent/be_exec_version_manager.h
+++ b/be/src/agent/be_exec_version_manager.h
@@ -28,6 +28,7 @@ namespace doris {
 constexpr inline int USE_NEW_FIXED_OBJECT_SERIALIZATION_VERSION = 10;
 constexpr inline int SUPPORT_ICEBERG_MERGE_CARDINALITY_VERSION = 11;
 constexpr inline int SUPPORT_ICEBERG_VARIANT_VERSION = 12;
+constexpr inline int SUPPORT_EXTERNAL_TABLE_SINK_HASH_VERSION = 13;
 
 class BeExecVersionManager {
 public:

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1980,7 +1980,7 @@ public class Config extends ConfigBase {
      * Max data version of backends serialize block.
      */
     @ConfField(mutable = false)
-    public static int max_be_exec_version = 12;
+    public static int max_be_exec_version = 13;
 
     /**
      * Min data version of backends serialize block.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #66685

Problem Summary:

The external table sink hash-routing feature was developed on `branch-4.1` in #66685 before it could land on master. BE execution versions must not fork across release branches.

Master now uses version 12 for Iceberg Variant compatibility. This PR therefore reserves version 13 for external table sink hash routing, advances the maximum BE execution version from 12 to 13, and defines `SUPPORT_EXTERNAL_TABLE_SINK_HASH_VERSION`. It intentionally does not bring the routing implementation to master.

After this reservation is merged into master, `branch-4.1` will be updated to use the same version 13 compatibility boundary.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test
    - [x] No need to test. This PR only reserves the compatibility version; compilation and tests were intentionally skipped.
- Behavior changed:
    - [ ] No.
    - [x] Yes. The maximum BE execution version advances from 12 to 13 without enabling external sink hash routing on master.
- Does this need documentation?
    - [x] No.
    - [ ] Yes.

Validation:

- `build-support/clang-format.sh`
- `git diff --check origin/master...HEAD`

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
