### PR TITLE
[refactor](snapshot) Allow overriding snapshot manager factory source

### DIFF
--- a/cloud/src/snapshot/CMakeLists.txt
+++ b/cloud/src/snapshot/CMakeLists.txt
@@ -18,4 +18,10 @@
 set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/snapshot")
 set(EXECUTABLE_OUTPUT_PATH "${BUILD_DIR}/src/snapshot")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lfdb_c -L${THIRDPARTY_DIR}/lib")
-add_library(Snapshot snapshot_manager.cpp snapshot_manager_factory.cpp)
+
+# Extension modules may replace the factory while reusing the public SnapshotManager API.
+if (NOT DORIS_CLOUD_SNAPSHOT_MANAGER_FACTORY_SOURCE)
+    set(DORIS_CLOUD_SNAPSHOT_MANAGER_FACTORY_SOURCE snapshot_manager_factory.cpp)
+endif()
+
+add_library(Snapshot snapshot_manager.cpp ${DORIS_CLOUD_SNAPSHOT_MANAGER_FACTORY_SOURCE})


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: The public Snapshot target always compiles its built-in factory, which forces an enterprise implementation to modify public source code. Add a source-level extension contract so an external snapshot module can replace only the factory while reusing the public SnapshotManager API. The open-source build continues to compile the same default factory.

### Release note

None

### Check List (For Author)

- Test: Full Cloud build
    - ./build.sh --cloud --clean -j 48
- Behavior changed: No. The default factory source remains unchanged unless an extension module overrides it.
- Does this need documentation: No