### PR TITLE
[fix](load) Fix row binlog memtable flush backpressure

### DIFF
--- a/be/src/load/delta_writer/delta_writer.cpp
+++ b/be/src/load/delta_writer/delta_writer.cpp
@@ -178,8 +178,10 @@ Status DeltaWriter::write(const Block* block, const TabletAddRowsPayload& rows,
     }
     {
         SCOPED_TIMER(_wait_flush_limit_timer);
-        while (_memtable_writer->flush_running_count() >=
-               config::memtable_flush_running_count_limit) {
+        const auto effective_flush_running_count_limit =
+                config::memtable_flush_running_count_limit *
+                (_req.write_req_type == WriteRequestType::GROUP ? 2 : 1);
+        while (_memtable_writer->flush_running_count() >= effective_flush_running_count_limit) {
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
     }


### PR DESCRIPTION
### What problem does this PR solve?

#### Problem summary

When row binlog is enabled, a `GROUP` request flushes both the data memtable and the row-binlog memtable. These are two independent physical flush tasks, and both increment `flush_running_count`.

Write backpressure previously compared this physical task count with the same configured limit used by a normal data-only memtable. As a result, row-binlog imports effectively had half of the configured logical flush concurrency. With a limit of 2, one group memtable could consume the entire allowance and subsequent writes had to wait, making memtable writing and flushing nearly serial.

#### Changes

- Keep the existing `flush_running_count` backpressure mechanism for storage-compute integrated mode.
- Use `memtable_flush_running_count_limit * 2` for `GROUP` requests because each logical row-binlog memtable creates two physical flush tasks.
- Keep the configured limit unchanged for normal data-only requests.

#### Impact

Row-binlog imports can use the intended logical memtable flush concurrency and keep memtable writing overlapped with flushing. Imports without row binlog are unchanged.

### Release note

None

### Check List (For Author)

- Test: Not run (per request)
- Behavior changed: Yes. Row-binlog `GROUP` requests use an effective physical flush-task limit of twice the configured logical limit.
- Does this need documentation: No
