### PR TITLE
[fix](compaction) Fix active cluster metadata synchronization for versioned tablet stats

### DIFF
--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -3341,6 +3341,14 @@ void MetaServiceImpl::get_rowset(::google::protobuf::RpcController* controller,
                 LOG(WARNING) << msg;
                 return;
             }
+
+            TabletStatsPB load_stats;
+            internal_get_load_tablet_stats(code, msg, reader, txn.get(), instance_id, idx,
+                                           load_stats);
+            if (code != MetaServiceCode::OK) {
+                return;
+            }
+            copy_last_active_cluster_info(load_stats, tablet_stat);
         }
         VLOG_DEBUG << "tablet_id=" << tablet_id << " stats=" << proto_to_json(tablet_stat);
 

--- a/cloud/src/meta-service/meta_service_tablet_stats.cpp
+++ b/cloud/src/meta-service/meta_service_tablet_stats.cpp
@@ -171,6 +171,30 @@ void merge_tablet_stats(TabletStatsPB& stats, const TabletStats& detached_stats)
     stats.set_segment_size(stats.segment_size() + detached_stats.segment_size);
 }
 
+void copy_last_active_cluster_info(const TabletStatsPB& source, TabletStatsPB& target) {
+    if (!source.has_last_active_cluster_id()) {
+        return;
+    }
+
+    target.set_last_active_cluster_id(source.last_active_cluster_id());
+    if (source.has_last_active_time_ms()) {
+        target.set_last_active_time_ms(source.last_active_time_ms());
+    } else {
+        target.clear_last_active_time_ms();
+    }
+    if (source.has_last_active_cluster_status()) {
+        target.set_last_active_cluster_status(source.last_active_cluster_status());
+    } else {
+        target.clear_last_active_cluster_status();
+    }
+    if (source.has_last_active_cluster_status_mtime_ms()) {
+        target.set_last_active_cluster_status_mtime_ms(
+                source.last_active_cluster_status_mtime_ms());
+    } else {
+        target.clear_last_active_cluster_status_mtime_ms();
+    }
+}
+
 void detach_tablet_stats(const TabletStatsPB& stats, TabletStats& detached_stats) {
     detached_stats.data_size = stats.data_size();
     detached_stats.num_rows = stats.num_rows();
@@ -200,21 +224,29 @@ void internal_get_load_tablet_stats(MetaServiceCode& code, std::string& msg,
     // Try to read existing versioned tablet stats
     TxnErrorCode err =
             meta_reader.get_tablet_load_stats(txn, tablet_id, &stats, &versionstamp, snapshot);
-    if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) {
-        // If versioned stats doesn't exist, read from single version
+    if (err != TxnErrorCode::TXN_OK && err != TxnErrorCode::TXN_KEY_NOT_FOUND) {
+        code = cast_as<ErrCategory::READ>(err);
+        msg = fmt::format("failed to get versioned tablet stats, err={}", err);
+        LOG(WARNING) << msg << " tablet_id=" << tablet_id;
+        return;
+    }
+    if (err == TxnErrorCode::TXN_KEY_NOT_FOUND || !stats.has_last_active_cluster_id()) {
+        bool versioned_stats_not_found = err == TxnErrorCode::TXN_KEY_NOT_FOUND;
+        // If versioned stats doesn't exist or lacks active cluster info, read from single version.
         TabletStatsPB compact_stats;
         TabletStats detached_stats;
         internal_get_tablet_stats(code, msg, txn, instance_id, tablet_idx, compact_stats,
                                   detached_stats, snapshot);
         if (code == MetaServiceCode::OK) {
-            // Only the detached stats are valid for load tablet stats.
-            merge_tablet_stats(stats, detached_stats);
+            if (versioned_stats_not_found) {
+                // Only the detached stats are valid for load tablet stats.
+                merge_tablet_stats(stats, detached_stats);
+            }
+            copy_last_active_cluster_info(compact_stats, stats);
+        } else if (!versioned_stats_not_found && code == MetaServiceCode::TABLET_NOT_FOUND) {
+            code = MetaServiceCode::OK;
+            msg.clear();
         }
-    } else if (err != TxnErrorCode::TXN_OK) {
-        code = cast_as<ErrCategory::READ>(err);
-        msg = fmt::format("failed to get versioned tablet stats, err={}", err);
-        LOG(WARNING) << msg << " tablet_id=" << tablet_id;
-        return;
     }
 }
 
@@ -251,16 +283,17 @@ void internal_get_load_tablet_stats_batch(
         (*tablet_stats)[tablet_id] = stats;
     }
 
-    // For tablets not found in versioned stats, fall back to single version detached stats
+    // For tablets without complete versioned load stats, fall back to single version stats.
     std::vector<int64_t> fallback_tablet_ids;
     for (int64_t tablet_id : tablet_ids) {
-        if (!versioned_stats.contains(tablet_id)) {
+        auto it = versioned_stats.find(tablet_id);
+        if (it == versioned_stats.end() || !it->second.has_last_active_cluster_id()) {
             fallback_tablet_ids.push_back(tablet_id);
         }
     }
 
     if (!fallback_tablet_ids.empty()) {
-        LOG(INFO) << "fallback to single version detached stats for " << fallback_tablet_ids.size()
+        LOG(INFO) << "fallback to single version tablet stats for " << fallback_tablet_ids.size()
                   << " tablets";
 
         // Fall back to single version for each tablet
@@ -270,21 +303,29 @@ void internal_get_load_tablet_stats_batch(
                 continue;
             }
             const TabletIndexPB& tablet_idx = it->second;
+            bool versioned_stats_not_found = !versioned_stats.contains(tablet_id);
 
             TabletStatsPB compact_stats;
             TabletStats detached_stats;
             internal_get_tablet_stats(code, msg, txn, instance_id, tablet_idx, compact_stats,
                                       detached_stats, snapshot);
             if (code != MetaServiceCode::OK) {
+                if (!versioned_stats_not_found && code == MetaServiceCode::TABLET_NOT_FOUND) {
+                    code = MetaServiceCode::OK;
+                    msg.clear();
+                    continue;
+                }
                 LOG(WARNING) << "failed to get detached tablet stats for fallback, tablet_id="
                              << tablet_id << " code=" << code << " msg=" << msg;
                 return;
             }
 
-            // Only the detached stats are valid for load tablet stats.
-            TabletStatsPB stats_pb;
-            merge_tablet_stats(stats_pb, detached_stats);
-            (*tablet_stats)[tablet_id] = std::move(stats_pb);
+            auto& stats_pb = (*tablet_stats)[tablet_id];
+            if (versioned_stats_not_found) {
+                // Only the detached stats are valid for load tablet stats.
+                merge_tablet_stats(stats_pb, detached_stats);
+            }
+            copy_last_active_cluster_info(compact_stats, stats_pb);
         }
     }
 }

