### PR TITLE
[fix](build) Keep relocated storage sources out of unity builds

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -55,10 +55,8 @@ pch_reuse(Storage)
 #   FORMAT_*_ADD_JSON_NODE, RETURN_IF_ERROR_) must not leak into unity siblings
 # - the three heaviest template-instantiation TUs (predicate creators) which
 #   would dominate any batch they join
-# - compaction/collection_statistics.cpp: its test compiles it a second time
-#   by #including the .cpp; the test object must shadow a never-pulled archive
-#   member, but a unity batch is pulled in for its siblings and the linker
-#   sees a duplicate definition
+# - segment/variant/v2/variant_storage_cell.cpp: it and variant_assembler.cpp
+#   define the same anonymous-namespace helper, which conflicts in one unity batch
 set(STORAGE_UNITY_SKIP
     ${CMAKE_CURRENT_SOURCE_DIR}/index/inverted/inverted_index_compound_reader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/index/inverted/inverted_index_fs_directory.cpp
@@ -70,7 +68,8 @@ set(STORAGE_UNITY_SKIP
     ${CMAKE_CURRENT_SOURCE_DIR}/predicate/predicate_creator_comparison.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/predicate/predicate_creator_in_list_in.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/predicate/predicate_creator_in_list_not_in.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/compaction/collection_statistics.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/index/inverted/similarity/collection_statistics.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/segment/variant/v2/variant_storage_cell.cpp)
 if (ENABLE_VARIANT_NESTED_GROUP)
     # Out-of-tree module sources swapped into this target: unity hygiene
     # unaudited, keep them individual.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #66052

Problem Summary:

PR #66052 moved `collection_statistics.cpp` from `be/src/storage/compaction/` to `be/src/storage/index/inverted/similarity/`. The Storage unity-build skip list still used the old path. The `doris_skip_unity_inclusion` helper intentionally rejects nonexistent entries, so a clean BE CMake configuration fails before compilation.

The relocated source must remain excluded from the unity batch. After updating the path, CMake repacks the remaining Storage sources and puts `variant_assembler.cpp` and `variant_storage_cell.cpp` in one generated unity translation unit. Both files define an implementation-local `publish_encoded` helper in an anonymous namespace; this is valid when compiled independently but becomes a redefinition in one unity translation unit.

This PR updates the collection-statistics exclusion to its new source path and excludes `variant_storage_cell.cpp` from unity builds, preserving the independent compilation boundary for both Variant files. It changes only build grouping and does not alter runtime behavior.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - Run `DORIS_HOME=/mnt/disk1/ganderun/doris cmake --build be/build_Release --target Storage -j192`.
        - Verify CMake accepts the relocated skip entry and the `Storage` target builds with unity builds enabled.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->