### PR TITLE
[Fix](dictionary) Retain multiple dict versions on BE to avoid FE/BE version mismatch

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1400,9 +1400,9 @@ DEFINE_Int32(max_depth_in_bkd_tree, "32");
 // index compaction
 DEFINE_mBool(inverted_index_compaction_enable, "true");
 // max historical versions retained per dictionary on BE; <=1 disables multi-version retention
-DEFINE_mInt32(dictionary_max_versions, "1");
+DEFINE_mInt32(dictionary_max_versions, "2");
 // TTL in seconds for non-latest dict versions; 0 disables time-based GC
-DEFINE_mInt32(dictionary_version_ttl_seconds, "0");
+DEFINE_mInt32(dictionary_version_ttl_seconds, "86400");
 // min interval between time-based GC passes triggered by commit
 DEFINE_mInt32(dictionary_gc_interval_seconds, "60");
 // Only for debug, do not use in production

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1399,6 +1399,8 @@ DEFINE_Int32(inverted_index_read_buffer_size, "4096");
 DEFINE_Int32(max_depth_in_bkd_tree, "32");
 // index compaction
 DEFINE_mBool(inverted_index_compaction_enable, "true");
+// max historical versions retained per dictionary on BE; <=1 disables multi-version retention
+DEFINE_mInt32(dictionary_max_versions, "1");
 // Only for debug, do not use in production
 DEFINE_mBool(debug_inverted_index_compaction, "false");
 // index by RAM directory

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1401,6 +1401,10 @@ DEFINE_Int32(max_depth_in_bkd_tree, "32");
 DEFINE_mBool(inverted_index_compaction_enable, "true");
 // max historical versions retained per dictionary on BE; <=1 disables multi-version retention
 DEFINE_mInt32(dictionary_max_versions, "1");
+// TTL in seconds for non-latest dict versions; 0 disables time-based GC
+DEFINE_mInt32(dictionary_version_ttl_seconds, "0");
+// min interval between time-based GC passes triggered by commit
+DEFINE_mInt32(dictionary_gc_interval_seconds, "60");
 // Only for debug, do not use in production
 DEFINE_mBool(debug_inverted_index_compaction, "false");
 // index by RAM directory

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1457,6 +1457,8 @@ DECLARE_mBool(debug_inverted_index_compaction);
 // index by RAM directory
 DECLARE_mBool(inverted_index_ram_dir_enable);
 DECLARE_mInt32(dictionary_max_versions);
+DECLARE_mInt32(dictionary_version_ttl_seconds);
+DECLARE_mInt32(dictionary_gc_interval_seconds);
 // wheather index by RAM directory when base compaction
 DECLARE_mBool(inverted_index_ram_dir_enable_when_base_compaction);
 // use num_broadcast_buffer blocks as buffer to do broadcast

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1456,6 +1456,7 @@ DECLARE_mBool(inverted_index_compaction_enable);
 DECLARE_mBool(debug_inverted_index_compaction);
 // index by RAM directory
 DECLARE_mBool(inverted_index_ram_dir_enable);
+DECLARE_mInt32(dictionary_max_versions);
 // wheather index by RAM directory when base compaction
 DECLARE_mBool(inverted_index_ram_dir_enable_when_base_compaction);
 // use num_broadcast_buffer blocks as buffer to do broadcast

--- a/be/src/exprs/function/dictionary.h
+++ b/be/src/exprs/function/dictionary.h
@@ -121,6 +121,9 @@ public:
 
     virtual size_t allocated_bytes() const;
 
+    void set_commit_time_ms(int64_t ts) { _commit_time_ms = ts; }
+    int64_t commit_time_ms() const { return _commit_time_ms; }
+
 protected:
     friend class DictionaryFactory;
 
@@ -204,6 +207,9 @@ protected:
 
     // mem_tracker comes from DictionaryFactory. If _mem_tracker is nullptr, it means it is in UT.
     std::shared_ptr<MemTrackerLimiter> _mem_tracker;
+
+    // set by DictionaryFactory at commit time, used for TTL-based GC
+    int64_t _commit_time_ms = 0;
 };
 
 using DictionaryPtr = std::shared_ptr<IDictionary>;

