### PR TITLE
[fix](compaction)Keep tablet active cluster metadata consistent in cloud mode

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -42,6 +42,7 @@
 #include <string>
 #include <thread>
 #include <type_traits>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -2523,7 +2524,7 @@ void calc_delete_bitmap_callback(CloudStorageEngine& engine, const TAgentTaskReq
 
 void make_cloud_committed_rs_visible_callback(CloudStorageEngine& engine,
                                               const TAgentTaskRequest& req) {
-    if (!config::enable_cloud_make_rs_visible_on_be) {
+    if (!config::enable_cloud_make_rs_visible_on_be && !config::enable_compaction_rw_separation) {
         return;
     }
     LOG(INFO) << "begin to make cloud tmp rs visible, txn_id="
@@ -2537,6 +2538,13 @@ void make_cloud_committed_rs_visible_callback(CloudStorageEngine& engine,
     int64_t version_update_time_ms = make_visible_req.__isset.version_update_time_ms
                                              ? make_visible_req.version_update_time_ms
                                              : 0;
+    std::string load_cluster_id =
+            make_visible_req.__isset.load_cluster_id ? make_visible_req.load_cluster_id : "";
+    std::unordered_set<int64_t> last_active_tablet_ids;
+    if (make_visible_req.__isset.last_active_tablet_ids) {
+        last_active_tablet_ids.insert(make_visible_req.last_active_tablet_ids.begin(),
+                                      make_visible_req.last_active_tablet_ids.end());
+    }
 
     // Process each tablet involved in this transaction on this BE
     for (int64_t tablet_id : make_visible_req.tablet_ids) {
@@ -2549,6 +2557,14 @@ void make_cloud_committed_rs_visible_callback(CloudStorageEngine& engine,
             continue;
         }
         auto cloud_tablet = tablet_result.value();
+
+        if (config::enable_compaction_rw_separation && !load_cluster_id.empty() &&
+            version_update_time_ms > 0 && last_active_tablet_ids.contains(tablet_id)) {
+            cloud_tablet->update_last_active_cluster_info(load_cluster_id, version_update_time_ms);
+        }
+        if (!config::enable_cloud_make_rs_visible_on_be) {
+            continue;
+        }
 
         int64_t partition_id = cloud_tablet->partition_id();
         auto version_iter = make_visible_req.partition_version_map.find(partition_id);

--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -996,8 +996,8 @@ Status CloudMetaMgr::sync_tablet_rowsets_unlocked(CloudTablet* tablet,
 
             // Sync last active cluster info for compaction read-write separation
             if (config::enable_compaction_rw_separation && stats.has_last_active_cluster_id()) {
-                tablet->set_last_active_cluster_info(stats.last_active_cluster_id(),
-                                                     stats.last_active_time_ms());
+                tablet->update_last_active_cluster_info(stats.last_active_cluster_id(),
+                                                        stats.last_active_time_ms());
             }
         }
         return Status::OK();

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -284,6 +284,15 @@ public:
         _last_active_cluster_id = cluster_id;
         _last_active_time_ms = time_ms;
     }
+    bool update_last_active_cluster_info(const std::string& cluster_id, int64_t time_ms) {
+        std::unique_lock lock(_cluster_info_mutex);
+        if (time_ms < _last_active_time_ms) {
+            return false;
+        }
+        _last_active_cluster_id = cluster_id;
+        _last_active_time_ms = time_ms;
+        return true;
+    }
 
     // MUST hold SHARED `_meta_lock`.
     std::vector<RowsetSharedPtr> pick_candidate_rowsets_to_base_compaction_unlocked();

--- a/be/test/cloud/cloud_cluster_info_test.cpp
+++ b/be/test/cloud/cloud_cluster_info_test.cpp
@@ -205,6 +205,14 @@ TEST_F(CloudClusterInfoTest, TabletLastActiveClusterInfo) {
     _tablet->set_last_active_cluster_info("cluster_y", now + 1000);
     EXPECT_EQ(_tablet->last_active_cluster_id(), "cluster_y");
     EXPECT_EQ(_tablet->last_active_time_ms(), now + 1000);
+
+    EXPECT_FALSE(_tablet->update_last_active_cluster_info("cluster_old", now));
+    EXPECT_EQ(_tablet->last_active_cluster_id(), "cluster_y");
+    EXPECT_EQ(_tablet->last_active_time_ms(), now + 1000);
+
+    EXPECT_TRUE(_tablet->update_last_active_cluster_info("cluster_z", now + 2000));
+    EXPECT_EQ(_tablet->last_active_cluster_id(), "cluster_z");
+    EXPECT_EQ(_tablet->last_active_time_ms(), now + 2000);
 }
 
 // Case 9: Active cluster is NORMAL but version count exceeds 80% threshold, force compaction

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -3341,6 +3341,14 @@ void MetaServiceImpl::get_rowset(::google::protobuf::RpcController* controller,
                 LOG(WARNING) << msg;
                 return;
             }
+
+            TabletStatsPB load_stats;
+            internal_get_load_tablet_stats(code, msg, reader, txn.get(), instance_id, idx,
+                                           load_stats);
+            if (code != MetaServiceCode::OK) {
+                return;
+            }
+            copy_last_active_cluster_info(load_stats, tablet_stat);
         }
         VLOG_DEBUG << "tablet_id=" << tablet_id << " stats=" << proto_to_json(tablet_stat);
 

--- a/cloud/src/meta-service/meta_service_job.cpp
+++ b/cloud/src/meta-service/meta_service_job.cpp
@@ -1483,6 +1483,23 @@ void process_schema_change_job(MetaServiceCode& code, std::string& msg, std::str
             }
         }
     }
+    TabletIndexPB old_tablet_idx = request->job().idx();
+    if (!old_tablet_idx.has_table_id() || !old_tablet_idx.has_index_id() ||
+        !old_tablet_idx.has_partition_id()) {
+        if (!is_versioned_read) {
+            get_tablet_idx(code, msg, txn.get(), instance_id, tablet_id, old_tablet_idx);
+            if (code != MetaServiceCode::OK) return;
+        } else {
+            TxnErrorCode err = reader.get_tablet_index(txn.get(), tablet_id, &old_tablet_idx);
+            if (err != TxnErrorCode::TXN_OK) {
+                code = err == TxnErrorCode::TXN_KEY_NOT_FOUND ? MetaServiceCode::TABLET_NOT_FOUND
+                                                              : cast_as<ErrCategory::READ>(err);
+                msg = fmt::format("failed to get old tablet index, tablet_id={}, err={}", tablet_id,
+                                  err);
+                return;
+            }
+        }
+    }
     int64_t new_table_id = new_tablet_idx.table_id();
     int64_t new_index_id = new_tablet_idx.index_id();
     int64_t new_partition_id = new_tablet_idx.partition_id();
@@ -1831,8 +1848,88 @@ void process_schema_change_job(MetaServiceCode& code, std::string& msg, std::str
     schema_change_update_tablet_stats(schema_change, stats, num_remove_rows, size_remove_rowsets,
                                       num_remove_rowsets, num_remove_segments,
                                       index_size_remove_rowsets, segment_size_remove_rowsets);
+
     auto stats_key = stats_tablet_key(
             {instance_id, new_table_id, new_index_id, new_partition_id, new_tablet_id});
+    auto has_active_cluster = [](const TabletStatsPB& tablet_stats) {
+        return tablet_stats.has_last_active_cluster_id() &&
+               !tablet_stats.last_active_cluster_id().empty();
+    };
+    auto copy_active_cluster = [](const TabletStatsPB& source, TabletStatsPB* target) {
+        target->set_last_active_cluster_id(source.last_active_cluster_id());
+        if (source.has_last_active_time_ms()) {
+            target->set_last_active_time_ms(source.last_active_time_ms());
+        }
+    };
+
+    if (!has_active_cluster(*stats) && is_versioned_read) {
+        std::string new_stats_val;
+        TxnErrorCode err = txn->get(stats_key, &new_stats_val);
+        if (err == TxnErrorCode::TXN_OK) {
+            TabletStatsPB new_tablet_stats;
+            if (!new_tablet_stats.ParseFromString(new_stats_val)) {
+                code = MetaServiceCode::PROTOBUF_PARSE_ERR;
+                msg = fmt::format("malformed new tablet stats for schema change, tablet_id={}",
+                                  new_tablet_id);
+                LOG(WARNING) << msg;
+                return;
+            }
+            if (has_active_cluster(new_tablet_stats)) {
+                copy_active_cluster(new_tablet_stats, stats);
+            }
+        } else if (err != TxnErrorCode::TXN_KEY_NOT_FOUND) {
+            code = cast_as<ErrCategory::READ>(err);
+            msg = fmt::format(
+                    "failed to get new tablet stats for schema change, tablet_id={}, err={}",
+                    new_tablet_id, err);
+            LOG(WARNING) << msg;
+            return;
+        }
+    }
+
+    if (!has_active_cluster(*stats)) {
+        TabletStatsPB old_tablet_stats;
+        auto old_stats_key =
+                stats_tablet_key({instance_id, old_tablet_idx.table_id(), old_tablet_idx.index_id(),
+                                  old_tablet_idx.partition_id(), tablet_id});
+        std::string old_stats_val;
+        TxnErrorCode err = txn->get(old_stats_key, &old_stats_val);
+        if (err == TxnErrorCode::TXN_OK) {
+            if (!old_tablet_stats.ParseFromString(old_stats_val)) {
+                code = MetaServiceCode::PROTOBUF_PARSE_ERR;
+                msg = fmt::format("malformed old tablet stats for schema change, tablet_id={}",
+                                  tablet_id);
+                LOG(WARNING) << msg;
+                return;
+            }
+        } else if (err == TxnErrorCode::TXN_KEY_NOT_FOUND && is_versioned_read) {
+            err = reader.get_tablet_compact_stats(txn.get(), tablet_id, &old_tablet_stats, nullptr,
+                                                  config::snapshot_get_tablet_stats);
+            if (err != TxnErrorCode::TXN_OK) {
+                if (err != TxnErrorCode::TXN_KEY_NOT_FOUND) {
+                    code = cast_as<ErrCategory::READ>(err);
+                    msg = fmt::format(
+                            "failed to get old tablet compact stats for schema change, "
+                            "tablet_id={}, err={}",
+                            tablet_id, err);
+                    LOG(WARNING) << msg;
+                    return;
+                }
+            }
+        } else if (err != TxnErrorCode::TXN_KEY_NOT_FOUND) {
+            code = cast_as<ErrCategory::READ>(err);
+            msg = fmt::format(
+                    "failed to get old tablet stats for schema change, tablet_id={}, err={}",
+                    tablet_id, err);
+            LOG(WARNING) << msg;
+            return;
+        }
+
+        if (has_active_cluster(old_tablet_stats)) {
+            copy_active_cluster(old_tablet_stats, stats);
+        }
+    }
+
     auto stats_val = stats->SerializeAsString();
     txn->put(stats_key, stats_val);
 

--- a/cloud/src/meta-service/meta_service_tablet_stats.cpp
+++ b/cloud/src/meta-service/meta_service_tablet_stats.cpp
@@ -171,6 +171,30 @@ void merge_tablet_stats(TabletStatsPB& stats, const TabletStats& detached_stats)
     stats.set_segment_size(stats.segment_size() + detached_stats.segment_size);
 }
 
