### PR TITLE
[chore](ci) Increase AI review timeout to 90 minutes

### DIFF
--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -55,9 +55,9 @@ permissions:
 jobs:
   code-review:
     runs-on: ubuntu-latest
-    # Pre-finalization steps can use 153 minutes and auth sync can use 8 more,
+    # Pre-finalization steps can use 183 minutes and auth sync can use 8 more,
     # leaving 12 minutes for runner setup and post-job cleanup.
-    timeout-minutes: 173
+    timeout-minutes: 203
     if: >-
       inputs.pr_number != '' ||
       (
@@ -657,7 +657,7 @@ jobs:
 
       - name: Run automated code review
         id: review
-        timeout-minutes: 60
+        timeout-minutes: 90
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: The automated Codex review step currently times out after 60 minutes, which can interrupt reviews of large pull requests before completion. Increase the review step timeout to 90 minutes and extend the enclosing job timeout from 173 to 203 minutes so the existing finalization and runner cleanup buffer remains intact.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Manual test (add detailed scripts or steps below)
        - Ruby YAML parsing passed.
        - `actionlint -shellcheck=` passed; full actionlint diagnostics are unchanged from `master`.
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] No need to test or manual test. Explain why:

- Behavior changed:
    - [ ] No.
    - [x] Yes. Automated AI reviews can run for up to 90 minutes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->