### PR TITLE
[improvement](cbo) Fetch column stats only for operative slots in olap scan

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
@@ -418,6 +418,13 @@ public class Rewriter extends AbstractBatchJobExecutor {
                                     topDown(new LimitSortToTopN()),
                                     topDown(new SplitLimit()),
                                     custom(RuleType.SET_PREAGG_STATUS, SetPreAggStatus::new),
+                                    // Derive operative columns on the plan recorded for materialized view
+                                    // pre rewrite: the pre rewrite runs a cost-based optimization on this
+                                    // recorded plan to choose the best materialized view, and without
+                                    // operative slots computeOlapScan would fall back to fetching column
+                                    // stats of all table columns. The derivation is repeated before "init
+                                    // join" and at the end of rewrite, where the operative slots of the
+                                    // plans finally stored into the memo are recomputed.
                                     custom(RuleType.OPERATIVE_COLUMN_DERIVE, OperativeColumnDerive::new),
                                     custom(RuleType.ADJUST_NULLABLE, () -> new AdjustNullable(false))
                             ),
@@ -681,6 +688,13 @@ public class Rewriter extends AbstractBatchJobExecutor {
                         topDown(new PushDownAggThroughJoinOnPkFk()),
                         topDown(new PullUpJoinFromUnionAll())
                 ),
