### PR TITLE
[fix](thirdparty) Scope the Arrow/Paimon fingerprint to its own inputs

### DIFF
--- a/thirdparty/arrow-paimon-vars.sh
+++ b/thirdparty/arrow-paimon-vars.sh
@@ -45,6 +45,25 @@ PAIMON_CPP_NAME="paimon-cpp-0a4f4e2.tar.gz"
 PAIMON_CPP_SOURCE="doris-thirdparty-paimon-cpp-0a4f4e2"
 PAIMON_CPP_MD5SUM="b8599a0421dbf1ec05e2f1a481d64e87"
 
+# Bump the corresponding schema version whenever output-affecting build options or
+# helper behavior in build_arrow() or build_paimon_cpp() changes. The fingerprints
+# below intentionally describe only this component stack so master and release
+# branches can reuse the same shared prebuilt when their semantic inputs match.
+ARROW_BUILD_SCHEMA_VERSION="1"
+PAIMON_BUILD_SCHEMA_VERSION="1"
+
+# The current shared automation prebuilt was published from master with the former
+# whole-script fingerprint. Keep these exact markers during the schema transition;
+# version and complete artifact validation are still mandatory before reuse.
+ARROW_LEGACY_COMPATIBLE_SEMANTIC_FINGERPRINT="ab79ab0bbfbf93f9860050fb751b20fee9e40d96"
+PAIMON_LEGACY_COMPATIBLE_SEMANTIC_FINGERPRINT="cb82e41ba46f534e611cdd52e66b53c227d49bf8"
+ARROW_LEGACY_BUILD_FINGERPRINTS=(
+    9d03645dd1cded5184a8126f5c7f4a6eb9b92b53
+)
+PAIMON_LEGACY_BUILD_FINGERPRINTS=(
+    dbb6ca6e243cb3aa783b7a8011f97afda9e7ea28
+)
+
 # Arrow consumes xsimd and Brotli as bundled source archives, but neither is a
 # build target in the focused Arrow/Paimon recovery path.
 ARROW_PAIMON_BUILD_PACKAGES=(arrow paimon_cpp)
@@ -82,23 +101,42 @@ prepare_arrow_paimon_download_packages() {
     done
 }
 
-# Identify the checked-in source, patch, and build inputs selected for Arrow.
-# Arrow and Paimon publish separate installed markers so a package-only build
-# cannot certify a component that it did not rebuild.
+# Print stable path-and-content records for fingerprint inputs. Including the path
+# makes patch selection and ordering part of the contract, not only file contents.
+arrow_paimon_fingerprint_files() {
+    local file
+    local blob
+    while IFS= read -r file; do
+        blob="$(git hash-object "${file}")" || return 1
+        printf 'file=%s\n' "${file}"
+        printf 'blob=%s\n' "${blob}"
+    done < <(printf '%s\n' "$@" | LC_ALL=C sort)
+}
+
+# Identify only the source, patch, and explicit build-schema inputs selected for
+# Arrow. Arrow and Paimon publish separate installed markers so a package-only
+# build cannot certify a component that it did not rebuild.
 arrow_build_fingerprint() {
     local vars_dir
     vars_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     (
+        set -o pipefail
         cd "${vars_dir}" || return 1
-        LC_ALL=C
-        git hash-object \
-            ../env.sh \
-            arrow-paimon-vars.sh \
-            vars.sh \
-            download-thirdparty.sh \
-            build-thirdparty.sh \
-            patches/apache-arrow-"${ARROW_VERSION}"-*.patch |
-            git hash-object --stdin
+        {
+            printf 'schema=%s\n' "${ARROW_BUILD_SCHEMA_VERSION}"
+            printf 'ARROW_VERSION=%s\n' "${ARROW_VERSION}"
+            printf 'ARROW_NAME=%s\n' "${ARROW_NAME}"
+            printf 'ARROW_SOURCE=%s\n' "${ARROW_SOURCE}"
+            printf 'ARROW_MD5SUM=%s\n' "${ARROW_MD5SUM}"
+            printf 'BROTLI_NAME=%s\n' "${BROTLI_NAME}"
+            printf 'BROTLI_SOURCE=%s\n' "${BROTLI_SOURCE}"
+            printf 'BROTLI_MD5SUM=%s\n' "${BROTLI_MD5SUM}"
+            printf 'XSIMD_NAME=%s\n' "${XSIMD_NAME}"
+            printf 'XSIMD_SOURCE=%s\n' "${XSIMD_SOURCE}"
+            printf 'XSIMD_MD5SUM=%s\n' "${XSIMD_MD5SUM}"
+            arrow_paimon_fingerprint_files \
+                patches/apache-arrow-"${ARROW_VERSION}"-*.patch
+        } | git hash-object --stdin
     )
 }
 
