### PR TITLE
[fix](parquet) Fill columns absent from the physical parquet schema

### DIFF
--- a/be/src/format/parquet/vparquet_reader.cpp
+++ b/be/src/format/parquet/vparquet_reader.cpp
@@ -512,6 +512,23 @@ Status ParquetReader::_do_init_reader(ReaderInitContext* base_ctx) {
             }
             if (!_table_info_node_ptr->children_column_exists(col_name)) {
                 _fill_missing_cols.insert(col_name);
+                continue;
+            }
+            // Safety net for schema-evolution mismatches: a table-format reader builds the schema
+            // tree from FE-supplied schema info (history_schema_info / field-id mapping), so it can
+            // map a table column to a file column that is NOT in this file's physical schema — e.g.
+            // a column added by schema change whose default was never materialized into the old
+            // data files. Such a column is neither read (_init_read_columns matches file-schema
+            // order, so it is silently dropped) nor filled, and later surfaces as a 0-row column
+            // that trips the "filter.size() == offsets.size()" check in filter_block_internal.
+            // Demote it to a missing column so it gets its default/null values instead.
+            const auto file_col_name = _table_info_node_ptr->children_file_column_name(col_name);
+            if (_file_metadata->schema().get_column_index(file_col_name) < 0) {
+                _fill_missing_cols.insert(col_name);
+                LOG(WARNING) << "Demoting table column '" << col_name << "' to a missing column: "
+                             << "it maps to file column '" << file_col_name
+                             << "' which is absent from the physical parquet schema, file="
+                             << _scan_range.path;
             }
         }
         if (_column_descs && !_fill_missing_cols.empty()) {


### PR DESCRIPTION

### What problem does this PR solve?
A table-format reader builds its schema-change tree from FE-supplied schema info (history_schema_info, field-id mapping), so it can map a table column to a file column that is not present in this file's physical parquet schema — for example a column added by schema change whose default was never materialized into the older data files.

Such a column was neither read nor filled: _init_read_columns walks the file schema in physical order, so the column was silently dropped, and because children_column_exists() reported it as present it was never classified as fill-missing either. It then surfaced downstream as a 0-row column, tripping the filter.size() == offsets.size() check in filter_block_internal.

Detect this case in _do_init_reader by checking the mapped file column against the physical schema, and demote the column to a missing column so it is filled with its default/null values.

Stack:
```text
F column_string.cpp:349] Check failed: filter.size() == offsets.size() (8160 vs. 0)
    doris::ColumnStr<>::filter()
    doris::ColumnNullable::filter()
    doris::Block::filter_block_internal()
    doris::RowGroupReader::next_batch()
    doris::ParquetReader::get_next_block()
    doris::HudiReader::get_next_block_inner()
    doris::FileScanner::_get_block_wrapped()
    ...
```

Issue Number: close #xxx

Related PR: #xxx


Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