+                // RBO rules that depend on statistics (e.g. InitJoinOrder, SkewJoin, Eager
+                // aggregation, DecomposeRepeatWithPreAggregation, DistinctAggStrategySelector)
+                // must be placed AFTER OperativeColumnDerive: StatsCalculator.computeOlapScan
+                // only fetches column stats of operative slots, so rules running before the
+                // derivation would fetch stats of all table columns, polluting the column stats
+                // cache and wasting time on wide tables.
+                custom(RuleType.OPERATIVE_COLUMN_DERIVE, OperativeColumnDerive::new),
                 topic("init join", bottomUp(ImmutableList.of(new InitJoinOrder()))),
                 topic("Eager aggregation",
                         cascadesContext -> cascadesContext.rewritePlanContainsTypes(
@@ -731,7 +745,8 @@ public class Rewriter extends AbstractBatchJobExecutor {
                                 new PruneOlapScanPartition(),
                                 new PruneEmptyPartition(),
                                 // Stream lowering needs the pruned partitions and must finish before
-                                // OperativeColumnDerive treats stream virtual columns as scan slots.
+                                // the final OperativeColumnDerive at the end of rewrite treats stream
+                                // virtual columns as scan slots.
                                 new NormalizeOlapTableStreamScan(),
                                 new PruneFileScanPartition(),
                                 new PushDownFilterIntoSchemaScan(),
@@ -830,6 +845,11 @@ public class Rewriter extends AbstractBatchJobExecutor {
                         )
                 ),
                 topDown(new CollectCteConsumerOutput()),
+                // Re-derive operative columns at the end of rewrite: rules after the early
+                // OperativeColumnDerive (before "init join") may rebuild scans or add virtual
+                // columns (e.g. stream scan normalization, variant virtual column push down),
+                // so the final operative slots are recomputed here for CBO stats derivation and
+                // backend lazy materialization.
                 custom(RuleType.OPERATIVE_COLUMN_DERIVE, OperativeColumnDerive::new)
             )
     );

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/stats/StatsCalculator.java
@@ -162,6 +162,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -505,7 +506,7 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
     // check validation of ndv.
     private Optional<String> checkNdvValidation(OlapScan olapScan, double rowCount) {
         OlapTableStatistics olapTableStats = Env.getCurrentEnv().getStatisticsCache().getOlapTableStats(olapScan);
-        for (Slot slot : ((Plan) olapScan).getOutput()) {
+        for (Slot slot : getStatsNeededSlots(olapScan)) {
             if (isVisibleSlotReference(slot)) {
                 ColumnStatistic cache = olapTableStats.getColumnStatistics(slot.getName(), connectContext);
                 if (!cache.isUnKnown) {
@@ -598,6 +599,11 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
                 builder.putColumnStatistics(slot, ColumnStatistic.UNKNOWN);
             }
         }
+        // Only operative slots' column stats are needed by the query, column stats of other slots
+        // are useless and fetching them would pollute the column stats cache and waste time on wide
+        // tables. If operative slots are not derived yet (e.g. stats derivation during RBO) or full
+        // stats fidelity is required (forbidUnknownColStats), fall back to all visible output slots.
+        Set<Slot> statsNeededSlots = new HashSet<>(getStatsNeededSlots(olapScan));
 
         if (!isRegisteredRowCount(olapScan)
                 && olapScan.getSelectedPartitionIds().size() < olapScan.getTable().getPartitionNum()) {
@@ -612,7 +618,11 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
                     && connectContext.getSessionVariable().enablePartitionAnalyze;
             for (SlotReference slot : visibleOutputSlots) {
                 ColumnStatistic cache;
-                if (enablePartitionStatics) {
+                if (!statsNeededSlots.contains(slot)) {
+                    // slot's stats are not needed by the query, use the cached value only if it is
+                    // already loaded, otherwise unknown, without triggering a stats cache load
+                    cache = olapTableStats.getColumnStatisticsIfPresent(slot.getName(), connectContext);
+                } else if (enablePartitionStatics) {
                     cache = getColumnStatistic(olapTableStats, slot.getName(), selectedPartitionNames);
                 } else {
                     cache = olapTableStats.getColumnStatistics(slot.getName(), connectContext);
@@ -633,7 +643,14 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
         } else {
             // get table level stats
             for (SlotReference slot : visibleOutputSlots) {
-                ColumnStatistic cache = olapTableStats.getColumnStatistics(slot.getName(), connectContext);
+                ColumnStatistic cache;
+                if (!statsNeededSlots.contains(slot)) {
+                    // slot's stats are not needed by the query, use the cached value only if it is
+                    // already loaded, otherwise unknown, without triggering a stats cache load
+                    cache = olapTableStats.getColumnStatisticsIfPresent(slot.getName(), connectContext);
+                } else {
+                    cache = olapTableStats.getColumnStatistics(slot.getName(), connectContext);
+                }
                 ColumnStatisticBuilder colStatsBuilder = new ColumnStatisticBuilder(cache, tableRowCount);
                 colStatsBuilder.normalizeAvgSizeByte(slot.getDataType());
                 builder.putColumnStatistics(slot, colStatsBuilder.build());
@@ -642,6 +659,22 @@ public class StatsCalculator extends DefaultPlanVisitor<Statistics, Void> {
             builder.setRowCount(tableRowCount);
         }
         return computeVirtualColumnStats(olapScan, builder.build());
+    }
+
+    /**
+     * Returns the slots whose column stats should be fetched for the query.
+     *
+     * <p>Only operative slots' column stats are needed by the query, column stats of other slots are
+     * useless and fetching them would pollute the column stats cache and waste time on wide tables.
+     * If operative slots are not derived yet (e.g. stats derivation during RBO) or full stats
+     * fidelity is required (forbidUnknownColStats), fall back to all output slots.
+     */
+    private List<Slot> getStatsNeededSlots(OlapScan olapScan) {
+        if (forbidUnknownColStats) {
+            return ((Plan) olapScan).getOutput();
+        }
+        List<Slot> operativeSlots = ((CatalogRelation) olapScan).getOperativeSlots();
+        return operativeSlots.isEmpty() ? ((Plan) olapScan).getOutput() : operativeSlots;
     }
 
     private Statistics computeVirtualColumnStats(OlapScan relation, Statistics stats) {

--- a/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/statistics/StatisticsCache.java
@@ -105,6 +105,25 @@ public class StatisticsCache {
         return doGetColumnStatistics(catalogId, dbId, tblId, idxId, colName, ctx);
     }
 
+    /**
+     * Returns the column statistic only when it is already present in the cache, without
+     * triggering a cache load. Used for columns whose stats are not needed by the query,
+     * so that useless columns do not pollute the cache nor issue queries to the stats table.
+     */
+    public ColumnStatistic getColumnStatisticsIfPresent(
+            long catalogId, long dbId, long tblId, long idxId, String colName, ConnectContext ctx) {
+        if (shouldReturnUnknownStats(catalogId, dbId, ctx)) {
+            return ColumnStatistic.UNKNOWN;
+        }
+        // Need to change base index id to -1 for OlapTable.
+        try {
+            idxId = changeBaseIndexId(catalogId, dbId, tblId, idxId);
+        } catch (Exception e) {
+            return ColumnStatistic.UNKNOWN;
+        }
+        return doGetColumnStatisticsIfPresent(catalogId, dbId, tblId, idxId, colName, ctx);
+    }
+
     public OlapTableStatistics getOlapTableStats(OlapScan olapScan) {
         return new OlapTableStatistics(olapScan);
     }
@@ -124,6 +143,28 @@ public class StatisticsCache {
             }
         } catch (Exception e) {
             LOG.warn("Unexpected exception while returning ColumnStatistic", e);
+        }
+        return ColumnStatistic.UNKNOWN;
+    }
+
+    /**
+     * Returns the column statistic only when it is already present in the cache, without
+     * triggering a cache load. Used for columns whose stats are not needed by the query,
+     * so that useless columns do not pollute the cache nor issue queries to the stats table.
+     */
+    private ColumnStatistic doGetColumnStatisticsIfPresent(
+            long catalogId, long dbId, long tblId, long idxId, String colName, ConnectContext ctx) {
+        StatisticsCacheKey k = new StatisticsCacheKey(catalogId, dbId, tblId, idxId, colName);
+        CompletableFuture<Optional<ColumnStatistic>> f = columnStatisticsCache.getIfPresent(k);
+        if (f != null && f.isDone()) {
+            try {
+                Optional<ColumnStatistic> columnStatistic = f.get();
+                if (columnStatistic != null && columnStatistic.isPresent()) {
+                    return columnStatistic.get();
+                }
+            } catch (Exception e) {
+                LOG.warn("Unexpected exception while returning ColumnStatistic", e);
+            }
         }
         return ColumnStatistic.UNKNOWN;
     }
@@ -421,6 +462,20 @@ public class StatisticsCache {
                 return ColumnStatistic.UNKNOWN;
             }
             return doGetColumnStatistics(
+                    catalogId, schemaId, tableId, selectIndexId, colName, ctx
+            );
+        }
+
+        /**
+         * Returns the column statistic only when it is already present in the cache, without
+         * triggering a cache load. Used for columns whose stats are not needed by the query,
+         * so that useless columns do not pollute the cache nor issue queries to the stats table.
+         */
+        public ColumnStatistic getColumnStatisticsIfPresent(String colName, ConnectContext ctx) {
+            if (shouldReturnUnknownStats(catalogId, schemaId, olapTable, ctx)) {
+                return ColumnStatistic.UNKNOWN;
+            }
+            return doGetColumnStatisticsIfPresent(
                     catalogId, schemaId, tableId, selectIndexId, colName, ctx
             );
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/stats/StatsCalculatorTest.java
@@ -249,6 +249,7 @@ public class StatsCalculatorTest {
         Mockito.when(scan.getSelectedIndexId()).thenReturn(baseIndexId);
         Mockito.when(scan.getSelectedPartitionIds()).thenReturn(ImmutableList.of(selectedPartitionId));
         Mockito.when(scan.getOutput()).thenReturn(ImmutableList.of(slot));
+        Mockito.when(scan.getOperativeSlots()).thenReturn(ImmutableList.of());
         Mockito.when(scan.getVirtualColumns()).thenReturn(ImmutableList.of());
         Mockito.when(table.getBaseIndexId()).thenReturn(baseIndexId);
         Mockito.when(table.getRowCountForIndex(baseIndexId, true)).thenReturn(12L);
@@ -273,6 +274,85 @@ public class StatsCalculatorTest {
             Assertions.assertEquals(1, result.numNulls, 0.001);
             Assertions.assertEquals("2", result.minExpr.getStringValue());
             Assertions.assertEquals("2", result.maxExpr.getStringValue());
+        } finally {
+            ConnectContext.remove();
+            if (previousContext != null) {
+                previousContext.setThreadLocalInfo();
+            }
+        }
+    }
+
+    @Test
+    public void testComputeOlapScanOnlyFetchesOperativeSlotsColumnStats() {
+        ConnectContext previousContext = ConnectContext.get();
+        ConnectContext connectContext = new ConnectContext();
+        connectContext.setThreadLocalInfo();
+
+        Env env = Mockito.mock(Env.class);
+        AnalysisManager analysisManager = Mockito.mock(AnalysisManager.class);
+        StatisticsCache statisticsCache = Mockito.mock(StatisticsCache.class);
+        StatisticsCache.OlapTableStatistics olapTableStatistics
+                = Mockito.mock(StatisticsCache.OlapTableStatistics.class);
+        OlapTable table = Mockito.mock(OlapTable.class);
+        LogicalOlapScan scan = Mockito.mock(LogicalOlapScan.class);
+
+        long baseIndexId = 10L;
+        Column columnA = new Column("a", PrimitiveType.INT);
+        Column columnB = new Column("b", PrimitiveType.INT);
+        SlotReference slotA = new SlotReference(new ExprId(1), "a", IntegerType.INSTANCE, true,
+                ImmutableList.of("test", "tbl"), table, columnA, table, columnA);
+        SlotReference slotB = new SlotReference(new ExprId(2), "b", IntegerType.INSTANCE, true,
+                ImmutableList.of("test", "tbl"), table, columnB, table, columnB);
+        ColumnStatistic statA = new ColumnStatisticBuilder(12)
+                .setNdv(3)
+                .setMinValue(1)
+                .setMaxValue(10)
+                .setNumNulls(0)
+                .build();
+        // "b" is not operative, its stats are only read from the cache if already present
+        ColumnStatistic statB = new ColumnStatisticBuilder(12)
+                .setNdv(5)
+                .setMinValue(1)
+                .setMaxValue(10)
+                .setNumNulls(0)
+                .build();
+
+        Mockito.when(env.getAnalysisManager()).thenReturn(analysisManager);
+        Mockito.when(env.getStatisticsCache()).thenReturn(statisticsCache);
+        Mockito.when(statisticsCache.getOlapTableStats(scan)).thenReturn(olapTableStatistics);
+        Mockito.when(olapTableStatistics.getColumnStatistics("a", connectContext)).thenReturn(statA);
+        Mockito.when(olapTableStatistics.getColumnStatisticsIfPresent("b", connectContext)).thenReturn(statB);
+        Mockito.when(scan.getTable()).thenReturn(table);
+        Mockito.when(scan.getSelectedIndexId()).thenReturn(baseIndexId);
+        Mockito.when(scan.getSelectedPartitionIds()).thenReturn(ImmutableList.of());
+        Mockito.when(scan.getOutput()).thenReturn(ImmutableList.of(slotA, slotB));
+        Mockito.when(scan.getOperativeSlots()).thenReturn(ImmutableList.of(slotA));
+        Mockito.when(scan.getVirtualColumns()).thenReturn(ImmutableList.of());
+        Mockito.when(table.getBaseIndexId()).thenReturn(baseIndexId);
+        Mockito.when(table.getRowCountForIndex(baseIndexId, true)).thenReturn(12L);
+        Mockito.when(table.getPartitionNum()).thenReturn(0);
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+
+            Statistics statistics = new StatsCalculator((CascadesContext) null).computeOlapScan(scan);
+
+            // operative slot's column stats are fetched
+            ColumnStatistic resultA = statistics.findColumnStatistics(slotA);
+            Assertions.assertNotNull(resultA);
+            Assertions.assertEquals(3, resultA.ndv, 0.001);
+            // non-operative slot's stats are read from the cache only if already present,
+            // no stats cache load is triggered
+            Assertions.assertEquals(5, statistics.findColumnStatistics(slotB).ndv, 0.001);
+            // only the operative slot triggers a column stats cache load
+            Mockito.verify(olapTableStatistics, Mockito.times(1))
+                    .getColumnStatistics("a", connectContext);
+            Mockito.verify(olapTableStatistics, Mockito.times(0))
+                    .getColumnStatistics("b", connectContext);
+            Mockito.verify(olapTableStatistics, Mockito.times(1))
+                    .getColumnStatisticsIfPresent("b", connectContext);
+            Mockito.verify(olapTableStatistics, Mockito.times(0))
+                    .getColumnStatisticsIfPresent("a", connectContext);
         } finally {
             ConnectContext.remove();
             if (previousContext != null) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Problem Summary:
`StatsCalculator.computeOlapScan` fetches column stats for all output slots of the olap scan, i.e. all columns of the table, but only operative slots' stats are needed by the query. This causes two problems:

1. The global column stats cache (`StatisticsCache.columnStatisticsCache`) is polluted by entries of columns never used by any query, evicting useful entries.
2. For wide tables, a large number of useless column stats are fetched, and each cache miss triggers a query against the internal statistics table.

Fix:
1. `computeOlapScan` now fetches column stats only for operative slots (derived by `OperativeColumnDerive`). For other visible output slots it reads the stats cache only when the value is already loaded (`StatisticsCache.getColumnStatisticsIfPresent`), so no cache load is triggered for columns the query does not need: the cache is not polluted and no stats table query is issued, while plans stay identical to before when the stats are already cached (e.g. injected via `ALTER TABLE SET STATS`). When operative slots are not derived yet or full stats fidelity is required (`forbid_unknown_col_stats`), it falls back to all visible output slots. `checkNdvValidation` is limited the same way to avoid useless cache loads.
2. `OperativeColumnDerive` is additionally run right before the "init join" rewrite topic, so RBO rules that derive statistics (`InitJoinOrder`, `SkewJoin`, Eager aggregation, etc.) also see operative slots and no longer fetch stats of all table columns. A comment documents that RBO rules depending on statistics must be placed after `OperativeColumnDerive`. The derivation at the end of rewrite is kept, because rules after "init join" (e.g. stream scan normalization, variant virtual column push down) may rebuild scans or add virtual columns, and the final operative slots are recomputed there for CBO stats derivation and backend lazy materialization.

### Release note

None