+void copy_last_active_cluster_info(const TabletStatsPB& source, TabletStatsPB& target) {
+    if (!source.has_last_active_cluster_id()) {
+        return;
+    }
+
+    target.set_last_active_cluster_id(source.last_active_cluster_id());
+    if (source.has_last_active_time_ms()) {
+        target.set_last_active_time_ms(source.last_active_time_ms());
+    } else {
+        target.clear_last_active_time_ms();
+    }
+    if (source.has_last_active_cluster_status()) {
+        target.set_last_active_cluster_status(source.last_active_cluster_status());
+    } else {
+        target.clear_last_active_cluster_status();
+    }
+    if (source.has_last_active_cluster_status_mtime_ms()) {
+        target.set_last_active_cluster_status_mtime_ms(
+                source.last_active_cluster_status_mtime_ms());
+    } else {
+        target.clear_last_active_cluster_status_mtime_ms();
+    }
+}
+
 void detach_tablet_stats(const TabletStatsPB& stats, TabletStats& detached_stats) {
     detached_stats.data_size = stats.data_size();
     detached_stats.num_rows = stats.num_rows();
@@ -200,21 +224,29 @@ void internal_get_load_tablet_stats(MetaServiceCode& code, std::string& msg,
     // Try to read existing versioned tablet stats
     TxnErrorCode err =
             meta_reader.get_tablet_load_stats(txn, tablet_id, &stats, &versionstamp, snapshot);
-    if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) {
-        // If versioned stats doesn't exist, read from single version
+    if (err != TxnErrorCode::TXN_OK && err != TxnErrorCode::TXN_KEY_NOT_FOUND) {
+        code = cast_as<ErrCategory::READ>(err);
+        msg = fmt::format("failed to get versioned tablet stats, err={}", err);
+        LOG(WARNING) << msg << " tablet_id=" << tablet_id;
+        return;
+    }
+    if (err == TxnErrorCode::TXN_KEY_NOT_FOUND || !stats.has_last_active_cluster_id()) {
+        bool versioned_stats_not_found = err == TxnErrorCode::TXN_KEY_NOT_FOUND;
+        // If versioned stats doesn't exist or lacks active cluster info, read from single version.
         TabletStatsPB compact_stats;
         TabletStats detached_stats;
         internal_get_tablet_stats(code, msg, txn, instance_id, tablet_idx, compact_stats,
                                   detached_stats, snapshot);
         if (code == MetaServiceCode::OK) {
-            // Only the detached stats are valid for load tablet stats.
-            merge_tablet_stats(stats, detached_stats);
+            if (versioned_stats_not_found) {
+                // Only the detached stats are valid for load tablet stats.
+                merge_tablet_stats(stats, detached_stats);
+            }
+            copy_last_active_cluster_info(compact_stats, stats);
+        } else if (!versioned_stats_not_found && code == MetaServiceCode::TABLET_NOT_FOUND) {
+            code = MetaServiceCode::OK;
+            msg.clear();
         }
-    } else if (err != TxnErrorCode::TXN_OK) {
-        code = cast_as<ErrCategory::READ>(err);
-        msg = fmt::format("failed to get versioned tablet stats, err={}", err);
-        LOG(WARNING) << msg << " tablet_id=" << tablet_id;
-        return;
     }
 }
 
@@ -251,16 +283,17 @@ void internal_get_load_tablet_stats_batch(
         (*tablet_stats)[tablet_id] = stats;
     }
 
-    // For tablets not found in versioned stats, fall back to single version detached stats
+    // For tablets without complete versioned load stats, fall back to single version stats.
     std::vector<int64_t> fallback_tablet_ids;
     for (int64_t tablet_id : tablet_ids) {
-        if (!versioned_stats.contains(tablet_id)) {
+        auto it = versioned_stats.find(tablet_id);
+        if (it == versioned_stats.end() || !it->second.has_last_active_cluster_id()) {
             fallback_tablet_ids.push_back(tablet_id);
         }
     }
 
     if (!fallback_tablet_ids.empty()) {
-        LOG(INFO) << "fallback to single version detached stats for " << fallback_tablet_ids.size()
+        LOG(INFO) << "fallback to single version tablet stats for " << fallback_tablet_ids.size()
                   << " tablets";
 
         // Fall back to single version for each tablet
@@ -270,21 +303,29 @@ void internal_get_load_tablet_stats_batch(
                 continue;
             }
             const TabletIndexPB& tablet_idx = it->second;
+            bool versioned_stats_not_found = !versioned_stats.contains(tablet_id);
 
             TabletStatsPB compact_stats;
             TabletStats detached_stats;
             internal_get_tablet_stats(code, msg, txn, instance_id, tablet_idx, compact_stats,
                                       detached_stats, snapshot);
             if (code != MetaServiceCode::OK) {
+                if (!versioned_stats_not_found && code == MetaServiceCode::TABLET_NOT_FOUND) {
+                    code = MetaServiceCode::OK;
+                    msg.clear();
+                    continue;
+                }
                 LOG(WARNING) << "failed to get detached tablet stats for fallback, tablet_id="
                              << tablet_id << " code=" << code << " msg=" << msg;
                 return;
             }
 
-            // Only the detached stats are valid for load tablet stats.
-            TabletStatsPB stats_pb;
-            merge_tablet_stats(stats_pb, detached_stats);
-            (*tablet_stats)[tablet_id] = std::move(stats_pb);
+            auto& stats_pb = (*tablet_stats)[tablet_id];
+            if (versioned_stats_not_found) {
+                // Only the detached stats are valid for load tablet stats.
+                merge_tablet_stats(stats_pb, detached_stats);
+            }
+            copy_last_active_cluster_info(compact_stats, stats_pb);
         }
     }
 }

