### PR TITLE
[improvement](profile) Detach physical plan from memo before storing in profile

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -35,6 +35,7 @@ import org.apache.doris.nereids.trees.plans.PlanNodeAndHash;
 import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.distribute.DistributedPlan;
 import org.apache.doris.nereids.trees.plans.distribute.FragmentIdMapping;
+import org.apache.doris.nereids.trees.plans.physical.AbstractPhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalRelation;
 import org.apache.doris.planner.Planner;
@@ -292,8 +293,17 @@ public class Profile {
 
             if (planner != null && planner instanceof NereidsPlanner) {
                 NereidsPlanner nereidsPlanner = ((NereidsPlanner) planner);
-                physicalPlan = nereidsPlanner.getPhysicalPlan();
-                physicalRelations.addAll(nereidsPlanner.getPhysicalRelations());
+                if (physicalPlan == null) {
+                    // Profile is a long-lived object. Clone the physical plan and detach it from the
+                    // memo (clear the group expression on every node), otherwise holding the original
+                    // plan would keep the whole memo alive and prevent it from being released early.
+                    physicalPlan = AbstractPhysicalPlan.copyPlanDetachedFromMemo(
+                            nereidsPlanner.getPhysicalPlan());
+                    for (PhysicalRelation relation : nereidsPlanner.getPhysicalRelations()) {
+                        physicalRelations.add((PhysicalRelation) AbstractPhysicalPlan
+                                .copyPlanDetachedFromMemo(relation));
+                    }
+                }
                 if (profileLevel >= 3) {
                     FragmentIdMapping<DistributedPlan> distributedPlans = nereidsPlanner.getDistributedPlans();
                     if (distributedPlans != null) {
@@ -762,10 +772,6 @@ public class Profile {
 
     public PhysicalPlan getPhysicalPlan() {
         return physicalPlan;
-    }
-
-    public void setPhysicalPlan(PhysicalPlan physicalPlan) {
-        this.physicalPlan = physicalPlan;
     }
 
     private void updateActualRowCountOnPhysicalPlan(Plan plan) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/AbstractPhysicalPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/AbstractPhysicalPlan.java
@@ -31,6 +31,7 @@ import org.apache.doris.statistics.Statistics;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -80,6 +81,81 @@ public abstract class AbstractPhysicalPlan extends AbstractPlan implements Physi
 
     public List<org.apache.doris.nereids.trees.plans.physical.RuntimeFilter> getAppliedRuntimeFilters() {
         return appliedRuntimeFilters;
+    }
+
+    /**
+     * Deep copy the physical plan tree and detach every node from the memo.
+     *
+     * <p>Each node of the plan produced by the optimizer keeps a reference to its
+     * {@link GroupExpression}, which in turn references the whole memo. If such a plan is
+     * held by a long-lived object (e.g. the query {@code Profile}), the memo and all its
+     * groups and group expressions can never be garbage collected even after
+     * {@link org.apache.doris.nereids.CascadesContext#releaseMemo()} is called.
+     *
+     * <p>This method returns a copy of the plan tree in which every node's group expression
+     * is cleared, so the copy shares no object with the memo and the memo can be released as
+     * early as possible. The copy preserves the plan structure, node ids, statistics, physical
+     * properties and group ids (stored as mutable state, so that
+     * {@link Plan#treeString()} output stays the same).
+     */
+    public static PhysicalPlan copyPlanDetachedFromMemo(PhysicalPlan plan) {
+        if (plan == null) {
+            return null;
+        }
+        if (plan instanceof PhysicalLazyMaterialize) {
+            PhysicalLazyMaterialize<?> lazy = (PhysicalLazyMaterialize<?>) plan;
+            Plan clonedChild = lazy.children().isEmpty()
+                    ? null : copyPlanDetachedFromMemo((PhysicalPlan) lazy.child(0));
+            return lazy.copyDetachedFromMemo(clonedChild);
+        }
+        if (plan instanceof PhysicalStorageLayerAggregate) {
+            PhysicalStorageLayerAggregate storageAgg = (PhysicalStorageLayerAggregate) plan;
+            PhysicalCatalogRelation detachedRelation = (PhysicalCatalogRelation) copyPlanDetachedFromMemo(
+                    storageAgg.getRelation());
+            PhysicalStorageLayerAggregate copy = new PhysicalStorageLayerAggregate(detachedRelation,
+                    storageAgg.getAggOp(), Optional.empty(), storageAgg.getLogicalProperties(),
+                    storageAgg.getPhysicalProperties(), storageAgg.getStats());
+            copyGroupId(storageAgg, copy);
+            return copy;
+        }
+        List<Plan> clonedChildren = new ArrayList<>(plan.arity());
+        boolean childChanged = false;
+        for (Plan child : plan.children()) {
+            if (child instanceof PhysicalPlan) {
+                PhysicalPlan clonedChild = copyPlanDetachedFromMemo((PhysicalPlan) child);
+                clonedChildren.add(clonedChild);
+                childChanged |= clonedChild != child;
+            } else {
+                clonedChildren.add(child);
+            }
+        }
+        // The whole subtree carries no memo reference, reuse the node directly.
+        if (plan.getGroupExpression().isEmpty() && !childChanged) {
+            return plan;
+        }
+        PhysicalProperties physicalProperties = plan.getPhysicalProperties();
+        Statistics statistics = plan.getStats();
+        Plan copied = plan.withChildren(clonedChildren);
+        if (copied.getGroupExpression().isPresent()) {
+            copied = copied.withGroupExpression(Optional.empty());
+        }
+        PhysicalPlan detached;
+        if (copied.getStats() == null && statistics != null) {
+            detached = ((PhysicalPlan) copied).withPhysicalPropertiesAndStats(physicalProperties, statistics);
+        } else {
+            detached = (PhysicalPlan) copied;
+        }
+        copyGroupId(plan, detached);
+        plan.getMutableState(MutableState.KEY_PUSH_TOPN_TO_AGG)
+                .ifPresent(value -> detached.setMutableState(MutableState.KEY_PUSH_TOPN_TO_AGG, value));
+        return detached;
+    }
+
+    private static void copyGroupId(Plan source, Plan target) {
+        String groupId = source.getGroupIdAsString();
+        if (!groupId.isEmpty()) {
+            target.setMutableState(MutableState.KEY_GROUP, groupId);
+        }
     }
 
     public void addAppliedRuntimeFilter(org.apache.doris.nereids.trees.plans.physical.RuntimeFilter filter) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/AbstractPhysicalPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/AbstractPhysicalPlan.java
@@ -145,16 +145,18 @@ public abstract class AbstractPhysicalPlan extends AbstractPlan implements Physi
                 clonedChildren.add(child);
             }
         }
-        // The whole subtree carries no memo reference, reuse the node directly.
-        if (plan.getGroupExpression().isEmpty() && !childChanged) {
+        // The whole subtree carries no memo reference, reuse the node directly. Nodes that still
+        // carry runtime filters must be copied as well: their filters reference other plan nodes,
+        // which would keep the memo reachable through the reused node.
+        if (plan.getGroupExpression().isEmpty() && !childChanged && !carriesRuntimeFilters(plan)) {
             return plan;
         }
         PhysicalProperties physicalProperties = plan.getPhysicalProperties();
         Statistics statistics = plan.getStats();
         Plan copied = plan.withChildren(clonedChildren);
-        if (copied.getGroupExpression().isPresent()) {
-            copied = copied.withGroupExpression(Optional.empty());
-        }
+        // Detach the group expression even if it is already empty, so that a leaf node (whose
+        // withChildren() returns the node itself) with runtime filters still gets a new node.
+        copied = copied.withGroupExpression(Optional.empty());
         PhysicalPlan detached;
         if (copied.getStats() == null && statistics != null) {
             detached = ((PhysicalPlan) copied).withPhysicalPropertiesAndStats(physicalProperties, statistics);
@@ -166,6 +168,12 @@ public abstract class AbstractPhysicalPlan extends AbstractPlan implements Physi
                 .ifPresent(value -> detached.setMutableState(MutableState.KEY_PUSH_TOPN_TO_AGG, value));
         originalToClone.put(plan, detached);
         return detached;
+    }
+
+    private static boolean carriesRuntimeFilters(Plan plan) {
+        return plan instanceof AbstractPhysicalPlan
+                && (!((AbstractPhysicalPlan) plan).getRuntimeFilters().isEmpty()
+                        || !((AbstractPhysicalPlan) plan).getAppliedRuntimeFilters().isEmpty());
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/AbstractPhysicalPlan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/AbstractPhysicalPlan.java
@@ -32,7 +32,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -95,34 +97,48 @@ public abstract class AbstractPhysicalPlan extends AbstractPlan implements Physi
      * <p>This method returns a copy of the plan tree in which every node's group expression
      * is cleared, so the copy shares no object with the memo and the memo can be released as
      * early as possible. The copy preserves the plan structure, node ids, statistics, physical
-     * properties and group ids (stored as mutable state, so that
-     * {@link Plan#treeString()} output stays the same).
+     * properties, group ids (stored as mutable state, so that {@link Plan#treeString()} output
+     * stays the same) and the runtime filters (re-created on the copied builder nodes and
+     * target scans, so the printed plan keeps the RF information without referencing the
+     * original plan nodes).
      */
     public static PhysicalPlan copyPlanDetachedFromMemo(PhysicalPlan plan) {
         if (plan == null) {
             return null;
         }
+        Map<Plan, Plan> originalToClone = new IdentityHashMap<>();
+        Map<RuntimeFilter, RuntimeFilter> rfCloneMap = new IdentityHashMap<>();
+        PhysicalPlan detached = copyPlanDetachedFromMemo(plan, originalToClone, rfCloneMap);
+        copyRuntimeFilters(originalToClone, rfCloneMap);
+        return detached;
+    }
+
+    static PhysicalPlan copyPlanDetachedFromMemo(PhysicalPlan plan,
+            Map<Plan, Plan> originalToClone, Map<RuntimeFilter, RuntimeFilter> rfCloneMap) {
         if (plan instanceof PhysicalLazyMaterialize) {
             PhysicalLazyMaterialize<?> lazy = (PhysicalLazyMaterialize<?>) plan;
             Plan clonedChild = lazy.children().isEmpty()
-                    ? null : copyPlanDetachedFromMemo((PhysicalPlan) lazy.child(0));
-            return lazy.copyDetachedFromMemo(clonedChild);
+                    ? null : copyPlanDetachedFromMemo((PhysicalPlan) lazy.child(0), originalToClone, rfCloneMap);
+            PhysicalLazyMaterialize<?> copy = lazy.copyDetachedFromMemo(clonedChild, originalToClone, rfCloneMap);
+            originalToClone.put(plan, copy);
+            return copy;
         }
         if (plan instanceof PhysicalStorageLayerAggregate) {
             PhysicalStorageLayerAggregate storageAgg = (PhysicalStorageLayerAggregate) plan;
             PhysicalCatalogRelation detachedRelation = (PhysicalCatalogRelation) copyPlanDetachedFromMemo(
-                    storageAgg.getRelation());
+                    storageAgg.getRelation(), originalToClone, rfCloneMap);
             PhysicalStorageLayerAggregate copy = new PhysicalStorageLayerAggregate(detachedRelation,
-                    storageAgg.getAggOp(), Optional.empty(), storageAgg.getLogicalProperties(),
-                    storageAgg.getPhysicalProperties(), storageAgg.getStats());
+                    storageAgg.getAggOp(), storageAgg.getCountArgumentExprIds(), Optional.empty(),
+                    storageAgg.getLogicalProperties(), storageAgg.getPhysicalProperties(), storageAgg.getStats());
             copyGroupId(storageAgg, copy);
+            originalToClone.put(plan, copy);
             return copy;
         }
         List<Plan> clonedChildren = new ArrayList<>(plan.arity());
         boolean childChanged = false;
         for (Plan child : plan.children()) {
             if (child instanceof PhysicalPlan) {
-                PhysicalPlan clonedChild = copyPlanDetachedFromMemo((PhysicalPlan) child);
+                PhysicalPlan clonedChild = copyPlanDetachedFromMemo((PhysicalPlan) child, originalToClone, rfCloneMap);
                 clonedChildren.add(clonedChild);
                 childChanged |= clonedChild != child;
             } else {
@@ -148,7 +164,56 @@ public abstract class AbstractPhysicalPlan extends AbstractPlan implements Physi
         copyGroupId(plan, detached);
         plan.getMutableState(MutableState.KEY_PUSH_TOPN_TO_AGG)
                 .ifPresent(value -> detached.setMutableState(MutableState.KEY_PUSH_TOPN_TO_AGG, value));
+        originalToClone.put(plan, detached);
         return detached;
+    }
+
+    /**
+     * Re-create the runtime filters on the copied nodes. Each runtime filter is cloned once and
+     * re-pointed to the copied builder node and target scan, so the copy keeps the runtime filter
+     * information of the printed plan without referencing the original plan nodes (and thus the memo).
+     */
+    private static void copyRuntimeFilters(Map<Plan, Plan> originalToClone,
+            Map<RuntimeFilter, RuntimeFilter> rfCloneMap) {
+        // Clone every runtime filter built on the copied nodes; the constructor attaches the clone
+        // to the copied builder node.
+        for (Map.Entry<Plan, Plan> entry : originalToClone.entrySet()) {
+            Plan original = entry.getKey();
+            Plan clone = entry.getValue();
+            if (original instanceof AbstractPhysicalPlan && clone instanceof AbstractPhysicalPlan) {
+                for (RuntimeFilter rf : ((AbstractPhysicalPlan) original).getRuntimeFilters()) {
+                    // Only clone when both the builder node and the target scan are copied, otherwise
+                    // the clone would reference (and mutate) the original plan nodes.
+                    if (originalToClone.containsKey(rf.getBuilderNode())
+                            && originalToClone.containsKey(rf.getTargetScan())) {
+                        rfCloneMap.computeIfAbsent(rf, r -> cloneRuntimeFilter(r, originalToClone));
+                    }
+                }
+            }
+        }
+        // Attach the cloned runtime filters to the copied target scans.
+        for (Map.Entry<Plan, Plan> entry : originalToClone.entrySet()) {
+            Plan original = entry.getKey();
+            Plan clone = entry.getValue();
+            if (original instanceof AbstractPhysicalPlan && clone instanceof AbstractPhysicalPlan) {
+                for (RuntimeFilter rf : ((AbstractPhysicalPlan) original).getAppliedRuntimeFilters()) {
+                    RuntimeFilter cloned = rfCloneMap.get(rf);
+                    if (cloned != null) {
+                        ((AbstractPhysicalPlan) clone).addAppliedRuntimeFilter(cloned);
+                    }
+                }
+            }
+        }
+    }
+
+    private static RuntimeFilter cloneRuntimeFilter(RuntimeFilter rf, Map<Plan, Plan> originalToClone) {
+        RuntimeFilter cloned = new RuntimeFilter(rf.getId(), rf.getSrcExpr(), rf.getTargetSlot(),
+                rf.getTargetExpression(), rf.getType(), rf.getExprOrder(),
+                (AbstractPhysicalPlan) originalToClone.get(rf.getBuilderNode()),
+                rf.getBuildSideNdv(), rf.isBloomFilterSizeCalculatedByNdv(), rf.gettMinMaxType(),
+                (PhysicalRelation) originalToClone.get(rf.getTargetScan()));
+        cloned.setNonBlocking(rf.isNonBlocking());
+        return cloned;
     }
 
     private static void copyGroupId(Plan source, Plan target) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterialize.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterialize.java
@@ -38,10 +38,13 @@ import org.apache.doris.nereids.util.ExpressionUtils;
 import org.apache.doris.statistics.Statistics;
 
 import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -260,6 +263,42 @@ public class PhysicalLazyMaterialize<CHILD_TYPE extends Plan> extends PhysicalUn
         return AbstractPlan.copyWithSameId(this, () -> new PhysicalLazyMaterialize(children.get(0),
                 materializeInput, materializedSlots, relationToLazySlotMap,
                 relationToRowId, materializeMap, physicalProperties, statistics));
+    }
+
+    /**
+     * Deep copy this node and replace every referenced relation with a copy that is detached
+     * from the memo (its group expression is cleared), so that holding this node does not keep
+     * the memo alive.
+     *
+     * <p>The relations recorded in {@code relationToLazySlotMap}, {@code relationToRowId} and
+     * {@code materializeMap} are the scan nodes of the original plan tree, which reference the
+     * memo through their group expressions. They are replaced by detached copies while the
+     * slot lists, which carry no memo reference, are reused as is.
+     *
+     * @param newChild the already detached child plan
+     */
+    public PhysicalLazyMaterialize<Plan> copyDetachedFromMemo(Plan newChild) {
+        Map<Relation, List<Slot>> newRelationToLazySlotMap = new HashMap<>();
+        Map<Relation, Relation> detachedRelationMap = new IdentityHashMap<>();
+        for (Map.Entry<Relation, List<Slot>> entry : relationToLazySlotMap.entrySet()) {
+            Relation detached = (Relation) AbstractPhysicalPlan.copyPlanDetachedFromMemo(
+                    (PhysicalPlan) entry.getKey());
+            detachedRelationMap.put(entry.getKey(), detached);
+            newRelationToLazySlotMap.put(detached, entry.getValue());
+        }
+        BiMap<Relation, SlotReference> newRelationToRowId = HashBiMap.create();
+        for (Map.Entry<Relation, SlotReference> entry : relationToRowId.entrySet()) {
+            newRelationToRowId.put(detachedRelationMap.get(entry.getKey()), entry.getValue());
+        }
+        Map<Slot, MaterializeSource> newMaterializeMap = new HashMap<>();
+        for (Map.Entry<Slot, MaterializeSource> entry : materializeMap.entrySet()) {
+            MaterializeSource source = entry.getValue();
+            newMaterializeMap.put(entry.getKey(),
+                    new MaterializeSource(detachedRelationMap.get(source.relation), source.baseSlot));
+        }
+        return new PhysicalLazyMaterialize<Plan>(newChild, materializeInput, materializedSlots,
+                newRelationToLazySlotMap, newRelationToRowId, newMaterializeMap,
+                physicalProperties, statistics);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterialize.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalLazyMaterialize.java
@@ -276,13 +276,16 @@ public class PhysicalLazyMaterialize<CHILD_TYPE extends Plan> extends PhysicalUn
      * slot lists, which carry no memo reference, are reused as is.
      *
      * @param newChild the already detached child plan
+     * @param originalToClone mapping from the original plan nodes to their detached copies
+     * @param rfCloneMap shared cache of cloned runtime filters
      */
-    public PhysicalLazyMaterialize<Plan> copyDetachedFromMemo(Plan newChild) {
+    PhysicalLazyMaterialize<Plan> copyDetachedFromMemo(Plan newChild,
+            Map<Plan, Plan> originalToClone, Map<RuntimeFilter, RuntimeFilter> rfCloneMap) {
         Map<Relation, List<Slot>> newRelationToLazySlotMap = new HashMap<>();
         Map<Relation, Relation> detachedRelationMap = new IdentityHashMap<>();
         for (Map.Entry<Relation, List<Slot>> entry : relationToLazySlotMap.entrySet()) {
             Relation detached = (Relation) AbstractPhysicalPlan.copyPlanDetachedFromMemo(
-                    (PhysicalPlan) entry.getKey());
+                    (PhysicalPlan) entry.getKey(), originalToClone, rfCloneMap);
             detachedRelationMap.put(entry.getKey(), detached);
             newRelationToLazySlotMap.put(detached, entry.getValue());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1275,10 +1275,6 @@ public class StmtExecutor {
         // failed, the insert stmt should be success
         try {
             profile.updateSummary(getSummaryInfo(isFinished), isFinished, this.planner);
-            if (planner instanceof NereidsPlanner) {
-                NereidsPlanner nereidsPlanner = ((NereidsPlanner) planner);
-                profile.setPhysicalPlan(nereidsPlanner.getPhysicalPlan());
-            }
         } catch (Throwable t) {
             LOG.warn("failed to update profile, ignore this error", t);
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/physical/PhysicalPlanDetachTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/physical/PhysicalPlanDetachTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.nereids.trees.plans.physical;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.nereids.hint.DistributeHint;
 import org.apache.doris.nereids.memo.Group;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.memo.GroupId;
@@ -34,6 +35,8 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.plans.AbstractPlan;
+import org.apache.doris.nereids.trees.plans.DistributeType;
+import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.LimitPhase;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PreAggStatus;
@@ -43,7 +46,10 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalStorageLayerAggrega
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.util.MutableState;
 import org.apache.doris.nereids.util.PlanConstructor;
+import org.apache.doris.planner.RuntimeFilterId;
 import org.apache.doris.statistics.Statistics;
+import org.apache.doris.thrift.TMinMaxRuntimeFilterType;
+import org.apache.doris.thrift.TRuntimeFilterType;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -63,7 +69,7 @@ import java.util.Optional;
 /**
  * Tests for {@link AbstractPhysicalPlan#copyPlanDetachedFromMemo(PhysicalPlan)}:
  * the copy must clear every node's group expression (breaking the reference to the memo)
- * while preserving node ids, statistics, physical properties and group ids.
+ * while preserving node ids, statistics, physical properties, group ids and runtime filters.
  */
 public class PhysicalPlanDetachTest {
 
@@ -204,6 +210,50 @@ public class PhysicalPlanDetachTest {
         Assertions.assertEquals(1, copy.getRelations().size());
         Assertions.assertNotSame(scan, copy.getRelations().get(0));
         Assertions.assertTrue(((Plan) copy.getRelations().get(0)).getGroupExpression().isEmpty());
+    }
+
+    @Test
+    public void testDetachRuntimeFilters() {
+        PhysicalOlapScan scan = olapScan();
+        PhysicalOneRowRelation left = oneRow();
+        PhysicalHashJoin<Plan, Plan> join = new PhysicalHashJoin<>(JoinType.INNER_JOIN,
+                ImmutableList.of(), ImmutableList.of(), new DistributeHint(DistributeType.NONE),
+                Optional.empty(), Optional.empty(), LOGICAL_PROPERTIES, left, scan);
+        join = attachToGroup(join).withPhysicalPropertiesAndStats(PhysicalProperties.GATHER, STATS);
+
+        SlotReference src = new SlotReference(new ExprId(0), "src", BigIntType.INSTANCE,
+                true, Lists.newArrayList());
+        SlotReference target = new SlotReference(new ExprId(1), "target", BigIntType.INSTANCE,
+                true, Lists.newArrayList());
+        RuntimeFilter rf = new RuntimeFilter(RuntimeFilterId.createGenerator().getNextId(), src,
+                target, target, TRuntimeFilterType.IN_OR_BLOOM, 0, join, -1L, true,
+                TMinMaxRuntimeFilterType.MIN_MAX, scan);
+        scan.addAppliedRuntimeFilter(rf);
+        Assertions.assertEquals(1, join.getRuntimeFilters().size());
+        Assertions.assertEquals(1, scan.getAppliedRuntimeFilters().size());
+
+        PhysicalPlan detached = AbstractPhysicalPlan.copyPlanDetachedFromMemo(join);
+        PhysicalHashJoin<?, ?> joinCopy = (PhysicalHashJoin<?, ?>) detached;
+        PhysicalOlapScan scanCopy = (PhysicalOlapScan) detached.child(1);
+
+        // The cloned join keeps its runtime filter, re-pointed to the cloned nodes.
+        Assertions.assertEquals(1, joinCopy.getRuntimeFilters().size());
+        RuntimeFilter rfCopy = joinCopy.getRuntimeFilters().get(0);
+        Assertions.assertSame(joinCopy, rfCopy.getBuilderNode());
+        Assertions.assertNotSame(join, rfCopy.getBuilderNode());
+        Assertions.assertSame(scanCopy, rfCopy.getTargetScan());
+        Assertions.assertNotSame(scan, rfCopy.getTargetScan());
+        Assertions.assertTrue(rfCopy.getTargetScan().getGroupExpression().isEmpty());
+        // The cloned scan keeps the applied runtime filter (same object as on the join).
+        Assertions.assertEquals(1, scanCopy.getAppliedRuntimeFilters().size());
+        Assertions.assertSame(rfCopy, scanCopy.getAppliedRuntimeFilters().get(0));
+        // The printed plan keeps the RF information.
+        Assertions.assertTrue(joinCopy.toString().contains("RFs"));
+        // The original tree is untouched.
+        Assertions.assertEquals(1, join.getRuntimeFilters().size());
+        Assertions.assertSame(join, join.getRuntimeFilters().get(0).getBuilderNode());
+        Assertions.assertEquals(1, scan.getAppliedRuntimeFilters().size());
+        Assertions.assertSame(rf, scan.getAppliedRuntimeFilters().get(0));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/physical/PhysicalPlanDetachTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/physical/PhysicalPlanDetachTest.java
@@ -1,0 +1,219 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.physical;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.nereids.memo.Group;
+import org.apache.doris.nereids.memo.GroupExpression;
+import org.apache.doris.nereids.memo.GroupId;
+import org.apache.doris.nereids.processor.post.materialize.MaterializeSource;
+import org.apache.doris.nereids.properties.DataTrait;
+import org.apache.doris.nereids.properties.LogicalProperties;
+import org.apache.doris.nereids.properties.PhysicalProperties;
+import org.apache.doris.nereids.trees.expressions.Alias;
+import org.apache.doris.nereids.trees.expressions.ExprId;
+import org.apache.doris.nereids.trees.expressions.NamedExpression;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
+import org.apache.doris.nereids.trees.plans.AbstractPlan;
+import org.apache.doris.nereids.trees.plans.LimitPhase;
+import org.apache.doris.nereids.trees.plans.Plan;
+import org.apache.doris.nereids.trees.plans.PreAggStatus;
+import org.apache.doris.nereids.trees.plans.RelationId;
+import org.apache.doris.nereids.trees.plans.algebra.Relation;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalStorageLayerAggregate.PushDownAggOp;
+import org.apache.doris.nereids.types.BigIntType;
+import org.apache.doris.nereids.util.MutableState;
+import org.apache.doris.nereids.util.PlanConstructor;
+import org.apache.doris.statistics.Statistics;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Tests for {@link AbstractPhysicalPlan#copyPlanDetachedFromMemo(PhysicalPlan)}:
+ * the copy must clear every node's group expression (breaking the reference to the memo)
+ * while preserving node ids, statistics, physical properties and group ids.
+ */
+public class PhysicalPlanDetachTest {
+
+    private static final LogicalProperties LOGICAL_PROPERTIES =
+            new LogicalProperties(() -> ImmutableList.of(), () -> DataTrait.EMPTY_TRAIT);
+
+    private static final Statistics STATS = new Statistics(100.0, ImmutableMap.of());
+
+    /** Attach a group expression (with a real owner group) to the plan node. */
+    private static <T extends AbstractPlan> T attachToGroup(T plan) {
+        GroupExpression groupExpression = new GroupExpression(plan, ImmutableList.of());
+        Group group = new Group(GroupId.createGenerator().getNextId(),
+                groupExpression.getPlan().getLogicalProperties());
+        groupExpression.setOwnerGroup(group);
+        return (T) groupExpression.getPlan();
+    }
+
+    private static PhysicalOlapScan olapScan() {
+        OlapTable table = PlanConstructor.newOlapTable(0, "t1", 0, KeysType.DUP_KEYS);
+        List<String> qualifier = new ArrayList<>();
+        qualifier.add("test");
+        List<Slot> output = new ArrayList<>();
+        SlotReference id = SlotReference.fromColumn(new ExprId(0), table,
+                new Column("id", org.apache.doris.catalog.Type.INT), qualifier);
+        output.add(id);
+        LogicalProperties tableProperties = new LogicalProperties(() -> output,
+                () -> DataTrait.EMPTY_TRAIT);
+        PhysicalOlapScan scan = new PhysicalOlapScan(RelationId.createGenerator().getNextId(), table,
+                qualifier, 0L, Collections.emptyList(), Collections.emptyList(), null,
+                PreAggStatus.on(), ImmutableList.of(), Optional.empty(), tableProperties, Optional.empty(),
+                ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(),
+                ImmutableList.of(), Optional.empty());
+        return (PhysicalOlapScan) attachToGroup(scan)
+                .withPhysicalPropertiesAndStats(PhysicalProperties.GATHER, STATS);
+    }
+
+    private static PhysicalOneRowRelation oneRow() {
+        PhysicalOneRowRelation leaf = new PhysicalOneRowRelation(
+                new RelationId(1),
+                ImmutableList.of(new Alias(Literal.of(1L), "a")),
+                LOGICAL_PROPERTIES);
+        return (PhysicalOneRowRelation) attachToGroup(leaf)
+                .withPhysicalPropertiesAndStats(PhysicalProperties.GATHER, STATS);
+    }
+
+    @Test
+    public void testDetachGenericTree() {
+        PhysicalOneRowRelation leaf = oneRow();
+        PhysicalLimit limit = new PhysicalLimit(1, 0, LimitPhase.ORIGIN, Optional.empty(),
+                LOGICAL_PROPERTIES, PhysicalProperties.GATHER, STATS, leaf);
+        limit = (PhysicalLimit) attachToGroup(limit)
+                .withPhysicalPropertiesAndStats(PhysicalProperties.GATHER, STATS);
+        List<NamedExpression> projects = ImmutableList.of(
+                new SlotReference(new ExprId(0), "a", BigIntType.INSTANCE, true, Lists.newArrayList()));
+        PhysicalProject root = new PhysicalProject<>(projects, Optional.empty(),
+                LOGICAL_PROPERTIES, PhysicalProperties.GATHER, STATS, limit);
+        root = (PhysicalProject) attachToGroup(root)
+                .withPhysicalPropertiesAndStats(PhysicalProperties.GATHER, STATS);
+
+        Assertions.assertTrue(root.getGroupExpression().isPresent());
+        Assertions.assertTrue(limit.getGroupExpression().isPresent());
+        Assertions.assertTrue(leaf.getGroupExpression().isPresent());
+
+        PhysicalPlan detached = AbstractPhysicalPlan.copyPlanDetachedFromMemo(root);
+
+        // Original tree is untouched.
+        Assertions.assertTrue(root.getGroupExpression().isPresent());
+        Assertions.assertTrue(limit.getGroupExpression().isPresent());
+        Assertions.assertTrue(leaf.getGroupExpression().isPresent());
+
+        // The copy has the same shape and node ids, but no group expression on any node.
+        List<Plan> originalNodes = root.collectToList(p -> true);
+        List<Plan> detachedNodes = detached.collectToList(p -> true);
+        Assertions.assertEquals(originalNodes.size(), detachedNodes.size());
+        for (int i = 0; i < originalNodes.size(); i++) {
+            AbstractPlan original = (AbstractPlan) originalNodes.get(i);
+            AbstractPlan copy = (AbstractPlan) detachedNodes.get(i);
+            Assertions.assertEquals(original.getId(), copy.getId(),
+                    "node id should be preserved");
+            Assertions.assertTrue(copy.getGroupExpression().isEmpty(),
+                    "group expression should be cleared on " + copy);
+            Assertions.assertSame(original.getStats(), copy.getStats(),
+                    "statistics should be preserved on " + copy);
+            Assertions.assertEquals(original.getGroupIdAsString(), copy.getGroupIdAsString(),
+                    "group id should be preserved on " + copy);
+        }
+        // Group ids are kept as mutable state instead of a memo reference.
+        Assertions.assertTrue(detached.getMutableState(MutableState.KEY_GROUP).isPresent());
+    }
+
+    @Test
+    public void testDetachStorageLayerAggregate() {
+        PhysicalOlapScan scan = olapScan();
+        PhysicalStorageLayerAggregate storageAgg = new PhysicalStorageLayerAggregate(scan, PushDownAggOp.COUNT);
+        storageAgg = (PhysicalStorageLayerAggregate) attachToGroup(storageAgg)
+                .withPhysicalPropertiesAndStats(PhysicalProperties.GATHER, STATS);
+        Assertions.assertTrue(storageAgg.getRelation().getGroupExpression().isPresent());
+
+        PhysicalPlan detached = AbstractPhysicalPlan.copyPlanDetachedFromMemo(storageAgg);
+
+        Assertions.assertTrue(detached instanceof PhysicalStorageLayerAggregate);
+        Assertions.assertTrue(detached.getGroupExpression().isEmpty());
+        Assertions.assertSame(STATS, detached.getStats());
+        Assertions.assertEquals(storageAgg.getGroupIdAsString(), detached.getGroupIdAsString());
+        // The inner relation must be detached as well.
+        PhysicalStorageLayerAggregate copy = (PhysicalStorageLayerAggregate) detached;
+        Assertions.assertFalse(copy.getRelation().getGroupExpression().isPresent());
+        Assertions.assertNotSame(scan, copy.getRelation());
+    }
+
+    @Test
+    public void testDetachLazyMaterialize() {
+        PhysicalOlapScan scan = olapScan();
+        PhysicalOneRowRelation child = oneRow();
+
+        Slot idSlot = scan.getOutput().get(0);
+        SlotReference rowId = new SlotReference(new ExprId(1), "row_id", BigIntType.INSTANCE,
+                true, Lists.newArrayList());
+        Map<Relation, List<Slot>> relationToLazySlotMap = new HashMap<>();
+        relationToLazySlotMap.put(scan, ImmutableList.of(idSlot));
+        BiMap<Relation, SlotReference> relationToRowId = HashBiMap.create();
+        relationToRowId.put(scan, rowId);
+        Map<Slot, MaterializeSource> materializeMap = new HashMap<>();
+        materializeMap.put(idSlot, new MaterializeSource(scan, (SlotReference) idSlot));
+
+        PhysicalLazyMaterialize<Plan> lazy = new PhysicalLazyMaterialize<>(child,
+                ImmutableList.of(idSlot, rowId), ImmutableList.of(idSlot),
+                relationToLazySlotMap, relationToRowId, materializeMap,
+                PhysicalProperties.GATHER, STATS);
+
+        PhysicalPlan detached = AbstractPhysicalPlan.copyPlanDetachedFromMemo(lazy);
+
+        Assertions.assertTrue(detached instanceof PhysicalLazyMaterialize);
+        Assertions.assertTrue(detached.getGroupExpression().isEmpty());
+        Assertions.assertSame(STATS, detached.getStats());
+        // The copy must not keep the original scan nodes (and thus the memo) alive.
+        PhysicalLazyMaterialize<?> copy = (PhysicalLazyMaterialize<?>) detached;
+        Assertions.assertEquals(1, copy.getRelations().size());
+        Assertions.assertNotSame(scan, copy.getRelations().get(0));
+        Assertions.assertTrue(((Plan) copy.getRelations().get(0)).getGroupExpression().isEmpty());
+    }
+
+    @Test
+    public void testDetachNullAndMemoFreePlan() {
+        Assertions.assertNull(AbstractPhysicalPlan.copyPlanDetachedFromMemo(null));
+        // A plan node without group expression and without memo-referencing children is reused as is.
+        PhysicalOneRowRelation leaf = new PhysicalOneRowRelation(
+                new RelationId(1),
+                ImmutableList.of(new Alias(Literal.of(1L), "a")),
+                LOGICAL_PROPERTIES);
+        Assertions.assertSame(leaf, AbstractPhysicalPlan.copyPlanDetachedFromMemo(leaf));
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/physical/PhysicalPlanDetachTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/physical/PhysicalPlanDetachTest.java
@@ -257,6 +257,45 @@ public class PhysicalPlanDetachTest {
     }
 
     @Test
+    public void testDetachRuntimeFiltersOnMemoFreeScan() {
+        // A scan without a group expression normally gets reused as is, but if it carries an
+        // applied runtime filter it must still be copied, otherwise the filter would reference
+        // the original (memo-carrying) builder node through the reused node.
+        PhysicalOlapScan scan = olapScan().withGroupExpression(Optional.empty())
+                .withPhysicalPropertiesAndStats(PhysicalProperties.GATHER, STATS);
+        Assertions.assertTrue(scan.getGroupExpression().isEmpty());
+        PhysicalOneRowRelation left = oneRow();
+        PhysicalHashJoin<Plan, Plan> join = new PhysicalHashJoin<>(JoinType.INNER_JOIN,
+                ImmutableList.of(), ImmutableList.of(), new DistributeHint(DistributeType.NONE),
+                Optional.empty(), Optional.empty(), LOGICAL_PROPERTIES, left, scan);
+        join = attachToGroup(join).withPhysicalPropertiesAndStats(PhysicalProperties.GATHER, STATS);
+
+        SlotReference src = new SlotReference(new ExprId(0), "src", BigIntType.INSTANCE,
+                true, Lists.newArrayList());
+        SlotReference target = new SlotReference(new ExprId(1), "target", BigIntType.INSTANCE,
+                true, Lists.newArrayList());
+        RuntimeFilter rf = new RuntimeFilter(RuntimeFilterId.createGenerator().getNextId(), src,
+                target, target, TRuntimeFilterType.IN_OR_BLOOM, 0, join, -1L, true,
+                TMinMaxRuntimeFilterType.MIN_MAX, scan);
+        scan.addAppliedRuntimeFilter(rf);
+
+        PhysicalPlan detached = AbstractPhysicalPlan.copyPlanDetachedFromMemo(join);
+        PhysicalHashJoin<?, ?> joinCopy = (PhysicalHashJoin<?, ?>) detached;
+        PhysicalOlapScan scanCopy = (PhysicalOlapScan) detached.child(1);
+
+        // The memo-free scan must be copied, not reused, because of its runtime filter.
+        Assertions.assertNotSame(scan, scanCopy);
+        Assertions.assertTrue(scanCopy.getGroupExpression().isEmpty());
+        Assertions.assertEquals(1, scanCopy.getAppliedRuntimeFilters().size());
+        RuntimeFilter rfCopy = scanCopy.getAppliedRuntimeFilters().get(0);
+        Assertions.assertSame(joinCopy, rfCopy.getBuilderNode());
+        Assertions.assertSame(scanCopy, rfCopy.getTargetScan());
+        // The original scan and join are untouched.
+        Assertions.assertSame(rf, scan.getAppliedRuntimeFilters().get(0));
+        Assertions.assertSame(join, join.getRuntimeFilters().get(0).getBuilderNode());
+    }
+
+    @Test
     public void testDetachNullAndMemoFreePlan() {
         Assertions.assertNull(AbstractPhysicalPlan.copyPlanDetachedFromMemo(null));
         // A plan node without group expression and without memo-referencing children is reused as is.


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary: The query Profile keeps the Nereids physical plan alive for its whole lifetime. Every node of the optimized plan references its GroupExpression, and a GroupExpression references the whole memo (owner group, child groups and all group expressions), so the memo cannot be garbage collected even after CascadesContext.releaseMemo() is called, keeping a large amount of optimizer memory alive as long as the profile is kept in memory.

Clone the physical plan (clearing the group expression on every node) before storing it in the profile, and also clone the physical relations. The profile then shares no object with the memo, so the memo can be released as early as possible. The clone preserves node ids, statistics, physical properties and group ids (kept as mutable state), so the profile output stays the same.

### Release note

None

### Check List (For Author)

- Test: Unit Test (new PhysicalPlanDetachTest; existing ProfileTest, AutoProfileTest, ProfileManagerTest)
- Behavior changed: No
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