--- a/be/src/exprs/function/dictionary_factory.cpp
+++ b/be/src/exprs/function/dictionary_factory.cpp
@@ -32,30 +32,34 @@ DictionaryFactory::DictionaryFactory()
 
 DictionaryFactory::~DictionaryFactory() {
     SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
-    _dict_id_to_dict_map.clear();
-    _dict_id_to_version_id_map.clear();
+    _dict_id_to_versioned_map.clear();
 }
 
 void DictionaryFactory::get_dictionary_status(std::vector<TDictionaryStatus>& result,
                                               std::vector<int64_t> dict_ids) {
+    // only report the latest version per dict; historical versions are invisible to FE
     std::shared_lock lc(_mutex);
-    if (dict_ids.empty()) { // empty means ALL
-        for (const auto& [dict_id, dict] : _dict_id_to_dict_map) {
-            TDictionaryStatus status;
-            status.__set_dictionary_id(dict_id);
-            status.__set_version_id(_dict_id_to_version_id_map[dict_id]);
-            status.__set_dictionary_memory_size(dict->allocated_bytes());
-            result.emplace_back(std::move(status));
+    auto build_latest_status = [&result](int64_t dict_id,
+                                         const std::map<int64_t, DictionaryPtr>& versioned_map) {
+        if (versioned_map.empty()) {
+            return;
+        }
+        const auto& [version_id, dict] = *versioned_map.rbegin();
+        TDictionaryStatus status;
+        status.__set_dictionary_id(dict_id);
+        status.__set_version_id(version_id);
+        status.__set_dictionary_memory_size(dict->allocated_bytes());
+        result.emplace_back(std::move(status));
+    };
+    if (dict_ids.empty()) {
+        for (const auto& [dict_id, versioned_map] : _dict_id_to_versioned_map) {
+            build_latest_status(dict_id, versioned_map);
         }
     } else {
         for (auto dict_id : dict_ids) {
-            if (_dict_id_to_dict_map.contains(dict_id)) {
-                TDictionaryStatus status;
-                status.__set_dictionary_id(dict_id);
-                status.__set_version_id(_dict_id_to_version_id_map[dict_id]);
-                status.__set_dictionary_memory_size(
-                        _dict_id_to_dict_map[dict_id]->allocated_bytes());
-                result.emplace_back(std::move(status));
+            auto it = _dict_id_to_versioned_map.find(dict_id);
+            if (it != _dict_id_to_versioned_map.end()) {
+                build_latest_status(dict_id, it->second);
             }
         }
     }

--- a/be/src/exprs/function/dictionary_factory.h
+++ b/be/src/exprs/function/dictionary_factory.h
@@ -20,12 +20,14 @@
 #include <gen_cpp/BackendService_types.h>
 
 #include <algorithm>
+#include <atomic>
 #include <mutex>
 
 #include "common/config.h"
 #include "common/logging.h"
 #include "exprs/function/dictionary.h"
 #include "util/debug_points.h"
+#include "util/time.h"
 
 namespace doris {
 class MemTrackerLimiter;
@@ -121,9 +123,11 @@ public:
                 .tag("dict_id", dict_id)
                 .tag("version_id", version_id)
                 .tag("dict name", dict->dict_name());
+        dict->set_commit_time_ms(UnixMillis());
         versioned_map[version_id] = dict;
-        _gc_versions_no_lock(dict_id, versioned_map);
         _refreshing_dict_map.erase(dict_id);
+        lc.unlock();
+        gc_if_needed();
         return Status::OK();
     }
 
@@ -150,20 +154,56 @@ public:
 
     std::shared_ptr<MemTrackerLimiter> mem_tracker() const { return _mem_tracker; }
 
+    // unified GC entry: count-based + ttl-based, with interval protection
+    void gc_if_needed() {
+        int64_t gc_interval_ms = std::max(1, config::dictionary_gc_interval_seconds) * 1000LL;
+        int64_t now = UnixMillis();
+        if (now - _last_gc_time_ms.load(std::memory_order_relaxed) < gc_interval_ms) {
+            return;
+        }
+        std::unique_lock<std::shared_mutex> lc(_mutex);
+        // re-check under lock to avoid duplicate GC
+        if (now - _last_gc_time_ms.load(std::memory_order_relaxed) < gc_interval_ms) {
+            return;
+        }
+        _last_gc_time_ms.store(now, std::memory_order_relaxed);
+        _gc_all_no_lock(now);
+    }
+
     void get_dictionary_status(std::vector<TDictionaryStatus>& result,
                                std::vector<int64_t> dict_ids);
 
 private:
-    // 0 or negative falls back to 1 (no multi-version retention)
-    void _gc_versions_no_lock(int64_t dict_id, std::map<int64_t, DictionaryPtr>& versioned_map) {
+    // GC all dicts: first count-based, then ttl-based. Always keeps the latest version.
+    void _gc_all_no_lock(int64_t now) {
         int32_t max_versions = std::max(1, config::dictionary_max_versions);
-        while (versioned_map.size() > max_versions) {
-            auto it = versioned_map.begin();
-            LOG_INFO("DictionaryFactory GC old version")
-                    .tag("dict_id", dict_id)
-                    .tag("version_id", it->first)
-                    .tag("dict name", it->second->dict_name());
-            versioned_map.erase(it);
+        int64_t ttl_ms = static_cast<int64_t>(config::dictionary_version_ttl_seconds) * 1000;
+        int64_t threshold_ms = ttl_ms > 0 ? now - ttl_ms : 0;
+        for (auto& [dict_id, versioned_map] : _dict_id_to_versioned_map) {
+            if (versioned_map.size() <= 1) {
+                continue;
+            }
+            // count-based: drop oldest while exceeding max_versions
+            while (versioned_map.size() > static_cast<size_t>(max_versions)) {
+                auto it = versioned_map.begin();
+                LOG_INFO("DictionaryFactory GC old version by count")
+                        .tag("dict_id", dict_id)
+                        .tag("version_id", it->first)
+                        .tag("dict name", it->second->dict_name());
+                versioned_map.erase(it);
+            }
+            // ttl-based: drop non-latest versions older than ttl
+            while (ttl_ms > 0 && versioned_map.size() > 1) {
+                auto it = versioned_map.begin();
+                if (it->second->commit_time_ms() >= threshold_ms) {
+                    break;
+                }
+                LOG_INFO("DictionaryFactory GC old version by ttl")
+                        .tag("dict_id", dict_id)
+                        .tag("version_id", it->first)
+                        .tag("age_sec", (now - it->second->commit_time_ms()) / 1000);
+                versioned_map.erase(it);
+            }
         }
     }
 
@@ -174,6 +214,8 @@ private:
             _refreshing_dict_map; // dict_id -> (version_id, dict)
 
     std::shared_mutex _mutex;
+
+    std::atomic<int64_t> _last_gc_time_ms {0};
 
     std::shared_ptr<MemTrackerLimiter> _mem_tracker;
 };

--- a/be/src/exprs/function/dictionary_factory.h
+++ b/be/src/exprs/function/dictionary_factory.h
@@ -19,11 +19,13 @@
 
 #include <gen_cpp/BackendService_types.h>
 
+#include <algorithm>
 #include <mutex>
 
 #include "common/config.h"
 #include "common/logging.h"
 #include "exprs/function/dictionary.h"
+#include "util/debug_points.h"
 
 namespace doris {
 class MemTrackerLimiter;
@@ -37,13 +39,13 @@ public:
 
     // Returns nullptr if failed
     std::shared_ptr<const IDictionary> get(int64_t dict_id, int64_t version_id) {
-        std::unique_lock lc(_mutex);
-        // dict_id and version_id must match
-        if (_dict_id_to_dict_map.contains(dict_id) &&
-            _dict_id_to_version_id_map[dict_id] == version_id) {
-            return _dict_id_to_dict_map[dict_id];
+        std::shared_lock lc(_mutex);
+        auto it = _dict_id_to_versioned_map.find(dict_id);
+        if (it == _dict_id_to_versioned_map.end()) {
+            return nullptr;
         }
-        return nullptr;
+        auto vit = it->second.find(version_id);
+        return vit == it->second.end() ? nullptr : vit->second;
     }
 
     Status refresh_dict(int64_t dict_id, int64_t version_id, DictionaryPtr dict) {
@@ -76,6 +78,16 @@ public:
     }
 
     Status commit_refresh_dict(int64_t dict_id, int64_t version_id) {
+        // sleep before commit to widen FE/BE version mismatch window
+        DBUG_EXECUTE_IF("dict_commit_delay", {
+            int sleep_sec = dp->param<int>("sleep_sec", 30);
+            LOG(INFO) << "debug point dict_commit_delay: sleeping " << sleep_sec
+                      << "s before commit"
+                      << " dict_id=" << dict_id << " version_id=" << version_id;
+            sleep(sleep_sec);
+            LOG(INFO) << "debug point dict_commit_delay: wake up, continue commit"
+                      << " dict_id=" << dict_id << " version_id=" << version_id;
+        });
         VLOG_DEBUG << "DictionaryFactory commit refresh dictionary"
                    << " dict_id: " << dict_id << " version_id: " << version_id;
         std::unique_lock lc(_mutex);
@@ -88,48 +100,51 @@ public:
                     "Version ID is not equal to the refreshing version ID. {} : {}", version_id,
                     refresh_version_id);
         }
-        {
-            // commit the dictionary
-            if (_dict_id_to_version_id_map.contains(dict_id)) {
-                // check version_id
-                if (version_id <= _dict_id_to_version_id_map[dict_id]) {
-                    LOG_WARNING(
-                            "DictionaryFactory Failed to commit dictionary because version ID "
-                            "is not greater than the existing version ID")
-                            .tag("dict_id", dict_id)
-                            .tag("version_id", version_id)
-                            .tag("dict name", dict->dict_name())
-                            .tag("existing version ID", _dict_id_to_version_id_map[dict_id]);
-                    return Status::InvalidArgument(
-                            "Version ID is not greater than the existing version ID for the "
-                            "dictionary. {} : {}",
-                            version_id, _dict_id_to_version_id_map[dict_id]);
-                }
+        auto& versioned_map = _dict_id_to_versioned_map[dict_id];
+        if (!versioned_map.empty()) {
+            int64_t latest = versioned_map.rbegin()->first;
+            if (version_id <= latest) {
+                LOG_WARNING(
+                        "DictionaryFactory Failed to commit dictionary because version ID "
+                        "is not greater than the existing version ID")
+                        .tag("dict_id", dict_id)
+                        .tag("version_id", version_id)
+                        .tag("dict name", dict->dict_name())
+                        .tag("existing version ID", latest);
+                return Status::InvalidArgument(
+                        "Version ID is not greater than the existing version ID for the "
+                        "dictionary. {} : {}",
+                        version_id, latest);
             }
-            LOG_INFO("DictionaryFactory Successfully commit dictionary")
-                    .tag("dict_id", dict_id)
-                    .tag("version_id", version_id)
-                    .tag("dict name", dict->dict_name());
-            _dict_id_to_dict_map[dict_id] = dict;
-            _dict_id_to_version_id_map[dict_id] = version_id;
-            _refreshing_dict_map.erase(dict_id);
         }
+        LOG_INFO("DictionaryFactory Successfully commit dictionary")
+                .tag("dict_id", dict_id)
+                .tag("version_id", version_id)
+                .tag("dict name", dict->dict_name());
+        versioned_map[version_id] = dict;
+        _gc_versions_no_lock(dict_id, versioned_map);
+        _refreshing_dict_map.erase(dict_id);
         return Status::OK();
     }
 
     Status delete_dict(int64_t dict_id) {
         VLOG_DEBUG << "DictionaryFactory delete dictionary, dict_id: " << dict_id;
         std::unique_lock lc(_mutex);
-        if (!_dict_id_to_dict_map.contains(dict_id)) {
-            LOG_WARNING("DictionaryFactory Failed to delete dictionary").tag("dict_id", dict_id);
+        auto it = _dict_id_to_versioned_map.find(dict_id);
+        if (it == _dict_id_to_versioned_map.end()) {
             return Status::OK();
         }
-        auto dict = _dict_id_to_dict_map[dict_id];
-        LOG_INFO("DictionaryFactory Successfully delete dictionary")
-                .tag("dict_id", dict_id)
-                .tag("dict name", dict->dict_name());
-        _dict_id_to_dict_map.erase(dict_id);
-        _dict_id_to_version_id_map.erase(dict_id);
+        if (it->second.empty()) {
+            LOG_WARNING("DictionaryFactory delete dictionary with empty version map")
+                    .tag("dict_id", dict_id);
+        } else {
+            auto latest_it = it->second.rbegin();
+            LOG_INFO("DictionaryFactory Successfully delete dictionary")
+                    .tag("dict_id", dict_id)
+                    .tag("dict name", latest_it->second->dict_name())
+                    .tag("latest version_id", latest_it->first);
+        }
+        _dict_id_to_versioned_map.erase(it);
         return Status::OK();
     }
 
@@ -139,8 +154,21 @@ public:
                                std::vector<int64_t> dict_ids);
 
 private:
-    std::map<int64_t, DictionaryPtr> _dict_id_to_dict_map;
-    std::map<int64_t, int64_t> _dict_id_to_version_id_map;
+    // 0 or negative falls back to 1 (no multi-version retention)
+    void _gc_versions_no_lock(int64_t dict_id, std::map<int64_t, DictionaryPtr>& versioned_map) {
+        int32_t max_versions = std::max(1, config::dictionary_max_versions);
+        while (versioned_map.size() > max_versions) {
+            auto it = versioned_map.begin();
+            LOG_INFO("DictionaryFactory GC old version")
+                    .tag("dict_id", dict_id)
+                    .tag("version_id", it->first)
+                    .tag("dict name", it->second->dict_name());
+            versioned_map.erase(it);
+        }
+    }
+
+    // dict_id -> (version_id -> dict)
+    std::map<int64_t, std::map<int64_t, DictionaryPtr>> _dict_id_to_versioned_map;
 
     std::map<int64_t, std::pair<int64_t, DictionaryPtr>>
             _refreshing_dict_map; // dict_id -> (version_id, dict)

--- a/be/src/exprs/function/dictionary_factory.h
+++ b/be/src/exprs/function/dictionary_factory.h
@@ -41,13 +41,31 @@ public:
 
     // Returns nullptr if failed
     std::shared_ptr<const IDictionary> get(int64_t dict_id, int64_t version_id) {
+        // simulate slow query holding old version_id
+        DBUG_EXECUTE_IF("dict_get_delay", {
+            int sleep_sec = dp->param<int>("sleep_sec", 10);
+            LOG(INFO) << "debug point dict_get_delay: sleeping " << sleep_sec
+                      << "s before get dict_id=" << dict_id << " version_id=" << version_id;
+            sleep(sleep_sec);
+        });
         std::shared_lock lc(_mutex);
         auto it = _dict_id_to_versioned_map.find(dict_id);
-        if (it == _dict_id_to_versioned_map.end()) {
-            return nullptr;
+        if (it != _dict_id_to_versioned_map.end()) {
+            auto vit = it->second.find(version_id);
+            if (vit != it->second.end()) {
+                return vit->second;
+            }
         }
-        auto vit = it->second.find(version_id);
-        return vit == it->second.end() ? nullptr : vit->second;
+        // fallback to staging: version may have been increased by FE but not yet committed
+        auto rit = _refreshing_dict_map.find(dict_id);
+        if (rit != _refreshing_dict_map.end() && rit->second.first == version_id) {
+            LOG_WARNING(
+                    "DictionaryFactory version not found in committed map, falling back to staging")
+                    .tag("dict_id", dict_id)
+                    .tag("version_id", version_id);
+            return rit->second.second;
+        }
+        return nullptr;
     }
 
     Status refresh_dict(int64_t dict_id, int64_t version_id, DictionaryPtr dict) {
@@ -80,16 +98,6 @@ public:
     }
 
     Status commit_refresh_dict(int64_t dict_id, int64_t version_id) {
-        // sleep before commit to widen FE/BE version mismatch window
-        DBUG_EXECUTE_IF("dict_commit_delay", {
-            int sleep_sec = dp->param<int>("sleep_sec", 30);
-            LOG(INFO) << "debug point dict_commit_delay: sleeping " << sleep_sec
-                      << "s before commit"
-                      << " dict_id=" << dict_id << " version_id=" << version_id;
-            sleep(sleep_sec);
-            LOG(INFO) << "debug point dict_commit_delay: wake up, continue commit"
-                      << " dict_id=" << dict_id << " version_id=" << version_id;
-        });
         VLOG_DEBUG << "DictionaryFactory commit refresh dictionary"
                    << " dict_id: " << dict_id << " version_id: " << version_id;
         std::unique_lock lc(_mutex);

--- a/be/src/exprs/function/dictionary_factory.h
+++ b/be/src/exprs/function/dictionary_factory.h
@@ -20,13 +20,11 @@
 #include <gen_cpp/BackendService_types.h>
 
 #include <algorithm>
-#include <atomic>
 #include <mutex>
 
 #include "common/config.h"
 #include "common/logging.h"
 #include "exprs/function/dictionary.h"
-#include "util/debug_points.h"
 #include "util/time.h"
 
 namespace doris {
@@ -41,13 +39,6 @@ public:
 
     // Returns nullptr if failed
     std::shared_ptr<const IDictionary> get(int64_t dict_id, int64_t version_id) {
-        // simulate slow query holding old version_id
-        DBUG_EXECUTE_IF("dict_get_delay", {
-            int sleep_sec = dp->param<int>("sleep_sec", 10);
-            LOG(INFO) << "debug point dict_get_delay: sleeping " << sleep_sec
-                      << "s before get dict_id=" << dict_id << " version_id=" << version_id;
-            sleep(sleep_sec);
-        });
         std::shared_lock lc(_mutex);
         auto it = _dict_id_to_versioned_map.find(dict_id);
         if (it != _dict_id_to_versioned_map.end()) {
@@ -113,16 +104,17 @@ public:
         auto& versioned_map = _dict_id_to_versioned_map[dict_id];
         if (!versioned_map.empty()) {
             int64_t latest = versioned_map.rbegin()->first;
-            if (version_id <= latest) {
+            // only reject out-of-order; allow == latest for idempotent re-commit after partial rollback
+            if (version_id < latest) {
                 LOG_WARNING(
                         "DictionaryFactory Failed to commit dictionary because version ID "
-                        "is not greater than the existing version ID")
+                        "is less than the existing version ID")
                         .tag("dict_id", dict_id)
                         .tag("version_id", version_id)
                         .tag("dict name", dict->dict_name())
                         .tag("existing version ID", latest);
                 return Status::InvalidArgument(
-                        "Version ID is not greater than the existing version ID for the "
+                        "Version ID is less than the existing version ID for the "
                         "dictionary. {} : {}",
                         version_id, latest);
             }
@@ -134,74 +126,58 @@ public:
         dict->set_commit_time_ms(UnixMillis());
         versioned_map[version_id] = dict;
         _refreshing_dict_map.erase(dict_id);
+        std::vector<DictionaryPtr> to_retire;
+        int64_t now = UnixMillis();
+        _gc_count_for_dict_no_lock(dict_id, versioned_map, to_retire);
+        _gc_ttl_if_needed_no_lock(now, to_retire);
         lc.unlock();
-        gc_if_needed();
         return Status::OK();
     }
 
     Status delete_dict(int64_t dict_id) {
         VLOG_DEBUG << "DictionaryFactory delete dictionary, dict_id: " << dict_id;
-        std::unique_lock lc(_mutex);
-        auto it = _dict_id_to_versioned_map.find(dict_id);
-        if (it == _dict_id_to_versioned_map.end()) {
-            return Status::OK();
+        std::vector<DictionaryPtr> to_retire;
+        {
+            std::unique_lock lc(_mutex);
+            auto it = _dict_id_to_versioned_map.find(dict_id);
+            if (it == _dict_id_to_versioned_map.end()) {
+                return Status::OK();
+            }
+            if (it->second.empty()) {
+                LOG_WARNING("DictionaryFactory delete dictionary with empty version map")
+                        .tag("dict_id", dict_id);
+            } else {
+                auto latest_it = it->second.rbegin();
+                LOG_INFO("DictionaryFactory Successfully delete dictionary")
+                        .tag("dict_id", dict_id)
+                        .tag("dict name", latest_it->second->dict_name())
+                        .tag("latest version_id", latest_it->first);
+            }
+            for (auto& [v_id, dict] : it->second) {
+                to_retire.push_back(std::move(dict));
+            }
+            _dict_id_to_versioned_map.erase(it);
         }
-        if (it->second.empty()) {
-            LOG_WARNING("DictionaryFactory delete dictionary with empty version map")
-                    .tag("dict_id", dict_id);
-        } else {
-            auto latest_it = it->second.rbegin();
-            LOG_INFO("DictionaryFactory Successfully delete dictionary")
-                    .tag("dict_id", dict_id)
-                    .tag("dict name", latest_it->second->dict_name())
-                    .tag("latest version_id", latest_it->first);
-        }
-        _dict_id_to_versioned_map.erase(it);
+        // destroy retired payloads outside _mutex
         return Status::OK();
     }
 
     std::shared_ptr<MemTrackerLimiter> mem_tracker() const { return _mem_tracker; }
 
-    // unified GC entry: count-based + ttl-based, with interval protection
-    void gc_if_needed() {
+    // TTL GC for all dicts, interval-gated. Caller must hold _mutex.
+    void _gc_ttl_if_needed_no_lock(int64_t now, std::vector<DictionaryPtr>& to_retire) {
         int64_t gc_interval_ms = std::max(1, config::dictionary_gc_interval_seconds) * 1000LL;
-        int64_t now = UnixMillis();
-        if (now - _last_gc_time_ms.load(std::memory_order_relaxed) < gc_interval_ms) {
+        if (now - _last_gc_time_ms < gc_interval_ms) {
             return;
         }
-        std::unique_lock<std::shared_mutex> lc(_mutex);
-        // re-check under lock to avoid duplicate GC
-        if (now - _last_gc_time_ms.load(std::memory_order_relaxed) < gc_interval_ms) {
-            return;
-        }
-        _last_gc_time_ms.store(now, std::memory_order_relaxed);
-        _gc_all_no_lock(now);
-    }
-
-    void get_dictionary_status(std::vector<TDictionaryStatus>& result,
-                               std::vector<int64_t> dict_ids);
-
-private:
-    // GC all dicts: first count-based, then ttl-based. Always keeps the latest version.
-    void _gc_all_no_lock(int64_t now) {
-        int32_t max_versions = std::max(1, config::dictionary_max_versions);
+        _last_gc_time_ms = now;
         int64_t ttl_ms = static_cast<int64_t>(config::dictionary_version_ttl_seconds) * 1000;
-        int64_t threshold_ms = ttl_ms > 0 ? now - ttl_ms : 0;
+        if (ttl_ms <= 0) {
+            return;
+        }
+        int64_t threshold_ms = now - ttl_ms;
         for (auto& [dict_id, versioned_map] : _dict_id_to_versioned_map) {
-            if (versioned_map.size() <= 1) {
-                continue;
-            }
-            // count-based: drop oldest while exceeding max_versions
-            while (versioned_map.size() > static_cast<size_t>(max_versions)) {
-                auto it = versioned_map.begin();
-                LOG_INFO("DictionaryFactory GC old version by count")
-                        .tag("dict_id", dict_id)
-                        .tag("version_id", it->first)
-                        .tag("dict name", it->second->dict_name());
-                versioned_map.erase(it);
-            }
-            // ttl-based: drop non-latest versions older than ttl
-            while (ttl_ms > 0 && versioned_map.size() > 1) {
+            while (versioned_map.size() > 1) {
                 auto it = versioned_map.begin();
                 if (it->second->commit_time_ms() >= threshold_ms) {
                     break;
@@ -210,8 +186,29 @@ private:
                         .tag("dict_id", dict_id)
                         .tag("version_id", it->first)
                         .tag("age_sec", (now - it->second->commit_time_ms()) / 1000);
+                to_retire.push_back(std::move(it->second));
                 versioned_map.erase(it);
             }
+        }
+    }
+
+    void get_dictionary_status(std::vector<TDictionaryStatus>& result,
+                               std::vector<int64_t> dict_ids);
+
+private:
+    // Count-based GC for a single dict: drop oldest versions while size > max_versions.
+    void _gc_count_for_dict_no_lock(int64_t dict_id,
+                                    std::map<int64_t, DictionaryPtr>& versioned_map,
+                                    std::vector<DictionaryPtr>& to_retire) {
+        int32_t max_versions = std::max(1, config::dictionary_max_versions);
+        while (versioned_map.size() > static_cast<size_t>(max_versions)) {
+            auto it = versioned_map.begin();
+            LOG_INFO("DictionaryFactory GC old version by count")
+                    .tag("dict_id", dict_id)
+                    .tag("version_id", it->first)
+                    .tag("dict name", it->second->dict_name());
+            to_retire.push_back(std::move(it->second));
+            versioned_map.erase(it);
         }
     }
 
@@ -223,7 +220,7 @@ private:
 
     std::shared_mutex _mutex;
 
-    std::atomic<int64_t> _last_gc_time_ms {0};
+    int64_t _last_gc_time_ms = 0;
 
     std::shared_ptr<MemTrackerLimiter> _mem_tracker;
 };

--- a/be/test/exec/dictionary/dictionary_multi_version_test.cpp
+++ b/be/test/exec/dictionary/dictionary_multi_version_test.cpp
@@ -40,7 +40,7 @@ static void commit_version(DictionaryFactory& f, int64_t dict_id, int64_t versio
     auto dict = make_dict("dict_" + std::to_string(dict_id));
     EXPECT_TRUE(f.refresh_dict(dict_id, version_id, dict));
     // reset GC timer to force GC on every commit
-    f._last_gc_time_ms.store(0, std::memory_order_relaxed);
+    f._last_gc_time_ms = 0;
     EXPECT_TRUE(f.commit_refresh_dict(dict_id, version_id));
 }
 
@@ -219,7 +219,7 @@ TEST(DictionaryMultiVersionTest, GCIntervalLarge) {
     config::dictionary_gc_interval_seconds = 1000000;
     config::dictionary_max_versions = 1;
     DictionaryFactory f;
-    f._last_gc_time_ms.store(UnixMillis(), std::memory_order_relaxed);
+    f._last_gc_time_ms = UnixMillis();
     // manual commit without resetting GC timer
     auto dict1 = make_dict("dict_1");
     EXPECT_TRUE(f.refresh_dict(1, 1, dict1));
@@ -227,8 +227,8 @@ TEST(DictionaryMultiVersionTest, GCIntervalLarge) {
     auto dict2 = make_dict("dict_1");
     EXPECT_TRUE(f.refresh_dict(1, 2, dict2));
     EXPECT_TRUE(f.commit_refresh_dict(1, 2));
-    // interval not elapsed; GC skipped; both kept
-    EXPECT_NE(nullptr, f.get(1, 1));
+    // count-based GC runs on every commit regardless of interval; v=1 dropped
+    EXPECT_EQ(nullptr, f.get(1, 1));
     EXPECT_NE(nullptr, f.get(1, 2));
     config::dictionary_gc_interval_seconds = old_interval;
     config::dictionary_max_versions = old_max;
@@ -236,14 +236,58 @@ TEST(DictionaryMultiVersionTest, GCIntervalLarge) {
 
 // ============ boundary scenarios ============
 
-TEST(DictionaryMultiVersionTest, CommitDuplicateVersion) {
+TEST(DictionaryMultiVersionTest, CommitOverwritesSameVersion) {
+    auto old_max = config::dictionary_max_versions;
+    config::dictionary_max_versions = 10;
     DictionaryFactory f;
     commit_version(f, 1, 1);
-    // commit same version again should fail
+    // commit same version again should overwrite (idempotent), not fail
+    auto dict = make_dict("dict_1");
+    EXPECT_TRUE(f.refresh_dict(1, 1, dict));
+    EXPECT_TRUE(f.commit_refresh_dict(1, 1));
+    // staging cleared after commit
+    EXPECT_TRUE(!f._refreshing_dict_map.contains(1));
+    // get still works
+    EXPECT_NE(nullptr, f.get(1, 1));
+    config::dictionary_max_versions = old_max;
+}
+
+TEST(DictionaryMultiVersionTest, CommitRejectsOutOfOrder) {
+    auto old_max = config::dictionary_max_versions;
+    config::dictionary_max_versions = 10;
+    DictionaryFactory f;
+    commit_version(f, 1, 2);
+    // commit v=1 when latest=v=2 should fail (out of order)
     auto dict = make_dict("dict_1");
     EXPECT_TRUE(f.refresh_dict(1, 1, dict));
     auto st = f.commit_refresh_dict(1, 1);
     EXPECT_FALSE(st.ok());
+    // staging still there (not consumed by failed commit)
+    EXPECT_TRUE(f._refreshing_dict_map.contains(1));
+    config::dictionary_max_versions = old_max;
+}
+
+TEST(DictionaryMultiVersionTest, PartialRollbackRecovery) {
+    auto old_max = config::dictionary_max_versions;
+    config::dictionary_max_versions = 10;
+    DictionaryFactory f;
+    // BE1 commit v=1 success
+    commit_version(f, 1, 1);
+    // simulate partial rollback: FE abort v=1 after commit succeeded.
+    // staging already consumed by commit, abort is silent OK, orphan v=1 remains.
+    EXPECT_TRUE(f.abort_refresh_dict(1, 1).ok());
+    // orphan v=1 still in versioned_map
+    EXPECT_NE(nullptr, f.get(1, 1));
+    // next refresh: FE INC to v=1 again, refresh_dict writes new staging v=1
+    auto dict_new = make_dict("dict_1");
+    EXPECT_TRUE(f.refresh_dict(1, 1, dict_new));
+    // commit v=1: should overwrite orphan, not fail with "version <= latest"
+    EXPECT_TRUE(f.commit_refresh_dict(1, 1));
+    // staging cleared
+    EXPECT_TRUE(!f._refreshing_dict_map.contains(1));
+    // get works
+    EXPECT_NE(nullptr, f.get(1, 1));
+    config::dictionary_max_versions = old_max;
 }
 
 TEST(DictionaryMultiVersionTest, GetNonExistentDict) {
@@ -252,8 +296,9 @@ TEST(DictionaryMultiVersionTest, GetNonExistentDict) {
 }
 
 TEST(DictionaryMultiVersionTest, DeleteAllVersions) {
-    DictionaryFactory f;
+    auto old = config::dictionary_max_versions;
     config::dictionary_max_versions = 10;
+    DictionaryFactory f;
     commit_version(f, 1, 1);
     commit_version(f, 1, 2);
     commit_version(f, 1, 3);
@@ -261,6 +306,7 @@ TEST(DictionaryMultiVersionTest, DeleteAllVersions) {
     EXPECT_EQ(nullptr, f.get(1, 1));
     EXPECT_EQ(nullptr, f.get(1, 2));
     EXPECT_EQ(nullptr, f.get(1, 3));
+    config::dictionary_max_versions = old;
 }
 
 TEST(DictionaryMultiVersionTest, DeleteNonExistent) {
@@ -281,20 +327,23 @@ TEST(DictionaryMultiVersionTest, DeleteAfterGC) {
 }
 
 TEST(DictionaryMultiVersionTest, CommitAfterDelete) {
-    DictionaryFactory f;
+    auto old = config::dictionary_max_versions;
     config::dictionary_max_versions = 10;
+    DictionaryFactory f;
     commit_version(f, 1, 1);
     EXPECT_TRUE(f.delete_dict(1).ok());
     // commit new version after delete
     commit_version(f, 1, 2);
     EXPECT_NE(nullptr, f.get(1, 2));
+    config::dictionary_max_versions = old;
 }
 
 // ============ get_dictionary_status ============
 
 TEST(DictionaryMultiVersionTest, GetStatusReportsLatest) {
-    DictionaryFactory f;
+    auto old = config::dictionary_max_versions;
     config::dictionary_max_versions = 10;
+    DictionaryFactory f;
     commit_version(f, 1, 1);
     commit_version(f, 1, 2);
     commit_version(f, 1, 3);
@@ -303,6 +352,7 @@ TEST(DictionaryMultiVersionTest, GetStatusReportsLatest) {
     EXPECT_EQ(1, result.size());
     EXPECT_EQ(1, result[0].dictionary_id);
     EXPECT_EQ(3, result[0].version_id);
+    config::dictionary_max_versions = old;
 }
 
 TEST(DictionaryMultiVersionTest, GetStatusEmptyAfterDelete) {

--- a/be/test/exec/dictionary/dictionary_multi_version_test.cpp
+++ b/be/test/exec/dictionary/dictionary_multi_version_test.cpp
@@ -1,0 +1,317 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.  The ASF
+// licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "core/block/columns_with_type_and_name.h"
+#include "core/data_type/data_type_number.h"
+#include "exprs/function/complex_hash_map_dictionary.h"
+#include "exprs/function/dictionary.h"
+#include "exprs/function/dictionary_factory.h"
+
+namespace doris {
+
+static DictionaryPtr make_dict(const std::string& name) {
+    return create_complex_hash_map_dict_from_column(
+            name,
+            ColumnsWithTypeAndName {
+                    {DataTypeInt32::ColumnType::create(), std::make_shared<DataTypeInt32>(), ""}},
+            ColumnsWithTypeAndName {
+                    ColumnWithTypeAndName {DataTypeInt32::ColumnType::create(),
+                                           std::make_shared<DataTypeInt32>(), ""},
+            });
+}
+
+static void commit_version(DictionaryFactory& f, int64_t dict_id, int64_t version_id) {
+    auto dict = make_dict("dict_" + std::to_string(dict_id));
+    EXPECT_TRUE(f.refresh_dict(dict_id, version_id, dict));
+    // reset GC timer to force GC on every commit
+    f._last_gc_time_ms.store(0, std::memory_order_relaxed);
+    EXPECT_TRUE(f.commit_refresh_dict(dict_id, version_id));
+}
+
+// ============ basic multi-version ============
+
+TEST(DictionaryMultiVersionTest, GetAfterMultipleCommits) {
+    auto old = config::dictionary_max_versions;
+    config::dictionary_max_versions = 10;
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    commit_version(f, 1, 2);
+    commit_version(f, 1, 3);
+
+    EXPECT_NE(nullptr, f.get(1, 3));
+    EXPECT_NE(nullptr, f.get(1, 2));
+    EXPECT_NE(nullptr, f.get(1, 1));
+    config::dictionary_max_versions = old;
+}
+
+TEST(DictionaryMultiVersionTest, GetMissingVersion) {
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    EXPECT_NE(nullptr, f.get(1, 1));
+    EXPECT_EQ(nullptr, f.get(1, 99));
+    EXPECT_EQ(nullptr, f.get(999, 1));
+}
+
+// ============ count-based GC ============
+
+TEST(DictionaryMultiVersionTest, GCByCount) {
+    auto old_max = config::dictionary_max_versions;
+    config::dictionary_max_versions = 2;
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    commit_version(f, 1, 2);
+    commit_version(f, 1, 3);
+    // max_versions=2, v=1 should be GC'd
+    EXPECT_EQ(nullptr, f.get(1, 1));
+    EXPECT_NE(nullptr, f.get(1, 2));
+    EXPECT_NE(nullptr, f.get(1, 3));
+    config::dictionary_max_versions = old_max;
+}
+
+TEST(DictionaryMultiVersionTest, GCByCountDefaultOne) {
+    auto old_max = config::dictionary_max_versions;
+    config::dictionary_max_versions = 1;
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    commit_version(f, 1, 2);
+    EXPECT_EQ(nullptr, f.get(1, 1));
+    EXPECT_NE(nullptr, f.get(1, 2));
+    config::dictionary_max_versions = old_max;
+}
+
+TEST(DictionaryMultiVersionTest, GCKeepsLatest) {
+    auto old_max = config::dictionary_max_versions;
+    config::dictionary_max_versions = 1;
+    DictionaryFactory f;
+    for (int i = 1; i <= 5; i++) {
+        commit_version(f, 1, i);
+    }
+    EXPECT_EQ(nullptr, f.get(1, 4));
+    EXPECT_NE(nullptr, f.get(1, 5));
+    config::dictionary_max_versions = old_max;
+}
+
+// ============ TTL-based GC ============
+
+TEST(DictionaryMultiVersionTest, TTLExpired) {
+    auto old_ttl = config::dictionary_version_ttl_seconds;
+    auto old_max = config::dictionary_max_versions;
+    config::dictionary_version_ttl_seconds = 1;
+    config::dictionary_max_versions = 10;
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    // simulate v=1 committed 2 seconds ago
+    f._dict_id_to_versioned_map[1][1]->set_commit_time_ms(UnixMillis() - 2000);
+    commit_version(f, 1, 2);
+    // GC triggered by commit should drop v=1 (expired)
+    EXPECT_EQ(nullptr, f.get(1, 1));
+    EXPECT_NE(nullptr, f.get(1, 2));
+    config::dictionary_version_ttl_seconds = old_ttl;
+    config::dictionary_max_versions = old_max;
+}
+
+TEST(DictionaryMultiVersionTest, TTLKeepsLatest) {
+    auto old_ttl = config::dictionary_version_ttl_seconds;
+    auto old_max = config::dictionary_max_versions;
+    config::dictionary_version_ttl_seconds = 1;
+    config::dictionary_max_versions = 10;
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    f._dict_id_to_versioned_map[1][1]->set_commit_time_ms(UnixMillis() - 2000);
+    commit_version(f, 1, 2);
+    f._dict_id_to_versioned_map[1][2]->set_commit_time_ms(UnixMillis() - 2000);
+    // both expired, but latest must survive
+    EXPECT_NE(nullptr, f.get(1, 2));
+    config::dictionary_version_ttl_seconds = old_ttl;
+    config::dictionary_max_versions = old_max;
+}
+
+TEST(DictionaryMultiVersionTest, TTLZero) {
+    auto old_ttl = config::dictionary_version_ttl_seconds;
+    auto old_max = config::dictionary_max_versions;
+    config::dictionary_version_ttl_seconds = 0;
+    config::dictionary_max_versions = 10;
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    f._dict_id_to_versioned_map[1][1]->set_commit_time_ms(UnixMillis() - 100000);
+    commit_version(f, 1, 2);
+    // ttl=0, no TTL GC; both kept
+    EXPECT_NE(nullptr, f.get(1, 1));
+    EXPECT_NE(nullptr, f.get(1, 2));
+    config::dictionary_version_ttl_seconds = old_ttl;
+    config::dictionary_max_versions = old_max;
+}
+
+// ============ extreme configs ============
+
+TEST(DictionaryMultiVersionTest, GCMaxVersionsZero) {
+    auto old = config::dictionary_max_versions;
+    config::dictionary_max_versions = 0;
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    commit_version(f, 1, 2);
+    // 0 falls back to 1; only latest kept
+    EXPECT_EQ(nullptr, f.get(1, 1));
+    EXPECT_NE(nullptr, f.get(1, 2));
+    config::dictionary_max_versions = old;
+}
+
+TEST(DictionaryMultiVersionTest, GCMaxVersionsNegative) {
+    auto old = config::dictionary_max_versions;
+    config::dictionary_max_versions = -5;
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    commit_version(f, 1, 2);
+    // negative falls back to 1; only latest kept
+    EXPECT_EQ(nullptr, f.get(1, 1));
+    EXPECT_NE(nullptr, f.get(1, 2));
+    config::dictionary_max_versions = old;
+}
+
+TEST(DictionaryMultiVersionTest, GCMaxVersionsLarge) {
+    auto old = config::dictionary_max_versions;
+    config::dictionary_max_versions = 1000000;
+    DictionaryFactory f;
+    for (int i = 1; i <= 5; i++) {
+        commit_version(f, 1, i);
+    }
+    // large max; all versions kept
+    for (int i = 1; i <= 5; i++) {
+        EXPECT_NE(nullptr, f.get(1, i));
+    }
+    config::dictionary_max_versions = old;
+}
+
+TEST(DictionaryMultiVersionTest, TTLNegative) {
+    auto old_ttl = config::dictionary_version_ttl_seconds;
+    auto old_max = config::dictionary_max_versions;
+    config::dictionary_version_ttl_seconds = -1;
+    config::dictionary_max_versions = 10;
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    f._dict_id_to_versioned_map[1][1]->set_commit_time_ms(UnixMillis() - 100000);
+    commit_version(f, 1, 2);
+    // negative ttl = no TTL GC
+    EXPECT_NE(nullptr, f.get(1, 1));
+    config::dictionary_version_ttl_seconds = old_ttl;
+    config::dictionary_max_versions = old_max;
+}
+
+TEST(DictionaryMultiVersionTest, GCIntervalLarge) {
+    auto old_interval = config::dictionary_gc_interval_seconds;
+    auto old_max = config::dictionary_max_versions;
+    config::dictionary_gc_interval_seconds = 1000000;
+    config::dictionary_max_versions = 1;
+    DictionaryFactory f;
+    f._last_gc_time_ms.store(UnixMillis(), std::memory_order_relaxed);
+    // manual commit without resetting GC timer
+    auto dict1 = make_dict("dict_1");
+    EXPECT_TRUE(f.refresh_dict(1, 1, dict1));
+    EXPECT_TRUE(f.commit_refresh_dict(1, 1));
+    auto dict2 = make_dict("dict_1");
+    EXPECT_TRUE(f.refresh_dict(1, 2, dict2));
+    EXPECT_TRUE(f.commit_refresh_dict(1, 2));
+    // interval not elapsed; GC skipped; both kept
+    EXPECT_NE(nullptr, f.get(1, 1));
+    EXPECT_NE(nullptr, f.get(1, 2));
+    config::dictionary_gc_interval_seconds = old_interval;
+    config::dictionary_max_versions = old_max;
+}
+
+// ============ boundary scenarios ============
+
+TEST(DictionaryMultiVersionTest, CommitDuplicateVersion) {
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    // commit same version again should fail
+    auto dict = make_dict("dict_1");
+    EXPECT_TRUE(f.refresh_dict(1, 1, dict));
+    auto st = f.commit_refresh_dict(1, 1);
+    EXPECT_FALSE(st.ok());
+}
+
+TEST(DictionaryMultiVersionTest, GetNonExistentDict) {
+    DictionaryFactory f;
+    EXPECT_EQ(nullptr, f.get(999, 1));
+}
+
+TEST(DictionaryMultiVersionTest, DeleteAllVersions) {
+    DictionaryFactory f;
+    config::dictionary_max_versions = 10;
+    commit_version(f, 1, 1);
+    commit_version(f, 1, 2);
+    commit_version(f, 1, 3);
+    EXPECT_TRUE(f.delete_dict(1).ok());
+    EXPECT_EQ(nullptr, f.get(1, 1));
+    EXPECT_EQ(nullptr, f.get(1, 2));
+    EXPECT_EQ(nullptr, f.get(1, 3));
+}
+
+TEST(DictionaryMultiVersionTest, DeleteNonExistent) {
+    DictionaryFactory f;
+    EXPECT_TRUE(f.delete_dict(999).ok());
+}
+
+TEST(DictionaryMultiVersionTest, DeleteAfterGC) {
+    auto old = config::dictionary_max_versions;
+    config::dictionary_max_versions = 1;
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    commit_version(f, 1, 2);
+    // v=1 already GC'd
+    EXPECT_TRUE(f.delete_dict(1).ok());
+    EXPECT_EQ(nullptr, f.get(1, 2));
+    config::dictionary_max_versions = old;
+}
+
+TEST(DictionaryMultiVersionTest, CommitAfterDelete) {
+    DictionaryFactory f;
+    config::dictionary_max_versions = 10;
+    commit_version(f, 1, 1);
+    EXPECT_TRUE(f.delete_dict(1).ok());
+    // commit new version after delete
+    commit_version(f, 1, 2);
+    EXPECT_NE(nullptr, f.get(1, 2));
+}
+
+// ============ get_dictionary_status ============
+
+TEST(DictionaryMultiVersionTest, GetStatusReportsLatest) {
+    DictionaryFactory f;
+    config::dictionary_max_versions = 10;
+    commit_version(f, 1, 1);
+    commit_version(f, 1, 2);
+    commit_version(f, 1, 3);
+    std::vector<TDictionaryStatus> result;
+    f.get_dictionary_status(result, {});
+    EXPECT_EQ(1, result.size());
+    EXPECT_EQ(1, result[0].dictionary_id);
+    EXPECT_EQ(3, result[0].version_id);
+}
+
+TEST(DictionaryMultiVersionTest, GetStatusEmptyAfterDelete) {
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    EXPECT_TRUE(f.delete_dict(1).ok());
+    std::vector<TDictionaryStatus> result;
+    f.get_dictionary_status(result, {});
+    EXPECT_EQ(0, result.size());
+}
+
+} // namespace doris

--- a/be/test/exec/dictionary/dictionary_multi_version_test.cpp
+++ b/be/test/exec/dictionary/dictionary_multi_version_test.cpp
@@ -84,7 +84,7 @@ TEST(DictionaryMultiVersionTest, GCByCount) {
     config::dictionary_max_versions = old_max;
 }
 
-TEST(DictionaryMultiVersionTest, GCByCountDefaultOne) {
+TEST(DictionaryMultiVersionTest, GCByCountOne) {
     auto old_max = config::dictionary_max_versions;
     config::dictionary_max_versions = 1;
     DictionaryFactory f;
@@ -312,6 +312,59 @@ TEST(DictionaryMultiVersionTest, GetStatusEmptyAfterDelete) {
     std::vector<TDictionaryStatus> result;
     f.get_dictionary_status(result, {});
     EXPECT_EQ(0, result.size());
+}
+
+// ============ staging fallback ============
+
+TEST(DictionaryMultiVersionTest, GetFromStagingFallback) {
+    DictionaryFactory f;
+    // commit v=1 to committed map
+    commit_version(f, 1, 1);
+    // refresh v=2 to staging (not committed yet)
+    auto dict2 = make_dict("dict_1");
+    EXPECT_TRUE(f.refresh_dict(1, 2, dict2));
+    // get(v=2): not in committed map, should fallback to staging
+    EXPECT_NE(nullptr, f.get(1, 2));
+}
+
+TEST(DictionaryMultiVersionTest, GetStagingVersionMismatch) {
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    // staging has v=3
+    auto dict3 = make_dict("dict_1");
+    EXPECT_TRUE(f.refresh_dict(1, 3, dict3));
+    // get(v=2): not in committed map, staging has v=3 (mismatch) -> nullptr
+    EXPECT_EQ(nullptr, f.get(1, 2));
+}
+
+TEST(DictionaryMultiVersionTest, GetAfterCommitRemovesStaging) {
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    // staging v=2
+    auto dict2 = make_dict("dict_1");
+    EXPECT_TRUE(f.refresh_dict(1, 2, dict2));
+    EXPECT_NE(nullptr, f.get(1, 2)); // staging fallback
+    // commit v=2: staging -> committed map
+    EXPECT_TRUE(f.commit_refresh_dict(1, 2));
+    // staging should be empty now
+    EXPECT_TRUE(!f._refreshing_dict_map.contains(1));
+    // get(v=2) should hit committed map
+    EXPECT_NE(nullptr, f.get(1, 2));
+}
+
+TEST(DictionaryMultiVersionTest, GetAfterAbortRemovesStaging) {
+    DictionaryFactory f;
+    commit_version(f, 1, 1);
+    // staging v=2
+    auto dict2 = make_dict("dict_1");
+    EXPECT_TRUE(f.refresh_dict(1, 2, dict2));
+    EXPECT_NE(nullptr, f.get(1, 2)); // staging fallback
+    // abort v=2: staging removed
+    EXPECT_TRUE(f.abort_refresh_dict(1, 2));
+    // get(v=2): not in committed map, staging gone -> nullptr
+    EXPECT_EQ(nullptr, f.get(1, 2));
+    // get(v=1): still in committed map
+    EXPECT_NE(nullptr, f.get(1, 1));
 }
 
 } // namespace doris

--- a/be/test/exec/dictionary/dictionary_version_test.cpp
+++ b/be/test/exec/dictionary/dictionary_version_test.cpp
@@ -112,8 +112,8 @@ TEST(DictionaryVersionTest, commit_dict) {
         auto status = dict_factory->commit_refresh_dict(3, 5);
         EXPECT_TRUE(status.ok());
         EXPECT_TRUE(!dict_factory->_refreshing_dict_map.contains(3));
-        EXPECT_TRUE(dict_factory->_dict_id_to_dict_map.contains(3));
-        EXPECT_EQ(dict_factory->_dict_id_to_version_id_map[3], 5);
+        EXPECT_TRUE(dict_factory->_dict_id_to_versioned_map.contains(3));
+        EXPECT_EQ(dict_factory->_dict_id_to_versioned_map[3].rbegin()->first, 5);
     }
 
     auto dict2 = create_complex_hash_map_dict_from_column(
@@ -136,8 +136,8 @@ TEST(DictionaryVersionTest, commit_dict) {
         auto status = dict_factory->commit_refresh_dict(3, 6);
         EXPECT_TRUE(status.ok());
         EXPECT_TRUE(!dict_factory->_refreshing_dict_map.contains(3));
-        EXPECT_TRUE(dict_factory->_dict_id_to_dict_map.contains(3));
-        EXPECT_EQ(dict_factory->_dict_id_to_version_id_map[3], 6);
+        EXPECT_TRUE(dict_factory->_dict_id_to_versioned_map.contains(3));
+        EXPECT_EQ(dict_factory->_dict_id_to_versioned_map[3].rbegin()->first, 6);
     }
 
     auto dict3 = create_complex_hash_map_dict_from_column(

--- a/fe/fe-core/src/main/java/org/apache/doris/dictionary/DictionaryManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/dictionary/DictionaryManager.java
@@ -538,7 +538,12 @@ public class DictionaryManager extends MasterDaemon implements Writable {
 
         // block here in test to simulate the race: INC journal written, commit not done yet.
         while (DebugPointUtil.isEnable("DictionaryManager.afterIncJournal")) {
-            Thread.sleep(100);
+            try {
+                Thread.sleep(1000);
+                LOG.info("block afterIncJournal for dict: {}", dictionary.getName());
+            } catch (InterruptedException e) {
+                LOG.warn("InterruptedException: ", e);
+            }
         }
 
         // commit and check the result. not modify metadata so dont need lock.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/ExpressionTranslator.java
@@ -50,6 +50,7 @@ import org.apache.doris.catalog.Index;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.dictionary.Dictionary;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.AggregateExpression;
@@ -649,7 +650,11 @@ public class ExpressionTranslator extends DefaultExpressionVisitor<Expr, PlanTra
         // set special fields
         TDictFunction dictFunction = new TDictFunction();
         dictFunction.setDictionaryId(dictionary.getId());
-        dictFunction.setVersionId(dictionary.getVersion());
+        long versionId = dictionary.getVersion();
+        // debug point to override version_id for testing multi-version retention
+        versionId = DebugPointUtil.getDebugParamOrDefault(
+                "ExpressionTranslator.dict_get_version", "version_id", versionId);
+        dictFunction.setVersionId(versionId);
         catalogFunction.setDictFunction(dictFunction);
 
         // create catalog FunctionCallExpr without analyze again

--- a/regression-test/suites/dictionary_p0/test_dict_version_consistency.groovy
+++ b/regression-test/suites/dictionary_p0/test_dict_version_consistency.groovy
@@ -1,0 +1,138 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+suite("test_dict_version_consistency", "nonConcurrent") {
+    sql "drop database if exists test_dict_version_consistency"
+    sql "create database test_dict_version_consistency"
+    sql "use test_dict_version_consistency"
+
+    sql """
+        create table src_dict(
+            k varchar(100) not null,
+            v varchar(100) not null
+        )
+        DISTRIBUTED BY HASH(`k`) BUCKETS 1
+        properties("replication_num" = "1");
+    """
+    sql "insert into src_dict values ('1', 'value1'), ('2', 'value2'), ('3', 'value3')"
+    sql """
+        create dictionary dict1 using src_dict
+        (k KEY, v VALUE) LAYOUT(HASH_MAP)
+        properties('data_lifetime'='600');
+    """
+    waitAllDictionariesReady()
+
+    def queryDict = { String key ->
+        sql "select dict_get('test_dict_version_consistency.dict1', 'v', '${key}')"
+    }
+
+    // get current dict version via show dictionaries
+    // columns: DictionaryId(0) DictionaryName(1) BaseTableName(2) Version(3) Status(4) ...
+    def getDictVersion = {
+        def rows = sql "show dictionaries"
+        for (def row : rows) {
+            if (row[1] == "dict1") return row[3] as int
+        }
+        return -1
+    }
+
+    // wait until dict version advances past baseline (FE increaseVersion done, commit still pending)
+    def waitVersionAdvanced = { int baseline, long timeoutMs ->
+        long deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            def v = getDictVersion()
+            if (v > baseline) return v
+            sleep(200)
+        }
+        throw new AssertionError("dict version did not advance past ${baseline} within ${timeoutMs}ms")
+    }
+
+    // baseline
+    def baselineVersion = getDictVersion()
+    def result = queryDict("1")
+    assertEquals("value1", result[0][0])
+
+    // ============ Test 1: staging fallback ============
+    // Scenario: FE increaseVersion() done (version N+1 visible) but commit RPC to BE not yet sent
+    //           (blocked at afterIncJournal debug point).
+    //           Query with version N+1 should succeed via _refreshing_dict_map fallback.
+    logger.info("=== Test 1: staging fallback ===")
+    GetDebugPoint().enableDebugPointForAllFEs("DictionaryManager.afterIncJournal")
+    try {
+        def executor = Executors.newSingleThreadExecutor()
+        def refreshFuture = executor.submit({
+            sql "use test_dict_version_consistency"
+            sql "refresh dictionary dict1"
+        })
+
+        // wait until FE has increased version (blocked at afterIncJournal, commit not done yet)
+        def advancedVersion = waitVersionAdvanced(baselineVersion, 10000)
+        logger.info("FE version advanced to ${advancedVersion}, commit still pending")
+
+        // query should succeed via staging fallback
+        result = queryDict("1")
+        assertEquals("value1", result[0][0])
+        logger.info("query succeeded via staging fallback")
+
+        GetDebugPoint().disableDebugPointForAllFEs("DictionaryManager.afterIncJournal")
+        refreshFuture.get(30, TimeUnit.SECONDS)
+        executor.shutdown()
+    } finally {
+        GetDebugPoint().disableDebugPointForAllFEs("DictionaryManager.afterIncJournal")
+    }
+    logger.info("=== Test 1 passed ===")
+
+    // ============ Test 2: multi-version retention ============
+    // Scenario: query holds old version N (dict_get_delay sleeps 5s at BE get()),
+    //           refresh commits new version N+1 during the sleep.
+    //           Verifies _dict_id_to_versioned_map retains old version N (max_versions=2).
+    logger.info("=== Test 2: multi-version retention ===")
+    update_all_be_config("dictionary_max_versions", "2")
+    GetDebugPoint().enableDebugPointForAllBEs("dict_get_delay", [sleep_sec: 5])
+    try {
+        def baselineVersion2 = getDictVersion()
+        // submit query in background: FE plan uses baselineVersion2, BE sleeps 5s at get()
+        def executor = Executors.newSingleThreadExecutor()
+        def queryResult = new java.util.concurrent.atomic.AtomicReference<List>()
+        def queryFuture = executor.submit({
+            sql "use test_dict_version_consistency"
+            queryResult.set(sql "select dict_get('test_dict_version_consistency.dict1', 'v', '1')")
+        })
+
+        // wait for BE to enter dict_get_delay (query is now sleeping with old version)
+        sleep(2000)
+
+        // refresh commits new version while query holds old version
+        sql "refresh dictionary dict1"
+        def newVersion = waitVersionAdvanced(baselineVersion2, 10000)
+        logger.info("refresh committed version ${newVersion}, query still holding ${baselineVersion2}")
+
+        // query should complete successfully using old version (multi-version retention)
+        queryFuture.get(30, TimeUnit.SECONDS)
+        executor.shutdown()
+        result = queryResult.get()
+        assertEquals("value1", result[0][0])
+        logger.info("query succeeded with old version (multi-version retention)")
+    } finally {
+        GetDebugPoint().disableDebugPointForAllBEs("dict_get_delay")
+        update_all_be_config("dictionary_max_versions", "1")
+    }
+    logger.info("=== Test 2 passed ===")
+}

--- a/regression-test/suites/dictionary_p0/test_dict_version_consistency.groovy
+++ b/regression-test/suites/dictionary_p0/test_dict_version_consistency.groovy
@@ -28,6 +28,7 @@ suite("test_dict_version_consistency", "nonConcurrent") {
             k varchar(100) not null,
             v varchar(100) not null
         )
+        UNIQUE KEY(`k`)
         DISTRIBUTED BY HASH(`k`) BUCKETS 1
         properties("replication_num" = "1");
     """
@@ -100,39 +101,40 @@ suite("test_dict_version_consistency", "nonConcurrent") {
     logger.info("=== Test 1 passed ===")
 
     // ============ Test 2: multi-version retention ============
-    // Scenario: query holds old version N (dict_get_delay sleeps 5s at BE get()),
-    //           refresh commits new version N+1 during the sleep.
-    //           Verifies _dict_id_to_versioned_map retains old version N (max_versions=2).
+    // Scenario: refresh commits version N+1 with new data, then query forced to use
+    //           old version N via FE debug point. Verifies _dict_id_to_versioned_map
+    //           retains old version N (max_versions=2) and returns old data.
     logger.info("=== Test 2: multi-version retention ===")
+    def prevMaxVersions = "2"
     update_all_be_config("dictionary_max_versions", "2")
-    GetDebugPoint().enableDebugPointForAllBEs("dict_get_delay", [sleep_sec: 5])
     try {
         def baselineVersion2 = getDictVersion()
-        // submit query in background: FE plan uses baselineVersion2, BE sleeps 5s at get()
-        def executor = Executors.newSingleThreadExecutor()
-        def queryResult = new java.util.concurrent.atomic.AtomicReference<List>()
-        def queryFuture = executor.submit({
-            sql "use test_dict_version_consistency"
-            queryResult.set(sql "select dict_get('test_dict_version_consistency.dict1', 'v', '1')")
-        })
 
-        // wait for BE to enter dict_get_delay (query is now sleeping with old version)
-        sleep(2000)
-
-        // refresh commits new version while query holds old version
+        // update src data so N+1 returns a distinguishable value (insert overwrites unique key)
+        sql "insert into src_dict values ('1', 'value1_v2')"
+        sql "sync"
         sql "refresh dictionary dict1"
         def newVersion = waitVersionAdvanced(baselineVersion2, 10000)
-        logger.info("refresh committed version ${newVersion}, query still holding ${baselineVersion2}")
+        logger.info("refresh committed version ${newVersion}, baseline was ${baselineVersion2}")
 
-        // query should complete successfully using old version (multi-version retention)
-        queryFuture.get(30, TimeUnit.SECONDS)
-        executor.shutdown()
-        result = queryResult.get()
-        assertEquals("value1", result[0][0])
-        logger.info("query succeeded with old version (multi-version retention)")
+        // query with forced old version N should return old data (multi-version retention)
+        GetDebugPoint().enableDebugPointForAllFEs("ExpressionTranslator.dict_get_version",
+                [version_id: baselineVersion2.toString()])
+        try {
+            result = queryDict("1")
+            assertEquals("value1", result[0][0])
+            logger.info("query with forced version ${baselineVersion2} returned old data")
+        } finally {
+            GetDebugPoint().disableDebugPointForAllFEs("ExpressionTranslator.dict_get_version")
+        }
+
+        // query with current version N+1 should return new data
+        result = queryDict("1")
+        assertEquals("value1_v2", result[0][0])
+        logger.info("query with current version ${newVersion} returned new data")
     } finally {
-        GetDebugPoint().disableDebugPointForAllBEs("dict_get_delay")
-        update_all_be_config("dictionary_max_versions", "1")
+        GetDebugPoint().disableDebugPointForAllFEs("ExpressionTranslator.dict_get_version")
+        update_all_be_config("dictionary_max_versions", prevMaxVersions)
     }
     logger.info("=== Test 2 passed ===")
 }


### PR DESCRIPTION
### What problem does this PR solve?

  ## Problem

  Two race conditions exist in dictionary version lifecycle between FE and BE:

  **1. FE version ahead of BE commit (N+1 vs N)**
  FE `dataLoad()` calls `increaseVersion()` before sending `commitNowVersion()` RPC to BE . 
During this window, queries with `dict_get(version_id=N+1)` fail on BE with "dictionary not found".

  **2. BE GCs old version while in-flight query still uses it (N+1 vs N)**
  BE previously stored only one version per dict. After a new version N+1 is
  committed, the old version N is immediately overwritten. In-flight queries
  that started with version N (already planned on FE) then fail on BE because
  version N no longer exists.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

