### PR TITLE
[fix](hive) Preserve simple HMS user identity

### DIFF
--- a/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveConnector.java
+++ b/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveConnector.java
@@ -131,6 +131,7 @@ public class HiveConnector implements Connector {
     private volatile Connector hudiSibling;
 
     public HiveConnector(Map<String, String> properties, ConnectorContext context) {
+        HmsConfHelper.initializeHadoopConfigDir(context);
         this.props = HiveCatalogProperties.of(properties);
         this.properties = props.getRaw();
         this.context = context;

--- a/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveConnector.java
+++ b/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveConnector.java
@@ -21,9 +21,11 @@ import org.apache.doris.connector.cache.ConnectorMetadataCache;
 import org.apache.doris.connector.hms.CachingHmsClient;
 import org.apache.doris.connector.hms.HmsClient;
 import org.apache.doris.connector.hms.HmsClientConfig;
+import org.apache.doris.connector.hms.HmsConfHelper;
 import org.apache.doris.connector.hms.ThriftHmsClient;
 import org.apache.doris.connector.hms.event.HmsEventSource;
 import org.apache.doris.connector.metastore.HmsMetaStoreProperties;
+import org.apache.doris.connector.metastore.spi.AbstractHmsMetaStoreProperties;
 import org.apache.doris.connector.metastore.spi.MetaStoreProviders;
 import org.apache.doris.connector.spi.Connector;
 import org.apache.doris.connector.spi.ConnectorCapability;
@@ -66,9 +68,6 @@ import java.util.function.Consumer;
 public class HiveConnector implements Connector {
 
     private static final Logger LOG = LogManager.getLogger(HiveConnector.class);
-
-    // Catalog property key gating the plugin-side Kerberos authenticator (value matches AuthType.KERBEROS).
-    private static final String HADOOP_SECURITY_AUTHENTICATION = "hadoop.security.authentication";
 
     // The sibling connector type a flipped hms gateway delegates iceberg-on-HMS tables to. A string literal
     // (not the iceberg plugin's own type constant, which is child-first and invisible from the hive loader);
@@ -593,7 +592,12 @@ public class HiveConnector implements Connector {
 
         // getHmsClientProperties(), not the raw map: the metastore URI must reach HiveConf under its canonical
         // key even when the catalog spells it with the "uri" short form.
-        HmsClientConfig config = new HmsClientConfig(props.getHmsClientProperties(), poolSize);
+        AbstractHmsMetaStoreProperties hms = (AbstractHmsMetaStoreProperties) MetaStoreProviders.bindForType(
+                HmsClientConfig.METASTORE_TYPE_HMS, props.getHmsClientProperties(), Collections.emptyMap());
+        HmsClientConfig config = new HmsClientConfig(hms.getConfResources(),
+                HmsConfHelper.mergeCatalogProperties(
+                        props.getHmsClientProperties(), hms.toHiveConfOverrides("")),
+                poolSize);
         LOG.info("Creating Hive connector client for catalog='{}', uri={}, type={}, poolSize={}",
                 context.getCatalogName(), config.getMetastoreUri(),
                 config.getMetastoreType(), poolSize);
@@ -672,17 +676,13 @@ public class HiveConnector implements Connector {
      * Resolves the plugin-side authenticator for the catalog. Authentication modes are covered in precedence
      * order, mirroring the legacy {@code HMSBaseProperties.initHadoopAuthenticator}:
      * <ol>
-     *   <li><b>Storage</b> Kerberos — the raw {@code hadoop.security.authentication=kerberos} passthrough
-     *       (HDFS login), built from the catalog Hadoop configuration. When storage is Kerberos this single
-     *       login also carries the HMS metastore RPC (same UGI).</li>
-     *   <li><b>HMS-metastore</b> Kerberos with non-Kerberos storage — a secured Hive Metastore whose data
-     *       storage is simple (e.g. a Kerberized HMS over S3). The HMS client principal/keytab facts
+     *   <li><b>Explicit HMS mode</b> — SIMPLE selects the configured metastore user even when storage is
+     *       Kerberos; KERBEROS uses the HMS client principal/keytab facts
      *       ({@link HmsMetaStoreProperties#kerberos()}, resolved through the shared metastore-spi parser) feed a
      *       {@link KerberosAuthenticationConfig}, so the {@code doAs} logs in the same client identity fe-core
-     *       used. The HMS <em>service</em> principal / SASL settings ride the catalog's own HiveConf, not the
-     *       login.</li>
-     *   <li><b>Simple HMS</b> — the configured {@code hive.metastore.username}/{@code hadoop.username}, or the
-     *       legacy {@code hadoop} default, becomes the current UGI for HMS {@code set_ugi} calls.</li>
+     *       used.</li>
+     *   <li><b>Storage fallback</b> — only when HMS mode is absent, storage Kerberos may supply the HMS login;
+     *       otherwise the configured simple user or legacy {@code hadoop} default drives {@code set_ugi}.</li>
      * </ol>
      * Package-visible + static for KDC-free unit testing.
      */
@@ -693,20 +693,17 @@ public class HiveConnector implements Connector {
         // SecurityUtil.<clinit>, whose internal `new Configuration()` captures the current TCCL. This runs on the
         // (unpinned) createClient thread, so without the pin it would resolve hadoop's DNSDomainNameResolver from
         // fe-core's system-loader copy and split-brain-poison SecurityUtil against the plugin copy (the same
-        // failure ThriftHmsClient.doAs guards). buildHadoopConf pins only the OUTER conf's loader, not the TCCL
+        // failure ThriftHmsClient.doAs guards). buildHmsConf pins only the OUTER conf's loader, not the TCCL
         // that SecurityUtil's own Configuration reads — so the thread pin is required here too.
         // (HadoopKerberosAuthenticator's keytab login is lazy in getUGI, already under doAs's pin.)
         ClassLoader previous = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(HiveConnector.class.getClassLoader());
-            if ("kerberos".equalsIgnoreCase(properties.get(HADOOP_SECURITY_AUTHENTICATION))) {
-                return HadoopAuthenticator.getHadoopAuthenticator(buildHadoopConf(properties));
-            }
-            HmsMetaStoreProperties hms = (HmsMetaStoreProperties) MetaStoreProviders.bindForType(
+            AbstractHmsMetaStoreProperties hms = (AbstractHmsMetaStoreProperties) MetaStoreProviders.bindForType(
                     HmsClientConfig.METASTORE_TYPE_HMS, properties, Collections.emptyMap());
             Optional<KerberosAuthSpec> spec = hms.kerberos();
             if (spec.isPresent() && spec.get().hasCredentials()) {
-                Configuration conf = buildHadoopConf(properties);
+                Configuration conf = buildHmsConf(hms);
                 conf.set("hadoop.security.authentication", "kerberos");
                 conf.set("hive.metastore.sasl.enabled", "true");
                 return HadoopAuthenticator.getHadoopAuthenticator(
@@ -715,12 +712,9 @@ public class HiveConnector implements Connector {
             if (hms.getAuthType() == AuthType.KERBEROS) {
                 return null;
             }
-            String hadoopUser = hms.toHiveConfOverrides("").get(AuthenticationConfig.HADOOP_USER_NAME);
-            Configuration conf = buildHadoopConf(properties);
-            if (hadoopUser != null) {
-                conf.set(AuthenticationConfig.HADOOP_USER_NAME, hadoopUser);
-            }
-            // HMS set_ugi reads the current UGI, so its simple-auth identity must match the DFS writer.
+            Configuration conf = buildHmsConf(hms);
+            // HMS set_ugi reads the current UGI; resolve it from the HMS configuration without changing the
+            // separate storage identity used by the connector's file operations.
             return HadoopAuthenticator.getHadoopAuthenticator(
                     AuthenticationConfig.getSimpleAuthenticationConfig(conf));
         } finally {
@@ -734,11 +728,8 @@ public class HiveConnector implements Connector {
      * hadoop-mapreduce onto the unit-test classpath. The classloader is pinned to the plugin loader so the
      * child-first (plugin) copy of the auth classes is resolved.
      */
-    private static Configuration buildHadoopConf(Map<String, String> properties) {
-        Configuration conf = new Configuration();
-        conf.setClassLoader(HiveConnector.class.getClassLoader());
-        properties.forEach(conf::set);
-        return conf;
+    private static Configuration buildHmsConf(AbstractHmsMetaStoreProperties hms) {
+        return HmsConfHelper.createHadoopConfWithResources(hms.getConfResources(), hms.toHiveConfOverrides(""));
     }
 
     @Override

--- a/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveConnector.java
+++ b/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveConnector.java
@@ -38,6 +38,8 @@ import org.apache.doris.connector.spi.handle.ConnectorTableHandle;
 import org.apache.doris.connector.spi.procedure.ConnectorProcedureOps;
 import org.apache.doris.connector.spi.scan.ConnectorScanPlanProvider;
 import org.apache.doris.connector.spi.write.ConnectorWritePlanProvider;
+import org.apache.doris.kerberos.AuthType;
+import org.apache.doris.kerberos.AuthenticationConfig;
 import org.apache.doris.kerberos.HadoopAuthenticator;
 import org.apache.doris.kerberos.KerberosAuthSpec;
 import org.apache.doris.kerberos.KerberosAuthenticationConfig;
@@ -596,9 +598,9 @@ public class HiveConnector implements Connector {
                 context.getCatalogName(), config.getMetastoreUri(),
                 config.getMetastoreType(), poolSize);
 
-        // For a Kerberos catalog run the metastore RPC under the PLUGIN's UGI doAs (buildPluginAuthenticator),
-        // NOT the FE-injected context: after the catalog flip that context resolves to NOOP (SIMPLE) auth, which
-        // would silently downgrade a Kerberos HMS. AuthAction.execute is a generic method (<T> T execute(...)),
+        // Run the metastore RPC under the PLUGIN's UGI doAs (buildPluginAuthenticator), NOT the FE-injected
+        // context: after the catalog flip that context resolves to NOOP auth and loses both the configured simple
+        // user and Kerberos login. AuthAction.execute is a generic method (<T> T execute(...)),
         // so it cannot be a lambda — use an anonymous class. ThriftHmsClient.doAs pins the RPC's TCCL to the
         // plugin (child-first) classloader (so SecurityUtil.<clinit> resolves hadoop from the plugin copy, not a
         // split-brain against fe-core's copy); the plugin's HadoopAuthenticator only wraps it in a UGI doAs.
@@ -649,11 +651,10 @@ public class HiveConnector implements Connector {
     }
 
     /**
-     * Lazily builds and memoizes the plugin-side Kerberos authenticator that {@link #createClient()} wraps the
+     * Lazily builds and memoizes the plugin-side authenticator that {@link #createClient()} wraps the
      * metastore RPC under, so the RPC uses the PLUGIN's own {@code UserGroupInformation} copy (hadoop +
-     * fe-kerberos are bundled child-first in the hive plugin). Returns {@code null} for a non-Kerberos catalog
-     * so the FE-injected auth path is preserved unchanged. Construction is cheap — the keytab login is lazy in
-     * {@code getUGI()} on the first {@code doAs}.
+     * fe-kerberos are bundled child-first in the hive plugin). Construction is cheap — the keytab login is lazy
+     * in {@code getUGI()} on the first {@code doAs}.
      */
     private HadoopAuthenticator pluginAuthenticator() {
         if (!pluginAuthComputed) {
@@ -668,9 +669,8 @@ public class HiveConnector implements Connector {
     }
 
     /**
-     * Resolves the plugin-side Kerberos authenticator for the catalog, or {@code null} for a non-Kerberos
-     * catalog. Two Kerberos sources are covered, in precedence order (mirroring the legacy
-     * {@code HMSBaseProperties.initHadoopAuthenticator}):
+     * Resolves the plugin-side authenticator for the catalog. Authentication modes are covered in precedence
+     * order, mirroring the legacy {@code HMSBaseProperties.initHadoopAuthenticator}:
      * <ol>
      *   <li><b>Storage</b> Kerberos — the raw {@code hadoop.security.authentication=kerberos} passthrough
      *       (HDFS login), built from the catalog Hadoop configuration. When storage is Kerberos this single
@@ -681,6 +681,8 @@ public class HiveConnector implements Connector {
      *       {@link KerberosAuthenticationConfig}, so the {@code doAs} logs in the same client identity fe-core
      *       used. The HMS <em>service</em> principal / SASL settings ride the catalog's own HiveConf, not the
      *       login.</li>
+     *   <li><b>Simple HMS</b> — the configured {@code hive.metastore.username}/{@code hadoop.username}, or the
+     *       legacy {@code hadoop} default, becomes the current UGI for HMS {@code set_ugi} calls.</li>
      * </ol>
      * Package-visible + static for KDC-free unit testing.
      */
@@ -710,7 +712,17 @@ public class HiveConnector implements Connector {
                 return HadoopAuthenticator.getHadoopAuthenticator(
                         new KerberosAuthenticationConfig(spec.get().getPrincipal(), spec.get().getKeytab(), conf));
             }
-            return null;
+            if (hms.getAuthType() == AuthType.KERBEROS) {
+                return null;
+            }
+            String hadoopUser = hms.toHiveConfOverrides("").get(AuthenticationConfig.HADOOP_USER_NAME);
+            Configuration conf = buildHadoopConf(properties);
+            if (hadoopUser != null) {
+                conf.set(AuthenticationConfig.HADOOP_USER_NAME, hadoopUser);
+            }
+            // HMS set_ugi reads the current UGI, so its simple-auth identity must match the DFS writer.
+            return HadoopAuthenticator.getHadoopAuthenticator(
+                    AuthenticationConfig.getSimpleAuthenticationConfig(conf));
         } finally {
             Thread.currentThread().setContextClassLoader(previous);
         }

--- a/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveConnector.java
+++ b/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveConnector.java
@@ -588,16 +588,8 @@ public class HiveConnector implements Connector {
         // connector's constructor built. A catalog created before the type was removed, or one carrying no
         // metastore URI, fails when the connector is (re)built — including on the lazy build an FE does for a
         // catalog it loaded from the image — with the same messages this method used to produce.
-        int poolSize = props.getHmsClientPoolSize();
-
-        // getHmsClientProperties(), not the raw map: the metastore URI must reach HiveConf under its canonical
-        // key even when the catalog spells it with the "uri" short form.
-        AbstractHmsMetaStoreProperties hms = (AbstractHmsMetaStoreProperties) MetaStoreProviders.bindForType(
-                HmsClientConfig.METASTORE_TYPE_HMS, props.getHmsClientProperties(), Collections.emptyMap());
-        HmsClientConfig config = new HmsClientConfig(hms.getConfResources(),
-                HmsConfHelper.mergeCatalogProperties(
-                        props.getHmsClientProperties(), hms.toHiveConfOverrides("")),
-                poolSize);
+        HmsClientConfig config = buildHmsClientConfig();
+        int poolSize = config.getPoolSize();
         LOG.info("Creating Hive connector client for catalog='{}', uri={}, type={}, poolSize={}",
                 context.getCatalogName(), config.getMetastoreUri(),
                 config.getMetastoreType(), poolSize);
@@ -627,6 +619,16 @@ public class HiveConnector implements Connector {
         // into a dead metadata field; the fix is to build the options here where the client is constructed.
         return wrapWithCache(new ThriftHmsClient(config, authAction,
                 HiveConnectorMetadata.buildTypeMappingOptions(props)));
+    }
+
+    HmsClientConfig buildHmsClientConfig() {
+        // Use canonical properties so the URI short alias and deployment timeout both reach HiveConf.
+        AbstractHmsMetaStoreProperties hms = (AbstractHmsMetaStoreProperties) MetaStoreProviders.bindForType(
+                HmsClientConfig.METASTORE_TYPE_HMS, props.getHmsClientProperties(), Collections.emptyMap());
+        return new HmsClientConfig(hms.getConfResources(), HmsConfHelper.mergeCatalogProperties(
+                props.getHmsClientProperties(),
+                hms.toHiveConfOverrides(HmsConfHelper.metastoreClientTimeoutSecond(context))),
+                props.getHmsClientPoolSize());
     }
 
     /**

--- a/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveConnectorPluginAuthenticatorTest.java
+++ b/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveConnectorPluginAuthenticatorTest.java
@@ -176,4 +176,12 @@ public class HiveConnectorPluginAuthenticatorTest {
                         "hive.metastore.authentication.type", "kerberos"));
         Assertions.assertNull(auth, "kerberos HMS without a client principal/keytab pair must not build one");
     }
+
+    @Test
+    public void hmsClientUsesFeConfiguredSocketTimeout() {
+        HiveConnector connector = new HiveConnector(HiveTestProperties.minimalMap(),
+                new FakeConnectorContext(Map.of("hive_metastore_client_timeout_second", "47")));
+        Assertions.assertEquals("47", connector.buildHmsClientConfig().getProperties()
+                .get("hive.metastore.client.socket.timeout"));
+    }
 }

--- a/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveConnectorPluginAuthenticatorTest.java
+++ b/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveConnectorPluginAuthenticatorTest.java
@@ -21,7 +21,10 @@ import org.apache.doris.kerberos.HadoopAuthenticator;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,6 +42,9 @@ import java.util.Map;
  * <p>The actual keytab login is lazy (on first {@code doAs}), so these assertions never touch a KDC.
  */
 public class HiveConnectorPluginAuthenticatorTest {
+
+    @TempDir
+    Path tempDir;
 
     private static Map<String, String> props(String... kv) {
         Map<String, String> m = new HashMap<>();
@@ -95,6 +101,51 @@ public class HiveConnectorPluginAuthenticatorTest {
 
         Assertions.assertNotNull(auth, "simple-auth HMS must support the metastore username alias");
         Assertions.assertEquals("hive", auth.getUGI().getUserName());
+    }
+
+    @Test
+    public void explicitSimpleHmsWinsOverKerberosStorage() throws Exception {
+        HadoopAuthenticator auth = HiveConnector.buildPluginAuthenticator(
+                props("hive.metastore.uris", "thrift://hms:9083",
+                        "hive.metastore.authentication.type", "simple",
+                        "hive.metastore.username", "metastore-user",
+                        "hadoop.security.authentication", "kerberos",
+                        "hadoop.kerberos.principal", "storage@EXAMPLE.COM",
+                        "hadoop.kerberos.keytab", "/etc/security/storage.keytab"));
+
+        Assertions.assertEquals("metastore-user", auth.getUGI().getUserName());
+    }
+
+    @Test
+    public void blankHadoopUserFallsBackToLegacyDefault() throws Exception {
+        for (String blank : new String[] {"", "   "}) {
+            HadoopAuthenticator auth = HiveConnector.buildPluginAuthenticator(
+                    props("hive.metastore.uris", "thrift://hms:9083",
+                            "hive.metastore.authentication.type", "simple",
+                            "hadoop.username", blank));
+            Assertions.assertEquals("hadoop", auth.getUGI().getUserName());
+        }
+    }
+
+    @Test
+    public void simpleHmsUserCanComeFromHiveConfResource() throws Exception {
+        Path resource = tempDir.resolve("hive-site.xml");
+        Files.writeString(resource, "<configuration><property><name>hadoop.username</name>"
+                + "<value>resource-user</value></property></configuration>");
+        String previous = System.setProperty("doris.hadoop.config.dir", tempDir + "/");
+        try {
+            HadoopAuthenticator auth = HiveConnector.buildPluginAuthenticator(
+                    props("hive.metastore.uris", "thrift://hms:9083",
+                            "hive.metastore.authentication.type", "simple",
+                            "hive.conf.resources", resource.getFileName().toString()));
+            Assertions.assertEquals("resource-user", auth.getUGI().getUserName());
+        } finally {
+            if (previous == null) {
+                System.clearProperty("doris.hadoop.config.dir");
+            } else {
+                System.setProperty("doris.hadoop.config.dir", previous);
+            }
+        }
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveConnectorPluginAuthenticatorTest.java
+++ b/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveConnectorPluginAuthenticatorTest.java
@@ -27,14 +27,14 @@ import java.util.Map;
 
 /**
  * Unit tests for {@link HiveConnector#buildPluginAuthenticator(Map)} — the connector-owned plugin-side
- * Kerberos authenticator resolution.
+ * authenticator resolution.
  *
  * <p>The load-bearing case is <b>HMS-metastore Kerberos with simple (non-Kerberos) storage</b>
  * (e.g. a Kerberized Hive Metastore over S3). After the catalog flip the FE-injected
  * {@code ConnectorContext.executeAuthenticated} resolves to NOOP (SIMPLE) auth, so a Kerberos HMS would be
  * silently downgraded unless the connector owns the login itself. These tests pin that the connector builds a
- * plugin authenticator from the HMS client principal/keytab facts, and does NOT build one when the metastore
- * is simple-auth (which would force needless SIMPLE-vs-Kerberos churn).
+ * plugin authenticator from the HMS client principal/keytab facts. Simple-auth cases also pin the HMS UGI to
+ * the configured Hadoop user, including the metastore alias and legacy default.
  *
  * <p>The actual keytab login is lazy (on first {@code doAs}), so these assertions never touch a KDC.
  */
@@ -75,21 +75,43 @@ public class HiveConnectorPluginAuthenticatorTest {
                 "HMS-metastore kerberos with simple storage must yield a plugin authenticator");
     }
 
-    /** A simple-auth HMS builds no authenticator (a spurious one would force needless SIMPLE-vs-Kerberos churn). */
     @Test
-    public void hmsSimpleAuthReturnsNull() {
+    public void hmsSimpleAuthUsesConfiguredHadoopUser() throws Exception {
+        HadoopAuthenticator auth = HiveConnector.buildPluginAuthenticator(
+                props("hive.metastore.uris", "thrift://hms:9083",
+                        "hive.metastore.authentication.type", "simple",
+                        "hadoop.username", "hive"));
+
+        Assertions.assertNotNull(auth, "simple-auth HMS must yield a plugin authenticator");
+        Assertions.assertEquals("hive", auth.getUGI().getUserName());
+    }
+
+    @Test
+    public void hmsSimpleAuthUsesMetastoreUsernameAlias() throws Exception {
+        HadoopAuthenticator auth = HiveConnector.buildPluginAuthenticator(
+                props("hive.metastore.uris", "thrift://hms:9083",
+                        "hive.metastore.authentication.type", "simple",
+                        "hive.metastore.username", "hive"));
+
+        Assertions.assertNotNull(auth, "simple-auth HMS must support the metastore username alias");
+        Assertions.assertEquals("hive", auth.getUGI().getUserName());
+    }
+
+    @Test
+    public void hmsSimpleAuthUsesLegacyDefaultUser() throws Exception {
         HadoopAuthenticator auth = HiveConnector.buildPluginAuthenticator(
                 props("hive.metastore.uris", "thrift://hms:9083",
                         "hive.metastore.authentication.type", "simple"));
-        Assertions.assertNull(auth, "simple-auth HMS must not build a plugin authenticator");
+        Assertions.assertNotNull(auth, "simple-auth HMS must yield a plugin authenticator");
+        Assertions.assertEquals("hadoop", auth.getUGI().getUserName());
     }
 
-    /** A plain HMS with no auth configured builds no authenticator. */
     @Test
-    public void plainHmsWithoutKerberosReturnsNull() {
+    public void plainHmsUsesLegacyDefaultUser() throws Exception {
         HadoopAuthenticator auth = HiveConnector.buildPluginAuthenticator(
                 props("hive.metastore.uris", "thrift://hms:9083"));
-        Assertions.assertNull(auth, "plain HMS without kerberos must not build an authenticator");
+        Assertions.assertNotNull(auth, "plain HMS must yield a plugin authenticator");
+        Assertions.assertEquals("hadoop", auth.getUGI().getUserName());
     }
 
     /**

--- a/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveConnectorPluginAuthenticatorTest.java
+++ b/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveConnectorPluginAuthenticatorTest.java
@@ -184,4 +184,29 @@ public class HiveConnectorPluginAuthenticatorTest {
         Assertions.assertEquals("47", connector.buildHmsClientConfig().getProperties()
                 .get("hive.metastore.client.socket.timeout"));
     }
+
+    @Test
+    public void firstConnectorInitializesConfiguredHadoopResourceDirectory() throws Exception {
+        Path resource = tempDir.resolve("hive-site.xml");
+        Files.writeString(resource, "<configuration><property><name>hadoop.username</name>"
+                + "<value>first-hive-user</value></property></configuration>");
+        Map<String, String> properties = props(
+                "hive.metastore.uris", "thrift://hms:9083",
+                "hive.metastore.authentication.type", "simple",
+                "hive.conf.resources", resource.getFileName().toString());
+        String previous = System.getProperty("doris.hadoop.config.dir");
+        System.clearProperty("doris.hadoop.config.dir");
+        try {
+            new HiveConnector(properties,
+                    new FakeConnectorContext(Map.of("hadoop_config_dir", tempDir.toString())));
+            Assertions.assertEquals("first-hive-user",
+                    HiveConnector.buildPluginAuthenticator(properties).getUGI().getUserName());
+        } finally {
+            if (previous == null) {
+                System.clearProperty("doris.hadoop.config.dir");
+            } else {
+                System.setProperty("doris.hadoop.config.dir", previous);
+            }
+        }
+    }
 }

--- a/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/HmsClientConfig.java
+++ b/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/HmsClientConfig.java
@@ -83,6 +83,7 @@ public final class HmsClientConfig {
     }
 
     private final Map<String, String> properties;
+    private final String confResources;
     private final int poolSize;
 
     /**
@@ -92,7 +93,15 @@ public final class HmsClientConfig {
      * @param poolSize   max pool connections; 0 means no pooling
      */
     public HmsClientConfig(Map<String, String> properties, int poolSize) {
+        this("", properties, poolSize);
+    }
+
+    /**
+     * Creates a client configuration with external Hive configuration resources layered below the overrides.
+     */
+    public HmsClientConfig(String confResources, Map<String, String> properties, int poolSize) {
         this.properties = Objects.requireNonNull(properties, "properties");
+        this.confResources = confResources;
         if (poolSize < 0) {
             throw new IllegalArgumentException("poolSize must be >= 0, got " + poolSize);
         }
@@ -101,6 +110,10 @@ public final class HmsClientConfig {
 
     public Map<String, String> getProperties() {
         return Collections.unmodifiableMap(properties);
+    }
+
+    public String getConfResources() {
+        return confResources;
     }
 
     public int getPoolSize() {

--- a/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/HmsConfHelper.java
+++ b/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/HmsConfHelper.java
@@ -17,6 +17,9 @@
 
 package org.apache.doris.connector.hms;
 
+import org.apache.doris.connector.spi.ConnectorConf;
+import org.apache.doris.connector.spi.ConnectorContext;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -35,7 +38,17 @@ import java.util.Map;
  */
 public final class HmsConfHelper {
 
+    private static final String CONF_METASTORE_CLIENT_TIMEOUT_SECOND = "metastore_client_timeout_second";
+    private static final String ENV_METASTORE_CLIENT_TIMEOUT_SECOND =
+            "hive_metastore_client_timeout_second";
+
     private HmsConfHelper() {
+    }
+
+    /** Resolves the shared HMS timeout from this plugin's config, then the legacy FE environment. */
+    public static String metastoreClientTimeoutSecond(ConnectorContext context) {
+        return ConnectorConf.get(context, CONF_METASTORE_CLIENT_TIMEOUT_SECOND,
+                ENV_METASTORE_CLIENT_TIMEOUT_SECOND, "10");
     }
 
     /**
@@ -85,7 +98,10 @@ public final class HmsConfHelper {
         // TSocket that a kerberized metastore drops with TTransportException.
         String hmsAuthType = properties.get("hive.metastore.authentication.type");
         boolean explicitSimple = "simple".equalsIgnoreCase(hmsAuthType);
-        if ("kerberos".equalsIgnoreCase(hmsAuthType)
+        if (explicitSimple) {
+            // The explicit HMS mode is authoritative even when a base hive-site.xml enables SASL.
+            hiveConf.set("hive.metastore.sasl.enabled", "false");
+        } else if ("kerberos".equalsIgnoreCase(hmsAuthType)
                 || (!explicitSimple
                         && "kerberos".equalsIgnoreCase(properties.get("hadoop.security.authentication")))) {
             hiveConf.set("hive.metastore.sasl.enabled", "true");

--- a/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/HmsConfHelper.java
+++ b/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/HmsConfHelper.java
@@ -17,8 +17,12 @@
 
 package org.apache.doris.connector.hms;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 
+import java.io.File;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -45,6 +49,13 @@ public final class HmsConfHelper {
      * @return a new HiveConf instance
      */
     public static HiveConf createHiveConf(Map<String, String> properties) {
+        return createHiveConfWithResources("", properties);
+    }
+
+    /**
+     * Create a {@link HiveConf} with resource files as the base and catalog properties as overrides.
+     */
+    public static HiveConf createHiveConfWithResources(String confResources, Map<String, String> properties) {
         HiveConf hiveConf = new HiveConf();
         // Pin the conf classloader to the plugin loader, mirroring PaimonCatalogFactory.assembleHiveConf.
         // HiveMetaStoreClient.loadFilterHooks resolves metastore.filter.hook via Configuration.getClass, which
@@ -58,7 +69,13 @@ public final class HmsConfHelper {
         // (fixes SecurityUtil.<clinit>) but cannot fix this conf-cached CL. Pinning here keeps the whole
         // hive-metastore class graph in one loader.
         hiveConf.setClassLoader(HmsConfHelper.class.getClassLoader());
+        addConfResources(hiveConf, confResources);
         for (Map.Entry<String, String> entry : properties.entrySet()) {
+            // A blank username was ignored by the legacy copy-if-present path; preserving a resource value (or
+            // the "hadoop" default) avoids createRemoteUser("") failing before the first HMS RPC.
+            if ("hadoop.username".equals(entry.getKey()) && isBlank(entry.getValue())) {
+                continue;
+            }
             hiveConf.set(entry.getKey(), entry.getValue());
         }
         // A kerberized HMS requires SASL transport on the metastore Thrift connection. The legacy fe-core
@@ -66,11 +83,76 @@ public final class HmsConfHelper {
         // metastore/hadoop auth was kerberos; preserve that here so a catalog that only declares kerberos auth
         // (without an explicit hive.metastore.sasl.enabled) still negotiates SASL, instead of opening a plain
         // TSocket that a kerberized metastore drops with TTransportException.
-        if ("kerberos".equalsIgnoreCase(properties.get("hadoop.security.authentication"))
-                || "kerberos".equalsIgnoreCase(properties.get("hive.metastore.authentication.type"))) {
+        String hmsAuthType = properties.get("hive.metastore.authentication.type");
+        boolean explicitSimple = "simple".equalsIgnoreCase(hmsAuthType);
+        if ("kerberos".equalsIgnoreCase(hmsAuthType)
+                || (!explicitSimple
+                        && "kerberos".equalsIgnoreCase(properties.get("hadoop.security.authentication")))) {
             hiveConf.set("hive.metastore.sasl.enabled", "true");
         }
         return hiveConf;
+    }
+
+    /**
+     * Creates the lightweight Hadoop configuration used only for UGI resolution.
+     */
+    public static Configuration createHadoopConfWithResources(String confResources,
+            Map<String, String> properties) {
+        Configuration conf = new Configuration();
+        conf.setClassLoader(HmsConfHelper.class.getClassLoader());
+        addConfResources(conf, confResources);
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            if ("hadoop.username".equals(entry.getKey()) && isBlank(entry.getValue())) {
+                continue;
+            }
+            conf.set(entry.getKey(), entry.getValue());
+        }
+        return conf;
+    }
+
+    /**
+     * Preserves connector-agnostic passthrough keys while applying canonical HMS overrides last.
+     */
+    public static Map<String, String> mergeCatalogProperties(Map<String, String> raw,
+            Map<String, String> overrides) {
+        Map<String, String> merged = new LinkedHashMap<>(raw);
+        // Canonical parsing deliberately omits a blank username; remove the raw value so it cannot reappear
+        // merely because the HMS client also preserves unrelated custom configuration keys.
+        if (isBlank(merged.get("hadoop.username"))) {
+            merged.remove("hadoop.username");
+        }
+        merged.putAll(overrides);
+        return merged;
+    }
+
+    private static void addConfResources(Configuration conf, String confResources) {
+        if (isBlank(confResources)) {
+            return;
+        }
+        String baseDir = resolveHadoopConfigDir();
+        for (String resource : confResources.split(",")) {
+            File file = new File(baseDir, resource.trim());
+            if (!file.isFile()) {
+                throw new IllegalArgumentException("Config resource file does not exist: " + file);
+            }
+            conf.addResource(new Path(file.toURI()));
+        }
+    }
+
+    private static String resolveHadoopConfigDir() {
+        String configured = System.getProperty("doris.hadoop.config.dir");
+        if (!isBlank(configured)) {
+            return configured;
+        }
+        String home = System.getenv("DORIS_HOME");
+        if (isBlank(home)) {
+            home = System.getProperty("doris.home", "");
+        }
+        return home + "/plugins/hadoop_conf/";
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
     }
 
     /**

--- a/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/HmsConfHelper.java
+++ b/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/HmsConfHelper.java
@@ -41,6 +41,8 @@ public final class HmsConfHelper {
     private static final String CONF_METASTORE_CLIENT_TIMEOUT_SECOND = "metastore_client_timeout_second";
     private static final String ENV_METASTORE_CLIENT_TIMEOUT_SECOND =
             "hive_metastore_client_timeout_second";
+    private static final String ENV_HADOOP_CONFIG_DIR = "hadoop_config_dir";
+    private static final String HADOOP_CONFIG_DIR_PROPERTY = "doris.hadoop.config.dir";
 
     private HmsConfHelper() {
     }
@@ -49,6 +51,15 @@ public final class HmsConfHelper {
     public static String metastoreClientTimeoutSecond(ConnectorContext context) {
         return ConnectorConf.get(context, CONF_METASTORE_CLIENT_TIMEOUT_SECOND,
                 ENV_METASTORE_CLIENT_TIMEOUT_SECOND, "10");
+    }
+
+    /** Publishes the FE-global Hadoop resource directory before a connector performs its first HMS lookup. */
+    public static void initializeHadoopConfigDir(ConnectorContext context) {
+        String configured = context.getEnvironment().get(ENV_HADOOP_CONFIG_DIR);
+        if (!isBlank(configured)) {
+            // HMS resource lookup can precede storage binding, so it cannot rely on that lazy path to publish this.
+            System.setProperty(HADOOP_CONFIG_DIR_PROPERTY, configured);
+        }
     }
 
     /**
@@ -156,7 +167,7 @@ public final class HmsConfHelper {
     }
 
     private static String resolveHadoopConfigDir() {
-        String configured = System.getProperty("doris.hadoop.config.dir");
+        String configured = System.getProperty(HADOOP_CONFIG_DIR_PROPERTY);
         if (!isBlank(configured)) {
             return configured;
         }

--- a/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/ThriftHmsClient.java
+++ b/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/ThriftHmsClient.java
@@ -137,7 +137,8 @@ public class ThriftHmsClient implements HmsClient {
     ThriftHmsClient(HmsClientConfig config, AuthAction authAction,
             MetaStoreClientProvider clientProvider,
             HmsTypeMapping.Options typeMappingOptions) {
-        this.hiveConf = HmsConfHelper.createHiveConf(config.getProperties());
+        this.hiveConf = HmsConfHelper.createHiveConfWithResources(
+                config.getConfResources(), config.getProperties());
         this.authAction = authAction != null ? authAction : Callable::call;
         this.clientProvider = clientProvider;
         this.typeMappingOptions = typeMappingOptions;

--- a/fe/fe-connector/fe-connector-hms/src/test/java/org/apache/doris/connector/hms/HmsConfHelperTest.java
+++ b/fe/fe-connector/fe-connector-hms/src/test/java/org/apache/doris/connector/hms/HmsConfHelperTest.java
@@ -17,10 +17,15 @@
 
 package org.apache.doris.connector.hms;
 
+import org.apache.doris.connector.spi.ConnectorContext;
+
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -38,6 +43,9 @@ import java.util.Map;
  * the injection is gated on kerberos, not just that it happens).</p>
  */
 public class HmsConfHelperTest {
+
+    @TempDir
+    Path tempDir;
 
     private static String saslOf(Map<String, String> props) {
         HiveConf conf = HmsConfHelper.createHiveConf(props);
@@ -86,6 +94,26 @@ public class HmsConfHelperTest {
     }
 
     @Test
+    public void explicitSimpleHmsOverridesSaslFromHiveConfResource() throws Exception {
+        Path resource = tempDir.resolve("hive-site.xml");
+        Files.writeString(resource, "<configuration><property>"
+                + "<name>hive.metastore.sasl.enabled</name><value>true</value>"
+                + "</property></configuration>");
+        String previous = System.setProperty("doris.hadoop.config.dir", tempDir + "/");
+        try {
+            HiveConf conf = HmsConfHelper.createHiveConfWithResources(resource.getFileName().toString(),
+                    Map.of("hive.metastore.authentication.type", "simple"));
+            Assertions.assertEquals("false", conf.get("hive.metastore.sasl.enabled"));
+        } finally {
+            if (previous == null) {
+                System.clearProperty("doris.hadoop.config.dir");
+            } else {
+                System.setProperty("doris.hadoop.config.dir", previous);
+            }
+        }
+    }
+
+    @Test
     public void noAuthPropertyDoesNotEnableSasl() {
         Map<String, String> props = new HashMap<>();
         props.put("hive.metastore.uris", "thrift://host:9083");
@@ -114,5 +142,26 @@ public class HmsConfHelperTest {
         Assertions.assertEquals("custom-value", merged.get("some.custom.key"));
         Assertions.assertEquals("thrift://host:9083", merged.get("hive.metastore.uris"));
         Assertions.assertFalse(merged.containsKey("hadoop.username"));
+    }
+
+    @Test
+    public void metastoreTimeoutFallsBackToFeEnvironment() {
+        ConnectorContext context = new ConnectorContext() {
+            @Override
+            public String getCatalogName() {
+                return "test";
+            }
+
+            @Override
+            public long getCatalogId() {
+                return 1L;
+            }
+
+            @Override
+            public Map<String, String> getEnvironment() {
+                return Map.of("hive_metastore_client_timeout_second", "47");
+            }
+        };
+        Assertions.assertEquals("47", HmsConfHelper.metastoreClientTimeoutSecond(context));
     }
 }

--- a/fe/fe-connector/fe-connector-hms/src/test/java/org/apache/doris/connector/hms/HmsConfHelperTest.java
+++ b/fe/fe-connector/fe-connector-hms/src/test/java/org/apache/doris/connector/hms/HmsConfHelperTest.java
@@ -78,6 +78,14 @@ public class HmsConfHelperTest {
     }
 
     @Test
+    public void explicitSimpleHmsOverridesKerberosStorageForSasl() {
+        Map<String, String> props = new HashMap<>();
+        props.put("hive.metastore.authentication.type", "simple");
+        props.put("hadoop.security.authentication", "kerberos");
+        Assertions.assertNotEquals("true", saslOf(props));
+    }
+
+    @Test
     public void noAuthPropertyDoesNotEnableSasl() {
         Map<String, String> props = new HashMap<>();
         props.put("hive.metastore.uris", "thrift://host:9083");
@@ -92,5 +100,19 @@ public class HmsConfHelperTest {
         HiveConf conf = HmsConfHelper.createHiveConf(props);
         Assertions.assertEquals("thrift://host:9083", conf.get("hive.metastore.uris"));
         Assertions.assertEquals("custom-value", conf.get("some.custom.key"));
+    }
+
+    @Test
+    public void canonicalOverridesPreserveUnrelatedKeysAndDropBlankUser() {
+        Map<String, String> raw = new HashMap<>();
+        raw.put("some.custom.key", "custom-value");
+        raw.put("hadoop.username", "  ");
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put("hive.metastore.uris", "thrift://host:9083");
+
+        Map<String, String> merged = HmsConfHelper.mergeCatalogProperties(raw, overrides);
+        Assertions.assertEquals("custom-value", merged.get("some.custom.key"));
+        Assertions.assertEquals("thrift://host:9083", merged.get("hive.metastore.uris"));
+        Assertions.assertFalse(merged.containsKey("hadoop.username"));
     }
 }

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnector.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnector.java
@@ -206,13 +206,8 @@ public class HudiConnector implements Connector {
         // The URI (either spelling) and the pool size were checked when this connector was constructed --
         // HudiCatalogProperties.of throws for a catalog without a metastore URI, so there is nothing left
         // to re-check here.
-        int poolSize = props.getHmsClientPoolSize();
-
-        AbstractHmsMetaStoreProperties hms = (AbstractHmsMetaStoreProperties) MetaStoreProviders.bindForType(
-                HmsClientConfig.METASTORE_TYPE_HMS, properties, Collections.emptyMap());
-        HmsClientConfig config = new HmsClientConfig(hms.getConfResources(),
-                HmsConfHelper.mergeCatalogProperties(properties, hms.toHiveConfOverrides("")),
-                poolSize);
+        HmsClientConfig config = buildHmsClientConfig();
+        int poolSize = config.getPoolSize();
         LOG.info("Creating Hudi connector HMS client for catalog='{}', uri={}, poolSize={}",
                 context.getCatalogName(), config.getMetastoreUri(), poolSize);
 
@@ -233,6 +228,15 @@ public class HudiConnector implements Connector {
             authAction = context::executeAuthenticated;
         }
         return wrapWithCache(new ThriftHmsClient(config, authAction));
+    }
+
+    HmsClientConfig buildHmsClientConfig() {
+        AbstractHmsMetaStoreProperties hms = (AbstractHmsMetaStoreProperties) MetaStoreProviders.bindForType(
+                HmsClientConfig.METASTORE_TYPE_HMS, properties, Collections.emptyMap());
+        // The FE fallback is deployment state, not a catalog property, but the live HiveConf still needs it.
+        return new HmsClientConfig(hms.getConfResources(), HmsConfHelper.mergeCatalogProperties(properties,
+                hms.toHiveConfOverrides(HmsConfHelper.metastoreClientTimeoutSecond(context))),
+                props.getHmsClientPoolSize());
     }
 
     /**

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnector.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnector.java
@@ -77,6 +77,7 @@ public class HudiConnector implements Connector {
     private volatile boolean storageAuthComputed;
 
     public HudiConnector(Map<String, String> properties, ConnectorContext context) {
+        HmsConfHelper.initializeHadoopConfigDir(context);
         this.props = HudiCatalogProperties.of(properties);
         this.properties = props.getRaw();
         this.context = context;

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnector.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnector.java
@@ -20,8 +20,9 @@ package org.apache.doris.connector.hudi;
 import org.apache.doris.connector.hms.CachingHmsClient;
 import org.apache.doris.connector.hms.HmsClient;
 import org.apache.doris.connector.hms.HmsClientConfig;
+import org.apache.doris.connector.hms.HmsConfHelper;
 import org.apache.doris.connector.hms.ThriftHmsClient;
-import org.apache.doris.connector.metastore.HmsMetaStoreProperties;
+import org.apache.doris.connector.metastore.spi.AbstractHmsMetaStoreProperties;
 import org.apache.doris.connector.metastore.spi.MetaStoreProviders;
 import org.apache.doris.connector.spi.Connector;
 import org.apache.doris.connector.spi.ConnectorContext;
@@ -30,6 +31,8 @@ import org.apache.doris.connector.spi.ConnectorSession;
 import org.apache.doris.connector.spi.DorisConnectorException;
 import org.apache.doris.connector.spi.handle.ConnectorTableHandle;
 import org.apache.doris.connector.spi.scan.ConnectorScanPlanProvider;
+import org.apache.doris.kerberos.AuthType;
+import org.apache.doris.kerberos.AuthenticationConfig;
 import org.apache.doris.kerberos.HadoopAuthenticator;
 import org.apache.doris.kerberos.KerberosAuthSpec;
 import org.apache.doris.kerberos.KerberosAuthenticationConfig;
@@ -61,26 +64,17 @@ public class HudiConnector implements Connector {
 
     private static final Logger LOG = LogManager.getLogger(HudiConnector.class);
 
-    // Catalog property key gating the plugin-side Kerberos authenticator (value matches AuthType.KERBEROS).
-    // Deliberately NOT a HudiCatalogProperties field: it is a raw hadoop storage key that buildHadoopConf
-    // below hands to the Configuration wholesale along with every other passthrough key, and what happens
-    // here is a peek at it, not this connector interpreting a property of its own.
-    private static final String HADOOP_SECURITY_AUTHENTICATION = "hadoop.security.authentication";
-
     private final HudiCatalogProperties props;
     private final Map<String, String> properties;
     private final ConnectorContext context;
     private volatile HmsClient hmsClient;
 
-    // Lazily-built plugin-side Kerberos authenticator (single-owner auth), null for a non-Kerberos catalog.
-    // Its doAs acts on the PLUGIN's UserGroupInformation copy — the one this connector's ThriftHmsClient RPC
-    // reads (hadoop + fe-kerberos bundled child-first in the hudi plugin zip) — not the app-loader copy the
-    // FE-injected context would use. Mirrors HiveConnector: after the catalog flip the sibling shares the hms
-    // gateway's context whose executeAuthenticated resolves to NOOP (SIMPLE), which would silently downgrade a
-    // Kerberos HMS. A hudi sibling runs in its OWN classloader, so it must own its authenticator (sharing the
-    // gateway's hive-loader authenticator would split the UGI copy across loaders).
-    private volatile HadoopAuthenticator pluginAuth;
-    private volatile boolean pluginAuthComputed;
+    // HMS and storage deliberately have separate authenticators: hive.metastore.username must affect set_ugi
+    // without changing the UGI used by HoodieTableMetaClient and FileIO.
+    private volatile HadoopAuthenticator hmsAuth;
+    private volatile boolean hmsAuthComputed;
+    private volatile HadoopAuthenticator storageAuth;
+    private volatile boolean storageAuthComputed;
 
     public HudiConnector(Map<String, String> properties, ConnectorContext context) {
         this.props = HudiCatalogProperties.of(properties);
@@ -98,9 +92,9 @@ public class HudiConnector implements Connector {
      * Builds the metaClient execute-wrapper the metadata partition/snapshot methods run their
      * {@code HoodieTableMetaClient}-touching work inside: a TCCL pin to the hudi plugin classloader (so
      * hudi-bundled reflection resolves the plugin's child-first copies) around the plugin UGI {@code doAs}
-     * (Kerberos) — or the FE-injected {@code context.executeAuthenticated} when this is a non-Kerberos
-     * catalog — restoring the previous TCCL in a {@code finally}. Mirrors the {@link #createClient()} auth
-     * choice; the TCCL pin is added because — unlike the HMS thrift RPC ({@code ThriftHmsClient.doAs} pins the
+     * (Kerberos) — or the FE-injected {@code context.executeAuthenticated} when storage is non-Kerberos —
+     * restoring the previous TCCL in a {@code finally}. The storage-specific choice is intentionally separate
+     * from HMS auth; the TCCL pin is added because — unlike the HMS thrift RPC (which pins the
      * system loader) — building a metaClient / listing partitions off the (unpinned) planning thread needs the
      * plugin loader. See {@link HudiMetaClientExecutor} and memory
      * {@code catalog-spi-plugin-tccl-classloader-gotcha}.
@@ -112,7 +106,7 @@ public class HudiConnector implements Connector {
                 ClassLoader previous = Thread.currentThread().getContextClassLoader();
                 Thread.currentThread().setContextClassLoader(HudiConnector.class.getClassLoader());
                 try {
-                    HadoopAuthenticator auth = pluginAuthenticator();
+                    HadoopAuthenticator auth = storageAuthenticator();
                     if (auth != null) {
                         return auth.doAs(action::call);
                     }
@@ -214,16 +208,19 @@ public class HudiConnector implements Connector {
         // to re-check here.
         int poolSize = props.getHmsClientPoolSize();
 
-        HmsClientConfig config = new HmsClientConfig(properties, poolSize);
+        AbstractHmsMetaStoreProperties hms = (AbstractHmsMetaStoreProperties) MetaStoreProviders.bindForType(
+                HmsClientConfig.METASTORE_TYPE_HMS, properties, Collections.emptyMap());
+        HmsClientConfig config = new HmsClientConfig(hms.getConfResources(),
+                HmsConfHelper.mergeCatalogProperties(properties, hms.toHiveConfOverrides("")),
+                poolSize);
         LOG.info("Creating Hudi connector HMS client for catalog='{}', uri={}, poolSize={}",
                 context.getCatalogName(), config.getMetastoreUri(), poolSize);
 
-        // For a Kerberos catalog run the metastore RPC under the PLUGIN's UGI doAs (buildPluginAuthenticator),
-        // NOT the FE-injected context: after the catalog flip that context resolves to NOOP (SIMPLE) auth, which
-        // would silently downgrade a Kerberos HMS. AuthAction.execute is a generic method (<T> T execute(...)),
-        // so it cannot be a lambda — use an anonymous class. ThriftHmsClient.doAs already pins the RPC's TCCL to
-        // the system classloader; the plugin's HadoopAuthenticator only wraps it in a UGI doAs (no TCCL change).
-        HadoopAuthenticator auth = pluginAuthenticator();
+        // HMS SIMPLE and Kerberos both need the plugin's UGI at set_ugi/client-RPC time; the separate storage
+        // authenticator is deliberately not reused because hive.metastore.username is not a FileIO identity.
+        // AuthAction.execute is generic, so it cannot be a lambda. ThriftHmsClient.doAs pins the RPC TCCL; the
+        // plugin authenticator here only adds the UGI doAs.
+        HadoopAuthenticator auth = hmsAuthenticator();
         ThriftHmsClient.AuthAction authAction;
         if (auth != null) {
             authAction = new ThriftHmsClient.AuthAction() {
@@ -253,54 +250,75 @@ public class HudiConnector implements Connector {
     }
 
     /**
-     * Lazily builds and memoizes the plugin-side Kerberos authenticator that {@link #createClient()} wraps the
+     * Lazily builds and memoizes the plugin-side authenticator that {@link #createClient()} wraps the
      * metastore RPC under, so the RPC uses the PLUGIN's own {@code UserGroupInformation} copy (hadoop +
-     * fe-kerberos are bundled child-first in the hudi plugin). Returns {@code null} for a non-Kerberos catalog
-     * so the FE-injected auth path is preserved unchanged. Construction is cheap — the keytab login is lazy in
-     * {@code getUGI()} on the first {@code doAs}. Mirrors {@code HiveConnector.pluginAuthenticator}.
+     * fe-kerberos are bundled child-first in the hudi plugin). Construction is cheap — a keytab login is lazy
+     * in {@code getUGI()} on the first {@code doAs}. Mirrors {@code HiveConnector.pluginAuthenticator}.
      */
-    private HadoopAuthenticator pluginAuthenticator() {
-        if (!pluginAuthComputed) {
+    private HadoopAuthenticator hmsAuthenticator() {
+        if (!hmsAuthComputed) {
             synchronized (this) {
-                if (!pluginAuthComputed) {
-                    pluginAuth = buildPluginAuthenticator(properties);
-                    pluginAuthComputed = true;
+                if (!hmsAuthComputed) {
+                    hmsAuth = buildHmsAuthenticator(properties);
+                    hmsAuthComputed = true;
                 }
             }
         }
-        return pluginAuth;
+        return hmsAuth;
+    }
+
+    private HadoopAuthenticator storageAuthenticator() {
+        if (!storageAuthComputed) {
+            synchronized (this) {
+                if (!storageAuthComputed) {
+                    storageAuth = buildPluginAuthenticator(properties);
+                    storageAuthComputed = true;
+                }
+            }
+        }
+        return storageAuth;
     }
 
     /**
-     * Resolves the plugin-side Kerberos authenticator for the catalog, or {@code null} for a non-Kerberos
-     * catalog. Byte-faithful mirror of {@code HiveConnector.buildPluginAuthenticator} — two Kerberos sources in
-     * precedence order (mirroring the legacy {@code HMSBaseProperties.initHadoopAuthenticator}):
-     * <ol>
-     *   <li><b>Storage</b> Kerberos — the raw {@code hadoop.security.authentication=kerberos} passthrough (HDFS
-     *       login). When storage is Kerberos this single login also carries the HMS metastore RPC (same UGI).</li>
-     *   <li><b>HMS-metastore</b> Kerberos with non-Kerberos storage — a secured Hive Metastore whose data
-     *       storage is simple (e.g. a Kerberized HMS over S3). The HMS client principal/keytab facts
-     *       ({@link HmsMetaStoreProperties#kerberos()}, resolved through the shared metastore-spi parser) feed a
-     *       {@link KerberosAuthenticationConfig}, so the {@code doAs} logs in the same client identity fe-core
-     *       used.</li>
-     * </ol>
-     * Package-visible + static for KDC-free unit testing.
+     * Resolves the plugin-side HMS authenticator. Explicit HMS SIMPLE/KERBEROS wins over storage fallback, so
+     * the metastore identity remains independent from the Hudi data-path identity. Package-visible + static for
+     * KDC-free unit testing.
      */
-    static HadoopAuthenticator buildPluginAuthenticator(Map<String, String> properties) {
-        if ("kerberos".equalsIgnoreCase(properties.get(HADOOP_SECURITY_AUTHENTICATION))) {
-            return HadoopAuthenticator.getHadoopAuthenticator(buildHadoopConf(properties));
-        }
-        HmsMetaStoreProperties hms = (HmsMetaStoreProperties) MetaStoreProviders.bindForType(
-                HmsClientConfig.METASTORE_TYPE_HMS, properties, Collections.emptyMap());
-        Optional<KerberosAuthSpec> spec = hms.kerberos();
-        if (spec.isPresent() && spec.get().hasCredentials()) {
-            Configuration conf = buildHadoopConf(properties);
-            conf.set("hadoop.security.authentication", "kerberos");
-            conf.set("hive.metastore.sasl.enabled", "true");
+    static HadoopAuthenticator buildHmsAuthenticator(Map<String, String> properties) {
+        ClassLoader previous = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(HudiConnector.class.getClassLoader());
+            AbstractHmsMetaStoreProperties hms = (AbstractHmsMetaStoreProperties) MetaStoreProviders.bindForType(
+                    HmsClientConfig.METASTORE_TYPE_HMS, properties, Collections.emptyMap());
+            Optional<KerberosAuthSpec> spec = hms.kerberos();
+            if (spec.isPresent() && spec.get().hasCredentials()) {
+                Configuration conf = buildHmsConf(hms);
+                conf.set("hadoop.security.authentication", "kerberos");
+                conf.set("hive.metastore.sasl.enabled", "true");
+                return HadoopAuthenticator.getHadoopAuthenticator(
+                        new KerberosAuthenticationConfig(
+                                spec.get().getPrincipal(), spec.get().getKeytab(), conf));
+            }
+            if (hms.getAuthType() == AuthType.KERBEROS) {
+                return null;
+            }
+            // HMS set_ugi uses the current UGI; scope this user to the metastore instead of Hudi FileIO.
             return HadoopAuthenticator.getHadoopAuthenticator(
-                    new KerberosAuthenticationConfig(spec.get().getPrincipal(), spec.get().getKeytab(), conf));
+                    AuthenticationConfig.getSimpleAuthenticationConfig(buildHmsConf(hms)));
+        } finally {
+            Thread.currentThread().setContextClassLoader(previous);
         }
-        return null;
+    }
+
+    /** Resolves only the storage Kerberos identity used by Hudi metadata and file operations. */
+    static HadoopAuthenticator buildPluginAuthenticator(Map<String, String> properties) {
+        if (!"kerberos".equalsIgnoreCase(properties.get("hadoop.security.authentication"))) {
+            return null;
+        }
+        Configuration conf = new Configuration();
+        conf.setClassLoader(HudiConnector.class.getClassLoader());
+        properties.forEach(conf::set);
+        return HadoopAuthenticator.getHadoopAuthenticator(conf);
     }
 
     /**
@@ -309,11 +327,8 @@ public class HudiConnector implements Connector {
      * hadoop-mapreduce onto the unit-test classpath. The classloader is pinned to the plugin loader so the
      * child-first (plugin) copy of the auth classes is resolved. Mirrors {@code HiveConnector.buildHadoopConf}.
      */
-    private static Configuration buildHadoopConf(Map<String, String> properties) {
-        Configuration conf = new Configuration();
-        conf.setClassLoader(HudiConnector.class.getClassLoader());
-        properties.forEach(conf::set);
-        return conf;
+    private static Configuration buildHmsConf(AbstractHmsMetaStoreProperties hms) {
+        return HmsConfHelper.createHadoopConfWithResources(hms.getConfResources(), hms.toHiveConfOverrides(""));
     }
 
     @Override

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiConnectorPluginAuthenticatorTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiConnectorPluginAuthenticatorTest.java
@@ -26,15 +26,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Unit tests for {@link HudiConnector#buildPluginAuthenticator(Map)} — the connector-owned plugin-side Kerberos
- * authenticator resolution for the hudi sibling. Mirrors {@code HiveConnectorPluginAuthenticatorTest}.
+ * Unit tests for Hudi's separate storage and HMS authenticator resolution.
  *
  * <p>The load-bearing case is <b>HMS-metastore Kerberos with simple (non-Kerberos) storage</b> (e.g. a
  * Kerberized Hive Metastore over S3). After the catalog flip the hudi sibling shares the hms gateway's
  * FE-injected {@code ConnectorContext}, whose {@code executeAuthenticated} resolves to NOOP (SIMPLE) auth, so a
  * Kerberos HMS would be silently downgraded unless the connector owns the login itself. A hudi sibling runs in
  * its OWN classloader, so it must build its OWN authenticator (sharing the gateway's hive-loader authenticator
- * would split the UGI copy across loaders).
+ * would split the UGI copy across loaders). SIMPLE cases pin the user sent by HMS {@code set_ugi}.
  *
  * <p>The actual keytab login is lazy (on first {@code doAs}), so these assertions never touch a KDC.
  */
@@ -67,7 +66,7 @@ public class HudiConnectorPluginAuthenticatorTest {
      */
     @Test
     public void hmsMetastoreKerberosWithSimpleStorageBuildsAuthenticator() {
-        HadoopAuthenticator auth = HudiConnector.buildPluginAuthenticator(
+        HadoopAuthenticator auth = HudiConnector.buildHmsAuthenticator(
                 props("hive.metastore.uris", "thrift://hms:9083",
                         "hive.metastore.authentication.type", "kerberos",
                         "hive.metastore.client.principal", "doris@EXAMPLE.COM",
@@ -76,21 +75,34 @@ public class HudiConnectorPluginAuthenticatorTest {
                 "HMS-metastore kerberos with simple storage must yield a plugin authenticator");
     }
 
-    /** A simple-auth HMS builds no authenticator (a spurious one would force needless SIMPLE-vs-Kerberos churn). */
+    /** A simple-auth HMS needs a UGI because HiveMetaStoreClient sends the current user in set_ugi. */
     @Test
-    public void hmsSimpleAuthReturnsNull() {
-        HadoopAuthenticator auth = HudiConnector.buildPluginAuthenticator(
+    public void hmsSimpleAuthUsesConfiguredUser() throws Exception {
+        HadoopAuthenticator auth = HudiConnector.buildHmsAuthenticator(
                 props("hive.metastore.uris", "thrift://hms:9083",
-                        "hive.metastore.authentication.type", "simple"));
-        Assertions.assertNull(auth, "simple-auth HMS must not build a plugin authenticator");
+                        "hive.metastore.authentication.type", "simple",
+                        "hive.metastore.username", "hudi-hms-user"));
+        Assertions.assertEquals("hudi-hms-user", auth.getUGI().getUserName());
     }
 
-    /** A plain HMS with no auth configured builds no authenticator. */
+    /** A plain HMS preserves the legacy simple-auth default. */
     @Test
-    public void plainHmsWithoutKerberosReturnsNull() {
-        HadoopAuthenticator auth = HudiConnector.buildPluginAuthenticator(
+    public void plainHmsUsesLegacyDefaultUser() throws Exception {
+        HadoopAuthenticator auth = HudiConnector.buildHmsAuthenticator(
                 props("hive.metastore.uris", "thrift://hms:9083"));
-        Assertions.assertNull(auth, "plain HMS without kerberos must not build an authenticator");
+        Assertions.assertEquals("hadoop", auth.getUGI().getUserName());
+    }
+
+    @Test
+    public void explicitSimpleHmsWinsOverKerberosStorage() throws Exception {
+        HadoopAuthenticator auth = HudiConnector.buildHmsAuthenticator(
+                props("hive.metastore.uris", "thrift://hms:9083",
+                        "hive.metastore.authentication.type", "simple",
+                        "hive.metastore.username", "hudi-hms-user",
+                        "hadoop.security.authentication", "kerberos",
+                        "hadoop.kerberos.principal", "storage@EXAMPLE.COM",
+                        "hadoop.kerberos.keytab", "/etc/security/storage.keytab"));
+        Assertions.assertEquals("hudi-hms-user", auth.getUGI().getUserName());
     }
 
     /**
@@ -99,7 +111,7 @@ public class HudiConnectorPluginAuthenticatorTest {
      */
     @Test
     public void hmsKerberosWithBlankCredsReturnsNull() {
-        HadoopAuthenticator auth = HudiConnector.buildPluginAuthenticator(
+        HadoopAuthenticator auth = HudiConnector.buildHmsAuthenticator(
                 props("hive.metastore.uris", "thrift://hms:9083",
                         "hive.metastore.authentication.type", "kerberos"));
         Assertions.assertNull(auth, "kerberos HMS without a client principal/keytab pair must not build one");

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiConnectorPluginAuthenticatorTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiConnectorPluginAuthenticatorTest.java
@@ -22,7 +22,10 @@ import org.apache.doris.kerberos.HadoopAuthenticator;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,6 +42,9 @@ import java.util.Map;
  * <p>The actual keytab login is lazy (on first {@code doAs}), so these assertions never touch a KDC.
  */
 public class HudiConnectorPluginAuthenticatorTest {
+
+    @TempDir
+    Path tempDir;
 
     private static Map<String, String> props(String... kv) {
         Map<String, String> m = new HashMap<>();
@@ -139,5 +145,45 @@ public class HudiConnectorPluginAuthenticatorTest {
         HudiConnector connector = new HudiConnector(HudiTestProperties.minimalMap(), context);
         Assertions.assertEquals("47", connector.buildHmsClientConfig().getProperties()
                 .get("hive.metastore.client.socket.timeout"));
+    }
+
+    @Test
+    public void firstConnectorInitializesConfiguredHadoopResourceDirectory() throws Exception {
+        Path resource = tempDir.resolve("hive-site.xml");
+        Files.writeString(resource, "<configuration><property><name>hadoop.username</name>"
+                + "<value>first-hudi-user</value></property></configuration>");
+        Map<String, String> properties = props(
+                "hive.metastore.uris", "thrift://hms:9083",
+                "hive.metastore.authentication.type", "simple",
+                "hive.conf.resources", resource.getFileName().toString());
+        ConnectorContext context = new ConnectorContext() {
+            @Override
+            public String getCatalogName() {
+                return "test";
+            }
+
+            @Override
+            public long getCatalogId() {
+                return 1L;
+            }
+
+            @Override
+            public Map<String, String> getEnvironment() {
+                return Map.of("hadoop_config_dir", tempDir.toString());
+            }
+        };
+        String previous = System.getProperty("doris.hadoop.config.dir");
+        System.clearProperty("doris.hadoop.config.dir");
+        try {
+            new HudiConnector(properties, context);
+            Assertions.assertEquals("first-hudi-user",
+                    HudiConnector.buildHmsAuthenticator(properties).getUGI().getUserName());
+        } finally {
+            if (previous == null) {
+                System.clearProperty("doris.hadoop.config.dir");
+            } else {
+                System.setProperty("doris.hadoop.config.dir", previous);
+            }
+        }
     }
 }

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiConnectorPluginAuthenticatorTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiConnectorPluginAuthenticatorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.connector.hudi;
 
+import org.apache.doris.connector.spi.ConnectorContext;
 import org.apache.doris.kerberos.HadoopAuthenticator;
 
 import org.junit.jupiter.api.Assertions;
@@ -115,5 +116,28 @@ public class HudiConnectorPluginAuthenticatorTest {
                 props("hive.metastore.uris", "thrift://hms:9083",
                         "hive.metastore.authentication.type", "kerberos"));
         Assertions.assertNull(auth, "kerberos HMS without a client principal/keytab pair must not build one");
+    }
+
+    @Test
+    public void hmsClientUsesFeConfiguredSocketTimeout() {
+        ConnectorContext context = new ConnectorContext() {
+            @Override
+            public String getCatalogName() {
+                return "test";
+            }
+
+            @Override
+            public long getCatalogId() {
+                return 1L;
+            }
+
+            @Override
+            public Map<String, String> getEnvironment() {
+                return Map.of("hive_metastore_client_timeout_second", "47");
+            }
+        };
+        HudiConnector connector = new HudiConnector(HudiTestProperties.minimalMap(), context);
+        Assertions.assertEquals("47", connector.buildHmsClientConfig().getProperties()
+                .get("hive.metastore.client.socket.timeout"));
     }
 }

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnector.java
@@ -990,7 +990,10 @@ public class IcebergConnector implements Connector {
     static String appendHmsCacheKeys(String existing) {
         String keys = appendCacheKey(existing, "conf:hadoop.username");
         keys = appendCacheKey(keys, "conf:hive.metastore.client.principal");
-        return appendCacheKey(keys, "conf:hadoop.kerberos.principal");
+        keys = appendCacheKey(keys, "conf:hive.metastore.kerberos.principal");
+        keys = appendCacheKey(keys, "conf:hadoop.kerberos.principal");
+        // Both settings are captured by the JVM-static SDK pool and must distinguish ALTER CATALOG generations.
+        return appendCacheKey(keys, "conf:hive.metastore.sasl.enabled");
     }
 
     static String appendCacheKey(String existing, String required) {

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnector.java
@@ -18,7 +18,6 @@
 package org.apache.doris.connector.iceberg;
 
 import org.apache.doris.connector.cache.ConnectorMetadataCache;
-import org.apache.doris.connector.metastore.HmsMetaStoreProperties;
 import org.apache.doris.connector.metastore.iceberg.jdbc.IcebergJdbcMetaStoreProperties;
 import org.apache.doris.connector.metastore.iceberg.rest.IcebergRestMetaStoreProperties;
 import org.apache.doris.connector.metastore.spi.AbstractHmsMetaStoreProperties;
@@ -41,6 +40,8 @@ import org.apache.doris.connector.spi.scan.ConnectorScanPlanProvider;
 import org.apache.doris.connector.spi.write.ConnectorWritePlanProvider;
 import org.apache.doris.filesystem.properties.S3CompatibleFileSystemProperties;
 import org.apache.doris.filesystem.properties.StorageProperties;
+import org.apache.doris.kerberos.AuthType;
+import org.apache.doris.kerberos.AuthenticationConfig;
 import org.apache.doris.kerberos.HadoopAuthenticator;
 import org.apache.doris.kerberos.KerberosAuthSpec;
 import org.apache.doris.kerberos.KerberosAuthenticationConfig;
@@ -941,6 +942,10 @@ public class IcebergConnector implements Connector {
                 conf = IcebergCatalogFactory.assembleHiveConf(
                         hms.getConfResources(),
                         hms.toHiveConfOverrides(IcebergConf.metastoreClientTimeoutSecond(context)));
+                // The SDK cache is JVM-static and URI-only by default. Use configuration-derived identities
+                // instead of the current UGI so catalog/FileIO construction can stay under the storage user.
+                catalogOptions.put("client-pool-cache-keys", appendHmsCacheKeys(
+                        catalogOptions.get("client-pool-cache-keys")));
                 break;
             }
             case IcebergCatalogProperties.TYPE_GLUE:
@@ -969,8 +974,32 @@ public class IcebergConnector implements Connector {
 
         LOG.info("Creating Iceberg catalog '{}' flavor='{}' impl='{}'",
                 catalogName, flavor, catalogOptions.get(CatalogProperties.CATALOG_IMPL));
-        return buildCatalogAuthenticated(flavor,
-                () -> CatalogUtil.buildIcebergCatalog(catalogName, catalogOptions, conf));
+        return buildCatalogAuthenticated(flavor, () -> {
+            if (!IcebergCatalogProperties.TYPE_HMS.equals(flavor)) {
+                return CatalogUtil.buildIcebergCatalog(catalogName, catalogOptions, conf);
+            }
+            HadoopAuthenticator hmsAuth = buildHmsAuthenticator(properties, storageHadoopConfig);
+            Catalog catalog = CatalogUtil.buildIcebergCatalog(catalogName, catalogOptions, conf);
+            return IcebergHmsClientPool.install(catalog, hmsAuth);
+        });
+    }
+
+    static String appendHmsCacheKeys(String existing) {
+        String keys = appendCacheKey(existing, "conf:hadoop.username");
+        keys = appendCacheKey(keys, "conf:hive.metastore.client.principal");
+        return appendCacheKey(keys, "conf:hadoop.kerberos.principal");
+    }
+
+    static String appendCacheKey(String existing, String required) {
+        if (StringUtils.isBlank(existing)) {
+            return required;
+        }
+        for (String element : existing.split(",")) {
+            if (required.equalsIgnoreCase(element.trim())) {
+                return existing;
+            }
+        }
+        return existing + "," + required;
     }
 
     /**
@@ -1248,22 +1277,8 @@ public class IcebergConnector implements Connector {
     }
 
     /**
-     * Resolves the plugin-side Kerberos authenticator for the catalog, or {@code null} for a non-Kerberos
-     * catalog. Two Kerberos sources are covered, in precedence order:
-     * <ol>
-     *   <li><b>Storage</b> Kerberos — the raw {@code hadoop.security.authentication=kerberos} passthrough
-     *       (HDFS / data-lake login), built from the storage Hadoop configuration. Unchanged prior behavior;
-     *       when storage is Kerberos this single login also carries the HMS metastore RPC (same UGI).</li>
-     *   <li><b>HMS-metastore</b> Kerberos with non-Kerberos storage — a secured Hive Metastore whose data
-     *       storage is simple (e.g. a Kerberized HMS over S3). Legacy fe-core served this from the fe-core
-     *       {@code IcebergHMSMetaStoreProperties} HMS authenticator (delivered via {@code DefaultConnectorContext});
-     *       once the fe-core iceberg property cluster is deleted the connector must own it. This mirrors
-     *       {@code HMSBaseProperties.initHadoopAuthenticator}: the HMS client principal/keytab facts
-     *       ({@link HmsMetaStoreProperties#kerberos()}) feed a {@link KerberosAuthenticationConfig}, so the
-     *       {@code doAs} logs in the same client identity fe-core used. The HMS <em>service</em> principal /
-     *       SASL settings ride the catalog's own HiveConf ({@code hms.toHiveConfOverrides}), not the login.</li>
-     * </ol>
-     * Package-visible + static for direct unit testing (mirrors the {@code metaFailureMessage} helpers).
+     * Resolves only the storage-side Kerberos authenticator used by FileIO. HMS authentication is intentionally
+     * resolved separately by {@link #buildHmsAuthenticator} and applied at the client-pool boundary.
      */
     static HadoopAuthenticator buildPluginAuthenticator(Map<String, String> properties,
             Map<String, String> storageHadoopConfig) {
@@ -1271,20 +1286,31 @@ public class IcebergConnector implements Connector {
             return HadoopAuthenticator.getHadoopAuthenticator(
                     IcebergCatalogFactory.buildHadoopConfiguration(properties, storageHadoopConfig));
         }
-        if (IcebergCatalogProperties.TYPE_HMS.equals(IcebergCatalogProperties.of(properties).getFlavor())) {
-            HmsMetaStoreProperties hms = (HmsMetaStoreProperties) MetaStoreProviders.bindForType(
-                    IcebergCatalogProperties.TYPE_HMS, properties, storageHadoopConfig);
-            Optional<KerberosAuthSpec> spec = hms.kerberos();
-            if (spec.isPresent() && spec.get().hasCredentials()) {
-                Configuration conf =
-                        IcebergCatalogFactory.buildHadoopConfiguration(properties, storageHadoopConfig);
-                conf.set("hadoop.security.authentication", "kerberos");
-                conf.set("hive.metastore.sasl.enabled", "true");
-                return HadoopAuthenticator.getHadoopAuthenticator(
-                        new KerberosAuthenticationConfig(spec.get().getPrincipal(), spec.get().getKeytab(), conf));
-            }
-        }
         return null;
+    }
+
+    static HadoopAuthenticator buildHmsAuthenticator(Map<String, String> properties,
+            Map<String, String> storageHadoopConfig) {
+        if (!IcebergCatalogProperties.TYPE_HMS.equals(IcebergCatalogProperties.of(properties).getFlavor())) {
+            return null;
+        }
+        AbstractHmsMetaStoreProperties hms = (AbstractHmsMetaStoreProperties) MetaStoreProviders.bindForType(
+                IcebergCatalogProperties.TYPE_HMS, properties, storageHadoopConfig);
+        Optional<KerberosAuthSpec> spec = hms.kerberos();
+        if (spec.isPresent() && spec.get().hasCredentials()) {
+            Configuration conf = IcebergCatalogFactory.assembleHiveConf(
+                    hms.getConfResources(), hms.toHiveConfOverrides(""));
+            conf.set("hadoop.security.authentication", "kerberos");
+            conf.set("hive.metastore.sasl.enabled", "true");
+            return HadoopAuthenticator.getHadoopAuthenticator(
+                    new KerberosAuthenticationConfig(spec.get().getPrincipal(), spec.get().getKeytab(), conf));
+        }
+        if (hms.getAuthType() == AuthType.KERBEROS) {
+            return null;
+        }
+        Configuration conf = IcebergCatalogFactory.assembleHiveConf(
+                hms.getConfResources(), hms.toHiveConfOverrides(""));
+        return HadoopAuthenticator.getHadoopAuthenticator(AuthenticationConfig.getSimpleAuthenticationConfig(conf));
     }
 
     private Catalog buildCatalogAuthenticated(String flavor, Callable<Catalog> builder) {

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnector.java
@@ -56,6 +56,8 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.ViewCatalog;
+import org.apache.iceberg.hive.HiveCatalog;
+import org.apache.iceberg.hive.HiveHadoopUtil;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.rest.RESTSessionCatalog;
@@ -979,6 +981,7 @@ public class IcebergConnector implements Connector {
                 return CatalogUtil.buildIcebergCatalog(catalogName, catalogOptions, conf);
             }
             HadoopAuthenticator hmsAuth = buildHmsAuthenticator(properties, storageHadoopConfig);
+            applyHmsTableOwner(catalogOptions, hmsAuth);
             Catalog catalog = CatalogUtil.buildIcebergCatalog(catalogName, catalogOptions, conf);
             return IcebergHmsClientPool.install(catalog, hmsAuth);
         });
@@ -995,11 +998,21 @@ public class IcebergConnector implements Connector {
             return required;
         }
         for (String element : existing.split(",")) {
-            if (required.equalsIgnoreCase(element.trim())) {
+            if (sameCacheKey(required, element.trim())) {
                 return existing;
             }
         }
         return existing + "," + required;
+    }
+
+    private static boolean sameCacheKey(String required, String existing) {
+        String prefix = "conf:";
+        if (required.regionMatches(true, 0, prefix, 0, prefix.length())
+                && existing.regionMatches(true, 0, prefix, 0, prefix.length())) {
+            // Iceberg accepts a case-insensitive marker, but Configuration property names remain case-sensitive.
+            return required.substring(prefix.length()).equals(existing.substring(prefix.length()));
+        }
+        return required.equalsIgnoreCase(existing);
     }
 
     /**
@@ -1311,6 +1324,18 @@ public class IcebergConnector implements Connector {
         Configuration conf = IcebergCatalogFactory.assembleHiveConf(
                 hms.getConfResources(), hms.toHiveConfOverrides(""));
         return HadoopAuthenticator.getHadoopAuthenticator(AuthenticationConfig.getSimpleAuthenticationConfig(conf));
+    }
+
+    static void applyHmsTableOwner(Map<String, String> catalogOptions,
+            HadoopAuthenticator hmsAuth) throws Exception {
+        if (hmsAuth == null || catalogOptions.containsKey(HiveCatalog.HMS_TABLE_OWNER)) {
+            return;
+        }
+        // Iceberg computes this default before entering its client pool, so capture it at the HMS boundary.
+        String owner = hmsAuth.doAs(HiveHadoopUtil::currentUser);
+        if (StringUtils.isNotBlank(owner)) {
+            catalogOptions.put(HiveCatalog.HMS_TABLE_OWNER, owner);
+        }
     }
 
     private Catalog buildCatalogAuthenticated(String flavor, Callable<Catalog> builder) {

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergHmsClientPool.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergHmsClientPool.java
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.iceberg;
+
+import org.apache.doris.connector.spi.DorisConnectorException;
+import org.apache.doris.kerberos.HadoopAuthenticator;
+
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.iceberg.ClientPool;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.hive.HiveCatalog;
+import org.apache.thrift.TException;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Field;
+import java.security.PrivilegedAction;
+
+/** Applies the HMS identity at Iceberg's metastore client acquisition and RPC boundary. */
+final class IcebergHmsClientPool implements ClientPool<IMetaStoreClient, TException> {
+
+    private final ClientPool<IMetaStoreClient, TException> delegate;
+    private final HadoopAuthenticator authenticator;
+
+    private IcebergHmsClientPool(ClientPool<IMetaStoreClient, TException> delegate,
+            HadoopAuthenticator authenticator) {
+        this.delegate = delegate;
+        this.authenticator = authenticator;
+    }
+
+    static ClientPool<IMetaStoreClient, TException> wrap(
+            ClientPool<IMetaStoreClient, TException> delegate, HadoopAuthenticator authenticator) {
+        return new IcebergHmsClientPool(delegate, authenticator);
+    }
+
+    static Catalog install(Catalog catalog, HadoopAuthenticator authenticator) {
+        if (authenticator == null) {
+            return catalog;
+        }
+        if (!(catalog instanceof HiveCatalog)) {
+            throw new DorisConnectorException("Expected an Iceberg HiveCatalog for HMS authentication");
+        }
+        try {
+            Field clients = HiveCatalog.class.getDeclaredField("clients");
+            clients.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            ClientPool<IMetaStoreClient, TException> delegate =
+                    (ClientPool<IMetaStoreClient, TException>) clients.get(catalog);
+            // HiveCatalog has no public pool injection point; replacing only this field keeps FileIO under the
+            // storage UGI while every lazy HMS client creation and RPC runs under the metastore UGI.
+            clients.set(catalog, wrap(delegate, authenticator));
+            return catalog;
+        } catch (ReflectiveOperationException e) {
+            throw new DorisConnectorException("Failed to install Iceberg HMS authentication boundary", e);
+        }
+    }
+
+    @Override
+    public <R> R run(Action<R, IMetaStoreClient, TException> action) throws TException, InterruptedException {
+        return run(action, false);
+    }
+
+    @Override
+    public <R> R run(Action<R, IMetaStoreClient, TException> action, boolean retry)
+            throws TException, InterruptedException {
+        try {
+            return authenticator.getUGI().doAs(
+                    (PrivilegedAction<R>) () -> runUnchecked(action, retry));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to execute an Iceberg HMS operation", e);
+        } catch (ClientPoolException e) {
+            throw (TException) e.getCause();
+        } catch (ClientPoolInterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw (InterruptedException) e.getCause();
+        }
+    }
+
+    private <R> R runUnchecked(Action<R, IMetaStoreClient, TException> action, boolean retry) {
+        try {
+            return delegate.run(action, retry);
+        } catch (TException e) {
+            throw new ClientPoolException(e);
+        } catch (InterruptedException e) {
+            throw new ClientPoolInterruptedException(e);
+        }
+    }
+
+    private static final class ClientPoolException extends RuntimeException {
+        private ClientPoolException(TException cause) {
+            super(cause);
+        }
+    }
+
+    private static final class ClientPoolInterruptedException extends RuntimeException {
+        private ClientPoolInterruptedException(InterruptedException cause) {
+            super(cause);
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergConnectorPluginAuthenticatorTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergConnectorPluginAuthenticatorTest.java
@@ -21,10 +21,12 @@ import org.apache.doris.kerberos.HadoopAuthenticator;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.iceberg.hive.CachedClientPool;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -110,10 +112,14 @@ public class IcebergConnectorPluginAuthenticatorTest {
     @Test
     public void hmsIdentitiesAreIncludedInClientPoolCacheKey() {
         Assertions.assertEquals(
-                "ugi,conf:hadoop.username,conf:hive.metastore.client.principal,conf:hadoop.kerberos.principal",
+                "ugi,conf:hadoop.username,conf:hive.metastore.client.principal,"
+                        + "conf:hive.metastore.kerberos.principal,conf:hadoop.kerberos.principal,"
+                        + "conf:hive.metastore.sasl.enabled",
                 IcebergConnector.appendHmsCacheKeys("ugi"));
         Assertions.assertEquals(
-                "conf:hadoop.username,conf:hive.metastore.client.principal,conf:hadoop.kerberos.principal",
+                "conf:hadoop.username,conf:hive.metastore.client.principal,"
+                        + "conf:hive.metastore.kerberos.principal,conf:hadoop.kerberos.principal,"
+                        + "conf:hive.metastore.sasl.enabled",
                 IcebergConnector.appendHmsCacheKeys("conf:hadoop.username"));
     }
 
@@ -121,8 +127,33 @@ public class IcebergConnectorPluginAuthenticatorTest {
     public void hmsCacheKeyPreservesCaseSensitiveConfigurationNames() {
         Assertions.assertEquals(
                 "conf:HADOOP.USERNAME,conf:hadoop.username,conf:hive.metastore.client.principal,"
-                        + "conf:hadoop.kerberos.principal",
+                        + "conf:hive.metastore.kerberos.principal,conf:hadoop.kerberos.principal,"
+                        + "conf:hive.metastore.sasl.enabled",
                 IcebergConnector.appendHmsCacheKeys("conf:HADOOP.USERNAME"));
+    }
+
+    @Test
+    public void transportChangesProduceDifferentSdkPoolKeys() throws Exception {
+        Configuration first = poolConf("service-a/_HOST@REALM", false);
+        Assertions.assertNotEquals(icebergPoolKey(first),
+                icebergPoolKey(poolConf("service-b/_HOST@REALM", false)));
+        Assertions.assertNotEquals(icebergPoolKey(first),
+                icebergPoolKey(poolConf("service-a/_HOST@REALM", true)));
+    }
+
+    private static Configuration poolConf(String servicePrincipal, boolean sasl) {
+        Configuration conf = new Configuration(false);
+        conf.set("hive.metastore.uris", "thrift://hms:9083");
+        conf.set("hive.metastore.kerberos.principal", servicePrincipal);
+        conf.setBoolean("hive.metastore.sasl.enabled", sasl);
+        return conf;
+    }
+
+    private static Object icebergPoolKey(Configuration conf) throws Exception {
+        Method extractKey = CachedClientPool.class.getDeclaredMethod(
+                "extractKey", String.class, Configuration.class);
+        extractKey.setAccessible(true);
+        return extractKey.invoke(null, IcebergConnector.appendHmsCacheKeys(null), conf);
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergConnectorPluginAuthenticatorTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergConnectorPluginAuthenticatorTest.java
@@ -19,6 +19,9 @@ package org.apache.doris.connector.iceberg;
 
 import org.apache.doris.kerberos.HadoopAuthenticator;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.iceberg.hive.HiveCatalog;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -112,6 +115,38 @@ public class IcebergConnectorPluginAuthenticatorTest {
         Assertions.assertEquals(
                 "conf:hadoop.username,conf:hive.metastore.client.principal,conf:hadoop.kerberos.principal",
                 IcebergConnector.appendHmsCacheKeys("conf:hadoop.username"));
+    }
+
+    @Test
+    public void hmsCacheKeyPreservesCaseSensitiveConfigurationNames() {
+        Assertions.assertEquals(
+                "conf:HADOOP.USERNAME,conf:hadoop.username,conf:hive.metastore.client.principal,"
+                        + "conf:hadoop.kerberos.principal",
+                IcebergConnector.appendHmsCacheKeys("conf:HADOOP.USERNAME"));
+    }
+
+    @Test
+    public void defaultTableOwnerIsResolvedUnderHmsIdentityOnly() throws Exception {
+        HadoopAuthenticator hmsAuth = IcebergConnector.buildHmsAuthenticator(
+                props("iceberg.catalog.type", "hms",
+                        "hive.metastore.uris", "thrift://hms:9083",
+                        "hive.metastore.authentication.type", "simple",
+                        "hive.metastore.username", "iceberg-hms-user"),
+                new HashMap<>());
+        Configuration storageConf = new Configuration(false);
+        storageConf.set("hadoop.username", "iceberg-storage-user");
+        HadoopAuthenticator storageAuth = HadoopAuthenticator.getHadoopAuthenticator(
+                org.apache.doris.kerberos.AuthenticationConfig.getSimpleAuthenticationConfig(storageConf));
+        Map<String, String> options = new HashMap<>();
+
+        storageAuth.doAs(() -> {
+            IcebergConnector.applyHmsTableOwner(options, hmsAuth);
+            Assertions.assertEquals("iceberg-storage-user",
+                    UserGroupInformation.getCurrentUser().getUserName());
+            return null;
+        });
+
+        Assertions.assertEquals("iceberg-hms-user", options.get(HiveCatalog.HMS_TABLE_OWNER));
     }
 
     /** A non-HMS flavor with no storage Kerberos builds no authenticator. */

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergConnectorPluginAuthenticatorTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergConnectorPluginAuthenticatorTest.java
@@ -26,16 +26,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Unit tests for {@link IcebergConnector#buildPluginAuthenticator(Map, Map)} — the connector-owned
- * plugin-side Kerberos authenticator resolution.
+ * Unit tests for Iceberg's separate storage and HMS authenticator resolution.
  *
  * <p>The load-bearing case is <b>HMS-metastore Kerberos with simple (non-Kerberos) storage</b>
  * (e.g. a Kerberized Hive Metastore over S3). Before the fe-core iceberg property cluster is deleted
  * that login was served fe-core-side by
  * {@code IcebergHMSMetaStoreProperties -> HadoopExecutionAuthenticator(hmsBaseProperties.getHmsAuthenticator())}
  * and delivered via {@code DefaultConnectorContext}; the connector must own it once that cluster is gone.
- * These tests pin that the connector builds a plugin authenticator from the HMS client principal/keytab
- * facts, and does NOT build one when the metastore is simple-auth (which would silently force SIMPLE auth).
+ * These tests pin that the connector resolves both Kerberos and SIMPLE identities for the HMS client-pool
+ * boundary without replacing the storage authenticator used by FileIO.
  *
  * <p>The actual keytab login is lazy (on first {@code doAs}), so these assertions never touch a KDC.
  */
@@ -68,7 +67,7 @@ public class IcebergConnectorPluginAuthenticatorTest {
      */
     @Test
     public void hmsMetastoreKerberosWithSimpleStorageBuildsAuthenticator() {
-        HadoopAuthenticator auth = IcebergConnector.buildPluginAuthenticator(
+        HadoopAuthenticator auth = IcebergConnector.buildHmsAuthenticator(
                 props("iceberg.catalog.type", "hms",
                         "hive.metastore.uris", "thrift://hms:9083",
                         "hive.metastore.authentication.type", "kerberos",
@@ -79,15 +78,40 @@ public class IcebergConnectorPluginAuthenticatorTest {
                 "HMS-metastore kerberos with simple storage must yield a plugin authenticator");
     }
 
-    /** A simple-auth HMS builds no authenticator (a spurious one would force needless SIMPLE-vs-Kerberos churn). */
+    /** HMS auth is resolved separately so it can be applied only at the HMS client-pool boundary. */
     @Test
-    public void hmsSimpleAuthReturnsNull() {
-        HadoopAuthenticator auth = IcebergConnector.buildPluginAuthenticator(
+    public void hmsSimpleAuthUsesConfiguredUser() throws Exception {
+        HadoopAuthenticator auth = IcebergConnector.buildHmsAuthenticator(
                 props("iceberg.catalog.type", "hms",
                         "hive.metastore.uris", "thrift://hms:9083",
-                        "hive.metastore.authentication.type", "simple"),
+                        "hive.metastore.authentication.type", "simple",
+                        "hive.metastore.username", "iceberg-hms-user"),
                 new HashMap<>());
-        Assertions.assertNull(auth, "simple-auth HMS must not build a plugin authenticator");
+        Assertions.assertEquals("iceberg-hms-user", auth.getUGI().getUserName());
+    }
+
+    @Test
+    public void explicitSimpleHmsKeepsItsUserWithKerberosStorage() throws Exception {
+        HadoopAuthenticator auth = IcebergConnector.buildHmsAuthenticator(
+                props("iceberg.catalog.type", "hms",
+                        "hive.metastore.uris", "thrift://hms:9083",
+                        "hive.metastore.authentication.type", "simple",
+                        "hive.metastore.username", "iceberg-hms-user",
+                        "hadoop.security.authentication", "kerberos",
+                        "hadoop.kerberos.principal", "storage@EXAMPLE.COM",
+                        "hadoop.kerberos.keytab", "/etc/security/storage.keytab"),
+                new HashMap<>());
+        Assertions.assertEquals("iceberg-hms-user", auth.getUGI().getUserName());
+    }
+
+    @Test
+    public void hmsIdentitiesAreIncludedInClientPoolCacheKey() {
+        Assertions.assertEquals(
+                "ugi,conf:hadoop.username,conf:hive.metastore.client.principal,conf:hadoop.kerberos.principal",
+                IcebergConnector.appendHmsCacheKeys("ugi"));
+        Assertions.assertEquals(
+                "conf:hadoop.username,conf:hive.metastore.client.principal,conf:hadoop.kerberos.principal",
+                IcebergConnector.appendHmsCacheKeys("conf:hadoop.username"));
     }
 
     /** A non-HMS flavor with no storage Kerberos builds no authenticator. */
@@ -106,7 +130,7 @@ public class IcebergConnectorPluginAuthenticatorTest {
      */
     @Test
     public void hmsKerberosWithBlankCredsReturnsNull() {
-        HadoopAuthenticator auth = IcebergConnector.buildPluginAuthenticator(
+        HadoopAuthenticator auth = IcebergConnector.buildHmsAuthenticator(
                 props("iceberg.catalog.type", "hms",
                         "hive.metastore.uris", "thrift://hms:9083",
                         "hive.metastore.authentication.type", "kerberos"),

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergHmsClientPoolTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergHmsClientPoolTest.java
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.iceberg;
+
+import org.apache.doris.kerberos.HadoopAuthenticator;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.iceberg.ClientPool;
+import org.apache.thrift.TException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+public class IcebergHmsClientPoolTest {
+
+    @Test
+    public void hmsActionRunsAsMetastoreUser() throws Exception {
+        Configuration conf = new Configuration();
+        conf.set("hadoop.username", "iceberg-hms-user");
+        HadoopAuthenticator auth = HadoopAuthenticator.getHadoopAuthenticator(conf);
+        ClientPool<IMetaStoreClient, TException> delegate = new ClientPool<IMetaStoreClient, TException>() {
+            @Override
+            public <R> R run(Action<R, IMetaStoreClient, TException> action)
+                    throws TException, InterruptedException {
+                return action.run(null);
+            }
+
+            @Override
+            public <R> R run(Action<R, IMetaStoreClient, TException> action, boolean retry)
+                    throws TException, InterruptedException {
+                return action.run(null);
+            }
+        };
+
+        String user = IcebergHmsClientPool.wrap(delegate, auth).run(client -> currentUser());
+        Assertions.assertEquals("iceberg-hms-user", user);
+    }
+
+    private static String currentUser() {
+        try {
+            return UserGroupInformation.getCurrentUser().getUserName();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-metastore-paimon/src/test/java/org/apache/doris/connector/metastore/paimon/hms/PaimonHmsMetaStorePropertiesTest.java
+++ b/fe/fe-connector/fe-connector-metastore-paimon/src/test/java/org/apache/doris/connector/metastore/paimon/hms/PaimonHmsMetaStorePropertiesTest.java
@@ -216,7 +216,17 @@ public class PaimonHmsMetaStorePropertiesTest {
                 "hadoop.kerberos.principal", "hdfs@REALM", "hadoop.kerberos.keytab", "/k",
                 "warehouse", "wh"));
         Assertions.assertFalse(props.kerberos().isPresent());
-        Assertions.assertFalse(props.toHiveConfOverrides("10").containsKey("hive.metastore.sasl.enabled"));
+        Assertions.assertEquals("false", props.toHiveConfOverrides("10").get("hive.metastore.sasl.enabled"));
+    }
+
+    @Test
+    public void explicitSimpleOverridesRawSaslSetting() {
+        Map<String, String> conf = of(raw(
+                "hive.metastore.uris", "thrift://h",
+                "hive.metastore.authentication.type", "simple",
+                "hive.metastore.sasl.enabled", "true",
+                "warehouse", "wh")).toHiveConfOverrides("10");
+        Assertions.assertEquals("false", conf.get("hive.metastore.sasl.enabled"));
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-metastore-spi/src/main/java/org/apache/doris/connector/metastore/spi/AbstractHmsMetaStoreProperties.java
+++ b/fe/fe-connector/fe-connector-metastore-spi/src/main/java/org/apache/doris/connector/metastore/spi/AbstractHmsMetaStoreProperties.java
@@ -201,6 +201,11 @@ public abstract class AbstractHmsMetaStoreProperties extends AbstractMetaStorePr
         }
         // 5. Storage overlay (legacy buildHiveConfiguration + appendUserHadoopConfig). BEFORE kerberos.
         MetaStoreParseUtils.applyStorageConfig(storageHadoopConfig, raw, conf::put);
+        // Legacy copyIfPresent ignored an explicitly blank username. Do not let the raw Hadoop passthrough
+        // overwrite a hive-site.xml user with "" or feed createRemoteUser an invalid empty identity.
+        if (raw.containsKey("hadoop.username") && StringUtils.isBlank(raw.get("hadoop.username"))) {
+            conf.remove("hadoop.username");
+        }
         // 6. Kerberos-conditional metastore block (legacy initHadoopAuthenticator), LAST.
         if (StringUtils.isNotBlank(servicePrincipal)) {
             conf.put("hive.metastore.kerberos.principal", servicePrincipal);

--- a/fe/fe-connector/fe-connector-metastore-spi/src/main/java/org/apache/doris/connector/metastore/spi/AbstractHmsMetaStoreProperties.java
+++ b/fe/fe-connector/fe-connector-metastore-spi/src/main/java/org/apache/doris/connector/metastore/spi/AbstractHmsMetaStoreProperties.java
@@ -216,7 +216,10 @@ public abstract class AbstractHmsMetaStoreProperties extends AbstractMetaStorePr
         boolean hdfsFallbackKerberos = !"simple".equalsIgnoreCase(hmsAuthType)
                 && !hmsKerberos
                 && "kerberos".equalsIgnoreCase(hdfsAuthType);
-        if (hmsKerberos || hdfsFallbackKerberos) {
+        if ("simple".equalsIgnoreCase(hmsAuthType)) {
+            // Canonical HMS auth must override a SASL value inherited from raw properties or hive-site.xml.
+            conf.put("hive.metastore.sasl.enabled", "false");
+        } else if (hmsKerberos || hdfsFallbackKerberos) {
             conf.put("hadoop.security.authentication", "kerberos");
             conf.put("hive.metastore.sasl.enabled", "true");
         }

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnector.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnector.java
@@ -41,19 +41,29 @@ import org.apache.doris.kerberos.KerberosAuthenticationConfig;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.paimon.catalog.CachingCatalog;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.hive.HiveCatalog;
+import org.apache.paimon.hive.HiveCatalogOptions;
+import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.privilege.PrivilegedCatalog;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -454,7 +464,7 @@ public class PaimonConnector implements Connector {
                         options.get("client-pool-cache.keys")));
                 HadoopAuthenticator hmsAuth = buildHmsAuthenticator(catalogProps.getRaw(), storageHadoopConfig);
                 return createCatalogFromContext(CatalogContext.create(options, hc), flavor,
-                        hmsAuth,
+                        hmsAuth, storageHadoopConfig,
                         "Failed to create Paimon catalog with HMS metastore");
             }
             default:
@@ -486,11 +496,11 @@ public class PaimonConnector implements Connector {
     }
 
     private Catalog createCatalogFromContext(CatalogContext catalogContext, String flavor, String failureMessage) {
-        return createCatalogFromContext(catalogContext, flavor, null, failureMessage);
+        return createCatalogFromContext(catalogContext, flavor, null, Collections.emptyMap(), failureMessage);
     }
 
     private Catalog createCatalogFromContext(CatalogContext catalogContext, String flavor,
-            HadoopAuthenticator hmsAuth, String failureMessage) {
+            HadoopAuthenticator hmsAuth, Map<String, String> storageHadoopConfig, String failureMessage) {
         // Pin the thread-context classloader to the plugin loader for the duration of catalog
         // creation (FIX-PAIMON-HADOOP-CLASSLOADER). Hadoop's FileSystem ServiceLoader
         // (FileSystem.loadFileSystems -> ServiceLoader.load(FileSystem.class)) and SecurityUtil's
@@ -503,18 +513,46 @@ public class PaimonConnector implements Connector {
         try {
             Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
             return context.executeAuthenticated(() -> {
-                // Paimon's CachedClientPool eagerly opens a SIMPLE client in the HiveCatalog constructor, so
-                // construction must cross the HMS boundary too. FileIO only stores its configuration here and
-                // still creates filesystems lazily under the connector's separate storage authenticator.
-                Catalog catalog = hmsAuth == null
-                        ? CatalogFactory.createCatalog(catalogContext)
-                        : hmsAuth.doAs(() -> CatalogFactory.createCatalog(catalogContext));
-                return PaimonHmsClientPool.install(catalog, hmsAuth);
+                Catalog catalog = PaimonCatalogProperties.HMS.equals(flavor)
+                        ? createHmsCatalog(catalogContext, hmsAuth, catalogProps.getRaw(),
+                                storageHadoopConfig)
+                        : CatalogFactory.createCatalog(catalogContext);
+                return catalog;
             });
         } catch (Exception e) {
             throw new RuntimeException(failureMessage + " (flavor=" + flavor + "): " + e.getMessage(), e);
         } finally {
             Thread.currentThread().setContextClassLoader(previous);
+        }
+    }
+
+    static Catalog createHmsCatalog(CatalogContext catalogContext, HadoopAuthenticator hmsAuth,
+            Map<String, String> properties, Map<String, String> storageHadoopConfig) {
+        HiveConf hiveConf = HiveCatalog.createHiveConf(catalogContext);
+        Options options = catalogContext.options();
+        String warehouse = options.get(CatalogOptions.WAREHOUSE);
+        if (warehouse == null) {
+            warehouse = hiveConf.get(HiveConf.ConfVars.METASTOREWAREHOUSE.varname,
+                    HiveConf.ConfVars.METASTOREWAREHOUSE.defaultStrVal);
+        }
+        Path warehousePath = new Path(warehouse);
+        Path fileIoPath = warehousePath.toUri().getScheme() == null
+                ? new Path(FileSystem.getDefaultUri(hiveConf)) : warehousePath;
+        try {
+            FileIO fileIO = FileIO.get(fileIoPath, catalogContext);
+            // Paimon checks or creates the warehouse eagerly; it must retain the outer storage identity.
+            fileIO.checkOrMkdirs(warehousePath);
+            String clientClass = options.get(HiveCatalogOptions.METASTORE_CLIENT_CLASS);
+            Catalog catalog = hmsAuth == null
+                    ? new HiveCatalog(fileIO, hiveConf, clientClass, options, warehousePath.toUri().toString())
+                    : hmsAuth.doAs(() -> new HiveCatalog(
+                            fileIO, hiveConf, clientClass, options, warehousePath.toUri().toString()));
+            catalog = PaimonHmsClientPool.install(catalog, hmsAuth);
+            catalog = PaimonHmsCatalog.install(catalog, properties, storageHadoopConfig);
+            catalog = CachingCatalog.tryToCreate(catalog, options);
+            return PrivilegedCatalog.tryToCreate(catalog, options);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -529,11 +567,21 @@ public class PaimonConnector implements Connector {
             return required;
         }
         for (String element : existing.split(",")) {
-            if (required.equalsIgnoreCase(element.trim())) {
+            if (sameCacheKey(required, element.trim())) {
                 return existing;
             }
         }
         return existing + "," + required;
+    }
+
+    private static boolean sameCacheKey(String required, String existing) {
+        String prefix = "conf:";
+        if (required.regionMatches(true, 0, prefix, 0, prefix.length())
+                && existing.regionMatches(true, 0, prefix, 0, prefix.length())) {
+            // Paimon accepts a case-insensitive marker, but Configuration property names remain case-sensitive.
+            return required.substring(prefix.length()).equals(existing.substring(prefix.length()));
+        }
+        return required.equalsIgnoreCase(existing);
     }
 
     /**

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnector.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnector.java
@@ -559,7 +559,10 @@ public class PaimonConnector implements Connector {
     static String appendHmsCacheKeys(String existing) {
         String keys = appendCacheKey(existing, "conf:hadoop.username");
         keys = appendCacheKey(keys, "conf:hive.metastore.client.principal");
-        return appendCacheKey(keys, "conf:hadoop.kerberos.principal");
+        keys = appendCacheKey(keys, "conf:hive.metastore.kerberos.principal");
+        keys = appendCacheKey(keys, "conf:hadoop.kerberos.principal");
+        // Both settings are captured by the JVM-static SDK pool and must distinguish ALTER CATALOG generations.
+        return appendCacheKey(keys, "conf:hive.metastore.sasl.enabled");
     }
 
     static String appendCacheKey(String existing, String required) {

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnector.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnector.java
@@ -18,7 +18,6 @@
 package org.apache.doris.connector.paimon;
 
 import org.apache.doris.connector.cache.ConnectorMetadataCache;
-import org.apache.doris.connector.metastore.HmsMetaStoreProperties;
 import org.apache.doris.connector.metastore.paimon.jdbc.PaimonJdbcMetaStoreProperties;
 import org.apache.doris.connector.metastore.spi.AbstractHmsMetaStoreProperties;
 import org.apache.doris.connector.metastore.spi.JdbcDriverSupport;
@@ -34,6 +33,8 @@ import org.apache.doris.connector.spi.ConnectorValidationContext;
 import org.apache.doris.connector.spi.handle.ConnectorTableHandle;
 import org.apache.doris.connector.spi.scan.ConnectorScanPlanProvider;
 import org.apache.doris.filesystem.properties.StorageProperties;
+import org.apache.doris.kerberos.AuthType;
+import org.apache.doris.kerberos.AuthenticationConfig;
 import org.apache.doris.kerberos.HadoopAuthenticator;
 import org.apache.doris.kerberos.KerberosAuthSpec;
 import org.apache.doris.kerberos.KerberosAuthenticationConfig;
@@ -190,26 +191,8 @@ public class PaimonConnector implements Connector {
     }
 
     /**
-     * Resolves the plugin-side Kerberos authenticator for the catalog, or {@code null} for a non-Kerberos
-     * catalog. Two Kerberos sources are covered, in precedence order:
-     * <ol>
-     *   <li><b>Storage</b> Kerberos — the raw {@code hadoop.security.authentication=kerberos} passthrough
-     *       (HDFS / data-lake login), built from the storage Hadoop configuration. Unchanged prior behavior;
-     *       when storage is Kerberos this single login also carries the HMS metastore RPC (same UGI). The
-     *       Kerberos keys ride the {@code hadoop.*} passthrough in
-     *       {@link PaimonCatalogFactory#buildHadoopConfiguration}; {@link HadoopAuthenticator#getHadoopAuthenticator}
-     *       resolves the plugin (child-first) copy of fe-kerberos, so its {@code doAs} acts on the plugin UGI.</li>
-     *   <li><b>HMS-metastore</b> Kerberos with non-Kerberos storage — a secured Hive Metastore whose data
-     *       storage is simple (e.g. a Kerberized HMS over S3). Legacy fe-core served this from the fe-core
-     *       {@code PaimonHMSMetaStoreProperties} HMS authenticator (delivered via {@code DefaultConnectorContext});
-     *       once the fe-core pre-execution authenticator is retired (design S6) the connector must own it,
-     *       mirroring {@code IcebergConnector.buildPluginAuthenticator}: the HMS client principal/keytab facts
-     *       ({@link HmsMetaStoreProperties#kerberos()}) feed a
-     *       {@link KerberosAuthenticationConfig}, so the {@code doAs} logs in the same client identity fe-core
-     *       used. The HMS <em>service</em> principal / SASL settings ride the catalog's own HiveConf, not the
-     *       login.</li>
-     * </ol>
-     * Package-visible + static for direct unit testing (mirrors {@code IcebergConnector.buildPluginAuthenticator}).
+     * Resolves only the storage-side Kerberos authenticator used by FileIO. HMS authentication is intentionally
+     * resolved separately by {@link #buildHmsAuthenticator} and applied at the client-pool boundary.
      */
     static HadoopAuthenticator buildPluginAuthenticator(Map<String, String> properties,
             Map<String, String> storageHadoopConfig) {
@@ -217,20 +200,39 @@ public class PaimonConnector implements Connector {
             return HadoopAuthenticator.getHadoopAuthenticator(
                     PaimonCatalogFactory.buildHadoopConfiguration(properties, storageHadoopConfig));
         }
-        if (PaimonCatalogProperties.HMS.equals(PaimonCatalogProperties.of(properties).getFlavor())) {
-            HmsMetaStoreProperties hms =
-                    (HmsMetaStoreProperties) MetaStoreProviders.bind(properties, storageHadoopConfig);
+        return null;
+    }
+
+    static HadoopAuthenticator buildHmsAuthenticator(Map<String, String> properties,
+            Map<String, String> storageHadoopConfig) {
+        ClassLoader previous = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(PaimonConnector.class.getClassLoader());
+            if (!PaimonCatalogProperties.HMS.equals(PaimonCatalogProperties.of(properties).getFlavor())) {
+                return null;
+            }
+            AbstractHmsMetaStoreProperties hms = (AbstractHmsMetaStoreProperties) MetaStoreProviders.bind(
+                    properties, storageHadoopConfig);
             Optional<KerberosAuthSpec> spec = hms.kerberos();
             if (spec.isPresent() && spec.get().hasCredentials()) {
-                Configuration conf =
-                        PaimonCatalogFactory.buildHadoopConfiguration(properties, storageHadoopConfig);
+                Configuration conf = PaimonCatalogFactory.assembleHiveConf(
+                        hms.getConfResources(), hms.toHiveConfOverrides(""));
                 conf.set("hadoop.security.authentication", "kerberos");
                 conf.set("hive.metastore.sasl.enabled", "true");
                 return HadoopAuthenticator.getHadoopAuthenticator(
-                        new KerberosAuthenticationConfig(spec.get().getPrincipal(), spec.get().getKeytab(), conf));
+                        new KerberosAuthenticationConfig(
+                                spec.get().getPrincipal(), spec.get().getKeytab(), conf));
             }
+            if (hms.getAuthType() == AuthType.KERBEROS) {
+                return null;
+            }
+            Configuration conf = PaimonCatalogFactory.assembleHiveConf(
+                    hms.getConfResources(), hms.toHiveConfOverrides(""));
+            return HadoopAuthenticator.getHadoopAuthenticator(
+                    AuthenticationConfig.getSimpleAuthenticationConfig(conf));
+        } finally {
+            Thread.currentThread().setContextClassLoader(previous);
         }
-        return null;
     }
 
     /**
@@ -446,7 +448,13 @@ public class PaimonConnector implements Connector {
                 HiveConf hc = PaimonCatalogFactory.assembleHiveConf(
                         hms.getConfResources(),
                         hms.toHiveConfOverrides(PaimonConf.metastoreClientTimeoutSecond(context)));
+                // Paimon's pool cache is JVM-static and URI-only by default. Configuration-derived identities
+                // isolate catalogs without coupling the cache key to whichever storage UGI creates the catalog.
+                options.set("client-pool-cache.keys", appendHmsCacheKeys(
+                        options.get("client-pool-cache.keys")));
+                HadoopAuthenticator hmsAuth = buildHmsAuthenticator(catalogProps.getRaw(), storageHadoopConfig);
                 return createCatalogFromContext(CatalogContext.create(options, hc), flavor,
+                        hmsAuth,
                         "Failed to create Paimon catalog with HMS metastore");
             }
             default:
@@ -478,6 +486,11 @@ public class PaimonConnector implements Connector {
     }
 
     private Catalog createCatalogFromContext(CatalogContext catalogContext, String flavor, String failureMessage) {
+        return createCatalogFromContext(catalogContext, flavor, null, failureMessage);
+    }
+
+    private Catalog createCatalogFromContext(CatalogContext catalogContext, String flavor,
+            HadoopAuthenticator hmsAuth, String failureMessage) {
         // Pin the thread-context classloader to the plugin loader for the duration of catalog
         // creation (FIX-PAIMON-HADOOP-CLASSLOADER). Hadoop's FileSystem ServiceLoader
         // (FileSystem.loadFileSystems -> ServiceLoader.load(FileSystem.class)) and SecurityUtil's
@@ -489,12 +502,38 @@ public class PaimonConnector implements Connector {
         ClassLoader previous = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
-            return context.executeAuthenticated(() -> CatalogFactory.createCatalog(catalogContext));
+            return context.executeAuthenticated(() -> {
+                // Paimon's CachedClientPool eagerly opens a SIMPLE client in the HiveCatalog constructor, so
+                // construction must cross the HMS boundary too. FileIO only stores its configuration here and
+                // still creates filesystems lazily under the connector's separate storage authenticator.
+                Catalog catalog = hmsAuth == null
+                        ? CatalogFactory.createCatalog(catalogContext)
+                        : hmsAuth.doAs(() -> CatalogFactory.createCatalog(catalogContext));
+                return PaimonHmsClientPool.install(catalog, hmsAuth);
+            });
         } catch (Exception e) {
             throw new RuntimeException(failureMessage + " (flavor=" + flavor + "): " + e.getMessage(), e);
         } finally {
             Thread.currentThread().setContextClassLoader(previous);
         }
+    }
+
+    static String appendHmsCacheKeys(String existing) {
+        String keys = appendCacheKey(existing, "conf:hadoop.username");
+        keys = appendCacheKey(keys, "conf:hive.metastore.client.principal");
+        return appendCacheKey(keys, "conf:hadoop.kerberos.principal");
+    }
+
+    static String appendCacheKey(String existing, String required) {
+        if (StringUtils.isBlank(existing)) {
+            return required;
+        }
+        for (String element : existing.split(",")) {
+            if (required.equalsIgnoreCase(element.trim())) {
+                return existing;
+            }
+        }
+        return existing + "," + required;
     }
 
     /**

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonHmsCatalog.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonHmsCatalog.java
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.paimon;
+
+import org.apache.doris.kerberos.HadoopAuthenticator;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogLoader;
+import org.apache.paimon.catalog.DelegateCatalog;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Keeps Paimon catalogs rebuilt by a retained loader inside the HMS authentication boundary. */
+final class PaimonHmsCatalog extends DelegateCatalog {
+
+    private final Map<String, String> properties;
+    private final Map<String, String> storageHadoopConfig;
+
+    private PaimonHmsCatalog(Catalog wrapped, Map<String, String> properties,
+            Map<String, String> storageHadoopConfig) {
+        super(wrapped);
+        this.properties = new HashMap<>(properties);
+        this.storageHadoopConfig = new HashMap<>(storageHadoopConfig);
+    }
+
+    static Catalog install(Catalog catalog, Map<String, String> properties,
+            Map<String, String> storageHadoopConfig) {
+        return new PaimonHmsCatalog(catalog, properties, storageHadoopConfig);
+    }
+
+    @Override
+    public CatalogLoader catalogLoader() {
+        return new AuthenticatedLoader(wrapped.catalogLoader(), properties, storageHadoopConfig);
+    }
+
+    private static final class AuthenticatedLoader implements CatalogLoader {
+        private static final long serialVersionUID = 1L;
+
+        private final CatalogLoader delegate;
+        private final Map<String, String> properties;
+        private final Map<String, String> storageHadoopConfig;
+
+        private AuthenticatedLoader(CatalogLoader delegate, Map<String, String> properties,
+                Map<String, String> storageHadoopConfig) {
+            this.delegate = delegate;
+            this.properties = new HashMap<>(properties);
+            this.storageHadoopConfig = new HashMap<>(storageHadoopConfig);
+        }
+
+        @Override
+        public Catalog load() {
+            HadoopAuthenticator authenticator =
+                    PaimonConnector.buildHmsAuthenticator(properties, storageHadoopConfig);
+            try {
+                // HiveCatalogLoader constructs a fresh eager client pool, so authentication must precede load().
+                Catalog loaded = authenticator == null
+                        ? delegate.load() : authenticator.doAs(delegate::load);
+                loaded = PaimonHmsClientPool.install(loaded, authenticator);
+                return new PaimonHmsCatalog(loaded, properties, storageHadoopConfig);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to load a Paimon HMS catalog", e);
+            }
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonHmsClientPool.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonHmsClientPool.java
@@ -1,0 +1,119 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.paimon;
+
+import org.apache.doris.kerberos.HadoopAuthenticator;
+
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.DelegateCatalog;
+import org.apache.paimon.client.ClientPool;
+import org.apache.paimon.hive.HiveCatalog;
+import org.apache.thrift.TException;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Field;
+import java.security.PrivilegedAction;
+
+/** Applies the HMS identity at Paimon's metastore client acquisition and RPC boundary. */
+final class PaimonHmsClientPool implements ClientPool<IMetaStoreClient, TException> {
+
+    private final ClientPool<IMetaStoreClient, TException> delegate;
+    private final HadoopAuthenticator authenticator;
+
+    private PaimonHmsClientPool(ClientPool<IMetaStoreClient, TException> delegate,
+            HadoopAuthenticator authenticator) {
+        this.delegate = delegate;
+        this.authenticator = authenticator;
+    }
+
+    static ClientPool<IMetaStoreClient, TException> wrap(
+            ClientPool<IMetaStoreClient, TException> delegate, HadoopAuthenticator authenticator) {
+        return new PaimonHmsClientPool(delegate, authenticator);
+    }
+
+    static Catalog install(Catalog catalog, HadoopAuthenticator authenticator) {
+        if (authenticator == null) {
+            return catalog;
+        }
+        Catalog root = DelegateCatalog.rootCatalog(catalog);
+        if (!(root instanceof HiveCatalog)) {
+            throw new IllegalStateException("Expected a Paimon HiveCatalog for HMS authentication");
+        }
+        try {
+            Field clients = HiveCatalog.class.getDeclaredField("clients");
+            clients.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            ClientPool<IMetaStoreClient, TException> delegate =
+                    (ClientPool<IMetaStoreClient, TException>) clients.get(root);
+            // Paimon exposes no client-pool injection seam; replacing only this field prevents the HMS user
+            // from leaking into FileIO while covering both cached-pool client creation and every metastore RPC.
+            clients.set(root, wrap(delegate, authenticator));
+            return catalog;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to install Paimon HMS authentication boundary", e);
+        }
+    }
+
+    @Override
+    public <R> R run(Action<R, IMetaStoreClient, TException> action) throws TException, InterruptedException {
+        try {
+            return authenticator.getUGI().doAs(
+                    (PrivilegedAction<R>) () -> runUnchecked(action));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to execute a Paimon HMS operation", e);
+        } catch (ClientPoolException e) {
+            throw (TException) e.getCause();
+        } catch (ClientPoolInterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw (InterruptedException) e.getCause();
+        }
+    }
+
+    private <R> R runUnchecked(Action<R, IMetaStoreClient, TException> action) {
+        try {
+            return delegate.run(action);
+        } catch (TException e) {
+            throw new ClientPoolException(e);
+        } catch (InterruptedException e) {
+            throw new ClientPoolInterruptedException(e);
+        }
+    }
+
+    @Override
+    public void execute(ExecuteAction<IMetaStoreClient, TException> action)
+            throws TException, InterruptedException {
+        run(client -> {
+            action.run(client);
+            return null;
+        });
+    }
+
+    private static final class ClientPoolException extends RuntimeException {
+        private ClientPoolException(TException cause) {
+            super(cause);
+        }
+    }
+
+    private static final class ClientPoolInterruptedException extends RuntimeException {
+        private ClientPoolInterruptedException(InterruptedException cause) {
+            super(cause);
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonHmsClientPool.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonHmsClientPool.java
@@ -20,6 +20,8 @@ package org.apache.doris.connector.paimon;
 import org.apache.doris.kerberos.HadoopAuthenticator;
 
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.DelegateCatalog;
 import org.apache.paimon.client.ClientPool;
@@ -29,6 +31,8 @@ import org.apache.thrift.TException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
 import java.security.PrivilegedAction;
 
 /** Applies the HMS identity at Paimon's metastore client acquisition and RPC boundary. */
@@ -88,12 +92,30 @@ final class PaimonHmsClientPool implements ClientPool<IMetaStoreClient, TExcepti
 
     private <R> R runUnchecked(Action<R, IMetaStoreClient, TException> action) {
         try {
-            return delegate.run(action);
+            return delegate.run(client -> action.run(withAuthenticatedOwner(client)));
         } catch (TException e) {
             throw new ClientPoolException(e);
         } catch (InterruptedException e) {
             throw new ClientPoolInterruptedException(e);
         }
+    }
+
+    private static IMetaStoreClient withAuthenticatedOwner(IMetaStoreClient client) {
+        return (IMetaStoreClient) Proxy.newProxyInstance(
+                IMetaStoreClient.class.getClassLoader(),
+                new Class<?>[] {IMetaStoreClient.class},
+                (proxy, method, args) -> {
+                    if ("createTable".equals(method.getName()) && args != null && args.length > 0
+                            && args[0] instanceof Table) {
+                        // Paimon builds format tables before entering the pool; persist the identity used by HMS RPC.
+                        ((Table) args[0]).setOwner(UserGroupInformation.getCurrentUser().getShortUserName());
+                    }
+                    try {
+                        return method.invoke(client, args);
+                    } catch (InvocationTargetException e) {
+                        throw e.getCause();
+                    }
+                });
     }
 
     @Override

--- a/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonConnectorPluginAuthenticatorTest.java
+++ b/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonConnectorPluginAuthenticatorTest.java
@@ -26,16 +26,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Unit tests for {@link PaimonConnector#buildPluginAuthenticator(Map, Map)} — the connector-owned plugin-side
- * Kerberos authenticator resolution (design S6, ported from {@code IcebergConnector.buildPluginAuthenticator}).
+ * Unit tests for Paimon's separate storage and HMS authenticator resolution.
  *
  * <p>The load-bearing NEW case is <b>HMS-metastore Kerberos with simple (non-Kerberos) storage</b> (e.g. a
  * Kerberized Hive Metastore over S3). Before design S6 retires the fe-core pre-execution authenticator, that
  * login was served fe-core-side by {@code PaimonHMSMetaStoreProperties} and delivered via
  * {@code DefaultConnectorContext}; the paimon connector must own it once that handle is a no-op — otherwise
- * S6 would silently drop Kerberos for a paimon secured-HMS-with-simple-storage catalog. These tests pin that
- * the connector builds a plugin authenticator from the HMS client principal/keytab facts, and does NOT build
- * one when the metastore is simple-auth (which would force needless SIMPLE-vs-Kerberos churn).
+ * S6 would silently drop Kerberos for a paimon secured-HMS-with-simple-storage catalog. These tests also pin
+ * SIMPLE HMS identity and client-pool cache isolation without replacing the storage UGI used by FileIO.
  *
  * <p>The actual keytab login is lazy (on first {@code doAs}), so these assertions never touch a KDC.
  */
@@ -70,7 +68,7 @@ public class PaimonConnectorPluginAuthenticatorTest {
      */
     @Test
     public void hmsMetastoreKerberosWithSimpleStorageBuildsAuthenticator() {
-        HadoopAuthenticator auth = PaimonConnector.buildPluginAuthenticator(
+        HadoopAuthenticator auth = PaimonConnector.buildHmsAuthenticator(
                 props("paimon.catalog.type", "hms",
                         "hive.metastore.uris", "thrift://hms:9083",
                         "hive.metastore.authentication.type", "kerberos",
@@ -81,15 +79,40 @@ public class PaimonConnectorPluginAuthenticatorTest {
                 "HMS-metastore kerberos with simple storage must yield a plugin authenticator");
     }
 
-    /** A simple-auth HMS builds no authenticator (a spurious one would force needless SIMPLE-vs-Kerberos churn). */
+    /** HMS auth is resolved separately so it can be applied only at the HMS client-pool boundary. */
     @Test
-    public void hmsSimpleAuthReturnsNull() {
-        HadoopAuthenticator auth = PaimonConnector.buildPluginAuthenticator(
+    public void hmsSimpleAuthUsesConfiguredUser() throws Exception {
+        HadoopAuthenticator auth = PaimonConnector.buildHmsAuthenticator(
                 props("paimon.catalog.type", "hms",
                         "hive.metastore.uris", "thrift://hms:9083",
-                        "hive.metastore.authentication.type", "simple"),
+                        "hive.metastore.authentication.type", "simple",
+                        "hive.metastore.username", "paimon-hms-user"),
                 new HashMap<>());
-        Assertions.assertNull(auth, "simple-auth HMS must not build a plugin authenticator");
+        Assertions.assertEquals("paimon-hms-user", auth.getUGI().getUserName());
+    }
+
+    @Test
+    public void explicitSimpleHmsKeepsItsUserWithKerberosStorage() throws Exception {
+        HadoopAuthenticator auth = PaimonConnector.buildHmsAuthenticator(
+                props("paimon.catalog.type", "hms",
+                        "hive.metastore.uris", "thrift://hms:9083",
+                        "hive.metastore.authentication.type", "simple",
+                        "hive.metastore.username", "paimon-hms-user",
+                        "hadoop.security.authentication", "kerberos",
+                        "hadoop.kerberos.principal", "storage@EXAMPLE.COM",
+                        "hadoop.kerberos.keytab", "/etc/security/storage.keytab"),
+                new HashMap<>());
+        Assertions.assertEquals("paimon-hms-user", auth.getUGI().getUserName());
+    }
+
+    @Test
+    public void hmsIdentitiesAreIncludedInClientPoolCacheKey() {
+        Assertions.assertEquals(
+                "ugi,conf:hadoop.username,conf:hive.metastore.client.principal,conf:hadoop.kerberos.principal",
+                PaimonConnector.appendHmsCacheKeys("ugi"));
+        Assertions.assertEquals(
+                "conf:hadoop.username,conf:hive.metastore.client.principal,conf:hadoop.kerberos.principal",
+                PaimonConnector.appendHmsCacheKeys("conf:hadoop.username"));
     }
 
     /** A non-HMS flavor with no storage Kerberos builds no authenticator. */
@@ -108,7 +131,7 @@ public class PaimonConnectorPluginAuthenticatorTest {
      */
     @Test
     public void hmsKerberosWithBlankCredsReturnsNull() {
-        HadoopAuthenticator auth = PaimonConnector.buildPluginAuthenticator(
+        HadoopAuthenticator auth = PaimonConnector.buildHmsAuthenticator(
                 props("paimon.catalog.type", "hms",
                         "hive.metastore.uris", "thrift://hms:9083",
                         "hive.metastore.authentication.type", "kerberos"),

--- a/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonConnectorPluginAuthenticatorTest.java
+++ b/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonConnectorPluginAuthenticatorTest.java
@@ -19,9 +19,12 @@ package org.apache.doris.connector.paimon;
 
 import org.apache.doris.kerberos.HadoopAuthenticator;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.paimon.hive.pool.CachedClientPool;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -108,10 +111,14 @@ public class PaimonConnectorPluginAuthenticatorTest {
     @Test
     public void hmsIdentitiesAreIncludedInClientPoolCacheKey() {
         Assertions.assertEquals(
-                "ugi,conf:hadoop.username,conf:hive.metastore.client.principal,conf:hadoop.kerberos.principal",
+                "ugi,conf:hadoop.username,conf:hive.metastore.client.principal,"
+                        + "conf:hive.metastore.kerberos.principal,conf:hadoop.kerberos.principal,"
+                        + "conf:hive.metastore.sasl.enabled",
                 PaimonConnector.appendHmsCacheKeys("ugi"));
         Assertions.assertEquals(
-                "conf:hadoop.username,conf:hive.metastore.client.principal,conf:hadoop.kerberos.principal",
+                "conf:hadoop.username,conf:hive.metastore.client.principal,"
+                        + "conf:hive.metastore.kerberos.principal,conf:hadoop.kerberos.principal,"
+                        + "conf:hive.metastore.sasl.enabled",
                 PaimonConnector.appendHmsCacheKeys("conf:hadoop.username"));
     }
 
@@ -119,8 +126,33 @@ public class PaimonConnectorPluginAuthenticatorTest {
     public void hmsCacheKeyPreservesCaseSensitiveConfigurationNames() {
         Assertions.assertEquals(
                 "conf:HADOOP.USERNAME,conf:hadoop.username,conf:hive.metastore.client.principal,"
-                        + "conf:hadoop.kerberos.principal",
+                        + "conf:hive.metastore.kerberos.principal,conf:hadoop.kerberos.principal,"
+                        + "conf:hive.metastore.sasl.enabled",
                 PaimonConnector.appendHmsCacheKeys("conf:HADOOP.USERNAME"));
+    }
+
+    @Test
+    public void transportChangesProduceDifferentSdkPoolKeys() throws Exception {
+        Configuration first = poolConf("service-a/_HOST@REALM", false);
+        Assertions.assertNotEquals(paimonPoolKey(first),
+                paimonPoolKey(poolConf("service-b/_HOST@REALM", false)));
+        Assertions.assertNotEquals(paimonPoolKey(first),
+                paimonPoolKey(poolConf("service-a/_HOST@REALM", true)));
+    }
+
+    private static Configuration poolConf(String servicePrincipal, boolean sasl) {
+        Configuration conf = new Configuration(false);
+        conf.set("hive.metastore.uris", "thrift://hms:9083");
+        conf.set("hive.metastore.kerberos.principal", servicePrincipal);
+        conf.setBoolean("hive.metastore.sasl.enabled", sasl);
+        return conf;
+    }
+
+    private static Object paimonPoolKey(Configuration conf) throws Exception {
+        Method extractKey = CachedClientPool.class.getDeclaredMethod(
+                "extractKey", String.class, String.class, Configuration.class);
+        extractKey.setAccessible(true);
+        return extractKey.invoke(null, "test-client", PaimonConnector.appendHmsCacheKeys(null), conf);
     }
 
     /** A non-HMS flavor with no storage Kerberos builds no authenticator. */

--- a/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonConnectorPluginAuthenticatorTest.java
+++ b/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonConnectorPluginAuthenticatorTest.java
@@ -115,6 +115,14 @@ public class PaimonConnectorPluginAuthenticatorTest {
                 PaimonConnector.appendHmsCacheKeys("conf:hadoop.username"));
     }
 
+    @Test
+    public void hmsCacheKeyPreservesCaseSensitiveConfigurationNames() {
+        Assertions.assertEquals(
+                "conf:HADOOP.USERNAME,conf:hadoop.username,conf:hive.metastore.client.principal,"
+                        + "conf:hadoop.kerberos.principal",
+                PaimonConnector.appendHmsCacheKeys("conf:HADOOP.USERNAME"));
+    }
+
     /** A non-HMS flavor with no storage Kerberos builds no authenticator. */
     @Test
     public void nonHmsFlavorWithoutStorageKerberosReturnsNull() {

--- a/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonHmsCatalogTest.java
+++ b/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonHmsCatalogTest.java
@@ -21,10 +21,14 @@ import org.apache.doris.kerberos.HadoopAuthenticator;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.DelegateCatalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.client.ClientPool;
 import org.apache.paimon.fs.FileIO;
 import org.apache.paimon.fs.FileIOLoader;
 import org.apache.paimon.fs.FileStatus;
@@ -32,13 +36,19 @@ import org.apache.paimon.fs.Path;
 import org.apache.paimon.fs.local.LocalFileIO;
 import org.apache.paimon.hive.HiveCatalog;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.Schema;
+import org.apache.paimon.types.DataTypes;
+import org.apache.thrift.TException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class PaimonHmsCatalogTest {
 
@@ -84,6 +94,83 @@ public class PaimonHmsCatalogTest {
         Field clients = HiveCatalog.class.getDeclaredField("clients");
         clients.setAccessible(true);
         Assertions.assertInstanceOf(PaimonHmsClientPool.class, clients.get(loadedRoot));
+    }
+
+    @Test
+    public void formatTableKeepsPreparationUnderStorageUserButPersistsHmsOwner() throws Exception {
+        Options options = Options.fromMap(Map.of(
+                "format-table.enabled", "true",
+                "warehouse", "record:///warehouse"));
+        HiveConf hiveConf = new HiveConf();
+        hiveConf.set("hive.metastore.sasl.enabled", "true");
+        HiveCatalog hiveCatalog = new HiveCatalog(
+                new RecordingFileIO(), hiveConf, null, options, "record:///warehouse");
+        AtomicReference<Table> createdTable = new AtomicReference<>();
+        AtomicReference<String> rpcUser = new AtomicReference<>();
+        IMetaStoreClient client = (IMetaStoreClient) Proxy.newProxyInstance(
+                getClass().getClassLoader(), new Class<?>[] {IMetaStoreClient.class}, (proxy, method, args) -> {
+                    if ("createTable".equals(method.getName())) {
+                        createdTable.set((Table) args[0]);
+                        rpcUser.set(UserGroupInformation.getCurrentUser().getUserName());
+                    }
+                    return null;
+                });
+        setClientPool(hiveCatalog, new ClientPool<IMetaStoreClient, TException>() {
+            @Override
+            public <R> R run(Action<R, IMetaStoreClient, TException> action)
+                    throws TException, InterruptedException {
+                return action.run(client);
+            }
+
+            @Override
+            public void execute(ExecuteAction<IMetaStoreClient, TException> action)
+                    throws TException, InterruptedException {
+                action.run(client);
+            }
+        });
+        Configuration hmsConf = new Configuration(false);
+        hmsConf.set("hadoop.username", "paimon-hms-user");
+        HadoopAuthenticator hmsAuth = HadoopAuthenticator.getHadoopAuthenticator(hmsConf);
+        PaimonHmsClientPool.install(hiveCatalog, hmsAuth);
+        Configuration storageConf = new Configuration(false);
+        storageConf.set("hadoop.username", "paimon-storage-user");
+        HadoopAuthenticator storageAuth = HadoopAuthenticator.getHadoopAuthenticator(storageConf);
+        AtomicReference<String> preparationUser = new AtomicReference<>();
+        Schema schema = new Schema(
+                List.of(DataTypes.FIELD(0, "id", DataTypes.INT())), List.of(), List.of(),
+                Map.of("type", "format-table", "file.format", "parquet",
+                        "path", "record:///warehouse/format_table"), null) {
+            @Override
+            public Map<String, String> options() {
+                preparationUser.set(currentUser());
+                return super.options();
+            }
+        };
+
+        storageAuth.doAs(() -> {
+            hiveCatalog.createFormatTable(Identifier.create("db", "format_table"), schema);
+            Assertions.assertEquals("paimon-storage-user", currentUser());
+            return null;
+        });
+
+        Assertions.assertEquals("paimon-storage-user", preparationUser.get());
+        Assertions.assertEquals("paimon-hms-user", rpcUser.get());
+        Assertions.assertEquals("paimon-hms-user", createdTable.get().getOwner());
+    }
+
+    private static void setClientPool(HiveCatalog catalog,
+            ClientPool<IMetaStoreClient, TException> clientPool) throws Exception {
+        Field clients = HiveCatalog.class.getDeclaredField("clients");
+        clients.setAccessible(true);
+        clients.set(catalog, clientPool);
+    }
+
+    private static String currentUser() {
+        try {
+            return UserGroupInformation.getCurrentUser().getUserName();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static final class RecordingFileIO extends LocalFileIO {

--- a/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonHmsCatalogTest.java
+++ b/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonHmsCatalogTest.java
@@ -1,0 +1,124 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.paimon;
+
+import org.apache.doris.kerberos.HadoopAuthenticator;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.CatalogContext;
+import org.apache.paimon.catalog.DelegateCatalog;
+import org.apache.paimon.fs.FileIO;
+import org.apache.paimon.fs.FileIOLoader;
+import org.apache.paimon.fs.FileStatus;
+import org.apache.paimon.fs.Path;
+import org.apache.paimon.fs.local.LocalFileIO;
+import org.apache.paimon.hive.HiveCatalog;
+import org.apache.paimon.options.Options;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PaimonHmsCatalogTest {
+
+    @Test
+    public void warehouseCheckUsesStorageIdentityAndLoaderReinstallsHmsBoundary() throws Exception {
+        RecordingFileIO fileIO = new RecordingFileIO();
+        FileIOLoader loader = new FileIOLoader() {
+            @Override
+            public String getScheme() {
+                return "record";
+            }
+
+            @Override
+            public FileIO load(Path path) {
+                return fileIO;
+            }
+        };
+        Options options = Options.fromMap(Map.of(
+                "metastore", "hive",
+                "warehouse", "record:///warehouse",
+                "uri", "thrift://hms:9083",
+                "cache-enabled", "false"));
+        HiveConf hiveConf = new HiveConf();
+        hiveConf.set("hive.metastore.sasl.enabled", "true");
+        CatalogContext catalogContext = CatalogContext.create(options, hiveConf, loader, null);
+        Map<String, String> properties = new HashMap<>(Map.of(
+                "paimon.catalog.type", "hms",
+                "warehouse", "record:///warehouse",
+                "hive.metastore.uris", "thrift://hms:9083",
+                "hive.metastore.authentication.type", "simple",
+                "hive.metastore.username", "paimon-hms-user"));
+        HadoopAuthenticator hmsAuth = PaimonConnector.buildHmsAuthenticator(properties, new HashMap<>());
+        Configuration storageConf = new Configuration(false);
+        storageConf.set("hadoop.username", "paimon-storage-user");
+        HadoopAuthenticator storageAuth = HadoopAuthenticator.getHadoopAuthenticator(storageConf);
+
+        Catalog catalog = storageAuth.doAs(() -> PaimonConnector.createHmsCatalog(
+                catalogContext, hmsAuth, properties, new HashMap<>()));
+        Assertions.assertEquals("paimon-storage-user", fileIO.checkUser);
+
+        Catalog loaded = storageAuth.doAs(() -> catalog.catalogLoader().load());
+        HiveCatalog loadedRoot = (HiveCatalog) DelegateCatalog.rootCatalog(loaded);
+        Field clients = HiveCatalog.class.getDeclaredField("clients");
+        clients.setAccessible(true);
+        Assertions.assertInstanceOf(PaimonHmsClientPool.class, clients.get(loadedRoot));
+    }
+
+    private static final class RecordingFileIO extends LocalFileIO {
+        private String checkUser;
+
+        @Override
+        public boolean exists(Path path) throws IOException {
+            checkUser = UserGroupInformation.getCurrentUser().getUserName();
+            return !path.toString().endsWith("user.sys");
+        }
+
+        @Override
+        public FileStatus getFileStatus(Path path) throws IOException {
+            checkUser = UserGroupInformation.getCurrentUser().getUserName();
+            return new FileStatus() {
+                @Override
+                public long getLen() {
+                    return 0;
+                }
+
+                @Override
+                public boolean isDir() {
+                    return true;
+                }
+
+                @Override
+                public Path getPath() {
+                    return path;
+                }
+
+                @Override
+                public long getModificationTime() {
+                    return 0;
+                }
+            };
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonHmsClientPoolTest.java
+++ b/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonHmsClientPoolTest.java
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.paimon;
+
+import org.apache.doris.kerberos.HadoopAuthenticator;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.paimon.client.ClientPool;
+import org.apache.thrift.TException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+public class PaimonHmsClientPoolTest {
+
+    @Test
+    public void hmsActionRunsAsMetastoreUser() throws Exception {
+        Configuration conf = new Configuration();
+        conf.set("hadoop.username", "paimon-hms-user");
+        HadoopAuthenticator auth = HadoopAuthenticator.getHadoopAuthenticator(conf);
+        ClientPool<IMetaStoreClient, TException> delegate = new ClientPool<IMetaStoreClient, TException>() {
+            @Override
+            public <R> R run(Action<R, IMetaStoreClient, TException> action)
+                    throws TException, InterruptedException {
+                return action.run(null);
+            }
+
+            @Override
+            public void execute(ExecuteAction<IMetaStoreClient, TException> action)
+                    throws TException, InterruptedException {
+                action.run(null);
+            }
+        };
+
+        String user = PaimonHmsClientPool.wrap(delegate, auth).run(client -> currentUser());
+        Assertions.assertEquals("paimon-hms-user", user);
+    }
+
+    private static String currentUser() {
+        try {
+            return UserGroupInformation.getCurrentUser().getUserName();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorContext.java
+++ b/fe/fe-connector/fe-connector-spi/src/main/java/org/apache/doris/connector/spi/ConnectorContext.java
@@ -45,6 +45,7 @@ public interface ConnectorContext {
      * <p>Known keys include:
      * <ul>
      *   <li>{@code doris_home} — the DORIS_HOME path</li>
+     *   <li>{@code hadoop_config_dir} — the configured Hadoop resource directory</li>
      *   <li>{@code jdbc_drivers_dir} — the configured JDBC drivers directory</li>
      * </ul>
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/connector/DefaultConnectorContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/connector/DefaultConnectorContext.java
@@ -603,6 +603,8 @@ public class DefaultConnectorContext implements ConnectorContext, ConnectorStora
         if (dorisHome != null) {
             env.put("doris_home", dorisHome);
         }
+        // HMS resources may be read before storage binding publishes this process-global FE setting.
+        env.put("hadoop_config_dir", Config.hadoop_config_dir);
         env.put("jdbc_drivers_dir", Config.jdbc_drivers_dir);
         env.put("force_sqlserver_jdbc_encrypt_false",
                 String.valueOf(Config.force_sqlserver_jdbc_encrypt_false));

--- a/fe/fe-core/src/test/java/org/apache/doris/connector/DefaultConnectorContextEnvironmentTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/connector/DefaultConnectorContextEnvironmentTest.java
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector;
+
+import org.apache.doris.common.Config;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class DefaultConnectorContextEnvironmentTest {
+
+    @Test
+    public void forwardsConfiguredHadoopResourceDirectory() {
+        String previous = Config.hadoop_config_dir;
+        try {
+            Config.hadoop_config_dir = "/configured/hadoop";
+            DefaultConnectorContext context = new DefaultConnectorContext("test", 1L);
+            Assertions.assertEquals("/configured/hadoop",
+                    context.getEnvironment().get("hadoop_config_dir"));
+        } finally {
+            Config.hadoop_config_dir = previous;
+        }
+    }
+}

--- a/fe/fe-kerberos/src/main/java/org/apache/doris/kerberos/HadoopAuthenticator.java
+++ b/fe/fe-kerberos/src/main/java/org/apache/doris/kerberos/HadoopAuthenticator.java
@@ -40,7 +40,13 @@ public interface HadoopAuthenticator {
             if (e.getCause() instanceof RuntimeException) {
                 throw (RuntimeException) e.getCause();
             } else {
-                throw new RuntimeException(e.getCause());
+                Throwable cause = e.getCause();
+                if (cause == null) {
+                    throw e;
+                }
+                // Keep checked-operation error text stable across UGI doAs; the cause chain still carries its type.
+                String message = cause.getMessage() == null ? cause.toString() : cause.getMessage();
+                throw new RuntimeException(message, cause);
             }
         }
     }

--- a/fe/fe-kerberos/src/test/java/org/apache/doris/kerberos/AuthenticationTest.java
+++ b/fe/fe-kerberos/src/test/java/org/apache/doris/kerberos/AuthenticationTest.java
@@ -42,4 +42,19 @@ public class AuthenticationTest {
         AuthenticationConfig conf3 = AuthenticationConfig.getKerberosConfig(conf);
         Assert.assertEquals(KerberosAuthenticationConfig.class, conf3.getClass());
     }
+
+    @Test
+    public void testDoAsPreservesCheckedExceptionMessage() {
+        Configuration conf = new Configuration(false);
+        conf.set(AuthenticationConfig.HADOOP_USER_NAME, "hms-user");
+        HadoopAuthenticator authenticator = HadoopAuthenticator.getHadoopAuthenticator(conf);
+
+        RuntimeException error = Assert.assertThrows(RuntimeException.class,
+                () -> authenticator.doAs(() -> {
+                    throw new Exception("Database db is not empty.");
+                }));
+
+        Assert.assertEquals("Database db is not empty.", error.getMessage());
+        Assert.assertEquals(Exception.class, error.getCause().getClass());
+    }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A
Related PR: #64304

Problem Summary: After external catalogs became plugin-driven, simple-auth Hive Metastore RPCs no longer ran under the catalog configured Hadoop user. HMS-created directories could therefore use the FE process user while data writes used the configured user, causing permission failures. Restore a plugin-side simple UGI for HMS RPCs and preserve the metastore username alias and legacy default user.

### Release note

Fix Hive Metastore writes failing when the configured Hadoop user differs from the FE process user.

### Check List (For Author)

- Test: Unit Test
    - HiveConnectorPluginAuthenticatorTest
- Behavior changed: Yes. Simple-auth HMS RPCs again run as the configured Hadoop user.
- Does this need documentation: No
