### PR TITLE
[fix](fe) Reject score on non-scoring SNII indexes

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckScoreUsage.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/CheckScoreUsage.java
@@ -133,15 +133,18 @@ public class CheckScoreUsage implements RewriteRuleFactory {
         if (selectedIndex == null) {
             return;
         }
+        boolean isSnii = scan.getTable().getInvertedIndexFileStorageFormat()
+                == TInvertedIndexFileStorageFormat.SNII;
         Map<String, String> properties = selectedIndex.getProperties();
-        if (properties == null
-                || !properties.containsKey(
-                        InvertedIndexProperties.INVERTED_INDEX_ANALYZER_NAME_KEY)) {
+        String analyzerName = properties == null ? null : properties.get(
+                InvertedIndexProperties.INVERTED_INDEX_ANALYZER_NAME_KEY);
+        if (analyzerName == null) {
+            if (isSnii) {
+                throw nonScoringSniiIndex(selectedIndex);
+            }
             return;
         }
 
-        String analyzerName = properties.get(
-                InvertedIndexProperties.INVERTED_INDEX_ANALYZER_NAME_KEY);
         boolean usesCommonGrams;
         try {
             usesCommonGrams = indexPolicyMgr.validateAnalyzerUsesCommonGrams(analyzerName);
@@ -149,13 +152,21 @@ public class CheckScoreUsage implements RewriteRuleFactory {
             throw new AnalysisException("score() cannot use inverted index '"
                     + selectedIndex.getIndexName() + "': " + e.getMessage(), e);
         }
-        if (usesCommonGrams
-                && scan.getTable().getInvertedIndexFileStorageFormat()
-                        != TInvertedIndexFileStorageFormat.SNII) {
+        if (isSnii && !usesCommonGrams) {
+            throw nonScoringSniiIndex(selectedIndex);
+        }
+        if (usesCommonGrams && !isSnii) {
             throw new AnalysisException("score() cannot use CommonGrams analyzer '"
                     + analyzerName + "' on inverted index '" + selectedIndex.getIndexName()
                     + "': CommonGrams scoring is supported only by SNII");
         }
+    }
+
+    private static AnalysisException nonScoringSniiIndex(Index selectedIndex) {
+        return new AnalysisException("score() cannot use SNII inverted index '"
+                + selectedIndex.getIndexName()
+                + "': the index does not persist scoring data; SNII scoring requires"
+                + " an index created with a CommonGrams analyzer");
     }
 
     private boolean hasScoreFunction(LogicalProject<?> project) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/CheckScoreUsageTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/CheckScoreUsageTest.java
@@ -76,9 +76,40 @@ public class CheckScoreUsageTest {
                         index("idx_body", "body", "domain_analyzer")),
                 "body", null);
 
-        Assertions.assertDoesNotThrow(() -> CheckScoreUsage.checkScoringPolicyAdmission(
-                filter, filter.child(), manager));
+        assertScorePushDownSucceeds(filter, manager);
         Mockito.verify(manager).validateAnalyzerUsesCommonGrams("domain_analyzer");
+    }
+
+    @Test
+    public void testRejectsBuiltInAnalyzerForSelectedSniiIndexWithoutScoringTier()
+            throws Exception {
+        IndexPolicyMgr manager = Mockito.mock(IndexPolicyMgr.class);
+        LogicalFilter<LogicalOlapScan> filter = scoreFilter(
+                table(TInvertedIndexFileStorageFormat.SNII,
+                        builtInIndex("idx_body", "body")),
+                "body", null);
+
+        AnalysisException exception = assertScorePushDownFails(filter, manager);
+        Assertions.assertTrue(exception.getMessage().contains("does not persist scoring data"),
+                exception.getMessage());
+        Mockito.verify(manager, Mockito.never()).validateAnalyzerUsesCommonGrams(Mockito.anyString());
+    }
+
+    @Test
+    public void testRejectsPlainCustomAnalyzerForSelectedSniiIndexWithoutScoringTier()
+            throws Exception {
+        IndexPolicyMgr manager = Mockito.mock(IndexPolicyMgr.class);
+        Mockito.when(manager.validateAnalyzerUsesCommonGrams("plain_analyzer"))
+                .thenReturn(false);
+        LogicalFilter<LogicalOlapScan> filter = scoreFilter(
+                table(TInvertedIndexFileStorageFormat.SNII,
+                        index("idx_body", "body", "plain_analyzer")),
+                "body", null);
+
+        AnalysisException exception = assertScorePushDownFails(filter, manager);
+        Assertions.assertTrue(exception.getMessage().contains("does not persist scoring data"),
+                exception.getMessage());
+        Mockito.verify(manager).validateAnalyzerUsesCommonGrams("plain_analyzer");
     }
 
     @Test
@@ -108,11 +139,13 @@ public class CheckScoreUsageTest {
     @Test
     public void testSearchScorePushDownRuleInvokesPolicyAdmission() throws Exception {
         IndexPolicyMgr manager = Mockito.mock(IndexPolicyMgr.class);
+        Mockito.when(manager.validateAnalyzerUsesCommonGrams("domain_analyzer"))
+                .thenReturn(true);
         Mockito.doThrow(new DdlException("Analyzer 'missing_analyzer' does not exist"))
                 .when(manager).validateAnalyzerUsesCommonGrams("missing_analyzer");
         LogicalFilter<LogicalOlapScan> filter = searchScoreFilter(
                 table(TInvertedIndexFileStorageFormat.SNII,
-                        builtInIndex("idx_body", "body"),
+                        index("idx_body", "body", "domain_analyzer"),
                         index("idx_other", "other", "missing_analyzer")),
                 "body", "other");
         LogicalTopN<LogicalProject<LogicalFilter<LogicalOlapScan>>> topN = scoreTopN(filter);
@@ -127,6 +160,7 @@ public class CheckScoreUsageTest {
             Assertions.assertTrue(exception.getMessage().contains(
                     "Analyzer 'missing_analyzer' does not exist"), exception.getMessage());
         }
+        Mockito.verify(manager).validateAnalyzerUsesCommonGrams("domain_analyzer");
         Mockito.verify(manager).validateAnalyzerUsesCommonGrams("missing_analyzer");
     }
 
@@ -239,7 +273,7 @@ public class CheckScoreUsageTest {
     public void testAnalyzerlessMatchSelectsFirstAnalyzedSiblingIndex() throws Exception {
         IndexPolicyMgr manager = Mockito.mock(IndexPolicyMgr.class);
         Mockito.when(manager.validateAnalyzerUsesCommonGrams("first_analyzer"))
-                .thenReturn(false);
+                .thenReturn(true);
         LogicalFilter<LogicalOlapScan> filter = scoreFilter(
                 table(TInvertedIndexFileStorageFormat.SNII,
                         index("idx_body_first", "body", "first_analyzer"),
@@ -256,7 +290,7 @@ public class CheckScoreUsageTest {
     public void testSearchSelectsFirstAnalyzedSiblingIndex() throws Exception {
         IndexPolicyMgr manager = Mockito.mock(IndexPolicyMgr.class);
         Mockito.when(manager.validateAnalyzerUsesCommonGrams("first_analyzer"))
-                .thenReturn(false);
+                .thenReturn(true);
         LogicalFilter<LogicalOlapScan> filter = searchScoreFilter(
                 table(TInvertedIndexFileStorageFormat.SNII,
                         index("idx_body_first", "body", "first_analyzer"),
@@ -439,6 +473,20 @@ public class CheckScoreUsageTest {
             mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
             Assertions.assertFalse(
                     rule.transform(topN, Mockito.mock(CascadesContext.class)).isEmpty());
+        }
+    }
+
+    private static AnalysisException assertScorePushDownFails(
+            LogicalFilter<LogicalOlapScan> filter, IndexPolicyMgr manager) {
+        LogicalTopN<LogicalProject<LogicalFilter<LogicalOlapScan>>> topN = scoreTopN(filter);
+        Rule rule = new PushDownScoreTopNIntoOlapScan().buildRules().get(0);
+        Env env = Mockito.mock(Env.class);
+        Mockito.when(env.getIndexPolicyMgr()).thenReturn(manager);
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            return Assertions.assertThrows(AnalysisException.class,
+                    () -> rule.transform(topN, Mockito.mock(CascadesContext.class)));
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #66052

Problem Summary: FE admitted score() plans for every phrase-enabled SNII inverted index, but built-in analyzers and ordinary custom analyzers write only the docs-and-positions tier. They do not persist norms or semantic scoring metadata, so the BE later failed while opening scoring statistics. This PR rejects those plans at the selected-index admission gate and admits SNII scoring only for indexes created with a CommonGrams analyzer, which writes the scoring tier. Existing V3 behavior is unchanged. The change is query admission only and does not modify index writes or the storage format.

### Release note

Reject score() queries on SNII indexes that do not persist scoring data instead of failing later in the BE.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

  Added end-to-end score pushdown cases for built-in, plain custom, and CommonGrams SNII analyzers. CheckScoreUsageTest passes all 20 tests. The full FE build passes with Checkstyle reporting zero violations.

- Behavior changed:
    - [ ] No.
    - [x] Yes. score() plans for non-scoring SNII indexes now fail during FE analysis; index writes and the storage format are unchanged.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label