### PR TITLE
[Feature](profile) Support enbale_profile by compute froup

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -152,6 +152,15 @@ public class Profile {
         this.autoProfileDurationMs = autoProfileDurationMs;
     }
 
+    /** Enable a profile that was disabled when its query executor was created. */
+    public synchronized void enable() {
+        if (!isQueryFinished) {
+            return;
+        }
+        summaryProfile.enable();
+        isQueryFinished = false;
+    }
+
     // check if the profile file is valid and create a file input stream
     // user need to close the file stream.
     static FileInputStream createPorfileFileInputStream(String path) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/Profile.java
@@ -161,6 +161,12 @@ public class Profile {
         isQueryFinished = false;
     }
 
+    /** Update query-scoped profile settings after statement-level SET_VAR hints take effect. */
+    public synchronized void updateProfileSettings(int profileLevel, long autoProfileDurationMs) {
+        this.profileLevel = profileLevel;
+        this.autoProfileDurationMs = autoProfileDurationMs;
+    }
+
     // check if the profile file is valid and create a file input stream
     // user need to close the file stream.
     static FileInputStream createPorfileFileInputStream(String path) {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -524,6 +524,10 @@ public class SummaryProfile {
         }
     }
 
+    void enable() {
+        init();
+    }
+
     // For UT usage
     public void fuzzyInit() {
         for (String key : SUMMARY_KEYS) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/SelectHintSetVar.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/properties/SelectHintSetVar.java
@@ -22,6 +22,7 @@ import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.qe.VariableMgr;
 
 import java.util.Map;
@@ -65,6 +66,10 @@ public class SelectHintSetVar extends SelectHint {
                         + key + "' = '" + value.get() + "'", t);
                 }
             }
