### PR TITLE
[fix](constant folding) avoid folding non-comparable ordered literals

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/FoldConstantRuleOnFE.java
@@ -284,8 +284,11 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (checkedExpr.isPresent()) {
             return checkedExpr.get();
         }
-        return BooleanLiteral.of(((ComparableLiteral) greaterThan.left())
-                .compareTo((ComparableLiteral) greaterThan.right()) > 0);
+        if (greaterThan.left() instanceof ComparableLiteral && greaterThan.right() instanceof ComparableLiteral) {
+            return BooleanLiteral.of(((ComparableLiteral) greaterThan.left())
+                    .compareTo((ComparableLiteral) greaterThan.right()) > 0);
+        }
+        return greaterThan;
     }
 
     @Override
@@ -295,8 +298,12 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (checkedExpr.isPresent()) {
             return checkedExpr.get();
         }
-        return BooleanLiteral.of(((ComparableLiteral) greaterThanEqual.left())
-                .compareTo((ComparableLiteral) greaterThanEqual.right()) >= 0);
+        if (greaterThanEqual.left() instanceof ComparableLiteral
+                && greaterThanEqual.right() instanceof ComparableLiteral) {
+            return BooleanLiteral.of(((ComparableLiteral) greaterThanEqual.left())
+                    .compareTo((ComparableLiteral) greaterThanEqual.right()) >= 0);
+        }
+        return greaterThanEqual;
     }
 
     @Override
@@ -306,8 +313,11 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (checkedExpr.isPresent()) {
             return checkedExpr.get();
         }
-        return BooleanLiteral.of(((ComparableLiteral) lessThan.left())
-                .compareTo((ComparableLiteral) lessThan.right()) < 0);
+        if (lessThan.left() instanceof ComparableLiteral && lessThan.right() instanceof ComparableLiteral) {
+            return BooleanLiteral.of(((ComparableLiteral) lessThan.left())
+                    .compareTo((ComparableLiteral) lessThan.right()) < 0);
+        }
+        return lessThan;
     }
 
     @Override
@@ -317,8 +327,12 @@ public class FoldConstantRuleOnFE extends AbstractExpressionRewriteRule
         if (checkedExpr.isPresent()) {
             return checkedExpr.get();
         }
-        return BooleanLiteral.of(((ComparableLiteral) lessThanEqual.left())
-                .compareTo((ComparableLiteral) lessThanEqual.right()) <= 0);
+        if (lessThanEqual.left() instanceof ComparableLiteral
+                && lessThanEqual.right() instanceof ComparableLiteral) {
+            return BooleanLiteral.of(((ComparableLiteral) lessThanEqual.left())
+                    .compareTo((ComparableLiteral) lessThanEqual.right()) <= 0);
+        }
+        return lessThanEqual;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -31,6 +31,9 @@ import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.Divide;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.GreaterThan;
+import org.apache.doris.nereids.trees.expressions.GreaterThanEqual;
+import org.apache.doris.nereids.trees.expressions.LessThan;
+import org.apache.doris.nereids.trees.expressions.LessThanEqual;
 import org.apache.doris.nereids.trees.expressions.Multiply;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
