### PR TITLE
branch-4.0: [fix](be) Report stream load size limits in MiB #66224

### DIFF
--- a/be/src/http/action/http_stream.cpp
+++ b/be/src/http/action/http_stream.cpp
@@ -63,6 +63,12 @@
 namespace doris {
 using namespace ErrorCode;
 
+namespace {
+
+constexpr size_t MEBIBYTE = 1024 * 1024;
+
+} // namespace
+
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(http_stream_requests_total, MetricUnit::REQUESTS);
 DEFINE_COUNTER_METRIC_PROTOTYPE_2ARG(http_stream_duration_ms, MetricUnit::MILLISECONDS);
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(http_stream_current_processing, MetricUnit::REQUESTS);
@@ -208,7 +214,8 @@ Status HttpStreamAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
     // TODO(zs) : need Need to request an FE to obtain information such as format
     // check content length
     ctx->body_bytes = 0;
-    size_t csv_max_body_bytes = config::streaming_load_max_mb * 1024 * 1024;
+    const auto csv_max_body_mb = config::streaming_load_max_mb;
+    size_t csv_max_body_bytes = csv_max_body_mb * MEBIBYTE;
     if (!http_req->header(HttpHeaders::CONTENT_LENGTH).empty()) {
         try {
             ctx->body_bytes = std::stol(http_req->header(HttpHeaders::CONTENT_LENGTH));
@@ -220,9 +227,11 @@ Status HttpStreamAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
         if (ctx->body_bytes > csv_max_body_bytes) {
             LOG(WARNING) << "body exceed max size." << ctx->brief();
             return Status::Error<ErrorCode::EXCEEDED_LIMIT>(
-                    "body size {} exceed BE's conf `streaming_load_max_mb` {}. increase it if you "
-                    "are sure this load is reasonable",
-                    ctx->body_bytes, csv_max_body_bytes);
+                    "body size {} bytes ({:.2f} MiB) exceeds the limit of {} bytes ({} MiB) set "
+                    "by BE config `streaming_load_max_mb`. Increase it if you are sure this load "
+                    "is reasonable",
+                    ctx->body_bytes, static_cast<double>(ctx->body_bytes) / MEBIBYTE,
+                    csv_max_body_bytes, csv_max_body_mb);
         }
     }
 

--- a/be/src/http/action/stream_load.cpp
+++ b/be/src/http/action/stream_load.cpp
@@ -81,6 +81,7 @@ bvar::LatencyRecorder g_stream_load_commit_and_publish_latency_ms("stream_load",
                                                                   "commit_and_publish_ms");
 
 static constexpr size_t MIN_CHUNK_SIZE = 64 * 1024;
+static constexpr size_t MEBIBYTE = 1024 * 1024;
 static const std::string CHUNK = "chunked";
 
 #ifdef BE_TEST
@@ -277,8 +278,10 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
 
     // check content length
     ctx->body_bytes = 0;
-    size_t csv_max_body_bytes = config::streaming_load_max_mb * 1024 * 1024;
-    size_t json_max_body_bytes = config::streaming_load_json_max_mb * 1024 * 1024;
+    const auto csv_max_body_mb = config::streaming_load_max_mb;
+    size_t csv_max_body_bytes = csv_max_body_mb * MEBIBYTE;
+    const auto json_max_body_mb = config::streaming_load_json_max_mb;
+    size_t json_max_body_bytes = json_max_body_mb * MEBIBYTE;
     bool read_json_by_line = false;
     if (!http_req->header(HTTP_READ_JSON_BY_LINE).empty()) {
         if (iequal(http_req->header(HTTP_READ_JSON_BY_LINE), "true")) {
@@ -296,17 +299,21 @@ Status StreamLoadAction::_on_header(HttpRequest* http_req, std::shared_ptr<Strea
         if ((ctx->format == TFileFormatType::FORMAT_JSON) &&
             (ctx->body_bytes > json_max_body_bytes) && !read_json_by_line) {
             return Status::Error<ErrorCode::EXCEEDED_LIMIT>(
-                    "json body size {} exceed BE's conf `streaming_load_json_max_mb` {}. increase "
-                    "it if you are sure this load is reasonable",
-                    ctx->body_bytes, json_max_body_bytes);
+                    "json body size {} bytes ({:.2f} MiB) exceeds the limit of {} bytes ({} MiB) "
+                    "set by BE's conf streaming_load_json_max_mb. Increase it if you are sure "
+                    "this load is reasonable",
+                    ctx->body_bytes, static_cast<double>(ctx->body_bytes) / MEBIBYTE,
+                    json_max_body_bytes, json_max_body_mb);
         }
         // csv max body size
         else if (ctx->body_bytes > csv_max_body_bytes) {
             LOG(WARNING) << "body exceed max size." << ctx->brief();
             return Status::Error<ErrorCode::EXCEEDED_LIMIT>(
-                    "body size {} exceed BE's conf `streaming_load_max_mb` {}. increase it if you "
-                    "are sure this load is reasonable",
-                    ctx->body_bytes, csv_max_body_bytes);
+                    "body size {} bytes ({:.2f} MiB) exceeds the limit of {} bytes ({} MiB) set "
+                    "by BE's conf streaming_load_max_mb. Increase it if you are sure this load is "
+                    "reasonable",
+                    ctx->body_bytes, static_cast<double>(ctx->body_bytes) / MEBIBYTE,
+                    csv_max_body_bytes, csv_max_body_mb);
         }
     } else {
 #ifndef BE_TEST

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -27,6 +27,7 @@
 #include "event2/http.h"
 #include "event2/http_struct.h"
 #include "evhttp.h"
+#include "http/action/http_stream.h"
 #include "http/ev_http_server.h"
 #include "http/http_channel.h"
 #include "http/http_common.h"
@@ -37,6 +38,8 @@
 #include "http/utils.h"
 #include "olap/wal/wal_manager.h"
 #include "runtime/exec_env.h"
+#include "runtime/stream_load/stream_load_context.h"
+#include "util/defer_op.h"
 
 namespace doris {
 
@@ -122,5 +125,74 @@ TEST_F(StreamLoadTest, TestHeader) {
         evhttp_req->uri_elems = nullptr;
         evhttp_request_free(evhttp_req);
     }
+}
+
+TEST_F(StreamLoadTest, JsonBodySizeLimitPlusOneErrorIncludesExactBytes) {
+    const auto original_json_max_mb = config::streaming_load_json_max_mb;
+    Defer restore_json_max_mb {
+            [original_json_max_mb] { config::streaming_load_json_max_mb = original_json_max_mb; }};
+    config::streaming_load_json_max_mb = 100;
+
+    auto* evhttp_req = evhttp_request_new(nullptr, nullptr);
+    HttpRequest req(evhttp_req);
+    req.set_header(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    req.set_header(HTTP_FORMAT_KEY, "json");
+    req.set_header(HttpHeaders::CONTENT_LENGTH, "104857601");
+
+    StreamLoadAction action(nullptr);
+    auto ctx = std::make_shared<StreamLoadContext>(nullptr);
+    auto status = action._on_header(&req, ctx);
+
+    EXPECT_TRUE(status.is<ErrorCode::EXCEEDED_LIMIT>());
+    EXPECT_EQ(status.to_string_no_stack(),
+              "[E-217]json body size 104857601 bytes (100.00 MiB) exceeds the limit of 104857600 "
+              "bytes (100 MiB) set by BE's conf streaming_load_json_max_mb. Increase it if you "
+              "are sure this load is reasonable");
+    evhttp_request_free(evhttp_req);
+}
+
+TEST_F(StreamLoadTest, CsvBodySizeLimitPlusOneErrorIncludesExactBytes) {
+    const auto original_max_mb = config::streaming_load_max_mb;
+    Defer restore_max_mb {[original_max_mb] { config::streaming_load_max_mb = original_max_mb; }};
+    config::streaming_load_max_mb = 100;
+
+    auto* evhttp_req = evhttp_request_new(nullptr, nullptr);
+    HttpRequest req(evhttp_req);
+    req.set_header(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    req.set_header(HTTP_FORMAT_KEY, "csv");
+    req.set_header(HttpHeaders::CONTENT_LENGTH, "104857601");
+
+    StreamLoadAction action(nullptr);
+    auto ctx = std::make_shared<StreamLoadContext>(nullptr);
+    auto status = action._on_header(&req, ctx);
+
+    EXPECT_TRUE(status.is<ErrorCode::EXCEEDED_LIMIT>());
+    EXPECT_EQ(status.to_string_no_stack(),
+              "[E-217]body size 104857601 bytes (100.00 MiB) exceeds the limit of 104857600 bytes "
+              "(100 MiB) set by BE's conf streaming_load_max_mb. Increase it if you are sure this "
+              "load is reasonable");
+    evhttp_request_free(evhttp_req);
+}
+
+TEST_F(StreamLoadTest, HttpStreamBodySizeLimitPlusOneErrorIncludesExactBytes) {
+    const auto original_max_mb = config::streaming_load_max_mb;
+    Defer restore_max_mb {[original_max_mb] { config::streaming_load_max_mb = original_max_mb; }};
+    config::streaming_load_max_mb = 100;
+
+    auto* evhttp_req = evhttp_request_new(nullptr, nullptr);
+    HttpRequest req(evhttp_req);
+    req.set_header(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    req.set_header(HttpHeaders::CONTENT_LENGTH, "104857601");
+
+    HttpStreamAction action(nullptr);
+    auto ctx = std::make_shared<StreamLoadContext>(nullptr);
+    auto status = action._on_header(&req, ctx);
+
+    EXPECT_TRUE(status.is<ErrorCode::EXCEEDED_LIMIT>());
+    EXPECT_EQ(status.to_string_no_stack(),
+              "[E-217]body size 104857601 bytes (100.00 MiB) exceeds the limit of 104857600 bytes "
+              "(100 MiB) set by BE config `streaming_load_max_mb`. Increase it if you are sure "
+              "this load is reasonable");
+    evhttp_request_free(evhttp_req);
 }
 } // namespace doris

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -135,9 +135,9 @@ TEST_F(StreamLoadTest, JsonBodySizeLimitPlusOneErrorIncludesExactBytes) {
 
     auto* evhttp_req = evhttp_request_new(nullptr, nullptr);
     HttpRequest req(evhttp_req);
-    req.set_header(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
-    req.set_header(HTTP_FORMAT_KEY, "json");
-    req.set_header(HttpHeaders::CONTENT_LENGTH, "104857601");
+    req._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    req._headers.emplace(HTTP_FORMAT_KEY, "json");
+    req._headers.emplace(HttpHeaders::CONTENT_LENGTH, "104857601");
 
     StreamLoadAction action(nullptr);
     auto ctx = std::make_shared<StreamLoadContext>(nullptr);
@@ -158,9 +158,9 @@ TEST_F(StreamLoadTest, CsvBodySizeLimitPlusOneErrorIncludesExactBytes) {
 
     auto* evhttp_req = evhttp_request_new(nullptr, nullptr);
     HttpRequest req(evhttp_req);
-    req.set_header(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
-    req.set_header(HTTP_FORMAT_KEY, "csv");
-    req.set_header(HttpHeaders::CONTENT_LENGTH, "104857601");
+    req._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    req._headers.emplace(HTTP_FORMAT_KEY, "csv");
+    req._headers.emplace(HttpHeaders::CONTENT_LENGTH, "104857601");
 
     StreamLoadAction action(nullptr);
     auto ctx = std::make_shared<StreamLoadContext>(nullptr);
@@ -181,8 +181,8 @@ TEST_F(StreamLoadTest, HttpStreamBodySizeLimitPlusOneErrorIncludesExactBytes) {
 
     auto* evhttp_req = evhttp_request_new(nullptr, nullptr);
     HttpRequest req(evhttp_req);
-    req.set_header(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
-    req.set_header(HttpHeaders::CONTENT_LENGTH, "104857601");
+    req._headers.emplace(HttpHeaders::AUTHORIZATION, "Basic cm9vdDo=");
+    req._headers.emplace(HttpHeaders::CONTENT_LENGTH, "104857601");
 
     HttpStreamAction action(nullptr);
     auto ctx = std::make_shared<StreamLoadContext>(nullptr);


### PR DESCRIPTION
<!-- pr-watcher:conflict-pick task_id=conflict-pick:f593c954e72b12097b16cfff907e88e364de8ef0f36d302cc253794954d64751 -->
### What problem does this PR solve?

Related PR: #66224

Backport [apache/doris#66224](https://github.com/apache/doris/pull/66224) to `branch-4.0`.

- Source merge commit: `12f262a678990e60449da8c3d77e4848ddc5913d`
- Target base commit: `461d003df3c01467c11270858e122615e8f69821`

### Conflict resolution

- `be/src/http/action/http_stream.cpp`: Kept branch-4.0’s implementation and added only the MiB constant required by the source PR; excluded an unrelated helper inherited from the newer source branch. (adapted)
- `be/test/http/stream_load_test.cpp`: Preserved branch-4.0’s HTTP, stream-load context, and WAL include paths while adding the headers required by the source PR’s three size-limit tests. (adapted)

### Checks actually run

- `git diff HEAD^ HEAD --check`: passed (exit 0)
- `clang-format --dry-run --Werror <changed C/C++ files>`: passed (exit 0)

No submodules were initialized. This automation only runs formatting/whitespace, provenance,
conflict-marker, and clean-worktree checks. It does not run builds, unit tests, or regression tests.