+        }
+        StmtExecutor executor = context.getConnectContext().getExecutor();
+        if (executor != null) {
+            executor.refreshEffectiveEnableProfileAfterSetVar(context);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/QeProcessorImpl.java
@@ -244,7 +244,7 @@ public final class QeProcessorImpl implements QeProcessor {
                     .fragmentInstanceInfos(info.getCoord().getFragmentInstanceInfos())
                     .profile(info.getCoord().getExecutionProfile().getRoot())
                     .queryStatistics(queryStatistics)
-                    .isReportSucc(context.getSessionVariable().enableProfile()).build();
+                    .isReportSucc(info.getCoord().getQueryOptions().enable_profile).build();
             querySet.put(queryIdStr, item);
         }
         return querySet;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -110,6 +110,7 @@ public class SessionVariable implements Serializable, Writable {
     public static final String MAX_EXECUTION_TIME = "max_execution_time";
     public static final String INSERT_TIMEOUT = "insert_timeout";
     public static final String ENABLE_PROFILE = "enable_profile";
+    public static final String ENABLE_PROFILE_COMPUTE_GROUPS = "enable_profile_compute_groups";
     public static final String RPC_VERBOSE_PROFILE_MAX_INSTANCE_COUNT = "rpc_verbose_profile_max_instance_count";
     public static final String AUTO_PROFILE_THRESHOLD_MS = "auto_profile_threshold_ms";
     public static final String SQL_MODE = "sql_mode";
@@ -1226,6 +1227,11 @@ public class SessionVariable implements Serializable, Writable {
     // if true, need report to coordinator when plan fragment execute successfully.
     @VarAttrDef.VarAttr(name = ENABLE_PROFILE, needForward = true)
     public boolean enableProfile = false;
+
+    @VarAttrDef.VarAttr(name = ENABLE_PROFILE_COMPUTE_GROUPS, needForward = true,
+            description = "Compute groups for which Profile is enabled, separated by commas; "
+                    + "empty means no restriction")
+    public String enableProfileComputeGroups = "";
 
     @VarAttrDef.VarAttr(name = RPC_VERBOSE_PROFILE_MAX_INSTANCE_COUNT, needForward = true)
     public int rpcVerboseProfileMaxInstanceCount = 5;
@@ -3955,7 +3961,22 @@ public class SessionVariable implements Serializable, Writable {
     }
 
     public boolean enableProfile() {
-        return enableProfile;
+        return enableProfile(ConnectContext.get());
+    }
+
+    public boolean enableProfile(ConnectContext connectContext) {
+        if (!enableProfile || !Config.isCloudMode() || Strings.isNullOrEmpty(enableProfileComputeGroups)
+                || enableProfileComputeGroups.trim().isEmpty()) {
+            return enableProfile;
+        }
+        String computeGroup = resolveCloudClusterName(connectContext);
+        return Arrays.stream(enableProfileComputeGroups.split(","))
+                .map(String::trim)
+                .anyMatch(computeGroup::equals);
+    }
+
+    public String getEnableProfileComputeGroups() {
+        return enableProfileComputeGroups;
     }
 
     public int getAutoProfileThresholdMs() {
@@ -5493,9 +5514,10 @@ public class SessionVariable implements Serializable, Writable {
         tResult.setMinFileScannersConcurrency(minFileScannersConcurrency);
 
         tResult.setQueryTimeout(queryTimeoutS);
-        tResult.setEnableProfile(enableProfile);
+        boolean effectiveEnableProfile = enableProfile();
+        tResult.setEnableProfile(effectiveEnableProfile);
         tResult.setRpcVerboseProfileMaxInstanceCount(rpcVerboseProfileMaxInstanceCount);
-        if (enableProfile) {
+        if (effectiveEnableProfile) {
             // If enable profile == true, then also set report success to true
             // be need report success to start report thread. But it is very tricky
             // we should modify BE in the future.

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -594,16 +594,33 @@ public class StmtExecutor {
         this.context.setStatementContext(statementContext);
     }
 
-    /** Refresh the profile decision after a prepared statement reapplies its SET_VAR hint. */
+    /**
+     * Refresh the profile decision after the current statement reapplies its SET_VAR hint.
+     * Multi-statement parsing can apply hints from later statements before this executor is created,
+     * so only the hint owned by this executor's statement context may refresh its decision.
+     */
     public void refreshEffectiveEnableProfileAfterSetVar(StatementContext hintStatementContext) {
-        if (!isComStmtExecute || statementContext != hintStatementContext) {
+        if (statementContext != hintStatementContext) {
             return;
         }
-        boolean enableProfile = context.getSessionVariable().enableProfile(context);
+        SessionVariable sessionVariable = context.getSessionVariable();
+        boolean enableProfile = sessionVariable.enableProfile(context);
+        profile.updateProfileSettings(
+                sessionVariable.getProfileLevel(), sessionVariable.getAutoProfileThresholdMs());
         if (enableProfile && !effectiveEnableProfile) {
             profile.enable();
         }
         effectiveEnableProfile = enableProfile;
+        snapshotChangedSessionVarsForProfile();
+    }
+
+    private void snapshotChangedSessionVarsForProfile() {
+        // Short circuit query should not dump changed session vars since it will impact performance.
+        if (!effectiveEnableProfile || statementContext.isShortCircuitQuery()) {
+            return;
+        }
+        List<List<String>> changedSessionVar = VariableMgr.dumpChangedVars(context.getSessionVariable());
+        profile.setChangedSessionVar(DebugUtil.prettyPrintChangedSessionVar(changedSessionVar));
     }
 
     public boolean isHandleQueryInFe() {
@@ -799,11 +816,7 @@ public class StmtExecutor {
         context.setStartTime();
 
         profile.getSummaryProfile().setQueryBeginTime(TimeUtils.getStartTimeMs());
-        // short circuit query should not dump changed session var since it will impact the performance.
-        if (effectiveEnableProfile && !statementContext.isShortCircuitQuery()) {
-            List<List<String>> changedSessionVar = VariableMgr.dumpChangedVars(context.getSessionVariable());
-            profile.setChangedSessionVar(DebugUtil.prettyPrintChangedSessionVar(changedSessionVar));
-        }
+        snapshotChangedSessionVarsForProfile();
         context.setStmtId(STMT_ID_GENERATOR.incrementAndGet());
 
         parseByNereids();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -217,6 +217,12 @@ public class StmtExecutor {
     private String mysqlLoadId;
     // Handle selects that fe can do without be
     private boolean isHandleQueryInFe = false;
+
+    // Prevent session_variable rollback after SET_VAR query
+    // e.g. set compute_group = cg_a
+    // SELECT /*+ SET_VAR(compute_group='cg_b') */ 1;
+    // After the query, it may rollback to `cg_a`, causing the profile to cancel reporting
+    private boolean effectiveEnableProfile;
     // The profile of this execution
     private final Profile profile;
     private Boolean isForwardedToMaster = null;
@@ -243,8 +249,9 @@ public class StmtExecutor {
         this.isProxy = isProxy;
         this.statementContext = new StatementContext(context, originStmt);
         this.context.setStatementContext(statementContext);
+        this.effectiveEnableProfile = this.context.getSessionVariable().enableProfile(this.context);
         this.profile = new Profile(
-                this.context.getSessionVariable().enableProfile(),
+                effectiveEnableProfile,
                 this.context.getSessionVariable().getProfileLevel(),
                 this.context.getSessionVariable().getAutoProfileThresholdMs());
     }
@@ -281,8 +288,9 @@ public class StmtExecutor {
             this.statementContext.setParsedStatement(parsedStmt);
         }
         this.context.setStatementContext(statementContext);
+        this.effectiveEnableProfile = context.getSessionVariable().enableProfile(context);
         this.profile = new Profile(
-                context.getSessionVariable().enableProfile(),
+                effectiveEnableProfile,
                 context.getSessionVariable().getProfileLevel(),
                 context.getSessionVariable().getAutoProfileThresholdMs());
     }
@@ -586,6 +594,18 @@ public class StmtExecutor {
         this.context.setStatementContext(statementContext);
     }
 
+    /** Refresh the profile decision after a prepared statement reapplies its SET_VAR hint. */
+    public void refreshEffectiveEnableProfileAfterSetVar(StatementContext hintStatementContext) {
+        if (!isComStmtExecute || statementContext != hintStatementContext) {
+            return;
+        }
+        boolean enableProfile = context.getSessionVariable().enableProfile(context);
+        if (enableProfile && !effectiveEnableProfile) {
+            profile.enable();
+        }
+        effectiveEnableProfile = enableProfile;
+    }
+
     public boolean isHandleQueryInFe() {
         return isHandleQueryInFe;
     }
@@ -780,7 +800,7 @@ public class StmtExecutor {
 
         profile.getSummaryProfile().setQueryBeginTime(TimeUtils.getStartTimeMs());
         // short circuit query should not dump changed session var since it will impact the performance.
-        if (context.getSessionVariable().enableProfile && !statementContext.isShortCircuitQuery()) {
+        if (effectiveEnableProfile && !statementContext.isShortCircuitQuery()) {
             List<List<String>> changedSessionVar = VariableMgr.dumpChangedVars(context.getSessionVariable());
             profile.setChangedSessionVar(DebugUtil.prettyPrintChangedSessionVar(changedSessionVar));
         }
@@ -1267,7 +1287,7 @@ public class StmtExecutor {
     }
 
     public void updateProfile(boolean isFinished) {
-        if (!context.getSessionVariable().enableProfile() || !isProfileSafeStmt()) {
+        if (!effectiveEnableProfile || !isProfileSafeStmt()) {
             return;
         }
         // If any error happened in update profile, we should ignore this error
@@ -1423,7 +1443,7 @@ public class StmtExecutor {
             if (resultSet.isPresent()) {
                 sendResultSet(resultSet.get(), ((Queriable) parsedStmt).getFieldInfos());
                 isHandleQueryInFe = true;
-                if (context.getSessionVariable().enableProfile()) {
+                if (effectiveEnableProfile) {
                     if (profile != null) {
                         this.profile.getSummaryProfile().setExecutedByFrontend(true);
                     }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
@@ -70,13 +70,59 @@ public class SessionVariablesTest extends TestWithFeService {
         Assertions.assertEquals(numOfForwardVars, vars.size());
 
         vars.put(SessionVariable.ENABLE_PROFILE, "true");
+        vars.put(SessionVariable.ENABLE_PROFILE_COMPUTE_GROUPS, "compute_group_1,compute_group_2");
         vars.put(SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE, "ERROR");
         sessionVariable.setForwardedSessionVariables(vars);
         Assertions.assertTrue(sessionVariable.enableProfile);
+        Assertions.assertEquals("compute_group_1,compute_group_2",
+                sessionVariable.getEnableProfileComputeGroups());
         Assertions.assertEquals(SessionVariable.INSERT_VISIBLE_TIMEOUT_RETURN_MODE_ERROR,
                 sessionVariable.getInsertVisibleTimeoutReturnMode());
         Assertions.assertEquals(SessionVariable.InsertVisibleTimeoutReturnMode.ERROR,
                 sessionVariable.getInsertVisibleTimeoutReturnModeEnum());
+    }
+
+    @Test
+    public void testEnableProfileComputeGroups() throws Exception {
+        String originalDeployMode = Config.deploy_mode;
+        String originalCloudUniqueId = Config.cloud_unique_id;
+        try {
+            Config.deploy_mode = "cloud";
+            Config.cloud_unique_id = "";
+
+            SessionVariable variable = new SessionVariable();
+            variable.enableProfile = true;
+            variable.cloudCluster = "compute_group_1";
+            Assertions.assertTrue(variable.enableProfile());
+
+            VariableMgr.setVar(variable, new SetVar(SessionVariable.ENABLE_PROFILE_COMPUTE_GROUPS,
+                    new StringLiteral("compute_group_1, compute_group_2")));
+            Assertions.assertTrue(variable.enableProfile());
+            Assertions.assertTrue(variable.toThrift().isEnableProfile());
+
+            variable.cloudCluster = "compute_group_2";
+            Assertions.assertTrue(variable.enableProfile());
+
+            variable.cloudCluster = "compute_group_3";
+            Assertions.assertFalse(variable.enableProfile());
+            Assertions.assertFalse(variable.toThrift().isEnableProfile());
+            Assertions.assertFalse(variable.toThrift().isIsReportSuccess());
+
+            variable.enableProfile = false;
+            variable.cloudCluster = "compute_group_1";
+            Assertions.assertFalse(variable.enableProfile());
+
+            variable.enableProfile = true;
+            variable.enableProfileComputeGroups = " ";
+            Assertions.assertTrue(variable.enableProfile());
+
+            Config.deploy_mode = "";
+            variable.enableProfileComputeGroups = "compute_group_2";
+            Assertions.assertTrue(variable.enableProfile());
+        } finally {
+            Config.deploy_mode = originalDeployMode;
+            Config.cloud_unique_id = originalCloudUniqueId;
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -25,13 +25,19 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ResourceMgr;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.profile.Profile;
 import org.apache.doris.common.profile.SummaryProfile;
 import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlCommand;
 import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.authenticate.TestLogAppender;
+import org.apache.doris.nereids.glue.LogicalPlanAdapter;
 import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.nereids.properties.SelectHint;
+import org.apache.doris.nereids.properties.SelectHintSetVar;
+import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.commands.PrepareCommand;
+import org.apache.doris.nereids.trees.plans.logical.LogicalSelectHint;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.planner.ResultFileSink;
@@ -91,28 +97,109 @@ public class StmtExecutorTest extends TestWithFeService {
         boolean originalEnableProfile = variable.enableProfile;
         String originalEnableProfileComputeGroups = variable.enableProfileComputeGroups;
         String originalCloudCluster = variable.cloudCluster;
+        int originalProfileLevel = variable.profileLevel;
+        int originalAutoProfileThresholdMs = variable.autoProfileThresholdMs;
         try {
             Config.deploy_mode = "cloud";
             Config.cloud_unique_id = "";
             variable.enableProfile = true;
             variable.enableProfileComputeGroups = "cg_b";
             variable.cloudCluster = "cg_a";
+            variable.profileLevel = 2;
+            variable.autoProfileThresholdMs = -1;
 
-            String sql = "select /*+ SET_VAR(compute_group='cg_b') */ 1";
+            String sql = "select /*+ SET_VAR(compute_group='cg_b', profile_level='3',"
+                    + " auto_profile_threshold_ms='10000') */ 1";
             StmtExecutor executor = prepareAndExecute(sql);
             Field effectiveEnableProfile = StmtExecutor.class.getDeclaredField("effectiveEnableProfile");
             effectiveEnableProfile.setAccessible(true);
+            Field profileLevel = Profile.class.getDeclaredField("profileLevel");
+            profileLevel.setAccessible(true);
+            Field autoProfileDurationMs = Profile.class.getDeclaredField("autoProfileDurationMs");
+            autoProfileDurationMs.setAccessible(true);
             Assertions.assertTrue(effectiveEnableProfile.getBoolean(executor));
+            Assertions.assertEquals(3, profileLevel.getInt(executor.getProfile()));
+            Assertions.assertEquals(10000L, autoProfileDurationMs.getLong(executor.getProfile()));
             Assertions.assertEquals(SummaryProfile.PROFILE_COMPLETION_STATE_RUNNING,
                     executor.getProfile().getProfileCompletionState());
+            String renderedProfile = executor.getProfile().getProfileByLevel();
+            Assertions.assertTrue(renderedProfile.contains("\"VarName\": \"compute_group\""));
+            Assertions.assertTrue(renderedProfile.contains("\"CurrentValue\": \"cg_b\""));
+            Assertions.assertTrue(renderedProfile.contains("\"VarName\": \"profile_level\""));
+            Assertions.assertTrue(renderedProfile.contains("\"CurrentValue\": \"3\""));
+            Assertions.assertTrue(renderedProfile.contains("\"VarName\": \"auto_profile_threshold_ms\""));
+            Assertions.assertTrue(renderedProfile.contains("\"CurrentValue\": \"10000\""));
             Assertions.assertEquals("cg_a", variable.cloudCluster);
             Assertions.assertFalse(variable.enableProfile(connectContext));
+            Assertions.assertEquals(2, variable.profileLevel);
+            Assertions.assertEquals(-1, variable.autoProfileThresholdMs);
 
             variable.enableProfileComputeGroups = "cg_a";
             StmtExecutor disabledExecutor = prepareAndExecute(sql);
             Assertions.assertFalse(effectiveEnableProfile.getBoolean(disabledExecutor));
+            Assertions.assertEquals(3, profileLevel.getInt(disabledExecutor.getProfile()));
+            Assertions.assertEquals(10000L, autoProfileDurationMs.getLong(disabledExecutor.getProfile()));
             Assertions.assertEquals("cg_a", variable.cloudCluster);
             Assertions.assertTrue(variable.enableProfile(connectContext));
+        } finally {
+            variable.enableProfile = originalEnableProfile;
+            variable.enableProfileComputeGroups = originalEnableProfileComputeGroups;
+            variable.cloudCluster = originalCloudCluster;
+            variable.profileLevel = originalProfileLevel;
+            variable.autoProfileThresholdMs = originalAutoProfileThresholdMs;
+            variable.setIsSingleSetVar(false);
+            variable.clearSessionOriginValue();
+            Config.deploy_mode = originalDeployMode;
+            Config.cloud_unique_id = originalCloudUniqueId;
+        }
+    }
+
+    @Test
+    public void testMultiStatementsRefreshProfileDecisionAfterSetVar() throws Exception {
+        String originalDeployMode = Config.deploy_mode;
+        String originalCloudUniqueId = Config.cloud_unique_id;
+        SessionVariable variable = connectContext.getSessionVariable();
+        boolean originalEnableProfile = variable.enableProfile;
+        String originalEnableProfileComputeGroups = variable.enableProfileComputeGroups;
+        String originalCloudCluster = variable.cloudCluster;
+        try {
+            Config.deploy_mode = "cloud";
+            Config.cloud_unique_id = "";
+            variable.enableProfile = true;
+            variable.enableProfileComputeGroups = "cg_a,cg_b";
+            variable.cloudCluster = "cg_a";
+            connectContext.setCommand(MysqlCommand.COM_QUERY);
+
+            String sql = "select /*+ SET_VAR(compute_group='cg_b') */ 1;"
+                    + "select /*+ SET_VAR(compute_group='cg_c') */ 2";
+            List<StatementBase> statements = new NereidsParser().parseSQL(sql, variable);
+            Assertions.assertEquals(2, statements.size());
+            Assertions.assertEquals("cg_c", variable.cloudCluster);
+
+            Field effectiveEnableProfile = StmtExecutor.class.getDeclaredField("effectiveEnableProfile");
+            effectiveEnableProfile.setAccessible(true);
+
+            StmtExecutor firstExecutor = new StmtExecutor(connectContext, statements.get(0));
+            connectContext.setExecutor(firstExecutor);
+            Assertions.assertFalse(effectiveEnableProfile.getBoolean(firstExecutor));
+            reapplySetVarHint((LogicalPlanAdapter) statements.get(0));
+            Assertions.assertTrue(effectiveEnableProfile.getBoolean(firstExecutor));
+            Assertions.assertTrue(variable.toThrift().isEnableProfile());
+            String renderedProfile = firstExecutor.getProfile().getProfileByLevel();
+            Assertions.assertTrue(renderedProfile.contains("\"VarName\": \"compute_group\""));
+            Assertions.assertTrue(renderedProfile.contains("\"CurrentValue\": \"cg_b\""));
+            Assertions.assertFalse(renderedProfile.contains("\"CurrentValue\": \"cg_c\""));
+
+            VariableMgr.revertSessionValue(variable);
+            variable.setIsSingleSetVar(false);
+            variable.clearSessionOriginValue();
+
+            StmtExecutor secondExecutor = new StmtExecutor(connectContext, statements.get(1));
+            connectContext.setExecutor(secondExecutor);
+            Assertions.assertTrue(effectiveEnableProfile.getBoolean(secondExecutor));
+            reapplySetVarHint((LogicalPlanAdapter) statements.get(1));
+            Assertions.assertFalse(effectiveEnableProfile.getBoolean(secondExecutor));
+            Assertions.assertFalse(variable.toThrift().isEnableProfile());
         } finally {
             variable.enableProfile = originalEnableProfile;
             variable.enableProfileComputeGroups = originalEnableProfileComputeGroups;
@@ -122,6 +209,18 @@ public class StmtExecutorTest extends TestWithFeService {
             Config.deploy_mode = originalDeployMode;
             Config.cloud_unique_id = originalCloudUniqueId;
         }
+    }
+
+    private void reapplySetVarHint(LogicalPlanAdapter statement) {
+        List<Plan> selectHints = statement.getLogicalPlan()
+                .collectToList(plan -> plan instanceof LogicalSelectHint);
+        Assertions.assertEquals(1, selectHints.size());
+        LogicalSelectHint<?> selectHint = (LogicalSelectHint<?>) selectHints.get(0);
+        SelectHint setVarHint = selectHint.getHints().stream()
+                .filter(hint -> hint instanceof SelectHintSetVar)
+                .findFirst()
+                .orElseThrow(AssertionError::new);
+        ((SelectHintSetVar) setVarHint).setVarOnceInSql(statement.getStatementContext());
     }
 
     private StmtExecutor prepareAndExecute(String sql) throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.qe;
 
+import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InternalSchemaInitializer;
@@ -24,9 +25,13 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ResourceMgr;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.profile.SummaryProfile;
 import org.apache.doris.mysql.MysqlChannel;
+import org.apache.doris.mysql.MysqlCommand;
 import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.authenticate.TestLogAppender;
+import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.nereids.trees.plans.commands.PrepareCommand;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.planner.ResultFileSink;
@@ -76,6 +81,82 @@ public class StmtExecutorTest extends TestWithFeService {
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, "");
         stmtExecutor.execute();
         Assert.assertEquals(QueryState.MysqlStateType.OK, connectContext.getState().getStateType());
+    }
+
+    @Test
+    public void testPreparedStatementRefreshesProfileDecisionAfterSetVar() throws Exception {
+        String originalDeployMode = Config.deploy_mode;
+        String originalCloudUniqueId = Config.cloud_unique_id;
+        SessionVariable variable = connectContext.getSessionVariable();
+        boolean originalEnableProfile = variable.enableProfile;
+        String originalEnableProfileComputeGroups = variable.enableProfileComputeGroups;
+        String originalCloudCluster = variable.cloudCluster;
+        try {
+            Config.deploy_mode = "cloud";
+            Config.cloud_unique_id = "";
+            variable.enableProfile = true;
+            variable.enableProfileComputeGroups = "cg_b";
+            variable.cloudCluster = "cg_a";
+
+            String sql = "select /*+ SET_VAR(compute_group='cg_b') */ 1";
+            StmtExecutor executor = prepareAndExecute(sql);
+            Field effectiveEnableProfile = StmtExecutor.class.getDeclaredField("effectiveEnableProfile");
+            effectiveEnableProfile.setAccessible(true);
+            Assertions.assertTrue(effectiveEnableProfile.getBoolean(executor));
+            Assertions.assertEquals(SummaryProfile.PROFILE_COMPLETION_STATE_RUNNING,
+                    executor.getProfile().getProfileCompletionState());
+            Assertions.assertEquals("cg_a", variable.cloudCluster);
+            Assertions.assertFalse(variable.enableProfile(connectContext));
+
+            variable.enableProfileComputeGroups = "cg_a";
+            StmtExecutor disabledExecutor = prepareAndExecute(sql);
+            Assertions.assertFalse(effectiveEnableProfile.getBoolean(disabledExecutor));
+            Assertions.assertEquals("cg_a", variable.cloudCluster);
+            Assertions.assertTrue(variable.enableProfile(connectContext));
+        } finally {
+            variable.enableProfile = originalEnableProfile;
+            variable.enableProfileComputeGroups = originalEnableProfileComputeGroups;
+            variable.cloudCluster = originalCloudCluster;
+            variable.setIsSingleSetVar(false);
+            variable.clearSessionOriginValue();
+            Config.deploy_mode = originalDeployMode;
+            Config.cloud_unique_id = originalCloudUniqueId;
+        }
+    }
+
+    private StmtExecutor prepareAndExecute(String sql) throws Exception {
+        connectContext.getState().reset();
+        connectContext.setCommand(MysqlCommand.COM_STMT_PREPARE);
+        StatementBase parsedStmt = new NereidsParser().parseSQL(sql, connectContext.getSessionVariable()).get(0);
+        parsedStmt.setOrigStmt(new OriginStatement(sql, 0));
+        StmtExecutor prepareExecutor = new StmtExecutor(connectContext, parsedStmt);
+        prepareExecutor.execute();
+
+        String stmtName = prepareExecutor.getPrepareStmtName();
+        PreparedStatementContext preparedStatementContext = connectContext.getPreparedStementContext(stmtName);
+        Assertions.assertNotNull(preparedStatementContext);
+        Assertions.assertFalse(connectContext.getSessionVariable().getIsSingleSetVar());
+
+        connectContext.getState().reset();
+        connectContext.setCommand(MysqlCommand.COM_STMT_EXECUTE);
+        TestMysqlConnectProcessor processor = new TestMysqlConnectProcessor(connectContext);
+        // The mocked FE has a non-cloud SystemInfoService, so cloud execution stops after
+        // preprocessing. That is late enough to exercise SET_VAR reapplication and refresh the
+        // executor state under test; MysqlConnectProcessor owns and records the later error.
+        processor.executePreparedStatement(preparedStatementContext.command, Long.parseLong(stmtName),
+                preparedStatementContext);
+        return connectContext.getExecutor();
+    }
+
+    private static class TestMysqlConnectProcessor extends MysqlConnectProcessor {
+        TestMysqlConnectProcessor(ConnectContext context) {
+            super(context);
+        }
+
+        void executePreparedStatement(PrepareCommand prepareCommand, long stmtId,
+                PreparedStatementContext preparedStatementContext) {
+            handleExecute(prepareCommand, stmtId, preparedStatementContext, ByteBuffer.allocate(0), null);
+        }
     }
 
     // Arrow Flight SQL keeps a query's coordinator alive across GetFlightInfo -> DoGet (see #62259);


### PR DESCRIPTION
### Release note

In cloud mode, enabling query profiles globally may introduce unnecessary overhead when only specific compute groups need profiling.

This PR adds compute-group-level profile filtering and fixes the profile decision lifecycle when a statement uses `SET_VAR(compute_group=...)`.

Add the session variable `enable_profile_compute_groups`, supports multiple compute groups separated by commas.
```sql
SET enable_profile_compute_groups='cg_a, cg_b'
```
