### PR TITLE
branch-4.0: [fix](thirdparty) repoint the dead libuuid download mirror

### DIFF
--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -505,7 +505,7 @@ JSONCPP_SOURCE="jsoncpp-1.9.5"
 JSONCPP_MD5SUM="d6c8c609f2162eff373db62b90a051c7"
 
 # libuuid
-LIBUUID_DOWNLOAD="https://nchc.dl.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz"
+LIBUUID_DOWNLOAD="https://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz"
 LIBUUID_NAME="libuuid-1.0.3.tar.gz"
 LIBUUID_SOURCE="libuuid-1.0.3"
 LIBUUID_MD5SUM="d44d866d06286c08ba0846aba1086d68"


### PR DESCRIPTION
## Proposed changes

`LIBUUID_DOWNLOAD` on this branch points at `nchc.dl.sourceforge.net`, a single
SourceForge mirror in Taiwan that is unreachable from GitHub Actions runners and
from several other networks — the TLS handshake fails outright.

Because `wget -O` creates its output file before the transfer, a failed download
leaves a 0-byte `libuuid-1.0.3.tar.gz` behind. The md5 check then fails and the
retry hits the same mirror. The `apache/doris-thirdparty` pipeline for this
branch has been logging it for a while:

```
Failed to download libuuid-1.0.3.tar.gz. attemp: 1
```

It currently survives on a retry, but it is a coin flip on every build, and the
same mirror already hard-fails `branch-3.1`.

This PR switches to the generic SourceForge redirector that `master` already
uses:

```
https://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz
```

It picks a working mirror per request and serves a byte-identical archive, so
`LIBUUID_MD5SUM` is unchanged — verified against the checksum already in
`vars.sh`:

```
libuuid-1.0.3.tar.gz  d44d866d06286c08ba0846aba1086d68  (318256 bytes)
```

A companion PR fixes the same mirror, plus the dead lzo one, on `branch-3.1`.

Issue Number: close #xxx
