### PR TITLE
[fix](be) Gate SNII prefix scoring by analyzed shape

### DIFF
--- a/be/src/storage/index/snii/snii_index_reader.cpp
+++ b/be/src/storage/index/snii/snii_index_reader.cpp
@@ -153,6 +153,9 @@ bool uses_plain_term_frequency_scoring(InvertedIndexQueryType query_type,
 
 bool uses_phrase_frequency_scoring(InvertedIndexQueryType query_type,
                                    const InvertedIndexQueryInfo& query_info) {
+    // A single-token phrase-prefix is a plain prefix query, not a phrase-frequency query. Like V3,
+    // direct MATCH therefore publishes no BM25 score, while FunctionSearch carries the bitmap as
+    // a constant-score BitSetQuery.
     return query_info.term_infos.size() > 1 &&
            (query_type == InvertedIndexQueryType::MATCH_PHRASE_QUERY ||
             query_type == InvertedIndexQueryType::MATCH_PHRASE_PREFIX_QUERY);
@@ -661,7 +664,7 @@ Status SniiIndexReader::_query(const IndexQueryContextPtr& context, const std::s
     // access below only for a segment that cannot contain gram terms.
     const bool initial_force_plain = common_grams_query_eligible && safety_requires_plain;
     const bool initial_allow_result_cache = !actual_similarity && !initial_force_plain;
-    const bool defer_result_cache_lookup = !actual_similarity && !initial_allow_result_cache;
+    const bool defer_result_cache_lookup = !initial_allow_result_cache;
     const InvertedIndexRawQuerySemantic raw_semantic {
             .raw_query_bytes = search_str,
             .query_type = query_type,
@@ -712,12 +715,6 @@ Status SniiIndexReader::_query(const IndexQueryContextPtr& context, const std::s
     const bool force_plain =
             common_grams_query_eligible && safety_requires_plain &&
             (effective_common_grams_configured || segment_may_contain_common_grams);
-    allow_result_cache = !actual_similarity && !force_plain;
-    if (defer_result_cache_lookup && allow_result_cache &&
-        handle_query_cache(context, cache, cache_key, &cache_handler, bit_map,
-                           allow_result_cache)) {
-        return finish_query(logical_reader);
-    }
     InvertedIndexQueryInfo execution_query_info = query_info;
     const auto plain_purpose = common_grams_query_eligible
                                        ? std::optional(inverted_index::AnalysisPurpose::kPlainQuery)
@@ -740,10 +737,17 @@ Status SniiIndexReader::_query(const IndexQueryContextPtr& context, const std::s
         return Status::Error<ErrorCode::INVERTED_INDEX_BYPASS>(
                 "CommonGrams term escaped the plain query analyzer");
     }
-    if (actual_similarity && query_type == InvertedIndexQueryType::MATCH_PHRASE_PREFIX_QUERY &&
-        execution_query_info.term_infos.size() == 1) {
-        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>(
-                "SNII scoring does not support a single-token phrase-prefix query");
+    const bool phrase_frequency_scoring =
+            actual_similarity && uses_phrase_frequency_scoring(query_type, execution_query_info);
+    const bool plain_term_frequency_scoring =
+            actual_similarity &&
+            uses_plain_term_frequency_scoring(query_type, execution_query_info);
+    const bool frequency_scoring = phrase_frequency_scoring || plain_term_frequency_scoring;
+    allow_result_cache = !frequency_scoring && !force_plain;
+    if (defer_result_cache_lookup && allow_result_cache &&
+        handle_query_cache(context, cache, cache_key, &cache_handler, bit_map,
+                           allow_result_cache)) {
+        return finish_query(logical_reader);
     }
     std::vector<std::string> terms = to_terms(execution_query_info);
 
@@ -781,10 +785,7 @@ Status SniiIndexReader::_query(const IndexQueryContextPtr& context, const std::s
             query_single_flight;
     std::shared_ptr<roaring::Roaring> result_bitmap;
     std::vector<::doris::snii::query::PhraseMatch> phrase_matches;
-    auto* phrase_matches_out =
-            actual_similarity && uses_phrase_frequency_scoring(query_type, execution_query_info)
-                    ? &phrase_matches
-                    : nullptr;
+    auto* phrase_matches_out = phrase_frequency_scoring ? &phrase_matches : nullptr;
     Status single_flight_status;
     if (!allow_result_cache) {
         single_flight_status =
@@ -832,7 +833,7 @@ Status SniiIndexReader::_query(const IndexQueryContextPtr& context, const std::s
     }
     RETURN_IF_ERROR(single_flight_status);
     DORIS_CHECK(result_bitmap != nullptr);
-    if (actual_similarity && !result_bitmap->isEmpty()) {
+    if (frequency_scoring && !result_bitmap->isEmpty()) {
         ::doris::snii::stats::SniiStatsProvider segment_stats;
         RETURN_IF_ERROR(
                 ::doris::snii::stats::SniiStatsProvider::open(logical_reader, &segment_stats));
@@ -840,7 +841,7 @@ Status SniiIndexReader::_query(const IndexQueryContextPtr& context, const std::s
             RETURN_IF_ERROR(score_phrase_matches(context, column_name, query_type,
                                                  execution_query_info, *logical_reader,
                                                  segment_stats, *result_bitmap, phrase_matches));
-        } else if (uses_plain_term_frequency_scoring(query_type, execution_query_info)) {
+        } else if (plain_term_frequency_scoring) {
             RETURN_IF_ERROR(score_plain_term_candidates(context, column_name, execution_query_info,
                                                         *logical_reader, segment_stats,
                                                         *result_bitmap));

--- a/be/test/storage/index/inverted/query_v2/phrase_prefix_query_test.cpp
+++ b/be/test/storage/index/inverted/query_v2/phrase_prefix_query_test.cpp
@@ -171,12 +171,12 @@ TEST_F(PhrasePrefixQueryV2Test, single_term_fallback_to_prefix) {
     auto terms = make_term_infos({"bro"});
 
     PhrasePrefixQuery q(ctx, field, terms);
-    auto w = q.weight(false);
+    auto w = q.weight(true);
     ASSERT_NE(w, nullptr);
 
     // Should be a PrefixWeight, not PhrasePrefixWeight
     auto prefix_w = std::dynamic_pointer_cast<PrefixWeight>(w);
-    EXPECT_NE(prefix_w, nullptr);
+    ASSERT_NE(prefix_w, nullptr);
 
     // Execute it
     QueryExecutionContext exec_ctx;
@@ -185,6 +185,8 @@ TEST_F(PhrasePrefixQueryV2Test, single_term_fallback_to_prefix) {
     exec_ctx.field_reader_bindings.emplace(field, reader);
 
     auto scorer = w->scorer(exec_ctx, "");
+    ASSERT_NE(scorer, nullptr);
+    EXPECT_FLOAT_EQ(scorer->score(), 1.0F);
     auto docs = collect_docs(scorer);
     // "bro*" should match: brown (many docs), brother (doc 10)
     EXPECT_GT(docs.size(), 0);

--- a/be/test/storage/index/snii/snii_index_reader_count_fallback_test.cpp
+++ b/be/test/storage/index/snii/snii_index_reader_count_fallback_test.cpp
@@ -937,11 +937,56 @@ TEST_F(SniiIndexReaderCountFallback, PublicPhraseQueriesScoreOccurrenceFrequency
     single_prefix.context->collection_similarity = std::make_shared<CollectionSimilarity>();
     const Field single_prefix_value = Field::create_field<TYPE_STRING>(std::string("be"));
     std::shared_ptr<roaring::Roaring> single_prefix_bitmap;
-    const Status single_prefix_status = opened.index_reader->query(
-            single_prefix.context, "scoring_phrase_content", single_prefix_value,
-            InvertedIndexQueryType::MATCH_PHRASE_PREFIX_QUERY, single_prefix_bitmap, &analyzer_ctx);
-    EXPECT_EQ(single_prefix_status.code(), ErrorCode::INVERTED_INDEX_NOT_SUPPORTED)
-            << single_prefix_status;
+    assert_ok(opened.index_reader->query(single_prefix.context, "scoring_phrase_content",
+                                         single_prefix_value,
+                                         InvertedIndexQueryType::MATCH_PHRASE_PREFIX_QUERY,
+                                         single_prefix_bitmap, &analyzer_ctx));
+    ASSERT_NE(single_prefix_bitmap, nullptr);
+    EXPECT_EQ(bitmap_docids(*single_prefix_bitmap), (std::vector<uint32_t> {1, 2}));
+    EXPECT_FLOAT_EQ(score_for_doc(*single_prefix.context->collection_similarity, 1), 0.0F);
+    EXPECT_FLOAT_EQ(score_for_doc(*single_prefix.context->collection_similarity, 2), 0.0F);
+}
+
+TEST_F(SniiIndexReaderCountFallback,
+       PublicSingleTokenPhrasePrefixWithSimilarityDoesNotRequireScoringMetadata) {
+    const auto provider = make_common_grams_provider();
+    InvertedIndexAnalyzerCtx analyzer_ctx;
+    analyzer_ctx.parser_type = InvertedIndexParserType::PARSER_ENGLISH;
+    analyzer_ctx.analyzer_provider = provider;
+    const Field query_value = Field::create_field<TYPE_STRING>(std::string("ord"));
+
+    QueryExecutionContext first(/*enable_query_cache=*/true);
+    first.context->collection_statistics = std::make_shared<FixedCollectionStatistics>();
+    first.context->collection_similarity = std::make_shared<CollectionSimilarity>();
+    std::shared_ptr<roaring::Roaring> first_bitmap;
+    const Status first_status = _index_reader->query(
+            first.context, "single_prefix_no_scoring_metadata", query_value,
+            InvertedIndexQueryType::MATCH_PHRASE_PREFIX_QUERY, first_bitmap, &analyzer_ctx);
+
+    ASSERT_TRUE(first_status.ok()) << first_status;
+    ASSERT_NE(first_bitmap, nullptr);
+    EXPECT_EQ(bitmap_docids(*first_bitmap), (std::vector<uint32_t> {0, 1, 2, 3, 4, 5}));
+    EXPECT_FLOAT_EQ(score_for_doc(*first.context->collection_similarity, 0), 0.0F);
+    EXPECT_EQ(first.stats.inverted_index_query_cache_lookup, 1);
+    EXPECT_EQ(first.stats.inverted_index_query_cache_miss, 1);
+    EXPECT_EQ(first.stats.inverted_index_query_cache_insert, 1);
+
+    QueryExecutionContext second(/*enable_query_cache=*/true);
+    second.context->collection_statistics = std::make_shared<FixedCollectionStatistics>();
+    second.context->collection_similarity = std::make_shared<CollectionSimilarity>();
+    std::shared_ptr<roaring::Roaring> second_bitmap;
+    const Status second_status = _index_reader->query(
+            second.context, "single_prefix_no_scoring_metadata", query_value,
+            InvertedIndexQueryType::MATCH_PHRASE_PREFIX_QUERY, second_bitmap, &analyzer_ctx);
+
+    ASSERT_TRUE(second_status.ok()) << second_status;
+    ASSERT_NE(second_bitmap, nullptr);
+    EXPECT_EQ(bitmap_docids(*second_bitmap), bitmap_docids(*first_bitmap));
+    EXPECT_FLOAT_EQ(score_for_doc(*second.context->collection_similarity, 0), 0.0F);
+    EXPECT_EQ(second.stats.inverted_index_query_cache_lookup, 1);
+    EXPECT_EQ(second.stats.inverted_index_query_cache_hit, 1);
+    EXPECT_EQ(second.stats.inverted_index_query_cache_miss, 0);
+    EXPECT_EQ(second.stats.inverted_index_query_cache_insert, 0);
 }
 
 TEST_F(SniiIndexReaderCountFallback, PublicPhraseQueryCacheHitLeavesPrxStatsUnchanged) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #66052

Problem Summary:

SNII treated the presence of a similarity context as proof that every phrase-prefix query required frequency scoring. A single-token phrase prefix is a plain prefix query with constant SEARCH scoring, but the reader opened scoring statistics before considering the analyzed query shape. Valid positional indexes without semantic scoring metadata therefore failed at query time, and those queries unnecessarily bypassed bitmap cache and single-flight.

This PR derives the scoring requirement after analysis. Only plain-term and multi-token phrase-frequency shapes open stats and norms. Single-token prefixes retain zero direct score and constant query_v2 score, and can use cache and single-flight. Multi-token phrase-prefix scoring is unchanged.

The change is query-only. It does not alter the SNII storage format or writer, so existing indexes can be upgraded in place. The independent terminal PREFIX syntax-marker fix is isolated in #66874.

### Release note

Allow single-token SNII phrase-prefix queries to use existing positional indexes without scoring metadata.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
        - SniiIndexReaderCountFallback.*
        - PhrasePrefixQueryV2Test.*
        - 43/43 focused ASAN unit tests passed
        - ./build.sh --be -j 192
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason? -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. Single-token phrase prefixes no longer require scoring metadata and may use bitmap cache and single-flight.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->