### PR TITLE
[fix](be) Isolate SNII cache across analyzer generations

### DIFF
--- a/be/src/storage/index/snii/snii_index_reader.cpp
+++ b/be/src/storage/index/snii/snii_index_reader.cpp
@@ -642,6 +642,12 @@ Status SniiIndexReader::_query(const IndexQueryContextPtr& context, const std::s
     const bool common_grams_query_eligible = common_grams_phrase_shape && !actual_similarity;
     const bool raw_pattern_query = query_type == InvertedIndexQueryType::MATCH_REGEXP_QUERY ||
                                    query_type == InvertedIndexQueryType::WILDCARD_QUERY;
+    // Pattern queries consume the raw bytes. Every other tokenizing path may share a pre-analysis
+    // result only when its context proves that the segment fixes the analyzer semantics.
+    const auto can_share_raw_query_semantics =
+            [raw_pattern_query](const InvertedIndexAnalyzerCtx* ctx) {
+                return raw_pattern_query || ctx == nullptr || ctx->can_share_raw_query_semantics();
+            };
     // Lucene-style CommonGrams: the plan decision is local to the segment and query. Snapshot the
     // switch once so this query's plan and cache identity use the same mode.
     const bool common_grams_query_plan_enabled = config::enable_common_grams_query_plan;
@@ -660,7 +666,8 @@ Status SniiIndexReader::_query(const IndexQueryContextPtr& context, const std::s
     // its metadata is open. Delay every eligible forced-plain lookup, then restore ordinary cache
     // access below only for a segment that cannot contain gram terms.
     const bool initial_force_plain = common_grams_query_eligible && safety_requires_plain;
-    const bool initial_allow_result_cache = !actual_similarity && !initial_force_plain;
+    const bool initial_allow_result_cache = !actual_similarity && !initial_force_plain &&
+                                            can_share_raw_query_semantics(analyzer_ctx);
     const bool defer_result_cache_lookup = !actual_similarity && !initial_allow_result_cache;
     const InvertedIndexRawQuerySemantic raw_semantic {
             .raw_query_bytes = search_str,
@@ -712,7 +719,8 @@ Status SniiIndexReader::_query(const IndexQueryContextPtr& context, const std::s
     const bool force_plain =
             common_grams_query_eligible && safety_requires_plain &&
             (effective_common_grams_configured || segment_may_contain_common_grams);
-    allow_result_cache = !actual_similarity && !force_plain;
+    allow_result_cache = !actual_similarity && !force_plain &&
+                         can_share_raw_query_semantics(effective_analyzer_context);
     if (defer_result_cache_lookup && allow_result_cache &&
         handle_query_cache(context, cache, cache_key, &cache_handler, bit_map,
                            allow_result_cache)) {

--- a/be/test/storage/index/inverted/inverted_index_reader_analysis_purpose_test.cpp
+++ b/be/test/storage/index/inverted/inverted_index_reader_analysis_purpose_test.cpp
@@ -561,7 +561,7 @@ TEST(InvertedIndexAnalyzerCtxTest, UsesProviderCommonGramsIdentityWithoutCopying
 }
 
 TEST_F(InvertedIndexReaderAnalysisPurposeTest,
-       SniiRawCacheLookupIsIndependentOfRequestAnalyzerIdentity) {
+       SniiRawCacheLookupRequiresImmutableAnalyzerIdentity) {
     const bool original = config::enable_common_grams_query_plan;
     Defer restore([original] {
         EXPECT_TRUE(config::set_config("enable_common_grams_query_plan",
@@ -575,16 +575,22 @@ TEST_F(InvertedIndexReaderAnalysisPurposeTest,
             .common_grams_dictionary_identity = "dictionary:complete",
             .base_analyzer_fingerprint = "base:complete",
             .common_grams_fingerprint = "grams:complete"};
-    const inverted_index::CommonGramsQueryIdentity empty_identity;
-    for (const auto& identity : {complete_identity, empty_identity}) {
-        expect_raw_cache_hit_before_analysis(
-                _snii_reader, _snii_file_reader,
-                std::make_shared<IdentityFailingAnalyzerProvider>(identity),
-                config::enable_common_grams_query_plan);
-    }
-    expect_raw_cache_hit_before_analysis(_snii_reader, _snii_file_reader,
-                                         std::make_shared<RecordingFailingAnalyzerProvider>(),
-                                         config::enable_common_grams_query_plan);
+    expect_raw_cache_hit_before_analysis(
+            _snii_reader, _snii_file_reader,
+            std::make_shared<IdentityFailingAnalyzerProvider>(complete_identity),
+            config::enable_common_grams_query_plan);
+
+    // The same raw query is already cached above. Providers without a complete immutable identity
+    // must still bypass it, enter the segment, and analyze under their own generation.
+    preload_legacy_searcher_cache_entries();
+    expect_analysis_failure_after_segment_admission(
+            _snii_reader, InvertedIndexQueryType::MATCH_PHRASE_QUERY, "the history", false,
+            AnalysisPurpose::kPlainQuery,
+            std::make_shared<IdentityFailingAnalyzerProvider>(
+                    inverted_index::CommonGramsQueryIdentity {}));
+    expect_provider_failure_after_segment_admission(
+            _snii_reader, InvertedIndexQueryType::MATCH_PHRASE_QUERY, "the history", false,
+            AnalysisPurpose::kPlainQuery);
 }
 
 TEST_F(InvertedIndexReaderAnalysisPurposeTest, DisabledResultCacheDoesNotLookupCountOrInsert) {
@@ -623,13 +629,13 @@ TEST_F(InvertedIndexReaderAnalysisPurposeTest, SniiSelectsPurposeAfterSegmentAdm
     preload_legacy_searcher_cache_entries();
     expect_provider_failure_after_segment_admission(
             _snii_reader, InvertedIndexQueryType::MATCH_PHRASE_QUERY, "the history", false,
-            AnalysisPurpose::kPlainQuery, /*expected_query_cache_lookups=*/1);
+            AnalysisPurpose::kPlainQuery);
     expect_provider_failure_after_segment_admission(
             _snii_reader, InvertedIndexQueryType::MATCH_PHRASE_QUERY, "the history ~2", false,
-            AnalysisPurpose::kPlainQuery, /*expected_query_cache_lookups=*/1);
+            AnalysisPurpose::kPlainQuery);
     expect_provider_failure_after_segment_admission(
             _snii_reader, InvertedIndexQueryType::MATCH_PHRASE_PREFIX_QUERY, "the hist", false,
-            AnalysisPurpose::kPlainQuery, /*expected_query_cache_lookups=*/1);
+            AnalysisPurpose::kPlainQuery);
     expect_provider_failure_after_segment_admission(
             _snii_reader, InvertedIndexQueryType::MATCH_PHRASE_QUERY, "the history", true,
             AnalysisPurpose::kPlainQuery);
@@ -640,7 +646,7 @@ TEST_F(InvertedIndexReaderAnalysisPurposeTest, PartialAnalysisFailureDoesNotPubl
     auto snii_provider = std::make_shared<RecordingPartialFailureAnalyzerProvider>();
     expect_analysis_failure_after_segment_admission(
             _snii_reader, InvertedIndexQueryType::MATCH_PHRASE_QUERY, "the history", false,
-            AnalysisPurpose::kPlainQuery, snii_provider, /*expected_query_cache_lookups=*/1);
+            AnalysisPurpose::kPlainQuery, snii_provider);
     EXPECT_EQ(snii_provider->emitted_tokens->load(std::memory_order_relaxed), 1);
 }
 

--- a/be/test/storage/index/snii/snii_index_reader_count_fallback_test.cpp
+++ b/be/test/storage/index/snii/snii_index_reader_count_fallback_test.cpp
@@ -965,7 +965,7 @@ TEST_F(SniiIndexReaderCountFallback, PublicPhraseQueryCacheHitLeavesPrxStatsUnch
     EXPECT_EQ(prx_stats_snapshot(cache_hit.stats), before);
 }
 
-TEST_F(SniiIndexReaderCountFallback, CustomAnalyzerWithNoneParserRetainsAnalyzedTermCache) {
+TEST_F(SniiIndexReaderCountFallback, CustomAnalyzerWithoutImmutableIdentityBypassesRawQueryCache) {
     inverted_index::Settings tokenizer_settings;
     tokenizer_settings.set("tokenize_on_chars", "[whitespace]");
     inverted_index::CustomAnalyzerConfig::Builder builder;
@@ -978,6 +978,7 @@ TEST_F(SniiIndexReaderCountFallback, CustomAnalyzerWithNoneParserRetainsAnalyzed
     analyzer_ctx.analyzer_name = "test_custom_analyzer";
     analyzer_ctx.parser_type = InvertedIndexParserType::PARSER_NONE;
     analyzer_ctx.analyzer_provider = std::move(provider);
+    ASSERT_FALSE(analyzer_ctx.can_share_raw_query_semantics());
     const Field query_value = Field::create_field<TYPE_STRING>(std::string("FAILED ORDER"));
 
     QueryExecutionContext first(/*enable_query_cache=*/true);
@@ -987,9 +988,9 @@ TEST_F(SniiIndexReaderCountFallback, CustomAnalyzerWithNoneParserRetainsAnalyzed
                                    &analyzer_ctx));
     ASSERT_NE(first_bitmap, nullptr);
     EXPECT_EQ(bitmap_docids(*first_bitmap), (std::vector<uint32_t> {0, 3, 5}));
-    EXPECT_EQ(first.stats.inverted_index_query_cache_lookup, 1);
-    EXPECT_EQ(first.stats.inverted_index_query_cache_miss, 1);
-    EXPECT_EQ(first.stats.inverted_index_query_cache_insert, 1);
+    EXPECT_EQ(first.stats.inverted_index_query_cache_lookup, 0);
+    EXPECT_EQ(first.stats.inverted_index_query_cache_miss, 0);
+    EXPECT_EQ(first.stats.inverted_index_query_cache_insert, 0);
 
     QueryExecutionContext second(/*enable_query_cache=*/true);
     std::shared_ptr<roaring::Roaring> second_bitmap;
@@ -998,10 +999,60 @@ TEST_F(SniiIndexReaderCountFallback, CustomAnalyzerWithNoneParserRetainsAnalyzed
                                    &analyzer_ctx));
     ASSERT_NE(second_bitmap, nullptr);
     EXPECT_EQ(bitmap_docids(*second_bitmap), bitmap_docids(*first_bitmap));
-    EXPECT_EQ(second.stats.inverted_index_query_cache_lookup, 1);
-    EXPECT_EQ(second.stats.inverted_index_query_cache_hit, 1);
+    EXPECT_EQ(second.stats.inverted_index_query_cache_lookup, 0);
+    EXPECT_EQ(second.stats.inverted_index_query_cache_hit, 0);
     EXPECT_EQ(second.stats.inverted_index_query_cache_miss, 0);
     EXPECT_EQ(second.stats.inverted_index_query_cache_insert, 0);
+}
+
+TEST_F(SniiIndexReaderCountFallback, CustomAnalyzerProviderGenerationsDoNotShareRawQueryCache) {
+    std::atomic<uint32_t> single_flight_leader_calls {0};
+    _index_reader->set_single_flight_leader_before_compute_observer_for_test(
+            record_single_flight_leader, &single_flight_leader_calls);
+    Defer clear_observer([this] {
+        _index_reader->set_single_flight_leader_before_compute_observer_for_test(nullptr, nullptr);
+    });
+
+    inverted_index::Settings tokenizer_settings;
+    tokenizer_settings.set("tokenize_on_chars", "[whitespace]");
+    inverted_index::CustomAnalyzerConfig::Builder whitespace_builder;
+    whitespace_builder.with_tokenizer_config("char_group", tokenizer_settings);
+    whitespace_builder.add_token_filter_config("lowercase", {});
+
+    InvertedIndexAnalyzerCtx old_analyzer_ctx;
+    old_analyzer_ctx.analyzer_name = "mutable_custom_analyzer";
+    old_analyzer_ctx.parser_type = InvertedIndexParserType::PARSER_NONE;
+    old_analyzer_ctx.analyzer_provider =
+            std::make_shared<inverted_index::CustomAnalyzerProvider>(whitespace_builder.build());
+
+    const Field query_value = Field::create_field<TYPE_STRING>(std::string("FAILED ORDER"));
+    QueryExecutionContext old_generation(/*enable_query_cache=*/true);
+    std::shared_ptr<roaring::Roaring> old_bitmap;
+    assert_ok(_index_reader->query(old_generation.context, "provider_generation_content",
+                                   query_value, InvertedIndexQueryType::MATCH_PHRASE_QUERY,
+                                   old_bitmap, &old_analyzer_ctx));
+    ASSERT_NE(old_bitmap, nullptr);
+    EXPECT_EQ(bitmap_docids(*old_bitmap), (std::vector<uint32_t> {0, 3, 5}));
+    EXPECT_EQ(old_generation.stats.inverted_index_query_cache_lookup, 0);
+    EXPECT_EQ(old_generation.stats.inverted_index_query_cache_insert, 0);
+
+    inverted_index::CustomAnalyzerConfig::Builder keyword_builder;
+    keyword_builder.with_tokenizer_config("keyword", {});
+    keyword_builder.add_token_filter_config("lowercase", {});
+    InvertedIndexAnalyzerCtx new_analyzer_ctx = old_analyzer_ctx;
+    new_analyzer_ctx.analyzer_provider =
+            std::make_shared<inverted_index::CustomAnalyzerProvider>(keyword_builder.build());
+
+    QueryExecutionContext new_generation(/*enable_query_cache=*/true);
+    std::shared_ptr<roaring::Roaring> new_bitmap;
+    assert_ok(_index_reader->query(new_generation.context, "provider_generation_content",
+                                   query_value, InvertedIndexQueryType::MATCH_PHRASE_QUERY,
+                                   new_bitmap, &new_analyzer_ctx));
+    ASSERT_NE(new_bitmap, nullptr);
+    EXPECT_TRUE(new_bitmap->isEmpty());
+    EXPECT_EQ(new_generation.stats.inverted_index_query_cache_lookup, 0);
+    EXPECT_EQ(new_generation.stats.inverted_index_query_cache_insert, 0);
+    EXPECT_EQ(single_flight_leader_calls.load(std::memory_order_relaxed), 0);
 }
 
 TEST_F(SniiIndexReaderCountFallback, CustomKeywordAnalyzerWithNoneParserNormalizesSingleTerm) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #66052

Problem Summary:

SNII keyed its result cache and query single-flight by the raw query before analysis. Plain custom-analyzer segments do not persist an immutable analyzer identity, so two live generations under the same analyzer name could tokenize identical raw bytes differently while reusing the first generation bitmap. Gate pre-analysis sharing with the existing analyzer-context capability. Providers without a segment-fixed identity now analyze independently, while raw pattern queries and contexts with complete immutable CommonGrams identity retain sharing. Existing admission and partial-failure tests now preload the same raw query and prove that providers without complete immutable identity bypass the stale entry.

### Release note

Prevent SNII queries from reusing cached results produced by a different custom analyzer generation.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

  Tests run:
  - InvertedIndexReaderAnalysisPurposeTest.*
  - SniiIndexReaderCountFallback.*
  - 37/37 focused ASAN unit tests passed
  - ./build.sh --be -j 192

- Behavior changed:
    - [ ] No.
    - [x] Yes. SNII bypasses pre-analysis result sharing when analyzer semantics are not fixed by immutable segment identity.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label