--- a/cloud/src/meta-service/meta_service_tablet_stats.h
+++ b/cloud/src/meta-service/meta_service_tablet_stats.h
@@ -47,6 +47,9 @@ void internal_get_tablet_stats(MetaServiceCode& code, std::string& msg, Transact
 // Merge `detached_stats` `stats` to `stats`.
 void merge_tablet_stats(TabletStatsPB& stats, const TabletStats& detached_stats);
 
+// Copy compaction read-write separation metadata between tablet stats.
+void copy_last_active_cluster_info(const TabletStatsPB& source, TabletStatsPB& target);
+
 // Detach tablet stats from `stats` to `detached_stats`.
 void detach_tablet_stats(const TabletStatsPB& stats, TabletStats& detached_stats);
 
@@ -57,7 +60,8 @@ void internal_get_tablet_stats(MetaServiceCode& code, std::string& msg, Transact
 
 // Get versioned load tablet stats via `txn`. If an error occurs, `code` will be set to non OK.
 //
-// If the versioned load stats doesn't exist, fall back to get single version detached tablet stats.
+// If the versioned load stats doesn't exist or lacks owner information, fall back to single-version
+// tablet stats for detached load statistics and compaction read-write separation metadata.
 void internal_get_load_tablet_stats(MetaServiceCode& code, std::string& msg,
                                     CloneChainReader& meta_reader, Transaction* txn,
                                     const std::string& instance_id, const TabletIndexPB& idx,
@@ -66,7 +70,8 @@ void internal_get_load_tablet_stats(MetaServiceCode& code, std::string& msg,
 // Batch version: Get versioned load tablet stats for multiple tablets via `txn`.
 // If an error occurs, `code` will be set to non OK.
 //
-// For tablets whose versioned load stats doesn't exist, fall back to get single version detached tablet stats.
+// For tablets whose versioned load stats doesn't exist or lacks owner information, fall back to
+// single-version tablet stats for detached load statistics and compaction read-write separation metadata.
 // tablet_indexes: map of tablet_id -> TabletIndexPB
 // tablet_stats: output map of tablet_id -> TabletStatsPB
 void internal_get_load_tablet_stats_batch(

--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -1474,9 +1474,18 @@ void scan_tmp_rowset(
     return;
 }
 
+void set_tablet_last_active_cluster(TabletStatsPB* stats, const std::string& cluster_id,
+                                    int64_t last_active_time_ms) {
+    stats->set_last_active_cluster_id(cluster_id);
+    stats->set_last_active_time_ms(last_active_time_ms);
+    stats->clear_last_active_cluster_status();
+    stats->clear_last_active_cluster_status_mtime_ms();
+}
+
 // Update the last active cluster info for a tablet
 void update_tablet_last_active_cluster(const StatsTabletKeyInfo& info,
                                        const std::string& cluster_id,
+                                       int64_t last_active_time_ms,
                                        std::unique_ptr<Transaction>& txn, MetaServiceCode& code,
                                        std::string& msg) {
     if (cluster_id.empty()) {
@@ -1505,10 +1514,7 @@ void update_tablet_last_active_cluster(const StatsTabletKeyInfo& info,
         return;
     }
 
-    stats_pb.set_last_active_cluster_id(cluster_id);
-    stats_pb.set_last_active_time_ms(::time(nullptr) * 1000);
-    // Clear the mtime when updating cluster to allow dynamic filling on next get_rowset
-    stats_pb.clear_last_active_cluster_status_mtime_ms();
+    set_tablet_last_active_cluster(&stats_pb, cluster_id, last_active_time_ms);
 
     stats_pb.SerializeToString(&val);
     txn->put(key, val);
@@ -2269,17 +2275,27 @@ void MetaServiceImpl::commit_txn_immediately(
             update_tablet_stats(info, stats, txn, code, msg);
             if (code != MetaServiceCode::OK) return;
 
+            TabletStatsPB versioned_stats;
+            if (is_versioned_write) {
+                versioned_stats = existing_versioned_stats[tablet_id];
+                merge_tablet_stats(versioned_stats, stats);
+            }
+
             // Update last active cluster if load has data
             if (!requester_cluster_id.empty() && stats.num_segs > 0) {
-                update_tablet_last_active_cluster(info, requester_cluster_id, txn, code, msg);
+                int64_t last_active_time_ms = ::time(nullptr) * 1000;
+                update_tablet_last_active_cluster(info, requester_cluster_id, last_active_time_ms,
+                                                  txn, code, msg);
                 if (code != MetaServiceCode::OK) return;
+                if (is_versioned_write) {
+                    set_tablet_last_active_cluster(&versioned_stats, requester_cluster_id,
+                                                   last_active_time_ms);
+                }
             }
 
             if (is_versioned_write) {
-                TabletStatsPB stats_pb = existing_versioned_stats[tablet_id];
-                merge_tablet_stats(stats_pb, stats);
                 std::string stats_key = versioned::tablet_load_stats_key({instance_id, tablet_id});
-                if (!versioned::document_put(txn.get(), stats_key, std::move(stats_pb))) {
+                if (!versioned::document_put(txn.get(), stats_key, std::move(versioned_stats))) {
                     code = MetaServiceCode::PROTOBUF_SERIALIZE_ERR;
                     msg = "failed to serialize versioned tablet stats";
                     LOG(WARNING) << msg << " tablet_id=" << tablet_id << " txn_id=" << txn_id;
@@ -3485,17 +3501,27 @@ void MetaServiceImpl::commit_txn_with_sub_txn(const CommitTxnRequest* request,
             update_tablet_stats(info, stats, txn, code, msg);
             if (code != MetaServiceCode::OK) return;
 
+            TabletStatsPB versioned_stats;
+            if (is_versioned_write) {
+                versioned_stats = existing_versioned_stats[tablet_id];
+                merge_tablet_stats(versioned_stats, stats);
+            }
+
             // Update last active cluster if load has data
             if (!requester_cluster_id_ev.empty() && stats.num_segs > 0) {
-                update_tablet_last_active_cluster(info, requester_cluster_id_ev, txn, code, msg);
+                int64_t last_active_time_ms = ::time(nullptr) * 1000;
+                update_tablet_last_active_cluster(info, requester_cluster_id_ev,
+                                                  last_active_time_ms, txn, code, msg);
                 if (code != MetaServiceCode::OK) return;
+                if (is_versioned_write) {
+                    set_tablet_last_active_cluster(&versioned_stats, requester_cluster_id_ev,
+                                                   last_active_time_ms);
+                }
             }
 
             if (is_versioned_write) {
-                TabletStatsPB stats_pb = existing_versioned_stats[tablet_id];
-                merge_tablet_stats(stats_pb, stats);
                 std::string stats_key = versioned::tablet_load_stats_key({instance_id, tablet_id});
-                if (!versioned::document_put(txn.get(), stats_key, std::move(stats_pb))) {
+                if (!versioned::document_put(txn.get(), stats_key, std::move(versioned_stats))) {
                     code = MetaServiceCode::PROTOBUF_SERIALIZE_ERR;
                     msg = "failed to serialize versioned tablet stats";
                     LOG(WARNING) << msg << " tablet_id=" << tablet_id << " txn_id=" << txn_id;

--- a/cloud/test/meta_service_versioned_read_test.cpp
+++ b/cloud/test/meta_service_versioned_read_test.cpp
@@ -1067,6 +1067,110 @@ TEST(MetaServiceVersionedReadTest, GetRowsetMetas) {
     LOG(INFO) << "GetRowsetMetas test completed successfully";
 }
 
+static void create_and_commit_rowset_with_cluster(MetaServiceProxy* service, int64_t db_id,
+                                                  int64_t table_id, int64_t partition_id,
+                                                  int64_t tablet_id,
+                                                  const std::string& cluster_id) {
+    brpc::Controller cntl;
+    BeginTxnRequest begin_req;
+    BeginTxnResponse begin_res;
+    begin_req.set_cloud_unique_id("test_cloud_unique_id");
+    auto* txn_info = begin_req.mutable_txn_info();
+    txn_info->set_db_id(db_id);
+    txn_info->set_label("get_rowset_last_active_cluster");
+    txn_info->add_table_ids(table_id);
+    txn_info->set_timeout_ms(36000);
+    txn_info->set_load_cluster_id(cluster_id);
+    service->begin_txn(&cntl, &begin_req, &begin_res, nullptr);
+    ASSERT_EQ(begin_res.status().code(), MetaServiceCode::OK) << begin_res.status().msg();
+
+    auto rowset = create_rowset(begin_res.txn_id(), tablet_id, partition_id, 2, 100);
+    CreateRowsetResponse rowset_res;
+    prepare_rowset(service, rowset, rowset_res);
+    ASSERT_EQ(rowset_res.status().code(), MetaServiceCode::OK) << rowset_res.status().msg();
+    commit_rowset(service, rowset, rowset_res);
+    ASSERT_EQ(rowset_res.status().code(), MetaServiceCode::OK) << rowset_res.status().msg();
+
+    CommitTxnRequest commit_req;
+    CommitTxnResponse commit_res;
+    commit_req.set_cloud_unique_id("test_cloud_unique_id");
+    commit_req.set_db_id(db_id);
+    commit_req.set_txn_id(begin_res.txn_id());
+    service->commit_txn(&cntl, &commit_req, &commit_res, nullptr);
+    ASSERT_EQ(commit_res.status().code(), MetaServiceCode::OK) << commit_res.status().msg();
+}
+
+static GetRowsetResponse get_rowsets(MetaServiceProxy* service, int64_t db_id, int64_t table_id,
+                                     int64_t index_id, int64_t partition_id, int64_t tablet_id) {
+    brpc::Controller cntl;
+    GetRowsetRequest req;
+    GetRowsetResponse res;
+    req.set_cloud_unique_id("test_cloud_unique_id");
+    auto* idx = req.mutable_idx();
+    idx->set_db_id(db_id);
+    idx->set_table_id(table_id);
+    idx->set_index_id(index_id);
+    idx->set_partition_id(partition_id);
+    idx->set_tablet_id(tablet_id);
+    req.set_start_version(0);
+    req.set_end_version(-1);
+    req.set_base_compaction_cnt(0);
+    req.set_cumulative_compaction_cnt(0);
+    req.set_cumulative_point(2);
+    service->get_rowset(&cntl, &req, &res, nullptr);
+    return res;
+}
+
+static void clear_versioned_last_active_cluster(MetaServiceProxy* service,
+                                                const std::string& instance_id, int64_t tablet_id) {
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+    std::string key = versioned::tablet_load_stats_key({instance_id, tablet_id});
+    Versionstamp versionstamp;
+    std::string value;
+    ASSERT_EQ(versioned_get(txn.get(), key, &versionstamp, &value), TxnErrorCode::TXN_OK);
+    TabletStatsPB load_stats;
+    ASSERT_TRUE(load_stats.ParseFromString(value));
+    load_stats.clear_last_active_cluster_id();
+    load_stats.clear_last_active_time_ms();
+    versioned_put(txn.get(), key, load_stats.SerializeAsString());
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+}
+
+static void expect_last_active_cluster(const GetRowsetResponse& response,
+                                       const std::string& cluster_id, bool expect_time) {
+    ASSERT_EQ(response.status().code(), MetaServiceCode::OK) << response.status().msg();
+    ASSERT_TRUE(response.stats().has_last_active_cluster_id());
+    EXPECT_EQ(response.stats().last_active_cluster_id(), cluster_id);
+    if (expect_time) {
+        EXPECT_TRUE(response.stats().has_last_active_time_ms());
+    }
+}
+
+TEST(MetaServiceVersionedReadTest, GetRowsetReturnsLastActiveCluster) {
+    auto service = get_meta_service(false);
+    std::string instance_id = "get_rowset_last_active_cluster_instance";
+    std::string cluster_id = "write_cluster_id";
+    constexpr int64_t db_id = 1;
+    constexpr int64_t table_id = 2;
+    constexpr int64_t index_id = 3;
+    constexpr int64_t partition_id = 4;
+    constexpr int64_t tablet_id = 5;
+
+    MOCK_GET_INSTANCE_ID(instance_id);
+    create_and_refresh_instance(service.get(), instance_id);
+    create_tablet(service.get(), table_id, index_id, partition_id, tablet_id);
+    create_and_commit_rowset_with_cluster(service.get(), db_id, table_id, partition_id, tablet_id,
+                                          cluster_id);
+
+    auto response = get_rowsets(service.get(), db_id, table_id, index_id, partition_id, tablet_id);
+    expect_last_active_cluster(response, cluster_id, true);
+
+    clear_versioned_last_active_cluster(service.get(), instance_id, tablet_id);
+    response = get_rowsets(service.get(), db_id, table_id, index_id, partition_id, tablet_id);
+    expect_last_active_cluster(response, cluster_id, false);
+}
+
 TEST(MetaServiceVersionedReadTest, UpdateTablet) {
     auto service = get_meta_service(false);
     std::string instance_id = "test_cloud_instance_id";

--- a/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation_versioned_read.groovy
+++ b/regression-test/suites/cloud_p0/compaction_rw_separation/test_compaction_rw_separation_versioned_read.groovy
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import groovy.json.JsonSlurper
+
+suite('test_compaction_rw_separation_versioned_read', 'docker') {
+    def options = new ClusterOptions()
+    options.feConfigs += [
+        'cloud_cluster_check_interval_second=1',
+        'cloud_tablet_rebalancer_interval_second=1',
+    ]
+    options.beConfigs += [
+        'enable_compaction_rw_separation=true',
+        'compaction_cluster_takeover_timeout_ms=600000',
+        'cluster_status_cache_refresh_interval_sec=5',
+        'file_cache_enter_disk_resource_limit_mode_percent=99',
+        'disable_auto_compaction=true',
+    ]
+    options.msConfigs += [
+        'enable_multi_version_status=true',
+    ]
+    options.cloudMode = true
+
+    def getTabletStatus = { ip, port, tabletId ->
+        def url = "http://${ip}:${port}/api/compaction/show?tablet_id=${tabletId}"
+        def response = new URL(url).text
+        return new JsonSlurper().parseText(response)
+    }
+
+    def getBeIpAndPort = { clusterName ->
+        def backends = sql """SHOW BACKENDS"""
+        def clusterBes = backends.findAll {
+            it[19].contains("""\"compute_group_name\" : \"${clusterName}\"""")
+        }
+        assertFalse(clusterBes.isEmpty(), "No BE found for cluster: ${clusterName}")
+        def firstBe = clusterBes[0]
+        return [ip: firstBe[1], httpPort: firstBe[4]]
+    }
+
+    docker(options) {
+        def writeCluster = 'versioned_write_cluster'
+        def readCluster = 'versioned_read_cluster'
+        cluster.addBackend(1, writeCluster)
+        cluster.addBackend(1, readCluster)
+
+        def readBe = getBeIpAndPort(readCluster)
+
+        sql """use @${writeCluster}"""
+        sql """DROP TABLE IF EXISTS test_compaction_rw_sep_versioned_read"""
+        sql """
+            CREATE TABLE test_compaction_rw_sep_versioned_read (
+                k1 INT NOT NULL,
+                v1 INT NOT NULL
+            ) UNIQUE KEY(`k1`)
+            DISTRIBUTED BY HASH(k1) BUCKETS 1
+            PROPERTIES (
+                "replication_num" = "1"
+            )
+        """
+
+        for (int i = 0; i < 10; i++) {
+            sql """INSERT INTO test_compaction_rw_sep_versioned_read VALUES (${i}, ${i * 10})"""
+        }
+
+        def tablets = sql_return_maparray """SHOW TABLETS FROM test_compaction_rw_sep_versioned_read"""
+        assertEquals(1, tablets.size())
+        def tabletId = tablets[0].TabletId
+
+        sql """use @${readCluster}"""
+        def result = sql """SELECT * FROM test_compaction_rw_sep_versioned_read ORDER BY k1"""
+        assertEquals(10, result.size())
+
+        // Auto compaction is still disabled while the read cluster refreshes the write cluster state.
+        sleep(7000)
+        def statusBefore = getTabletStatus(readBe.ip, readBe.httpPort, tabletId)
+        def lastCumuTimeBefore = statusBefore['last cumulative success time']
+
+        def (code, out, err) = curl(
+            'POST',
+            String.format(
+                'http://%s:%s/api/update_config?disable_auto_compaction=false',
+                readBe.ip,
+                readBe.httpPort))
+        assertEquals(0, code, "Failed to enable compaction on read cluster: ${out}, ${err}")
+
+        sleep(30000)
+        def statusAfter = getTabletStatus(readBe.ip, readBe.httpPort, tabletId)
+        def lastCumuTimeAfter = statusAfter['last cumulative success time']
+        assertEquals(
+            lastCumuTimeBefore,
+            lastCumuTimeAfter,
+            "Read cluster should skip compaction in MULTI_VERSION_READ_WRITE mode")
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #CIR-27564

Related PR: #xxx

Problem Summary:

In multi-version read/write mode, tablet statistics are maintained in both
ordinary and versioned metadata.

The versioned tablet stats may be missing `last_active_cluster_id` or
`last_active_time_ms`. As a result, the versioned read and compaction paths
may fail to identify the cluster that most recently modified the tablet. This
can cause a cluster to make an incorrect compaction decision and break
compaction read/write separation.

This PR synchronizes the active-cluster metadata between ordinary and
versioned tablet stats. It also adds fallback logic for missing or incomplete
versioned load stats, while preserving valid versioned statistics.

The changes include:

- Update both ordinary and versioned tablet stats during transaction commit.
- Keep `last_active_cluster_id` and `last_active_time_ms` consistent.
- Fall back to ordinary tablet stats when versioned load stats are missing or
  lack active-cluster metadata.
- Make the versioned `GetRowset` path correctly combine compact and load stats.
- Add unit tests and regression tests for versioned-read compaction
  read/write separation.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
  - [x] Regression test
  - [x] Unit Test
  - [ ] Manual test (add detailed scripts or steps below)
  - [ ] No need to test or manual test. Explain why:
    - [ ] This is a refactor/code format and no logic has been changed.
    - [ ] Previous test can cover this change.
    - [ ] No code files have been changed.
    - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
  - [ ] No.
  - [x] Yes. <!-- Explain the behavior change -->

  This change fixes the behavior of versioned read/write mode when active
  cluster metadata is missing or inconsistent. It ensures that compaction
  decisions use the correct active-cluster information and preserves
  compaction read/write separation.

- Does this need documentation?
  - [x] No.
  - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->