### PR TITLE
[fix](fe) Preserve config for replace table binlogs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/Alter.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.alter;
 
+import org.apache.doris.catalog.BinlogConfig;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DataProperty;
 import org.apache.doris.catalog.Database;
@@ -678,10 +679,12 @@ public class Alter {
                 if (swapTable) {
                     origTable.checkAndSetName(newTblName, true);
                 }
+                BinlogConfig origTblBinlogConfig = new BinlogConfig(origTable.getBinlogConfig());
                 replaceTableInternal(db, origTable, olapNewTbl, swapTable, false, isForce);
                 // write edit log
                 ReplaceTableOperationLog log = new ReplaceTableOperationLog(db.getId(),
-                        origTable.getId(), oldTblName, olapNewTbl.getId(), newTblName, swapTable, isForce);
+                        origTable.getId(), oldTblName, olapNewTbl.getId(), newTblName, swapTable, isForce,
+                        origTblBinlogConfig);
                 Env.getCurrentEnv().getEditLog().logReplaceTable(log);
                 LOG.info("finish replacing table {} with table {}, is swap: {}", oldTblName, newTblName, swapTable);
             } finally {

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogConfigCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogConfigCache.java
@@ -173,6 +173,15 @@ public class BinlogConfigCache {
         return tableBinlogConfig.isEnableForCCR();
     }
 
+    public void putTableBinlogConfig(long tableId, BinlogConfig binlogConfig) {
+        lock.writeLock().lock();
+        try {
+            dbTableBinlogEnableMap.put(tableId, new BinlogConfig(binlogConfig));
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
     public long getTableTtlSeconds(long dbId, long tableId) {
         BinlogConfig tableBinlogConfig = getTableBinlogConfig(dbId, tableId);
         if (tableBinlogConfig == null) {

--- a/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/binlog/BinlogManager.java
@@ -19,6 +19,7 @@ package org.apache.doris.binlog;
 
 import org.apache.doris.alter.AlterJobV2;
 import org.apache.doris.alter.IndexChangeJob;
+import org.apache.doris.catalog.BinlogConfig;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
@@ -444,6 +445,8 @@ public class BinlogManager {
             return;
         }
 
+        cacheReplacedTableBinlogConfig(info);
+
         long dbId = info.getDbId();
         List<Long> tableIds = Lists.newArrayList();
         tableIds.add(info.getOrigTblId());
@@ -452,6 +455,14 @@ public class BinlogManager {
         String data = info.toJson();
 
         addBinlog(dbId, tableIds, commitSeq, timestamp, type, data, false, info);
+    }
+
+    private void cacheReplacedTableBinlogConfig(ReplaceTableOperationLog info) {
+        BinlogConfig binlogConfig = info.getOrigTblBinlogConfig();
+        // Old edit logs do not contain the config snapshot. Keep their legacy lookup behavior.
+        if (!info.isSwapTable() && binlogConfig != null) {
+            binlogConfigCache.putTableBinlogConfig(info.getOrigTblId(), binlogConfig);
+        }
     }
 
     public void addModifyDistributionNum(ModifyTableDefaultDistributionBucketNumOperationLog info, long commitSeq) {
@@ -797,64 +808,94 @@ public class BinlogManager {
         int size = dis.readInt();
         LOG.info("read binlogs length: {}", size);
 
-        // Step 2: read all binlogs from dis
+        // Keep the disabled-feature path streaming so an image does not retain binlogs that will be discarded.
+        if (!Config.enable_feature_binlog) {
+            try {
+                for (int i = 0; i < size; i++) {
+                    readTBinlogFromStream(dis);
+                }
+            } catch (TException e) {
+                throw new IOException("failed to read binlog from TMemoryBuffer", e);
+            }
+            return checksum;
+        }
+
+        // Images are grouped by database. Buffer one existing-database region so snapshots stored after table
+        // dummies can be restored first. Missing-database regions remain streaming and are discarded.
         long currentDbId = -1;
-        boolean currentDbBinlogEnable = false;
-        List<TBinlog> tableDummies = Lists.newArrayList();
+        Database currentDb = null;
+        List<TBinlog> dbBinlogs = Lists.newArrayList();
         try {
             for (int i = 0; i < size; i++) {
-                // Step 2.1: read a binlog
                 TBinlog binlog = readTBinlogFromStream(dis);
-
-                if (!Config.enable_feature_binlog) {
-                    continue;
-                }
-
-                long dbId = binlog.getDbId();
-                if (binlog.getType().getValue() >= TBinlogType.MIN_UNKNOWN.getValue()) {
-                    LOG.warn("skip unknown binlog, type: {}, db: {}", binlog.getType().getValue(), dbId);
-                    continue;
-                }
-
-                // Step 2.2: check if there is in next db Binlogs region
-                if (dbId != currentDbId) {
-                    // if there is in next db Binlogs region, check and update metadata
-                    Database db = Env.getCurrentInternalCatalog().getDbNullable(dbId);
-                    if (db == null) {
-                        LOG.warn("db not found. dbId: {}", dbId);
-                        continue;
+                if (currentDbId != -1 && currentDbId != binlog.getDbId()) {
+                    if (currentDb != null) {
+                        recoverDbBinlogs(currentDb, dbBinlogs);
                     }
-                    currentDbId = dbId;
-                    currentDbBinlogEnable = db.getBinlogConfig().isEnableForCCR();
-                    tableDummies = Lists.newArrayList();
+                    dbBinlogs = Lists.newArrayList();
                 }
-
-                // step 2.3: recover binlog
-                if (binlog.getType() == TBinlogType.DUMMY) {
-                    // collect tableDummyBinlogs and dbDummyBinlog to recover DBBinlog and TableBinlog
-                    if (binlog.getBelong() == -1) {
-                        DBBinlog dbBinlog = DBBinlog.recoverDbBinlog(binlogConfigCache, binlog, tableDummies,
-                                currentDbBinlogEnable);
-                        dbBinlogMap.put(dbId, dbBinlog);
-                    } else {
-                        tableDummies.add(binlog);
+                if (currentDbId != binlog.getDbId()) {
+                    currentDbId = binlog.getDbId();
+                    currentDb = Env.getCurrentInternalCatalog().getDbNullable(currentDbId);
+                    if (currentDb == null) {
+                        LOG.warn("db not found. dbId: {}", currentDbId);
                     }
-                } else {
-                    // recover common binlogs
-                    DBBinlog dbBinlog = dbBinlogMap.get(dbId);
-                    if (dbBinlog == null) {
-                        LOG.warn("dbBinlog recover fail! binlog {} is before dummy. dbId: {}", binlog, dbId);
-                        continue;
-                    }
-                    binlog.setTableRef(0);
-                    dbBinlog.recoverBinlog(binlog, currentDbBinlogEnable);
+                }
+                if (currentDb != null) {
+                    dbBinlogs.add(binlog);
                 }
             }
         } catch (TException e) {
             throw new IOException("failed to read binlog from TMemoryBuffer", e);
         }
+        if (currentDb != null) {
+            recoverDbBinlogs(currentDb, dbBinlogs);
+        }
 
         return checksum;
+    }
+
+    private void recoverDbBinlogs(Database db, List<TBinlog> binlogs) {
+        if (binlogs.isEmpty()) {
+            return;
+        }
+
+        long dbId = binlogs.get(0).getDbId();
+        // Config snapshots are stored after table dummies, so restore them in a first pass.
+        for (TBinlog binlog : binlogs) {
+            if (binlog.getType() == TBinlogType.REPLACE_TABLE) {
+                cacheReplacedTableBinlogConfig(ReplaceTableOperationLog.fromJson(binlog.getData()));
+            }
+        }
+
+        boolean dbBinlogEnable = db.getBinlogConfig().isEnableForCCR();
+        List<TBinlog> tableDummies = Lists.newArrayList();
+        for (TBinlog binlog : binlogs) {
+            if (binlog.getType().getValue() >= TBinlogType.MIN_UNKNOWN.getValue()) {
+                LOG.warn("skip unknown binlog, type: {}, db: {}", binlog.getType().getValue(), dbId);
+                continue;
+            }
+
+            if (binlog.getType() == TBinlogType.DUMMY) {
+                // collect tableDummyBinlogs and dbDummyBinlog to recover DBBinlog and TableBinlog
+                if (binlog.getBelong() == -1) {
+                    DBBinlog dbBinlog = DBBinlog.recoverDbBinlog(binlogConfigCache, binlog, tableDummies,
+                            dbBinlogEnable);
+                    dbBinlogMap.put(dbId, dbBinlog);
+                } else {
+                    tableDummies.add(binlog);
+                }
+            } else {
+                // recover common binlogs
+                DBBinlog dbBinlog = dbBinlogMap.get(dbId);
+                if (dbBinlog == null) {
+                    LOG.warn("dbBinlog recover fail! binlog {} is before dummy. dbId: {}", binlog, dbId);
+                    continue;
+                }
+                binlog.setTableRef(0);
+                dbBinlog.recoverBinlog(binlog, dbBinlogEnable);
+            }
+        }
     }
 
     public ProcResult getBinlogInfo() {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/ReplaceTableOperationLog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/ReplaceTableOperationLog.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.persist;
 
+import org.apache.doris.catalog.BinlogConfig;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.gson.GsonUtils;
@@ -42,10 +43,18 @@ public class ReplaceTableOperationLog implements Writable {
     private boolean swapTable;
     @SerializedName(value = "isForce")
     private boolean isForce = true; // older version it was force. so keep same.
+    @SerializedName(value = "origTblBinlogConfig")
+    private BinlogConfig origTblBinlogConfig;
 
     public ReplaceTableOperationLog(long dbId, long origTblId,
             String origTblName, long newTblId, String newTblName,
             boolean swapTable, boolean isForce) {
+        this(dbId, origTblId, origTblName, newTblId, newTblName, swapTable, isForce, null);
+    }
+
+    public ReplaceTableOperationLog(long dbId, long origTblId,
+            String origTblName, long newTblId, String newTblName,
+            boolean swapTable, boolean isForce, BinlogConfig origTblBinlogConfig) {
         this.dbId = dbId;
         this.origTblId = origTblId;
         this.origTblName = origTblName;
@@ -53,6 +62,7 @@ public class ReplaceTableOperationLog implements Writable {
         this.newTblName = newTblName;
         this.swapTable = swapTable;
         this.isForce = isForce;
+        this.origTblBinlogConfig = origTblBinlogConfig == null ? null : new BinlogConfig(origTblBinlogConfig);
     }
 
     public long getDbId() {
@@ -81,6 +91,10 @@ public class ReplaceTableOperationLog implements Writable {
 
     public boolean isForce() {
         return isForce;
+    }
+
+    public BinlogConfig getOrigTblBinlogConfig() {
+        return origTblBinlogConfig;
     }
 
     public String toJson() {

--- a/fe/fe-core/src/test/java/org/apache/doris/binlog/BinlogManagerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/binlog/BinlogManagerTest.java
@@ -26,6 +26,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.persist.BinlogGcInfo;
+import org.apache.doris.persist.ReplaceTableOperationLog;
 import org.apache.doris.thrift.TBinlog;
 import org.apache.doris.thrift.TBinlogType;
 import org.apache.doris.thrift.TStatus;
@@ -33,6 +34,7 @@ import org.apache.doris.thrift.TStatusCode;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -52,6 +54,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class BinlogManagerTest {
     private Map<Long, List<Long>> frameWork;
@@ -66,6 +69,8 @@ public class BinlogManagerTest {
     private long ttl = 3;
 
     private boolean enableDbBinlog = false;
+    private Set<Long> coldTableIds;
+    private Set<Long> missingDbIds;
 
     private MockedConstruction<BinlogConfigCache> mockedBinlogConfigCacheConstruction;
     private MockedConstruction<BinlogConfig> mockedBinlogConfigConstruction;
@@ -81,6 +86,8 @@ public class BinlogManagerTest {
     @Before
     public void setUp() {
         Assert.assertTrue(tableNumPerDb < 100);
+        coldTableIds = Sets.newHashSet();
+        missingDbIds = Sets.newHashSet();
         frameWork = Maps.newHashMap();
         for (int dbOff = 1; dbOff <= dbNum; ++dbOff) {
             long dbId = dbOff * dbBaseId;
@@ -104,12 +111,29 @@ public class BinlogManagerTest {
         mockedBinlogConfigCacheConstruction = Mockito.mockConstruction(BinlogConfigCache.class,
                 Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
                 (mock, context) -> {
-                    Mockito.doAnswer(inv -> new BinlogConfig()).when(mock)
-                            .getDBBinlogConfig(Mockito.anyLong());
-                    Mockito.doAnswer(inv -> new BinlogConfig()).when(mock)
-                            .getTableBinlogConfig(Mockito.anyLong(), Mockito.anyLong());
-                    Mockito.doReturn(true).when(mock)
-                            .isEnableTable(Mockito.anyLong(), Mockito.anyLong());
+                    Map<Long, BinlogConfig> tableBinlogConfigs = Maps.newHashMap();
+                    Mockito.doAnswer(inv -> new BinlogConfig()).when(mock).getDBBinlogConfig(Mockito.anyLong());
+                    Mockito.doAnswer(inv -> {
+                        long tableId = inv.getArgument(1);
+                        BinlogConfig config = tableBinlogConfigs.get(tableId);
+                        if (config != null || coldTableIds.contains(tableId)) {
+                            return config;
+                        }
+                        return new BinlogConfig();
+                    }).when(mock).getTableBinlogConfig(Mockito.anyLong(), Mockito.anyLong());
+                    Mockito.doAnswer(inv -> {
+                        long tableId = inv.getArgument(0);
+                        tableBinlogConfigs.put(tableId, inv.getArgument(1));
+                        return null;
+                    }).when(mock).putTableBinlogConfig(Mockito.anyLong(), Mockito.any());
+                    Mockito.doAnswer(inv -> {
+                        long tableId = inv.getArgument(1);
+                        BinlogConfig config = tableBinlogConfigs.get(tableId);
+                        if (config != null) {
+                            return config.isEnableForCCR();
+                        }
+                        return !coldTableIds.contains(tableId);
+                    }).when(mock).isEnableTable(Mockito.anyLong(), Mockito.anyLong());
                     Mockito.doAnswer(inv -> enableDbBinlog).when(mock)
                             .isEnableDB(Mockito.anyLong());
                     Mockito.doReturn(false).when(mock)
@@ -127,8 +151,8 @@ public class BinlogManagerTest {
         mockedInternalCatalogConstruction = Mockito.mockConstruction(InternalCatalog.class,
                 Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS),
                 (mock, context) -> {
-                    Mockito.doAnswer(inv -> new Database()).when(mock)
-                            .getDbNullable(Mockito.anyLong());
+                    Mockito.doAnswer(inv -> missingDbIds.contains((long) inv.getArgument(0))
+                            ? null : new Database()).when(mock).getDbNullable(Mockito.anyLong());
                 });
 
         mockedEnv = Mockito.mockStatic(Env.class);
@@ -303,6 +327,118 @@ public class BinlogManagerTest {
                         newBinlogList.get(i).getCommitSeq());
             }
         }
+    }
+
+    @Test
+    public void testReplaceTableWithColdConfigCachePersists() throws IOException {
+        mockedBinlogConfigConstruction.close();
+        mockedBinlogConfigConstruction = null;
+
+        long dbId = dbBaseId;
+        long origTableId = tableBaseId;
+        coldTableIds.add(origTableId);
+        BinlogConfig config = new BinlogConfig(true, 11L, 22L, 33L,
+                BinlogConfig.BinlogFormat.STATEMENT_AND_SNAPSHOT, false);
+        ReplaceTableOperationLog log = new ReplaceTableOperationLog(dbId, origTableId, "old_table",
+                tableBaseId + 1, "new_table", false, false, config);
+
+        BinlogManager manager = new BinlogManager();
+        manager.addReplaceTable(log, baseNum);
+        assertReplaceTableBinlog(manager, dbId, origTableId);
+
+        BinlogConfigCache cache = mockedBinlogConfigCacheConstruction.constructed().get(0);
+        Assert.assertEquals(config, cache.getTableBinlogConfig(dbId, origTableId));
+
+        ByteArrayOutputStream arrayOutputStream = new ByteArrayOutputStream();
+        manager.write(new DataOutputStream(arrayOutputStream), 0L);
+
+        BinlogManager recoveredManager = new BinlogManager();
+        recoveredManager.read(new DataInputStream(new ByteArrayInputStream(arrayOutputStream.toByteArray())), 0L);
+        assertReplaceTableBinlog(recoveredManager, dbId, origTableId);
+
+        BinlogConfigCache recoveredCache = mockedBinlogConfigCacheConstruction.constructed().get(1);
+        Assert.assertEquals(config, recoveredCache.getTableBinlogConfig(dbId, origTableId));
+    }
+
+    @Test
+    public void testLegacyReplaceTableWithColdConfigCacheKeepsLegacyBehavior() {
+        long dbId = dbBaseId;
+        long origTableId = tableBaseId;
+        coldTableIds.add(origTableId);
+        ReplaceTableOperationLog log = new ReplaceTableOperationLog(dbId, origTableId, "old_table",
+                tableBaseId + 1, "new_table", false, false);
+
+        BinlogManager manager = new BinlogManager();
+        manager.addReplaceTable(log, baseNum);
+
+        Pair<TStatus, TBinlog> result = manager.getBinlog(dbId, origTableId, 0L);
+        Assert.assertEquals(TStatusCode.BINLOG_NOT_FOUND_DB, result.first.getStatusCode());
+        Assert.assertNull(result.second);
+    }
+
+    @Test
+    public void testImageRecoveryAcrossMissingDatabaseRegion() throws Exception {
+        mockedBinlogConfigConstruction.close();
+        mockedBinlogConfigConstruction = null;
+
+        long firstDbId = dbBaseId;
+        long missingDbId = dbBaseId + 1;
+        long lastDbId = dbBaseId + 2;
+        long missingTableId = tableBaseId + 1;
+        missingDbIds.add(missingDbId);
+        coldTableIds.add(missingTableId);
+
+        BinlogConfig config = new BinlogConfig(true, 11L, 22L, 33L,
+                BinlogConfig.BinlogFormat.STATEMENT_AND_SNAPSHOT, false);
+        ReplaceTableOperationLog replaceLog = new ReplaceTableOperationLog(missingDbId, missingTableId, "old_table",
+                missingTableId + 1, "new_table", false, false, config);
+        TBinlog replaceBinlog = new TBinlog();
+        replaceBinlog.setDbId(missingDbId);
+        replaceBinlog.setTableIds(Lists.newArrayList(missingTableId));
+        replaceBinlog.setType(TBinlogType.REPLACE_TABLE);
+        replaceBinlog.setCommitSeq(20L);
+        replaceBinlog.setTimestamp(20L);
+        replaceBinlog.setData(replaceLog.toJson());
+        replaceBinlog.setTableRef(0);
+
+        List<TBinlog> imageBinlogs = Lists.newArrayList(
+                BinlogUtils.newDummyBinlog(firstDbId, -1),
+                BinlogTestUtils.newBinlog(firstDbId, tableBaseId, 10L, 10L),
+                BinlogUtils.newDummyBinlog(missingDbId, -1),
+                replaceBinlog,
+                BinlogUtils.newDummyBinlog(lastDbId, -1),
+                BinlogTestUtils.newBinlog(lastDbId, tableBaseId + 2, 30L, 30L));
+        ByteArrayOutputStream arrayOutputStream = new ByteArrayOutputStream();
+        DataOutputStream outputStream = new DataOutputStream(arrayOutputStream);
+        outputStream.writeInt(imageBinlogs.size());
+        Method writeBinlog = BinlogManager.class.getDeclaredMethod(
+                "writeTBinlogToStream", DataOutputStream.class, TBinlog.class);
+        writeBinlog.setAccessible(true);
+        for (TBinlog binlog : imageBinlogs) {
+            writeBinlog.invoke(null, outputStream, binlog);
+        }
+
+        BinlogManager manager = new BinlogManager();
+        manager.read(new DataInputStream(new ByteArrayInputStream(arrayOutputStream.toByteArray())), 0L);
+
+        assertTableBinlogType(manager, firstDbId, tableBaseId, TBinlogType.ALTER_JOB);
+        Pair<TStatus, TBinlog> missingResult = manager.getBinlog(missingDbId, missingTableId, 0L);
+        Assert.assertEquals(TStatusCode.BINLOG_NOT_FOUND_DB, missingResult.first.getStatusCode());
+        Assert.assertNull(missingResult.second);
+        BinlogConfigCache cache = mockedBinlogConfigCacheConstruction.constructed().get(0);
+        Assert.assertNull(cache.getTableBinlogConfig(missingDbId, missingTableId));
+        assertTableBinlogType(manager, lastDbId, tableBaseId + 2, TBinlogType.ALTER_JOB);
+    }
+
+    private void assertReplaceTableBinlog(BinlogManager manager, long dbId, long tableId) {
+        assertTableBinlogType(manager, dbId, tableId, TBinlogType.REPLACE_TABLE);
+    }
+
+    private void assertTableBinlogType(BinlogManager manager, long dbId, long tableId, TBinlogType type) {
+        Pair<TStatus, TBinlog> result = manager.getBinlog(dbId, tableId, 0L);
+        Assert.assertEquals(TStatusCode.OK, result.first.getStatusCode());
+        Assert.assertNotNull(result.second);
+        Assert.assertEquals(type, result.second.getType());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/ReplaceTableOperationLogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/ReplaceTableOperationLogTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.persist;
 
+import org.apache.doris.catalog.BinlogConfig;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,7 +36,10 @@ public class ReplaceTableOperationLogTest {
         file.createNewFile();
         DataOutputStream dos = new DataOutputStream(new FileOutputStream(file));
 
-        ReplaceTableOperationLog log = new ReplaceTableOperationLog(1, 2, "old", 3, "new", true, true);
+        BinlogConfig binlogConfig = new BinlogConfig(true, 10L, 20L, 30L,
+                BinlogConfig.BinlogFormat.STATEMENT_AND_SNAPSHOT, false);
+        ReplaceTableOperationLog log = new ReplaceTableOperationLog(1, 2, "old", 3, "new", true, true,
+                binlogConfig);
         log.write(dos);
 
         dos.flush();
@@ -50,9 +55,17 @@ public class ReplaceTableOperationLogTest {
         Assert.assertTrue(readLog.isSwapTable() == log.isSwapTable());
         Assert.assertTrue(readLog.getOrigTblName().equals(log.getOrigTblName()));
         Assert.assertTrue(readLog.getNewTblName().equals(log.getNewTblName()));
+        Assert.assertEquals(binlogConfig, readLog.getOrigTblBinlogConfig());
 
         // 3. delete files
         dis.close();
         file.delete();
+    }
+
+    @Test
+    public void testLegacySerializationWithoutBinlogConfig() {
+        ReplaceTableOperationLog log = new ReplaceTableOperationLog(1, 2, "old", 3, "new", false, true);
+        ReplaceTableOperationLog readLog = ReplaceTableOperationLog.fromJson(log.toJson());
+        Assert.assertNull(readLog.getOrigTblBinlogConfig());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #66571

Related PR: None

Problem Summary:

When database-level binlog is disabled and only the original table has binlog enabled, a `swap=false` `REPLACE TABLE` can skip its binlog after an FE restart or failover. The original table is removed before a cold `BinlogConfigCache` can resolve its configuration.

This change captures the original table's `BinlogConfig` before replacement and persists it in `ReplaceTableOperationLog`. Live emission, follower replay, table-level GC settings, and image recovery use that snapshot. Image recovery pre-processes one existing database region at a time before filtering table dummies, while missing databases and disabled-binlog images remain streaming. Legacy logs without a snapshot retain their previous behavior.

### Release note

Fix missing `REPLACE TABLE` binlogs when only table-level binlog is enabled and the FE binlog config cache is cold.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. `REPLACE TABLE` now preserves the original table's binlog configuration for emission and recovery.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg. https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->