### PR TITLE
[fix](security) Mask private key password in backend configuration

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -2551,6 +2551,9 @@ std::vector<std::vector<std::string>> get_config_info() {
         if (it.first == "sys_log_dir" && config_val == "") {
             config_val = fmt::format("{}/log", std::getenv("DORIS_HOME"));
         }
+        if (it.first == "tls_private_key_password") {
+            config_val = "******";
+        }
 
         _config.emplace_back(field_it->second.type);
         if (0 == strcmp(field_it->second.type, "bool")) {


### PR DESCRIPTION
Problem Summary:

The `tls_private_key_password` configuration value is exposed in plaintext through `information_schema.backend_configuration`.

The value is collected by `config::get_config_info()` from the BE configuration map and returned without masking. Since the default role has read access to `information_schema.*`, an authenticated user can query the table and obtain the TLS private key password.

This change masks `tls_private_key_password` as `******` at the shared configuration export layer. The masking applies to `information_schema.backend_configuration` and other output paths that reuse `get_config_info()`, while preserving the configuration name, type, and mutability fields.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
  - [ ] Regression test
  - [ ] Unit Test
  - [ ] Manual test (add detailed scripts or steps below)
  - [x] No need to test or manual test. Explain why:
    - [ ] This is a refactor/code format and no logic has been changed.
    - [ ] Previous test can cover this change.
    - [ ] No code files have been changed.
    - [x] Other reason: The change is limited to replacing one sensitive configuration value at the shared output point. `clang-format`, `git diff --check`, and `config.cpp` compilation passed.

- Behavior changed:
  - [ ] No.
  - [x] Yes. `tls_private_key_password` is now returned as `******` instead of its plaintext value.