@@ -106,15 +144,15 @@ paimon_build_fingerprint() {
     local vars_dir
     vars_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     (
+        set -o pipefail
         cd "${vars_dir}" || return 1
-        LC_ALL=C
         {
             arrow_build_fingerprint
-            git hash-object \
-                arrow-paimon-vars.sh \
-                vars.sh \
-                download-thirdparty.sh \
-                build-thirdparty.sh \
+            printf 'schema=%s\n' "${PAIMON_BUILD_SCHEMA_VERSION}"
+            printf 'PAIMON_CPP_NAME=%s\n' "${PAIMON_CPP_NAME}"
+            printf 'PAIMON_CPP_SOURCE=%s\n' "${PAIMON_CPP_SOURCE}"
+            printf 'PAIMON_CPP_MD5SUM=%s\n' "${PAIMON_CPP_MD5SUM}"
+            arrow_paimon_fingerprint_files \
                 paimon-cpp-cache.cmake \
                 patches/paimon-cpp-*.patch
         } | git hash-object --stdin
@@ -128,6 +166,27 @@ arrow_paimon_build_fingerprint() {
         arrow_build_fingerprint
         paimon_build_fingerprint
     } | git hash-object --stdin
+}
+
+arrow_paimon_fingerprint_matches() {
+    local installed_fingerprint="$1"
+    local expected_fingerprint="$2"
+    local legacy_compatible_expected_fingerprint="$3"
+    shift 3
+    local compatible_fingerprint
+
+    if [[ "${installed_fingerprint}" == "${expected_fingerprint}" ]]; then
+        return 0
+    fi
+    if [[ "${expected_fingerprint}" != "${legacy_compatible_expected_fingerprint}" ]]; then
+        return 1
+    fi
+    for compatible_fingerprint in "$@"; do
+        if [[ "${installed_fingerprint}" == "${compatible_fingerprint}" ]]; then
+            return 0
+        fi
+    done
+    return 1
 }
 
 ARROW_REQUIRED_LIBRARIES=(
@@ -216,7 +275,9 @@ arrow_prebuilt_valid() {
     fi
     expected_fingerprint="$(arrow_build_fingerprint)"
     installed_fingerprint="$(<"${arrow_fingerprint_mark}")"
-    if [[ "${installed_fingerprint}" != "${expected_fingerprint}" ]]; then
+    if ! arrow_paimon_fingerprint_matches "${installed_fingerprint}" \
+        "${expected_fingerprint}" "${ARROW_LEGACY_COMPATIBLE_SEMANTIC_FINGERPRINT}" \
+        "${ARROW_LEGACY_BUILD_FINGERPRINTS[@]}"; then
         echo "Arrow build fingerprint does not match selected inputs" >&2
         return 1
     fi
@@ -235,7 +296,9 @@ paimon_prebuilt_valid() {
     fi
     expected_fingerprint="$(paimon_build_fingerprint)"
     installed_fingerprint="$(<"${paimon_fingerprint_mark}")"
-    if [[ "${installed_fingerprint}" != "${expected_fingerprint}" ]]; then
+    if ! arrow_paimon_fingerprint_matches "${installed_fingerprint}" \
+        "${expected_fingerprint}" "${PAIMON_LEGACY_COMPATIBLE_SEMANTIC_FINGERPRINT}" \
+        "${PAIMON_LEGACY_BUILD_FINGERPRINTS[@]}"; then
         echo "Paimon build fingerprint does not match selected inputs" >&2
         return 1
     fi

--- a/thirdparty/test/arrow-paimon-lifecycle-test.sh
+++ b/thirdparty/test/arrow-paimon-lifecycle-test.sh
@@ -28,6 +28,101 @@ fail() {
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "${tmpdir}"' EXIT
 
+create_fingerprint_fixture() {
+    local destination="$1"
+
+    mkdir -p "${destination}/patches"
+    cp "${ROOT}/arrow-paimon-vars.sh" "${destination}/arrow-paimon-vars.sh"
+    cp "${ROOT}/paimon-cpp-cache.cmake" "${destination}/paimon-cpp-cache.cmake"
+    cp "${ROOT}"/patches/apache-arrow-24.0.0-*.patch "${destination}/patches/"
+    cp "${ROOT}"/patches/paimon-cpp-*.patch "${destination}/patches/"
+}
+
+fingerprint_from_fixture() {
+    local fixture="$1"
+    local component="$2"
+    local result_variable="$3"
+    local fingerprint
+
+    fingerprint="$(
+        set -e
+        # shellcheck source=/dev/null
+        . "${fixture}/arrow-paimon-vars.sh"
+        "${component}_build_fingerprint"
+    )"
+    printf -v "${result_variable}" '%s' "${fingerprint}"
+}
+
+exercise_semantic_fingerprints() {
+    local first_fixture="${tmpdir}/fingerprint-first"
+    local second_fixture="${tmpdir}/fingerprint-second"
+    local first_arrow
+    local first_paimon
+    local second_arrow
+    local second_paimon
+    local changed_arrow
+    local changed_paimon
+
+    create_fingerprint_fixture "${first_fixture}"
+    create_fingerprint_fixture "${second_fixture}"
+
+    printf '%s\n' first-env >"${first_fixture}/env.sh"
+    printf '%s\n' second-env >"${second_fixture}/env.sh"
+    printf '%s\n' first-vars >"${first_fixture}/vars.sh"
+    printf '%s\n' second-vars >"${second_fixture}/vars.sh"
+    printf '%s\n' first-download >"${first_fixture}/download-thirdparty.sh"
+    printf '%s\n' second-download >"${second_fixture}/download-thirdparty.sh"
+    printf '%s\n' first-build >"${first_fixture}/build-thirdparty.sh"
+    printf '%s\n' second-build >"${second_fixture}/build-thirdparty.sh"
+    printf '%s\n' '# release-branch-only comment' >>"${second_fixture}/arrow-paimon-vars.sh"
+
+    fingerprint_from_fixture "${first_fixture}" arrow first_arrow
+    fingerprint_from_fixture "${first_fixture}" paimon first_paimon
+    [[ "${first_arrow}" == "${ARROW_LEGACY_COMPATIBLE_SEMANTIC_FINGERPRINT}" ]] ||
+        fail "the Arrow legacy marker migration target is stale"
+    [[ "${first_paimon}" == "${PAIMON_LEGACY_COMPATIBLE_SEMANTIC_FINGERPRINT}" ]] ||
+        fail "the Paimon legacy marker migration target is stale"
+    fingerprint_from_fixture "${second_fixture}" arrow second_arrow
+    fingerprint_from_fixture "${second_fixture}" paimon second_paimon
+    [[ "${first_arrow}" == "${second_arrow}" ]] ||
+        fail "unrelated branch scripts changed the Arrow fingerprint"
+    [[ "${first_paimon}" == "${second_paimon}" ]] ||
+        fail "unrelated branch scripts changed the Paimon fingerprint"
+
+    printf '%s\n' semantic-change \
+        >>"${second_fixture}/patches/apache-arrow-24.0.0-lzo.patch"
+    fingerprint_from_fixture "${second_fixture}" arrow changed_arrow
+    fingerprint_from_fixture "${second_fixture}" paimon changed_paimon
+    [[ "${changed_arrow}" != "${first_arrow}" ]] ||
+        fail "an Arrow patch change did not change the Arrow fingerprint"
+    [[ "${changed_paimon}" != "${first_paimon}" ]] ||
+        fail "an Arrow patch change did not change the Paimon fingerprint"
+
+    cp "${first_fixture}/patches/apache-arrow-24.0.0-lzo.patch" \
+        "${second_fixture}/patches/apache-arrow-24.0.0-lzo.patch"
+    printf '%s\n' semantic-change >>"${second_fixture}/paimon-cpp-cache.cmake"
+    fingerprint_from_fixture "${second_fixture}" arrow second_arrow
+    fingerprint_from_fixture "${second_fixture}" paimon changed_paimon
+    [[ "${second_arrow}" == "${first_arrow}" ]] ||
+        fail "a Paimon-only cache change changed the Arrow fingerprint"
+    [[ "${changed_paimon}" != "${first_paimon}" ]] ||
+        fail "a Paimon cache change did not change the Paimon fingerprint"
+
+    changed_arrow="$(
+        set -e
+        # shellcheck source=/dev/null
+        . "${first_fixture}/arrow-paimon-vars.sh"
+        ARROW_BUILD_SCHEMA_VERSION="${ARROW_BUILD_SCHEMA_VERSION}-changed"
+        arrow_build_fingerprint
+    )"
+    [[ "${changed_arrow}" != "${first_arrow}" ]] ||
+        fail "an Arrow build-schema change did not change its fingerprint"
+}
+
+# shellcheck source=../arrow-paimon-vars.sh
+. "${ROOT}/arrow-paimon-vars.sh"
+exercise_semantic_fingerprints
+
 harness="${tmpdir}/harness"
 mkdir -p "${harness}/src" "${harness}/patches" "${harness}/installed"
 cp "${ROOT}/download-thirdparty.sh" "${harness}/download-thirdparty.sh"
@@ -282,7 +377,6 @@ exercise_generic_recovery_dispatch
 
 # A Paimon-only build may publish only its own fingerprint. It must not make a
 # stale Arrow installation pass the shared prebuilt validation.
-. "${ROOT}/arrow-paimon-vars.sh"
 prebuilt="${tmpdir}/prebuilt"
 mkdir -p "${prebuilt}/include/arrow/util" "${prebuilt}/lib64"
 printf '#define ARROW_VERSION_STRING "%s"\n' "${ARROW_VERSION}" \
@@ -302,6 +396,25 @@ prepare_arrow_paimon_download_packages "${ARROW_PAIMON_BUILD_PACKAGES[@]}"
 arrow_paimon_build_fingerprint >"${prebuilt}/arrow-paimon-build-fingerprint.txt"
 if arrow_paimon_prebuilt_valid "${prebuilt}" >/dev/null 2>&1; then
     fail "legacy combined marker certified an unversioned component closure"
+fi
+
+printf '%s\n' "${ARROW_LEGACY_BUILD_FINGERPRINTS[0]}" \
+    >"${prebuilt}/arrow-build-fingerprint.txt"
+printf '%s\n' "${PAIMON_LEGACY_BUILD_FINGERPRINTS[0]}" \
+    >"${prebuilt}/paimon-build-fingerprint.txt"
+arrow_paimon_prebuilt_valid "${prebuilt}" ||
+    fail "the complete shared prebuilt was rejected during fingerprint migration"
+if (
+    ARROW_BUILD_SCHEMA_VERSION="${ARROW_BUILD_SCHEMA_VERSION}-changed"
+    arrow_prebuilt_valid "${prebuilt}"
+) >/dev/null 2>&1; then
+    fail "the legacy Arrow marker survived a semantic fingerprint change"
+fi
+if (
+    PAIMON_BUILD_SCHEMA_VERSION="${PAIMON_BUILD_SCHEMA_VERSION}-changed"
+    paimon_prebuilt_valid "${prebuilt}"
+) >/dev/null 2>&1; then
+    fail "the legacy Paimon marker survived a semantic fingerprint change"
 fi
 
 publish_arrow_prebuilt_marker "${prebuilt}"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
arrow_build_fingerprint() hashed env.sh, vars.sh, download-thirdparty.sh and build-thirdparty.sh in full, so any unrelated thirdparty edit changed it and the build failed with "Arrow build fingerprint does not match selected inputs". The value changed six times in two weeks on master and none of those commits touched Arrow. Those whole-script inputs also differ between master and branch-4.1, so the two branches could never agree on a fingerprint even though they select the same Arrow closure and are meant to share one thirdparty installation.

Hash only the inputs that determine the Arrow/Paimon output: an explicit build-schema version, the selected source variables, and the path plus blob of each applied patch. Including the path keeps patch selection and ordering part of the contract. Output-affecting build options in build_arrow() and build_paimon_cpp() are now carried by ARROW_BUILD_SCHEMA_VERSION and PAIMON_BUILD_SCHEMA_VERSION, which have to be bumped when those options change.

The shared prebuilt in circulation was published with the former whole-script markers, so keep accepting them, but only while the selected inputs still hash to the fingerprint the migration was pinned to. Any later Arrow or Paimon change retires the legacy markers automatically.

This matches the implementation already on branch-4.1, so both branches compute the same fingerprints and can reuse the same prebuilt.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