--- a/cloud/src/meta-service/meta_service_tablet_stats.h
+++ b/cloud/src/meta-service/meta_service_tablet_stats.h
@@ -47,6 +47,9 @@ void internal_get_tablet_stats(MetaServiceCode& code, std::string& msg, Transact
 // Merge `detached_stats` `stats` to `stats`.
 void merge_tablet_stats(TabletStatsPB& stats, const TabletStats& detached_stats);
 
+// Copy compaction read-write separation metadata between tablet stats.
+void copy_last_active_cluster_info(const TabletStatsPB& source, TabletStatsPB& target);
+
 // Detach tablet stats from `stats` to `detached_stats`.
 void detach_tablet_stats(const TabletStatsPB& stats, TabletStats& detached_stats);
 
@@ -57,7 +60,8 @@ void internal_get_tablet_stats(MetaServiceCode& code, std::string& msg, Transact
 
 // Get versioned load tablet stats via `txn`. If an error occurs, `code` will be set to non OK.
 //
-// If the versioned load stats doesn't exist, fall back to get single version detached tablet stats.
+// If the versioned load stats doesn't exist or lacks owner information, fall back to single-version
+// tablet stats for detached load statistics and compaction read-write separation metadata.
 void internal_get_load_tablet_stats(MetaServiceCode& code, std::string& msg,
                                     CloneChainReader& meta_reader, Transaction* txn,
                                     const std::string& instance_id, const TabletIndexPB& idx,
@@ -66,7 +70,8 @@ void internal_get_load_tablet_stats(MetaServiceCode& code, std::string& msg,
 // Batch version: Get versioned load tablet stats for multiple tablets via `txn`.
 // If an error occurs, `code` will be set to non OK.
 //
-// For tablets whose versioned load stats doesn't exist, fall back to get single version detached tablet stats.
+// For tablets whose versioned load stats doesn't exist or lacks owner information, fall back to
+// single-version tablet stats for detached load statistics and compaction read-write separation metadata.
 // tablet_indexes: map of tablet_id -> TabletIndexPB
 // tablet_stats: output map of tablet_id -> TabletStatsPB
 void internal_get_load_tablet_stats_batch(

--- a/cloud/src/meta-service/meta_service_tablet_stats.h
+++ b/cloud/src/meta-service/meta_service_tablet_stats.h
@@ -20,6 +20,7 @@
 #include <gen_cpp/cloud.pb.h>
 
 #include "meta-store/clone_chain_reader.h"
+#include "meta-store/keys.h"
 #include "resource-manager/resource_manager.h"
 
 namespace doris::cloud {
@@ -49,6 +50,15 @@ void merge_tablet_stats(TabletStatsPB& stats, const TabletStats& detached_stats)
 
 // Copy compaction read-write separation metadata between tablet stats.
 void copy_last_active_cluster_info(const TabletStatsPB& source, TabletStatsPB& target);
+
+void set_tablet_last_active_cluster(TabletStatsPB* stats, const std::string& cluster_id,
+                                    int64_t last_active_time_ms);
+
+void update_tablet_last_active_cluster(const StatsTabletKeyInfo& info,
+                                       const std::string& cluster_id,
+                                       int64_t last_active_time_ms,
+                                       std::unique_ptr<Transaction>& txn, MetaServiceCode& code,
+                                       std::string& msg);
 
 // Detach tablet stats from `stats` to `detached_stats`.
 void detach_tablet_stats(const TabletStatsPB& stats, TabletStats& detached_stats);

--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -1474,9 +1474,18 @@ void scan_tmp_rowset(
     return;
 }
 
+void set_tablet_last_active_cluster(TabletStatsPB* stats, const std::string& cluster_id,
+                                    int64_t last_active_time_ms) {
+    stats->set_last_active_cluster_id(cluster_id);
+    stats->set_last_active_time_ms(last_active_time_ms);
+    stats->clear_last_active_cluster_status();
+    stats->clear_last_active_cluster_status_mtime_ms();
+}
+
 // Update the last active cluster info for a tablet
 void update_tablet_last_active_cluster(const StatsTabletKeyInfo& info,
                                        const std::string& cluster_id,
+                                       int64_t last_active_time_ms,
                                        std::unique_ptr<Transaction>& txn, MetaServiceCode& code,
                                        std::string& msg) {
     if (cluster_id.empty()) {
@@ -1505,10 +1514,7 @@ void update_tablet_last_active_cluster(const StatsTabletKeyInfo& info,
         return;
     }
 
-    stats_pb.set_last_active_cluster_id(cluster_id);
-    stats_pb.set_last_active_time_ms(::time(nullptr) * 1000);
-    // Clear the mtime when updating cluster to allow dynamic filling on next get_rowset
-    stats_pb.clear_last_active_cluster_status_mtime_ms();
+    set_tablet_last_active_cluster(&stats_pb, cluster_id, last_active_time_ms);
 
     stats_pb.SerializeToString(&val);
     txn->put(key, val);
@@ -2269,17 +2275,27 @@ void MetaServiceImpl::commit_txn_immediately(
             update_tablet_stats(info, stats, txn, code, msg);
             if (code != MetaServiceCode::OK) return;
 
+            TabletStatsPB versioned_stats;
+            if (is_versioned_write) {
+                versioned_stats = existing_versioned_stats[tablet_id];
+                merge_tablet_stats(versioned_stats, stats);
+            }
+
             // Update last active cluster if load has data
             if (!requester_cluster_id.empty() && stats.num_segs > 0) {
-                update_tablet_last_active_cluster(info, requester_cluster_id, txn, code, msg);
+                int64_t last_active_time_ms = ::time(nullptr) * 1000;
+                update_tablet_last_active_cluster(info, requester_cluster_id, last_active_time_ms,
+                                                  txn, code, msg);
                 if (code != MetaServiceCode::OK) return;
+                if (is_versioned_write) {
+                    set_tablet_last_active_cluster(&versioned_stats, requester_cluster_id,
+                                                   last_active_time_ms);
+                }
             }
 
             if (is_versioned_write) {
-                TabletStatsPB stats_pb = existing_versioned_stats[tablet_id];
-                merge_tablet_stats(stats_pb, stats);
                 std::string stats_key = versioned::tablet_load_stats_key({instance_id, tablet_id});
-                if (!versioned::document_put(txn.get(), stats_key, std::move(stats_pb))) {
+                if (!versioned::document_put(txn.get(), stats_key, std::move(versioned_stats))) {
                     code = MetaServiceCode::PROTOBUF_SERIALIZE_ERR;
                     msg = "failed to serialize versioned tablet stats";
                     LOG(WARNING) << msg << " tablet_id=" << tablet_id << " txn_id=" << txn_id;
@@ -3485,17 +3501,27 @@ void MetaServiceImpl::commit_txn_with_sub_txn(const CommitTxnRequest* request,
             update_tablet_stats(info, stats, txn, code, msg);
             if (code != MetaServiceCode::OK) return;
 
+            TabletStatsPB versioned_stats;
+            if (is_versioned_write) {
+                versioned_stats = existing_versioned_stats[tablet_id];
+                merge_tablet_stats(versioned_stats, stats);
+            }
+
             // Update last active cluster if load has data
             if (!requester_cluster_id_ev.empty() && stats.num_segs > 0) {
-                update_tablet_last_active_cluster(info, requester_cluster_id_ev, txn, code, msg);
+                int64_t last_active_time_ms = ::time(nullptr) * 1000;
+                update_tablet_last_active_cluster(info, requester_cluster_id_ev,
+                                                  last_active_time_ms, txn, code, msg);
                 if (code != MetaServiceCode::OK) return;
+                if (is_versioned_write) {
+                    set_tablet_last_active_cluster(&versioned_stats, requester_cluster_id_ev,
+                                                   last_active_time_ms);
+                }
             }
 
             if (is_versioned_write) {
-                TabletStatsPB stats_pb = existing_versioned_stats[tablet_id];
-                merge_tablet_stats(stats_pb, stats);
                 std::string stats_key = versioned::tablet_load_stats_key({instance_id, tablet_id});
-                if (!versioned::document_put(txn.get(), stats_key, std::move(stats_pb))) {
+                if (!versioned::document_put(txn.get(), stats_key, std::move(versioned_stats))) {
                     code = MetaServiceCode::PROTOBUF_SERIALIZE_ERR;
                     msg = "failed to serialize versioned tablet stats";
                     LOG(WARNING) << msg << " tablet_id=" << tablet_id << " txn_id=" << txn_id;

--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -1476,6 +1476,10 @@ void scan_tmp_rowset(
 
 void set_tablet_last_active_cluster(TabletStatsPB* stats, const std::string& cluster_id,
                                     int64_t last_active_time_ms) {
+    if (stats->has_last_active_time_ms() &&
+        last_active_time_ms < stats->last_active_time_ms()) {
+        return;
+    }
     stats->set_last_active_cluster_id(cluster_id);
     stats->set_last_active_time_ms(last_active_time_ms);
     stats->clear_last_active_cluster_status();
@@ -2283,14 +2287,14 @@ void MetaServiceImpl::commit_txn_immediately(
 
             // Update last active cluster if load has data
             if (!requester_cluster_id.empty() && stats.num_segs > 0) {
-                int64_t last_active_time_ms = ::time(nullptr) * 1000;
-                update_tablet_last_active_cluster(info, requester_cluster_id, last_active_time_ms,
-                                                  txn, code, msg);
+                update_tablet_last_active_cluster(info, requester_cluster_id,
+                                                  version_update_time_ms, txn, code, msg);
                 if (code != MetaServiceCode::OK) return;
                 if (is_versioned_write) {
                     set_tablet_last_active_cluster(&versioned_stats, requester_cluster_id,
-                                                   last_active_time_ms);
+                                                   version_update_time_ms);
                 }
+                response->add_last_active_tablet_ids(tablet_id);
             }
 
             if (is_versioned_write) {
@@ -3509,14 +3513,14 @@ void MetaServiceImpl::commit_txn_with_sub_txn(const CommitTxnRequest* request,
 
             // Update last active cluster if load has data
             if (!requester_cluster_id_ev.empty() && stats.num_segs > 0) {
-                int64_t last_active_time_ms = ::time(nullptr) * 1000;
                 update_tablet_last_active_cluster(info, requester_cluster_id_ev,
-                                                  last_active_time_ms, txn, code, msg);
+                                                  version_update_time_ms, txn, code, msg);
                 if (code != MetaServiceCode::OK) return;
                 if (is_versioned_write) {
                     set_tablet_last_active_cluster(&versioned_stats, requester_cluster_id_ev,
-                                                   last_active_time_ms);
+                                                   version_update_time_ms);
                 }
+                response->add_last_active_tablet_ids(tablet_id);
             }
 
             if (is_versioned_write) {

--- a/cloud/src/meta-service/txn_lazy_committer.cpp
+++ b/cloud/src/meta-service/txn_lazy_committer.cpp
@@ -213,7 +213,8 @@ void convert_tmp_rowsets(
         std::vector<std::pair<std::string, doris::RowsetMetaCloudPB>>& tmp_rowsets_meta,
         std::map<int64_t, TabletIndexPB>& tablet_ids, bool is_versioned_write,
         bool is_versioned_read, Versionstamp versionstamp, ResourceManager* resource_mgr,
-        bool defer_deleting_pending_delete_bitmaps, int64_t commit_tso) {
+        bool defer_deleting_pending_delete_bitmaps, int64_t commit_tso,
+        const std::string& load_cluster_id, int64_t last_active_time_ms) {
     std::stringstream ss;
     std::unique_ptr<Transaction> txn;
     TxnErrorCode err = txn_kv->create_txn(&txn);
@@ -467,9 +468,18 @@ void convert_tmp_rowsets(
         update_tablet_stats(info, stats, txn, code, msg);
         if (code != MetaServiceCode::OK) return;
 
+        if (!load_cluster_id.empty() && stats.num_segs > 0) {
+            update_tablet_last_active_cluster(info, load_cluster_id, last_active_time_ms, txn, code,
+                                              msg);
+            if (code != MetaServiceCode::OK) return;
+        }
+
         if (is_versioned_write) {
             TabletStatsPB stats_pb = existing_versioned_stats[tablet_id];
             merge_tablet_stats(stats_pb, stats);
+            if (!load_cluster_id.empty() && stats.num_segs > 0) {
+                set_tablet_last_active_cluster(&stats_pb, load_cluster_id, last_active_time_ms);
+            }
             std::string stats_key = versioned::tablet_load_stats_key({instance_id, tablet_id});
 
             // put with specified versionstamp
@@ -738,7 +748,8 @@ void TxnLazyCommitTask::commit() {
                         return commit_partition(
                                 db_id, partition_id, partition_to_tmp_rowset_metas.at(partition_id),
                                 is_versioned_read, is_versioned_write,
-                                defer_deleting_pending_delete_bitmaps, txn_info.commit_tso());
+                                defer_deleting_pending_delete_bitmaps, txn_info.commit_tso(),
+                                txn_info.load_cluster_id());
                     });
                 }
                 bool finished = false;
@@ -760,7 +771,8 @@ void TxnLazyCommitTask::commit() {
                     std::tie(code_, msg_) = commit_partition(
                             db_id, partition_id, partition_to_tmp_rowset_metas[partition_id],
                             is_versioned_read, is_versioned_write,
-                            defer_deleting_pending_delete_bitmaps, txn_info.commit_tso());
+                            defer_deleting_pending_delete_bitmaps, txn_info.commit_tso(),
+                            txn_info.load_cluster_id());
                     if (code_ != MetaServiceCode::OK) break;
                 }
             }
@@ -780,7 +792,7 @@ std::pair<MetaServiceCode, std::string> TxnLazyCommitTask::commit_partition(
         int64_t db_id, int64_t partition_id,
         const std::vector<std::pair<std::string, doris::RowsetMetaCloudPB>>& tmp_rowset_metas,
         bool is_versioned_read, bool is_versioned_write, bool defer_deleting_pending_delete_bitmaps,
-        int64_t commit_tso) {
+        int64_t commit_tso, const std::string& load_cluster_id) {
     std::stringstream ss;
     CloneChainReader meta_reader(instance_id_, txn_kv_.get(),
                                  txn_lazy_committer_->resource_manager().get());
@@ -854,7 +866,8 @@ std::pair<MetaServiceCode, std::string> TxnLazyCommitTask::commit_partition(
                             sub_partition_tmp_rowset_metas, tablet_ids, is_versioned_write,
                             is_versioned_read, versionstamp,
                             txn_lazy_committer_->resource_manager().get(),
-                            defer_deleting_pending_delete_bitmaps, commit_tso);
+                            defer_deleting_pending_delete_bitmaps, commit_tso, load_cluster_id,
+                            original_partition_version.update_time_ms());
         if (code != MetaServiceCode::OK) {
             return {code, msg};
         }

--- a/cloud/src/meta-service/txn_lazy_committer.h
+++ b/cloud/src/meta-service/txn_lazy_committer.h
@@ -54,7 +54,8 @@ private:
             int64_t db_id, int64_t partition_id,
             const std::vector<std::pair<std::string, doris::RowsetMetaCloudPB>>& tmp_rowset_metas,
             bool is_versioned_write, bool is_versioned_read,
-            bool defer_deleting_pending_delete_bitmaps, int64_t commit_tso);
+            bool defer_deleting_pending_delete_bitmaps, int64_t commit_tso,
+            const std::string& load_cluster_id);
 
     std::string instance_id_;
     int64_t txn_id_;

--- a/cloud/src/resource-manager/resource_manager.cpp
+++ b/cloud/src/resource-manager/resource_manager.cpp
@@ -873,13 +873,12 @@ std::string ResourceManager::update_cluster(
     if (!msg.empty()) {
         return msg;
     }
-    ClusterPB now = clusters[idx];
     auto now_time = std::chrono::system_clock::now();
     uint64_t time =
             std::chrono::duration_cast<std::chrono::seconds>(now_time.time_since_epoch()).count();
-    now.set_mtime(time);
+    clusters[idx].set_mtime(time);
     LOG(INFO) << "before update cluster original: " << proto_to_json(original)
-              << " after update now: " << proto_to_json(now);
+              << " after update now: " << proto_to_json(clusters[idx]);
 
     InstanceKeyInfo key_info {instance_id};
     std::string key;

--- a/cloud/test/compaction_rw_separation_test.cpp
+++ b/cloud/test/compaction_rw_separation_test.cpp
@@ -154,6 +154,8 @@ TEST(CompactionRWSeparationTest, CommitTxnUpdatesLastActiveCluster) {
 
         meta_service.commit_txn(&cntl, &req, &res, nullptr);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK) << res.status().msg();
+        ASSERT_EQ(res.last_active_tablet_ids_size(), 1);
+        EXPECT_EQ(res.last_active_tablet_ids(0), tablet_id);
     }
 
     // Get rowset and check last_active_cluster_id

--- a/cloud/test/meta_service_job_test.cpp
+++ b/cloud/test/meta_service_job_test.cpp
@@ -1445,6 +1445,22 @@ TEST(MetaServiceJobVersionedReadTest, SchemaChangeJobTest) {
         insert_rowset(meta_service.get(), 1, "commit_rowset_3", table_id, partition_id, tablet_id);
     }
 
+    constexpr int64_t last_active_time_ms = 123456789;
+    {
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+        auto stats_key =
+                stats_tablet_key({instance_id, table_id, index_id, partition_id, tablet_id});
+        std::string stats_val;
+        ASSERT_EQ(txn->get(stats_key, &stats_val), TxnErrorCode::TXN_OK);
+        TabletStatsPB stats;
+        ASSERT_TRUE(stats.ParseFromString(stats_val));
+        stats.set_last_active_cluster_id("cluster_a");
+        stats.set_last_active_time_ms(last_active_time_ms);
+        txn->put(stats_key, stats.SerializeAsString());
+        ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+    }
+
     auto get_tablet_stats = [&](int64_t tid) -> TabletStatsPB {
         GetTabletStatsRequest get_tablet_stats_req;
         get_tablet_stats_req.set_cloud_unique_id(cloud_unique_id);
@@ -1576,6 +1592,8 @@ TEST(MetaServiceJobVersionedReadTest, SchemaChangeJobTest) {
                           req.job().schema_change().segment_size_output_rowsets());
         EXPECT_EQ(new_stats.cumulative_point(),
                   req.job().schema_change().output_cumulative_point());
+        EXPECT_EQ(new_stats.last_active_cluster_id(), "cluster_a");
+        EXPECT_EQ(new_stats.last_active_time_ms(), last_active_time_ms);
     }
 
     {
@@ -3626,6 +3644,22 @@ TEST(MetaServiceJobTest, SchemaChangeJobTest) {
         ASSERT_EQ(res.status().code(), MetaServiceCode::JOB_ALREADY_SUCCESS);
     }
 
+    constexpr int64_t last_active_time_ms = 123456789;
+    {
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+        auto stats_key =
+                stats_tablet_key({instance_id, table_id, index_id, partition_id, tablet_id});
+        std::string stats_val;
+        ASSERT_EQ(txn->get(stats_key, &stats_val), TxnErrorCode::TXN_OK);
+        TabletStatsPB stats;
+        ASSERT_TRUE(stats.ParseFromString(stats_val));
+        stats.set_last_active_cluster_id("cluster_a");
+        stats.set_last_active_time_ms(last_active_time_ms);
+        txn->put(stats_key, stats.SerializeAsString());
+        ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+    }
+
     // commit schema_change job with txn_ids
     {
         int64_t new_tablet_id = 24;
@@ -3665,6 +3699,8 @@ TEST(MetaServiceJobTest, SchemaChangeJobTest) {
         EXPECT_EQ(tablet_stats.data_size(), 50000);
         EXPECT_EQ(tablet_stats.index_size(), 25000);
         EXPECT_EQ(tablet_stats.segment_size(), 25000);
+        EXPECT_EQ(tablet_stats.last_active_cluster_id(), "cluster_a");
+        EXPECT_EQ(tablet_stats.last_active_time_ms(), last_active_time_ms);
 
         std::unique_ptr<Transaction> txn;
         ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);

--- a/cloud/test/meta_service_versioned_read_test.cpp
+++ b/cloud/test/meta_service_versioned_read_test.cpp
@@ -1067,6 +1067,110 @@ TEST(MetaServiceVersionedReadTest, GetRowsetMetas) {
     LOG(INFO) << "GetRowsetMetas test completed successfully";
 }
 
+static void create_and_commit_rowset_with_cluster(MetaServiceProxy* service, int64_t db_id,
+                                                  int64_t table_id, int64_t partition_id,
+                                                  int64_t tablet_id,
+                                                  const std::string& cluster_id) {
+    brpc::Controller cntl;
+    BeginTxnRequest begin_req;
+    BeginTxnResponse begin_res;
+    begin_req.set_cloud_unique_id("test_cloud_unique_id");
+    auto* txn_info = begin_req.mutable_txn_info();
+    txn_info->set_db_id(db_id);
+    txn_info->set_label("get_rowset_last_active_cluster");
+    txn_info->add_table_ids(table_id);
+    txn_info->set_timeout_ms(36000);
+    txn_info->set_load_cluster_id(cluster_id);
+    service->begin_txn(&cntl, &begin_req, &begin_res, nullptr);
+    ASSERT_EQ(begin_res.status().code(), MetaServiceCode::OK) << begin_res.status().msg();
+
+    auto rowset = create_rowset(begin_res.txn_id(), tablet_id, partition_id, 2, 100);
+    CreateRowsetResponse rowset_res;
+    prepare_rowset(service, rowset, rowset_res);
+    ASSERT_EQ(rowset_res.status().code(), MetaServiceCode::OK) << rowset_res.status().msg();
+    commit_rowset(service, rowset, rowset_res);
+    ASSERT_EQ(rowset_res.status().code(), MetaServiceCode::OK) << rowset_res.status().msg();
+
+    CommitTxnRequest commit_req;
+    CommitTxnResponse commit_res;
+    commit_req.set_cloud_unique_id("test_cloud_unique_id");
+    commit_req.set_db_id(db_id);
+    commit_req.set_txn_id(begin_res.txn_id());
+    service->commit_txn(&cntl, &commit_req, &commit_res, nullptr);
+    ASSERT_EQ(commit_res.status().code(), MetaServiceCode::OK) << commit_res.status().msg();
+}
+
+static GetRowsetResponse get_rowsets(MetaServiceProxy* service, int64_t db_id, int64_t table_id,
+                                     int64_t index_id, int64_t partition_id, int64_t tablet_id) {
+    brpc::Controller cntl;
+    GetRowsetRequest req;
+    GetRowsetResponse res;
+    req.set_cloud_unique_id("test_cloud_unique_id");
+    auto* idx = req.mutable_idx();
+    idx->set_db_id(db_id);
+    idx->set_table_id(table_id);
+    idx->set_index_id(index_id);
+    idx->set_partition_id(partition_id);
+    idx->set_tablet_id(tablet_id);
+    req.set_start_version(0);
+    req.set_end_version(-1);
+    req.set_base_compaction_cnt(0);
+    req.set_cumulative_compaction_cnt(0);
+    req.set_cumulative_point(2);
+    service->get_rowset(&cntl, &req, &res, nullptr);
+    return res;
+}
+
+static void clear_versioned_last_active_cluster(MetaServiceProxy* service,
+                                                const std::string& instance_id, int64_t tablet_id) {
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+    std::string key = versioned::tablet_load_stats_key({instance_id, tablet_id});
+    Versionstamp versionstamp;
+    std::string value;
+    ASSERT_EQ(versioned_get(txn.get(), key, &versionstamp, &value), TxnErrorCode::TXN_OK);
+    TabletStatsPB load_stats;
+    ASSERT_TRUE(load_stats.ParseFromString(value));
+    load_stats.clear_last_active_cluster_id();
+    load_stats.clear_last_active_time_ms();
+    versioned_put(txn.get(), key, load_stats.SerializeAsString());
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+}
+
+static void expect_last_active_cluster(const GetRowsetResponse& response,
+                                       const std::string& cluster_id, bool expect_time) {
+    ASSERT_EQ(response.status().code(), MetaServiceCode::OK) << response.status().msg();
+    ASSERT_TRUE(response.stats().has_last_active_cluster_id());
+    EXPECT_EQ(response.stats().last_active_cluster_id(), cluster_id);
+    if (expect_time) {
+        EXPECT_TRUE(response.stats().has_last_active_time_ms());
+    }
+}
+
+TEST(MetaServiceVersionedReadTest, GetRowsetReturnsLastActiveCluster) {
+    auto service = get_meta_service(false);
+    std::string instance_id = "get_rowset_last_active_cluster_instance";
+    std::string cluster_id = "write_cluster_id";
+    constexpr int64_t db_id = 1;
+    constexpr int64_t table_id = 2;
+    constexpr int64_t index_id = 3;
+    constexpr int64_t partition_id = 4;
+    constexpr int64_t tablet_id = 5;
+
+    MOCK_GET_INSTANCE_ID(instance_id);
+    create_and_refresh_instance(service.get(), instance_id);
+    create_tablet(service.get(), table_id, index_id, partition_id, tablet_id);
+    create_and_commit_rowset_with_cluster(service.get(), db_id, table_id, partition_id, tablet_id,
+                                          cluster_id);
+
+    auto response = get_rowsets(service.get(), db_id, table_id, index_id, partition_id, tablet_id);
+    expect_last_active_cluster(response, cluster_id, true);
+
+    clear_versioned_last_active_cluster(service.get(), instance_id, tablet_id);
+    response = get_rowsets(service.get(), db_id, table_id, index_id, partition_id, tablet_id);
+    expect_last_active_cluster(response, cluster_id, false);
+}
+
 TEST(MetaServiceVersionedReadTest, UpdateTablet) {
     auto service = get_meta_service(false);
     std::string instance_id = "test_cloud_instance_id";

--- a/cloud/test/txn_lazy_commit_test.cpp
+++ b/cloud/test/txn_lazy_commit_test.cpp
@@ -802,6 +802,7 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithDbIdTest) {
     txn_info_pb.set_label("test_label_commit_txn_eventually2");
     txn_info_pb.add_table_ids(table_id);
     txn_info_pb.set_timeout_ms(36000);
+    txn_info_pb.set_load_cluster_id("cluster_2");
     req.mutable_txn_info()->CopyFrom(txn_info_pb);
     BeginTxnResponse res;
     meta_service->begin_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req, &res,
@@ -815,11 +816,30 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithDbIdTest) {
         create_tablet_with_db_id(meta_service.get(), db_id, table_id, index_id, partition_id,
                                  tablet_id_base + i);
         auto tmp_rowset = create_rowset(txn_id, tablet_id_base + i, index_id, partition_id);
+        if (i == 0) {
+            tmp_rowset.set_num_segments(1);
+        }
         CreateRowsetResponse res;
         prepare_rowset(meta_service.get(), tmp_rowset, res);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
         commit_rowset(meta_service.get(), tmp_rowset, res);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+    }
+
+    {
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+        std::string stats_key;
+        stats_tablet_key({"test_instance", table_id, index_id, partition_id, tablet_id_base},
+                         &stats_key);
+        std::string stats_val;
+        ASSERT_EQ(txn->get(stats_key, &stats_val), TxnErrorCode::TXN_OK);
+        TabletStatsPB stats_pb;
+        ASSERT_TRUE(stats_pb.ParseFromString(stats_val));
+        stats_pb.set_last_active_cluster_id("cluster_1");
+        stats_pb.set_last_active_time_ms(1);
+        txn->put(stats_key, stats_pb.SerializeAsString());
+        ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
     }
 
     {
@@ -849,6 +869,16 @@ TEST(TxnLazyCommitTest, CommitTxnEventuallyWithDbIdTest) {
             check_tmp_rowset_not_exist(txn, tablet_id, txn_id);
             check_rowset_meta_exist(txn, tablet_id, 2);
         }
+
+        std::string stats_key;
+        stats_tablet_key({mock_instance, table_id, index_id, partition_id, tablet_id_base},
+                         &stats_key);
+        std::string stats_val;
+        ASSERT_EQ(txn->get(stats_key, &stats_val), TxnErrorCode::TXN_OK);
+        TabletStatsPB stats_pb;
+        ASSERT_TRUE(stats_pb.ParseFromString(stats_val));
+        EXPECT_EQ(stats_pb.last_active_cluster_id(), "cluster_2");
+        EXPECT_GT(stats_pb.last_active_time_ms(), 1);
     }
 }
 
@@ -912,6 +942,7 @@ TEST(TxnLazyCommitVersionedReadTest, CommitTxnEventually) {
         txn_info_pb.set_label("test_label_commit_txn_eventually2");
         txn_info_pb.add_table_ids(table_id);
         txn_info_pb.set_timeout_ms(36000);
+        txn_info_pb.set_load_cluster_id("cluster_2");
         req.mutable_txn_info()->CopyFrom(txn_info_pb);
         BeginTxnResponse res;
         meta_service->begin_txn(reinterpret_cast<::google::protobuf::RpcController*>(&cntl), &req,
@@ -926,6 +957,9 @@ TEST(TxnLazyCommitVersionedReadTest, CommitTxnEventually) {
         create_tablet_with_db_id(meta_service.get(), db_id, table_id, index_id, partition_id,
                                  tablet_id_base + i);
         auto tmp_rowset = create_rowset(txn_id, tablet_id_base + i, index_id, partition_id);
+        if (i == 0) {
+            tmp_rowset.set_num_segments(1);
+        }
         CreateRowsetResponse res;
         prepare_rowset(meta_service.get(), tmp_rowset, res);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
@@ -971,6 +1005,16 @@ TEST(TxnLazyCommitVersionedReadTest, CommitTxnEventually) {
             Versionstamp versionstamp;
             ASSERT_EQ(versioned::document_get(txn.get(), rowset_key, &rowset_val, &versionstamp),
                       TxnErrorCode::TXN_OK);
+
+            if (i == 0) {
+                std::string stats_key =
+                        versioned::tablet_load_stats_key({mock_instance, tablet_id});
+                TabletStatsPB stats_pb;
+                ASSERT_EQ(versioned::document_get(txn.get(), stats_key, &stats_pb, &versionstamp),
+                          TxnErrorCode::TXN_OK);
+                EXPECT_EQ(stats_pb.last_active_cluster_id(), "cluster_2");
+                EXPECT_GT(stats_pb.last_active_time_ms(), 0);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -2883,8 +2883,11 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
                     commitTxnResponse.getTxnInfo().getTxnId());
             return;
         }
+        boolean hasLastActiveClusterUpdate = commitTxnResponse.getTxnInfo().hasLoadClusterId()
+                && !commitTxnResponse.getTxnInfo().getLoadClusterId().isEmpty()
+                && commitTxnResponse.getLastActiveTabletIdsCount() > 0;
         if (tabletCommitInfos == null || tabletCommitInfos.isEmpty()
-                || !Config.enable_notify_be_after_load_txn_commit) {
+                || (!Config.enable_notify_be_after_load_txn_commit && !hasLastActiveClusterUpdate)) {
             return;
         }
         long txnId = commitTxnResponse.getTxnInfo().getTxnId();
@@ -2913,10 +2916,14 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
             }
 
             long updateVersionVisibleTime = commitTxnResponse.getVersionUpdateTimeMs();
+            String loadClusterId = commitTxnResponse.getTxnInfo().hasLoadClusterId()
+                    ? commitTxnResponse.getTxnInfo().getLoadClusterId() : "";
+            Set<Long> lastActiveTabletIds =
+                    new HashSet<>(commitTxnResponse.getLastActiveTabletIdsList());
 
             // Send tasks to notify BEs
             sendMakeCloudTmpRsVisibleTasks(txnId, tTabletCommitInfos,
-                    partitionVersionMap, updateVersionVisibleTime);
+                    partitionVersionMap, updateVersionVisibleTime, loadClusterId, lastActiveTabletIds);
         } catch (Throwable t) {
             // According to normal logic, no exceptions will be thrown,
             // but in order to avoid bugs affecting the original logic, all exceptions are caught
@@ -2935,17 +2942,23 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
      * @param commitInfos tablet commit infos containing backend and tablet mapping
      * @param partitionVersionMap partition id to version mapping
      * @param updateVersionVisibleTime visible time for the version
+     * @param loadClusterId cluster that performed the load
+     * @param lastActiveTabletIds tablets whose owner changed in this commit
      */
     public void sendMakeCloudTmpRsVisibleTasks(long txnId,
                                                List<TTabletCommitInfo> commitInfos,
                                                Map<Long, Long> partitionVersionMap,
-                                               long updateVersionVisibleTime) {
+                                               long updateVersionVisibleTime,
+                                               String loadClusterId,
+                                               Set<Long> lastActiveTabletIds) {
         if (commitInfos == null || commitInfos.isEmpty()) {
             LOG.info("no commit infos to send make cloud tmp rs visible tasks, txn_id: {}", txnId);
             return;
         }
 
         // Group tablet_ids by backend_id
+        Set<Long> ownerChangedTabletIds = lastActiveTabletIds == null
+                ? Collections.emptySet() : lastActiveTabletIds;
         Map<Long, List<Long>> beToTabletIds = Maps.newHashMap();
         for (TTabletCommitInfo commitInfo : commitInfos) {
             long backendId = commitInfo.getBackendId();
@@ -2963,9 +2976,12 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
         for (Map.Entry<Long, List<Long>> entry : beToTabletIds.entrySet()) {
             long backendId = entry.getKey();
             List<Long> tabletIds = entry.getValue();
+            List<Long> backendLastActiveTabletIds = tabletIds.stream()
+                    .filter(ownerChangedTabletIds::contains).collect(Collectors.toList());
 
             MakeCloudTmpRsVisibleTask task = new MakeCloudTmpRsVisibleTask(
-                    backendId, txnId, tabletIds, partitionVersionMap, updateVersionVisibleTime);
+                    backendId, txnId, tabletIds, partitionVersionMap, updateVersionVisibleTime,
+                    loadClusterId, backendLastActiveTabletIds);
             batchTask.addTask(task);
 
             if (LOG.isDebugEnabled()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/task/MakeCloudTmpRsVisibleTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/MakeCloudTmpRsVisibleTask.java
@@ -33,17 +33,23 @@ public class MakeCloudTmpRsVisibleTask extends AgentTask {
     private final List<Long> tabletIds; // tablets on this BE involved in the transaction
     private final Map<Long, Long> partitionVersionMap; // partition_id -> version
     private final long updateVersionVisibleTime;
+    private final String loadClusterId;
+    private final List<Long> lastActiveTabletIds;
 
     public MakeCloudTmpRsVisibleTask(long backendId, long txnId,
                                      List<Long> tabletIds,
                                      Map<Long, Long> partitionVersionMap,
-                                     long updateVersionVisibleTime) {
+                                     long updateVersionVisibleTime,
+                                     String loadClusterId,
+                                     List<Long> lastActiveTabletIds) {
         super(null, backendId, TTaskType.MAKE_CLOUD_COMMITTED_RS_VISIBLE,
                 -1L, -1L, -1L, -1L, -1L, txnId, System.currentTimeMillis());
         this.txnId = txnId;
         this.tabletIds = tabletIds;
         this.partitionVersionMap = partitionVersionMap;
         this.updateVersionVisibleTime = updateVersionVisibleTime;
+        this.loadClusterId = loadClusterId;
+        this.lastActiveTabletIds = lastActiveTabletIds;
     }
 
     public long getTxnId() {
@@ -68,6 +74,12 @@ public class MakeCloudTmpRsVisibleTask extends AgentTask {
         request.setTabletIds(tabletIds);
         request.setPartitionVersionMap(partitionVersionMap);
         request.setVersionUpdateTimeMs(updateVersionVisibleTime);
+        if (loadClusterId != null && !loadClusterId.isEmpty()) {
+            request.setLoadClusterId(loadClusterId);
+        }
+        if (lastActiveTabletIds != null && !lastActiveTabletIds.isEmpty()) {
+            request.setLastActiveTabletIds(lastActiveTabletIds);
+        }
         return request;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
@@ -56,8 +56,10 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.lang.reflect.Method;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -300,24 +302,37 @@ public class CloudGlobalTransactionMgrTest {
     @Test
     public void testMakeTmpRsVisibleForNonLazyCommit() throws Exception {
         CommitTxnResponse response = CommitTxnResponse.newBuilder()
-                .setTxnInfo(TxnInfoPB.newBuilder().setTxnId(12348L).build())
+                .setTxnInfo(TxnInfoPB.newBuilder().setTxnId(12348L)
+                        .setLoadClusterId("cluster_b").build())
                 .setIsLazyCommit(false)
                 .setIsLazyCommitIncomplete(false)
+                .addLastActiveTabletIds(10001L)
                 .build();
 
-        Assert.assertTrue(invokeNotifyBesMakeTmpRsVisible(response));
+        Assert.assertTrue(invokeNotifyBesMakeTmpRsVisible(response, false));
     }
 
     private boolean invokeNotifyBesMakeTmpRsVisible(CommitTxnResponse response) throws Exception {
+        return invokeNotifyBesMakeTmpRsVisible(response, true);
+    }
+
+    private boolean invokeNotifyBesMakeTmpRsVisible(
+            CommitTxnResponse response, boolean enableRowsetNotification) throws Exception {
         boolean originalEnableNotify = Config.enable_notify_be_after_load_txn_commit;
         try {
-            Config.enable_notify_be_after_load_txn_commit = true;
+            Config.enable_notify_be_after_load_txn_commit = enableRowsetNotification;
             AtomicBoolean notified = new AtomicBoolean(false);
             CloudGlobalTransactionMgr transactionMgr = new CloudGlobalTransactionMgr() {
                 @Override
                 public void sendMakeCloudTmpRsVisibleTasks(long txnId,
                         List<TTabletCommitInfo> commitInfos, Map<Long, Long> partitionVersionMap,
-                        long updateVersionVisibleTime) {
+                        long updateVersionVisibleTime, String loadClusterId,
+                        Set<Long> lastActiveTabletIds) {
+                    String expectedLoadClusterId = response.getTxnInfo().hasLoadClusterId()
+                            ? response.getTxnInfo().getLoadClusterId() : "";
+                    Assert.assertEquals(expectedLoadClusterId, loadClusterId);
+                    Assert.assertEquals(new HashSet<>(response.getLastActiveTabletIdsList()),
+                            lastActiveTabletIds);
                     notified.set(true);
                 }
             };

--- a/fe/fe-core/src/test/java/org/apache/doris/task/MakeCloudTmpRsVisibleTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/task/MakeCloudTmpRsVisibleTaskTest.java
@@ -1,0 +1,40 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.task;
+
+import org.apache.doris.thrift.TMakeCloudTmpRsVisibleRequest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class MakeCloudTmpRsVisibleTaskTest {
+    @Test
+    public void testToThriftIncludesLastActiveClusterInfo() {
+        MakeCloudTmpRsVisibleTask task = new MakeCloudTmpRsVisibleTask(
+                100L, 200L, List.of(300L, 301L), Map.of(400L, 500L), 600L,
+                "cluster_b", List.of(300L));
+
+        TMakeCloudTmpRsVisibleRequest request = task.toThrift();
+
+        Assert.assertEquals("cluster_b", request.getLoadClusterId());
+        Assert.assertEquals(List.of(300L), request.getLastActiveTabletIds());
+    }
+}

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -1115,6 +1115,8 @@ message CommitTxnResponse {
     // The lazy commit has only completed its first phase. FE must not notify BE to make
     // temporary rowsets visible until BE observes the final metadata from meta-service.
     optional bool is_lazy_commit_incomplete = 9;
+    // Tablets whose last active cluster was updated by this commit.
+    repeated int64 last_active_tablet_ids = 10;
 }
 
 message AbortTxnRequest {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -597,6 +597,8 @@ struct TMakeCloudTmpRsVisibleRequest {
     2: required list<Types.TTabletId> tablet_ids // tablets on this BE involved in the transaction
     3: required map<Types.TPartitionId, Types.TVersion> partition_version_map
     4: optional i64 version_update_time_ms
+    5: optional string load_cluster_id
+    6: optional list<Types.TTabletId> last_active_tablet_ids
 }
 
 struct TAgentTaskRequest {

--- a/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation_lazy_commit_owner.groovy
+++ b/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation_lazy_commit_owner.groovy
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import groovy.json.JsonSlurper
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_compaction_rw_separation_lazy_commit_owner', 'docker') {
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+    ]
+    options.beConfigs += [
+        'enable_compaction_rw_separation=true',
+        'enable_cloud_make_rs_visible_on_be=false',
+        'enable_cloud_txn_lazy_commit=true',
+        'compaction_cluster_takeover_timeout_ms=600000',
+        'cluster_status_cache_refresh_interval_sec=5',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'disable_auto_compaction=true',
+    ]
+    options.msConfigs += [
+        'enable_multi_version_status=true',
+        'enable_cloud_txn_lazy_commit=true',
+        'cloud_txn_lazy_commit_fuzzy_possibility=100',
+    ]
+    options.cloudMode = true
+
+    def getTabletStatus = { ip, port, tabletId ->
+        def response = new URL(
+                "http://${ip}:${port}/api/compaction/show?tablet_id=${tabletId}").text
+        return new JsonSlurper().parseText(response)
+    }
+
+    def getBeIpAndPort = { clusterName ->
+        def backends = sql "SHOW BACKENDS"
+        def clusterBes = backends.findAll {
+            it[19].contains("\"compute_group_name\" : \"${clusterName}\"")
+        }
+        assertFalse(clusterBes.isEmpty(), "No BE found for cluster: ${clusterName}")
+        def firstBe = clusterBes[0]
+        return [ip: firstBe[1], httpPort: firstBe[4]]
+    }
+
+    def updateCompaction = { be, boolean enabled ->
+        def (code, out, err) = curl(
+                'POST',
+                "http://${be.ip}:${be.httpPort}/api/update_config?disable_auto_compaction=${!enabled}")
+        assertEquals(0, code, "Failed to update compaction config: ${out}, ${err}")
+    }
+
+    docker(options) {
+        def firstCluster = 'lazy_commit_owner_first'
+        def secondCluster = 'lazy_commit_owner_second'
+        cluster.addBackend(1, firstCluster)
+        cluster.addBackend(1, secondCluster)
+
+        def secondBe = getBeIpAndPort(secondCluster)
+
+        sql "use @${firstCluster}"
+        sql "DROP TABLE IF EXISTS test_compaction_rw_sep_lazy_commit_owner FORCE"
+        sql """
+            CREATE TABLE test_compaction_rw_sep_lazy_commit_owner (
+                k1 INT NOT NULL,
+                v1 INT NOT NULL
+            ) UNIQUE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 1
+            PROPERTIES ("replication_num" = "1")
+        """
+
+        for (int i = 0; i < 10; i++) {
+            sql "INSERT INTO test_compaction_rw_sep_lazy_commit_owner VALUES (${i}, ${i * 10})"
+        }
+
+        def tablets = sql_return_maparray "SHOW TABLETS FROM test_compaction_rw_sep_lazy_commit_owner"
+        assertEquals(1, tablets.size())
+        def tabletId = tablets[0].TabletId
+
+        sql "use @${secondCluster}"
+        def cachedRows = sql "SELECT COUNT(*) FROM test_compaction_rw_sep_lazy_commit_owner"
+        assertEquals(10, cachedRows[0][0])
+        sleep(7000)
+
+        for (int i = 10; i < 20; i++) {
+            sql "INSERT INTO test_compaction_rw_sep_lazy_commit_owner VALUES (${i}, ${i * 10})"
+        }
+        sql "SYNC"
+
+        updateCompaction(secondBe, true)
+        sleep(30000)
+        def secondStatus = getTabletStatus(secondBe.ip, secondBe.httpPort, tabletId)
+        assertTrue(secondStatus['last cumulative success time'] != '1970-01-01 08:00:00.000',
+                'The lazy commit path should refresh the owner on the second cluster')
+    }
+}

--- a/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation_load_commit_owner.groovy
+++ b/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation_load_commit_owner.groovy
@@ -1,0 +1,110 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import groovy.json.JsonSlurper
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_compaction_rw_separation_load_commit_owner', 'docker') {
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+    ]
+    options.beConfigs += [
+        'enable_compaction_rw_separation=true',
+        'enable_cloud_make_rs_visible_on_be=false',
+        'compaction_cluster_takeover_timeout_ms=600000',
+        'cluster_status_cache_refresh_interval_sec=5',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'disable_auto_compaction=true',
+    ]
+    options.cloudMode = true
+
+    def getTabletStatus = { ip, port, tabletId ->
+        def response = new URL(
+                "http://${ip}:${port}/api/compaction/show?tablet_id=${tabletId}").text
+        return new JsonSlurper().parseText(response)
+    }
+
+    def getBeIpAndPort = { clusterName ->
+        def backends = sql "SHOW BACKENDS"
+        def clusterBes = backends.findAll {
+            it[19].contains("\"compute_group_name\" : \"${clusterName}\"")
+        }
+        assertFalse(clusterBes.isEmpty(), "No BE found for cluster: ${clusterName}")
+        def firstBe = clusterBes[0]
+        return [ip: firstBe[1], httpPort: firstBe[4]]
+    }
+
+    def updateCompaction = { be, boolean enabled ->
+        def (code, out, err) = curl(
+                'POST',
+                "http://${be.ip}:${be.httpPort}/api/update_config?disable_auto_compaction=${!enabled}")
+        assertEquals(0, code, "Failed to update compaction config: ${out}, ${err}")
+    }
+
+    docker(options) {
+        def firstCluster = 'load_commit_owner_first'
+        def secondCluster = 'load_commit_owner_second'
+        cluster.addBackend(1, firstCluster)
+        cluster.addBackend(1, secondCluster)
+
+        def firstBe = getBeIpAndPort(firstCluster)
+        def secondBe = getBeIpAndPort(secondCluster)
+
+        sql "use @${firstCluster}"
+        sql "DROP TABLE IF EXISTS test_compaction_rw_sep_load_commit_owner FORCE"
+        sql """
+            CREATE TABLE test_compaction_rw_sep_load_commit_owner (
+                k1 INT NOT NULL,
+                v1 INT NOT NULL
+            ) UNIQUE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 1
+            PROPERTIES ("replication_num" = "1")
+        """
+
+        for (int i = 0; i < 10; i++) {
+            sql "INSERT INTO test_compaction_rw_sep_load_commit_owner VALUES (${i}, ${i * 10})"
+        }
+
+        def tablets = sql_return_maparray "SHOW TABLETS FROM test_compaction_rw_sep_load_commit_owner"
+        assertEquals(1, tablets.size())
+        def tabletId = tablets[0].TabletId
+
+        sql "use @${secondCluster}"
+        def cachedRows = sql "SELECT COUNT(*) FROM test_compaction_rw_sep_load_commit_owner"
+        assertEquals(10, cachedRows[0][0])
+        sleep(7000)
+
+        updateCompaction(firstBe, true)
+        sleep(30000)
+        def firstStatus = getTabletStatus(firstBe.ip, firstBe.httpPort, tabletId)
+        assertTrue(firstStatus['last cumulative success time'] != '1970-01-01 08:00:00.000',
+                'The first cluster should compact before the owner changes')
+        updateCompaction(firstBe, false)
+
+        for (int i = 10; i < 20; i++) {
+            sql "INSERT INTO test_compaction_rw_sep_load_commit_owner VALUES (${i}, ${i * 10})"
+        }
+
+        updateCompaction(secondBe, true)
+        sleep(30000)
+        def secondStatus = getTabletStatus(secondBe.ip, secondBe.httpPort, tabletId)
+        assertTrue(secondStatus['last cumulative success time'] != '1970-01-01 08:00:00.000',
+                'The second cluster should refresh its owner after load commit and compact')
+    }
+}

--- a/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation_schema_change_owner.groovy
+++ b/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation_schema_change_owner.groovy
@@ -1,0 +1,132 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import groovy.json.JsonSlurper
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_compaction_rw_separation_schema_change_owner', 'docker') {
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+    ]
+    options.beConfigs += [
+        'enable_compaction_rw_separation=true',
+        'compaction_cluster_takeover_timeout_ms=600000',
+        'cluster_status_cache_refresh_interval_sec=5',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'disable_auto_compaction=true',
+    ]
+    options.cloudMode = true
+
+    def getTabletStatus = { ip, port, tabletId ->
+        def response = new URL(
+                "http://${ip}:${port}/api/compaction/show?tablet_id=${tabletId}").text
+        return new JsonSlurper().parseText(response)
+    }
+
+    def getBeIpAndPort = { clusterName ->
+        def backends = sql "SHOW BACKENDS"
+        def clusterBes = backends.findAll {
+            it[19].contains("\"compute_group_name\" : \"${clusterName}\"")
+        }
+        assertFalse(clusterBes.isEmpty(), "No BE found for cluster: ${clusterName}")
+        def firstBe = clusterBes[0]
+        return [ip: firstBe[1], httpPort: firstBe[4]]
+    }
+
+    def updateCompaction = { be, boolean enabled ->
+        def (code, out, err) = curl(
+                'POST',
+                "http://${be.ip}:${be.httpPort}/api/update_config?disable_auto_compaction=${!enabled}")
+        assertEquals(0, code, "Failed to update compaction config: ${out}, ${err}")
+    }
+
+    docker(options) {
+        def writeCluster = 'schema_change_owner_write'
+        def readCluster = 'schema_change_owner_read'
+        cluster.addBackend(1, writeCluster)
+        cluster.addBackend(1, readCluster)
+
+        def writeBe = getBeIpAndPort(writeCluster)
+        def readBe = getBeIpAndPort(readCluster)
+
+        sql "use @${writeCluster}"
+        sql "DROP TABLE IF EXISTS test_compaction_rw_sep_schema_change_owner FORCE"
+        sql """
+            CREATE TABLE test_compaction_rw_sep_schema_change_owner (
+                k1 INT NOT NULL,
+                v1 INT NOT NULL,
+                v2 INT NOT NULL
+            ) UNIQUE KEY(k1)
+            DISTRIBUTED BY HASH(k1) BUCKETS 1
+            PROPERTIES ("replication_num" = "1")
+        """
+
+        for (int i = 0; i < 10; i++) {
+            sql "INSERT INTO test_compaction_rw_sep_schema_change_owner VALUES (${i}, ${i}, ${i})"
+        }
+
+        sql "use @${readCluster}"
+        def beforeSchemaChange = sql "SELECT COUNT(*) FROM test_compaction_rw_sep_schema_change_owner"
+        assertEquals(10, beforeSchemaChange[0][0])
+
+        sql "use @${writeCluster}"
+        sql "ALTER TABLE test_compaction_rw_sep_schema_change_owner DROP COLUMN v2"
+
+        def alterState = ''
+        for (int i = 0; i < 120; i++) {
+            def alterResult = sql """
+                SHOW ALTER TABLE COLUMN
+                WHERE IndexName = 'test_compaction_rw_sep_schema_change_owner'
+                ORDER BY createtime DESC LIMIT 1
+            """
+            if (!alterResult.isEmpty()) {
+                alterState = alterResult[0][9]
+                if (alterState == 'FINISHED' || alterState == 'CANCELLED') {
+                    break
+                }
+            }
+            sleep(1000)
+        }
+        assertEquals('FINISHED', alterState, "Schema change did not finish: ${alterState}")
+
+        sql "use @${readCluster}"
+        def tablets = sql_return_maparray "SHOW TABLETS FROM test_compaction_rw_sep_schema_change_owner"
+        assertEquals(1, tablets.size())
+        def tabletId = tablets[0].TabletId
+        def afterSchemaChange = sql "SELECT COUNT(*) FROM test_compaction_rw_sep_schema_change_owner"
+        assertEquals(10, afterSchemaChange[0][0])
+        sleep(7000)
+
+        def readStatusBefore = getTabletStatus(readBe.ip, readBe.httpPort, tabletId)
+        def readCumuTimeBefore = readStatusBefore['last cumulative success time']
+        updateCompaction(readBe, true)
+        sleep(30000)
+        def readStatusAfter = getTabletStatus(readBe.ip, readBe.httpPort, tabletId)
+        def readCumuTimeAfter = readStatusAfter['last cumulative success time']
+        assertEquals(readCumuTimeBefore, readCumuTimeAfter,
+                'The read cluster must not compact after schema change owner preservation')
+
+        updateCompaction(readBe, false)
+        updateCompaction(writeBe, true)
+        sleep(30000)
+        def writeStatus = getTabletStatus(writeBe.ip, writeBe.httpPort, tabletId)
+        assertTrue(writeStatus['last cumulative success time'] != '1970-01-01 08:00:00.000',
+                'The original write cluster should compact after schema change')
+    }
+}

--- a/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation_versioned_read.groovy
+++ b/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation_versioned_read.groovy
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import groovy.json.JsonSlurper
+
+suite('test_compaction_rw_separation_versioned_read', 'docker') {
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+    ]
+    options.beConfigs += [
+        'enable_compaction_rw_separation=true',
+        'compaction_cluster_takeover_timeout_ms=600000',
+        'cluster_status_cache_refresh_interval_sec=5',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'disable_auto_compaction=true',
+    ]
+    options.msConfigs += [
+        'enable_multi_version_status=true',
+    ]
+    options.cloudMode = true
+
+    def getTabletStatus = { ip, port, tabletId ->
+        def url = "http://${ip}:${port}/api/compaction/show?tablet_id=${tabletId}"
+        def response = new URL(url).text
+        return new JsonSlurper().parseText(response)
+    }
+
+    def getBeIpAndPort = { clusterName ->
+        def backends = sql """SHOW BACKENDS"""
+        def clusterBes = backends.findAll {
+            it[19].contains("""\"compute_group_name\" : \"${clusterName}\"""")
+        }
+        assertFalse(clusterBes.isEmpty(), "No BE found for cluster: ${clusterName}")
+        def firstBe = clusterBes[0]
+        return [ip: firstBe[1], httpPort: firstBe[4]]
+    }
+
+    docker(options) {
+        def writeCluster = 'versioned_write_cluster'
+        def readCluster = 'versioned_read_cluster'
+        cluster.addBackend(1, writeCluster)
+        cluster.addBackend(1, readCluster)
+
+        def readBe = getBeIpAndPort(readCluster)
+
+        sql """use @${writeCluster}"""
+        sql """DROP TABLE IF EXISTS test_compaction_rw_sep_versioned_read"""
+        sql """
+            CREATE TABLE test_compaction_rw_sep_versioned_read (
+                k1 INT NOT NULL,
+                v1 INT NOT NULL
+            ) UNIQUE KEY(`k1`)
+            DISTRIBUTED BY HASH(k1) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1"
+            )
+        """
+
+        for (int i = 0; i < 10; i++) {
+            sql """INSERT INTO test_compaction_rw_sep_versioned_read VALUES (${i}, ${i * 10})"""
+        }
+
+        def tablets = sql_return_maparray """SHOW TABLETS FROM test_compaction_rw_sep_versioned_read"""
+        assertEquals(1, tablets.size())
+        def tabletId = tablets[0].TabletId
+
+        sql """use @${readCluster}"""
+        def result = sql """SELECT * FROM test_compaction_rw_sep_versioned_read ORDER BY k1"""
+        assertEquals(10, result.size())
+
+        // Auto compaction is still disabled while the read cluster refreshes the write cluster state.
+        sleep(7000)
+        def statusBefore = getTabletStatus(readBe.ip, readBe.httpPort, tabletId)
+        def lastCumuTimeBefore = statusBefore['last cumulative success time']
+
+        def (code, out, err) = curl(
+            'POST',
+            String.format(
+                'http://%s:%s/api/update_config?disable_auto_compaction=false',
+                readBe.ip,
+                readBe.httpPort))
+        assertEquals(0, code, "Failed to enable compaction on read cluster: ${out}, ${err}")
+
+        sleep(30000)
+        def statusAfter = getTabletStatus(readBe.ip, readBe.httpPort, tabletId)
+        def lastCumuTimeAfter = statusAfter['last cumulative success time']
+        assertEquals(
+            lastCumuTimeBefore,
+            lastCumuTimeAfter,
+            "Read cluster should skip compaction in MULTI_VERSION_READ_WRITE mode")
+    }
+}

--- a/regression-test/suites/cloud_p0/node_mgr/test_update_cluster_mtime.groovy
+++ b/regression-test/suites/cloud_p0/node_mgr/test_update_cluster_mtime.groovy
@@ -1,0 +1,99 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import org.apache.doris.regression.suite.ClusterOptions
+
+suite('test_update_cluster_mtime', 'docker') {
+    def options = new ClusterOptions()
+    options.cloudMode = true
+
+    def getClusterInfo = { clusterName ->
+        def backends = sql "SHOW BACKENDS"
+        def backend = backends.find {
+            it[19].contains("\"compute_group_name\" : \"${clusterName}\"")
+        }
+        assertNotNull(backend, "No BE found for cluster: ${clusterName}")
+        def tag = new JsonSlurper().parseText(backend[19])
+        return [clusterId: tag.compute_group_id, uniqueId: tag.cloud_unique_id]
+    }
+
+    def getCluster = { ms, String uniqueId, String clusterId ->
+        def responseHolder = []
+        httpTest {
+            endpoint ms.host + ':' + ms.httpPort
+            uri '/MetaService/http/get_cluster_status?token=greedisgood9999'
+            body JsonOutput.toJson([cloud_unique_ids: [uniqueId]])
+            check { respCode, body ->
+                assertEquals(200, respCode, "Failed to get cluster status: ${body}")
+                def response = new JsonSlurper().parseText(body)
+                assertTrue(response.code.equalsIgnoreCase('OK'), "Failed to get cluster status: ${body}")
+                responseHolder << response.result.details[0].clusters.find { it.cluster_id == clusterId }
+            }
+        }
+        assertFalse(responseHolder.isEmpty(), "Cluster ${clusterId} was not returned by MetaService")
+        assertNotNull(responseHolder[0], "Cluster ${clusterId} was not returned by MetaService")
+        return responseHolder[0]
+    }
+
+    def setClusterStatus = { ms, String uniqueId, String clusterId, String status ->
+        def responseHolder = []
+        httpTest {
+            endpoint ms.host + ':' + ms.httpPort
+            uri '/MetaService/http/set_cluster_status?token=greedisgood9999'
+            body JsonOutput.toJson([
+                cloud_unique_id: uniqueId,
+                cluster: [cluster_id: clusterId, cluster_status: status]
+            ])
+            check { respCode, body ->
+                assertEquals(200, respCode, "Failed to set cluster status: ${body}")
+                def response = new JsonSlurper().parseText(body)
+                assertTrue(response.code.equalsIgnoreCase('OK'), "Failed to set cluster status: ${body}")
+                responseHolder << response
+            }
+        }
+        assertFalse(responseHolder.isEmpty())
+    }
+
+    docker(options) {
+        def clusterName = 'mtime_regression_cluster'
+        cluster.addBackend(1, clusterName)
+        def ms = cluster.getAllMetaservices().get(0)
+        def clusterInfo = getClusterInfo(clusterName)
+
+        def normalBefore = getCluster(ms, clusterInfo.uniqueId, clusterInfo.clusterId)
+        sleep(1500)
+        setClusterStatus(ms, clusterInfo.uniqueId, clusterInfo.clusterId, 'SUSPENDED')
+        def suspended = getCluster(ms, clusterInfo.uniqueId, clusterInfo.clusterId)
+
+        assertEquals('SUSPENDED', suspended.cluster_status)
+        assertNotNull(suspended.mtime, 'Suspending a cluster must persist mtime')
+        if (normalBefore.mtime != null) {
+            assertTrue(suspended.mtime > normalBefore.mtime,
+                    "Cluster mtime did not advance: before=${normalBefore.mtime}, after=${suspended.mtime}")
+        }
+
+        sleep(1500)
+        setClusterStatus(ms, clusterInfo.uniqueId, clusterInfo.clusterId, 'NORMAL')
+        def normalAfter = getCluster(ms, clusterInfo.uniqueId, clusterInfo.clusterId)
+        assertEquals('NORMAL', normalAfter.cluster_status)
+        assertNotNull(normalAfter.mtime, 'Resuming a cluster must persist mtime')
+        assertTrue(normalAfter.mtime > suspended.mtime,
+                "Cluster mtime did not advance on recovery: suspended=${suspended.mtime}, normal=${normalAfter.mtime}")
+    }
+}


### PR DESCRIPTION
What problem does this PR solve?
Issue Number: 
Problem Summary:
Tablet active cluster metadata may be lost, returned incorrectly, or not updated in several cloud paths, including heavy schema change, versioned reads, cluster takeover, and lazy transaction commit. This can leave last_active_cluster_id and last_active_time_ms inconsistent and affect compaction read-write separation.
What changes are included?
- Preserve active cluster metadata during heavy schema change.
- Resolve incomplete old tablet index information and support versioned metadata reads.
- Return active cluster metadata correctly for versioned reads.
- Correct cluster takeover timestamp handling.
- Update tablet owner during lazy commit and prevent older updates from overwriting newer metadata.
Test Plan
- Add tests for versioned and non-versioned schema change flows.
- Add tests for active cluster metadata reads and lazy commit owner updates.