@@ -115,6 +118,7 @@ import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.TimeV2Literal;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.trees.plans.RelationId;
@@ -263,6 +267,44 @@ class FoldConstantTest extends ExpressionRewriteTestHelper {
         assertRewriteAfterTypeCoercion("not 1 > 2", "true");
         assertRewriteAfterTypeCoercion("not null + 1 > 2", "null");
         assertRewriteAfterTypeCoercion("not (1 + 5) / 2 + (10 - 1) * 3 > 3 * 5 + 1", "false");
+    }
+
+    @Test
+    void testComparisonFoldWithNonComparableLiteral() {
+        executor = new ExpressionRuleExecutor(ImmutableList.of(
+                bottomUp(FoldConstantRuleOnFE.VISITOR_INSTANCE)
+        ));
+
+        Expression analyzed = ExpressionAnalyzer.analyzeFunction(null, null,
+                PARSER.parseExpression("curtime() >= '20:00:00'"));
+        Expression rewritten = executor.rewrite(analyzed, context);
+        Assertions.assertTrue(rewritten instanceof GreaterThanEqual);
+        Assertions.assertTrue(rewritten.child(0) instanceof TimeV2Literal);
+        Assertions.assertTrue(rewritten.child(1) instanceof TimeV2Literal);
+
+        analyzed = ExpressionAnalyzer.analyzeFunction(null, null,
+                PARSER.parseExpression("curtime() > '20:00:00'"));
+        rewritten = executor.rewrite(analyzed, context);
+        Assertions.assertTrue(rewritten instanceof GreaterThan);
+        Assertions.assertTrue(rewritten.child(0) instanceof TimeV2Literal);
+        Assertions.assertTrue(rewritten.child(1) instanceof TimeV2Literal);
+
+        analyzed = ExpressionAnalyzer.analyzeFunction(null, null,
+                PARSER.parseExpression("curtime() <= '20:00:00'"));
+        rewritten = executor.rewrite(analyzed, context);
+        Assertions.assertTrue(rewritten instanceof LessThanEqual);
+        Assertions.assertTrue(rewritten.child(0) instanceof TimeV2Literal);
+        Assertions.assertTrue(rewritten.child(1) instanceof TimeV2Literal);
+
+        analyzed = ExpressionAnalyzer.analyzeFunction(null, null,
+                PARSER.parseExpression("curtime() < '20:00:00'"));
+        rewritten = executor.rewrite(analyzed, context);
+        Assertions.assertTrue(rewritten instanceof LessThan);
+        Assertions.assertTrue(rewritten.child(0) instanceof TimeV2Literal);
+        Assertions.assertTrue(rewritten.child(1) instanceof TimeV2Literal);
+
+        assertRewriteAfterTypeCoercion("curtime() = '20:00:00'", "false");
+        assertRewriteAfterTypeCoercion("curtime() <=> '20:00:00'", "false");
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66829

Problem Summary:
The FE FoldConstantRuleOnFE visitors for the ordered comparisons
`>`, `>=`, `<`, `<=` unconditionally cast both operands to
`ComparableLiteral` before folding. When a child folds to a literal that
extends `Literal` but does not implement `ComparableLiteral` (for
example `curtime()` folding to `TimeV2Literal`), the cast throws a
`java.lang.ClassCastException` during planning, crashing queries such as
`curtime() >= '20:00:00'`.

Root cause: `visitGreaterThan`, `visitGreaterThanEqual`, `visitLessThan`,
and `visitLessThanEqual` perform the cast without first checking that
both children are `ComparableLiteral`, unlike the already-correct
`visitEqualTo` and `visitNullSafeEqual` visitors which guard with
`instanceof ComparableLiteral`.

Fix: guard each of the four ordered-comparison visitors with the same
`instanceof ComparableLiteral` check. When both operands are comparable
the fold proceeds as before; otherwise the original comparison
expression is returned unchanged so the predicate is preserved for later
evaluation instead of crashing at plan time.

### Release note

Fix a ClassCastException in the Nereids FE constant-folding rule when an
ordered comparison (>, >=, <, <=) has an operand that folds to a
non-comparable literal such as a TIME value; the comparison is now kept
as a predicate instead of crashing planning.

### Check List (For Author)

- Test: Unit Test
    - Added FoldConstantTest#testComparisonFoldWithNonComparableLiteral
      covering all four ordered operators (>, >=, <, <=) with
      TimeV2Literal, asserting the comparison stays un-folded and both
      children remain TimeV2Literal; verified red before the fix
      (ClassCastException) and green after. Full FoldConstantTest class
      passes (25 tests). FE checkstyle and FE build pass.
- Behavior changed: Yes. Previously an ordered comparison over a
  non-comparable folded literal threw a ClassCastException during
  planning; it is now preserved as a predicate and evaluated normally.
- Does this need documentation: No