### PR TITLE
[fix](be) Reuse segment magic constants in meta tool

### DIFF
--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -53,6 +53,7 @@
 #include "storage/olap_common.h"
 #include "storage/options.h"
 #include "storage/segment/column_reader.h"
+#include "storage/segment/common.h"
 #include "storage/segment/encoding_info.h"
 #include "storage/segment/page_pointer.h"
 #include "storage/storage_engine.h"
@@ -288,9 +289,8 @@ Status get_segment_footer(doris::io::FileReader* file_reader, SegmentFooterPB* f
     RETURN_IF_ERROR(file_reader->read_at(file_size - 12, slice, &bytes_read));
 
     // validate magic number
-    const char* k_segment_magic = "D0R1";
-    const uint32_t k_segment_magic_length = 4;
-    if (memcmp(fixed_buf + 8, k_segment_magic, k_segment_magic_length) != 0) {
+    if (memcmp(fixed_buf + 8, doris::segment_v2::k_segment_magic,
+               doris::segment_v2::k_segment_magic_length) != 0) {
         return Status::Corruption("Bad segment file {}: magic number not match", file_name);
     }
 
@@ -1034,9 +1034,8 @@ void gen_empty_segment() {
     footer_slices.push_back(Slice(footer_checksum_buf, 4));
 
     // Magic number (4 bytes): "D0R1"
-    const char* k_segment_magic = "D0R1";
-    const uint32_t k_segment_magic_length = 4;
-    footer_slices.push_back(Slice(k_segment_magic, k_segment_magic_length));
+    footer_slices.push_back(
+            Slice(doris::segment_v2::k_segment_magic, doris::segment_v2::k_segment_magic_length));
 
     // Write index page first, then footer
     for (const auto& slice : index_body) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #66789

Problem Summary:

PR #66789 centralized the segment footer magic constants in `storage/segment/common.h`, but `meta_tool.cpp` still declared the same names locally in its segment read and write paths. When `BUILD_META_TOOL=ON`, Clang reports four `-Wshadow` diagnostics and the ASAN build fails because warnings are treated as errors.

This change includes the defining header explicitly and reuses `doris::segment_v2::k_segment_magic` and `k_segment_magic_length` in both paths.

### Release note

None

### Check List (For Author)

- Test
  - [x] Manual test
    - `build-support/clang-format.sh`
    - `build-support/check-format.sh`
    - `git diff --check`
    - Internal TeamCity ASAN `--meta-tool`: [build #2823](http://172.20.48.17:8111/buildConfiguration/Doris_Doris_x64_Master_Compile/208178) passed at commit `4b656bd7aa126b9d5581db84ff8b339dbb109298`.
- Behavior changed:
  - [x] No
- Does this need documentation?
  - [x] No
