### PR TITLE
branch-3.1: [fix](thirdparty) repoint the dead lzo and libuuid download mirrors

### DIFF
--- a/.github/workflows/build-thirdparty.yml
+++ b/.github/workflows/build-thirdparty.yml
@@ -55,16 +55,22 @@ jobs:
         run: |
           git clone -b v7 https://github.com/easimon/maximize-build-space
 
-      - name: Maximize build space
-        uses: ./maximize-build-space
-        with:
-            root-reserve-mb: 4096
-            swap-size-mb: 8192
-            remove-dotnet: 'true'
-            remove-android: 'true'
-            remove-haskell: 'true'
-            remove-codeql: 'true'
-            remove-docker-images: 'true'
+      # Disabled, as on master and branch-4.0. The runner already boots with
+      # ~88G free on /, and this action hands that space to an LVM on the
+      # workspace while leaving / at 100% full (100M). gcc writes its assembler
+      # temporaries to /tmp on /, so the build then dies on "No space left on
+      # device" partway through aws-sdk-cpp.
+      #- name: Maximize build space
+      #  uses: ./maximize-build-space
+      #  with:
+      #      root-reserve-mb: 4096
+      #      temp-reserve-mb: 4096
+      #      swap-size-mb: 8192
+      #      remove-dotnet: 'true'
+      #      remove-android: 'true'
+      #      remove-haskell: 'true'
+      #      remove-codeql: 'true'
+      #      remove-docker-images: 'true'
 
       - name: Checkout ${{ github.ref }}
         uses: actions/checkout@v4

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -128,7 +128,7 @@ BZIP_SOURCE=bzip2-1.0.8
 BZIP_MD5SUM="67e051268d0c475ea773822f7500d0e5"
 
 # lzo2
-LZO2_DOWNLOAD="https://fossies.org/linux/misc/lzo-2.10.tar.gz"
+LZO2_DOWNLOAD="https://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz"
 LZO2_NAME=lzo-2.10.tar.gz
 LZO2_SOURCE=lzo-2.10
 LZO2_MD5SUM="39d3f3f9c55c87b1e5d6888e1420f4b5"
@@ -499,7 +499,7 @@ JSONCPP_SOURCE="jsoncpp-1.9.5"
 JSONCPP_MD5SUM="d6c8c609f2162eff373db62b90a051c7"
 
 # libuuid
-LIBUUID_DOWNLOAD="https://nchc.dl.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz"
+LIBUUID_DOWNLOAD="https://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz"
 LIBUUID_NAME="libuuid-1.0.3.tar.gz"
 LIBUUID_SOURCE="libuuid-1.0.3"
 LIBUUID_MD5SUM="d44d866d06286c08ba0846aba1086d68"


### PR DESCRIPTION
## Proposed changes

Two download mirrors in `thirdparty/vars.sh` on this branch are dead, and they
break every third party build:

| package | current URL | status |
|---|---|---|
| lzo | `https://fossies.org/linux/misc/lzo-2.10.tar.gz` | **410 Gone** |
| libuuid | `https://nchc.dl.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz` | unreachable (TLS handshake fails) |

The failure is not a clean one. `wget -O` creates its output file before the
transfer, so a dead URL leaves a 0-byte archive behind; the md5 check then fails
and the retry hits the same dead URL:

```
thirdparty/src/lzo-2.10.tar.gz md5sum check failed!
except-md5 39d3f3f9c55c87b1e5d6888e1420f4b5
actual-md5 d41d8cd98f00b204e9800998ecf8427e     <- md5 of an empty file
Downloading lzo-2.10.tar.gz from https://fossies.org/linux/misc/lzo-2.10.tar.gz
Failed to download lzo-2.10.tar.gz. attemp: 2
Failed to download lzo-2.10.tar.gz
```

This has been failing the `apache/doris-thirdparty` prebuilt pipeline for this
branch on every scheduled run since 2026-08-13 — 28 out of 28 runs red in the
last 15 hours alone. It also hits anyone building `thirdparty/` from source on
this branch.

This PR points both at the mirrors `master` already uses:

- lzo → `https://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz` (upstream)
- libuuid → `https://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz` (generic SourceForge redirector)

Both serve byte-identical archives, verified against the checksums already in
`vars.sh`, so `LZO2_MD5SUM` and `LIBUUID_MD5SUM` are unchanged:

```
lzo-2.10.tar.gz      39d3f3f9c55c87b1e5d6888e1420f4b5   (LZO2_MD5SUM,    600622 bytes)
libuuid-1.0.3.tar.gz d44d866d06286c08ba0846aba1086d68   (LIBUUID_MD5SUM, 318256 bytes)
```

`master` and `branch-4.0` already carry the lzo fix; this is the missing
backport. A companion PR fixes libuuid on `branch-4.0`.

Issue Number: close #xxx


---

## Second commit: the Linux CI leg could not pass without it

Touching `thirdparty/**` is what makes `Build Third Party Libraries` run its
heavy jobs, so this PR is the first thing in a while to exercise the Linux leg
on this branch — and it fails, 55 minutes in:

```
AWSXmlClient.cpp:212:1: fatal error: error writing to /tmp/cc3xHclc.s: No space left on device
```

Not a mirror problem. `easimon/maximize-build-space` is doing it. The runner
boots with plenty of room and the action hands all of it to an LVM on the
workspace:

```
before:  /dev/root  146G   59G   88G   40% /
after:   /dev/root  146G  146G  100M  100% /
```

gcc writes its assembler temporaries to `/tmp`, which is on `/`, so a unity
build file such as `ub_S3.cpp` has nowhere to go. `root-reserve-mb` does not
cover that — `temp-reserve-mb` does — and 4G would not have been enough anyway.

`master` and `branch-4.0` already comment this step out and build fine on the
stock runner disk. The second commit does the same here.

`branch-3.0` still has the active step and will hit this the next time someone
touches `thirdparty/**` there.

## Evidence the mirror fix itself works

From the same run, before it ran out of disk — the stale `automation-3.0` source
tarball still carries the 0-byte lzo, and the new mirror repairs it:

```
thirdparty/src/lzo-2.10.tar.gz md5sum check failed!
actual-md5 d41d8cd98f00b204e9800998ecf8427e
Archive lzo-2.10.tar.gz will be removed and download again.
Downloading lzo-2.10.tar.gz from https://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz
Success to download lzo-2.10.tar.gz
```

libuuid downloaded without a retry, and `Build Third Party Libraries
(macOS-arm64)` passed end to end in 1h9m.
