### PR TITLE
[fix](security) Mask sensitive fields in encryption keys schema table

### DIFF
--- a/be/src/information_schema/schema_encryption_keys_scanner.cpp
+++ b/be/src/information_schema/schema_encryption_keys_scanner.cpp
@@ -160,12 +160,10 @@ Status SchemaEncryptionKeysScanner::_fill_block_impl(Block* block) {
                     }
                     break;
                 case 6:
-                    column_value = encryption_key.has_iv_base64() ? encryption_key.iv_base64() : "";
+                    column_value = encryption_key.has_iv_base64() ? "******" : "";
                     break;
                 case 7:
-                    column_value = encryption_key.has_ciphertext_base64()
-                                           ? encryption_key.ciphertext_base64()
-                                           : "";
+                    column_value = encryption_key.has_ciphertext_base64() ? "******" : "";
                     break;
                 }
 

--- a/be/test/exec/schema_scanner/schema_encryption_keys_scanner_test.cpp
+++ b/be/test/exec/schema_scanner/schema_encryption_keys_scanner_test.cpp
@@ -33,13 +33,26 @@ class ScheamEncryptionKeysScannerTest : public testing::Test {
 TEST_F(ScheamEncryptionKeysScannerTest, test_get_next_block_internal) {
     SchemaEncryptionKeysScanner scanner;
     auto& keys = scanner._master_keys;
-    EncryptionKeyPB key;
-    keys.push_back(key);
+    keys.emplace_back();
+    EncryptionKeyPB key_with_sensitive_values;
+    key_with_sensitive_values.set_iv_base64("sensitive iv");
+    key_with_sensitive_values.set_ciphertext_base64("sensitive cipher");
+    keys.push_back(key_with_sensitive_values);
 
     auto data_block = Block::create_unique();
     scanner._init_block(data_block.get());
 
     auto st = scanner._fill_block_impl(data_block.get());
+    ASSERT_EQ(Status::OK(), st);
+    ASSERT_EQ(2, data_block->rows());
+
+    const auto& iv_column = data_block->safe_get_by_position(6).column;
+    EXPECT_EQ("", (*iv_column)[0].get<TYPE_STRING>());
+    EXPECT_EQ("******", (*iv_column)[1].get<TYPE_STRING>());
+
+    const auto& cipher_column = data_block->safe_get_by_position(7).column;
+    EXPECT_EQ("", (*cipher_column)[0].get<TYPE_STRING>());
+    EXPECT_EQ("******", (*cipher_column)[1].get<TYPE_STRING>());
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #CIR-27838

Related PR: #xxx

Problem Summary:

Querying `information_schema.encryption_keys` exposes the original Base64-encoded initialization vector and ciphertext through the `IV` and `CIPHER` columns.

The schema scanner previously copied `iv_base64` and `ciphertext_base64` directly into the result block. This change masks both fields with `******` when their values are present, while preserving the existing empty-string behavior when the fields are absent.

A BE unit test is added to verify both the masked-value and empty-value cases.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
  - [ ] Regression test
  - [x] Unit Test
  - [ ] Manual test (add detailed scripts or steps below)
  - [ ] No need to test or manual test. Explain why:
    - [ ] This is a refactor/code format and no logic has been changed.
    - [ ] Previous test can cover this change.
    - [ ] No code files have been changed.
    - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
  - [ ] No.
  - [x] Yes. The `IV` and `CIPHER` columns in `information_schema.encryption_keys` now return `******` instead of exposing their original values.

- Does this need documentation?
  - [x] No.
  - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->