### PR TITLE
[fix](be) Preserve SNII NULL-docid memory accounting

### DIFF
--- a/be/src/storage/index/index_file_writer.cpp
+++ b/be/src/storage/index/index_file_writer.cpp
@@ -226,7 +226,7 @@ void IndexFileWriter::_release_snii_blob_directories() {
 }
 
 Status IndexFileWriter::add_snii_index(const TabletIndex* index_meta, uint32_t doc_count,
-                                       std::vector<uint32_t> null_docids,
+                                       doris::snii::writer::TrackedNullDocids null_docids,
                                        doris::snii::writer::SpimiTermBuffer* const term_buffer,
                                        doris::snii::format::IndexConfig index_config,
                                        SniiAddIndexOptions options,
@@ -249,14 +249,13 @@ Status IndexFileWriter::add_snii_index(const TabletIndex* index_meta, uint32_t d
     input.index_suffix = index_meta->get_index_suffix();
     input.config = index_config;
     input.doc_count = doc_count;
-    input.null_docids = std::move(null_docids);
     input.encoded_norms = std::move(options.encoded_norms);
     input.common_grams_metadata = std::move(options.common_grams_metadata);
     input.common_grams_posting_policy = options.common_grams_posting_policy;
     input.term_source = term_buffer;
     input.mem_reporter = mem_reporter;
     snii_resolve_index_write_params(options.is_direct_load, &input);
-    RETURN_IF_ERROR(_snii_compound_writer->add_logical_index(input));
+    RETURN_IF_ERROR(_snii_compound_writer->add_logical_index(input, std::move(null_docids)));
     ++_snii_index_count;
     return Status::OK();
 }

--- a/be/src/storage/index/index_file_writer.h
+++ b/be/src/storage/index/index_file_writer.h
@@ -106,7 +106,7 @@ public:
                 snii::format::CommonGramsPostingPolicy::kNone;
     };
     Status add_snii_index(const TabletIndex* index_meta, uint32_t doc_count,
-                          std::vector<uint32_t> null_docids,
+                          doris::snii::writer::TrackedNullDocids null_docids,
                           doris::snii::writer::SpimiTermBuffer* const term_buffer,
                           doris::snii::format::IndexConfig index_config,
                           SniiAddIndexOptions options,

--- a/be/src/storage/index/snii/snii_index_writer.cpp
+++ b/be/src/storage/index/snii/snii_index_writer.cpp
@@ -88,6 +88,7 @@ Status SniiIndexColumnWriter::init() {
             ::doris::snii::writer::snii_build_consume_release(
                     ::doris::snii::writer::BuildMemoryPopulation::kRegistered),
             spill_threshold, ::doris::snii::writer::MemoryReporter::CapPolicy::kSpillThreshold);
+    _null_docids_reservation = _memory_reporter->make_reservation();
     _term_buffer = std::make_unique<::doris::snii::writer::SpimiTermBuffer>(
             _has_positions, spill_threshold, _memory_reporter.get());
     // G09: join the PROCESS-WIDE build-RAM limiter. The per-writer spill threshold above
@@ -377,16 +378,22 @@ Status SniiIndexColumnWriter::add_array_values(size_t field_size, const void* va
     return Status::OK();
 }
 
-void SniiIndexColumnWriter::_report_null_docids_capacity(bool release_all) {
+Status SniiIndexColumnWriter::_reserve_null_docids_for_append(size_t count) {
+    const size_t need = _null_docids.size() + count;
+    if (need <= _null_docids.capacity()) {
+        return Status::OK();
+    }
+    const size_t target_capacity = std::max(need, _null_docids.capacity() * 2);
     if (_memory_reporter == nullptr) {
-        return;
+        _null_docids.reserve(target_capacity);
+        return Status::OK();
     }
-    const int64_t now =
-            release_all ? 0 : static_cast<int64_t>(_null_docids.capacity() * sizeof(uint32_t));
-    if (now != _null_docids_charged_bytes) {
-        _memory_reporter->report(now - _null_docids_charged_bytes);
-        _null_docids_charged_bytes = now;
-    }
+    ::doris::snii::writer::MemoryReporter::Reservation replacement;
+    RETURN_IF_ERROR(_null_docids_reservation.prepare_replacement(
+            static_cast<uint64_t>(target_capacity) * sizeof(uint32_t), &replacement));
+    _null_docids.reserve(target_capacity);
+    _null_docids_reservation = std::move(replacement);
+    return Status::OK();
 }
 
 void SniiIndexColumnWriter::_report_encoded_norms_capacity(bool release_all) {
@@ -414,10 +421,7 @@ Status SniiIndexColumnWriter::add_nulls(uint32_t count) {
     // the compaction ran 8+x slower than V3 (whose add_nulls is a roaring
     // addRange). Doubling on overflow keeps the O(count) amortization AND makes
     // one large run pay at most one reallocation.
-    const size_t need = _null_docids.size() + count;
-    if (need > _null_docids.capacity()) {
-        _null_docids.reserve(std::max(need, _null_docids.capacity() * 2));
-    }
+    RETURN_IF_ERROR(_reserve_null_docids_for_append(count));
     for (uint32_t i = 0; i < count; ++i) {
         _null_docids.push_back(_rid + i);
     }
@@ -426,7 +430,6 @@ Status SniiIndexColumnWriter::add_nulls(uint32_t count) {
         _encoded_norms.insert(_encoded_norms.end(), count, ::doris::snii::query::encode_norm(0));
         _report_encoded_norms_capacity();
     }
-    _report_null_docids_capacity();
     return Status::OK();
 }
 
@@ -438,13 +441,14 @@ Status SniiIndexColumnWriter::add_array_nulls(const uint8_t* null_map, size_t nu
     if (num_rows == 0 || null_map == nullptr) {
         return Status::OK();
     }
+    const size_t null_count = std::count(null_map, null_map + num_rows, static_cast<uint8_t>(1));
+    RETURN_IF_ERROR(_reserve_null_docids_for_append(null_count));
     const auto first_row = _rid - num_rows;
     for (size_t i = 0; i < num_rows; ++i) {
         if (null_map[i] == 1) {
             _null_docids.push_back(cast_set<uint32_t>(first_row + i));
         }
     }
-    _report_null_docids_capacity();
     return Status::OK();
 }
 
@@ -457,10 +461,6 @@ Status SniiIndexColumnWriter::finish() {
     if (!status.ok()) {
         return Status::InternalError("SNII term buffer error: {}", status.to_string());
     }
-    // Ownership of _null_docids hands off to the flush below (transient,
-    // flush-scoped); release the accumulation-phase charge so the retained
-    // reporter (and the observation tracker behind it) balances to zero.
-    _report_null_docids_capacity(/*release_all=*/true);
     IndexFileWriter::SniiAddIndexOptions options {};
     options.is_direct_load = _is_direct_load;
     if (_uses_common_grams) {
@@ -470,8 +470,10 @@ Status SniiIndexColumnWriter::finish() {
                 ::doris::snii::format::CommonGramsPostingPolicy::kHybridV1;
     }
     status = _index_file_writer->add_snii_index(
-            _index_meta, cast_set<uint32_t>(_rid), std::move(_null_docids), _term_buffer.get(),
-            _config, std::move(options), _memory_reporter.get());
+            _index_meta, cast_set<uint32_t>(_rid),
+            ::doris::snii::writer::TrackedNullDocids(std::move(_null_docids_reservation),
+                                                     std::move(_null_docids)),
+            _term_buffer.get(), _config, std::move(options), _memory_reporter.get());
     _report_encoded_norms_capacity(/*release_all=*/true);
     RETURN_IF_ERROR(status);
     _index_file_writer->retain_snii_memory_reporter(std::move(_memory_reporter));
@@ -500,11 +502,10 @@ Status SniiIndexColumnWriter::_latch_analysis_failure(Status status) {
 
 void SniiIndexColumnWriter::close_on_error() {
     _term_buffer.reset();
-    // Balance the observation-tracker mirror before dropping the reporter.
-    _report_null_docids_capacity(/*release_all=*/true);
+    std::vector<uint32_t>().swap(_null_docids);
+    _null_docids_reservation.reset();
     _report_encoded_norms_capacity(/*release_all=*/true);
     _memory_reporter.reset();
-    _null_docids.clear();
     std::vector<uint8_t>().swap(_encoded_norms);
     _scoring_token_count = 0;
 }

--- a/be/src/storage/index/snii/snii_index_writer.h
+++ b/be/src/storage/index/snii/snii_index_writer.h
@@ -96,9 +96,7 @@ private:
     Status _add_value_tokens(const Slice& value, uint32_t docid, uint32_t position_base,
                              uint32_t* max_position, uint32_t* semantic_length);
     inverted_index::CommonGramsSegmentMetadata _build_common_grams_metadata() const;
-    // Mirrors _null_docids' capacity into _memory_reporter (delta-charged);
-    // release_all zeroes the charge (finish() handoff / close_on_error()).
-    void _report_null_docids_capacity(bool release_all = false);
+    Status _reserve_null_docids_for_append(size_t count);
     void _report_encoded_norms_capacity(bool release_all = false);
     Status _latch_analysis_failure(Status status);
 
@@ -126,17 +124,12 @@ private:
     std::shared_ptr<lucene::analysis::Analyzer> _analyzer;
     inverted_index::CommonGramsFilter* _common_grams_filter = nullptr;
     std::unique_ptr<::doris::snii::writer::MemoryReporter> _memory_reporter;
+    ::doris::snii::writer::MemoryReporter::Reservation _null_docids_reservation;
     std::unique_ptr<::doris::snii::writer::SpimiTermBuffer> _term_buffer;
     std::vector<uint32_t> _null_docids;
     std::vector<uint8_t> _encoded_norms;
     uint64_t _scoring_token_count = 0;
     std::optional<inverted_index::CommonGramsSegmentMetadata> _common_grams_metadata_seed;
-    // Bytes of _null_docids capacity currently mirrored into _memory_reporter
-    // (and through it the SNII index-build observation tracker). Re-charged on
-    // growth in add_nulls / add_array_nulls, released in finish() / close_on_error() --
-    // without it a large interleaved-null segment accumulates untracked RSS the
-    // G09 limiter cannot see.
-    int64_t _null_docids_charged_bytes = 0;
     int64_t _encoded_norms_charged_bytes = 0;
     Status _failure_status = Status::OK();
 };

--- a/be/src/storage/index/snii/writer/logical_index_writer.cpp
+++ b/be/src/storage/index/snii/writer/logical_index_writer.cpp
@@ -449,9 +449,6 @@ FreqStats fuse_freq_stats_for_test(const std::vector<uint32_t>& freqs) {
 }
 } // namespace testing
 
-LogicalIndexWriter::LogicalIndexWriter(const SniiIndexInput& in)
-        : LogicalIndexWriter(in, TrackedNullDocids(std::vector<uint32_t>(in.null_docids))) {}
-
 LogicalIndexWriter::LogicalIndexWriter(const SniiIndexInput& in, TrackedNullDocids null_docids)
         : index_id_(in.index_id),
           index_suffix_(in.index_suffix),

--- a/be/src/storage/index/snii/writer/logical_index_writer.h
+++ b/be/src/storage/index/snii/writer/logical_index_writer.h
@@ -239,7 +239,7 @@ struct FreqStats {
 // Builds and holds the section bytes + meta sub-sections for one logical index.
 class LogicalIndexWriter {
 public:
-    explicit LogicalIndexWriter(const SniiIndexInput& in);
+    LogicalIndexWriter(const SniiIndexInput& in, TrackedNullDocids null_docids);
     // Out-of-line: stream_state_ points at the private nested BlockState, which
     // is incomplete here (unique_ptr needs the complete type at destruction).
     ~LogicalIndexWriter();
@@ -323,7 +323,6 @@ public:
 
 private:
     friend class SniiStreamedIndexSession;
-    LogicalIndexWriter(const SniiIndexInput& in, TrackedNullDocids null_docids);
 
     // One DICT block's directory record. The block's serialized bytes are appended to
     // the in-RAM dict buffer as soon as the block is cut; only this compact summary

--- a/be/src/storage/index/snii/writer/snii_compound_writer.cpp
+++ b/be/src/storage/index/snii/writer/snii_compound_writer.cpp
@@ -134,6 +134,29 @@ Status SniiCompoundWriter::inherit(const reader::SniiRewriteSnapshot& snapshot,
 }
 
 Status SniiCompoundWriter::add_logical_index(const SniiIndexInput& in) {
+    std::vector<uint32_t> null_docids(in.null_docids);
+    MemoryReporter::Reservation null_docids_reservation =
+            in.mem_reporter == nullptr ? MemoryReporter::Reservation()
+                                       : in.mem_reporter->make_reservation();
+    if (in.mem_reporter != nullptr) {
+        RETURN_IF_ERROR(null_docids_reservation.set_bytes(
+                static_cast<uint64_t>(null_docids.capacity()) * sizeof(uint32_t)));
+    }
+    return _add_logical_index(
+            in, TrackedNullDocids(std::move(null_docids_reservation), std::move(null_docids)));
+}
+
+Status SniiCompoundWriter::add_logical_index(const SniiIndexInput& in,
+                                             TrackedNullDocids null_docids) {
+    if (!in.null_docids.empty()) {
+        return Status::Error<ErrorCode::INVALID_ARGUMENT, false>(
+                "compound: tracked NULL docids must not also be present in input");
+    }
+    return _add_logical_index(in, std::move(null_docids));
+}
+
+Status SniiCompoundWriter::_add_logical_index(const SniiIndexInput& in,
+                                              TrackedNullDocids null_docids) {
     if (out_ == nullptr)
         return Status::Error<ErrorCode::INVALID_ARGUMENT, false>("compound: null file writer");
     if (finished_)
@@ -158,7 +181,7 @@ Status SniiCompoundWriter::add_logical_index(const SniiIndexInput& in) {
         }
     }
     RETURN_IF_ERROR(ensure_bootstrap());
-    auto liw = std::make_unique<LogicalIndexWriter>(in);
+    auto liw = std::make_unique<LogicalIndexWriter>(in, std::move(null_docids));
     Placement p;
     // The posting region streams DIRECTLY into the container during build() -- no temp
     // round-trip for the bulk -- followed immediately by this index's compact DICT

--- a/be/src/storage/index/snii/writer/snii_compound_writer.h
+++ b/be/src/storage/index/snii/writer/snii_compound_writer.h
@@ -200,10 +200,11 @@ public:
     // holding a partial prefix.
     Status inherit(const reader::SniiRewriteSnapshot& snapshot, io::FileReader* source);
 
-    // Buffers one logical index: builds its section bytes and meta sub-sections.
-    // The actual file writing happens in finish() (single front-to-back pass).
-    // The key (index_id, suffix) must not collide with an inherited one.
+    // Builds one logical index synchronously. The convenience overload copies
+    // and charges in.null_docids; ingestion uses the tracked overload to transfer
+    // the already-charged allocation without a second resident vector.
     Status add_logical_index(const SniiIndexInput& in);
+    Status add_logical_index(const SniiIndexInput& in, TrackedNullDocids null_docids);
 
     // Registers one opaque BLOB logical index (kind must not be kInverted).
     // Registration is pure bookkeeping -- NOT A BYTE is written here, so it is
@@ -287,6 +288,7 @@ private:
     Status write_index_aux_sections(size_t index);
     Status write_tail();
     Status append(const std::vector<uint8_t>& bytes);
+    Status _add_logical_index(const SniiIndexInput& in, TrackedNullDocids null_docids);
     Status poison(Status status);
     // Argument validation for one add_blob_index call; see the .cpp.
     static Status validate_blob_registration(format::LogicalIndexKind kind,

--- a/be/test/storage/index/snii/compaction/snii_streamed_session_test.cpp
+++ b/be/test/storage/index/snii/compaction/snii_streamed_session_test.cpp
@@ -693,6 +693,43 @@ TEST(SniiStreamedWriterSessionTest, NullDocidsStorageIsTransferredIntoStreamedWr
     assert_ok(compound.finish());
 }
 
+TEST(SniiStreamedWriterSessionTest, OrdinaryLargeNullHandoffTracksRetainedCapacity) {
+    constexpr uint32_t kNullCount = 1U << 20;
+    SniiIndexInput input = empty_input(119, "ordinary_null_handoff", kNullCount);
+    input.null_docids.resize(kNullCount);
+    std::iota(input.null_docids.begin(), input.null_docids.end(), 0U);
+    const uint64_t retained_null_bytes = input.null_docids.capacity() * sizeof(uint32_t);
+    const uint64_t bitmap_build_bytes = format::NullBitmapWriter::build_memory_upper_bound(
+            std::span<const uint32_t>(input.null_docids));
+
+    int64_t mirrored_bytes = 0;
+    int64_t peak_bytes = 0;
+    writer::MemoryReporter reporter([&](int64_t delta) {
+        mirrored_bytes += delta;
+        peak_bytes = std::max(peak_bytes, mirrored_bytes);
+    });
+    input.mem_reporter = &reporter;
+    std::vector<uint32_t> null_docids;
+    null_docids.swap(input.null_docids);
+    auto null_docids_reservation = reporter.make_reservation();
+    assert_ok(null_docids_reservation.set_bytes(retained_null_bytes));
+    writer::TrackedNullDocids tracked_null_docids(std::move(null_docids_reservation),
+                                                  std::move(null_docids));
+    EXPECT_EQ(reporter.current_bytes(), retained_null_bytes);
+    EXPECT_EQ(mirrored_bytes, retained_null_bytes);
+
+    MemoryFile file;
+    SniiCompoundWriter compound(&file);
+    assert_ok(compound.add_logical_index(input, std::move(tracked_null_docids)));
+
+    EXPECT_GE(peak_bytes, static_cast<int64_t>(retained_null_bytes + bitmap_build_bytes));
+    EXPECT_EQ(reporter.current_bytes(), 0);
+    EXPECT_EQ(mirrored_bytes, 0);
+    assert_ok(compound.finish());
+    EXPECT_EQ(reporter.current_bytes(), 0);
+    EXPECT_EQ(mirrored_bytes, 0);
+}
+
 TEST(SniiStreamedWriterSessionTest, NullBitmapFinalizationHonorsReporterCap) {
     SniiIndexInput input = empty_input(95, "null_memory_cap", 2);
     input.null_docids = {1};

--- a/be/test/storage/index/snii/writer/spimi_streaming_writer_test.cpp
+++ b/be/test/storage/index/snii/writer/spimi_streaming_writer_test.cpp
@@ -209,7 +209,7 @@ TEST(SniiSpimiStreamingWriter, StreamingConsumesSource) {
 
     SniiIndexInput in = BaseInput(50);
     in.term_source = &buf;
-    LogicalIndexWriter writer(in);
+    LogicalIndexWriter writer(in, TrackedNullDocids(std::move(in.null_docids)));
     // build() streams the posting region straight into a FileWriter sink; this test
     // only asserts the source is drained, so a throwaway temp sink suffices.
     const std::string post_path = TempPath();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #66052

Problem Summary: SNII released the ingestion writer NULL-docid memory charge before flush, then copied the still-live vector into `LogicalIndexWriter` without a `Reservation`. A one-million-NULL segment retained a 4 MiB docid vector while the build reporter observed only about 674 KiB of bitmap scratch, and the handoff briefly held two complete vectors. This PR carries the existing move-only vector and `Reservation` through `IndexFileWriter` and `SniiCompoundWriter`, precharges geometric vector replacements during growth, and releases the charge only after the NULL bitmap consumes the docids. A real one-million-NULL compound build verifies reporter current/peak bytes and terminal zero balance.

### Release note

Reduce and accurately account SNII build memory for NULL-heavy segments.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

  `SniiStreamedWriterSessionTest.*`, `SniiSpimiStreamingWriter.*`, `SniiWriterNullDocids.*`, `SniiWriterFailureLatch.*`, and `SniiMemoryReporterTest.*` (56 tests); `./build.sh --be -j 192`.

- Behavior changed:
    - [ ] No.
    - [x] Yes. SNII NULL-docid build memory is transferred without a duplicate vector and remains accurately accounted during flush.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->