### PR TITLE
[fix](docker) Propagate BE registration failures

### DIFF
--- a/docker/runtime/be/resource/be_disaggregated_entrypoint.sh
+++ b/docker/runtime/be/resource/be_disaggregated_entrypoint.sh
@@ -38,8 +38,6 @@ DORIS_ROOT=${DORIS_ROOT:-"/opt/apache-doris"}
 AUTH_PATH="/etc/basic_auth"
 DORIS_HOME=${DORIS_ROOT}/be
 BE_CONFIG=$DORIS_HOME/conf/be.conf
-# represents self in fe meta or not.
-REGISTERED=false
 
 DB_ADMIN_USER=${USER:-"root"}
 
@@ -514,18 +512,13 @@ function check_and_register()
     local addrArr=(${addrs//,/ })
     for addr in ${addrArr[@]}
     do
-        first_deploy_start $addr
-        if [[ $REGISTERED ]]; then
-            break;
+        if first_deploy_start $addr; then
+            return 0
         fi
     done
 
-    if [[ $REGISTERED ]]; then
-        return 0
-    else
-        log_stderr  "not find master in fe cluster, please use mysql connect to fe for verfing the master exist and verify domain connectivity with two pods in different node. "
-        exit 1
-    fi
+    log_stderr  "not find master in fe cluster, please use mysql connect to fe for verfing the master exist and verify domain connectivity with two pods in different node. "
+    return 1
 }
 
 # when start workload group resource control, should pre mkdir the directory `/sys/fs/cgroup/cpu/doris`
@@ -643,7 +636,7 @@ collect_env_info
 wait_for_fqdn_ready || exit 1
 ./doris-debug --component be
 #add_self $fe_addr || exit $?
-check_and_register $fe_addrs
+check_and_register $fe_addrs || exit 1
 ulimit -c unlimited
 log_stderr "run start_be.sh"
 # the server will start in the current terminal session, and the log output and console interaction will be printed to that terminal

--- a/docker/runtime/be/resource/be_entrypoint.sh
+++ b/docker/runtime/be/resource/be_entrypoint.sh
@@ -38,8 +38,6 @@ DORIS_ROOT=${DORIS_ROOT:-"/opt/apache-doris"}
 AUTH_PATH="/etc/basic_auth"
 DORIS_HOME=${DORIS_ROOT}/be
 BE_CONFIG=$DORIS_HOME/conf/be.conf
-# represents self in fe meta or not.
-REGISTERED=false
 
 DB_ADMIN_USER=${USER:-"root"}
 
@@ -452,19 +450,13 @@ function check_and_register()
     local addrArr=(${addrs//,/ })
     for addr in ${addrArr[@]}
     do
-        add_self $addr
-
-        if [[ $REGISTERED ]]; then
-            break;
+        if add_self $addr; then
+            return 0
         fi
     done
 
-    if [[ $REGISTERED ]]; then
-        return 0
-    else
-        log_stderr  "not find master in fe cluster, please use mysql connect to fe for verfing the master exist and verify domain connectivity with two pods in different node. "
-        exit 1
-    fi
+    log_stderr  "not find master in fe cluster, please use mysql connect to fe for verfing the master exist and verify domain connectivity with two pods in different node. "
+    return 1
 }
 
 function make_dir_for_workloadgroup() {
@@ -530,7 +522,7 @@ parse_tls_connection_variables
 collect_env_info
 wait_for_fqdn_ready || exit 1
 #add_self $fe_addr || exit $?
-check_and_register $fe_addrs
+check_and_register $fe_addrs || exit 1
 ./doris-debug --component be
 log_stderr "run start_be.sh"
 #allow create core file


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

The Kubernetes BE entrypoint scripts initialized `REGISTERED` to the literal string `false` and later evaluated it with `[[ $REGISTERED ]]`. In Bash, every non-empty string is true, so an FE registration failure could be treated as success and the script would continue to start BE without registering it with FE.

This PR removes the unused string flag and uses the exit status from `add_self` / `first_deploy_start` directly. Each configured FE address is tried in order. If all registration attempts fail, the entrypoint exits before `start_be.sh`, allowing Kubernetes to restart the container and retry after FE becomes available.

### Release note

Fix Kubernetes BE containers to restart instead of starting unregistered when FE registration fails.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - `bash -n docker/runtime/be/resource/be_entrypoint.sh`
        - `bash -n docker/runtime/be/resource/be_disaggregated_entrypoint.sh`
        - `build-support/shell-check.sh`
        - Mocked registration success, first-address failover, and all-addresses-failed return paths for both scripts
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. BE containers now exit when all FE registration attempts fail instead of starting unregistered.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label