### PR TITLE
branch-4.1:[fix](variant) Serve shredded Variant leaves without rebuilding the root

### DIFF
--- a/be/src/core/column/variant_v2/column_variant_v2.cpp
+++ b/be/src/core/column/variant_v2/column_variant_v2.cpp
@@ -500,31 +500,33 @@ public:
         if (_segments.empty()) {
             return std::nullopt;
         }
-        std::vector<VariantShreddedTypedValue> matches;
+        std::vector<std::optional<VariantShreddedTypedValue>> matches;
         matches.reserve(_segments.size());
         bool all_direct = true;
         for (const auto& segment : _segments) {
             auto match = segment->find_typed_value(path);
             if (!match.has_value()) {
                 all_direct = false;
-                break;
             }
-            matches.push_back(std::move(*match));
+            // Visit every segment even after one requests normalized fallback. Format states use
+            // find_typed_value() as their validation boundary, so stopping early would let a later
+            // segment publish an unvalidated normalized value and make errors depend on row order.
+            matches.push_back(std::move(match));
         }
 
-        const bool homogeneous = all_direct && matches.front().column && matches.front().type &&
+        const auto& first = matches.front();
+        const bool homogeneous = all_direct && first->column && first->type &&
                                  std::ranges::all_of(matches, [&](const auto& match) {
-                                     return match.column && match.type && !match.normalized &&
-                                            exact_typed_identity(matches.front().type, match.type);
+                                     return match->column && match->type && !match->normalized &&
+                                            exact_typed_identity(first->type, match->type);
                                  });
         if (homogeneous) {
-            MutableColumnPtr combined = matches.front().column->clone_empty();
+            MutableColumnPtr combined = first->column->clone_empty();
             for (const auto& match : matches) {
-                combined->insert_range_from(*match.column, 0, match.column->size());
+                combined->insert_range_from(*match->column, 0, match->column->size());
             }
-            return VariantShreddedTypedValue {.column = std::move(combined),
-                                              .type = matches.front().type,
-                                              .normalized = nullptr};
+            return VariantShreddedTypedValue {
+                    .column = std::move(combined), .type = first->type, .normalized = nullptr};
         }
 
         auto normalized = find_normalized_value(path);

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -1907,20 +1907,15 @@ static bool build_variant_leaf_path_projection(const ColumnMapping& mapping,
         return false;
     }
     *root_projection = LocalColumnIndex::partial_local(*mapping.file_local_id);
-    // The root dictionary validates every direct result and decodes any retained residual. Keep the
-    // root residual as well: when typed_value is present it must still be an object, and omitting the
-    // carrier would let the leaf path hide malformed input that complete materialization rejects.
+    // Decoding a residual needs the root key dictionary. The root `value` itself stays unprojected:
+    // it holds every unshredded field, so reading it would give back all the pruned I/O. Shredding
+    // keeps a present typed object's residual keys disjoint from its shredded fields, and a null
+    // typed object means the value is not an object, so the requested path is absent either way.
     const auto* root_metadata = find_file_child_by_name(mapping.original_file_children, "metadata");
     if (root_metadata == nullptr) {
         return false;
     }
     root_projection->children.push_back(LocalColumnIndex::local(root_metadata->file_local_id()));
-    if (const auto* root_residual =
-                find_file_child_by_name(mapping.original_file_children, "value");
-        root_residual != nullptr) {
-        root_projection->children.push_back(
-                LocalColumnIndex::local(root_residual->file_local_id()));
-    }
     const auto* root_typed = find_file_child_by_name(mapping.original_file_children, "typed_value");
     if (root_typed == nullptr || root_typed->children.empty() || root_typed->type == nullptr ||
         remove_nullable(root_typed->type)->get_primitive_type() != TYPE_STRUCT) {
@@ -1938,14 +1933,6 @@ static bool build_variant_leaf_path_projection(const ColumnMapping& mapping,
         current_projection->children.push_back(
                 LocalColumnIndex::partial_local(wrapper->file_local_id()));
         current_projection = &current_projection->children.back();
-        // Every wrapper carrier participates in corruption validation, including object ancestors.
-        // Row-group finalization can still prune these residual columns when their null statistics
-        // prove that no row carries one.
-        if (const auto* residual = find_file_child_by_name(wrapper->children, "value");
-            residual != nullptr) {
-            current_projection->children.push_back(
-                    LocalColumnIndex::local(residual->file_local_id()));
-        }
         const auto* typed = find_file_child_by_name(wrapper->children, "typed_value");
         if (typed == nullptr) {
             return false;
@@ -1957,6 +1944,13 @@ static bool build_variant_leaf_path_projection(const ColumnMapping& mapping,
             // values still need their wrapper shape and therefore keep the full Variant fallback.
             if (!variant_leaf_is_projectable_scalar(*typed)) {
                 return false;
+            }
+            // The residual beside the leaf carries the rows whose value did not match the shredded
+            // type. Reading it lets the reader merge those rows instead of rejecting the batch.
+            if (const auto* residual = find_file_child_by_name(wrapper->children, "value");
+                residual != nullptr) {
+                current_projection->children.push_back(
+                        LocalColumnIndex::local(residual->file_local_id()));
             }
             typed_projection.project_all_children = true;
         } else if (typed->type == nullptr ||

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -1907,15 +1907,20 @@ static bool build_variant_leaf_path_projection(const ColumnMapping& mapping,
         return false;
     }
     *root_projection = LocalColumnIndex::partial_local(*mapping.file_local_id);
-    // Decoding a residual needs the root key dictionary. The root `value` itself stays unprojected:
-    // it holds every unshredded field, so reading it would give back all the pruned I/O. Shredding
-    // keeps a present typed object's residual keys disjoint from its shredded fields, and a null
-    // typed object means the value is not an object, so the requested path is absent either way.
+    // The root dictionary validates every direct result and decodes any retained residual. Keep the
+    // root residual as well: when typed_value is present it must still be an object, and omitting the
+    // carrier would let the leaf path hide malformed input that complete materialization rejects.
     const auto* root_metadata = find_file_child_by_name(mapping.original_file_children, "metadata");
     if (root_metadata == nullptr) {
         return false;
     }
     root_projection->children.push_back(LocalColumnIndex::local(root_metadata->file_local_id()));
+    if (const auto* root_residual =
+                find_file_child_by_name(mapping.original_file_children, "value");
+        root_residual != nullptr) {
+        root_projection->children.push_back(
+                LocalColumnIndex::local(root_residual->file_local_id()));
+    }
     const auto* root_typed = find_file_child_by_name(mapping.original_file_children, "typed_value");
     if (root_typed == nullptr || root_typed->children.empty() || root_typed->type == nullptr ||
         remove_nullable(root_typed->type)->get_primitive_type() != TYPE_STRUCT) {
@@ -1933,6 +1938,14 @@ static bool build_variant_leaf_path_projection(const ColumnMapping& mapping,
         current_projection->children.push_back(
                 LocalColumnIndex::partial_local(wrapper->file_local_id()));
         current_projection = &current_projection->children.back();
+        // Every wrapper carrier participates in corruption validation, including object ancestors.
+        // Row-group finalization can still prune these residual columns when their null statistics
+        // prove that no row carries one.
+        if (const auto* residual = find_file_child_by_name(wrapper->children, "value");
+            residual != nullptr) {
+            current_projection->children.push_back(
+                    LocalColumnIndex::local(residual->file_local_id()));
+        }
         const auto* typed = find_file_child_by_name(wrapper->children, "typed_value");
         if (typed == nullptr) {
             return false;
@@ -1944,13 +1957,6 @@ static bool build_variant_leaf_path_projection(const ColumnMapping& mapping,
             // values still need their wrapper shape and therefore keep the full Variant fallback.
             if (!variant_leaf_is_projectable_scalar(*typed)) {
                 return false;
-            }
-            // The residual beside the leaf carries the rows whose value did not match the shredded
-            // type. Reading it lets the reader merge those rows instead of rejecting the batch.
-            if (const auto* residual = find_file_child_by_name(wrapper->children, "value");
-                residual != nullptr) {
-                current_projection->children.push_back(
-                        LocalColumnIndex::local(residual->file_local_id()));
             }
             typed_projection.project_all_children = true;
         } else if (typed->type == nullptr ||

--- a/be/src/format_v2/column_mapper.cpp
+++ b/be/src/format_v2/column_mapper.cpp
@@ -1875,27 +1875,15 @@ static const ColumnDefinition* find_file_child_by_name(
     return child_it == children.end() ? nullptr : &*child_it;
 }
 
-static bool variant_leaf_type_preserves_physical_identity(const ColumnDefinition& leaf) {
+static bool variant_leaf_is_projectable_scalar(const ColumnDefinition& leaf) {
     if (!leaf.children.empty() || leaf.type == nullptr) {
         return false;
     }
-    // ColumnDefinition does not transport Parquet's raw-binary/UUID and timestamp-unit tags.
-    // Limit direct leaves to identities fully described by the Doris scalar type; every ambiguous
-    // identity must retain the complete wrapper so reconstruction can inspect its physical schema.
-    switch (remove_nullable(leaf.type)->get_primitive_type()) {
-    case TYPE_BOOLEAN:
-    case TYPE_TINYINT:
-    case TYPE_SMALLINT:
-    case TYPE_INT:
-    case TYPE_BIGINT:
-    case TYPE_FLOAT:
-    case TYPE_DOUBLE:
-    case TYPE_DECIMAL128I:
-    case TYPE_DATEV2:
-        return true;
-    default:
-        return false;
-    }
+    // Physical identity - raw binary versus UTF-8, UUID, timestamp units - is resolved by the
+    // reader from ParquetColumnSchema::type_descriptor, which the projected schema copies verbatim.
+    // The mapper only decides which columns to read, so every scalar leaf is projectable. Complex
+    // leaves keep the complete wrapper because reconstruction still needs their full shape.
+    return !is_complex_type(remove_nullable(leaf.type)->get_primitive_type());
 }
 
 static bool build_variant_leaf_path_projection(const ColumnMapping& mapping,
@@ -1919,6 +1907,15 @@ static bool build_variant_leaf_path_projection(const ColumnMapping& mapping,
         return false;
     }
     *root_projection = LocalColumnIndex::partial_local(*mapping.file_local_id);
+    // Decoding a residual needs the root key dictionary. The root `value` itself stays unprojected:
+    // it holds every unshredded field, so reading it would give back all the pruned I/O. Shredding
+    // keeps a present typed object's residual keys disjoint from its shredded fields, and a null
+    // typed object means the value is not an object, so the requested path is absent either way.
+    const auto* root_metadata = find_file_child_by_name(mapping.original_file_children, "metadata");
+    if (root_metadata == nullptr) {
+        return false;
+    }
+    root_projection->children.push_back(LocalColumnIndex::local(root_metadata->file_local_id()));
     const auto* root_typed = find_file_child_by_name(mapping.original_file_children, "typed_value");
     if (root_typed == nullptr || root_typed->children.empty() || root_typed->type == nullptr ||
         remove_nullable(root_typed->type)->get_primitive_type() != TYPE_STRUCT) {
@@ -1945,8 +1942,15 @@ static bool build_variant_leaf_path_projection(const ColumnMapping& mapping,
         if (leaf) {
             // Only primitive typed values can be returned as a direct vector. Complex shredded
             // values still need their wrapper shape and therefore keep the full Variant fallback.
-            if (!variant_leaf_type_preserves_physical_identity(*typed)) {
+            if (!variant_leaf_is_projectable_scalar(*typed)) {
                 return false;
+            }
+            // The residual beside the leaf carries the rows whose value did not match the shredded
+            // type. Reading it lets the reader merge those rows instead of rejecting the batch.
+            if (const auto* residual = find_file_child_by_name(wrapper->children, "value");
+                residual != nullptr) {
+                current_projection->children.push_back(
+                        LocalColumnIndex::local(residual->file_local_id()));
             }
             typed_projection.project_all_children = true;
         } else if (typed->type == nullptr ||

--- a/be/src/format_v2/parquet/parquet_profile.cpp
+++ b/be/src/format_v2/parquet/parquet_profile.cpp
@@ -73,8 +73,8 @@ void ParquetProfile::init(RuntimeProfile* profile) {
                                                             TUnit::UNIT, parquet_profile, 1);
     variant_leaf_projection_row_group_columns = ADD_CHILD_COUNTER_WITH_LEVEL(
             profile, "VariantLeafProjectionRowGroupColumns", TUnit::UNIT, parquet_profile, 1);
-    variant_full_projection_row_group_columns = ADD_CHILD_COUNTER_WITH_LEVEL(
-            profile, "VariantFullProjectionRowGroupColumns", TUnit::UNIT, parquet_profile, 1);
+    variant_residual_projection_row_group_columns = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "VariantResidualProjectionRowGroupColumns", TUnit::UNIT, parquet_profile, 1);
     pages_skipped_by_data_page_filter = ADD_CHILD_COUNTER_WITH_LEVEL(
             profile, "PagesSkippedByDataPageFilter", TUnit::UNIT, parquet_profile, 1);
     data_page_filter_skip_bytes = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "DataPageFilterSkipBytes",
@@ -378,8 +378,7 @@ ParquetColumnReaderProfile ParquetProfile::column_reader_profile() const {
             .variant_direct_leaf_rows = variant_direct_leaf_rows,
             .variant_direct_leaf_path_misses = variant_direct_leaf_path_misses,
             .variant_direct_leaf_residual_fallbacks = variant_direct_leaf_residual_fallbacks,
-            .variant_direct_leaf_residual_merged_rows =
-                    variant_direct_leaf_residual_merged_rows,
+            .variant_direct_leaf_residual_merged_rows = variant_direct_leaf_residual_merged_rows,
             .variant_direct_leaf_unsupported_fallbacks = variant_direct_leaf_unsupported_fallbacks,
             .hybrid_selection_batches = hybrid_selection_batches,
             .hybrid_selection_ranges = hybrid_selection_ranges,

--- a/be/src/format_v2/parquet/parquet_profile.cpp
+++ b/be/src/format_v2/parquet/parquet_profile.cpp
@@ -135,6 +135,8 @@ void ParquetProfile::init(RuntimeProfile* profile) {
             profile, "VariantDirectLeafResidualFallbacks", TUnit::UNIT, parquet_profile);
     variant_direct_leaf_residual_merged_rows = add_persistent_counter(
             profile, "VariantDirectLeafResidualMergedRows", TUnit::UNIT, parquet_profile);
+    variant_residual_seek_rows = add_persistent_counter(profile, "VariantResidualSeekRows",
+                                                        TUnit::UNIT, parquet_profile);
     variant_direct_leaf_unsupported_fallbacks = add_persistent_counter(
             profile, "VariantDirectLeafUnsupportedFallbacks", TUnit::UNIT, parquet_profile);
     hybrid_selection_batches = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "HybridSelectionBatches",
@@ -379,6 +381,7 @@ ParquetColumnReaderProfile ParquetProfile::column_reader_profile() const {
             .variant_direct_leaf_path_misses = variant_direct_leaf_path_misses,
             .variant_direct_leaf_residual_fallbacks = variant_direct_leaf_residual_fallbacks,
             .variant_direct_leaf_residual_merged_rows = variant_direct_leaf_residual_merged_rows,
+            .variant_residual_seek_rows = variant_residual_seek_rows,
             .variant_direct_leaf_unsupported_fallbacks = variant_direct_leaf_unsupported_fallbacks,
             .hybrid_selection_batches = hybrid_selection_batches,
             .hybrid_selection_ranges = hybrid_selection_ranges,

--- a/be/src/format_v2/parquet/parquet_profile.cpp
+++ b/be/src/format_v2/parquet/parquet_profile.cpp
@@ -75,6 +75,8 @@ void ParquetProfile::init(RuntimeProfile* profile) {
             profile, "VariantLeafProjectionRowGroupColumns", TUnit::UNIT, parquet_profile, 1);
     variant_residual_projection_row_group_columns = ADD_CHILD_COUNTER_WITH_LEVEL(
             profile, "VariantResidualProjectionRowGroupColumns", TUnit::UNIT, parquet_profile, 1);
+    variant_full_projection_row_group_columns = ADD_CHILD_COUNTER_WITH_LEVEL(
+            profile, "VariantFullProjectionRowGroupColumns", TUnit::UNIT, parquet_profile, 1);
     pages_skipped_by_data_page_filter = ADD_CHILD_COUNTER_WITH_LEVEL(
             profile, "PagesSkippedByDataPageFilter", TUnit::UNIT, parquet_profile, 1);
     data_page_filter_skip_bytes = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "DataPageFilterSkipBytes",

--- a/be/src/format_v2/parquet/parquet_profile.cpp
+++ b/be/src/format_v2/parquet/parquet_profile.cpp
@@ -133,6 +133,8 @@ void ParquetProfile::init(RuntimeProfile* profile) {
                                                              TUnit::UNIT, parquet_profile);
     variant_direct_leaf_residual_fallbacks = add_persistent_counter(
             profile, "VariantDirectLeafResidualFallbacks", TUnit::UNIT, parquet_profile);
+    variant_direct_leaf_residual_merged_rows = add_persistent_counter(
+            profile, "VariantDirectLeafResidualMergedRows", TUnit::UNIT, parquet_profile);
     variant_direct_leaf_unsupported_fallbacks = add_persistent_counter(
             profile, "VariantDirectLeafUnsupportedFallbacks", TUnit::UNIT, parquet_profile);
     hybrid_selection_batches = ADD_CHILD_COUNTER_WITH_LEVEL(profile, "HybridSelectionBatches",
@@ -376,6 +378,8 @@ ParquetColumnReaderProfile ParquetProfile::column_reader_profile() const {
             .variant_direct_leaf_rows = variant_direct_leaf_rows,
             .variant_direct_leaf_path_misses = variant_direct_leaf_path_misses,
             .variant_direct_leaf_residual_fallbacks = variant_direct_leaf_residual_fallbacks,
+            .variant_direct_leaf_residual_merged_rows =
+                    variant_direct_leaf_residual_merged_rows,
             .variant_direct_leaf_unsupported_fallbacks = variant_direct_leaf_unsupported_fallbacks,
             .hybrid_selection_batches = hybrid_selection_batches,
             .hybrid_selection_ranges = hybrid_selection_ranges,

--- a/be/src/format_v2/parquet/parquet_profile.h
+++ b/be/src/format_v2/parquet/parquet_profile.h
@@ -169,7 +169,7 @@ struct ParquetProfile {
     RuntimeProfile::Counter* variant_leaf_projections = nullptr;
     // Row-group outcomes for candidate Variant projections, counted per projected column opened.
     RuntimeProfile::Counter* variant_leaf_projection_row_group_columns = nullptr;
-    RuntimeProfile::Counter* variant_full_projection_row_group_columns = nullptr;
+    RuntimeProfile::Counter* variant_residual_projection_row_group_columns = nullptr;
 
     // ======== Page Skip ========
     RuntimeProfile::Counter* pages_skipped_by_data_page_filter = nullptr;

--- a/be/src/format_v2/parquet/parquet_profile.h
+++ b/be/src/format_v2/parquet/parquet_profile.h
@@ -171,6 +171,7 @@ struct ParquetProfile {
     // Row-group outcomes for candidate Variant projections, counted per projected column opened.
     RuntimeProfile::Counter* variant_leaf_projection_row_group_columns = nullptr;
     RuntimeProfile::Counter* variant_residual_projection_row_group_columns = nullptr;
+    RuntimeProfile::Counter* variant_full_projection_row_group_columns = nullptr;
 
     // ======== Page Skip ========
     RuntimeProfile::Counter* pages_skipped_by_data_page_filter = nullptr;

--- a/be/src/format_v2/parquet/parquet_profile.h
+++ b/be/src/format_v2/parquet/parquet_profile.h
@@ -56,6 +56,7 @@ struct ParquetColumnReaderProfile {
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_rows;
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_path_misses;
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_residual_fallbacks;
+    std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_residual_merged_rows;
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_unsupported_fallbacks;
     RuntimeProfile::Counter* hybrid_selection_batches = nullptr;
     RuntimeProfile::Counter* hybrid_selection_ranges = nullptr;
@@ -204,6 +205,7 @@ struct ParquetProfile {
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_rows;
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_path_misses;
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_residual_fallbacks;
+    std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_residual_merged_rows;
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_unsupported_fallbacks;
     RuntimeProfile::Counter* hybrid_selection_batches = nullptr;
     RuntimeProfile::Counter* hybrid_selection_ranges = nullptr;

--- a/be/src/format_v2/parquet/parquet_profile.h
+++ b/be/src/format_v2/parquet/parquet_profile.h
@@ -57,6 +57,7 @@ struct ParquetColumnReaderProfile {
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_path_misses;
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_residual_fallbacks;
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_residual_merged_rows;
+    std::shared_ptr<RuntimeProfile::Counter> variant_residual_seek_rows;
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_unsupported_fallbacks;
     RuntimeProfile::Counter* hybrid_selection_batches = nullptr;
     RuntimeProfile::Counter* hybrid_selection_ranges = nullptr;
@@ -206,6 +207,7 @@ struct ParquetProfile {
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_path_misses;
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_residual_fallbacks;
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_residual_merged_rows;
+    std::shared_ptr<RuntimeProfile::Counter> variant_residual_seek_rows;
     std::shared_ptr<RuntimeProfile::Counter> variant_direct_leaf_unsupported_fallbacks;
     RuntimeProfile::Counter* hybrid_selection_batches = nullptr;
     RuntimeProfile::Counter* hybrid_selection_ranges = nullptr;

--- a/be/src/format_v2/parquet/parquet_reader.cpp
+++ b/be/src/format_v2/parquet/parquet_reader.cpp
@@ -182,6 +182,49 @@ void prune_variant_residual_columns_impl(const ParquetColumnSchema& schema,
 
 } // namespace
 
+namespace {
+
+// A leaf projection can only answer rows whose value sits outside the shredded leaf if it actually
+// reads the residual beside that leaf, and the root dictionary needed to decode it. A projection
+// that omits either cannot serve those rows, and nothing else would notice: the leaf would report
+// them as absent.
+bool variant_projection_carries_residuals_impl(const ParquetColumnSchema& schema,
+                                               const format::LocalColumnIndex& projection) {
+    const auto* value = schema_child_by_name(schema, "value");
+    const auto* typed_value = schema_child_by_name(schema, "typed_value");
+    const auto projects = [&projection](int32_t local_id) {
+        return std::ranges::any_of(projection.children, [local_id](const auto& child) {
+            return child.local_id() == local_id;
+        });
+    };
+    if (value != nullptr && typed_value != nullptr) {
+        if (typed_value->kind == ParquetColumnSchemaKind::PRIMITIVE) {
+            return projects(value->local_id);
+        }
+        if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
+            const auto* metadata = schema_child_by_name(schema, "metadata");
+            if (metadata == nullptr || !projects(metadata->local_id)) {
+                return false;
+            }
+        }
+    }
+    for (const auto& child_projection : projection.children) {
+        const auto* child = projected_schema_child(schema, child_projection.local_id());
+        if (child != nullptr &&
+            !variant_projection_carries_residuals_impl(*child, child_projection)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+bool detail::variant_projection_carries_residuals(const ParquetColumnSchema& schema,
+                                                  const format::LocalColumnIndex& projection) {
+    return variant_projection_carries_residuals_impl(schema, projection);
+}
+
 void detail::prune_variant_residual_columns(const ParquetColumnSchema& schema,
                                             format::LocalColumnIndex* projection) {
     DORIS_CHECK(projection != nullptr);
@@ -193,21 +236,35 @@ void detail::prune_variant_residual_columns(const ParquetColumnSchema& schema,
 size_t detail::finalize_variant_leaf_projection_for_row_group(const tparquet::RowGroup& row_group,
                                                               const ParquetColumnSchema& schema,
                                                               format::LocalColumnIndex* projection,
-                                                              size_t* residual_projections) {
+                                                              size_t* residual_projections,
+                                                              size_t* full_projections) {
     DORIS_CHECK(projection != nullptr);
     if (!format::is_partial_projection(projection)) {
         return 0;
     }
     if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
-        // The residual null_count is row-group scoped, so the decision is per reader. Either way
-        // the projection stays a leaf projection: a row group whose residual carries values just
-        // reads that residual too and lets the reader merge those rows.
+        // The residual null_count is row-group scoped, so the decision is per reader.
         if (variant_residual_columns_are_prunable_for_row_group(row_group, schema, *projection)) {
             detail::prune_variant_residual_columns(schema, projection);
-        } else if (residual_projections != nullptr) {
-            ++*residual_projections;
+            return 1;
         }
-        return 1;
+        if (variant_projection_carries_residuals_impl(schema, *projection)) {
+            // The reader merges the rows stored outside the shredded leaves, so the row group
+            // keeps reading leaves instead of the complete Variant.
+            if (residual_projections != nullptr) {
+                ++*residual_projections;
+            }
+            return 1;
+        }
+        // Nothing proves the residual is empty and the projection cannot read it. Restore the
+        // complete Variant wrapper for only this reader so another row group can still keep its
+        // typed-leaf projection.
+        projection->project_all_children = true;
+        projection->children.clear();
+        if (full_projections != nullptr) {
+            ++*full_projections;
+        }
+        return 0;
     }
 
     size_t retained = 0;
@@ -215,7 +272,8 @@ size_t detail::finalize_variant_leaf_projection_for_row_group(const tparquet::Ro
         const auto* child_schema = projected_schema_child(schema, child_projection.local_id());
         DORIS_CHECK(child_schema != nullptr);
         retained += finalize_variant_leaf_projection_for_row_group(
-                row_group, *child_schema, &child_projection, residual_projections);
+                row_group, *child_schema, &child_projection, residual_projections,
+                full_projections);
     }
     return retained;
 }

--- a/be/src/format_v2/parquet/parquet_reader.cpp
+++ b/be/src/format_v2/parquet/parquet_reader.cpp
@@ -72,9 +72,9 @@ const ParquetColumnSchema* schema_child_by_name(const ParquetColumnSchema& schem
     return child_it == schema.children.end() ? nullptr : child_it->get();
 }
 
-bool collect_variant_residual_leaf_ids(const ParquetColumnSchema& schema,
-                                       const format::LocalColumnIndex& projection,
-                                       std::vector<int>* residual_leaf_ids) {
+bool collect_variant_terminal_fallback_leaf_ids(const ParquetColumnSchema& schema,
+                                                const format::LocalColumnIndex& projection,
+                                                std::vector<int>* residual_leaf_ids) {
     DORIS_CHECK(residual_leaf_ids != nullptr);
     const auto* value = schema_child_by_name(schema, "value");
     const auto* typed_value = schema_child_by_name(schema, "typed_value");
@@ -90,17 +90,19 @@ bool collect_variant_residual_leaf_ids(const ParquetColumnSchema& schema,
         if (typed_projection_it == projection.children.end()) {
             return false;
         }
-        // Ancestor residuals cannot supply a shredded descendant, but they are still carriers that
-        // must be read and validated unless row-group statistics prove every entry is NULL.
+        if (typed_value->kind != ParquetColumnSchemaKind::PRIMITIVE) {
+            return collect_variant_terminal_fallback_leaf_ids(*typed_value, *typed_projection_it,
+                                                              residual_leaf_ids);
+        }
+        // Object residual keys are disjoint from shredded keys. Only the fallback paired with the
+        // terminal typed leaf can supply that projected path; ancestor values contain other keys.
         residual_leaf_ids->push_back(value->leaf_column_id);
-        return typed_value->kind == ParquetColumnSchemaKind::PRIMITIVE ||
-               collect_variant_residual_leaf_ids(*typed_value, *typed_projection_it,
-                                                 residual_leaf_ids);
+        return true;
     }
     for (const auto& child_projection : projection.children) {
         const auto* child = projected_schema_child(schema, child_projection.local_id());
-        if (child == nullptr ||
-            !collect_variant_residual_leaf_ids(*child, child_projection, residual_leaf_ids)) {
+        if (child == nullptr || !collect_variant_terminal_fallback_leaf_ids(
+                                        *child, child_projection, residual_leaf_ids)) {
             return false;
         }
     }
@@ -117,7 +119,7 @@ bool variant_residual_columns_are_prunable_impl(const tparquet::RowGroup& row_gr
         return false;
     }
     std::vector<int> residual_leaf_ids;
-    if (!collect_variant_residual_leaf_ids(schema, projection, &residual_leaf_ids) ||
+    if (!collect_variant_terminal_fallback_leaf_ids(schema, projection, &residual_leaf_ids) ||
         residual_leaf_ids.empty()) {
         return false;
     }
@@ -157,16 +159,19 @@ void prune_variant_residual_columns_impl(const ParquetColumnSchema& schema,
                                          format::LocalColumnIndex* projection) {
     const auto* value = schema_child_by_name(schema, "value");
     const auto* typed_value = schema_child_by_name(schema, "typed_value");
-    if (value != nullptr && typed_value != nullptr) {
-        // Statistics proved every carrier on the requested path is entirely NULL for this row
-        // group, so none of the residual columns is needed for value or corruption semantics.
+    if (value != nullptr && typed_value != nullptr &&
+        typed_value->kind == ParquetColumnSchemaKind::PRIMITIVE) {
+        // Terminal wrapper: statistics proved its residual is entirely NULL for this row group,
+        // so the shredded leaf alone answers every row.
         remove_child_projection(projection, value->local_id);
-        if (typed_value->kind == ParquetColumnSchemaKind::PRIMITIVE) {
-            return;
+        return;
+    }
+    if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
+        // The root dictionary is only needed to decode a residual.
+        if (const auto* metadata = schema_child_by_name(schema, "metadata"); metadata != nullptr) {
+            remove_child_projection(projection, metadata->local_id);
         }
     }
-    // Root metadata remains projected even when residuals are all NULL. Direct and normalized leaf
-    // handoff must validate the required dictionary just like complete materialization does.
     for (auto& child_projection : projection->children) {
         const auto* child = projected_schema_child(schema, child_projection.local_id());
         if (child != nullptr) {
@@ -199,8 +204,8 @@ bool variant_projection_carries_residuals_impl(const ParquetColumnSchema& schema
         });
     };
     if (value != nullptr && typed_value != nullptr) {
-        if (!projects(value->local_id)) {
-            return false;
+        if (typed_value->kind == ParquetColumnSchemaKind::PRIMITIVE) {
+            return projects(value->local_id);
         }
         if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
             const auto* metadata = schema_child_by_name(schema, "metadata");
@@ -287,8 +292,8 @@ size_t count_variant_leaf_projection_candidates(const ParquetColumnSchema& schem
     if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
         std::vector<int> residual_leaf_ids;
         return schema.max_repetition_level == 0 &&
-                               collect_variant_residual_leaf_ids(schema, projection,
-                                                                 &residual_leaf_ids) &&
+                               collect_variant_terminal_fallback_leaf_ids(schema, projection,
+                                                                          &residual_leaf_ids) &&
                                !residual_leaf_ids.empty()
                        ? 1
                        : 0;

--- a/be/src/format_v2/parquet/parquet_reader.cpp
+++ b/be/src/format_v2/parquet/parquet_reader.cpp
@@ -111,9 +111,9 @@ bool collect_variant_terminal_fallback_leaf_ids(const ParquetColumnSchema& schem
 
 namespace {
 
-bool variant_leaf_projection_is_safe_for_row_group_impl(
-        const tparquet::RowGroup& row_group, const ParquetColumnSchema& schema,
-        const format::LocalColumnIndex& projection) {
+bool variant_residual_columns_are_prunable_impl(const tparquet::RowGroup& row_group,
+                                                const ParquetColumnSchema& schema,
+                                                const format::LocalColumnIndex& projection) {
     if (schema.kind != ParquetColumnSchemaKind::VARIANT || schema.max_repetition_level != 0 ||
         !format::is_partial_projection(&projection)) {
         return false;
@@ -141,32 +141,73 @@ bool variant_leaf_projection_is_safe_for_row_group_impl(
 
 } // namespace
 
-bool detail::variant_leaf_projection_is_safe_for_row_group(
+bool detail::variant_residual_columns_are_prunable_for_row_group(
         const tparquet::RowGroup& row_group, const ParquetColumnSchema& schema,
         const format::LocalColumnIndex& projection) {
-    return variant_leaf_projection_is_safe_for_row_group_impl(row_group, schema, projection);
+    return variant_residual_columns_are_prunable_impl(row_group, schema, projection);
+}
+
+namespace {
+
+void remove_child_projection(format::LocalColumnIndex* projection, int32_t local_id) {
+    std::erase_if(projection->children, [local_id](const format::LocalColumnIndex& child) {
+        return child.local_id() == local_id;
+    });
+}
+
+void prune_variant_residual_columns_impl(const ParquetColumnSchema& schema,
+                                         format::LocalColumnIndex* projection) {
+    const auto* value = schema_child_by_name(schema, "value");
+    const auto* typed_value = schema_child_by_name(schema, "typed_value");
+    if (value != nullptr && typed_value != nullptr &&
+        typed_value->kind == ParquetColumnSchemaKind::PRIMITIVE) {
+        // Terminal wrapper: statistics proved its residual is entirely NULL for this row group,
+        // so the shredded leaf alone answers every row.
+        remove_child_projection(projection, value->local_id);
+        return;
+    }
+    if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
+        // The root dictionary is only needed to decode a residual.
+        if (const auto* metadata = schema_child_by_name(schema, "metadata"); metadata != nullptr) {
+            remove_child_projection(projection, metadata->local_id);
+        }
+    }
+    for (auto& child_projection : projection->children) {
+        const auto* child = projected_schema_child(schema, child_projection.local_id());
+        if (child != nullptr) {
+            prune_variant_residual_columns_impl(*child, &child_projection);
+        }
+    }
+}
+
+} // namespace
+
+void detail::prune_variant_residual_columns(const ParquetColumnSchema& schema,
+                                            format::LocalColumnIndex* projection) {
+    DORIS_CHECK(projection != nullptr);
+    if (format::is_partial_projection(projection)) {
+        prune_variant_residual_columns_impl(schema, projection);
+    }
 }
 
 size_t detail::finalize_variant_leaf_projection_for_row_group(const tparquet::RowGroup& row_group,
                                                               const ParquetColumnSchema& schema,
                                                               format::LocalColumnIndex* projection,
-                                                              size_t* full_projections) {
+                                                              size_t* residual_projections) {
     DORIS_CHECK(projection != nullptr);
     if (!format::is_partial_projection(projection)) {
         return 0;
     }
     if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
-        if (variant_leaf_projection_is_safe_for_row_group(row_group, schema, *projection)) {
-            return 1;
+        // The residual null_count is row-group scoped, so the decision is per reader. Either way
+        // the projection stays a leaf projection: a row group whose residual carries values just
+        // reads that residual too and lets the reader merge those rows.
+        if (variant_residual_columns_are_prunable_for_row_group(row_group, schema, *projection)) {
+            detail::prune_variant_residual_columns(schema, projection);
+        } else if (residual_projections != nullptr) {
+            ++*residual_projections;
         }
-        // The residual null_count is row-group scoped. Restore the complete Variant wrapper for
-        // only this reader so another row group can still keep the typed-leaf projection.
-        projection->project_all_children = true;
-        projection->children.clear();
-        if (full_projections != nullptr) {
-            ++*full_projections;
-        }
-        return 0;
+        return 1;
     }
 
     size_t retained = 0;
@@ -174,7 +215,7 @@ size_t detail::finalize_variant_leaf_projection_for_row_group(const tparquet::Ro
         const auto* child_schema = projected_schema_child(schema, child_projection.local_id());
         DORIS_CHECK(child_schema != nullptr);
         retained += finalize_variant_leaf_projection_for_row_group(
-                row_group, *child_schema, &child_projection, full_projections);
+                row_group, *child_schema, &child_projection, residual_projections);
     }
     return retained;
 }

--- a/be/src/format_v2/parquet/parquet_reader.cpp
+++ b/be/src/format_v2/parquet/parquet_reader.cpp
@@ -190,6 +190,12 @@ namespace {
 // them as absent.
 bool variant_projection_carries_residuals_impl(const ParquetColumnSchema& schema,
                                                const format::LocalColumnIndex& projection) {
+    if (schema.kind == ParquetColumnSchemaKind::VARIANT && schema.max_repetition_level != 0) {
+        // A repeated Variant produces one physical entry per array element, not per row. The
+        // per-row residual merge and the row-group statistics both address rows, so a repeated
+        // Variant keeps the complete wrapper exactly as it did before leaf projections existed.
+        return false;
+    }
     const auto* value = schema_child_by_name(schema, "value");
     const auto* typed_value = schema_child_by_name(schema, "typed_value");
     const auto projects = [&projection](int32_t local_id) {

--- a/be/src/format_v2/parquet/parquet_reader.cpp
+++ b/be/src/format_v2/parquet/parquet_reader.cpp
@@ -72,9 +72,9 @@ const ParquetColumnSchema* schema_child_by_name(const ParquetColumnSchema& schem
     return child_it == schema.children.end() ? nullptr : child_it->get();
 }
 
-bool collect_variant_terminal_fallback_leaf_ids(const ParquetColumnSchema& schema,
-                                                const format::LocalColumnIndex& projection,
-                                                std::vector<int>* residual_leaf_ids) {
+bool collect_variant_residual_leaf_ids(const ParquetColumnSchema& schema,
+                                       const format::LocalColumnIndex& projection,
+                                       std::vector<int>* residual_leaf_ids) {
     DORIS_CHECK(residual_leaf_ids != nullptr);
     const auto* value = schema_child_by_name(schema, "value");
     const auto* typed_value = schema_child_by_name(schema, "typed_value");
@@ -90,19 +90,17 @@ bool collect_variant_terminal_fallback_leaf_ids(const ParquetColumnSchema& schem
         if (typed_projection_it == projection.children.end()) {
             return false;
         }
-        if (typed_value->kind != ParquetColumnSchemaKind::PRIMITIVE) {
-            return collect_variant_terminal_fallback_leaf_ids(*typed_value, *typed_projection_it,
-                                                              residual_leaf_ids);
-        }
-        // Object residual keys are disjoint from shredded keys. Only the fallback paired with the
-        // terminal typed leaf can supply that projected path; ancestor values contain other keys.
+        // Ancestor residuals cannot supply a shredded descendant, but they are still carriers that
+        // must be read and validated unless row-group statistics prove every entry is NULL.
         residual_leaf_ids->push_back(value->leaf_column_id);
-        return true;
+        return typed_value->kind == ParquetColumnSchemaKind::PRIMITIVE ||
+               collect_variant_residual_leaf_ids(*typed_value, *typed_projection_it,
+                                                 residual_leaf_ids);
     }
     for (const auto& child_projection : projection.children) {
         const auto* child = projected_schema_child(schema, child_projection.local_id());
-        if (child == nullptr || !collect_variant_terminal_fallback_leaf_ids(
-                                        *child, child_projection, residual_leaf_ids)) {
+        if (child == nullptr ||
+            !collect_variant_residual_leaf_ids(*child, child_projection, residual_leaf_ids)) {
             return false;
         }
     }
@@ -119,7 +117,7 @@ bool variant_residual_columns_are_prunable_impl(const tparquet::RowGroup& row_gr
         return false;
     }
     std::vector<int> residual_leaf_ids;
-    if (!collect_variant_terminal_fallback_leaf_ids(schema, projection, &residual_leaf_ids) ||
+    if (!collect_variant_residual_leaf_ids(schema, projection, &residual_leaf_ids) ||
         residual_leaf_ids.empty()) {
         return false;
     }
@@ -159,19 +157,16 @@ void prune_variant_residual_columns_impl(const ParquetColumnSchema& schema,
                                          format::LocalColumnIndex* projection) {
     const auto* value = schema_child_by_name(schema, "value");
     const auto* typed_value = schema_child_by_name(schema, "typed_value");
-    if (value != nullptr && typed_value != nullptr &&
-        typed_value->kind == ParquetColumnSchemaKind::PRIMITIVE) {
-        // Terminal wrapper: statistics proved its residual is entirely NULL for this row group,
-        // so the shredded leaf alone answers every row.
+    if (value != nullptr && typed_value != nullptr) {
+        // Statistics proved every carrier on the requested path is entirely NULL for this row
+        // group, so none of the residual columns is needed for value or corruption semantics.
         remove_child_projection(projection, value->local_id);
-        return;
-    }
-    if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
-        // The root dictionary is only needed to decode a residual.
-        if (const auto* metadata = schema_child_by_name(schema, "metadata"); metadata != nullptr) {
-            remove_child_projection(projection, metadata->local_id);
+        if (typed_value->kind == ParquetColumnSchemaKind::PRIMITIVE) {
+            return;
         }
     }
+    // Root metadata remains projected even when residuals are all NULL. Direct and normalized leaf
+    // handoff must validate the required dictionary just like complete materialization does.
     for (auto& child_projection : projection->children) {
         const auto* child = projected_schema_child(schema, child_projection.local_id());
         if (child != nullptr) {
@@ -204,8 +199,8 @@ bool variant_projection_carries_residuals_impl(const ParquetColumnSchema& schema
         });
     };
     if (value != nullptr && typed_value != nullptr) {
-        if (typed_value->kind == ParquetColumnSchemaKind::PRIMITIVE) {
-            return projects(value->local_id);
+        if (!projects(value->local_id)) {
+            return false;
         }
         if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
             const auto* metadata = schema_child_by_name(schema, "metadata");
@@ -292,8 +287,8 @@ size_t count_variant_leaf_projection_candidates(const ParquetColumnSchema& schem
     if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
         std::vector<int> residual_leaf_ids;
         return schema.max_repetition_level == 0 &&
-                               collect_variant_terminal_fallback_leaf_ids(schema, projection,
-                                                                          &residual_leaf_ids) &&
+                               collect_variant_residual_leaf_ids(schema, projection,
+                                                                 &residual_leaf_ids) &&
                                !residual_leaf_ids.empty()
                        ? 1
                        : 0;

--- a/be/src/format_v2/parquet/parquet_scan.cpp
+++ b/be/src/format_v2/parquet/parquet_scan.cpp
@@ -331,14 +331,19 @@ void collect_variant_projection_decisions(const tparquet::RowGroup& row_group,
         return;
     }
     if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
-        // Every candidate keeps its leaf projection. The statistics only decide whether the
-        // residual columns beside the leaves can be dropped from this row group's read.
-        ++row_group_plan->variant_leaf_projection_columns;
         if (detail::variant_residual_columns_are_prunable_for_row_group(row_group, schema,
                                                                         projection)) {
+            // The statistics prove no residual can contribute, so this row group reads pure leaves.
             row_group_plan->prunable_variant_projection_ordinals.push_back(*candidate_ordinal);
-        } else {
+            ++row_group_plan->variant_leaf_projection_columns;
+        } else if (detail::variant_projection_carries_residuals(schema, projection)) {
+            // The reader merges the rows stored outside the shredded leaves.
+            ++row_group_plan->variant_leaf_projection_columns;
             ++row_group_plan->variant_residual_projection_columns;
+        } else {
+            // Nothing proves the residual is empty and the projection cannot read it.
+            row_group_plan->full_variant_projection_ordinals.push_back(*candidate_ordinal);
+            ++row_group_plan->variant_full_projection_columns;
         }
         ++*candidate_ordinal;
         return;
@@ -370,6 +375,7 @@ void collect_variant_projection_decisions(
 void apply_variant_projection_decisions(const ParquetColumnSchema& schema,
                                         format::LocalColumnIndex* projection,
                                         std::span<const size_t> prunable_ordinals,
+                                        std::span<const size_t> full_ordinals,
                                         size_t* candidate_ordinal) {
     DORIS_CHECK(projection != nullptr && candidate_ordinal != nullptr);
     if (!format::is_partial_projection(projection)) {
@@ -378,6 +384,9 @@ void apply_variant_projection_decisions(const ParquetColumnSchema& schema,
     if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
         if (std::ranges::binary_search(prunable_ordinals, *candidate_ordinal)) {
             detail::prune_variant_residual_columns(schema, projection);
+        } else if (std::ranges::binary_search(full_ordinals, *candidate_ordinal)) {
+            projection->project_all_children = true;
+            projection->children.clear();
         }
         ++*candidate_ordinal;
         return;
@@ -386,14 +395,15 @@ void apply_variant_projection_decisions(const ParquetColumnSchema& schema,
         const auto* child_schema = projection_schema_child(schema, child_projection.local_id());
         DORIS_CHECK(child_schema != nullptr);
         apply_variant_projection_decisions(*child_schema, &child_projection, prunable_ordinals,
-                                           candidate_ordinal);
+                                           full_ordinals, candidate_ordinal);
     }
 }
 
 void apply_variant_projection_decisions(
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         std::vector<format::LocalColumnIndex>* projections,
-        std::span<const size_t> prunable_ordinals, size_t* candidate_ordinal) {
+        std::span<const size_t> prunable_ordinals, std::span<const size_t> full_ordinals,
+        size_t* candidate_ordinal) {
     DORIS_CHECK(projections != nullptr);
     for (auto& projection : *projections) {
         const int32_t local_id = projection.local_id();
@@ -402,7 +412,7 @@ void apply_variant_projection_decisions(
             continue;
         }
         apply_variant_projection_decisions(*file_schema[local_id], &projection, prunable_ordinals,
-                                           candidate_ordinal);
+                                           full_ordinals, candidate_ordinal);
     }
 }
 
@@ -412,8 +422,10 @@ void prepare_row_group_physical_projection(
         const format::FileScanRequest& request, RowGroupReadPlan* row_group_plan) {
     DORIS_CHECK(row_group_plan != nullptr);
     row_group_plan->prunable_variant_projection_ordinals.clear();
+    row_group_plan->full_variant_projection_ordinals.clear();
     row_group_plan->variant_leaf_projection_columns = 0;
     row_group_plan->variant_residual_projection_columns = 0;
+    row_group_plan->variant_full_projection_columns = 0;
     size_t candidate_ordinal = 0;
     collect_variant_projection_decisions(row_group, file_schema, request.predicate_columns,
                                          &candidate_ordinal, row_group_plan);
@@ -487,7 +499,7 @@ std::optional<std::unordered_set<int>> row_group_leaf_column_ids(
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const format::FileScanRequest& request, const RowGroupReadPlan& row_group_plan,
         const std::unordered_set<int>& request_leaf_ids) {
-    if (row_group_plan.prunable_variant_projection_ordinals.empty()) {
+    if (!row_group_plan.has_row_group_physical_projection()) {
         return std::nullopt;
     }
     // Pruning removes columns, so this set cannot be derived by adding to the request-level set:
@@ -513,9 +525,11 @@ void materialize_row_group_projection(
     size_t candidate_ordinal = 0;
     apply_variant_projection_decisions(file_schema, &physical_request->predicate_columns,
                                        row_group_plan.prunable_variant_projection_ordinals,
+                                       row_group_plan.full_variant_projection_ordinals,
                                        &candidate_ordinal);
     apply_variant_projection_decisions(file_schema, &physical_request->non_predicate_columns,
                                        row_group_plan.prunable_variant_projection_ordinals,
+                                       row_group_plan.full_variant_projection_ordinals,
                                        &candidate_ordinal);
 }
 
@@ -1585,6 +1599,9 @@ Status ParquetScanScheduler::open_next_row_group(
         update_counter_if_not_null(
                 _parquet_profile->variant_residual_projection_row_group_columns,
                 cast_set<int64_t>(row_group_plan.variant_residual_projection_columns));
+        update_counter_if_not_null(
+                _parquet_profile->variant_full_projection_row_group_columns,
+                cast_set<int64_t>(row_group_plan.variant_full_projection_columns));
     }
     *has_row_group = true;
     return Status::OK();

--- a/be/src/format_v2/parquet/parquet_scan.cpp
+++ b/be/src/format_v2/parquet/parquet_scan.cpp
@@ -331,11 +331,14 @@ void collect_variant_projection_decisions(const tparquet::RowGroup& row_group,
         return;
     }
     if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
-        if (detail::variant_leaf_projection_is_safe_for_row_group(row_group, schema, projection)) {
-            ++row_group_plan->variant_leaf_projection_columns;
+        // Every candidate keeps its leaf projection. The statistics only decide whether the
+        // residual columns beside the leaves can be dropped from this row group's read.
+        ++row_group_plan->variant_leaf_projection_columns;
+        if (detail::variant_residual_columns_are_prunable_for_row_group(row_group, schema,
+                                                                        projection)) {
+            row_group_plan->prunable_variant_projection_ordinals.push_back(*candidate_ordinal);
         } else {
-            row_group_plan->full_variant_projection_ordinals.push_back(*candidate_ordinal);
-            ++row_group_plan->variant_full_projection_columns;
+            ++row_group_plan->variant_residual_projection_columns;
         }
         ++*candidate_ordinal;
         return;
@@ -366,16 +369,15 @@ void collect_variant_projection_decisions(
 
 void apply_variant_projection_decisions(const ParquetColumnSchema& schema,
                                         format::LocalColumnIndex* projection,
-                                        std::span<const size_t> full_ordinals,
+                                        std::span<const size_t> prunable_ordinals,
                                         size_t* candidate_ordinal) {
     DORIS_CHECK(projection != nullptr && candidate_ordinal != nullptr);
     if (!format::is_partial_projection(projection)) {
         return;
     }
     if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
-        if (std::ranges::binary_search(full_ordinals, *candidate_ordinal)) {
-            projection->project_all_children = true;
-            projection->children.clear();
+        if (std::ranges::binary_search(prunable_ordinals, *candidate_ordinal)) {
+            detail::prune_variant_residual_columns(schema, projection);
         }
         ++*candidate_ordinal;
         return;
@@ -383,15 +385,15 @@ void apply_variant_projection_decisions(const ParquetColumnSchema& schema,
     for (auto& child_projection : projection->children) {
         const auto* child_schema = projection_schema_child(schema, child_projection.local_id());
         DORIS_CHECK(child_schema != nullptr);
-        apply_variant_projection_decisions(*child_schema, &child_projection, full_ordinals,
+        apply_variant_projection_decisions(*child_schema, &child_projection, prunable_ordinals,
                                            candidate_ordinal);
     }
 }
 
 void apply_variant_projection_decisions(
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
-        std::vector<format::LocalColumnIndex>* projections, std::span<const size_t> full_ordinals,
-        size_t* candidate_ordinal) {
+        std::vector<format::LocalColumnIndex>* projections,
+        std::span<const size_t> prunable_ordinals, size_t* candidate_ordinal) {
     DORIS_CHECK(projections != nullptr);
     for (auto& projection : *projections) {
         const int32_t local_id = projection.local_id();
@@ -399,7 +401,7 @@ void apply_variant_projection_decisions(
             file_schema[local_id] == nullptr || !file_schema[local_id]->contains_variant) {
             continue;
         }
-        apply_variant_projection_decisions(*file_schema[local_id], &projection, full_ordinals,
+        apply_variant_projection_decisions(*file_schema[local_id], &projection, prunable_ordinals,
                                            candidate_ordinal);
     }
 }
@@ -409,9 +411,9 @@ void prepare_row_group_physical_projection(
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const format::FileScanRequest& request, RowGroupReadPlan* row_group_plan) {
     DORIS_CHECK(row_group_plan != nullptr);
-    row_group_plan->full_variant_projection_ordinals.clear();
+    row_group_plan->prunable_variant_projection_ordinals.clear();
     row_group_plan->variant_leaf_projection_columns = 0;
-    row_group_plan->variant_full_projection_columns = 0;
+    row_group_plan->variant_residual_projection_columns = 0;
     size_t candidate_ordinal = 0;
     collect_variant_projection_decisions(row_group, file_schema, request.predicate_columns,
                                          &candidate_ordinal, row_group_plan);
@@ -419,23 +421,17 @@ void prepare_row_group_physical_projection(
                                          &candidate_ordinal, row_group_plan);
 }
 
+// The row-group residual decision is written into the projection itself, so collecting the leaf
+// columns is a pure function of the projection shape.
 void collect_physical_leaf_column_ids(const ParquetColumnSchema& schema,
                                       const format::LocalColumnIndex& projection,
-                                      std::span<const size_t> full_ordinals,
-                                      size_t* candidate_ordinal,
                                       std::unordered_set<int>* leaf_column_ids) {
-    DORIS_CHECK(candidate_ordinal != nullptr && leaf_column_ids != nullptr);
+    DORIS_CHECK(leaf_column_ids != nullptr);
     if (projection.project_all_children) {
         collect_all_leaf_column_ids(schema, leaf_column_ids);
         return;
     }
     if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
-        if (std::ranges::binary_search(full_ordinals, *candidate_ordinal)) {
-            collect_all_leaf_column_ids(schema, leaf_column_ids);
-            ++*candidate_ordinal;
-            return;
-        }
-        ++*candidate_ordinal;
         collect_projected_leaf_column_ids(schema, projection, leaf_column_ids);
         return;
     }
@@ -446,27 +442,21 @@ void collect_physical_leaf_column_ids(const ParquetColumnSchema& schema,
     for (const auto& child_projection : projection.children) {
         const auto* child_schema = projection_schema_child(schema, child_projection.local_id());
         DORIS_CHECK(child_schema != nullptr);
-        collect_physical_leaf_column_ids(*child_schema, child_projection, full_ordinals,
-                                         candidate_ordinal, leaf_column_ids);
+        collect_physical_leaf_column_ids(*child_schema, child_projection, leaf_column_ids);
     }
 }
 
-std::unordered_set<int> request_leaf_column_ids(
+std::unordered_set<int> collect_request_leaf_column_ids(
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const format::FileScanRequest& request) {
-#ifdef BE_TEST
-    detail::physical_leaf_set_builds.fetch_add(1, std::memory_order_relaxed);
-#endif
     std::unordered_set<int> leaf_column_ids;
-    size_t candidate_ordinal = 0;
     const auto collect_projection = [&](const format::LocalColumnIndex& projection) {
         const int32_t local_id = projection.local_id();
         if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size()) ||
             file_schema[local_id] == nullptr) {
             return;
         }
-        collect_physical_leaf_column_ids(*file_schema[local_id], projection, {}, &candidate_ordinal,
-                                         &leaf_column_ids);
+        collect_physical_leaf_column_ids(*file_schema[local_id], projection, &leaf_column_ids);
     };
     for (const auto& projection : request.predicate_columns) {
         collect_projection(projection);
@@ -479,54 +469,35 @@ std::unordered_set<int> request_leaf_column_ids(
     return leaf_column_ids;
 }
 
-void collect_full_variant_leaf_delta(const ParquetColumnSchema& schema,
-                                     const format::LocalColumnIndex& projection,
-                                     std::span<const size_t> full_ordinals,
-                                     size_t* candidate_ordinal,
-                                     std::unordered_set<int>* leaf_column_ids) {
-    DORIS_CHECK(candidate_ordinal != nullptr && leaf_column_ids != nullptr);
-    if (!format::is_partial_projection(&projection)) {
-        return;
-    }
-    if (schema.kind == ParquetColumnSchemaKind::VARIANT) {
-        if (std::ranges::binary_search(full_ordinals, *candidate_ordinal)) {
-            collect_all_leaf_column_ids(schema, leaf_column_ids);
-        }
-        ++*candidate_ordinal;
-        return;
-    }
-    for (const auto& child_projection : projection.children) {
-        const auto* child_schema = projection_schema_child(schema, child_projection.local_id());
-        DORIS_CHECK(child_schema != nullptr);
-        collect_full_variant_leaf_delta(*child_schema, child_projection, full_ordinals,
-                                        candidate_ordinal, leaf_column_ids);
-    }
+void materialize_row_group_projection(
+        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        const format::FileScanRequest& request, const RowGroupReadPlan& row_group_plan,
+        format::FileScanRequest* physical_request);
+
+std::unordered_set<int> request_leaf_column_ids(
+        const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
+        const format::FileScanRequest& request) {
+#ifdef BE_TEST
+    detail::physical_leaf_set_builds.fetch_add(1, std::memory_order_relaxed);
+#endif
+    return collect_request_leaf_column_ids(file_schema, request);
 }
 
 std::optional<std::unordered_set<int>> row_group_leaf_column_ids(
         const std::vector<std::unique_ptr<ParquetColumnSchema>>& file_schema,
         const format::FileScanRequest& request, const RowGroupReadPlan& row_group_plan,
         const std::unordered_set<int>& request_leaf_ids) {
-    if (row_group_plan.full_variant_projection_ordinals.empty()) {
+    if (row_group_plan.prunable_variant_projection_ordinals.empty()) {
         return std::nullopt;
     }
-    auto leaf_column_ids = request_leaf_ids;
-    size_t candidate_ordinal = 0;
-    const auto collect_projection = [&](const format::LocalColumnIndex& projection) {
-        const int32_t local_id = projection.local_id();
-        if (local_id < 0 || local_id >= static_cast<int32_t>(file_schema.size()) ||
-            file_schema[local_id] == nullptr || !file_schema[local_id]->contains_variant) {
-            return;
-        }
-        collect_full_variant_leaf_delta(*file_schema[local_id], projection,
-                                        row_group_plan.full_variant_projection_ordinals,
-                                        &candidate_ordinal, &leaf_column_ids);
-    };
-    for (const auto& projection : request.predicate_columns) {
-        collect_projection(projection);
-    }
-    for (const auto& projection : request.non_predicate_columns) {
-        collect_projection(projection);
+    // Pruning removes columns, so this set cannot be derived by adding to the request-level set:
+    // the same Variant can appear pruned under a predicate projection and unpruned under the
+    // deferred output projection at once. Rebuild it from the rewritten projections instead.
+    format::FileScanRequest physical_request;
+    materialize_row_group_projection(file_schema, request, row_group_plan, &physical_request);
+    auto leaf_column_ids = collect_request_leaf_column_ids(file_schema, physical_request);
+    if (leaf_column_ids == request_leaf_ids) {
+        return std::nullopt;
     }
     return leaf_column_ids;
 }
@@ -541,10 +512,10 @@ void materialize_row_group_projection(
     physical_request->count_star_placeholder_columns = request.count_star_placeholder_columns;
     size_t candidate_ordinal = 0;
     apply_variant_projection_decisions(file_schema, &physical_request->predicate_columns,
-                                       row_group_plan.full_variant_projection_ordinals,
+                                       row_group_plan.prunable_variant_projection_ordinals,
                                        &candidate_ordinal);
     apply_variant_projection_decisions(file_schema, &physical_request->non_predicate_columns,
-                                       row_group_plan.full_variant_projection_ordinals,
+                                       row_group_plan.prunable_variant_projection_ordinals,
                                        &candidate_ordinal);
 }
 
@@ -1612,8 +1583,8 @@ Status ParquetScanScheduler::open_next_row_group(
                 _parquet_profile->variant_leaf_projection_row_group_columns,
                 cast_set<int64_t>(row_group_plan.variant_leaf_projection_columns));
         update_counter_if_not_null(
-                _parquet_profile->variant_full_projection_row_group_columns,
-                cast_set<int64_t>(row_group_plan.variant_full_projection_columns));
+                _parquet_profile->variant_residual_projection_row_group_columns,
+                cast_set<int64_t>(row_group_plan.variant_residual_projection_columns));
     }
     *has_row_group = true;
     return Status::OK();

--- a/be/src/format_v2/parquet/parquet_scan.h
+++ b/be/src/format_v2/parquet/parquet_scan.h
@@ -81,12 +81,17 @@ struct AdaptivePredicateStats {
 size_t finalize_variant_leaf_projection_for_row_group(const tparquet::RowGroup& row_group,
                                                       const ParquetColumnSchema& schema,
                                                       format::LocalColumnIndex* projection,
-                                                      size_t* residual_projections = nullptr);
+                                                      size_t* residual_projections = nullptr,
+                                                      size_t* full_projections = nullptr);
 // True when this row group's statistics prove every residual beside a projected leaf is NULL, so
 // the residual columns and the root dictionary can be dropped from the read.
 bool variant_residual_columns_are_prunable_for_row_group(
         const tparquet::RowGroup& row_group, const ParquetColumnSchema& schema,
         const format::LocalColumnIndex& projection);
+// True when the projection reads every terminal residual the file schema declares, plus the root
+// dictionary. A projection that omits one cannot serve the rows stored outside its shredded leaves.
+bool variant_projection_carries_residuals(const ParquetColumnSchema& schema,
+                                          const format::LocalColumnIndex& projection);
 void prune_variant_residual_columns(const ParquetColumnSchema& schema,
                                     format::LocalColumnIndex* projection);
 
@@ -136,17 +141,20 @@ struct RowGroupReadPlan {
     // same remote index reads a second time while opening the row group.
     std::unordered_map<int, tparquet::OffsetIndex> offset_indexes;
     // Candidate ordinals refer to a deterministic traversal of the immutable request projection.
-    // Only prunable candidates are retained, keeping the row-group delta independent of projection
-    // size.
+    // Only candidates whose projection this row group changes are retained, keeping the row-group
+    // delta independent of projection size.
     std::vector<size_t> prunable_variant_projection_ordinals;
+    std::vector<size_t> full_variant_projection_ordinals;
     size_t variant_leaf_projection_columns = 0;
     size_t variant_residual_projection_columns = 0;
+    size_t variant_full_projection_columns = 0;
     // Footer statistics are cheap and eager. Remote dictionary/Bloom/page-index probes fill the
     // remaining fields only when this row group reaches the scheduler.
     bool expensive_pruning_pending = false;
 
     bool has_row_group_physical_projection() const {
-        return !prunable_variant_projection_ordinals.empty();
+        return !prunable_variant_projection_ordinals.empty() ||
+               !full_variant_projection_ordinals.empty();
     }
 };
 

--- a/be/src/format_v2/parquet/parquet_scan.h
+++ b/be/src/format_v2/parquet/parquet_scan.h
@@ -81,10 +81,14 @@ struct AdaptivePredicateStats {
 size_t finalize_variant_leaf_projection_for_row_group(const tparquet::RowGroup& row_group,
                                                       const ParquetColumnSchema& schema,
                                                       format::LocalColumnIndex* projection,
-                                                      size_t* full_projections = nullptr);
-bool variant_leaf_projection_is_safe_for_row_group(const tparquet::RowGroup& row_group,
-                                                   const ParquetColumnSchema& schema,
-                                                   const format::LocalColumnIndex& projection);
+                                                      size_t* residual_projections = nullptr);
+// True when this row group's statistics prove every residual beside a projected leaf is NULL, so
+// the residual columns and the root dictionary can be dropped from the read.
+bool variant_residual_columns_are_prunable_for_row_group(
+        const tparquet::RowGroup& row_group, const ParquetColumnSchema& schema,
+        const format::LocalColumnIndex& projection);
+void prune_variant_residual_columns(const ParquetColumnSchema& schema,
+                                    format::LocalColumnIndex* projection);
 
 std::vector<size_t> order_adaptive_predicates(
         const std::vector<size_t>& positions,
@@ -132,16 +136,17 @@ struct RowGroupReadPlan {
     // same remote index reads a second time while opening the row group.
     std::unordered_map<int, tparquet::OffsetIndex> offset_indexes;
     // Candidate ordinals refer to a deterministic traversal of the immutable request projection.
-    // Only full fallbacks are retained, keeping the row-group delta independent of projection size.
-    std::vector<size_t> full_variant_projection_ordinals;
+    // Only prunable candidates are retained, keeping the row-group delta independent of projection
+    // size.
+    std::vector<size_t> prunable_variant_projection_ordinals;
     size_t variant_leaf_projection_columns = 0;
-    size_t variant_full_projection_columns = 0;
+    size_t variant_residual_projection_columns = 0;
     // Footer statistics are cheap and eager. Remote dictionary/Bloom/page-index probes fill the
     // remaining fields only when this row group reaches the scheduler.
     bool expensive_pruning_pending = false;
 
     bool has_row_group_physical_projection() const {
-        return !full_variant_projection_ordinals.empty();
+        return !prunable_variant_projection_ordinals.empty();
     }
 };
 

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -654,7 +654,7 @@ const ParquetColumnSchema* child_named(const ParquetColumnSchema& parent, std::s
 }
 
 struct ResolvedVariantShredding {
-    const ParquetColumnSchema* fallback_value = nullptr;
+    std::vector<const ParquetColumnSchema*> fallback_values;
     const ParquetColumnSchema* typed_value = nullptr;
 };
 
@@ -756,6 +756,8 @@ std::optional<ResolvedVariantShredding> resolve_variant_shredding(
     if (wrapper == nullptr || wrapper->kind != ParquetColumnSchemaKind::VARIANT) {
         return std::nullopt;
     }
+    std::vector<const ParquetColumnSchema*> fallback_values;
+    fallback_values.reserve(predicate.path.size() + 1);
     for (const auto& component : predicate.path) {
         const auto* fallback = child_named(*wrapper, "value");
         const auto* typed_object = child_named(*wrapper, "typed_value");
@@ -763,6 +765,7 @@ std::optional<ResolvedVariantShredding> resolve_variant_shredding(
             typed_object == nullptr || typed_object->kind != ParquetColumnSchemaKind::STRUCT) {
             return std::nullopt;
         }
+        fallback_values.push_back(fallback);
         wrapper = child_named(*typed_object, component);
         if (wrapper == nullptr || wrapper->kind != ParquetColumnSchemaKind::STRUCT) {
             return std::nullopt;
@@ -783,7 +786,9 @@ std::optional<ResolvedVariantShredding> resolve_variant_shredding(
         !expr_zonemap::data_types_compatible(predicate.comparison_type, predicate.literal_type)) {
         return std::nullopt;
     }
-    return ResolvedVariantShredding {.fallback_value = fallback, .typed_value = typed};
+    fallback_values.push_back(fallback);
+    return ResolvedVariantShredding {.fallback_values = std::move(fallback_values),
+                                     .typed_value = typed};
 }
 
 bool fallback_is_all_null(const tparquet::RowGroup& row_group,
@@ -797,6 +802,14 @@ bool fallback_is_all_null(const tparquet::RowGroup& row_group,
            chunk.meta_data.num_values == row_group.num_rows && chunk.meta_data.__isset.statistics &&
            chunk.meta_data.statistics.__isset.null_count &&
            chunk.meta_data.statistics.null_count == chunk.meta_data.num_values;
+}
+
+bool all_fallbacks_are_all_null(const tparquet::RowGroup& row_group,
+                                const std::vector<const ParquetColumnSchema*>& fallback_values) {
+    return !fallback_values.empty() &&
+           std::ranges::all_of(fallback_values, [&](const auto* fallback) {
+               return fallback != nullptr && fallback_is_all_null(row_group, *fallback);
+           });
 }
 
 bool variant_statistics_exclude(const VariantShreddedPredicate& predicate,
@@ -1086,10 +1099,10 @@ bool check_shredded_variant_statistics(
         const auto shredding = resolve_variant_shredding(file_schema, request, *predicate);
         if (!shredding.has_value() || shredding->typed_value->leaf_column_id < 0 ||
             shredding->typed_value->leaf_column_id >= static_cast<int>(row_group.columns.size()) ||
-            // Partially shredded object residuals contain only keys not present in typed_value,
-            // so ancestors cannot shadow this path. The terminal fallback is the sole guard.
-            shredding->fallback_value == nullptr ||
-            !fallback_is_all_null(row_group, *shredding->fallback_value) ||
+            // Doris resolves the path from the first ancestor whose typed value is absent. Typed
+            // leaf statistics are therefore authoritative only when every possible fallback on
+            // the path is proven NULL for this row group.
+            !all_fallbacks_are_all_null(row_group, shredding->fallback_values) ||
             !variant_metadata_predicate_is_type_safe(*shredding->typed_value) ||
             !detail::has_supported_type_defined_order(metadata,
                                                       shredding->typed_value->leaf_column_id)) {
@@ -2067,8 +2080,7 @@ Status select_row_group_ranges_by_native_page_index(
         }
         const auto shredding = resolve_variant_shredding(file_schema, request, *predicate);
         if (!shredding.has_value() || shredding->typed_value->leaf_column_id < 0 ||
-            shredding->fallback_value == nullptr ||
-            !fallback_is_all_null(row_group, *shredding->fallback_value) ||
+            !all_fallbacks_are_all_null(row_group, shredding->fallback_values) ||
             !variant_metadata_predicate_is_type_safe(*shredding->typed_value) ||
             !detail::has_supported_type_defined_order(metadata,
                                                       shredding->typed_value->leaf_column_id)) {

--- a/be/src/format_v2/parquet/parquet_statistics.cpp
+++ b/be/src/format_v2/parquet/parquet_statistics.cpp
@@ -654,7 +654,7 @@ const ParquetColumnSchema* child_named(const ParquetColumnSchema& parent, std::s
 }
 
 struct ResolvedVariantShredding {
-    std::vector<const ParquetColumnSchema*> fallback_values;
+    const ParquetColumnSchema* fallback_value = nullptr;
     const ParquetColumnSchema* typed_value = nullptr;
 };
 
@@ -756,8 +756,6 @@ std::optional<ResolvedVariantShredding> resolve_variant_shredding(
     if (wrapper == nullptr || wrapper->kind != ParquetColumnSchemaKind::VARIANT) {
         return std::nullopt;
     }
-    std::vector<const ParquetColumnSchema*> fallback_values;
-    fallback_values.reserve(predicate.path.size() + 1);
     for (const auto& component : predicate.path) {
         const auto* fallback = child_named(*wrapper, "value");
         const auto* typed_object = child_named(*wrapper, "typed_value");
@@ -765,7 +763,6 @@ std::optional<ResolvedVariantShredding> resolve_variant_shredding(
             typed_object == nullptr || typed_object->kind != ParquetColumnSchemaKind::STRUCT) {
             return std::nullopt;
         }
-        fallback_values.push_back(fallback);
         wrapper = child_named(*typed_object, component);
         if (wrapper == nullptr || wrapper->kind != ParquetColumnSchemaKind::STRUCT) {
             return std::nullopt;
@@ -786,9 +783,7 @@ std::optional<ResolvedVariantShredding> resolve_variant_shredding(
         !expr_zonemap::data_types_compatible(predicate.comparison_type, predicate.literal_type)) {
         return std::nullopt;
     }
-    fallback_values.push_back(fallback);
-    return ResolvedVariantShredding {.fallback_values = std::move(fallback_values),
-                                     .typed_value = typed};
+    return ResolvedVariantShredding {.fallback_value = fallback, .typed_value = typed};
 }
 
 bool fallback_is_all_null(const tparquet::RowGroup& row_group,
@@ -802,14 +797,6 @@ bool fallback_is_all_null(const tparquet::RowGroup& row_group,
            chunk.meta_data.num_values == row_group.num_rows && chunk.meta_data.__isset.statistics &&
            chunk.meta_data.statistics.__isset.null_count &&
            chunk.meta_data.statistics.null_count == chunk.meta_data.num_values;
-}
-
-bool all_fallbacks_are_all_null(const tparquet::RowGroup& row_group,
-                                const std::vector<const ParquetColumnSchema*>& fallback_values) {
-    return !fallback_values.empty() &&
-           std::ranges::all_of(fallback_values, [&](const auto* fallback) {
-               return fallback != nullptr && fallback_is_all_null(row_group, *fallback);
-           });
 }
 
 bool variant_statistics_exclude(const VariantShreddedPredicate& predicate,
@@ -1099,10 +1086,10 @@ bool check_shredded_variant_statistics(
         const auto shredding = resolve_variant_shredding(file_schema, request, *predicate);
         if (!shredding.has_value() || shredding->typed_value->leaf_column_id < 0 ||
             shredding->typed_value->leaf_column_id >= static_cast<int>(row_group.columns.size()) ||
-            // Doris resolves the path from the first ancestor whose typed value is absent. Typed
-            // leaf statistics are therefore authoritative only when every possible fallback on
-            // the path is proven NULL for this row group.
-            !all_fallbacks_are_all_null(row_group, shredding->fallback_values) ||
+            // Partially shredded object residuals contain only keys not present in typed_value,
+            // so ancestors cannot shadow this path. The terminal fallback is the sole guard.
+            shredding->fallback_value == nullptr ||
+            !fallback_is_all_null(row_group, *shredding->fallback_value) ||
             !variant_metadata_predicate_is_type_safe(*shredding->typed_value) ||
             !detail::has_supported_type_defined_order(metadata,
                                                       shredding->typed_value->leaf_column_id)) {
@@ -2080,7 +2067,8 @@ Status select_row_group_ranges_by_native_page_index(
         }
         const auto shredding = resolve_variant_shredding(file_schema, request, *predicate);
         if (!shredding.has_value() || shredding->typed_value->leaf_column_id < 0 ||
-            !all_fallbacks_are_all_null(row_group, shredding->fallback_values) ||
+            shredding->fallback_value == nullptr ||
+            !fallback_is_all_null(row_group, *shredding->fallback_value) ||
             !variant_metadata_predicate_is_type_safe(*shredding->typed_value) ||
             !detail::has_supported_type_defined_order(metadata,
                                                       shredding->typed_value->leaf_column_id)) {

--- a/be/src/format_v2/parquet/reader/variant_column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/variant_column_reader.cpp
@@ -22,6 +22,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <functional>
 #include <limits>
 #include <mutex>
 #include <optional>
@@ -1266,42 +1267,71 @@ bool residual_supplies_any_row(const ShreddedPathLevel& level, size_t rows) {
     return false;
 }
 
-// Seeks object paths inside encoded residual bytes, resolving each key to a dictionary field id
-// once per distinct metadata dictionary instead of once per row. Iceberg normally repeats a single
-// dictionary across a decoded batch, so the dictionary list stays at one entry and identifying a
-// row's dictionary is a byte-range comparison.
+// Identifies the metadata dictionary of every row once per decoded batch. Iceberg normally repeats
+// a single dictionary across a batch, so the list stays at one entry. Sharing this across the paths
+// of one batch is what keeps a wide projection from re-scanning the dictionary column per path.
+struct VariantMetadataIndex {
+    static constexpr uint32_t MISSING_DICTIONARY = std::numeric_limits<uint32_t>::max();
+
+    DorisVector<StringRef> dictionaries;
+    DorisVector<uint32_t> row_dictionaries;
+};
+
+std::shared_ptr<const VariantMetadataIndex> build_variant_metadata_index(
+        const NullableColumnView& metadata, size_t rows) {
+    auto index = std::make_shared<VariantMetadataIndex>();
+    index->row_dictionaries.assign(rows, VariantMetadataIndex::MISSING_DICTIONARY);
+    for (size_t row = 0; row < rows; ++row) {
+        if (metadata.is_null(row)) {
+            continue;
+        }
+        const StringRef bytes = metadata.values->get_data_at(row);
+        uint32_t dictionary = 0;
+        while (dictionary < index->dictionaries.size() &&
+               index->dictionaries[dictionary] != bytes) {
+            ++dictionary;
+        }
+        if (dictionary == index->dictionaries.size()) {
+            index->dictionaries.push_back(bytes);
+        }
+        index->row_dictionaries[row] = dictionary;
+    }
+    return index;
+}
+
+// Seeks object paths inside encoded residual bytes. Keys resolve to a dictionary field id once per
+// distinct dictionary instead of once per row, and the dictionary index is built only when a path
+// still has keys to resolve - a residual that already is the requested value needs no dictionary.
 class VariantResidualSeeker {
 public:
-    VariantResidualSeeker(const NullableColumnView& metadata, size_t rows, size_t path_length)
-            : _path_length(path_length) {
-        _row_dictionaries.assign(rows, MISSING_DICTIONARY);
-        for (size_t row = 0; row < rows; ++row) {
-            if (metadata.is_null(row)) {
-                continue;
-            }
-            const StringRef bytes = metadata.values->get_data_at(row);
-            uint32_t dictionary = 0;
-            while (dictionary < _dictionaries.size() && _dictionaries[dictionary] != bytes) {
-                ++dictionary;
-            }
-            if (dictionary == _dictionaries.size()) {
-                _dictionaries.push_back(bytes);
-            }
-            _row_dictionaries[row] = dictionary;
-        }
-        _field_ids.assign(_dictionaries.size() * _path_length, UNRESOLVED_FIELD_ID);
-    }
+    using MetadataIndexProvider = std::function<const VariantMetadataIndex&()>;
+
+    VariantResidualSeeker(const NullableColumnView& metadata, size_t path_length,
+                          MetadataIndexProvider provider)
+            : _metadata(metadata), _path_length(path_length), _provider(std::move(provider)) {}
 
     // Resolves path[path_offset..] inside `value`. The offset keeps the cache keyed by absolute
     // path position, because different rows can enter the residual at different depths.
     bool seek(size_t row, StringRef value, size_t path_offset,
               std::span<const VariantShreddedPathSegment> path, VariantRef* output) {
         DORIS_CHECK(output != nullptr);
-        const uint32_t dictionary = _row_dictionaries[row];
-        if (dictionary == MISSING_DICTIONARY) {
+        if (path.empty()) {
+            // The residual already is the requested value; only its dictionary travels with it.
+            if (_metadata.is_null(row)) {
+                return false;
+            }
+            const StringRef bytes = _metadata.values->get_data_at(row);
+            *output = VariantRef {.metadata = {.data = bytes.data, .size = bytes.size},
+                                  .value = value};
+            return true;
+        }
+
+        const VariantMetadataIndex& index = _index == nullptr ? _resolve_index() : *_index;
+        const uint32_t dictionary = index.row_dictionaries[row];
+        if (dictionary == VariantMetadataIndex::MISSING_DICTIONARY) {
             return false;
         }
-        const StringRef dictionary_bytes = _dictionaries[dictionary];
+        const StringRef dictionary_bytes = index.dictionaries[dictionary];
         VariantRef current {
                 .metadata = {.data = dictionary_bytes.data, .size = dictionary_bytes.size},
                 .value = value};
@@ -1339,12 +1369,18 @@ public:
     }
 
 private:
-    static constexpr uint32_t MISSING_DICTIONARY = std::numeric_limits<uint32_t>::max();
     static constexpr int64_t UNRESOLVED_FIELD_ID = -2;
 
+    const VariantMetadataIndex& _resolve_index() {
+        _index = &_provider();
+        _field_ids.assign(_index->dictionaries.size() * _path_length, UNRESOLVED_FIELD_ID);
+        return *_index;
+    }
+
+    const NullableColumnView& _metadata;
     size_t _path_length;
-    DorisVector<StringRef> _dictionaries;
-    DorisVector<uint32_t> _row_dictionaries;
+    MetadataIndexProvider _provider;
+    const VariantMetadataIndex* _index = nullptr;
     DorisVector<int64_t> _field_ids;
 };
 
@@ -1356,13 +1392,14 @@ private:
 ColumnPtr resolve_variant_path_rows(const ParquetColumnSchema* leaf_schema, const IColumn* leaf,
                                     const NullableColumnView& metadata, size_t rows,
                                     std::span<const ShreddedPathLevel> levels,
-                                    std::span<const VariantShreddedPathSegment> path) {
+                                    std::span<const VariantShreddedPathSegment> path,
+                                    VariantResidualSeeker::MetadataIndexProvider provider) {
     DORIS_CHECK(!levels.empty() && levels.size() <= path.size() + 1);
     // A shredded leaf always sits one level below the last path segment. Without one the walk
     // stopped early, and the deepest collected level is where the remaining path resolves.
     DORIS_CHECK(leaf == nullptr || levels.size() == path.size() + 1);
     const auto* nullable = leaf == nullptr ? nullptr : &assert_cast<const ColumnNullable&>(*leaf);
-    VariantResidualSeeker seeker(metadata, rows, path.size());
+    VariantResidualSeeker seeker(metadata, path.size(), std::move(provider));
     VariantBatchBuilder builder(VariantBatchBuilder::ReserveHint {.rows = rows});
     auto nulls = ColumnUInt8::create();
     nulls->get_data().reserve(rows);
@@ -1583,6 +1620,10 @@ public:
         auto mutable_physical = IColumn::mutate(std::move(_physical));
         append_compatible_column(*mutable_physical, *parquet_source->_physical);
         _physical = std::move(mutable_physical);
+        {
+            std::lock_guard index_lock(_metadata_index_lock);
+            _metadata_index.reset();
+        }
         std::lock_guard lock(_materialization_lock);
         _unshredded_path_cache.reset();
         _unshredded_metadata_index.reset();
@@ -1634,6 +1675,15 @@ public:
         // A key the shredding schema does not describe can only live in the residual beside the
         // object that was searched, so seeking it there answers the path exactly. Rebuilding the
         // canonical root would reach the same value after re-encoding every unrelated field.
+        // Every path of one decoded batch shares the dictionary identification; it is built on the
+        // first path that still has keys to resolve, and never at all for the paths that do not.
+        const auto metadata_index = [this, &metadata]() -> const VariantMetadataIndex& {
+            std::lock_guard lock(_metadata_index_lock);
+            if (!_metadata_index) {
+                _metadata_index = build_variant_metadata_index(metadata, _physical->size());
+            }
+            return *_metadata_index;
+        };
         const auto seek_residual = [&]() -> std::optional<VariantShreddedTypedValue> {
             if (!metadata.present() || !levels.back().residual_view.present()) {
                 return path_miss();
@@ -1643,7 +1693,7 @@ public:
                     .column = nullptr,
                     .type = nullptr,
                     .normalized = resolve_variant_path_rows(nullptr, nullptr, metadata, rows,
-                                                            levels, path)};
+                                                            levels, path, metadata_index)};
         };
 
         for (size_t position = 0; position < path.size(); ++position) {
@@ -1714,11 +1764,11 @@ public:
                 update_counter(_profile.variant_direct_leaf_rows, static_cast<int64_t>(rows));
                 update_counter(_profile.variant_direct_leaf_residual_merged_rows,
                                static_cast<int64_t>(rows));
-                return VariantShreddedTypedValue {
-                        .column = nullptr,
-                        .type = nullptr,
-                        .normalized = resolve_variant_path_rows(typed_schema, typed.get(), metadata,
-                                                                rows, levels, path)};
+                return VariantShreddedTypedValue {.column = nullptr,
+                                                  .type = nullptr,
+                                                  .normalized = resolve_variant_path_rows(
+                                                          typed_schema, typed.get(), metadata, rows,
+                                                          levels, path, metadata_index)};
             }
 
             update_counter(_profile.variant_direct_leaf_rows, static_cast<int64_t>(rows));
@@ -1961,6 +2011,8 @@ private:
     mutable ColumnPtr _normalized_prefix;
     mutable ColumnVariantV2::MutablePtr _materialized;
     mutable ColumnVariantV2::MutablePtr _serialized;
+    mutable std::mutex _metadata_index_lock;
+    mutable std::shared_ptr<const VariantMetadataIndex> _metadata_index;
 };
 
 MutableColumnPtr build_variant_column(std::shared_ptr<const ParquetColumnSchema> schema,

--- a/be/src/format_v2/parquet/reader/variant_column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/variant_column_reader.cpp
@@ -661,8 +661,8 @@ bool supports_direct_typed_variant_state(const ParquetColumnSchema& schema) {
     if (schema.type == nullptr || schema.kind != ParquetColumnSchemaKind::PRIMITIVE) {
         return false;
     }
-    // ColumnVariantV2 typed state carries only a Doris type. Binary/UUID annotations, temporal
-    // units, and other Parquet-only identity must therefore reconstruct canonical Variant bytes.
+    // ColumnVariantV2 typed state carries only a Doris type, so any identity the Doris type does
+    // not pin down has to be rebuilt from the Parquet schema instead.
     switch (remove_nullable(schema.type)->get_primitive_type()) {
     case TYPE_BOOLEAN:
     case TYPE_TINYINT:
@@ -674,6 +674,13 @@ bool supports_direct_typed_variant_state(const ParquetColumnSchema& schema) {
     case TYPE_DECIMAL128I:
     case TYPE_DATEV2:
         return true;
+    case TYPE_STRING:
+    case TYPE_CHAR:
+    case TYPE_VARCHAR:
+        // BYTE_ARRAY carries strings, raw binary and UUID alike; only the UTF-8 annotation makes
+        // the value a Variant string. Temporal identities stay excluded because the typed state
+        // cannot record a timestamp's unit or its UTC adjustment.
+        return schema.type_descriptor.is_string_annotation && !schema.type_descriptor.is_uuid;
     default:
         return false;
     }

--- a/be/src/format_v2/parquet/reader/variant_column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/variant_column_reader.cpp
@@ -186,12 +186,13 @@ void append_typed_scalar(const ParquetColumnSchema& schema, const IColumn& colum
         return;
     }
     case TYPE_TIMEV2: {
-        const double seconds = assert_cast<const ColumnTimeV2&>(column).get_data()[row];
-        if (!std::isfinite(seconds) ||
-            std::abs(seconds) > static_cast<double>(std::numeric_limits<int64_t>::max()) / 1e6) {
+        // Doris TIMEV2 already stores signed microseconds in a double; see TimeValue::make_time.
+        const double micros = assert_cast<const ColumnTimeV2&>(column).get_data()[row];
+        if (!std::isfinite(micros) ||
+            std::abs(micros) > static_cast<double>(std::numeric_limits<int64_t>::max())) {
             throw Exception(ErrorCode::CORRUPTION, "Invalid Parquet Variant TIME value");
         }
-        builder.add_time_ntz_micros(static_cast<int64_t>(std::llround(seconds * 1e6)));
+        builder.add_time_ntz_micros(static_cast<int64_t>(std::llround(micros)));
         return;
     }
     case TYPE_DATETIMEV2: {
@@ -1267,44 +1268,12 @@ bool residual_supplies_any_row(const ShreddedPathLevel& level, size_t rows) {
     return false;
 }
 
-// Identifies the metadata dictionary of every row once per decoded batch. Iceberg normally repeats
-// a single dictionary across a batch, so the list stays at one entry. Sharing this across the paths
-// of one batch is what keeps a wide projection from re-scanning the dictionary column per path.
-struct VariantMetadataIndex {
-    static constexpr uint32_t MISSING_DICTIONARY = std::numeric_limits<uint32_t>::max();
-
-    DorisVector<StringRef> dictionaries;
-    DorisVector<uint32_t> row_dictionaries;
-};
-
-std::shared_ptr<const VariantMetadataIndex> build_variant_metadata_index(
-        const NullableColumnView& metadata, size_t rows) {
-    auto index = std::make_shared<VariantMetadataIndex>();
-    index->row_dictionaries.assign(rows, VariantMetadataIndex::MISSING_DICTIONARY);
-    for (size_t row = 0; row < rows; ++row) {
-        if (metadata.is_null(row)) {
-            continue;
-        }
-        const StringRef bytes = metadata.values->get_data_at(row);
-        uint32_t dictionary = 0;
-        while (dictionary < index->dictionaries.size() &&
-               index->dictionaries[dictionary] != bytes) {
-            ++dictionary;
-        }
-        if (dictionary == index->dictionaries.size()) {
-            index->dictionaries.push_back(bytes);
-        }
-        index->row_dictionaries[row] = dictionary;
-    }
-    return index;
-}
-
 // Seeks object paths inside encoded residual bytes. Keys resolve to a dictionary field id once per
 // distinct dictionary instead of once per row, and the dictionary index is built only when a path
 // still has keys to resolve - a residual that already is the requested value needs no dictionary.
 class VariantResidualSeeker {
 public:
-    using MetadataIndexProvider = std::function<const VariantMetadataIndex&()>;
+    using MetadataIndexProvider = std::function<const UnshreddedMetadataIndex&()>;
 
     VariantResidualSeeker(const NullableColumnView& metadata, size_t path_length,
                           MetadataIndexProvider provider)
@@ -1326,15 +1295,12 @@ public:
             return true;
         }
 
-        const VariantMetadataIndex& index = _index == nullptr ? _resolve_index() : *_index;
-        const uint32_t dictionary = index.row_dictionaries[row];
-        if (dictionary == VariantMetadataIndex::MISSING_DICTIONARY) {
+        const UnshreddedMetadataIndex& index = _index == nullptr ? _resolve_index() : *_index;
+        const uint32_t dictionary = index.row_dictionary_ids[row];
+        if (dictionary == UnshreddedMetadataIndex::NULL_ROW) {
             return false;
         }
-        const StringRef dictionary_bytes = index.dictionaries[dictionary];
-        VariantRef current {
-                .metadata = {.data = dictionary_bytes.data, .size = dictionary_bytes.size},
-                .value = value};
+        VariantRef current {.metadata = index.dictionaries[dictionary], .value = value};
         for (size_t position = 0; position < path.size(); ++position) {
             if (path[position].kind != VariantShreddedPathSegment::Kind::OBJECT_KEY) {
                 // Array segments never reach a residual: a shredded array lives in its typed_value,
@@ -1371,7 +1337,7 @@ public:
 private:
     static constexpr int64_t UNRESOLVED_FIELD_ID = -2;
 
-    const VariantMetadataIndex& _resolve_index() {
+    const UnshreddedMetadataIndex& _resolve_index() {
         _index = &_provider();
         _field_ids.assign(_index->dictionaries.size() * _path_length, UNRESOLVED_FIELD_ID);
         return *_index;
@@ -1380,7 +1346,7 @@ private:
     const NullableColumnView& _metadata;
     size_t _path_length;
     MetadataIndexProvider _provider;
-    const VariantMetadataIndex* _index = nullptr;
+    const UnshreddedMetadataIndex* _index = nullptr;
     DorisVector<int64_t> _field_ids;
 };
 
@@ -1620,10 +1586,6 @@ public:
         auto mutable_physical = IColumn::mutate(std::move(_physical));
         append_compatible_column(*mutable_physical, *parquet_source->_physical);
         _physical = std::move(mutable_physical);
-        {
-            std::lock_guard index_lock(_metadata_index_lock);
-            _metadata_index.reset();
-        }
         std::lock_guard lock(_materialization_lock);
         _unshredded_path_cache.reset();
         _unshredded_metadata_index.reset();
@@ -1675,17 +1637,18 @@ public:
         // A key the shredding schema does not describe can only live in the residual beside the
         // object that was searched, so seeking it there answers the path exactly. Rebuilding the
         // canonical root would reach the same value after re-encoding every unrelated field.
-        // Every path of one decoded batch shares the dictionary identification; it is built on the
-        // first path that still has keys to resolve, and never at all for the paths that do not.
-        const auto metadata_index = [this, &metadata]() -> const VariantMetadataIndex& {
-            std::lock_guard lock(_metadata_index_lock);
-            if (!_metadata_index) {
-                _metadata_index = build_variant_metadata_index(metadata, _physical->size());
-            }
-            return *_metadata_index;
+        // Every path of one decoded batch shares the dictionary identification, which the state
+        // caches: it is built on the first path that still has keys to resolve, and never at all
+        // for the paths that do not.
+        size_t metadata_position = 0;
+        const bool has_metadata_child =
+                find_child(*_schema, "metadata", &metadata_position) != nullptr;
+        const auto metadata_index = [this, metadata_position]() -> const UnshreddedMetadataIndex& {
+            return *get_unshredded_metadata_index({metadata_position, metadata_position});
         };
         const auto seek_residual = [&]() -> std::optional<VariantShreddedTypedValue> {
-            if (!metadata.present() || !levels.back().residual_view.present()) {
+            if (!metadata.present() || !has_metadata_child ||
+                !levels.back().residual_view.present()) {
                 return path_miss();
             }
             update_counter(_profile.variant_residual_seek_rows, static_cast<int64_t>(rows));
@@ -1718,11 +1681,12 @@ public:
             add_level(std::move(residual), typed);
 
             if (position + 1 < path.size()) {
-                // Every intermediate typed_value must be an object. A legacy untyped path
-                // produced through an array/explode operation cannot cross a repeated node, so
-                // those rows resolve from the residual beside it instead.
+                // An intermediate typed_value that is not an object cannot carry the rest of the
+                // path, so those rows resolve from the residual of this very wrapper - the object
+                // form of this field is what did not match its shredded type. The level just added
+                // is that residual; dropping it would search the parent instead, where shredding
+                // guarantees this key can never appear.
                 if (typed_schema->kind != ParquetColumnSchemaKind::STRUCT) {
-                    levels.pop_back();
                     return seek_residual();
                 }
                 continue;
@@ -2011,8 +1975,6 @@ private:
     mutable ColumnPtr _normalized_prefix;
     mutable ColumnVariantV2::MutablePtr _materialized;
     mutable ColumnVariantV2::MutablePtr _serialized;
-    mutable std::mutex _metadata_index_lock;
-    mutable std::shared_ptr<const VariantMetadataIndex> _metadata_index;
 };
 
 MutableColumnPtr build_variant_column(std::shared_ptr<const ParquetColumnSchema> schema,

--- a/be/src/format_v2/parquet/reader/variant_column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/variant_column_reader.cpp
@@ -1211,6 +1211,105 @@ ColumnPtr normalize_materialized_path(const ColumnVariantV2& materialized,
     return ColumnNullable::create(std::move(values), std::move(nulls));
 }
 
+// Column-level access to one optional Parquet column. Caching the null map beside the values lets
+// the row loops resolve a path without repeating the ColumnNullable cast for every row.
+struct NullableColumnView {
+    const IColumn* values = nullptr;
+    const uint8_t* nulls = nullptr;
+
+    bool present() const { return values != nullptr; }
+    bool is_null(size_t row) const {
+        return values == nullptr || (nulls != nullptr && nulls[row] != 0);
+    }
+};
+
+NullableColumnView view_column(const ColumnPtr& column) {
+    if (!column) {
+        return {};
+    }
+    if (const auto* nullable = check_and_get_column<ColumnNullable>(*column)) {
+        return {.values = &nullable->get_nested_column(),
+                .nulls = nullable->get_null_map_data().data()};
+    }
+    return {.values = column.get(), .nulls = nullptr};
+}
+
+// One `value`/`typed_value` pair along a shredded object path. Level 0 is the Variant root and
+// level i + 1 belongs to path[i], so the residual at level i encodes the value of that path prefix
+// for every row whose typed value beside it is null.
+struct ShreddedPathLevel {
+    ColumnPtr residual;
+    ColumnPtr typed;
+    NullableColumnView residual_view;
+    NullableColumnView typed_view;
+};
+
+// A residual can only supply the requested path for rows whose typed value is null. Shredding keeps
+// an object's residual keys disjoint from its shredded fields, so a present typed value always owns
+// the path and the residual beside it holds unrelated keys.
+bool residual_supplies_any_row(const ShreddedPathLevel& level, size_t rows) {
+    if (!level.residual_view.present()) {
+        return false;
+    }
+    for (size_t row = 0; row < rows; ++row) {
+        if (level.typed_view.is_null(row) && !level.residual_view.is_null(row)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Resolves the requested leaf row by row for a batch that mixes shredded values with residuals.
+// Rows served by the shredded leaf keep their exact Parquet identity through append_typed_scalar;
+// the rest copy the encoded value found beside the first null typed value on the path. Rebuilding
+// the complete Variant root would produce the same result at the cost of every unrelated field.
+ColumnPtr merge_typed_leaf_with_residuals(const ParquetColumnSchema& leaf_schema,
+                                          const IColumn& leaf, const NullableColumnView& metadata,
+                                          std::span<const ShreddedPathLevel> levels,
+                                          std::span<const VariantShreddedPathSegment> path) {
+    DORIS_CHECK(levels.size() == path.size() + 1);
+    const auto& nullable = assert_cast<const ColumnNullable&>(leaf);
+    const size_t rows = nullable.size();
+    VariantBatchBuilder builder(VariantBatchBuilder::ReserveHint {.rows = rows});
+    auto nulls = ColumnUInt8::create();
+    nulls->get_data().reserve(rows);
+    for (size_t row = 0; row < rows; ++row) {
+        auto output_row = builder.begin_row();
+        bool is_null = true;
+        size_t level = 0;
+        for (; level < levels.size(); ++level) {
+            if (!levels[level].typed_view.is_null(row)) {
+                continue;
+            }
+            VariantRef value;
+            const StringRef metadata_bytes =
+                    metadata.is_null(row) ? StringRef() : metadata.values->get_data_at(row);
+            if (!levels[level].residual_view.is_null(row) && metadata_bytes.data != nullptr &&
+                find_materialized_path(
+                        VariantRef {.metadata = {.data = metadata_bytes.data,
+                                                 .size = metadata_bytes.size},
+                                    .value = levels[level].residual_view.values->get_data_at(row)},
+                        path.subspan(level), &value)) {
+                output_row.add_value(value);
+                is_null = false;
+            }
+            break;
+        }
+        if (level == levels.size()) {
+            // Every typed value on the path is present, so the shredded leaf owns this row.
+            append_typed_scalar(leaf_schema, nullable.get_nested_column(), row, output_row);
+            is_null = false;
+        } else if (is_null) {
+            output_row.add_null();
+        }
+        output_row.finish();
+        nulls->get_data().push_back(static_cast<uint8_t>(is_null));
+    }
+    auto values = ColumnVariantV2::create();
+    values->insert_encoded_batch(builder.finish_batch());
+    return ColumnNullable::create(std::move(values), std::move(nulls));
+}
+
 bool same_data_type(const DataTypePtr& left, const DataTypePtr& right) {
     return (!left && !right) || (left && right && left->equals(*right));
 }
@@ -1422,6 +1521,21 @@ public:
             return path_miss();
         }
 
+        // Track the residual beside every typed value on the path, starting at the Variant root. A
+        // projected state omits those columns; its row-group validation already proved that no
+        // residual can contribute, so those levels simply carry an absent residual view.
+        DorisVector<ShreddedPathLevel> levels;
+        levels.reserve(path.size() + 1);
+        const auto add_level = [&levels](ColumnPtr residual, ColumnPtr typed_value) {
+            ShreddedPathLevel level;
+            level.residual_view = view_column(residual);
+            level.typed_view = view_column(typed_value);
+            level.residual = std::move(residual);
+            level.typed = std::move(typed_value);
+            levels.push_back(std::move(level));
+        };
+        add_level(struct_child(*_schema, _physical, "value", nullptr), typed);
+
         for (size_t position = 0; position < path.size(); ++position) {
             if (path[position].kind != VariantShreddedPathSegment::Kind::OBJECT_KEY) {
                 return path_miss();
@@ -1433,26 +1547,51 @@ public:
             if (!wrapper) {
                 return path_miss();
             }
-
-            if (ColumnPtr residual = struct_child(*wrapper_schema, wrapper, "value", nullptr);
-                static_cast<bool>(residual) && has_present_value(residual)) {
-                // A residual value can contribute data to the same logical object. Reconstructing
-                // is required in that case; returning only the typed leaf would drop information.
-                update_counter(_profile.variant_direct_leaf_residual_fallbacks, 1);
-                return std::nullopt;
-            }
-
+            ColumnPtr residual = struct_child(*wrapper_schema, wrapper, "value", nullptr);
             typed = struct_child(*wrapper_schema, wrapper, "typed_value", &typed_schema);
             if (!typed) {
                 return path_miss();
             }
-            if (position + 1 == path.size()) {
-                if (typed_schema->kind != ParquetColumnSchemaKind::PRIMITIVE ||
-                    check_and_get_column<ColumnNullable>(*typed) == nullptr) {
-                    update_counter(_profile.variant_direct_leaf_unsupported_fallbacks, 1);
+            add_level(std::move(residual), typed);
+
+            if (position + 1 < path.size()) {
+                // Every intermediate typed_value must be an object. This prevents a legacy untyped
+                // path produced through an array/explode operation from crossing a repeated node.
+                if (typed_schema->kind != ParquetColumnSchemaKind::STRUCT) {
+                    return path_miss();
+                }
+                continue;
+            }
+
+            if (typed_schema->kind != ParquetColumnSchemaKind::PRIMITIVE ||
+                check_and_get_column<ColumnNullable>(*typed) == nullptr) {
+                update_counter(_profile.variant_direct_leaf_unsupported_fallbacks, 1);
+                if (!_complete) {
+                    // Binary element_at evaluates complex prefixes before the validated leaf.
+                    // Serialize only retained descendants so projected-out fields stay hidden.
+                    if (auto normalized = find_normalized_value(path); normalized.has_value()) {
+                        return VariantShreddedTypedValue {
+                                .column = nullptr, .type = nullptr, .normalized = *normalized};
+                    }
+                }
+                return std::nullopt;
+            }
+
+            const size_t rows = typed->size();
+            const bool needs_row_merge =
+                    std::ranges::any_of(levels, [rows](const ShreddedPathLevel& level) {
+                        return residual_supplies_any_row(level, rows);
+                    });
+            if (needs_row_merge) {
+                // Decoding a residual needs the root dictionary. A state that projected the
+                // metadata away cannot serve those rows, so it keeps the complete fallback.
+                ColumnPtr metadata_column = struct_child(*_schema, _physical, "metadata", nullptr);
+                const NullableColumnView metadata = view_column(metadata_column);
+                if (!metadata.present()) {
+                    update_counter(_profile.variant_direct_leaf_residual_fallbacks, 1);
                     if (!_complete) {
-                        // Binary element_at evaluates complex prefixes before the validated leaf.
-                        // Serialize only retained descendants so projected-out fields stay hidden.
+                        // A projected state cannot rebuild its root, so serialize the retained
+                        // descendants instead of demanding the complete Variant.
                         if (auto normalized = find_normalized_value(path); normalized.has_value()) {
                             return VariantShreddedTypedValue {
                                     .column = nullptr, .type = nullptr, .normalized = *normalized};
@@ -1460,29 +1599,32 @@ public:
                     }
                     return std::nullopt;
                 }
-                if (!supports_direct_typed_variant_state(*typed_schema)) {
-                    if (_complete) {
-                        update_counter(_profile.variant_direct_leaf_unsupported_fallbacks, 1);
-                        return std::nullopt;
-                    }
-                    // A partial projection cannot reconstruct its root. Normalize only the exact
-                    // requested leaf so Parquet annotations survive heterogeneous file schemas.
-                    update_counter(_profile.variant_direct_leaf_rows,
-                                   static_cast<int64_t>(typed->size()));
-                    return VariantShreddedTypedValue {
-                            .column = nullptr,
-                            .type = nullptr,
-                            .normalized = normalize_projected_primitive_leaf(*typed_schema, typed)};
-                }
-                update_counter(_profile.variant_direct_leaf_rows,
-                               static_cast<int64_t>(typed->size()));
-                return VariantShreddedTypedValue {.column = std::move(typed),
-                                                  .type = remove_nullable(typed_schema->type),
-                                                  .normalized = nullptr};
+                update_counter(_profile.variant_direct_leaf_rows, static_cast<int64_t>(rows));
+                update_counter(_profile.variant_direct_leaf_residual_merged_rows,
+                               static_cast<int64_t>(rows));
+                return VariantShreddedTypedValue {
+                        .column = nullptr,
+                        .type = nullptr,
+                        .normalized = merge_typed_leaf_with_residuals(*typed_schema, *typed,
+                                                                      metadata, levels, path)};
             }
-            if (typed_schema->kind != ParquetColumnSchemaKind::STRUCT) {
-                return path_miss();
+
+            update_counter(_profile.variant_direct_leaf_rows, static_cast<int64_t>(rows));
+            if (!supports_direct_typed_variant_state(*typed_schema)) {
+                // ColumnVariantV2 typed state carries only a Doris type, so binary/UUID
+                // annotations and temporal units would be lost. Normalizing the leaf through its
+                // Parquet schema keeps them exact and still skips the complete Variant rebuild.
+                return VariantShreddedTypedValue {
+                        .column = nullptr,
+                        .type = nullptr,
+                        .normalized = normalize_projected_primitive_leaf(*typed_schema, typed)};
             }
+            // The typed ColumnVariantV2 retains the exact decoded Parquet leaf. Only the SQL result
+            // null map is produced later, so predicates and casts can consume the leaf without
+            // reconstructing canonical Variant rows.
+            return VariantShreddedTypedValue {.column = std::move(typed),
+                                              .type = remove_nullable(typed_schema->type),
+                                              .normalized = nullptr};
         }
         return std::nullopt;
     }

--- a/be/src/format_v2/parquet/reader/variant_column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/variant_column_reader.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cmath>
 #include <cstdint>
 #include <cstring>
@@ -49,12 +50,29 @@
 #include "core/data_type/data_type_string.h"
 #include "core/data_type/data_type_variant_v2.h"
 #include "core/value/variant/variant_batch_builder.h"
-#include "core/value/variant/variant_field.h"
 #include "core/value/variant/variant_metadata.h"
 #include "core/value/variant/variant_scalar.h"
 #include "format_v2/parquet/parquet_column_schema.h"
 
 namespace doris::format::parquet {
+
+#ifdef BE_TEST
+namespace {
+std::atomic<size_t> residual_validation_count {0};
+} // namespace
+
+namespace detail {
+void reset_variant_shredded_validation_counts() {
+    residual_validation_count.store(0, std::memory_order_relaxed);
+}
+
+size_t variant_shredded_residual_validation_count() {
+    return residual_validation_count.load(std::memory_order_relaxed);
+}
+
+} // namespace detail
+#endif
+
 namespace {
 
 struct Cell {
@@ -689,24 +707,6 @@ bool supports_direct_typed_variant_state(const ParquetColumnSchema& schema) {
     }
 }
 
-void validate_direct_typed_variant_state(const ParquetColumnSchema& schema,
-                                         const ColumnPtr& typed) {
-    if (schema.type == nullptr ||
-        remove_nullable(schema.type)->get_primitive_type() != TYPE_STRING ||
-        !schema.type_descriptor.is_string_annotation || schema.type_descriptor.is_uuid) {
-        return;
-    }
-    const auto& nullable = assert_cast<const ColumnNullable&>(*typed);
-    const auto& strings = assert_cast<const ColumnString&>(nullable.get_nested_column());
-    for (size_t row = 0; row < nullable.size(); ++row) {
-        if (nullable.get_null_map_data()[row] == 0) {
-            // The typed ColumnVariantV2 path otherwise publishes the decoded bytes without ever
-            // reaching VariantScalarRef::string(), whose UTF-8 check protects canonical values.
-            static_cast<void>(VariantScalarRef::string(strings.get_data_at(row)));
-        }
-    }
-}
-
 ColumnPtr normalize_projected_primitive_leaf(const ParquetColumnSchema& schema,
                                              const ColumnPtr& typed) {
     const auto& nullable = assert_cast<const ColumnNullable&>(*typed);
@@ -1282,83 +1282,53 @@ struct ShreddedPathLevel {
     const ParquetColumnSchema* typed_schema = nullptr;
 };
 
-// A residual can only supply the requested path for rows whose typed value is null. Shredding keeps
-// an object's residual keys disjoint from its shredded fields, so a present typed value always owns
-// the path and the residual beside it holds unrelated keys.
-bool residual_supplies_any_row(const ShreddedPathLevel& level, size_t rows) {
-    if (!level.residual_view.present()) {
-        return false;
-    }
-    for (size_t row = 0; row < rows; ++row) {
-        if (level.typed_view.is_null(row) && !level.residual_view.is_null(row)) {
-            return true;
-        }
-    }
-    return false;
-}
+struct ValidatedResidualColumn {
+    const IColumn* identity = nullptr;
+    bool supplies_any_row = false;
+};
 
-void validate_shredded_path_levels(const UnshreddedMetadataIndex* metadata_index, size_t rows,
-                                   std::span<const ShreddedPathLevel> levels) {
-    if (metadata_index != nullptr) {
-        DORIS_CHECK_EQ(metadata_index->row_dictionary_ids.size(), rows);
-    }
+bool validate_shredded_path_level(size_t rows, const ShreddedPathLevel& level) {
+#ifdef BE_TEST
+    residual_validation_count.fetch_add(1, std::memory_order_relaxed);
+#endif
+    bool supplies_any_row = false;
     for (size_t row = 0; row < rows; ++row) {
-        uint32_t dictionary_id = UnshreddedMetadataIndex::NULL_ROW;
-        if (metadata_index != nullptr) {
-            dictionary_id = metadata_index->row_dictionary_ids[row];
-            if (dictionary_id == UnshreddedMetadataIndex::NULL_ROW) {
-                // The metadata index uses NULL_ROW only for an outer-null Variant row. Its child
-                // columns carry decoder defaults that are not part of the logical value.
-                continue;
-            }
-            DORIS_CHECK_LT(dictionary_id, metadata_index->dictionaries.size());
+        if (level.residual_view.is_null(row)) {
+            continue;
         }
-
-        for (const auto& level : levels) {
-            if (level.residual_view.is_null(row)) {
-                continue;
-            }
-            const StringRef bytes = level.residual_view.values->get_data_at(row);
-            VariantRef residual {.metadata = metadata_index == nullptr
-                                                     ? VariantMetadataRef {}
-                                                     : metadata_index->dictionaries[dictionary_id],
-                                 .value = bytes};
-            if (!level.typed_view.is_null(row)) {
-                if (level.typed_schema == nullptr) {
-                    throw Exception(ErrorCode::CORRUPTION,
-                                    "Parquet Variant wrapper has conflicting carriers without a "
-                                    "typed schema");
-                }
-                switch (level.typed_schema->kind) {
-                case ParquetColumnSchemaKind::PRIMITIVE:
-                    throw Exception(
-                            ErrorCode::CORRUPTION,
+        if (level.typed_view.is_null(row)) {
+            supplies_any_row = true;
+            continue;
+        }
+        const StringRef bytes = level.residual_view.values->get_data_at(row);
+        VariantRef residual {.metadata = {}, .value = bytes};
+        if (level.typed_schema == nullptr) {
+            throw Exception(ErrorCode::CORRUPTION,
+                            "Parquet Variant wrapper has conflicting carriers without a "
+                            "typed schema");
+        }
+        switch (level.typed_schema->kind) {
+        case ParquetColumnSchemaKind::PRIMITIVE:
+            throw Exception(ErrorCode::CORRUPTION,
                             "Parquet Variant scalar typed_value cannot have residual value bytes");
-                case ParquetColumnSchemaKind::STRUCT:
-                    if (residual.basic_type() != VariantBasicType::OBJECT) {
-                        throw Exception(
-                                ErrorCode::CORRUPTION,
+        case ParquetColumnSchemaKind::STRUCT:
+            if (residual.basic_type() != VariantBasicType::OBJECT) {
+                throw Exception(ErrorCode::CORRUPTION,
                                 "Parquet Variant object typed_value has non-object residual value");
-                    }
-                    break;
-                case ParquetColumnSchemaKind::LIST:
-                    throw Exception(
-                            ErrorCode::CORRUPTION,
+            }
+            break;
+        case ParquetColumnSchemaKind::LIST:
+            throw Exception(ErrorCode::CORRUPTION,
                             "Parquet Variant array typed_value cannot have residual value bytes");
-                case ParquetColumnSchemaKind::MAP:
-                case ParquetColumnSchemaKind::VARIANT:
-                    throw Exception(ErrorCode::CORRUPTION,
-                                    "Invalid Parquet Variant typed_value schema {}",
-                                    level.typed_schema->name);
-                }
-            }
-            if (metadata_index != nullptr) {
-                // Direct lookup may touch only one child. Validate the complete residual once here
-                // so malformed sibling IDs, offsets, values, and UTF-8 cannot be hidden by a hit.
-                validate_variant_payload(residual);
-            }
+        case ParquetColumnSchemaKind::MAP:
+        case ParquetColumnSchemaKind::VARIANT:
+            throw Exception(ErrorCode::CORRUPTION, "Invalid Parquet Variant typed_value schema {}",
+                            level.typed_schema->name);
         }
+        // The seeker and VariantBatchBuilder validate the accessed container chain and selected
+        // value. Unrelated siblings remain a whole-Variant/materialization validation concern.
     }
+    return supplies_any_row;
 }
 
 // Seeks object paths inside encoded residual bytes. Keys resolve to a dictionary field id once per
@@ -1368,9 +1338,8 @@ class VariantResidualSeeker {
 public:
     using MetadataIndexProvider = std::function<const UnshreddedMetadataIndex&()>;
 
-    VariantResidualSeeker(const NullableColumnView& metadata, size_t path_length,
-                          MetadataIndexProvider provider)
-            : _metadata(metadata), _path_length(path_length), _provider(std::move(provider)) {}
+    VariantResidualSeeker(size_t path_length, MetadataIndexProvider provider)
+            : _path_length(path_length), _provider(std::move(provider)) {}
 
     // Resolves path[path_offset..] inside `value`. The offset keeps the cache keyed by absolute
     // path position, because different rows can enter the residual at different depths.
@@ -1378,13 +1347,14 @@ public:
               std::span<const VariantShreddedPathSegment> path, VariantRef* output) {
         DORIS_CHECK(output != nullptr);
         if (path.empty()) {
-            // The residual already is the requested value; only its dictionary travels with it.
-            if (_metadata.is_null(row)) {
+            // The residual already is the requested value. Resolve its validated dictionary through
+            // the shared index so terminal fallbacks do not re-parse identical metadata per row.
+            const UnshreddedMetadataIndex& index = _index == nullptr ? _resolve_index() : *_index;
+            const uint32_t dictionary = index.row_dictionary_ids[row];
+            if (dictionary == UnshreddedMetadataIndex::NULL_ROW) {
                 return false;
             }
-            const StringRef bytes = _metadata.values->get_data_at(row);
-            *output = VariantRef {.metadata = {.data = bytes.data, .size = bytes.size},
-                                  .value = value};
+            *output = VariantRef {.metadata = index.dictionaries[dictionary], .value = value};
             return true;
         }
 
@@ -1436,7 +1406,6 @@ private:
         return *_index;
     }
 
-    const NullableColumnView& _metadata;
     size_t _path_length;
     MetadataIndexProvider _provider;
     const UnshreddedMetadataIndex* _index = nullptr;
@@ -1449,8 +1418,7 @@ private:
 // the shredding schema can only live in the residual beside it. Rebuilding the complete Variant
 // root would produce the same result at the cost of every unrelated field.
 ColumnPtr resolve_variant_path_rows(const ParquetColumnSchema* leaf_schema, const IColumn* leaf,
-                                    const NullableColumnView& metadata, size_t rows,
-                                    std::span<const ShreddedPathLevel> levels,
+                                    size_t rows, std::span<const ShreddedPathLevel> levels,
                                     std::span<const VariantShreddedPathSegment> path,
                                     VariantResidualSeeker::MetadataIndexProvider provider) {
     DORIS_CHECK(!levels.empty() && levels.size() <= path.size() + 1);
@@ -1458,7 +1426,7 @@ ColumnPtr resolve_variant_path_rows(const ParquetColumnSchema* leaf_schema, cons
     // stopped early, and the deepest collected level is where the remaining path resolves.
     DORIS_CHECK(leaf == nullptr || levels.size() == path.size() + 1);
     const auto* nullable = leaf == nullptr ? nullptr : &assert_cast<const ColumnNullable&>(*leaf);
-    VariantResidualSeeker seeker(metadata, path.size(), std::move(provider));
+    VariantResidualSeeker seeker(path.size(), std::move(provider));
     VariantBatchBuilder builder(VariantBatchBuilder::ReserveHint {.rows = rows});
     auto nulls = ColumnUInt8::create();
     nulls->get_data().reserve(rows);
@@ -1576,6 +1544,7 @@ public:
         return _physical->byte_size() +
                (_unshredded_path_cache ? _unshredded_path_cache->byte_size() : 0) +
                (_unshredded_metadata_index ? _unshredded_metadata_index->byte_size() : 0) +
+               _validated_residual_columns.size() * sizeof(ValidatedResidualColumn) +
                (_normalized_prefix ? _normalized_prefix->byte_size() : 0) +
                (_materialized ? _materialized->byte_size() : 0) +
                (_serialized ? _serialized->byte_size() : 0);
@@ -1585,6 +1554,7 @@ public:
         return _physical->allocated_bytes() +
                (_unshredded_path_cache ? _unshredded_path_cache->allocated_bytes() : 0) +
                (_unshredded_metadata_index ? _unshredded_metadata_index->allocated_bytes() : 0) +
+               _validated_residual_columns.capacity() * sizeof(ValidatedResidualColumn) +
                (_normalized_prefix ? _normalized_prefix->allocated_bytes() : 0) +
                (_materialized ? _materialized->allocated_bytes() : 0) +
                (_serialized ? _serialized->allocated_bytes() : 0);
@@ -1606,6 +1576,9 @@ public:
         if (_normalized_prefix) {
             _normalized_prefix->sanity_check();
         }
+        DORIS_CHECK(std::ranges::none_of(_validated_residual_columns, [](const auto& validation) {
+            return validation.identity == nullptr;
+        }));
     }
 
     void for_each_subcolumn(const IColumn::ImutableColumnCallback& callback) const override {
@@ -1682,6 +1655,7 @@ public:
         std::lock_guard lock(_materialization_lock);
         _unshredded_path_cache.reset();
         _unshredded_metadata_index.reset();
+        _validated_residual_columns.clear();
         _normalized_prefix.reset();
         _materialized.reset();
         _serialized.reset();
@@ -1711,14 +1685,14 @@ public:
                                             : nullptr;
         const NullableColumnView metadata = view_column(metadata_column);
         std::shared_ptr<const UnshreddedMetadataIndex> validated_metadata_index;
-        if (has_metadata_child && metadata.present()) {
-            // The index validates each distinct required dictionary exactly once. Keep the shared
-            // result alive for carrier validation and every residual seek performed by this path.
-            validated_metadata_index =
-                    get_unshredded_metadata_index({metadata_position, metadata_position});
-        }
-        const auto metadata_index = [validated_metadata_index]() -> const UnshreddedMetadataIndex& {
-            DORIS_CHECK(validated_metadata_index != nullptr);
+        const auto metadata_index = [&]() -> const UnshreddedMetadataIndex& {
+            DORIS_CHECK(has_metadata_child && metadata.present());
+            if (!validated_metadata_index) {
+                // Direct typed leaves do not consult the dictionary. Build and validate it lazily
+                // only when a retained residual actually participates in the requested result.
+                validated_metadata_index =
+                        get_unshredded_metadata_index({metadata_position, metadata_position});
+            }
             return *validated_metadata_index;
         };
 
@@ -1728,9 +1702,9 @@ public:
             return path_miss();
         }
 
-        // Track the residual beside every typed value on the path, starting at the Variant root. A
-        // projected state omits those columns; its row-group validation already proved that no
-        // residual can contribute, so those levels simply carry an absent residual view.
+        // Track every residual present in the decoded state. Demand-driven projections omit
+        // unrelated ancestor carriers, and row-group statistics may also remove an all-NULL
+        // terminal fallback; either case is represented by an absent residual view.
         DorisVector<ShreddedPathLevel> levels;
         levels.reserve(path.size() + 1);
         const auto add_level = [&levels](ColumnPtr residual, ColumnPtr typed_value,
@@ -1750,13 +1724,13 @@ public:
         // object that was searched, so seeking it there answers the path exactly. Rebuilding the
         // canonical root would reach the same value after re-encoding every unrelated field.
         // Every path of one decoded batch shares the dictionary identification, which the state
-        // caches: it is built on the first path that still has keys to resolve, and never at all
-        // for the paths that do not.
+        // caches: it is built on the first path that consumes a residual and never for pure typed
+        // leaves.
         const auto validate_levels = [&]() {
-            validate_shredded_path_levels(validated_metadata_index.get(), rows, levels);
+            return validate_shredded_path_levels_once(rows, levels);
         };
         const auto seek_residual = [&]() -> std::optional<VariantShreddedTypedValue> {
-            validate_levels();
+            static_cast<void>(validate_levels());
             if (!metadata.present() || !has_metadata_child ||
                 !levels.back().residual_view.present()) {
                 return path_miss();
@@ -1765,8 +1739,8 @@ public:
             return VariantShreddedTypedValue {
                     .column = nullptr,
                     .type = nullptr,
-                    .normalized = resolve_variant_path_rows(nullptr, nullptr, metadata, rows,
-                                                            levels, path, metadata_index)};
+                    .normalized = resolve_variant_path_rows(nullptr, nullptr, rows, levels, path,
+                                                            metadata_index)};
         };
 
         for (size_t position = 0; position < path.size(); ++position) {
@@ -1804,7 +1778,7 @@ public:
 
             if (typed_schema->kind != ParquetColumnSchemaKind::PRIMITIVE ||
                 check_and_get_column<ColumnNullable>(*typed) == nullptr) {
-                validate_levels();
+                static_cast<void>(validate_levels());
                 update_counter(_profile.variant_direct_leaf_unsupported_fallbacks, 1);
                 if (!_complete) {
                     // Binary element_at evaluates complex prefixes before the validated leaf.
@@ -1817,11 +1791,7 @@ public:
                 return std::nullopt;
             }
 
-            validate_levels();
-            const bool needs_row_merge =
-                    std::ranges::any_of(levels, [rows](const ShreddedPathLevel& level) {
-                        return residual_supplies_any_row(level, rows);
-                    });
+            const bool needs_row_merge = validate_levels();
             if (needs_row_merge) {
                 // Decoding a residual needs the root dictionary. A state that projected the
                 // metadata away cannot serve those rows, so it keeps the complete fallback.
@@ -1840,11 +1810,11 @@ public:
                 update_counter(_profile.variant_direct_leaf_rows, static_cast<int64_t>(rows));
                 update_counter(_profile.variant_direct_leaf_residual_merged_rows,
                                static_cast<int64_t>(rows));
-                return VariantShreddedTypedValue {.column = nullptr,
-                                                  .type = nullptr,
-                                                  .normalized = resolve_variant_path_rows(
-                                                          typed_schema, typed.get(), metadata, rows,
-                                                          levels, path, metadata_index)};
+                return VariantShreddedTypedValue {
+                        .column = nullptr,
+                        .type = nullptr,
+                        .normalized = resolve_variant_path_rows(typed_schema, typed.get(), rows,
+                                                                levels, path, metadata_index)};
             }
 
             update_counter(_profile.variant_direct_leaf_rows, static_cast<int64_t>(rows));
@@ -1857,7 +1827,6 @@ public:
                         .type = nullptr,
                         .normalized = normalize_projected_primitive_leaf(*typed_schema, typed)};
             }
-            validate_direct_typed_variant_state(*typed_schema, typed);
             // The typed ColumnVariantV2 retains the exact decoded Parquet leaf. Only the SQL result
             // null map is produced later, so predicates and casts can consume the leaf without
             // reconstructing canonical Variant rows.
@@ -1973,6 +1942,51 @@ public:
     }
 
 private:
+    std::optional<bool> cached_residual_supplies(const IColumn* identity) const {
+        std::lock_guard lock(_materialization_lock);
+        const auto found = std::ranges::find_if(
+                _validated_residual_columns,
+                [identity](const auto& validation) { return validation.identity == identity; });
+        return found == _validated_residual_columns.end()
+                       ? std::nullopt
+                       : std::optional<bool>(found->supplies_any_row);
+    }
+
+    void remember_validation(const IColumn* identity, bool supplies_any_row) const {
+        DORIS_CHECK(identity != nullptr);
+        std::lock_guard lock(_materialization_lock);
+        const auto found = std::ranges::find_if(
+                _validated_residual_columns,
+                [identity](const auto& validation) { return validation.identity == identity; });
+        if (found == _validated_residual_columns.end()) {
+            _validated_residual_columns.push_back(
+                    {.identity = identity, .supplies_any_row = supplies_any_row});
+        } else {
+            DORIS_CHECK_EQ(found->supplies_any_row, supplies_any_row);
+        }
+    }
+
+    bool validate_shredded_path_levels_once(size_t rows,
+                                            std::span<const ShreddedPathLevel> levels) const {
+        bool supplies_any_row = false;
+        for (const auto& level : levels) {
+            if (!level.residual) {
+                continue;
+            }
+            const IColumn* identity = level.residual.get();
+            if (const auto cached = cached_residual_supplies(identity); cached.has_value()) {
+                supplies_any_row = supplies_any_row || *cached;
+                continue;
+            }
+            // Fuse the carrier proof with the row-merge decision. Both need the same two null maps,
+            // so a separate residual-supplies scan would repeat O(rows) work for every path.
+            const bool level_supplies = validate_shredded_path_level(rows, level);
+            remember_validation(identity, level_supplies);
+            supplies_any_row = supplies_any_row || level_supplies;
+        }
+        return supplies_any_row;
+    }
+
     template <typename PathCacheSelector>
     std::shared_ptr<ParquetVariantShreddedState> select_state(
             ColumnPtr selected_physical, const PathCacheSelector& select_path_cache) const {
@@ -2085,6 +2099,7 @@ private:
     std::shared_ptr<const UnshreddedPathCache> _unshredded_path_cache;
     mutable std::mutex _materialization_lock;
     mutable std::shared_ptr<const UnshreddedMetadataIndex> _unshredded_metadata_index;
+    mutable DorisVector<ValidatedResidualColumn> _validated_residual_columns;
     mutable ColumnPtr _normalized_prefix;
     mutable ColumnVariantV2::MutablePtr _materialized;
     mutable ColumnVariantV2::MutablePtr _serialized;

--- a/be/src/format_v2/parquet/reader/variant_column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/variant_column_reader.cpp
@@ -1266,47 +1266,132 @@ bool residual_supplies_any_row(const ShreddedPathLevel& level, size_t rows) {
     return false;
 }
 
-// Resolves the requested leaf row by row for a batch that mixes shredded values with residuals.
-// Rows served by the shredded leaf keep their exact Parquet identity through append_typed_scalar;
-// the rest copy the encoded value found beside the first null typed value on the path. Rebuilding
-// the complete Variant root would produce the same result at the cost of every unrelated field.
-ColumnPtr merge_typed_leaf_with_residuals(const ParquetColumnSchema& leaf_schema,
-                                          const IColumn& leaf, const NullableColumnView& metadata,
-                                          std::span<const ShreddedPathLevel> levels,
-                                          std::span<const VariantShreddedPathSegment> path) {
-    DORIS_CHECK(levels.size() == path.size() + 1);
-    const auto& nullable = assert_cast<const ColumnNullable&>(leaf);
-    const size_t rows = nullable.size();
+// Seeks object paths inside encoded residual bytes, resolving each key to a dictionary field id
+// once per distinct metadata dictionary instead of once per row. Iceberg normally repeats a single
+// dictionary across a decoded batch, so the dictionary list stays at one entry and identifying a
+// row's dictionary is a byte-range comparison.
+class VariantResidualSeeker {
+public:
+    VariantResidualSeeker(const NullableColumnView& metadata, size_t rows, size_t path_length)
+            : _path_length(path_length) {
+        _row_dictionaries.assign(rows, MISSING_DICTIONARY);
+        for (size_t row = 0; row < rows; ++row) {
+            if (metadata.is_null(row)) {
+                continue;
+            }
+            const StringRef bytes = metadata.values->get_data_at(row);
+            uint32_t dictionary = 0;
+            while (dictionary < _dictionaries.size() && _dictionaries[dictionary] != bytes) {
+                ++dictionary;
+            }
+            if (dictionary == _dictionaries.size()) {
+                _dictionaries.push_back(bytes);
+            }
+            _row_dictionaries[row] = dictionary;
+        }
+        _field_ids.assign(_dictionaries.size() * _path_length, UNRESOLVED_FIELD_ID);
+    }
+
+    // Resolves path[path_offset..] inside `value`. The offset keeps the cache keyed by absolute
+    // path position, because different rows can enter the residual at different depths.
+    bool seek(size_t row, StringRef value, size_t path_offset,
+              std::span<const VariantShreddedPathSegment> path, VariantRef* output) {
+        DORIS_CHECK(output != nullptr);
+        const uint32_t dictionary = _row_dictionaries[row];
+        if (dictionary == MISSING_DICTIONARY) {
+            return false;
+        }
+        const StringRef dictionary_bytes = _dictionaries[dictionary];
+        VariantRef current {
+                .metadata = {.data = dictionary_bytes.data, .size = dictionary_bytes.size},
+                .value = value};
+        for (size_t position = 0; position < path.size(); ++position) {
+            if (path[position].kind != VariantShreddedPathSegment::Kind::OBJECT_KEY) {
+                // Array segments never reach a residual: a shredded array lives in its typed_value,
+                // and the caller keeps those paths on the reconstruction path.
+                return false;
+            }
+            if (current.basic_type() != VariantBasicType::OBJECT) {
+                return false;
+            }
+            int64_t& field_id = _field_ids[dictionary * _path_length + path_offset + position];
+            bool layout_validated = false;
+            if (field_id == UNRESOLVED_FIELD_ID) {
+                // object_find() validates the object layout before consulting the dictionary, so
+                // resolving a key has to validate it here too.
+                static_cast<void>(current.num_elements());
+                layout_validated = true;
+                field_id = current.metadata.find_key(path[position].key);
+            }
+            if (field_id < 0) {
+                // A cached dictionary miss must not hide a corrupt object in a later row.
+                if (!layout_validated) {
+                    static_cast<void>(current.num_elements());
+                }
+                return false;
+            }
+            if (!current.object_find_by_id(static_cast<uint32_t>(field_id), &current)) {
+                return false;
+            }
+        }
+        *output = current;
+        return true;
+    }
+
+private:
+    static constexpr uint32_t MISSING_DICTIONARY = std::numeric_limits<uint32_t>::max();
+    static constexpr int64_t UNRESOLVED_FIELD_ID = -2;
+
+    size_t _path_length;
+    DorisVector<StringRef> _dictionaries;
+    DorisVector<uint32_t> _row_dictionaries;
+    DorisVector<int64_t> _field_ids;
+};
+
+// Resolves the requested path row by row. The first level whose typed value is missing owns the
+// row: its residual holds the value for that path prefix. When `leaf` is null the shredded schema
+// does not describe the path at all, so the deepest collected level owns every row - a key outside
+// the shredding schema can only live in the residual beside it. Rebuilding the complete Variant
+// root would produce the same result at the cost of every unrelated field.
+ColumnPtr resolve_variant_path_rows(const ParquetColumnSchema* leaf_schema, const IColumn* leaf,
+                                    const NullableColumnView& metadata, size_t rows,
+                                    std::span<const ShreddedPathLevel> levels,
+                                    std::span<const VariantShreddedPathSegment> path) {
+    DORIS_CHECK(!levels.empty() && levels.size() <= path.size() + 1);
+    // A shredded leaf always sits one level below the last path segment. Without one the walk
+    // stopped early, and the deepest collected level is where the remaining path resolves.
+    DORIS_CHECK(leaf == nullptr || levels.size() == path.size() + 1);
+    const auto* nullable = leaf == nullptr ? nullptr : &assert_cast<const ColumnNullable&>(*leaf);
+    VariantResidualSeeker seeker(metadata, rows, path.size());
     VariantBatchBuilder builder(VariantBatchBuilder::ReserveHint {.rows = rows});
     auto nulls = ColumnUInt8::create();
     nulls->get_data().reserve(rows);
     for (size_t row = 0; row < rows; ++row) {
         auto output_row = builder.begin_row();
         bool is_null = true;
-        size_t level = 0;
-        for (; level < levels.size(); ++level) {
-            if (!levels[level].typed_view.is_null(row)) {
-                continue;
+        size_t seek_level = levels.size();
+        for (size_t level = 0; level < levels.size(); ++level) {
+            if (levels[level].typed_view.is_null(row)) {
+                seek_level = level;
+                break;
             }
+        }
+        if (seek_level == levels.size() && nullable == nullptr) {
+            seek_level = levels.size() - 1;
+        }
+        if (seek_level == levels.size()) {
+            // Every typed value on the path is present, so the shredded leaf owns this row.
+            append_typed_scalar(*leaf_schema, nullable->get_nested_column(), row, output_row);
+            is_null = false;
+        } else if (!levels[seek_level].residual_view.is_null(row)) {
             VariantRef value;
-            const StringRef metadata_bytes =
-                    metadata.is_null(row) ? StringRef() : metadata.values->get_data_at(row);
-            if (!levels[level].residual_view.is_null(row) && metadata_bytes.data != nullptr &&
-                find_materialized_path(
-                        VariantRef {.metadata = {.data = metadata_bytes.data,
-                                                 .size = metadata_bytes.size},
-                                    .value = levels[level].residual_view.values->get_data_at(row)},
-                        path.subspan(level), &value)) {
+            if (seeker.seek(row, levels[seek_level].residual_view.values->get_data_at(row),
+                            seek_level, path.subspan(seek_level), &value)) {
                 output_row.add_value(value);
                 is_null = false;
             }
-            break;
         }
-        if (level == levels.size()) {
-            // Every typed value on the path is present, so the shredded leaf owns this row.
-            append_typed_scalar(leaf_schema, nullable.get_nested_column(), row, output_row);
-            is_null = false;
-        } else if (is_null) {
+        if (is_null) {
             output_row.add_null();
         }
         output_row.finish();
@@ -1543,6 +1628,24 @@ public:
         };
         add_level(struct_child(*_schema, _physical, "value", nullptr), typed);
 
+        const size_t rows = _physical->size();
+        ColumnPtr metadata_column = struct_child(*_schema, _physical, "metadata", nullptr);
+        const NullableColumnView metadata = view_column(metadata_column);
+        // A key the shredding schema does not describe can only live in the residual beside the
+        // object that was searched, so seeking it there answers the path exactly. Rebuilding the
+        // canonical root would reach the same value after re-encoding every unrelated field.
+        const auto seek_residual = [&]() -> std::optional<VariantShreddedTypedValue> {
+            if (!metadata.present() || !levels.back().residual_view.present()) {
+                return path_miss();
+            }
+            update_counter(_profile.variant_residual_seek_rows, static_cast<int64_t>(rows));
+            return VariantShreddedTypedValue {
+                    .column = nullptr,
+                    .type = nullptr,
+                    .normalized = resolve_variant_path_rows(nullptr, nullptr, metadata, rows,
+                                                            levels, path)};
+        };
+
         for (size_t position = 0; position < path.size(); ++position) {
             if (path[position].kind != VariantShreddedPathSegment::Kind::OBJECT_KEY) {
                 return path_miss();
@@ -1552,20 +1655,25 @@ public:
             const ParquetColumnSchema* wrapper_schema = nullptr;
             ColumnPtr wrapper = struct_child(*typed_schema, typed, key, &wrapper_schema);
             if (!wrapper) {
-                return path_miss();
+                return seek_residual();
             }
             ColumnPtr residual = struct_child(*wrapper_schema, wrapper, "value", nullptr);
             typed = struct_child(*wrapper_schema, wrapper, "typed_value", &typed_schema);
             if (!typed) {
-                return path_miss();
+                // The wrapper stores this field unshredded. Its residual holds the whole value, so
+                // the remainder of the path resolves inside those bytes.
+                add_level(std::move(residual), nullptr);
+                return seek_residual();
             }
             add_level(std::move(residual), typed);
 
             if (position + 1 < path.size()) {
-                // Every intermediate typed_value must be an object. This prevents a legacy untyped
-                // path produced through an array/explode operation from crossing a repeated node.
+                // Every intermediate typed_value must be an object. A legacy untyped path
+                // produced through an array/explode operation cannot cross a repeated node, so
+                // those rows resolve from the residual beside it instead.
                 if (typed_schema->kind != ParquetColumnSchemaKind::STRUCT) {
-                    return path_miss();
+                    levels.pop_back();
+                    return seek_residual();
                 }
                 continue;
             }
@@ -1584,7 +1692,6 @@ public:
                 return std::nullopt;
             }
 
-            const size_t rows = typed->size();
             const bool needs_row_merge =
                     std::ranges::any_of(levels, [rows](const ShreddedPathLevel& level) {
                         return residual_supplies_any_row(level, rows);
@@ -1592,8 +1699,6 @@ public:
             if (needs_row_merge) {
                 // Decoding a residual needs the root dictionary. A state that projected the
                 // metadata away cannot serve those rows, so it keeps the complete fallback.
-                ColumnPtr metadata_column = struct_child(*_schema, _physical, "metadata", nullptr);
-                const NullableColumnView metadata = view_column(metadata_column);
                 if (!metadata.present()) {
                     update_counter(_profile.variant_direct_leaf_residual_fallbacks, 1);
                     if (!_complete) {
@@ -1612,8 +1717,8 @@ public:
                 return VariantShreddedTypedValue {
                         .column = nullptr,
                         .type = nullptr,
-                        .normalized = merge_typed_leaf_with_residuals(*typed_schema, *typed,
-                                                                      metadata, levels, path)};
+                        .normalized = resolve_variant_path_rows(typed_schema, typed.get(), metadata,
+                                                                rows, levels, path)};
             }
 
             update_counter(_profile.variant_direct_leaf_rows, static_cast<int64_t>(rows));

--- a/be/src/format_v2/parquet/reader/variant_column_reader.cpp
+++ b/be/src/format_v2/parquet/reader/variant_column_reader.cpp
@@ -49,6 +49,7 @@
 #include "core/data_type/data_type_string.h"
 #include "core/data_type/data_type_variant_v2.h"
 #include "core/value/variant/variant_batch_builder.h"
+#include "core/value/variant/variant_field.h"
 #include "core/value/variant/variant_metadata.h"
 #include "core/value/variant/variant_scalar.h"
 #include "format_v2/parquet/parquet_column_schema.h"
@@ -688,6 +689,24 @@ bool supports_direct_typed_variant_state(const ParquetColumnSchema& schema) {
     }
 }
 
+void validate_direct_typed_variant_state(const ParquetColumnSchema& schema,
+                                         const ColumnPtr& typed) {
+    if (schema.type == nullptr ||
+        remove_nullable(schema.type)->get_primitive_type() != TYPE_STRING ||
+        !schema.type_descriptor.is_string_annotation || schema.type_descriptor.is_uuid) {
+        return;
+    }
+    const auto& nullable = assert_cast<const ColumnNullable&>(*typed);
+    const auto& strings = assert_cast<const ColumnString&>(nullable.get_nested_column());
+    for (size_t row = 0; row < nullable.size(); ++row) {
+        if (nullable.get_null_map_data()[row] == 0) {
+            // The typed ColumnVariantV2 path otherwise publishes the decoded bytes without ever
+            // reaching VariantScalarRef::string(), whose UTF-8 check protects canonical values.
+            static_cast<void>(VariantScalarRef::string(strings.get_data_at(row)));
+        }
+    }
+}
+
 ColumnPtr normalize_projected_primitive_leaf(const ParquetColumnSchema& schema,
                                              const ColumnPtr& typed) {
     const auto& nullable = assert_cast<const ColumnNullable&>(*typed);
@@ -759,6 +778,15 @@ std::shared_ptr<const UnshreddedMetadataIndex> build_unshredded_metadata_index(
                                std::equal_to<std::string_view>,
                                CustomStdAllocator<std::pair<const std::string_view, uint32_t>>>;
     MetadataIdMap dictionary_ids;
+    const auto append_dictionary = [&](StringRef bytes) {
+        VariantMetadataRef metadata {.data = bytes.data, .size = bytes.size};
+        validate_variant_metadata(metadata);
+        if (index->dictionaries.size() == std::numeric_limits<uint32_t>::max()) {
+            throw Exception(ErrorCode::INVALID_ARGUMENT,
+                            "Parquet Variant metadata dictionary exceeds the uint32 id limit");
+        }
+        index->dictionaries.push_back(metadata);
+    };
     for (size_t row = 0; row < physical.size(); ++row) {
         if (outer_nullable != nullptr && outer_nullable->get_null_map_data()[row] != 0) {
             continue;
@@ -771,7 +799,7 @@ std::shared_ptr<const UnshreddedMetadataIndex> build_unshredded_metadata_index(
         const StringRef bytes = metadata.column->get_data_at(row);
         uint32_t dictionary_id = 0;
         if (index->dictionaries.empty()) {
-            index->dictionaries.push_back({.data = bytes.data, .size = bytes.size});
+            append_dictionary(bytes);
         } else if (index->dictionaries.size() == 1 && dictionary_ids.empty() &&
                    StringRef(index->dictionaries.front().data, index->dictionaries.front().size) ==
                            bytes) {
@@ -787,7 +815,7 @@ std::shared_ptr<const UnshreddedMetadataIndex> build_unshredded_metadata_index(
                 dictionary_id = found->second;
             } else {
                 dictionary_id = static_cast<uint32_t>(index->dictionaries.size());
-                index->dictionaries.push_back({.data = bytes.data, .size = bytes.size});
+                append_dictionary(bytes);
                 dictionary_ids.emplace(key, dictionary_id);
             }
         }
@@ -1251,6 +1279,7 @@ struct ShreddedPathLevel {
     ColumnPtr typed;
     NullableColumnView residual_view;
     NullableColumnView typed_view;
+    const ParquetColumnSchema* typed_schema = nullptr;
 };
 
 // A residual can only supply the requested path for rows whose typed value is null. Shredding keeps
@@ -1266,6 +1295,70 @@ bool residual_supplies_any_row(const ShreddedPathLevel& level, size_t rows) {
         }
     }
     return false;
+}
+
+void validate_shredded_path_levels(const UnshreddedMetadataIndex* metadata_index, size_t rows,
+                                   std::span<const ShreddedPathLevel> levels) {
+    if (metadata_index != nullptr) {
+        DORIS_CHECK_EQ(metadata_index->row_dictionary_ids.size(), rows);
+    }
+    for (size_t row = 0; row < rows; ++row) {
+        uint32_t dictionary_id = UnshreddedMetadataIndex::NULL_ROW;
+        if (metadata_index != nullptr) {
+            dictionary_id = metadata_index->row_dictionary_ids[row];
+            if (dictionary_id == UnshreddedMetadataIndex::NULL_ROW) {
+                // The metadata index uses NULL_ROW only for an outer-null Variant row. Its child
+                // columns carry decoder defaults that are not part of the logical value.
+                continue;
+            }
+            DORIS_CHECK_LT(dictionary_id, metadata_index->dictionaries.size());
+        }
+
+        for (const auto& level : levels) {
+            if (level.residual_view.is_null(row)) {
+                continue;
+            }
+            const StringRef bytes = level.residual_view.values->get_data_at(row);
+            VariantRef residual {.metadata = metadata_index == nullptr
+                                                     ? VariantMetadataRef {}
+                                                     : metadata_index->dictionaries[dictionary_id],
+                                 .value = bytes};
+            if (!level.typed_view.is_null(row)) {
+                if (level.typed_schema == nullptr) {
+                    throw Exception(ErrorCode::CORRUPTION,
+                                    "Parquet Variant wrapper has conflicting carriers without a "
+                                    "typed schema");
+                }
+                switch (level.typed_schema->kind) {
+                case ParquetColumnSchemaKind::PRIMITIVE:
+                    throw Exception(
+                            ErrorCode::CORRUPTION,
+                            "Parquet Variant scalar typed_value cannot have residual value bytes");
+                case ParquetColumnSchemaKind::STRUCT:
+                    if (residual.basic_type() != VariantBasicType::OBJECT) {
+                        throw Exception(
+                                ErrorCode::CORRUPTION,
+                                "Parquet Variant object typed_value has non-object residual value");
+                    }
+                    break;
+                case ParquetColumnSchemaKind::LIST:
+                    throw Exception(
+                            ErrorCode::CORRUPTION,
+                            "Parquet Variant array typed_value cannot have residual value bytes");
+                case ParquetColumnSchemaKind::MAP:
+                case ParquetColumnSchemaKind::VARIANT:
+                    throw Exception(ErrorCode::CORRUPTION,
+                                    "Invalid Parquet Variant typed_value schema {}",
+                                    level.typed_schema->name);
+                }
+            }
+            if (metadata_index != nullptr) {
+                // Direct lookup may touch only one child. Validate the complete residual once here
+                // so malformed sibling IDs, offsets, values, and UTF-8 cannot be hidden by a hit.
+                validate_variant_payload(residual);
+            }
+        }
+    }
 }
 
 // Seeks object paths inside encoded residual bytes. Keys resolve to a dictionary field id once per
@@ -1610,6 +1703,25 @@ public:
                     .column = nullptr, .type = nullptr, .normalized = direct_unshredded_path(path)};
         }
 
+        size_t metadata_position = 0;
+        const bool has_metadata_child =
+                find_child(*_schema, "metadata", &metadata_position) != nullptr;
+        ColumnPtr metadata_column = has_metadata_child
+                                            ? struct_child(*_schema, _physical, "metadata", nullptr)
+                                            : nullptr;
+        const NullableColumnView metadata = view_column(metadata_column);
+        std::shared_ptr<const UnshreddedMetadataIndex> validated_metadata_index;
+        if (has_metadata_child && metadata.present()) {
+            // The index validates each distinct required dictionary exactly once. Keep the shared
+            // result alive for carrier validation and every residual seek performed by this path.
+            validated_metadata_index =
+                    get_unshredded_metadata_index({metadata_position, metadata_position});
+        }
+        const auto metadata_index = [validated_metadata_index]() -> const UnshreddedMetadataIndex& {
+            DORIS_CHECK(validated_metadata_index != nullptr);
+            return *validated_metadata_index;
+        };
+
         const ParquetColumnSchema* typed_schema = nullptr;
         ColumnPtr typed = struct_child(*_schema, _physical, "typed_value", &typed_schema);
         if (!typed || typed_schema->kind != ParquetColumnSchemaKind::STRUCT) {
@@ -1621,32 +1733,30 @@ public:
         // residual can contribute, so those levels simply carry an absent residual view.
         DorisVector<ShreddedPathLevel> levels;
         levels.reserve(path.size() + 1);
-        const auto add_level = [&levels](ColumnPtr residual, ColumnPtr typed_value) {
+        const auto add_level = [&levels](ColumnPtr residual, ColumnPtr typed_value,
+                                         const ParquetColumnSchema* level_typed_schema) {
             ShreddedPathLevel level;
             level.residual_view = view_column(residual);
             level.typed_view = view_column(typed_value);
             level.residual = std::move(residual);
             level.typed = std::move(typed_value);
+            level.typed_schema = level_typed_schema;
             levels.push_back(std::move(level));
         };
-        add_level(struct_child(*_schema, _physical, "value", nullptr), typed);
+        add_level(struct_child(*_schema, _physical, "value", nullptr), typed, typed_schema);
 
         const size_t rows = _physical->size();
-        ColumnPtr metadata_column = struct_child(*_schema, _physical, "metadata", nullptr);
-        const NullableColumnView metadata = view_column(metadata_column);
         // A key the shredding schema does not describe can only live in the residual beside the
         // object that was searched, so seeking it there answers the path exactly. Rebuilding the
         // canonical root would reach the same value after re-encoding every unrelated field.
         // Every path of one decoded batch shares the dictionary identification, which the state
         // caches: it is built on the first path that still has keys to resolve, and never at all
         // for the paths that do not.
-        size_t metadata_position = 0;
-        const bool has_metadata_child =
-                find_child(*_schema, "metadata", &metadata_position) != nullptr;
-        const auto metadata_index = [this, metadata_position]() -> const UnshreddedMetadataIndex& {
-            return *get_unshredded_metadata_index({metadata_position, metadata_position});
+        const auto validate_levels = [&]() {
+            validate_shredded_path_levels(validated_metadata_index.get(), rows, levels);
         };
         const auto seek_residual = [&]() -> std::optional<VariantShreddedTypedValue> {
+            validate_levels();
             if (!metadata.present() || !has_metadata_child ||
                 !levels.back().residual_view.present()) {
                 return path_miss();
@@ -1675,10 +1785,10 @@ public:
             if (!typed) {
                 // The wrapper stores this field unshredded. Its residual holds the whole value, so
                 // the remainder of the path resolves inside those bytes.
-                add_level(std::move(residual), nullptr);
+                add_level(std::move(residual), nullptr, nullptr);
                 return seek_residual();
             }
-            add_level(std::move(residual), typed);
+            add_level(std::move(residual), typed, typed_schema);
 
             if (position + 1 < path.size()) {
                 // An intermediate typed_value that is not an object cannot carry the rest of the
@@ -1694,6 +1804,7 @@ public:
 
             if (typed_schema->kind != ParquetColumnSchemaKind::PRIMITIVE ||
                 check_and_get_column<ColumnNullable>(*typed) == nullptr) {
+                validate_levels();
                 update_counter(_profile.variant_direct_leaf_unsupported_fallbacks, 1);
                 if (!_complete) {
                     // Binary element_at evaluates complex prefixes before the validated leaf.
@@ -1706,6 +1817,7 @@ public:
                 return std::nullopt;
             }
 
+            validate_levels();
             const bool needs_row_merge =
                     std::ranges::any_of(levels, [rows](const ShreddedPathLevel& level) {
                         return residual_supplies_any_row(level, rows);
@@ -1745,6 +1857,7 @@ public:
                         .type = nullptr,
                         .normalized = normalize_projected_primitive_leaf(*typed_schema, typed)};
             }
+            validate_direct_typed_variant_state(*typed_schema, typed);
             // The typed ColumnVariantV2 retains the exact decoded Parquet leaf. Only the SQL result
             // null map is produced later, so predicates and casts can consume the leaf without
             // reconstructing canonical Variant rows.

--- a/be/src/format_v2/parquet/reader/variant_column_reader.h
+++ b/be/src/format_v2/parquet/reader/variant_column_reader.h
@@ -64,4 +64,11 @@ Status materialize_variant_columns(const VariantMaterializationNode& plan, Colum
                                    MutableColumnPtr& output,
                                    const ParquetColumnReaderProfile& profile = {});
 
+#ifdef BE_TEST
+namespace detail {
+void reset_variant_shredded_validation_counts();
+size_t variant_shredded_residual_validation_count();
+} // namespace detail
+#endif
+
 } // namespace doris::format::parquet

--- a/be/test/core/column/column_variant_v2_test.cpp
+++ b/be/test/core/column/column_variant_v2_test.cpp
@@ -284,6 +284,69 @@ private:
     ColumnVariantV2::MutablePtr _serialized;
 };
 
+class ValidatingShreddedState final : public VariantShreddedState {
+public:
+    enum class TypedLookup { MISS, ERROR };
+
+    ValidatingShreddedState(size_t rows, TypedLookup lookup,
+                            std::shared_ptr<size_t> typed_lookup_calls)
+            : _rows(rows),
+              _lookup(lookup),
+              _typed_lookup_calls(std::move(typed_lookup_calls)),
+              _serialized(ColumnVariantV2::create()) {
+        _serialized->insert_many_defaults(rows);
+        auto normalized = ColumnVariantV2::create();
+        normalized->insert_many_defaults(rows);
+        _normalized = ColumnNullable::create(std::move(normalized), ColumnUInt8::create(rows, 0));
+    }
+
+    size_t size() const override { return _rows; }
+    size_t byte_size() const override { return 0; }
+    size_t allocated_bytes() const override { return 0; }
+    void sanity_check() const override {}
+    void for_each_subcolumn(const IColumn::ImutableColumnCallback&) const override {}
+    std::shared_ptr<VariantShreddedState> filter(const IColumn::Filter& filter,
+                                                 ssize_t) const override {
+        return select(std::count(filter.begin(), filter.end(), UInt8 {1}));
+    }
+    std::shared_ptr<VariantShreddedState> select_range(size_t, size_t length) const override {
+        return select(length);
+    }
+    std::shared_ptr<VariantShreddedState> select_indices(
+            const uint32_t* indices_begin, const uint32_t* indices_end) const override {
+        return select(indices_end - indices_begin);
+    }
+    bool can_materialize() const override { return false; }
+    bool try_append(const VariantShreddedState&) override { return false; }
+    std::optional<VariantShreddedTypedValue> find_typed_value(
+            std::span<const VariantShreddedPathSegment>) const override {
+        ++*_typed_lookup_calls;
+        if (_lookup == TypedLookup::ERROR) {
+            throw Exception(ErrorCode::CORRUPTION, "late composite segment validation failed");
+        }
+        return std::nullopt;
+    }
+    std::optional<ColumnPtr> find_normalized_value(
+            std::span<const VariantShreddedPathSegment>) const override {
+        return _normalized;
+    }
+    const ColumnVariantV2& materialized_column() const override {
+        throw Exception(ErrorCode::INTERNAL_ERROR, "validating shredded state cannot materialize");
+    }
+    const ColumnVariantV2& serialized_column() const override { return *_serialized; }
+
+private:
+    std::shared_ptr<VariantShreddedState> select(size_t rows) const {
+        return std::make_shared<ValidatingShreddedState>(rows, _lookup, _typed_lookup_calls);
+    }
+
+    size_t _rows;
+    TypedLookup _lookup;
+    std::shared_ptr<size_t> _typed_lookup_calls;
+    ColumnVariantV2::MutablePtr _serialized;
+    ColumnPtr _normalized;
+};
+
 class MaterializableShreddedState final : public VariantShreddedState {
 public:
     explicit MaterializableShreddedState(ColumnPtr materialized)
@@ -1686,6 +1749,24 @@ TEST(ColumnVariantV2Test, CompositeShreddedSizeDoesNotRecountSegments) {
         EXPECT_EQ(composite->size(), 5);
     }
     EXPECT_EQ(*size_calls, 0);
+}
+
+TEST(ColumnVariantV2Test, CompositeValidatesSegmentsAfterFirstTypedMiss) {
+    auto first_calls = std::make_shared<size_t>(0);
+    auto second_calls = std::make_shared<size_t>(0);
+    auto first = ColumnVariantV2::create_shredded(std::make_shared<ValidatingShreddedState>(
+            1, ValidatingShreddedState::TypedLookup::MISS, first_calls));
+    auto second = ColumnVariantV2::create_shredded(std::make_shared<ValidatingShreddedState>(
+            1, ValidatingShreddedState::TypedLookup::ERROR, second_calls));
+    auto composite = ColumnVariantV2::create();
+    composite->insert_range_from(*first, 0, first->size());
+    composite->insert_range_from(*second, 0, second->size());
+
+    const std::array path {VariantShreddedPathSegment {
+            .kind = VariantShreddedPathSegment::Kind::OBJECT_KEY, .key = StringRef("a")}};
+    EXPECT_THROW(static_cast<void>(composite->find_shredded_typed_value(path)), Exception);
+    EXPECT_EQ(*first_calls, 1);
+    EXPECT_EQ(*second_calls, 1);
 }
 
 TEST(ColumnVariantV2Test, PopBackAndResizeCoverBoundsShrinkAndGrowth) {

--- a/be/test/format_v2/column_mapper_test.cpp
+++ b/be/test/format_v2/column_mapper_test.cpp
@@ -4107,17 +4107,15 @@ TEST(ColumnMapperTest, VariantAccessPathProjectsTypedLeafWithResidualAndMetadata
     const auto& root = request.non_predicate_columns[0];
     ASSERT_FALSE(root.project_all_children);
 
-    // The root keeps metadata(0), value(1), and typed_value(2). The residual is needed to reject an
-    // invalid non-object carrier beside the shredded object before publishing a direct leaf.
-    ASSERT_EQ(root.children.size(), 3);
+    // The root keeps metadata(0) and typed_value(2). Its own value(1) stays unprojected: it holds
+    // every unshredded field, so reading it would give back all the pruned I/O.
+    ASSERT_EQ(root.children.size(), 2);
     EXPECT_EQ(root.children[0].local_id(), 0);
     EXPECT_TRUE(root.children[0].project_all_children);
-    EXPECT_EQ(root.children[1].local_id(), 1);
-    EXPECT_TRUE(root.children[1].project_all_children);
-    EXPECT_EQ(root.children[2].local_id(), 2);
+    EXPECT_EQ(root.children[1].local_id(), 2);
 
-    ASSERT_EQ(root.children[2].children.size(), 1);
-    const auto& wrapper = root.children[2].children[0];
+    ASSERT_EQ(root.children[1].children.size(), 1);
+    const auto& wrapper = root.children[1].children[0];
     EXPECT_EQ(wrapper.local_id(), 0);
 
     // The wrapper keeps value(0) beside typed_value(1) so rows stored outside the shredded leaf
@@ -4218,17 +4216,16 @@ TEST(ColumnMapperTest, NestedVariantAccessPathProjectsPhysicalTypedLeaf) {
     ASSERT_EQ(root.children.size(), 1);
     const auto& variant = root.children[0];
     EXPECT_EQ(variant.local_id(), 0);
-    // The root dictionary and carrier travel with typed_value, and the wrapper keeps its residual
-    // beside the typed leaf so rows stored outside the leaf can be merged and validated.
-    ASSERT_EQ(variant.children.size(), 3);
+    // The root dictionary travels with typed_value, and the wrapper keeps its residual beside the
+    // typed leaf so rows stored outside the leaf can be merged.
+    ASSERT_EQ(variant.children.size(), 2);
     EXPECT_EQ(variant.children[0].local_id(), 0);
-    EXPECT_EQ(variant.children[1].local_id(), 1);
-    EXPECT_EQ(variant.children[2].local_id(), 2);
-    ASSERT_EQ(variant.children[2].children.size(), 1);
-    EXPECT_EQ(variant.children[2].children[0].local_id(), 0);
-    ASSERT_EQ(variant.children[2].children[0].children.size(), 2);
-    EXPECT_EQ(variant.children[2].children[0].children[0].local_id(), 0);
-    EXPECT_EQ(variant.children[2].children[0].children[1].local_id(), 1);
+    EXPECT_EQ(variant.children[1].local_id(), 2);
+    ASSERT_EQ(variant.children[1].children.size(), 1);
+    EXPECT_EQ(variant.children[1].children[0].local_id(), 0);
+    ASSERT_EQ(variant.children[1].children[0].children.size(), 2);
+    EXPECT_EQ(variant.children[1].children[0].children[0].local_id(), 0);
+    EXPECT_EQ(variant.children[1].children[0].children[1].local_id(), 1);
 }
 
 TEST(ColumnMapperTest, NestedVariantAllAccessPathKeepsPhysicalTypedLeaf) {
@@ -4262,13 +4259,12 @@ TEST(ColumnMapperTest, NestedVariantAllAccessPathKeepsPhysicalTypedLeaf) {
     ASSERT_EQ(root.children.size(), 1);
     const auto& variant = root.children[0];
     ASSERT_FALSE(variant.project_all_children);
-    ASSERT_EQ(variant.children.size(), 3);
+    ASSERT_EQ(variant.children.size(), 2);
     EXPECT_EQ(variant.children[0].local_id(), 0);
-    EXPECT_EQ(variant.children[1].local_id(), 1);
-    EXPECT_EQ(variant.children[2].local_id(), 2);
-    ASSERT_EQ(variant.children[2].children.size(), 1);
-    ASSERT_EQ(variant.children[2].children[0].children.size(), 2);
-    EXPECT_EQ(variant.children[2].children[0].children[1].local_id(), 1);
+    EXPECT_EQ(variant.children[1].local_id(), 2);
+    ASSERT_EQ(variant.children[1].children.size(), 1);
+    ASSERT_EQ(variant.children[1].children[0].children.size(), 2);
+    EXPECT_EQ(variant.children[1].children[0].children[1].local_id(), 1);
 }
 
 TEST(ColumnMapperTest, ArrayAndMapNestedVariantPathsReachPhysicalTypedLeaf) {
@@ -4284,13 +4280,12 @@ TEST(ColumnMapperTest, ArrayAndMapNestedVariantPathsReachPhysicalTypedLeaf) {
     };
     auto assert_variant_leaf = [](const LocalColumnIndex& variant) {
         ASSERT_FALSE(variant.project_all_children);
-        ASSERT_EQ(variant.children.size(), 3);
+        ASSERT_EQ(variant.children.size(), 2);
         EXPECT_EQ(variant.children[0].local_id(), 0);
-        EXPECT_EQ(variant.children[1].local_id(), 1);
-        EXPECT_EQ(variant.children[2].local_id(), 2);
-        ASSERT_EQ(variant.children[2].children.size(), 1);
-        ASSERT_EQ(variant.children[2].children[0].children.size(), 2);
-        EXPECT_EQ(variant.children[2].children[0].children[1].local_id(), 1);
+        EXPECT_EQ(variant.children[1].local_id(), 2);
+        ASSERT_EQ(variant.children[1].children.size(), 1);
+        ASSERT_EQ(variant.children[1].children[0].children.size(), 2);
+        EXPECT_EQ(variant.children[1].children[0].children[1].local_id(), 1);
     };
 
     {
@@ -4414,16 +4409,14 @@ TEST(ColumnMapperTest, VariantDeepObjectPathProjectsPhysicalTypedLeaf) {
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     const auto& root = request.non_predicate_columns[0];
     ASSERT_FALSE(root.project_all_children);
-    ASSERT_EQ(root.children.size(), 3);
+    ASSERT_EQ(root.children.size(), 2);
     EXPECT_EQ(root.children[0].local_id(), 0);
-    EXPECT_EQ(root.children[1].local_id(), 1);
-    EXPECT_EQ(root.children[2].local_id(), 2);
-    ASSERT_EQ(root.children[2].children.size(), 1);
-    EXPECT_EQ(root.children[2].children[0].local_id(), 0);
-    ASSERT_EQ(root.children[2].children[0].children.size(), 2);
-    EXPECT_EQ(root.children[2].children[0].children[0].local_id(), 0);
-    EXPECT_EQ(root.children[2].children[0].children[1].local_id(), 1);
-    const auto& object_typed = root.children[2].children[0].children[1];
+    EXPECT_EQ(root.children[1].local_id(), 2);
+    ASSERT_EQ(root.children[1].children.size(), 1);
+    EXPECT_EQ(root.children[1].children[0].local_id(), 0);
+    ASSERT_EQ(root.children[1].children[0].children.size(), 1);
+    EXPECT_EQ(root.children[1].children[0].children[0].local_id(), 1);
+    const auto& object_typed = root.children[1].children[0].children[0];
     ASSERT_EQ(object_typed.children.size(), 2);
     EXPECT_EQ(object_typed.children[0].local_id(), 0);
     EXPECT_EQ(object_typed.children[1].local_id(), 1);
@@ -4494,10 +4487,9 @@ TEST(ColumnMapperTest, VariantLeafProjectionAcceptsAmbiguousPrimitiveIdentity) {
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     const auto& root = request.non_predicate_columns[0];
     ASSERT_FALSE(root.project_all_children);
-    ASSERT_EQ(root.children.size(), 3);
+    ASSERT_EQ(root.children.size(), 2);
     EXPECT_EQ(root.children[0].local_id(), 0);
-    EXPECT_EQ(root.children[1].local_id(), 1);
-    EXPECT_EQ(root.children[2].local_id(), 2);
+    EXPECT_EQ(root.children[1].local_id(), 2);
 }
 
 TEST(ColumnMapperTest, VariantLeafProjectionDeclinesComplexTypedLeaf) {

--- a/be/test/format_v2/column_mapper_test.cpp
+++ b/be/test/format_v2/column_mapper_test.cpp
@@ -4216,12 +4216,16 @@ TEST(ColumnMapperTest, NestedVariantAccessPathProjectsPhysicalTypedLeaf) {
     ASSERT_EQ(root.children.size(), 1);
     const auto& variant = root.children[0];
     EXPECT_EQ(variant.local_id(), 0);
-    ASSERT_EQ(variant.children.size(), 1);
-    EXPECT_EQ(variant.children[0].local_id(), 2);
-    ASSERT_EQ(variant.children[0].children.size(), 1);
-    EXPECT_EQ(variant.children[0].children[0].local_id(), 0);
-    ASSERT_EQ(variant.children[0].children[0].children.size(), 1);
-    EXPECT_EQ(variant.children[0].children[0].children[0].local_id(), 1);
+    // The root dictionary travels with typed_value, and the wrapper keeps its residual beside the
+    // typed leaf so rows stored outside the leaf can be merged.
+    ASSERT_EQ(variant.children.size(), 2);
+    EXPECT_EQ(variant.children[0].local_id(), 0);
+    EXPECT_EQ(variant.children[1].local_id(), 2);
+    ASSERT_EQ(variant.children[1].children.size(), 1);
+    EXPECT_EQ(variant.children[1].children[0].local_id(), 0);
+    ASSERT_EQ(variant.children[1].children[0].children.size(), 2);
+    EXPECT_EQ(variant.children[1].children[0].children[0].local_id(), 0);
+    EXPECT_EQ(variant.children[1].children[0].children[1].local_id(), 1);
 }
 
 TEST(ColumnMapperTest, NestedVariantAllAccessPathKeepsPhysicalTypedLeaf) {
@@ -4255,11 +4259,12 @@ TEST(ColumnMapperTest, NestedVariantAllAccessPathKeepsPhysicalTypedLeaf) {
     ASSERT_EQ(root.children.size(), 1);
     const auto& variant = root.children[0];
     ASSERT_FALSE(variant.project_all_children);
-    ASSERT_EQ(variant.children.size(), 1);
-    EXPECT_EQ(variant.children[0].local_id(), 2);
-    ASSERT_EQ(variant.children[0].children.size(), 1);
-    ASSERT_EQ(variant.children[0].children[0].children.size(), 1);
-    EXPECT_EQ(variant.children[0].children[0].children[0].local_id(), 1);
+    ASSERT_EQ(variant.children.size(), 2);
+    EXPECT_EQ(variant.children[0].local_id(), 0);
+    EXPECT_EQ(variant.children[1].local_id(), 2);
+    ASSERT_EQ(variant.children[1].children.size(), 1);
+    ASSERT_EQ(variant.children[1].children[0].children.size(), 2);
+    EXPECT_EQ(variant.children[1].children[0].children[1].local_id(), 1);
 }
 
 TEST(ColumnMapperTest, ArrayAndMapNestedVariantPathsReachPhysicalTypedLeaf) {
@@ -4275,11 +4280,12 @@ TEST(ColumnMapperTest, ArrayAndMapNestedVariantPathsReachPhysicalTypedLeaf) {
     };
     auto assert_variant_leaf = [](const LocalColumnIndex& variant) {
         ASSERT_FALSE(variant.project_all_children);
-        ASSERT_EQ(variant.children.size(), 1);
-        EXPECT_EQ(variant.children[0].local_id(), 2);
-        ASSERT_EQ(variant.children[0].children.size(), 1);
-        ASSERT_EQ(variant.children[0].children[0].children.size(), 1);
-        EXPECT_EQ(variant.children[0].children[0].children[0].local_id(), 1);
+        ASSERT_EQ(variant.children.size(), 2);
+        EXPECT_EQ(variant.children[0].local_id(), 0);
+        EXPECT_EQ(variant.children[1].local_id(), 2);
+        ASSERT_EQ(variant.children[1].children.size(), 1);
+        ASSERT_EQ(variant.children[1].children[0].children.size(), 2);
+        EXPECT_EQ(variant.children[1].children[0].children[1].local_id(), 1);
     };
 
     {
@@ -4403,19 +4409,22 @@ TEST(ColumnMapperTest, VariantDeepObjectPathProjectsPhysicalTypedLeaf) {
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     const auto& root = request.non_predicate_columns[0];
     ASSERT_FALSE(root.project_all_children);
-    ASSERT_EQ(root.children.size(), 1);
-    EXPECT_EQ(root.children[0].local_id(), 2);
-    ASSERT_EQ(root.children[0].children.size(), 1);
-    EXPECT_EQ(root.children[0].children[0].local_id(), 0);
-    ASSERT_EQ(root.children[0].children[0].children.size(), 1);
-    EXPECT_EQ(root.children[0].children[0].children[0].local_id(), 1);
-    const auto& object_typed = root.children[0].children[0].children[0];
+    ASSERT_EQ(root.children.size(), 2);
+    EXPECT_EQ(root.children[0].local_id(), 0);
+    EXPECT_EQ(root.children[1].local_id(), 2);
+    ASSERT_EQ(root.children[1].children.size(), 1);
+    EXPECT_EQ(root.children[1].children[0].local_id(), 0);
+    ASSERT_EQ(root.children[1].children[0].children.size(), 1);
+    EXPECT_EQ(root.children[1].children[0].children[0].local_id(), 1);
+    const auto& object_typed = root.children[1].children[0].children[0];
     ASSERT_EQ(object_typed.children.size(), 2);
     EXPECT_EQ(object_typed.children[0].local_id(), 0);
     EXPECT_EQ(object_typed.children[1].local_id(), 1);
+    // Both leaf wrappers keep their residual beside the typed leaf.
     for (const auto& projected_leaf_wrapper : object_typed.children) {
-        ASSERT_EQ(projected_leaf_wrapper.children.size(), 1);
-        EXPECT_EQ(projected_leaf_wrapper.children[0].local_id(), 1);
+        ASSERT_EQ(projected_leaf_wrapper.children.size(), 2);
+        EXPECT_EQ(projected_leaf_wrapper.children[0].local_id(), 0);
+        EXPECT_EQ(projected_leaf_wrapper.children[1].local_id(), 1);
     }
 }
 

--- a/be/test/format_v2/column_mapper_test.cpp
+++ b/be/test/format_v2/column_mapper_test.cpp
@@ -4107,15 +4107,17 @@ TEST(ColumnMapperTest, VariantAccessPathProjectsTypedLeafWithResidualAndMetadata
     const auto& root = request.non_predicate_columns[0];
     ASSERT_FALSE(root.project_all_children);
 
-    // The root keeps metadata(0) and typed_value(2). Its own value(1) stays unprojected: it holds
-    // every unshredded field, so reading it would give back all the pruned I/O.
-    ASSERT_EQ(root.children.size(), 2);
+    // The root keeps metadata(0), value(1), and typed_value(2). The residual is needed to reject an
+    // invalid non-object carrier beside the shredded object before publishing a direct leaf.
+    ASSERT_EQ(root.children.size(), 3);
     EXPECT_EQ(root.children[0].local_id(), 0);
     EXPECT_TRUE(root.children[0].project_all_children);
-    EXPECT_EQ(root.children[1].local_id(), 2);
+    EXPECT_EQ(root.children[1].local_id(), 1);
+    EXPECT_TRUE(root.children[1].project_all_children);
+    EXPECT_EQ(root.children[2].local_id(), 2);
 
-    ASSERT_EQ(root.children[1].children.size(), 1);
-    const auto& wrapper = root.children[1].children[0];
+    ASSERT_EQ(root.children[2].children.size(), 1);
+    const auto& wrapper = root.children[2].children[0];
     EXPECT_EQ(wrapper.local_id(), 0);
 
     // The wrapper keeps value(0) beside typed_value(1) so rows stored outside the shredded leaf
@@ -4216,16 +4218,17 @@ TEST(ColumnMapperTest, NestedVariantAccessPathProjectsPhysicalTypedLeaf) {
     ASSERT_EQ(root.children.size(), 1);
     const auto& variant = root.children[0];
     EXPECT_EQ(variant.local_id(), 0);
-    // The root dictionary travels with typed_value, and the wrapper keeps its residual beside the
-    // typed leaf so rows stored outside the leaf can be merged.
-    ASSERT_EQ(variant.children.size(), 2);
+    // The root dictionary and carrier travel with typed_value, and the wrapper keeps its residual
+    // beside the typed leaf so rows stored outside the leaf can be merged and validated.
+    ASSERT_EQ(variant.children.size(), 3);
     EXPECT_EQ(variant.children[0].local_id(), 0);
-    EXPECT_EQ(variant.children[1].local_id(), 2);
-    ASSERT_EQ(variant.children[1].children.size(), 1);
-    EXPECT_EQ(variant.children[1].children[0].local_id(), 0);
-    ASSERT_EQ(variant.children[1].children[0].children.size(), 2);
-    EXPECT_EQ(variant.children[1].children[0].children[0].local_id(), 0);
-    EXPECT_EQ(variant.children[1].children[0].children[1].local_id(), 1);
+    EXPECT_EQ(variant.children[1].local_id(), 1);
+    EXPECT_EQ(variant.children[2].local_id(), 2);
+    ASSERT_EQ(variant.children[2].children.size(), 1);
+    EXPECT_EQ(variant.children[2].children[0].local_id(), 0);
+    ASSERT_EQ(variant.children[2].children[0].children.size(), 2);
+    EXPECT_EQ(variant.children[2].children[0].children[0].local_id(), 0);
+    EXPECT_EQ(variant.children[2].children[0].children[1].local_id(), 1);
 }
 
 TEST(ColumnMapperTest, NestedVariantAllAccessPathKeepsPhysicalTypedLeaf) {
@@ -4259,12 +4262,13 @@ TEST(ColumnMapperTest, NestedVariantAllAccessPathKeepsPhysicalTypedLeaf) {
     ASSERT_EQ(root.children.size(), 1);
     const auto& variant = root.children[0];
     ASSERT_FALSE(variant.project_all_children);
-    ASSERT_EQ(variant.children.size(), 2);
+    ASSERT_EQ(variant.children.size(), 3);
     EXPECT_EQ(variant.children[0].local_id(), 0);
-    EXPECT_EQ(variant.children[1].local_id(), 2);
-    ASSERT_EQ(variant.children[1].children.size(), 1);
-    ASSERT_EQ(variant.children[1].children[0].children.size(), 2);
-    EXPECT_EQ(variant.children[1].children[0].children[1].local_id(), 1);
+    EXPECT_EQ(variant.children[1].local_id(), 1);
+    EXPECT_EQ(variant.children[2].local_id(), 2);
+    ASSERT_EQ(variant.children[2].children.size(), 1);
+    ASSERT_EQ(variant.children[2].children[0].children.size(), 2);
+    EXPECT_EQ(variant.children[2].children[0].children[1].local_id(), 1);
 }
 
 TEST(ColumnMapperTest, ArrayAndMapNestedVariantPathsReachPhysicalTypedLeaf) {
@@ -4280,12 +4284,13 @@ TEST(ColumnMapperTest, ArrayAndMapNestedVariantPathsReachPhysicalTypedLeaf) {
     };
     auto assert_variant_leaf = [](const LocalColumnIndex& variant) {
         ASSERT_FALSE(variant.project_all_children);
-        ASSERT_EQ(variant.children.size(), 2);
+        ASSERT_EQ(variant.children.size(), 3);
         EXPECT_EQ(variant.children[0].local_id(), 0);
-        EXPECT_EQ(variant.children[1].local_id(), 2);
-        ASSERT_EQ(variant.children[1].children.size(), 1);
-        ASSERT_EQ(variant.children[1].children[0].children.size(), 2);
-        EXPECT_EQ(variant.children[1].children[0].children[1].local_id(), 1);
+        EXPECT_EQ(variant.children[1].local_id(), 1);
+        EXPECT_EQ(variant.children[2].local_id(), 2);
+        ASSERT_EQ(variant.children[2].children.size(), 1);
+        ASSERT_EQ(variant.children[2].children[0].children.size(), 2);
+        EXPECT_EQ(variant.children[2].children[0].children[1].local_id(), 1);
     };
 
     {
@@ -4409,14 +4414,16 @@ TEST(ColumnMapperTest, VariantDeepObjectPathProjectsPhysicalTypedLeaf) {
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     const auto& root = request.non_predicate_columns[0];
     ASSERT_FALSE(root.project_all_children);
-    ASSERT_EQ(root.children.size(), 2);
+    ASSERT_EQ(root.children.size(), 3);
     EXPECT_EQ(root.children[0].local_id(), 0);
-    EXPECT_EQ(root.children[1].local_id(), 2);
-    ASSERT_EQ(root.children[1].children.size(), 1);
-    EXPECT_EQ(root.children[1].children[0].local_id(), 0);
-    ASSERT_EQ(root.children[1].children[0].children.size(), 1);
-    EXPECT_EQ(root.children[1].children[0].children[0].local_id(), 1);
-    const auto& object_typed = root.children[1].children[0].children[0];
+    EXPECT_EQ(root.children[1].local_id(), 1);
+    EXPECT_EQ(root.children[2].local_id(), 2);
+    ASSERT_EQ(root.children[2].children.size(), 1);
+    EXPECT_EQ(root.children[2].children[0].local_id(), 0);
+    ASSERT_EQ(root.children[2].children[0].children.size(), 2);
+    EXPECT_EQ(root.children[2].children[0].children[0].local_id(), 0);
+    EXPECT_EQ(root.children[2].children[0].children[1].local_id(), 1);
+    const auto& object_typed = root.children[2].children[0].children[1];
     ASSERT_EQ(object_typed.children.size(), 2);
     EXPECT_EQ(object_typed.children[0].local_id(), 0);
     EXPECT_EQ(object_typed.children[1].local_id(), 1);
@@ -4487,9 +4494,10 @@ TEST(ColumnMapperTest, VariantLeafProjectionAcceptsAmbiguousPrimitiveIdentity) {
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     const auto& root = request.non_predicate_columns[0];
     ASSERT_FALSE(root.project_all_children);
-    ASSERT_EQ(root.children.size(), 2);
+    ASSERT_EQ(root.children.size(), 3);
     EXPECT_EQ(root.children[0].local_id(), 0);
-    EXPECT_EQ(root.children[1].local_id(), 2);
+    EXPECT_EQ(root.children[1].local_id(), 1);
+    EXPECT_EQ(root.children[2].local_id(), 2);
 }
 
 TEST(ColumnMapperTest, VariantLeafProjectionDeclinesComplexTypedLeaf) {

--- a/be/test/format_v2/column_mapper_test.cpp
+++ b/be/test/format_v2/column_mapper_test.cpp
@@ -4087,7 +4087,7 @@ TEST_F(ColumnMapperCastTest, ColumnMapperKeepsTableSlotIdWhenFileBlockPositionCh
     conjunct->close();
 }
 
-TEST(ColumnMapperTest, VariantAccessPathProjectsOnlyPhysicalTypedLeaf) {
+TEST(ColumnMapperTest, VariantAccessPathProjectsTypedLeafWithResidualAndMetadata) {
     auto table_variant = field_id_col("v", 10, variant_v2());
     table_variant.variant_access_paths = {{"typed_col"}};
 
@@ -4106,13 +4106,25 @@ TEST(ColumnMapperTest, VariantAccessPathProjectsOnlyPhysicalTypedLeaf) {
     ASSERT_EQ(request.non_predicate_columns.size(), 1);
     const auto& root = request.non_predicate_columns[0];
     ASSERT_FALSE(root.project_all_children);
-    ASSERT_EQ(root.children.size(), 1);
-    EXPECT_EQ(root.children[0].local_id(), 2);
-    ASSERT_EQ(root.children[0].children.size(), 1);
-    EXPECT_EQ(root.children[0].children[0].local_id(), 0);
-    ASSERT_EQ(root.children[0].children[0].children.size(), 1);
-    EXPECT_EQ(root.children[0].children[0].children[0].local_id(), 1);
-    EXPECT_TRUE(root.children[0].children[0].children[0].project_all_children);
+
+    // The root keeps metadata(0) and typed_value(2). Its own value(1) stays unprojected: it holds
+    // every unshredded field, so reading it would give back all the pruned I/O.
+    ASSERT_EQ(root.children.size(), 2);
+    EXPECT_EQ(root.children[0].local_id(), 0);
+    EXPECT_TRUE(root.children[0].project_all_children);
+    EXPECT_EQ(root.children[1].local_id(), 2);
+
+    ASSERT_EQ(root.children[1].children.size(), 1);
+    const auto& wrapper = root.children[1].children[0];
+    EXPECT_EQ(wrapper.local_id(), 0);
+
+    // The wrapper keeps value(0) beside typed_value(1) so rows stored outside the shredded leaf
+    // can be merged instead of rejecting the batch.
+    ASSERT_EQ(wrapper.children.size(), 2);
+    EXPECT_EQ(wrapper.children[0].local_id(), 0);
+    EXPECT_TRUE(wrapper.children[0].project_all_children);
+    EXPECT_EQ(wrapper.children[1].local_id(), 1);
+    EXPECT_TRUE(wrapper.children[1].project_all_children);
 }
 
 TEST(ColumnMapperTest, PredicateAccessPathsCreateDeferredStructOutputProjection) {
@@ -4446,7 +4458,9 @@ TEST(ColumnMapperTest, VariantDeepLeafProjectionRejectsRepeatedAncestor) {
     EXPECT_TRUE(request.non_predicate_columns[0].project_all_children);
 }
 
-TEST(ColumnMapperTest, VariantLeafProjectionDeclinesAmbiguousPrimitiveIdentity) {
+TEST(ColumnMapperTest, VariantLeafProjectionAcceptsAmbiguousPrimitiveIdentity) {
+    // BYTE_ARRAY carries strings, raw binary and UUID alike. The reader resolves which one a leaf
+    // holds from its ParquetColumnSchema, so the mapper only has to decide which columns to read.
     auto field_wrapper = struct_name_col(
             "binary_col",
             {name_col("value", varbinary(), 0), name_col("typed_value", varbinary(), 1)}, 0);
@@ -4457,6 +4471,31 @@ TEST(ColumnMapperTest, VariantLeafProjectionDeclinesAmbiguousPrimitiveIdentity) 
 
     auto table_variant = field_id_col("v", 10, variant_v2());
     table_variant.variant_access_paths = {{"binary_col"}};
+    ParquetColumnMapper mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
+    ASSERT_TRUE(mapper.create_mapping({table_variant}, {}, {file_variant}).ok());
+    FileScanRequest request;
+    ASSERT_TRUE(mapper.create_scan_request({}, {table_variant}, &request).ok());
+    ASSERT_EQ(request.non_predicate_columns.size(), 1);
+    const auto& root = request.non_predicate_columns[0];
+    ASSERT_FALSE(root.project_all_children);
+    ASSERT_EQ(root.children.size(), 2);
+    EXPECT_EQ(root.children[0].local_id(), 0);
+    EXPECT_EQ(root.children[1].local_id(), 2);
+}
+
+TEST(ColumnMapperTest, VariantLeafProjectionDeclinesComplexTypedLeaf) {
+    // A complex shredded value still needs its wrapper shape to be reconstructed, so the whole
+    // Variant stays projected.
+    auto inner_typed = struct_name_col("typed_value", {name_col("x", i64(), 0)}, 1);
+    auto field_wrapper = struct_name_col(
+            "object_col", {name_col("value", varbinary(), 0), std::move(inner_typed)}, 0);
+    auto typed_value = struct_name_col("typed_value", {std::move(field_wrapper)}, 2);
+    auto file_variant = field_id_col("v", 10, variant_v2(), 0);
+    file_variant.children = {name_col("metadata", varbinary(), 0),
+                             name_col("value", varbinary(), 1), std::move(typed_value)};
+
+    auto table_variant = field_id_col("v", 10, variant_v2());
+    table_variant.variant_access_paths = {{"object_col"}};
     ParquetColumnMapper mapper({.mode = TableColumnMappingMode::BY_FIELD_ID});
     ASSERT_TRUE(mapper.create_mapping({table_variant}, {}, {file_variant}).ok());
     FileScanRequest request;

--- a/be/test/format_v2/parquet/parquet_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_reader_test.cpp
@@ -1917,35 +1917,41 @@ TEST(ParquetVariantProjectionTest, ResidualStatisticsGuardPhysicalLeafProjection
     EXPECT_EQ(residual_projections, 0);
     row_group.columns[1].meta_data.statistics.__set_null_count(10);
 
-    // A terminal residual that carries values no longer forfeits the leaf projection. The reader
-    // reads that residual beside the leaf and merges the affected rows, so the row group keeps
-    // reading leaves instead of the complete Variant.
+    // This projection does not read the residual beside the leaf, so a residual that carries
+    // values cannot be served from leaves and the complete Variant comes back.
+    size_t full_projections = 0;
     row_group.columns[2].meta_data.statistics.__set_null_count(9);
     row_group_projection = projection;
     residual_projections = 0;
     EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
-                      row_group, *root, &row_group_projection, &residual_projections),
-              1);
-    EXPECT_FALSE(row_group_projection.project_all_children);
-    EXPECT_EQ(residual_projections, 1);
+                      row_group, *root, &row_group_projection, &residual_projections,
+                      &full_projections),
+              0);
+    EXPECT_TRUE(row_group_projection.project_all_children);
+    EXPECT_EQ(residual_projections, 0);
+    EXPECT_EQ(full_projections, 1);
     row_group.columns[2].meta_data.__set_num_values(9);
     row_group.columns[2].meta_data.statistics.__set_null_count(9);
     row_group_projection = projection;
     residual_projections = 0;
+    full_projections = 0;
     EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
-                      row_group, *root, &row_group_projection, &residual_projections),
-              1);
-    EXPECT_FALSE(row_group_projection.project_all_children);
-    EXPECT_EQ(residual_projections, 1);
+                      row_group, *root, &row_group_projection, &residual_projections,
+                      &full_projections),
+              0);
+    EXPECT_TRUE(row_group_projection.project_all_children);
+    EXPECT_EQ(full_projections, 1);
     row_group.columns[2].meta_data.__set_num_values(10);
     row_group.columns[2].meta_data.__isset.statistics = false;
     row_group_projection = projection;
     residual_projections = 0;
+    full_projections = 0;
     EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
-                      row_group, *root, &row_group_projection, &residual_projections),
-              1);
-    EXPECT_FALSE(row_group_projection.project_all_children);
-    EXPECT_EQ(residual_projections, 1);
+                      row_group, *root, &row_group_projection, &residual_projections,
+                      &full_projections),
+              0);
+    EXPECT_TRUE(row_group_projection.project_all_children);
+    EXPECT_EQ(full_projections, 1);
 }
 
 TEST(ParquetVariantProjectionTest, PrunesResidualColumnsOnlyWhenStatisticsProveThemNull) {
@@ -2251,6 +2257,8 @@ TEST(ParquetVariantProjectionTest, FinalizesNestedVariantProjectionPerRowGroup) 
               1);
     EXPECT_FALSE(projection.children[0].project_all_children);
 
+    // This projection does not read the residual, so a residual that carries values restores the
+    // complete Variant.
     auto fallback = projection;
     row_group.columns[2].meta_data.statistics.__set_null_count(9);
     EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
@@ -2258,6 +2266,8 @@ TEST(ParquetVariantProjectionTest, FinalizesNestedVariantProjectionPerRowGroup) 
               0);
     EXPECT_TRUE(fallback.children[0].project_all_children);
 
+    // Row-group null counts are per value, not per row, so a repeated Variant can never prove its
+    // residual is empty either.
     auto repeated = projection;
     root->children[0]->max_repetition_level = 1;
     EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
@@ -2451,10 +2461,14 @@ TEST_F(NewParquetReaderTest, SwitchesVariantLeafProjectionPerRowGroup) {
         rows += batch_rows;
     }
     EXPECT_EQ(rows, 2);
+    // This request projects the typed leaf without the residual beside it, so the row group whose
+    // residual carries values cannot be served from leaves and restores the complete Variant.
     ASSERT_NE(profile.get_counter("VariantLeafProjectionRowGroupColumns"), nullptr);
     EXPECT_EQ(profile.get_counter("VariantLeafProjectionRowGroupColumns")->value(), 1);
     ASSERT_NE(profile.get_counter("VariantResidualProjectionRowGroupColumns"), nullptr);
-    EXPECT_EQ(profile.get_counter("VariantResidualProjectionRowGroupColumns")->value(), 1);
+    EXPECT_EQ(profile.get_counter("VariantResidualProjectionRowGroupColumns")->value(), 0);
+    ASSERT_NE(profile.get_counter("VariantFullProjectionRowGroupColumns"), nullptr);
+    EXPECT_EQ(profile.get_counter("VariantFullProjectionRowGroupColumns")->value(), 1);
 
     const auto& nullable = assert_cast<const ColumnNullable&>(*block.get_by_position(0).column);
     const auto& variants = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());

--- a/be/test/format_v2/parquet/parquet_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_reader_test.cpp
@@ -1898,51 +1898,128 @@ TEST(ParquetVariantProjectionTest, ResidualStatisticsGuardPhysicalLeafProjection
         row_group.columns.push_back(std::move(chunk));
     }
     auto row_group_projection = projection;
-    size_t full_projections = 0;
+    size_t residual_projections = 0;
     EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
-                      row_group, *root, &row_group_projection, &full_projections),
+                      row_group, *root, &row_group_projection, &residual_projections),
               1);
     EXPECT_FALSE(row_group_projection.project_all_children);
-    EXPECT_EQ(full_projections, 0);
+    EXPECT_EQ(residual_projections, 0);
 
     // A conforming partially shredded object keeps unrelated keys in the ancestor residual. The
     // requested field is still complete when its own value column is all null.
     row_group.columns[1].meta_data.statistics.__set_null_count(9);
     row_group_projection = projection;
-    full_projections = 0;
+    residual_projections = 0;
     EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
-                      row_group, *root, &row_group_projection, &full_projections),
+                      row_group, *root, &row_group_projection, &residual_projections),
               1);
     EXPECT_FALSE(row_group_projection.project_all_children);
-    EXPECT_EQ(full_projections, 0);
+    EXPECT_EQ(residual_projections, 0);
     row_group.columns[1].meta_data.statistics.__set_null_count(10);
 
+    // A terminal residual that carries values no longer forfeits the leaf projection. The reader
+    // reads that residual beside the leaf and merges the affected rows, so the row group keeps
+    // reading leaves instead of the complete Variant.
     row_group.columns[2].meta_data.statistics.__set_null_count(9);
     row_group_projection = projection;
-    full_projections = 0;
+    residual_projections = 0;
     EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
-                      row_group, *root, &row_group_projection, &full_projections),
-              0);
-    EXPECT_TRUE(row_group_projection.project_all_children);
-    EXPECT_EQ(full_projections, 1);
+                      row_group, *root, &row_group_projection, &residual_projections),
+              1);
+    EXPECT_FALSE(row_group_projection.project_all_children);
+    EXPECT_EQ(residual_projections, 1);
     row_group.columns[2].meta_data.__set_num_values(9);
     row_group.columns[2].meta_data.statistics.__set_null_count(9);
     row_group_projection = projection;
-    full_projections = 0;
+    residual_projections = 0;
     EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
-                      row_group, *root, &row_group_projection, &full_projections),
-              0);
-    EXPECT_TRUE(row_group_projection.project_all_children);
-    EXPECT_EQ(full_projections, 1);
+                      row_group, *root, &row_group_projection, &residual_projections),
+              1);
+    EXPECT_FALSE(row_group_projection.project_all_children);
+    EXPECT_EQ(residual_projections, 1);
     row_group.columns[2].meta_data.__set_num_values(10);
     row_group.columns[2].meta_data.__isset.statistics = false;
     row_group_projection = projection;
-    full_projections = 0;
+    residual_projections = 0;
     EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
-                      row_group, *root, &row_group_projection, &full_projections),
-              0);
-    EXPECT_TRUE(row_group_projection.project_all_children);
-    EXPECT_EQ(full_projections, 1);
+                      row_group, *root, &row_group_projection, &residual_projections),
+              1);
+    EXPECT_FALSE(row_group_projection.project_all_children);
+    EXPECT_EQ(residual_projections, 1);
+}
+
+TEST(ParquetVariantProjectionTest, PrunesResidualColumnsOnlyWhenStatisticsProveThemNull) {
+    using format::parquet::ParquetColumnSchema;
+    using format::parquet::ParquetColumnSchemaKind;
+    auto node = [](std::string name, int32_t local_id, ParquetColumnSchemaKind kind,
+                   int leaf_id = -1) {
+        auto result = std::make_unique<ParquetColumnSchema>();
+        result->name = std::move(name);
+        result->local_id = local_id;
+        result->kind = kind;
+        result->leaf_column_id = leaf_id;
+        return result;
+    };
+    auto root = node("v", 0, ParquetColumnSchemaKind::VARIANT);
+    root->children.push_back(node("metadata", 0, ParquetColumnSchemaKind::PRIMITIVE, 0));
+    root->children.push_back(node("value", 1, ParquetColumnSchemaKind::PRIMITIVE, 1));
+    auto root_typed = node("typed_value", 2, ParquetColumnSchemaKind::STRUCT);
+    auto wrapper = node("n", 0, ParquetColumnSchemaKind::STRUCT);
+    wrapper->children.push_back(node("value", 0, ParquetColumnSchemaKind::PRIMITIVE, 2));
+    wrapper->children.push_back(node("typed_value", 1, ParquetColumnSchemaKind::PRIMITIVE, 3));
+    root_typed->children.push_back(std::move(wrapper));
+    root->children.push_back(std::move(root_typed));
+
+    // The projection the mapper now produces: root metadata beside typed_value, and the terminal
+    // wrapper's residual beside its typed leaf.
+    auto projection = format::LocalColumnIndex::partial_local(0);
+    projection.children.push_back(format::LocalColumnIndex::local(0));
+    projection.children.push_back(format::LocalColumnIndex::partial_local(2));
+    auto& typed_projection = projection.children.back();
+    typed_projection.children.push_back(format::LocalColumnIndex::partial_local(0));
+    auto& wrapper_projection = typed_projection.children.back();
+    wrapper_projection.children.push_back(format::LocalColumnIndex::local(0));
+    wrapper_projection.children.push_back(format::LocalColumnIndex::local(1));
+
+    tparquet::RowGroup row_group;
+    row_group.__set_num_rows(10);
+    for (int leaf = 0; leaf < 4; ++leaf) {
+        tparquet::Statistics statistics;
+        statistics.__set_null_count(leaf == 2 ? 10 : 0);
+        tparquet::ColumnMetaData column_metadata;
+        column_metadata.__set_num_values(10);
+        column_metadata.__set_statistics(std::move(statistics));
+        tparquet::ColumnChunk chunk;
+        chunk.__set_meta_data(std::move(column_metadata));
+        row_group.columns.push_back(std::move(chunk));
+    }
+
+    // The terminal residual is entirely NULL, so the shredded leaf alone answers every row and
+    // both the residual and the root dictionary can be dropped from the read.
+    auto pruned = projection;
+    EXPECT_TRUE(format::parquet::detail::variant_residual_columns_are_prunable_for_row_group(
+            row_group, *root, pruned));
+    format::parquet::detail::prune_variant_residual_columns(*root, &pruned);
+    ASSERT_EQ(pruned.children.size(), 1);
+    EXPECT_EQ(pruned.children[0].local_id(), 2);
+    ASSERT_EQ(pruned.children[0].children.size(), 1);
+    ASSERT_EQ(pruned.children[0].children[0].children.size(), 1);
+    EXPECT_EQ(pruned.children[0].children[0].children[0].local_id(), 1);
+
+    // One residual row is enough to keep the columns, but the projection stays a leaf projection:
+    // the reader merges those rows instead of rebuilding the complete Variant.
+    row_group.columns[2].meta_data.statistics.__set_null_count(9);
+    auto retained = projection;
+    EXPECT_FALSE(format::parquet::detail::variant_residual_columns_are_prunable_for_row_group(
+            row_group, *root, retained));
+    size_t residual_projections = 0;
+    EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
+                      row_group, *root, &retained, &residual_projections),
+              1);
+    EXPECT_FALSE(retained.project_all_children);
+    EXPECT_EQ(residual_projections, 1);
+    ASSERT_EQ(retained.children.size(), 2);
+    EXPECT_EQ(retained.children[0].local_id(), 0);
 }
 
 TEST(ParquetVariantProjectionTest, FinalizesPhysicalProjectionBeforeFooterPruning) {
@@ -2029,9 +2106,14 @@ TEST(ParquetVariantProjectionTest, FinalizesPhysicalProjectionBeforeFooterPrunin
     thrift_metadata.__set_column_orders({order, order, order, order, order});
     format::parquet::NativeParquetMetadata metadata(std::move(thrift_metadata), 0);
 
+    // The shape the mapper builds: the root dictionary and the terminal residual travel with the
+    // typed leaf so a row group whose residual carries values can still be served from leaves.
     auto leaf_projection = format::LocalColumnIndex::partial_local(1);
+    leaf_projection.children.push_back(format::LocalColumnIndex::local(0));
     leaf_projection.children.push_back(format::LocalColumnIndex::partial_local(2));
     leaf_projection.children.back().children.push_back(format::LocalColumnIndex::partial_local(0));
+    leaf_projection.children.back().children.back().children.push_back(
+            format::LocalColumnIndex::local(0));
     leaf_projection.children.back().children.back().children.push_back(
             format::LocalColumnIndex::local(1));
     format::FileScanRequest request;
@@ -2050,9 +2132,11 @@ TEST(ParquetVariantProjectionTest, FinalizesPhysicalProjectionBeforeFooterPrunin
                                                          &plan, nullptr, nullptr, &file_context)
                         .ok());
     EXPECT_TRUE(plan.row_groups.empty());
-    // Footer accounting uses id plus all Variant leaves for the first row group (150 bytes), then
-    // id plus the retained typed leaf for the fully shredded row group (60 bytes).
-    EXPECT_EQ(plan.pruning_stats.filtered_bytes, 210);
+    // Footer accounting uses id plus the projected Variant leaves - dictionary, residual and typed
+    // leaf - for the first row group (120 bytes). The fully shredded row group proves its residual
+    // is NULL, so it drops the dictionary and the residual and reads id plus the typed leaf
+    // (60 bytes).
+    EXPECT_EQ(plan.pruning_stats.filtered_bytes, 180);
 
     request.conjuncts.clear();
     ASSERT_TRUE(format::parquet::plan_parquet_row_groups(metadata, schema, request,
@@ -2060,14 +2144,16 @@ TEST(ParquetVariantProjectionTest, FinalizesPhysicalProjectionBeforeFooterPrunin
                                                          &plan, nullptr, nullptr, &file_context)
                         .ok());
     ASSERT_EQ(plan.row_groups.size(), 2);
-    EXPECT_TRUE(plan.row_groups[0].has_row_group_physical_projection());
-    EXPECT_EQ(plan.row_groups[0].full_variant_projection_ordinals, std::vector<size_t> {0});
-    EXPECT_EQ(plan.row_groups[0].variant_leaf_projection_columns, 0);
-    EXPECT_EQ(plan.row_groups[0].variant_full_projection_columns, 1);
-    EXPECT_FALSE(plan.row_groups[1].has_row_group_physical_projection());
-    EXPECT_TRUE(plan.row_groups[1].full_variant_projection_ordinals.empty());
+    // Both row groups keep a leaf projection. Only the fully shredded one can additionally drop
+    // the residual columns, so only it carries a row-group specific physical projection.
+    EXPECT_FALSE(plan.row_groups[0].has_row_group_physical_projection());
+    EXPECT_TRUE(plan.row_groups[0].prunable_variant_projection_ordinals.empty());
+    EXPECT_EQ(plan.row_groups[0].variant_leaf_projection_columns, 1);
+    EXPECT_EQ(plan.row_groups[0].variant_residual_projection_columns, 1);
+    EXPECT_TRUE(plan.row_groups[1].has_row_group_physical_projection());
+    EXPECT_EQ(plan.row_groups[1].prunable_variant_projection_ordinals, std::vector<size_t> {0});
     EXPECT_EQ(plan.row_groups[1].variant_leaf_projection_columns, 1);
-    EXPECT_EQ(plan.row_groups[1].variant_full_projection_columns, 0);
+    EXPECT_EQ(plan.row_groups[1].variant_residual_projection_columns, 0);
 }
 
 TEST(ParquetVariantProjectionTest, ReusesWideNonVariantLeafSetAcrossRowGroups) {
@@ -2249,8 +2335,8 @@ TEST_F(NewParquetReaderTest, ReadsFullyShreddedVariantTypedLeafProjection) {
     EXPECT_EQ(profile.get_counter("VariantReconstructedRows")->value(), 0);
     ASSERT_NE(profile.get_counter("VariantLeafProjectionRowGroupColumns"), nullptr);
     EXPECT_EQ(profile.get_counter("VariantLeafProjectionRowGroupColumns")->value(), 1);
-    ASSERT_NE(profile.get_counter("VariantFullProjectionRowGroupColumns"), nullptr);
-    EXPECT_EQ(profile.get_counter("VariantFullProjectionRowGroupColumns")->value(), 0);
+    ASSERT_NE(profile.get_counter("VariantResidualProjectionRowGroupColumns"), nullptr);
+    EXPECT_EQ(profile.get_counter("VariantResidualProjectionRowGroupColumns")->value(), 0);
     const std::array missing_path {VariantShreddedPathSegment {
             .kind = VariantShreddedPathSegment::Kind::OBJECT_KEY, .key = StringRef("missing")}};
     EXPECT_FALSE(variants.find_shredded_typed_value(missing_path).has_value());
@@ -2367,8 +2453,8 @@ TEST_F(NewParquetReaderTest, SwitchesVariantLeafProjectionPerRowGroup) {
     EXPECT_EQ(rows, 2);
     ASSERT_NE(profile.get_counter("VariantLeafProjectionRowGroupColumns"), nullptr);
     EXPECT_EQ(profile.get_counter("VariantLeafProjectionRowGroupColumns")->value(), 1);
-    ASSERT_NE(profile.get_counter("VariantFullProjectionRowGroupColumns"), nullptr);
-    EXPECT_EQ(profile.get_counter("VariantFullProjectionRowGroupColumns")->value(), 1);
+    ASSERT_NE(profile.get_counter("VariantResidualProjectionRowGroupColumns"), nullptr);
+    EXPECT_EQ(profile.get_counter("VariantResidualProjectionRowGroupColumns")->value(), 1);
 
     const auto& nullable = assert_cast<const ColumnNullable&>(*block.get_by_position(0).column);
     const auto& variants = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());

--- a/be/test/format_v2/parquet/parquet_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_reader_test.cpp
@@ -1905,25 +1905,21 @@ TEST(ParquetVariantProjectionTest, ResidualStatisticsGuardPhysicalLeafProjection
     EXPECT_FALSE(row_group_projection.project_all_children);
     EXPECT_EQ(residual_projections, 0);
 
-    // An ancestor residual that is not projected cannot be validated. Even though conforming files
-    // use it only for unrelated keys, this shape must restore the complete Variant rather than hide
-    // a malformed non-object carrier.
+    // A partially shredded object's ancestor residual contains unrelated keys. The requested field
+    // remains complete when its own terminal fallback column is all NULL.
     row_group.columns[1].meta_data.statistics.__set_null_count(9);
     row_group_projection = projection;
     residual_projections = 0;
-    size_t full_projections = 0;
     EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
-                      row_group, *root, &row_group_projection, &residual_projections,
-                      &full_projections),
-              0);
-    EXPECT_TRUE(row_group_projection.project_all_children);
+                      row_group, *root, &row_group_projection, &residual_projections),
+              1);
+    EXPECT_FALSE(row_group_projection.project_all_children);
     EXPECT_EQ(residual_projections, 0);
-    EXPECT_EQ(full_projections, 1);
     row_group.columns[1].meta_data.statistics.__set_null_count(10);
 
     // This projection does not read the residual beside the leaf, so a residual that carries
     // values cannot be served from leaves and the complete Variant comes back.
-    full_projections = 0;
+    size_t full_projections = 0;
     row_group.columns[2].meta_data.statistics.__set_null_count(9);
     row_group_projection = projection;
     residual_projections = 0;
@@ -1980,11 +1976,10 @@ TEST(ParquetVariantProjectionTest, PrunesResidualColumnsOnlyWhenStatisticsProveT
     root_typed->children.push_back(std::move(wrapper));
     root->children.push_back(std::move(root_typed));
 
-    // The projection the mapper now produces: root metadata/value beside typed_value, and the
-    // terminal wrapper's residual beside its typed leaf.
+    // The projection the mapper produces: root metadata beside typed_value, and the terminal
+    // wrapper's residual beside its typed leaf.
     auto projection = format::LocalColumnIndex::partial_local(0);
     projection.children.push_back(format::LocalColumnIndex::local(0));
-    projection.children.push_back(format::LocalColumnIndex::local(1));
     projection.children.push_back(format::LocalColumnIndex::partial_local(2));
     auto& typed_projection = projection.children.back();
     typed_projection.children.push_back(format::LocalColumnIndex::partial_local(0));
@@ -1996,7 +1991,7 @@ TEST(ParquetVariantProjectionTest, PrunesResidualColumnsOnlyWhenStatisticsProveT
     row_group.__set_num_rows(10);
     for (int leaf = 0; leaf < 4; ++leaf) {
         tparquet::Statistics statistics;
-        statistics.__set_null_count(leaf == 1 || leaf == 2 ? 10 : 0);
+        statistics.__set_null_count(leaf == 2 ? 10 : 0);
         tparquet::ColumnMetaData column_metadata;
         column_metadata.__set_num_values(10);
         column_metadata.__set_statistics(std::move(statistics));
@@ -2006,17 +2001,16 @@ TEST(ParquetVariantProjectionTest, PrunesResidualColumnsOnlyWhenStatisticsProveT
     }
 
     // The terminal residual is entirely NULL, so the shredded leaf alone answers every row and
-    // residual carriers can be dropped, while root metadata remains for direct-result validation.
+    // both the residual and unused root dictionary can be dropped from the read.
     auto pruned = projection;
     EXPECT_TRUE(format::parquet::detail::variant_residual_columns_are_prunable_for_row_group(
             row_group, *root, pruned));
     format::parquet::detail::prune_variant_residual_columns(*root, &pruned);
-    ASSERT_EQ(pruned.children.size(), 2);
-    EXPECT_EQ(pruned.children[0].local_id(), 0);
-    EXPECT_EQ(pruned.children[1].local_id(), 2);
-    ASSERT_EQ(pruned.children[1].children.size(), 1);
-    ASSERT_EQ(pruned.children[1].children[0].children.size(), 1);
-    EXPECT_EQ(pruned.children[1].children[0].children[0].local_id(), 1);
+    ASSERT_EQ(pruned.children.size(), 1);
+    EXPECT_EQ(pruned.children[0].local_id(), 2);
+    ASSERT_EQ(pruned.children[0].children.size(), 1);
+    ASSERT_EQ(pruned.children[0].children[0].children.size(), 1);
+    EXPECT_EQ(pruned.children[0].children[0].children[0].local_id(), 1);
 
     // One residual row is enough to keep the columns, but the projection stays a leaf projection:
     // the reader merges those rows instead of rebuilding the complete Variant.
@@ -2030,9 +2024,8 @@ TEST(ParquetVariantProjectionTest, PrunesResidualColumnsOnlyWhenStatisticsProveT
               1);
     EXPECT_FALSE(retained.project_all_children);
     EXPECT_EQ(residual_projections, 1);
-    ASSERT_EQ(retained.children.size(), 3);
+    ASSERT_EQ(retained.children.size(), 2);
     EXPECT_EQ(retained.children[0].local_id(), 0);
-    EXPECT_EQ(retained.children[1].local_id(), 1);
 }
 
 TEST(ParquetVariantProjectionTest, RepeatedVariantKeepsTheCompleteWrapper) {
@@ -2063,7 +2056,6 @@ TEST(ParquetVariantProjectionTest, RepeatedVariantKeepsTheCompleteWrapper) {
     // can send this row group back to the complete Variant is the repetition level.
     auto projection = format::LocalColumnIndex::partial_local(0);
     projection.children.push_back(format::LocalColumnIndex::local(0));
-    projection.children.push_back(format::LocalColumnIndex::local(1));
     projection.children.push_back(format::LocalColumnIndex::partial_local(2));
     auto& typed_projection = projection.children.back();
     typed_projection.children.push_back(format::LocalColumnIndex::partial_local(0));
@@ -2180,11 +2172,10 @@ TEST(ParquetVariantProjectionTest, FinalizesPhysicalProjectionBeforeFooterPrunin
     thrift_metadata.__set_column_orders({order, order, order, order, order});
     format::parquet::NativeParquetMetadata metadata(std::move(thrift_metadata), 0);
 
-    // The shape the mapper builds: the root dictionary, root carrier, and terminal residual travel
-    // with the typed leaf so direct results preserve complete corruption semantics.
+    // The shape the mapper builds: the root dictionary and terminal residual travel with the typed
+    // leaf so a row group whose residual carries values can still be served from leaves.
     auto leaf_projection = format::LocalColumnIndex::partial_local(1);
     leaf_projection.children.push_back(format::LocalColumnIndex::local(0));
-    leaf_projection.children.push_back(format::LocalColumnIndex::local(1));
     leaf_projection.children.push_back(format::LocalColumnIndex::partial_local(2));
     leaf_projection.children.back().children.push_back(format::LocalColumnIndex::partial_local(0));
     leaf_projection.children.back().children.back().children.push_back(
@@ -2207,10 +2198,10 @@ TEST(ParquetVariantProjectionTest, FinalizesPhysicalProjectionBeforeFooterPrunin
                                                          &plan, nullptr, nullptr, &file_context)
                         .ok());
     EXPECT_TRUE(plan.row_groups.empty());
-    // Footer accounting uses id plus dictionary, root/terminal residual, and typed leaf for the
-    // first row group (150 bytes). The fully shredded row group drops both residuals but retains
-    // required metadata validation, so it reads id, dictionary, and typed leaf (80 bytes).
-    EXPECT_EQ(plan.pruning_stats.filtered_bytes, 230);
+    // Footer accounting uses id plus the projected Variant leaves - dictionary, residual and typed
+    // leaf - for the first row group (120 bytes). The fully shredded row group drops dictionary and
+    // residual and reads id plus the typed leaf (60 bytes).
+    EXPECT_EQ(plan.pruning_stats.filtered_bytes, 180);
 
     request.conjuncts.clear();
     ASSERT_TRUE(format::parquet::plan_parquet_row_groups(metadata, schema, request,

--- a/be/test/format_v2/parquet/parquet_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_reader_test.cpp
@@ -2028,6 +2028,66 @@ TEST(ParquetVariantProjectionTest, PrunesResidualColumnsOnlyWhenStatisticsProveT
     EXPECT_EQ(retained.children[0].local_id(), 0);
 }
 
+TEST(ParquetVariantProjectionTest, RepeatedVariantKeepsTheCompleteWrapper) {
+    using format::parquet::ParquetColumnSchema;
+    using format::parquet::ParquetColumnSchemaKind;
+    auto node = [](std::string name, int32_t local_id, ParquetColumnSchemaKind kind,
+                   int leaf_id = -1) {
+        auto result = std::make_unique<ParquetColumnSchema>();
+        result->name = std::move(name);
+        result->local_id = local_id;
+        result->kind = kind;
+        result->leaf_column_id = leaf_id;
+        return result;
+    };
+    auto root = node("v", 0, ParquetColumnSchemaKind::VARIANT);
+    // One physical entry per array element, not per row.
+    root->max_repetition_level = 1;
+    root->children.push_back(node("metadata", 0, ParquetColumnSchemaKind::PRIMITIVE, 0));
+    root->children.push_back(node("value", 1, ParquetColumnSchemaKind::PRIMITIVE, 1));
+    auto root_typed = node("typed_value", 2, ParquetColumnSchemaKind::STRUCT);
+    auto wrapper = node("n", 0, ParquetColumnSchemaKind::STRUCT);
+    wrapper->children.push_back(node("value", 0, ParquetColumnSchemaKind::PRIMITIVE, 2));
+    wrapper->children.push_back(node("typed_value", 1, ParquetColumnSchemaKind::PRIMITIVE, 3));
+    root_typed->children.push_back(std::move(wrapper));
+    root->children.push_back(std::move(root_typed));
+
+    // A projection that does carry its residual and the root dictionary, so the only thing that
+    // can send this row group back to the complete Variant is the repetition level.
+    auto projection = format::LocalColumnIndex::partial_local(0);
+    projection.children.push_back(format::LocalColumnIndex::local(0));
+    projection.children.push_back(format::LocalColumnIndex::partial_local(2));
+    auto& typed_projection = projection.children.back();
+    typed_projection.children.push_back(format::LocalColumnIndex::partial_local(0));
+    auto& wrapper_projection = typed_projection.children.back();
+    wrapper_projection.children.push_back(format::LocalColumnIndex::local(0));
+    wrapper_projection.children.push_back(format::LocalColumnIndex::local(1));
+
+    EXPECT_FALSE(format::parquet::detail::variant_projection_carries_residuals(*root, projection));
+
+    tparquet::RowGroup row_group;
+    row_group.__set_num_rows(10);
+    for (int leaf = 0; leaf < 4; ++leaf) {
+        tparquet::Statistics statistics;
+        statistics.__set_null_count(leaf == 2 ? 10 : 0);
+        tparquet::ColumnMetaData column_metadata;
+        column_metadata.__set_num_values(10);
+        column_metadata.__set_statistics(std::move(statistics));
+        tparquet::ColumnChunk chunk;
+        chunk.__set_meta_data(std::move(column_metadata));
+        row_group.columns.push_back(std::move(chunk));
+    }
+    auto finalized = projection;
+    size_t residual_projections = 0;
+    size_t full_projections = 0;
+    EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
+                      row_group, *root, &finalized, &residual_projections, &full_projections),
+              0);
+    EXPECT_TRUE(finalized.project_all_children);
+    EXPECT_EQ(residual_projections, 0);
+    EXPECT_EQ(full_projections, 1);
+}
+
 TEST(ParquetVariantProjectionTest, FinalizesPhysicalProjectionBeforeFooterPruning) {
     using format::parquet::ParquetColumnSchema;
     using format::parquet::ParquetColumnSchemaKind;

--- a/be/test/format_v2/parquet/parquet_reader_test.cpp
+++ b/be/test/format_v2/parquet/parquet_reader_test.cpp
@@ -1905,21 +1905,25 @@ TEST(ParquetVariantProjectionTest, ResidualStatisticsGuardPhysicalLeafProjection
     EXPECT_FALSE(row_group_projection.project_all_children);
     EXPECT_EQ(residual_projections, 0);
 
-    // A conforming partially shredded object keeps unrelated keys in the ancestor residual. The
-    // requested field is still complete when its own value column is all null.
+    // An ancestor residual that is not projected cannot be validated. Even though conforming files
+    // use it only for unrelated keys, this shape must restore the complete Variant rather than hide
+    // a malformed non-object carrier.
     row_group.columns[1].meta_data.statistics.__set_null_count(9);
     row_group_projection = projection;
     residual_projections = 0;
+    size_t full_projections = 0;
     EXPECT_EQ(format::parquet::detail::finalize_variant_leaf_projection_for_row_group(
-                      row_group, *root, &row_group_projection, &residual_projections),
-              1);
-    EXPECT_FALSE(row_group_projection.project_all_children);
+                      row_group, *root, &row_group_projection, &residual_projections,
+                      &full_projections),
+              0);
+    EXPECT_TRUE(row_group_projection.project_all_children);
     EXPECT_EQ(residual_projections, 0);
+    EXPECT_EQ(full_projections, 1);
     row_group.columns[1].meta_data.statistics.__set_null_count(10);
 
     // This projection does not read the residual beside the leaf, so a residual that carries
     // values cannot be served from leaves and the complete Variant comes back.
-    size_t full_projections = 0;
+    full_projections = 0;
     row_group.columns[2].meta_data.statistics.__set_null_count(9);
     row_group_projection = projection;
     residual_projections = 0;
@@ -1976,10 +1980,11 @@ TEST(ParquetVariantProjectionTest, PrunesResidualColumnsOnlyWhenStatisticsProveT
     root_typed->children.push_back(std::move(wrapper));
     root->children.push_back(std::move(root_typed));
 
-    // The projection the mapper now produces: root metadata beside typed_value, and the terminal
-    // wrapper's residual beside its typed leaf.
+    // The projection the mapper now produces: root metadata/value beside typed_value, and the
+    // terminal wrapper's residual beside its typed leaf.
     auto projection = format::LocalColumnIndex::partial_local(0);
     projection.children.push_back(format::LocalColumnIndex::local(0));
+    projection.children.push_back(format::LocalColumnIndex::local(1));
     projection.children.push_back(format::LocalColumnIndex::partial_local(2));
     auto& typed_projection = projection.children.back();
     typed_projection.children.push_back(format::LocalColumnIndex::partial_local(0));
@@ -1991,7 +1996,7 @@ TEST(ParquetVariantProjectionTest, PrunesResidualColumnsOnlyWhenStatisticsProveT
     row_group.__set_num_rows(10);
     for (int leaf = 0; leaf < 4; ++leaf) {
         tparquet::Statistics statistics;
-        statistics.__set_null_count(leaf == 2 ? 10 : 0);
+        statistics.__set_null_count(leaf == 1 || leaf == 2 ? 10 : 0);
         tparquet::ColumnMetaData column_metadata;
         column_metadata.__set_num_values(10);
         column_metadata.__set_statistics(std::move(statistics));
@@ -2001,16 +2006,17 @@ TEST(ParquetVariantProjectionTest, PrunesResidualColumnsOnlyWhenStatisticsProveT
     }
 
     // The terminal residual is entirely NULL, so the shredded leaf alone answers every row and
-    // both the residual and the root dictionary can be dropped from the read.
+    // residual carriers can be dropped, while root metadata remains for direct-result validation.
     auto pruned = projection;
     EXPECT_TRUE(format::parquet::detail::variant_residual_columns_are_prunable_for_row_group(
             row_group, *root, pruned));
     format::parquet::detail::prune_variant_residual_columns(*root, &pruned);
-    ASSERT_EQ(pruned.children.size(), 1);
-    EXPECT_EQ(pruned.children[0].local_id(), 2);
-    ASSERT_EQ(pruned.children[0].children.size(), 1);
-    ASSERT_EQ(pruned.children[0].children[0].children.size(), 1);
-    EXPECT_EQ(pruned.children[0].children[0].children[0].local_id(), 1);
+    ASSERT_EQ(pruned.children.size(), 2);
+    EXPECT_EQ(pruned.children[0].local_id(), 0);
+    EXPECT_EQ(pruned.children[1].local_id(), 2);
+    ASSERT_EQ(pruned.children[1].children.size(), 1);
+    ASSERT_EQ(pruned.children[1].children[0].children.size(), 1);
+    EXPECT_EQ(pruned.children[1].children[0].children[0].local_id(), 1);
 
     // One residual row is enough to keep the columns, but the projection stays a leaf projection:
     // the reader merges those rows instead of rebuilding the complete Variant.
@@ -2024,8 +2030,9 @@ TEST(ParquetVariantProjectionTest, PrunesResidualColumnsOnlyWhenStatisticsProveT
               1);
     EXPECT_FALSE(retained.project_all_children);
     EXPECT_EQ(residual_projections, 1);
-    ASSERT_EQ(retained.children.size(), 2);
+    ASSERT_EQ(retained.children.size(), 3);
     EXPECT_EQ(retained.children[0].local_id(), 0);
+    EXPECT_EQ(retained.children[1].local_id(), 1);
 }
 
 TEST(ParquetVariantProjectionTest, RepeatedVariantKeepsTheCompleteWrapper) {
@@ -2056,6 +2063,7 @@ TEST(ParquetVariantProjectionTest, RepeatedVariantKeepsTheCompleteWrapper) {
     // can send this row group back to the complete Variant is the repetition level.
     auto projection = format::LocalColumnIndex::partial_local(0);
     projection.children.push_back(format::LocalColumnIndex::local(0));
+    projection.children.push_back(format::LocalColumnIndex::local(1));
     projection.children.push_back(format::LocalColumnIndex::partial_local(2));
     auto& typed_projection = projection.children.back();
     typed_projection.children.push_back(format::LocalColumnIndex::partial_local(0));
@@ -2172,10 +2180,11 @@ TEST(ParquetVariantProjectionTest, FinalizesPhysicalProjectionBeforeFooterPrunin
     thrift_metadata.__set_column_orders({order, order, order, order, order});
     format::parquet::NativeParquetMetadata metadata(std::move(thrift_metadata), 0);
 
-    // The shape the mapper builds: the root dictionary and the terminal residual travel with the
-    // typed leaf so a row group whose residual carries values can still be served from leaves.
+    // The shape the mapper builds: the root dictionary, root carrier, and terminal residual travel
+    // with the typed leaf so direct results preserve complete corruption semantics.
     auto leaf_projection = format::LocalColumnIndex::partial_local(1);
     leaf_projection.children.push_back(format::LocalColumnIndex::local(0));
+    leaf_projection.children.push_back(format::LocalColumnIndex::local(1));
     leaf_projection.children.push_back(format::LocalColumnIndex::partial_local(2));
     leaf_projection.children.back().children.push_back(format::LocalColumnIndex::partial_local(0));
     leaf_projection.children.back().children.back().children.push_back(
@@ -2198,11 +2207,10 @@ TEST(ParquetVariantProjectionTest, FinalizesPhysicalProjectionBeforeFooterPrunin
                                                          &plan, nullptr, nullptr, &file_context)
                         .ok());
     EXPECT_TRUE(plan.row_groups.empty());
-    // Footer accounting uses id plus the projected Variant leaves - dictionary, residual and typed
-    // leaf - for the first row group (120 bytes). The fully shredded row group proves its residual
-    // is NULL, so it drops the dictionary and the residual and reads id plus the typed leaf
-    // (60 bytes).
-    EXPECT_EQ(plan.pruning_stats.filtered_bytes, 180);
+    // Footer accounting uses id plus dictionary, root/terminal residual, and typed leaf for the
+    // first row group (150 bytes). The fully shredded row group drops both residuals but retains
+    // required metadata validation, so it reads id, dictionary, and typed leaf (80 bytes).
+    EXPECT_EQ(plan.pruning_stats.filtered_bytes, 230);
 
     request.conjuncts.clear();
     ASSERT_TRUE(format::parquet::plan_parquet_row_groups(metadata, schema, request,

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -2182,8 +2182,10 @@ TEST(ParquetScanConditionCacheTest, HitKeepsCachedBaseWhenCurrentPlanStartsLater
              .page_skip_plans = {},
              .offset_indexes = {},
              .prunable_variant_projection_ordinals = {},
+             .full_variant_projection_ordinals = {},
              .variant_leaf_projection_columns = 0,
              .variant_residual_projection_columns = 0,
+             .variant_full_projection_columns = 0,
              .expensive_pruning_pending = false});
 
     format::parquet::ParquetScanScheduler scheduler;

--- a/be/test/format_v2/parquet/parquet_scan_test.cpp
+++ b/be/test/format_v2/parquet/parquet_scan_test.cpp
@@ -2181,9 +2181,9 @@ TEST(ParquetScanConditionCacheTest, HitKeepsCachedBaseWhenCurrentPlanStartsLater
              .selected_ranges = {{.start = 0, .length = ConditionCacheContext::GRANULE_SIZE}},
              .page_skip_plans = {},
              .offset_indexes = {},
-             .full_variant_projection_ordinals = {},
+             .prunable_variant_projection_ordinals = {},
              .variant_leaf_projection_columns = 0,
-             .variant_full_projection_columns = 0,
+             .variant_residual_projection_columns = 0,
              .expensive_pruning_pending = false});
 
     format::parquet::ParquetScanScheduler scheduler;

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -400,15 +400,20 @@ private:
 
 VExprContextSPtr variant_path_gt_conjunct(int32_t literal_value,
                                           bool add_narrowing_intermediate_cast = false,
-                                          bool decimal_comparison = false) {
+                                          bool decimal_comparison = false,
+                                          std::vector<std::string> path = {"col"}) {
     auto slot = VSlotRef::create_shared(0, 0, -1,
                                         make_nullable(std::make_shared<DataTypeVariantV2>()), "v");
-    auto key = VLiteral::create_shared(std::make_shared<DataTypeString>(),
-                                       Field::create_field<TYPE_STRING>("col"));
-    auto element_at = std::make_shared<VariantPathTestExpr>(
-            "element_at", make_nullable(std::make_shared<DataTypeVariantV2>()));
-    element_at->add_child(slot);
-    element_at->add_child(key);
+    VExprSPtr value_expr = slot;
+    for (auto& component : path) {
+        auto key = VLiteral::create_shared(std::make_shared<DataTypeString>(),
+                                           Field::create_field<TYPE_STRING>(component));
+        auto element_at = std::make_shared<VariantPathTestExpr>(
+                "element_at", make_nullable(std::make_shared<DataTypeVariantV2>()));
+        element_at->add_child(std::move(value_expr));
+        element_at->add_child(std::move(key));
+        value_expr = std::move(element_at);
+    }
     DataTypePtr comparison_type = decimal_comparison
                                           ? DataTypePtr(std::make_shared<DataTypeDecimal128>(38, 9))
                                           : DataTypePtr(std::make_shared<DataTypeInt32>());
@@ -417,10 +422,10 @@ VExprContextSPtr variant_path_gt_conjunct(int32_t literal_value,
     if (add_narrowing_intermediate_cast) {
         auto narrowing = std::make_shared<VariantPathTestExpr>(
                 "CAST", make_nullable(std::make_shared<DataTypeInt8>()), TExprNodeType::CAST_EXPR);
-        narrowing->add_child(element_at);
+        narrowing->add_child(value_expr);
         cast->add_child(narrowing);
     } else {
-        cast->add_child(element_at);
+        cast->add_child(value_expr);
     }
     auto literal = decimal_comparison
                            ? VLiteral::create_shared(
@@ -1992,8 +1997,8 @@ TEST(NativeParquetStatisticsTest, ShreddedVariantTypedValueDrivesPageFiltering) 
                         .ok());
     EXPECT_EQ(selected_row_groups, std::vector<int>({0}));
 
-    // Object residual keys are disjoint from shredded fields, so an unrelated root residual must
-    // not disable statistics for a complete nested field.
+    // Doris resolves a path from the first level whose typed object is absent. A root residual may
+    // therefore own the requested field, so typed-leaf statistics alone cannot exclude this group.
     footer_only_metadata = metadata;
     footer_only_metadata.row_groups[0].columns[3].meta_data.statistics.__set_max_value(
             encode_int32(2));
@@ -2003,7 +2008,7 @@ TEST(NativeParquetStatisticsTest, ShreddedVariantTypedValueDrivesPageFiltering) 
                         nullptr, nullptr, nullptr, nullptr, {},
                         format::parquet::ParquetMetadataProbeMode::FOOTER_ONLY)
                         .ok());
-    EXPECT_TRUE(selected_row_groups.empty());
+    EXPECT_EQ(selected_row_groups, std::vector<int>({0}));
 
     // A contradictory non-repeated value count cannot prove that every row lacks fallback bytes.
     footer_only_metadata = metadata;
@@ -2061,8 +2066,83 @@ TEST(NativeParquetStatisticsTest, ShreddedVariantTypedValueDrivesPageFiltering) 
                         &selected_ranges, &skip_plans, nullptr)
                         .ok());
     ASSERT_EQ(selected_ranges.size(), 1);
-    EXPECT_EQ(selected_ranges[0].start, 50);
-    EXPECT_EQ(selected_ranges[0].length, 50);
+    EXPECT_EQ(selected_ranges[0].start, 0);
+    EXPECT_EQ(selected_ranges[0].length, 100);
+
+    // The same rule applies at an intermediate object wrapper: if that level's typed object is
+    // absent, Doris continues the remaining path inside its residual value.
+    auto nested_variant = std::make_unique<format::parquet::ParquetColumnSchema>();
+    nested_variant->name = "v";
+    nested_variant->local_id = 0;
+    nested_variant->kind = format::parquet::ParquetColumnSchemaKind::VARIANT;
+    nested_variant->contains_variant = true;
+    nested_variant->type = make_nullable(std::make_shared<DataTypeVariantV2>());
+    nested_variant->children.push_back(bytes("metadata", 0, 0));
+    nested_variant->children.push_back(bytes("value", 1, 1));
+    auto nested_root_typed = std::make_unique<format::parquet::ParquetColumnSchema>();
+    nested_root_typed->name = "typed_value";
+    nested_root_typed->local_id = 2;
+    nested_root_typed->kind = format::parquet::ParquetColumnSchemaKind::STRUCT;
+    auto parent = std::make_unique<format::parquet::ParquetColumnSchema>();
+    parent->name = "parent";
+    parent->local_id = 0;
+    parent->kind = format::parquet::ParquetColumnSchemaKind::STRUCT;
+    parent->children.push_back(bytes("value", 0, 2));
+    auto parent_typed = std::make_unique<format::parquet::ParquetColumnSchema>();
+    parent_typed->name = "typed_value";
+    parent_typed->local_id = 1;
+    parent_typed->kind = format::parquet::ParquetColumnSchemaKind::STRUCT;
+    auto nested_field = std::make_unique<format::parquet::ParquetColumnSchema>();
+    nested_field->name = "col";
+    nested_field->local_id = 0;
+    nested_field->kind = format::parquet::ParquetColumnSchemaKind::STRUCT;
+    nested_field->children.push_back(bytes("value", 0, 3));
+    nested_field->children.push_back(primitive("typed_value", 1, 4));
+    parent_typed->children.push_back(std::move(nested_field));
+    parent->children.push_back(std::move(parent_typed));
+    nested_root_typed->children.push_back(std::move(parent));
+    nested_variant->children.push_back(std::move(nested_root_typed));
+    std::vector<std::unique_ptr<format::parquet::ParquetColumnSchema>> nested_schema;
+    nested_schema.push_back(std::move(nested_variant));
+
+    tparquet::RowGroup nested_row_group;
+    nested_row_group.__set_num_rows(100);
+    nested_row_group.__set_columns({chunk(tparquet::Type::BYTE_ARRAY, 100, 0),
+                                    chunk(tparquet::Type::BYTE_ARRAY, 100, 100),
+                                    chunk(tparquet::Type::BYTE_ARRAY, 100, 99),
+                                    chunk(tparquet::Type::BYTE_ARRAY, 100, 100),
+                                    chunk(tparquet::Type::INT32, 100, 0, 1, 2)});
+    tparquet::FileMetaData nested_metadata;
+    nested_metadata.__set_row_groups({nested_row_group});
+    nested_metadata.__set_column_orders({order, order, order, order, order});
+    format::FileScanRequest nested_request;
+    nested_request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
+    nested_request.predicate_columns = {
+            format::LocalColumnIndex::top_level(format::LocalColumnId(0))};
+    nested_request.conjuncts = {variant_path_gt_conjunct(50, false, false, {"parent", "col"})};
+
+    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
+                        nested_metadata, nested_schema, nested_request, nullptr,
+                        &selected_row_groups, false, nullptr, nullptr, nullptr, nullptr, {},
+                        format::parquet::ParquetMetadataProbeMode::FOOTER_ONLY)
+                        .ok());
+    EXPECT_EQ(selected_row_groups, std::vector<int>({0}));
+
+    format::parquet::NativeParquetPageIndex nested_typed_pages;
+    nested_typed_pages.column_index.__set_min_values({encode_int32(1)});
+    nested_typed_pages.column_index.__set_max_values({encode_int32(2)});
+    nested_typed_pages.column_index.__set_null_pages({false});
+    nested_typed_pages.column_index.__set_null_counts({0});
+    nested_typed_pages.offset_index.__set_page_locations({first});
+    std::unordered_map<int, format::parquet::NativeParquetPageIndex> nested_page_indexes;
+    nested_page_indexes.emplace(4, std::move(nested_typed_pages));
+    ASSERT_TRUE(format::parquet::select_row_group_ranges_by_native_page_index(
+                        nested_metadata, nested_row_group, nested_page_indexes, nested_schema,
+                        nested_request, 100, &selected_ranges, &skip_plans, nullptr)
+                        .ok());
+    ASSERT_EQ(selected_ranges.size(), 1);
+    EXPECT_EQ(selected_ranges[0].start, 0);
+    EXPECT_EQ(selected_ranges[0].length, 100);
 
     // Direct Variant numeric comparisons coerce integral literals to a wide DECIMAL domain.
     request.conjuncts = {variant_path_gt_conjunct(50, false, true)};

--- a/be/test/format_v2/parquet/parquet_statistics_test.cpp
+++ b/be/test/format_v2/parquet/parquet_statistics_test.cpp
@@ -400,20 +400,15 @@ private:
 
 VExprContextSPtr variant_path_gt_conjunct(int32_t literal_value,
                                           bool add_narrowing_intermediate_cast = false,
-                                          bool decimal_comparison = false,
-                                          std::vector<std::string> path = {"col"}) {
+                                          bool decimal_comparison = false) {
     auto slot = VSlotRef::create_shared(0, 0, -1,
                                         make_nullable(std::make_shared<DataTypeVariantV2>()), "v");
-    VExprSPtr value_expr = slot;
-    for (auto& component : path) {
-        auto key = VLiteral::create_shared(std::make_shared<DataTypeString>(),
-                                           Field::create_field<TYPE_STRING>(component));
-        auto element_at = std::make_shared<VariantPathTestExpr>(
-                "element_at", make_nullable(std::make_shared<DataTypeVariantV2>()));
-        element_at->add_child(std::move(value_expr));
-        element_at->add_child(std::move(key));
-        value_expr = std::move(element_at);
-    }
+    auto key = VLiteral::create_shared(std::make_shared<DataTypeString>(),
+                                       Field::create_field<TYPE_STRING>("col"));
+    auto element_at = std::make_shared<VariantPathTestExpr>(
+            "element_at", make_nullable(std::make_shared<DataTypeVariantV2>()));
+    element_at->add_child(slot);
+    element_at->add_child(key);
     DataTypePtr comparison_type = decimal_comparison
                                           ? DataTypePtr(std::make_shared<DataTypeDecimal128>(38, 9))
                                           : DataTypePtr(std::make_shared<DataTypeInt32>());
@@ -422,10 +417,10 @@ VExprContextSPtr variant_path_gt_conjunct(int32_t literal_value,
     if (add_narrowing_intermediate_cast) {
         auto narrowing = std::make_shared<VariantPathTestExpr>(
                 "CAST", make_nullable(std::make_shared<DataTypeInt8>()), TExprNodeType::CAST_EXPR);
-        narrowing->add_child(value_expr);
+        narrowing->add_child(element_at);
         cast->add_child(narrowing);
     } else {
-        cast->add_child(value_expr);
+        cast->add_child(element_at);
     }
     auto literal = decimal_comparison
                            ? VLiteral::create_shared(
@@ -1997,8 +1992,8 @@ TEST(NativeParquetStatisticsTest, ShreddedVariantTypedValueDrivesPageFiltering) 
                         .ok());
     EXPECT_EQ(selected_row_groups, std::vector<int>({0}));
 
-    // Doris resolves a path from the first level whose typed object is absent. A root residual may
-    // therefore own the requested field, so typed-leaf statistics alone cannot exclude this group.
+    // An unrelated root residual is outside the demand-driven leaf projection and does not disable
+    // typed statistics for a complete terminal field.
     footer_only_metadata = metadata;
     footer_only_metadata.row_groups[0].columns[3].meta_data.statistics.__set_max_value(
             encode_int32(2));
@@ -2008,7 +2003,7 @@ TEST(NativeParquetStatisticsTest, ShreddedVariantTypedValueDrivesPageFiltering) 
                         nullptr, nullptr, nullptr, nullptr, {},
                         format::parquet::ParquetMetadataProbeMode::FOOTER_ONLY)
                         .ok());
-    EXPECT_EQ(selected_row_groups, std::vector<int>({0}));
+    EXPECT_TRUE(selected_row_groups.empty());
 
     // A contradictory non-repeated value count cannot prove that every row lacks fallback bytes.
     footer_only_metadata = metadata;
@@ -2066,83 +2061,8 @@ TEST(NativeParquetStatisticsTest, ShreddedVariantTypedValueDrivesPageFiltering) 
                         &selected_ranges, &skip_plans, nullptr)
                         .ok());
     ASSERT_EQ(selected_ranges.size(), 1);
-    EXPECT_EQ(selected_ranges[0].start, 0);
-    EXPECT_EQ(selected_ranges[0].length, 100);
-
-    // The same rule applies at an intermediate object wrapper: if that level's typed object is
-    // absent, Doris continues the remaining path inside its residual value.
-    auto nested_variant = std::make_unique<format::parquet::ParquetColumnSchema>();
-    nested_variant->name = "v";
-    nested_variant->local_id = 0;
-    nested_variant->kind = format::parquet::ParquetColumnSchemaKind::VARIANT;
-    nested_variant->contains_variant = true;
-    nested_variant->type = make_nullable(std::make_shared<DataTypeVariantV2>());
-    nested_variant->children.push_back(bytes("metadata", 0, 0));
-    nested_variant->children.push_back(bytes("value", 1, 1));
-    auto nested_root_typed = std::make_unique<format::parquet::ParquetColumnSchema>();
-    nested_root_typed->name = "typed_value";
-    nested_root_typed->local_id = 2;
-    nested_root_typed->kind = format::parquet::ParquetColumnSchemaKind::STRUCT;
-    auto parent = std::make_unique<format::parquet::ParquetColumnSchema>();
-    parent->name = "parent";
-    parent->local_id = 0;
-    parent->kind = format::parquet::ParquetColumnSchemaKind::STRUCT;
-    parent->children.push_back(bytes("value", 0, 2));
-    auto parent_typed = std::make_unique<format::parquet::ParquetColumnSchema>();
-    parent_typed->name = "typed_value";
-    parent_typed->local_id = 1;
-    parent_typed->kind = format::parquet::ParquetColumnSchemaKind::STRUCT;
-    auto nested_field = std::make_unique<format::parquet::ParquetColumnSchema>();
-    nested_field->name = "col";
-    nested_field->local_id = 0;
-    nested_field->kind = format::parquet::ParquetColumnSchemaKind::STRUCT;
-    nested_field->children.push_back(bytes("value", 0, 3));
-    nested_field->children.push_back(primitive("typed_value", 1, 4));
-    parent_typed->children.push_back(std::move(nested_field));
-    parent->children.push_back(std::move(parent_typed));
-    nested_root_typed->children.push_back(std::move(parent));
-    nested_variant->children.push_back(std::move(nested_root_typed));
-    std::vector<std::unique_ptr<format::parquet::ParquetColumnSchema>> nested_schema;
-    nested_schema.push_back(std::move(nested_variant));
-
-    tparquet::RowGroup nested_row_group;
-    nested_row_group.__set_num_rows(100);
-    nested_row_group.__set_columns({chunk(tparquet::Type::BYTE_ARRAY, 100, 0),
-                                    chunk(tparquet::Type::BYTE_ARRAY, 100, 100),
-                                    chunk(tparquet::Type::BYTE_ARRAY, 100, 99),
-                                    chunk(tparquet::Type::BYTE_ARRAY, 100, 100),
-                                    chunk(tparquet::Type::INT32, 100, 0, 1, 2)});
-    tparquet::FileMetaData nested_metadata;
-    nested_metadata.__set_row_groups({nested_row_group});
-    nested_metadata.__set_column_orders({order, order, order, order, order});
-    format::FileScanRequest nested_request;
-    nested_request.local_positions.emplace(format::LocalColumnId(0), format::LocalIndex(0));
-    nested_request.predicate_columns = {
-            format::LocalColumnIndex::top_level(format::LocalColumnId(0))};
-    nested_request.conjuncts = {variant_path_gt_conjunct(50, false, false, {"parent", "col"})};
-
-    ASSERT_TRUE(format::parquet::select_row_groups_by_metadata(
-                        nested_metadata, nested_schema, nested_request, nullptr,
-                        &selected_row_groups, false, nullptr, nullptr, nullptr, nullptr, {},
-                        format::parquet::ParquetMetadataProbeMode::FOOTER_ONLY)
-                        .ok());
-    EXPECT_EQ(selected_row_groups, std::vector<int>({0}));
-
-    format::parquet::NativeParquetPageIndex nested_typed_pages;
-    nested_typed_pages.column_index.__set_min_values({encode_int32(1)});
-    nested_typed_pages.column_index.__set_max_values({encode_int32(2)});
-    nested_typed_pages.column_index.__set_null_pages({false});
-    nested_typed_pages.column_index.__set_null_counts({0});
-    nested_typed_pages.offset_index.__set_page_locations({first});
-    std::unordered_map<int, format::parquet::NativeParquetPageIndex> nested_page_indexes;
-    nested_page_indexes.emplace(4, std::move(nested_typed_pages));
-    ASSERT_TRUE(format::parquet::select_row_group_ranges_by_native_page_index(
-                        nested_metadata, nested_row_group, nested_page_indexes, nested_schema,
-                        nested_request, 100, &selected_ranges, &skip_plans, nullptr)
-                        .ok());
-    ASSERT_EQ(selected_ranges.size(), 1);
-    EXPECT_EQ(selected_ranges[0].start, 0);
-    EXPECT_EQ(selected_ranges[0].length, 100);
+    EXPECT_EQ(selected_ranges[0].start, 50);
+    EXPECT_EQ(selected_ranges[0].length, 50);
 
     // Direct Variant numeric comparisons coerce integral literals to a wide DECIMAL domain.
     request.conjuncts = {variant_path_gt_conjunct(50, false, true)};

--- a/be/test/format_v2/parquet/variant_column_reader_test.cpp
+++ b/be/test/format_v2/parquet/variant_column_reader_test.cpp
@@ -3753,6 +3753,8 @@ TEST(VariantColumnReaderTest, CompleteShreddedRootResidualObjectStillResolvesPat
         auto object = row.start_object();
         object.add_key(StringRef("a"));
         row.add_int(5);
+        object.add_key(StringRef("b"));
+        row.add_int(6);
         object.finish();
         row.finish();
     }
@@ -3779,6 +3781,7 @@ TEST(VariantColumnReaderTest, CompleteShreddedRootResidualObjectStillResolvesPat
     ASSERT_TRUE(materialize_variant_rows(shredded_object_schema(), *physical, output).ok());
     const auto& nullable = assert_cast<const ColumnNullable&>(*output);
 
+    detail::reset_variant_shredded_validation_counts();
     const auto extracted = extract_object_key(nullable, {StringRef("a")});
     const auto& extracted_nullable = assert_cast<const ColumnNullable&>(*extracted);
     const auto& extracted_variant =
@@ -3786,6 +3789,18 @@ TEST(VariantColumnReaderTest, CompleteShreddedRootResidualObjectStillResolvesPat
     EXPECT_EQ(extracted_nullable.get_null_map_data(), (NullMap {0, 0}));
     EXPECT_EQ(extracted_variant.get_value_ref(0).get_int(), 11);
     EXPECT_EQ(extracted_variant.get_value_ref(1).get_int(), 5);
+    const size_t validations = detail::variant_shredded_residual_validation_count();
+    EXPECT_EQ(validations, 1);
+
+    // Q10 evaluates many distinct paths that share one physical root carrier. Validation is keyed
+    // by that carrier rather than by path, so a second key must reuse the first successful scan.
+    const auto extracted_again = extract_object_key(nullable, {StringRef("b")});
+    const auto& extracted_again_nullable = assert_cast<const ColumnNullable&>(*extracted_again);
+    const auto& extracted_again_variant =
+            assert_cast<const ColumnVariantV2&>(extracted_again_nullable.get_nested_column());
+    EXPECT_EQ(extracted_again_nullable.get_null_map_data(), (NullMap {1, 0}));
+    EXPECT_EQ(extracted_again_variant.get_value_ref(1).get_int(), 6);
+    EXPECT_EQ(detail::variant_shredded_residual_validation_count(), validations);
 }
 
 TEST(VariantColumnReaderTest, AnnotatedStringLeafIsHandedOverWithoutCopying) {
@@ -4161,7 +4176,7 @@ TEST(VariantColumnReaderTest, ScalarIntermediateResolvesFromItsOwnResidual) {
               5);
 }
 
-TEST(VariantColumnReaderTest, DirectStringLeafRejectsInvalidUtf8) {
+TEST(VariantColumnReaderTest, DirectStringLeafDefersUtf8Validation) {
     auto schema = shredded_binary_object_schema();
     schema.children.back()->children[0]->children[0]->type_descriptor.is_string_annotation = true;
 
@@ -4183,14 +4198,22 @@ TEST(VariantColumnReaderTest, DirectStringLeafRejectsInvalidUtf8) {
     auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
     ASSERT_TRUE(materialize_variant_rows(schema, *physical, output).ok());
     const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    const auto& variants = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());
     ColumnPtr extracted;
     const Status status = extract_object_path(nullable, {StringRef("a")}, &extracted);
-    EXPECT_FALSE(status.ok());
-    EXPECT_NE(status.to_string().find("not valid UTF-8"), std::string::npos) << status;
-    EXPECT_FALSE(extracted);
+    ASSERT_TRUE(status.ok()) << status;
+    const auto& extracted_variants = assert_cast<const ColumnVariantV2&>(
+            assert_cast<const ColumnNullable&>(*extracted).get_nested_column());
+    ASSERT_TRUE(extracted_variants.is_typed());
+    const auto& typed = assert_cast<const ColumnNullable&>(extracted_variants.typed_column());
+    EXPECT_EQ(assert_cast<const ColumnString&>(typed.get_nested_column()).get_data_at(0),
+              StringRef(invalid_utf8.data(), invalid_utf8.size()));
+
+    // Complete Variant materialization still enforces Variant's UTF-8 requirement.
+    EXPECT_THROW(static_cast<void>(variants.get_value_ref(0)), Exception);
 }
 
-TEST(VariantColumnReaderTest, DirectLeafValidatesRootMetadata) {
+TEST(VariantColumnReaderTest, DirectLeafDefersUnusedRootMetadataValidation) {
     MutableColumns wrapper_fields;
     wrapper_fields.push_back(nullable_int64({7}, {0}));
     MutableColumns object_fields;
@@ -4205,6 +4228,46 @@ TEST(VariantColumnReaderTest, DirectLeafValidatesRootMetadata) {
 
     auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
     ASSERT_TRUE(materialize_variant_rows(shredded_object_schema(), *physical, output).ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    const auto& variants = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());
+    ColumnPtr extracted;
+    const Status status = extract_object_path(nullable, {StringRef("a")}, &extracted);
+    ASSERT_TRUE(status.ok()) << status;
+    const auto& extracted_variants = assert_cast<const ColumnVariantV2&>(
+            assert_cast<const ColumnNullable&>(*extracted).get_nested_column());
+    ASSERT_TRUE(extracted_variants.is_typed());
+    const auto& typed = assert_cast<const ColumnNullable&>(extracted_variants.typed_column());
+    EXPECT_EQ(assert_cast<const ColumnInt64&>(typed.get_nested_column()).get_data()[0], 7);
+
+    // Whole-Variant access still consumes the dictionary and therefore retains strict validation.
+    EXPECT_THROW(static_cast<void>(variants.get_value_ref(0)), Exception);
+}
+
+TEST(VariantColumnReaderTest, ResidualLeafValidatesRootMetadataOnDemand) {
+    VariantBatchBuilder residual_builder;
+    auto residual_row = residual_builder.begin_row();
+    residual_row.add_int(5);
+    residual_row.finish();
+    const VariantBatchBuilder residual_batch = residual_builder.finish_batch();
+    const VariantRef residual = residual_batch.value_at(0);
+
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(nullable_strings({residual.value}, {0}));
+    wrapper_fields.push_back(nullable_int64({0}, {1}));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(nullable_strings({StringRef("bad")}, {0}));
+    root_fields.push_back(nullable_strings({empty_bytes()}, {1}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(shredded_object_schema_with_field_residual(), *physical,
+                                         output)
+                        .ok());
     const auto& nullable = assert_cast<const ColumnNullable&>(*output);
     ColumnPtr extracted;
     const Status status = extract_object_path(nullable, {StringRef("a")}, &extracted);
@@ -4291,7 +4354,7 @@ TEST(VariantColumnReaderTest, DirectLeafRejectsNonObjectAncestorCarrier) {
     EXPECT_FALSE(extracted);
 }
 
-TEST(VariantColumnReaderTest, ResidualSeekRejectsCorruptSiblingPayload) {
+TEST(VariantColumnReaderTest, ResidualSeekDefersUnrelatedSiblingValidation) {
     VariantBatchBuilder residual_builder;
     auto residual_row = residual_builder.begin_row();
     auto residual_object = residual_row.start_object();
@@ -4326,11 +4389,16 @@ TEST(VariantColumnReaderTest, ResidualSeekRejectsCorruptSiblingPayload) {
     auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
     ASSERT_TRUE(materialize_variant_rows(shredded_object_schema(), *physical, output).ok());
     const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    const auto& variants = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());
     ColumnPtr extracted;
     const Status status = extract_object_path(nullable, {StringRef("b")}, &extracted);
-    EXPECT_FALSE(status.ok());
-    EXPECT_NE(status.to_string().find("Variant"), std::string::npos) << status;
-    EXPECT_FALSE(extracted);
+    ASSERT_TRUE(status.ok()) << status;
+    const auto& extracted_variants = assert_cast<const ColumnVariantV2&>(
+            assert_cast<const ColumnNullable&>(*extracted).get_nested_column());
+    EXPECT_EQ(extracted_variants.get_value_ref(0).get_int(), 5);
+
+    // Whole-Variant materialization still validates the complete residual, including siblings.
+    EXPECT_THROW(static_cast<void>(variants.get_value_ref(0)), Exception);
 }
 
 TEST(VariantColumnReaderTest, ResidualSeekRejectsNonterminalPrimitiveCarrierConflict) {

--- a/be/test/format_v2/parquet/variant_column_reader_test.cpp
+++ b/be/test/format_v2/parquet/variant_column_reader_test.cpp
@@ -45,6 +45,7 @@
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_string.h"
 #include "core/data_type/data_type_struct.h"
+#include "core/data_type/data_type_time.h"
 #include "core/data_type/data_type_timestamptz.h"
 #include "core/data_type/data_type_variant_v2.h"
 #include "core/value/timestamptz_value.h"
@@ -3500,6 +3501,33 @@ ParquetColumnSchema shredded_object_schema_with_field_residual() {
     return schema;
 }
 
+// Object shredding where an intermediate path field is shredded as a scalar, so a row whose value
+// for that field is an object cannot use the typed leaf and must come from the wrapper's residual.
+ParquetColumnSchema shredded_object_schema_with_scalar_intermediate() {
+    auto schema = unshredded_schema();
+    auto root_typed = std::make_unique<ParquetColumnSchema>();
+    root_typed->name = "typed_value";
+    root_typed->kind = ParquetColumnSchemaKind::STRUCT;
+
+    auto field = std::make_unique<ParquetColumnSchema>();
+    field->name = "b";
+    field->kind = ParquetColumnSchemaKind::STRUCT;
+    auto residual = std::make_unique<ParquetColumnSchema>();
+    residual->name = "value";
+    residual->kind = ParquetColumnSchemaKind::PRIMITIVE;
+    residual->type = make_nullable(std::make_shared<DataTypeString>());
+    auto field_typed = std::make_unique<ParquetColumnSchema>();
+    field_typed->name = "typed_value";
+    field_typed->kind = ParquetColumnSchemaKind::PRIMITIVE;
+    field_typed->type = make_nullable(std::make_shared<DataTypeInt64>());
+    field_typed->type_descriptor.integer_bit_width = 64;
+    field->children.push_back(std::move(residual));
+    field->children.push_back(std::move(field_typed));
+    root_typed->children.push_back(std::move(field));
+    schema.children.push_back(std::move(root_typed));
+    return schema;
+}
+
 // Object shredding where the requested field is stored unshredded: its wrapper carries a residual
 // `value` and no typed_value at all.
 ParquetColumnSchema shredded_object_schema_with_fallback_only_field() {
@@ -4089,6 +4117,67 @@ TEST(VariantColumnReaderTest, FallbackOnlyFieldResolvesFromItsOwnResidual) {
                       .get_value_ref(0)
                       .get_string(),
               StringRef("wrapped"));
+}
+
+TEST(VariantColumnReaderTest, ScalarIntermediateResolvesFromItsOwnResidual) {
+    // "b" is shredded as an int64, so a row whose "b" is an object stores it in b's own residual.
+    // Searching the root residual instead would never find it: shredding keeps "b" out of there.
+    VariantBatchBuilder residual_builder;
+    {
+        auto row = residual_builder.begin_row();
+        auto object = row.start_object();
+        object.add_key(StringRef("c"));
+        row.add_int(5);
+        object.finish();
+        row.finish();
+    }
+    const VariantBatchBuilder residual_batch = residual_builder.finish_batch();
+    const VariantRef residual = residual_batch.value_at(0);
+
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(
+            nullable_strings({StringRef(residual.value.data, residual.value.size)}, {0}));
+    wrapper_fields.push_back(nullable_int64({0}, {1}));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(
+            nullable_strings({StringRef(residual.metadata.data, residual.metadata.size)}, {0}));
+    root_fields.push_back(nullable_strings({empty_bytes()}, {1}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(shredded_object_schema_with_scalar_intermediate(),
+                                         *physical, output)
+                        .ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+
+    const auto extracted = extract_object_key(nullable, {StringRef("b"), StringRef("c")});
+    const auto& extracted_nullable = assert_cast<const ColumnNullable&>(*extracted);
+    ASSERT_EQ(extracted_nullable.get_null_map_data()[0], 0);
+    EXPECT_EQ(assert_cast<const ColumnVariantV2&>(extracted_nullable.get_nested_column())
+                      .get_value_ref(0)
+                      .get_int(),
+              5);
+}
+
+TEST(VariantColumnReaderTest, ShreddedTimeLeafKeepsItsMicrosecondScale) {
+    // Doris TIMEV2 stores microseconds, so encoding must not rescale it.
+    auto schema = shredded_primitive_schema(std::make_shared<DataTypeTimeV2>(6));
+    constexpr double MICROS = 3723000000.0; // 01:02:03
+    auto times = ColumnTimeV2::create();
+    times->get_data().push_back(MICROS);
+    auto physical = shredded_primitive_physical(
+            ColumnNullable::create(std::move(times), ColumnUInt8::create(1, 0)));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(schema, *physical, output).ok());
+    const auto& variants = assert_cast<const ColumnVariantV2&>(
+            assert_cast<const ColumnNullable&>(*output).get_nested_column());
+    EXPECT_EQ(variants.get_value_ref(0).get_time_ntz_micros(), static_cast<int64_t>(MICROS));
 }
 
 } // namespace doris::format::parquet

--- a/be/test/format_v2/parquet/variant_column_reader_test.cpp
+++ b/be/test/format_v2/parquet/variant_column_reader_test.cpp
@@ -1036,7 +1036,7 @@ TEST(VariantColumnReaderTest, UnshreddedCachedMissingStillValidatesEveryObject) 
     EXPECT_FALSE(result);
 }
 
-TEST(VariantColumnReaderTest, UnshreddedIntegerLeafKeepsCorruptMetadataOnFallback) {
+TEST(VariantColumnReaderTest, UnshreddedIntegerLeafRejectsCorruptMetadataBeforeHandoff) {
     VariantBatchBuilder builder;
     auto row = builder.begin_row();
     auto root = row.start_object();
@@ -1067,17 +1067,14 @@ TEST(VariantColumnReaderTest, UnshreddedIntegerLeafKeepsCorruptMetadataOnFallbac
     std::unique_ptr<ResolvedVariantElementV2Path> path;
     ASSERT_TRUE(resolve_variant_element_v2_path(segments, &path).ok());
     ColumnPtr result;
-    ASSERT_TRUE(extract_variant_element_v2(
-                        root_variants, *path,
-                        std::span<const uint8_t>(root_nullable.get_null_map_data().data(),
-                                                 root_nullable.get_null_map_data().size()),
-                        &result)
-                        .ok());
-
-    const auto& result_variants = assert_cast<const ColumnVariantV2&>(
-            assert_cast<const ColumnNullable&>(*result).get_nested_column());
-    ASSERT_TRUE(result_variants.is_shredded());
-    EXPECT_THROW((void)result_variants.get_value_ref(0), Exception);
+    const Status status = extract_variant_element_v2(
+            root_variants, *path,
+            std::span<const uint8_t>(root_nullable.get_null_map_data().data(),
+                                     root_nullable.get_null_map_data().size()),
+            &result);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("UTF-8"), std::string::npos) << status;
+    EXPECT_FALSE(result);
 }
 
 TEST(VariantColumnReaderTest, UnshreddedIntegerLeafValidatesLeadingJsonNull) {
@@ -1123,17 +1120,14 @@ TEST(VariantColumnReaderTest, UnshreddedIntegerLeafValidatesLeadingJsonNull) {
     std::unique_ptr<ResolvedVariantElementV2Path> path;
     ASSERT_TRUE(resolve_variant_element_v2_path(segments, &path).ok());
     ColumnPtr result;
-    ASSERT_TRUE(extract_variant_element_v2(
-                        root_variants, *path,
-                        std::span<const uint8_t>(root_nullable.get_null_map_data().data(),
-                                                 root_nullable.get_null_map_data().size()),
-                        &result)
-                        .ok());
-
-    const auto& result_variants = assert_cast<const ColumnVariantV2&>(
-            assert_cast<const ColumnNullable&>(*result).get_nested_column());
-    ASSERT_TRUE(result_variants.is_shredded());
-    EXPECT_THROW((void)result_variants.get_value_ref(0), Exception);
+    const Status status = extract_variant_element_v2(
+            root_variants, *path,
+            std::span<const uint8_t>(root_nullable.get_null_map_data().data(),
+                                     root_nullable.get_null_map_data().size()),
+            &result);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("UTF-8"), std::string::npos) << status;
+    EXPECT_FALSE(result);
 }
 
 TEST(VariantColumnReaderTest, UnshreddedIntegerLeafReportsCorruptPayloadOnFallback) {
@@ -3561,19 +3555,22 @@ StringRef empty_bytes() {
     return {EMPTY_BYTES.data(), 0};
 }
 
-ColumnPtr extract_object_key(const ColumnNullable& source, std::initializer_list<StringRef> keys) {
+Status extract_object_path(const ColumnNullable& source, std::initializer_list<StringRef> keys,
+                           ColumnPtr* extracted) {
     std::vector<VariantElementV2PathSegment> segments;
     segments.reserve(keys.size());
     for (const StringRef key : keys) {
         segments.push_back(VariantElementV2PathSegment::object_key(key));
     }
     std::unique_ptr<ResolvedVariantElementV2Path> resolved;
-    EXPECT_TRUE(resolve_variant_element_v2_path(segments, &resolved).ok());
-    ColumnPtr extracted;
+    RETURN_IF_ERROR(resolve_variant_element_v2_path(segments, &resolved));
     const auto& variants = assert_cast<const ColumnVariantV2&>(source.get_nested_column());
-    EXPECT_TRUE(
-            extract_variant_element_v2(variants, *resolved, source.get_null_map_data(), &extracted)
-                    .ok());
+    return extract_variant_element_v2(variants, *resolved, source.get_null_map_data(), extracted);
+}
+
+ColumnPtr extract_object_key(const ColumnNullable& source, std::initializer_list<StringRef> keys) {
+    ColumnPtr extracted;
+    EXPECT_TRUE(extract_object_path(source, keys, &extracted).ok());
     return extracted;
 }
 
@@ -4162,6 +4159,217 @@ TEST(VariantColumnReaderTest, ScalarIntermediateResolvesFromItsOwnResidual) {
                       .get_value_ref(0)
                       .get_int(),
               5);
+}
+
+TEST(VariantColumnReaderTest, DirectStringLeafRejectsInvalidUtf8) {
+    auto schema = shredded_binary_object_schema();
+    schema.children.back()->children[0]->children[0]->type_descriptor.is_string_annotation = true;
+
+    const StringRef metadata(VARIANT_EMPTY_METADATA.data(), VARIANT_EMPTY_METADATA.size());
+    const std::array<char, 1> invalid_utf8 {static_cast<char>(0xff)};
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(
+            nullable_strings({StringRef(invalid_utf8.data(), invalid_utf8.size())}, {0}));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(nullable_strings({metadata}, {0}));
+    root_fields.push_back(nullable_strings({empty_bytes()}, {1}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(schema, *physical, output).ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    ColumnPtr extracted;
+    const Status status = extract_object_path(nullable, {StringRef("a")}, &extracted);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("not valid UTF-8"), std::string::npos) << status;
+    EXPECT_FALSE(extracted);
+}
+
+TEST(VariantColumnReaderTest, DirectLeafValidatesRootMetadata) {
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(nullable_int64({7}, {0}));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(nullable_strings({StringRef("bad")}, {0}));
+    root_fields.push_back(nullable_strings({empty_bytes()}, {1}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(shredded_object_schema(), *physical, output).ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    ColumnPtr extracted;
+    const Status status = extract_object_path(nullable, {StringRef("a")}, &extracted);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("metadata"), std::string::npos) << status;
+    EXPECT_FALSE(extracted);
+}
+
+TEST(VariantColumnReaderTest, DirectLeafRejectsTerminalPrimitiveCarrierConflict) {
+    VariantBatchBuilder residual_builder;
+    auto residual_row = residual_builder.begin_row();
+    residual_row.add_int(5);
+    residual_row.finish();
+    const VariantBatchBuilder residual_batch = residual_builder.finish_batch();
+    const VariantRef residual = residual_batch.value_at(0);
+
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(nullable_strings({residual.value}, {0}));
+    wrapper_fields.push_back(nullable_int64({7}, {0}));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(
+            nullable_strings({StringRef(residual.metadata.data, residual.metadata.size)}, {0}));
+    root_fields.push_back(nullable_strings({empty_bytes()}, {1}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(shredded_object_schema_with_field_residual(), *physical,
+                                         output)
+                        .ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    ColumnPtr extracted;
+    const Status status = extract_object_path(nullable, {StringRef("a")}, &extracted);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("scalar typed_value cannot have residual"), std::string::npos)
+            << status;
+    EXPECT_FALSE(extracted);
+}
+
+TEST(VariantColumnReaderTest, DirectLeafRejectsNonObjectAncestorCarrier) {
+    VariantBatchBuilder residual_builder;
+    auto residual_row = residual_builder.begin_row();
+    residual_row.add_int(5);
+    residual_row.finish();
+    const VariantBatchBuilder residual_batch = residual_builder.finish_batch();
+    const VariantRef residual = residual_batch.value_at(0);
+
+    MutableColumns address_wrapper_fields;
+    address_wrapper_fields.push_back(nullable_int64({7}, {0}));
+    MutableColumns profile_object_fields;
+    profile_object_fields.push_back(ColumnNullable::create(
+            ColumnStruct::create(std::move(address_wrapper_fields)), ColumnUInt8::create(1, 0)));
+    MutableColumns profile_wrapper_fields;
+    profile_wrapper_fields.push_back(nullable_strings({residual.value}, {0}));
+    profile_wrapper_fields.push_back(ColumnNullable::create(
+            ColumnStruct::create(std::move(profile_object_fields)), ColumnUInt8::create(1, 0)));
+    MutableColumns root_object_fields;
+    root_object_fields.push_back(ColumnNullable::create(
+            ColumnStruct::create(std::move(profile_wrapper_fields)), ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(
+            nullable_strings({StringRef(residual.metadata.data, residual.metadata.size)}, {0}));
+    root_fields.push_back(nullable_strings({empty_bytes()}, {1}));
+    root_fields.push_back(ColumnNullable::create(
+            ColumnStruct::create(std::move(root_object_fields)), ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(shredded_deep_object_schema_with_ancestor_residual(),
+                                         *physical, output)
+                        .ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    ColumnPtr extracted;
+    const Status status =
+            extract_object_path(nullable, {StringRef("profile"), StringRef("address")}, &extracted);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("object typed_value has non-object residual"),
+              std::string::npos)
+            << status;
+    EXPECT_FALSE(extracted);
+}
+
+TEST(VariantColumnReaderTest, ResidualSeekRejectsCorruptSiblingPayload) {
+    VariantBatchBuilder residual_builder;
+    auto residual_row = residual_builder.begin_row();
+    auto residual_object = residual_row.start_object();
+    residual_object.add_key(StringRef("b"));
+    residual_row.add_int(5);
+    residual_object.add_key(StringRef("z"));
+    residual_row.add_int(7);
+    residual_object.finish();
+    residual_row.finish();
+    const VariantBatchBuilder residual_batch = residual_builder.finish_batch();
+    const VariantRef residual = residual_batch.value_at(0);
+    VariantRef sibling;
+    ASSERT_TRUE(residual.object_find(StringRef("z"), &sibling));
+    std::string corrupt_value(residual.value.data, residual.value.size);
+    const size_t sibling_offset = static_cast<size_t>(sibling.value.data - residual.value.data);
+    ASSERT_LT(sibling_offset, corrupt_value.size());
+    corrupt_value[sibling_offset] = static_cast<char>(0xff);
+
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(nullable_int64({11}, {0}));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(
+            nullable_strings({StringRef(residual.metadata.data, residual.metadata.size)}, {0}));
+    root_fields.push_back(nullable_strings({StringRef(corrupt_value)}, {0}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(shredded_object_schema(), *physical, output).ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    ColumnPtr extracted;
+    const Status status = extract_object_path(nullable, {StringRef("b")}, &extracted);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("Variant"), std::string::npos) << status;
+    EXPECT_FALSE(extracted);
+}
+
+TEST(VariantColumnReaderTest, ResidualSeekRejectsNonterminalPrimitiveCarrierConflict) {
+    VariantBatchBuilder residual_builder;
+    auto residual_row = residual_builder.begin_row();
+    auto residual_object = residual_row.start_object();
+    residual_object.add_key(StringRef("c"));
+    residual_row.add_int(5);
+    residual_object.finish();
+    residual_row.finish();
+    const VariantBatchBuilder residual_batch = residual_builder.finish_batch();
+    const VariantRef residual = residual_batch.value_at(0);
+
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(nullable_strings({residual.value}, {0}));
+    wrapper_fields.push_back(nullable_int64({9}, {0}));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(
+            nullable_strings({StringRef(residual.metadata.data, residual.metadata.size)}, {0}));
+    root_fields.push_back(nullable_strings({empty_bytes()}, {1}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(shredded_object_schema_with_scalar_intermediate(),
+                                         *physical, output)
+                        .ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    ColumnPtr extracted;
+    const Status status =
+            extract_object_path(nullable, {StringRef("b"), StringRef("c")}, &extracted);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("scalar typed_value cannot have residual"), std::string::npos)
+            << status;
+    EXPECT_FALSE(extracted);
 }
 
 TEST(VariantColumnReaderTest, ShreddedTimeLeafKeepsItsMicrosecondScale) {

--- a/be/test/format_v2/parquet/variant_column_reader_test.cpp
+++ b/be/test/format_v2/parquet/variant_column_reader_test.cpp
@@ -3587,7 +3587,14 @@ TEST(VariantColumnReaderTest, CompleteShreddedStringLeafSkipsCanonicalMaterializ
     ASSERT_EQ(extracted_nullable.get_null_map_data()[0], 0);
     const auto& extracted_variant =
             assert_cast<const ColumnVariantV2&>(extracted_nullable.get_nested_column());
-    EXPECT_EQ(extracted_variant.get_value_ref(0).get_string(), StringRef("abc"));
+    // The UTF-8 annotation lets the leaf ride the typed state, so the result keeps the decoded
+    // string column rather than encoded Variant rows.
+    ASSERT_TRUE(extracted_variant.is_typed());
+    EXPECT_EQ(assert_cast<const ColumnString&>(
+                      assert_cast<const ColumnNullable&>(extracted_variant.typed_column())
+                              .get_nested_column())
+                      .get_data_at(0),
+              StringRef("abc"));
 
     auto* reconstructed_rows = runtime_profile.get_counter("VariantReconstructedRows");
     ASSERT_NE(reconstructed_rows, nullptr);
@@ -3887,9 +3894,10 @@ TEST(VariantColumnReaderTest, UnshreddedKeySeeksRootResidualWithoutMaterializing
     auto* reconstructed_rows = runtime_profile.get_counter("VariantReconstructedRows");
     ASSERT_NE(reconstructed_rows, nullptr);
     EXPECT_EQ(reconstructed_rows->value(), 0);
+    // One row, resolved once through find_shredded_typed_value and once through element_at.
     auto* seek_rows = runtime_profile.get_counter("VariantResidualSeekRows");
     ASSERT_NE(seek_rows, nullptr);
-    EXPECT_EQ(seek_rows->value(), 1);
+    EXPECT_EQ(seek_rows->value(), 2);
 }
 
 TEST(VariantColumnReaderTest, KeyAbsentFromShreddingAndResidualResolvesToNull) {

--- a/be/test/format_v2/parquet/variant_column_reader_test.cpp
+++ b/be/test/format_v2/parquet/variant_column_reader_test.cpp
@@ -2486,7 +2486,7 @@ TEST(VariantColumnReaderTest, RetainedSchemaFollowsDecodedProjectionOrder) {
               22);
 }
 
-TEST(VariantColumnReaderTest, AmbiguousTypedIdentityRequiresCanonicalMaterialization) {
+TEST(VariantColumnReaderTest, AmbiguousTypedIdentityNormalizesLeafInsteadOfMaterializing) {
     const std::array<char, 1> ignored {0};
     const StringRef metadata(VARIANT_EMPTY_METADATA.data(), VARIANT_EMPTY_METADATA.size());
     MutableColumns wrapper_fields;
@@ -2508,7 +2508,20 @@ TEST(VariantColumnReaderTest, AmbiguousTypedIdentityRequiresCanonicalMaterializa
             assert_cast<const ColumnNullable&>(*output).get_nested_column());
     const std::array path {VariantShreddedPathSegment {
             .kind = VariantShreddedPathSegment::Kind::OBJECT_KEY, .key = StringRef("a")}};
-    EXPECT_FALSE(variants.find_shredded_typed_value(path).has_value());
+    // A binary annotation cannot ride the typed Variant state, but the leaf's Parquet schema still
+    // describes it exactly. Normalizing that leaf yields the same value the canonical rebuild would
+    // produce, so the complete root never has to be reconstructed.
+    const auto match = variants.find_shredded_typed_value(path);
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->column.get(), nullptr);
+    ASSERT_NE(match->normalized.get(), nullptr);
+    const auto& normalized = assert_cast<const ColumnNullable&>(*match->normalized);
+    ASSERT_EQ(normalized.get_null_map_data()[0], 0);
+    EXPECT_EQ(assert_cast<const ColumnVariantV2&>(normalized.get_nested_column())
+                      .get_value_ref(0)
+                      .get_binary(),
+              StringRef("abc"));
+
     VariantRef field;
     ASSERT_TRUE(variants.get_value_ref(0).object_find(StringRef("a"), &field));
     EXPECT_EQ(field.get_binary(), StringRef("abc"));
@@ -3470,6 +3483,264 @@ TEST(VariantColumnReaderTest, NestedMaterializationMovesUnaffectedSiblingBuffers
     EXPECT_NE(output.get(), empty_output);
     const auto& output_struct = assert_cast<const ColumnStruct&>(*output);
     EXPECT_EQ(&output_struct.get_column(0), decoded_label);
+}
+
+
+namespace {
+
+// Object shredding where the requested field wrapper also carries a residual `value` column, i.e.
+// rows whose value does not match the shredded leaf type.
+ParquetColumnSchema shredded_object_schema_with_field_residual() {
+    auto schema = shredded_object_schema();
+    auto* field = schema.children.back()->children[0].get();
+    auto value = std::make_unique<ParquetColumnSchema>();
+    value->name = "value";
+    value->kind = ParquetColumnSchemaKind::PRIMITIVE;
+    value->type = make_nullable(std::make_shared<DataTypeString>());
+    field->children.insert(field->children.begin(), std::move(value));
+    return schema;
+}
+
+// Deep object shredding where an ancestor of the requested leaf carries residual keys. Those keys
+// are disjoint from the shredded schema, so they can never supply the requested path.
+ParquetColumnSchema shredded_deep_object_schema_with_ancestor_residual() {
+    auto schema = shredded_deep_object_schema();
+    auto* profile = schema.children.back()->children[0].get();
+    auto value = std::make_unique<ParquetColumnSchema>();
+    value->name = "value";
+    value->kind = ParquetColumnSchemaKind::PRIMITIVE;
+    value->type = make_nullable(std::make_shared<DataTypeString>());
+    profile->children.insert(profile->children.begin(), std::move(value));
+    return schema;
+}
+
+constexpr std::array<char, 1> EMPTY_BYTES {0};
+
+StringRef empty_bytes() {
+    return {EMPTY_BYTES.data(), 0};
+}
+
+ColumnPtr extract_object_key(const ColumnNullable& source, std::initializer_list<StringRef> keys) {
+    std::vector<VariantElementV2PathSegment> segments;
+    segments.reserve(keys.size());
+    for (const StringRef key : keys) {
+        segments.push_back(VariantElementV2PathSegment::object_key(key));
+    }
+    std::unique_ptr<ResolvedVariantElementV2Path> resolved;
+    EXPECT_TRUE(resolve_variant_element_v2_path(segments, &resolved).ok());
+    ColumnPtr extracted;
+    const auto& variants = assert_cast<const ColumnVariantV2&>(source.get_nested_column());
+    EXPECT_TRUE(extract_variant_element_v2(variants, *resolved, source.get_null_map_data(),
+                                           &extracted)
+                        .ok());
+    return extracted;
+}
+
+} // namespace
+
+TEST(VariantColumnReaderTest, CompleteShreddedStringLeafSkipsCanonicalMaterialization) {
+    auto schema = shredded_binary_object_schema();
+    schema.children.back()->children[0]->children[0]->type_descriptor.is_string_annotation = true;
+
+    const StringRef metadata(VARIANT_EMPTY_METADATA.data(), VARIANT_EMPTY_METADATA.size());
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(nullable_strings({StringRef("abc")}, {0}));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(
+            ColumnStruct::create(std::move(wrapper_fields)), ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(nullable_strings({metadata}, {0}));
+    root_fields.push_back(nullable_strings({empty_bytes()}, {1}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    RuntimeProfile runtime_profile("complete-shredded-string-leaf");
+    ParquetProfile parquet_profile;
+    parquet_profile.init(&runtime_profile);
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(schema, *physical, output,
+                                         parquet_profile.column_reader_profile())
+                        .ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    const auto& variants = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());
+
+    const std::array path {VariantShreddedPathSegment {
+            .kind = VariantShreddedPathSegment::Kind::OBJECT_KEY, .key = StringRef("a")}};
+    ASSERT_TRUE(variants.find_shredded_typed_value(path).has_value());
+
+    const auto extracted = extract_object_key(nullable, {StringRef("a")});
+    const auto& extracted_nullable = assert_cast<const ColumnNullable&>(*extracted);
+    ASSERT_EQ(extracted_nullable.get_null_map_data()[0], 0);
+    const auto& extracted_variant =
+            assert_cast<const ColumnVariantV2&>(extracted_nullable.get_nested_column());
+    EXPECT_EQ(extracted_variant.get_value_ref(0).get_string(), StringRef("abc"));
+
+    auto* reconstructed_rows = runtime_profile.get_counter("VariantReconstructedRows");
+    ASSERT_NE(reconstructed_rows, nullptr);
+    EXPECT_EQ(reconstructed_rows->value(), 0);
+}
+
+TEST(VariantColumnReaderTest, CompleteShreddedLeafMergesTerminalResidualRows) {
+    VariantBatchBuilder residual_builder;
+    {
+        auto row = residual_builder.begin_row();
+        row.add_string(StringRef("x"));
+        row.finish();
+    }
+    const VariantBatchBuilder residual_batch = residual_builder.finish_batch();
+    const VariantRef residual = residual_batch.value_at(0);
+    const StringRef residual_metadata(residual.metadata.data, residual.metadata.size);
+    const StringRef residual_value(residual.value.data, residual.value.size);
+
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(
+            nullable_strings({empty_bytes(), residual_value, empty_bytes()}, {1, 0, 1}));
+    wrapper_fields.push_back(nullable_int64({11, 0, 0}, {0, 1, 1}));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(
+            ColumnStruct::create(std::move(wrapper_fields)), ColumnUInt8::create(3, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(nullable_strings(
+            {residual_metadata, residual_metadata, residual_metadata}, {0, 0, 0}));
+    root_fields.push_back(
+            nullable_strings({empty_bytes(), empty_bytes(), empty_bytes()}, {1, 1, 1}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 ColumnUInt8::create(3, 0)));
+    auto physical = root_wrapper(std::move(root_fields), NullMap(3, 0));
+
+    RuntimeProfile runtime_profile("complete-shredded-terminal-residual");
+    ParquetProfile parquet_profile;
+    parquet_profile.init(&runtime_profile);
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(shredded_object_schema_with_field_residual(), *physical,
+                                         output, parquet_profile.column_reader_profile())
+                        .ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    const auto& variants = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());
+
+    const std::array path {VariantShreddedPathSegment {
+            .kind = VariantShreddedPathSegment::Kind::OBJECT_KEY, .key = StringRef("a")}};
+    ASSERT_TRUE(variants.find_shredded_typed_value(path).has_value());
+
+    const auto extracted = extract_object_key(nullable, {StringRef("a")});
+    const auto& extracted_nullable = assert_cast<const ColumnNullable&>(*extracted);
+    const auto& extracted_variant =
+            assert_cast<const ColumnVariantV2&>(extracted_nullable.get_nested_column());
+    EXPECT_EQ(extracted_nullable.get_null_map_data(), (NullMap {0, 0, 1}));
+    EXPECT_EQ(extracted_variant.get_value_ref(0).get_int(), 11);
+    EXPECT_EQ(extracted_variant.get_value_ref(1).get_string(), StringRef("x"));
+
+    auto* reconstructed_rows = runtime_profile.get_counter("VariantReconstructedRows");
+    ASSERT_NE(reconstructed_rows, nullptr);
+    EXPECT_EQ(reconstructed_rows->value(), 0);
+}
+
+TEST(VariantColumnReaderTest, CompleteShreddedAncestorResidualKeepsDirectLeaf) {
+    VariantBatchBuilder residual_builder;
+    {
+        auto row = residual_builder.begin_row();
+        auto object = row.start_object();
+        object.add_key(StringRef("unrelated"));
+        row.add_int(7);
+        object.finish();
+        row.finish();
+    }
+    const VariantBatchBuilder residual_batch = residual_builder.finish_batch();
+    const VariantRef residual = residual_batch.value_at(0);
+
+    MutableColumnPtr address_leaf = nullable_int64({5}, {0});
+    const IColumn* const decoded_address_leaf = address_leaf.get();
+    MutableColumns address_wrapper_fields;
+    address_wrapper_fields.push_back(std::move(address_leaf));
+    MutableColumns profile_object_fields;
+    profile_object_fields.push_back(ColumnNullable::create(
+            ColumnStruct::create(std::move(address_wrapper_fields)), ColumnUInt8::create(1, 0)));
+    MutableColumns profile_wrapper_fields;
+    profile_wrapper_fields.push_back(
+            nullable_strings({StringRef(residual.value.data, residual.value.size)}, {0}));
+    profile_wrapper_fields.push_back(ColumnNullable::create(
+            ColumnStruct::create(std::move(profile_object_fields)), ColumnUInt8::create(1, 0)));
+    MutableColumns root_object_fields;
+    root_object_fields.push_back(ColumnNullable::create(
+            ColumnStruct::create(std::move(profile_wrapper_fields)), ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(
+            nullable_strings({StringRef(residual.metadata.data, residual.metadata.size)}, {0}));
+    root_fields.push_back(nullable_strings({empty_bytes()}, {1}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(root_object_fields)),
+                                                 ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    RuntimeProfile runtime_profile("complete-shredded-ancestor-residual");
+    ParquetProfile parquet_profile;
+    parquet_profile.init(&runtime_profile);
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(shredded_deep_object_schema_with_ancestor_residual(),
+                                         *physical, output,
+                                         parquet_profile.column_reader_profile())
+                        .ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    const auto& variants = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());
+
+    const std::array path {
+            VariantShreddedPathSegment {.kind = VariantShreddedPathSegment::Kind::OBJECT_KEY,
+                                        .key = StringRef("profile")},
+            VariantShreddedPathSegment {.kind = VariantShreddedPathSegment::Kind::OBJECT_KEY,
+                                        .key = StringRef("address")}};
+    const auto match = variants.find_shredded_typed_value(path);
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->column.get(), decoded_address_leaf);
+
+    const auto extracted = extract_object_key(nullable, {StringRef("profile"), StringRef("address")});
+    const auto& extracted_nullable = assert_cast<const ColumnNullable&>(*extracted);
+    ASSERT_EQ(extracted_nullable.get_null_map_data()[0], 0);
+
+    auto* reconstructed_rows = runtime_profile.get_counter("VariantReconstructedRows");
+    ASSERT_NE(reconstructed_rows, nullptr);
+    EXPECT_EQ(reconstructed_rows->value(), 0);
+}
+
+TEST(VariantColumnReaderTest, CompleteShreddedRootResidualObjectStillResolvesPath) {
+    VariantBatchBuilder residual_builder;
+    {
+        auto row = residual_builder.begin_row();
+        auto object = row.start_object();
+        object.add_key(StringRef("a"));
+        row.add_int(5);
+        object.finish();
+        row.finish();
+    }
+    const VariantBatchBuilder residual_batch = residual_builder.finish_batch();
+    const VariantRef residual = residual_batch.value_at(0);
+    const StringRef residual_metadata(residual.metadata.data, residual.metadata.size);
+    const StringRef residual_value(residual.value.data, residual.value.size);
+
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(nullable_int64({11, 0}, {0, 1}));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(
+            ColumnStruct::create(std::move(wrapper_fields)), ColumnUInt8::create(2, 0)));
+    auto object_nulls = ColumnUInt8::create();
+    object_nulls->get_data().assign(NullMap {0, 1});
+    MutableColumns root_fields;
+    root_fields.push_back(nullable_strings({residual_metadata, residual_metadata}, {0, 0}));
+    root_fields.push_back(nullable_strings({empty_bytes(), residual_value}, {1, 0}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 std::move(object_nulls)));
+    auto physical = root_wrapper(std::move(root_fields), NullMap(2, 0));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(shredded_object_schema(), *physical, output).ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+
+    const auto extracted = extract_object_key(nullable, {StringRef("a")});
+    const auto& extracted_nullable = assert_cast<const ColumnNullable&>(*extracted);
+    const auto& extracted_variant =
+            assert_cast<const ColumnVariantV2&>(extracted_nullable.get_nested_column());
+    EXPECT_EQ(extracted_nullable.get_null_map_data(), (NullMap {0, 0}));
+    EXPECT_EQ(extracted_variant.get_value_ref(0).get_int(), 11);
+    EXPECT_EQ(extracted_variant.get_value_ref(1).get_int(), 5);
 }
 
 } // namespace doris::format::parquet

--- a/be/test/format_v2/parquet/variant_column_reader_test.cpp
+++ b/be/test/format_v2/parquet/variant_column_reader_test.cpp
@@ -3485,7 +3485,6 @@ TEST(VariantColumnReaderTest, NestedMaterializationMovesUnaffectedSiblingBuffers
     EXPECT_EQ(&output_struct.get_column(0), decoded_label);
 }
 
-
 namespace {
 
 // Object shredding where the requested field wrapper also carries a residual `value` column, i.e.
@@ -3530,9 +3529,9 @@ ColumnPtr extract_object_key(const ColumnNullable& source, std::initializer_list
     EXPECT_TRUE(resolve_variant_element_v2_path(segments, &resolved).ok());
     ColumnPtr extracted;
     const auto& variants = assert_cast<const ColumnVariantV2&>(source.get_nested_column());
-    EXPECT_TRUE(extract_variant_element_v2(variants, *resolved, source.get_null_map_data(),
-                                           &extracted)
-                        .ok());
+    EXPECT_TRUE(
+            extract_variant_element_v2(variants, *resolved, source.get_null_map_data(), &extracted)
+                    .ok());
     return extracted;
 }
 
@@ -3546,8 +3545,8 @@ TEST(VariantColumnReaderTest, CompleteShreddedStringLeafSkipsCanonicalMaterializ
     MutableColumns wrapper_fields;
     wrapper_fields.push_back(nullable_strings({StringRef("abc")}, {0}));
     MutableColumns object_fields;
-    object_fields.push_back(ColumnNullable::create(
-            ColumnStruct::create(std::move(wrapper_fields)), ColumnUInt8::create(1, 0)));
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(1, 0)));
     MutableColumns root_fields;
     root_fields.push_back(nullable_strings({metadata}, {0}));
     root_fields.push_back(nullable_strings({empty_bytes()}, {1}));
@@ -3598,11 +3597,11 @@ TEST(VariantColumnReaderTest, CompleteShreddedLeafMergesTerminalResidualRows) {
             nullable_strings({empty_bytes(), residual_value, empty_bytes()}, {1, 0, 1}));
     wrapper_fields.push_back(nullable_int64({11, 0, 0}, {0, 1, 1}));
     MutableColumns object_fields;
-    object_fields.push_back(ColumnNullable::create(
-            ColumnStruct::create(std::move(wrapper_fields)), ColumnUInt8::create(3, 0)));
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(3, 0)));
     MutableColumns root_fields;
-    root_fields.push_back(nullable_strings(
-            {residual_metadata, residual_metadata, residual_metadata}, {0, 0, 0}));
+    root_fields.push_back(
+            nullable_strings({residual_metadata, residual_metadata, residual_metadata}, {0, 0, 0}));
     root_fields.push_back(
             nullable_strings({empty_bytes(), empty_bytes(), empty_bytes()}, {1, 1, 1}));
     root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
@@ -3668,8 +3667,8 @@ TEST(VariantColumnReaderTest, CompleteShreddedAncestorResidualKeepsDirectLeaf) {
     root_fields.push_back(
             nullable_strings({StringRef(residual.metadata.data, residual.metadata.size)}, {0}));
     root_fields.push_back(nullable_strings({empty_bytes()}, {1}));
-    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(root_object_fields)),
-                                                 ColumnUInt8::create(1, 0)));
+    root_fields.push_back(ColumnNullable::create(
+            ColumnStruct::create(std::move(root_object_fields)), ColumnUInt8::create(1, 0)));
     auto physical = root_wrapper(std::move(root_fields));
 
     RuntimeProfile runtime_profile("complete-shredded-ancestor-residual");
@@ -3677,8 +3676,7 @@ TEST(VariantColumnReaderTest, CompleteShreddedAncestorResidualKeepsDirectLeaf) {
     parquet_profile.init(&runtime_profile);
     auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
     ASSERT_TRUE(materialize_variant_rows(shredded_deep_object_schema_with_ancestor_residual(),
-                                         *physical, output,
-                                         parquet_profile.column_reader_profile())
+                                         *physical, output, parquet_profile.column_reader_profile())
                         .ok());
     const auto& nullable = assert_cast<const ColumnNullable&>(*output);
     const auto& variants = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());
@@ -3692,7 +3690,8 @@ TEST(VariantColumnReaderTest, CompleteShreddedAncestorResidualKeepsDirectLeaf) {
     ASSERT_TRUE(match.has_value());
     EXPECT_EQ(match->column.get(), decoded_address_leaf);
 
-    const auto extracted = extract_object_key(nullable, {StringRef("profile"), StringRef("address")});
+    const auto extracted =
+            extract_object_key(nullable, {StringRef("profile"), StringRef("address")});
     const auto& extracted_nullable = assert_cast<const ColumnNullable&>(*extracted);
     ASSERT_EQ(extracted_nullable.get_null_map_data()[0], 0);
 
@@ -3719,8 +3718,8 @@ TEST(VariantColumnReaderTest, CompleteShreddedRootResidualObjectStillResolvesPat
     MutableColumns wrapper_fields;
     wrapper_fields.push_back(nullable_int64({11, 0}, {0, 1}));
     MutableColumns object_fields;
-    object_fields.push_back(ColumnNullable::create(
-            ColumnStruct::create(std::move(wrapper_fields)), ColumnUInt8::create(2, 0)));
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(2, 0)));
     auto object_nulls = ColumnUInt8::create();
     object_nulls->get_data().assign(NullMap {0, 1});
     MutableColumns root_fields;
@@ -3741,6 +3740,84 @@ TEST(VariantColumnReaderTest, CompleteShreddedRootResidualObjectStillResolvesPat
     EXPECT_EQ(extracted_nullable.get_null_map_data(), (NullMap {0, 0}));
     EXPECT_EQ(extracted_variant.get_value_ref(0).get_int(), 11);
     EXPECT_EQ(extracted_variant.get_value_ref(1).get_int(), 5);
+}
+
+TEST(VariantColumnReaderTest, AnnotatedStringLeafIsHandedOverWithoutCopying) {
+    auto schema = shredded_binary_object_schema();
+    schema.children.back()->children[0]->children[0]->type_descriptor.is_string_annotation = true;
+
+    const StringRef metadata(VARIANT_EMPTY_METADATA.data(), VARIANT_EMPTY_METADATA.size());
+    MutableColumnPtr typed_leaf = nullable_strings({StringRef("example.com")}, {0});
+    const IColumn* const decoded_leaf = typed_leaf.get();
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(std::move(typed_leaf));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(nullable_strings({metadata}, {0}));
+    root_fields.push_back(nullable_strings({empty_bytes()}, {1}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(schema, *physical, output).ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    const auto& variants = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());
+
+    const std::array path {VariantShreddedPathSegment {
+            .kind = VariantShreddedPathSegment::Kind::OBJECT_KEY, .key = StringRef("a")}};
+    const auto match = variants.find_shredded_typed_value(path);
+    ASSERT_TRUE(match.has_value());
+    // A UTF-8 annotated leaf is handed over as decoded, with no re-encoding at all.
+    EXPECT_EQ(match->column.get(), decoded_leaf);
+    EXPECT_EQ(match->normalized.get(), nullptr);
+    ASSERT_NE(match->type, nullptr);
+    EXPECT_EQ(match->type->get_primitive_type(), TYPE_STRING);
+
+    const auto extracted = extract_object_key(nullable, {StringRef("a")});
+    const auto& extracted_nullable = assert_cast<const ColumnNullable&>(*extracted);
+    const auto& extracted_variant =
+            assert_cast<const ColumnVariantV2&>(extracted_nullable.get_nested_column());
+    ASSERT_TRUE(extracted_variant.is_typed());
+    EXPECT_EQ(&extracted_variant.typed_column(), decoded_leaf);
+}
+
+TEST(VariantColumnReaderTest, UnannotatedByteArrayLeafStillNormalizes) {
+    // Without the UTF-8 annotation a BYTE_ARRAY leaf is raw binary. The typed state stores only a
+    // Doris type and could not tell the two apart, so the leaf keeps its normalized form.
+    auto schema = shredded_binary_object_schema();
+
+    const StringRef metadata(VARIANT_EMPTY_METADATA.data(), VARIANT_EMPTY_METADATA.size());
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(nullable_strings({StringRef("abc")}, {0}));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(nullable_strings({metadata}, {0}));
+    root_fields.push_back(nullable_strings({empty_bytes()}, {1}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(schema, *physical, output).ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    const auto& variants = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());
+
+    const std::array path {VariantShreddedPathSegment {
+            .kind = VariantShreddedPathSegment::Kind::OBJECT_KEY, .key = StringRef("a")}};
+    const auto match = variants.find_shredded_typed_value(path);
+    ASSERT_TRUE(match.has_value());
+    EXPECT_EQ(match->column.get(), nullptr);
+    ASSERT_NE(match->normalized.get(), nullptr);
+    const auto& normalized = assert_cast<const ColumnNullable&>(*match->normalized);
+    EXPECT_EQ(assert_cast<const ColumnVariantV2&>(normalized.get_nested_column())
+                      .get_value_ref(0)
+                      .get_binary(),
+              StringRef("abc"));
 }
 
 } // namespace doris::format::parquet

--- a/be/test/format_v2/parquet/variant_column_reader_test.cpp
+++ b/be/test/format_v2/parquet/variant_column_reader_test.cpp
@@ -3500,6 +3500,20 @@ ParquetColumnSchema shredded_object_schema_with_field_residual() {
     return schema;
 }
 
+// Object shredding where the requested field is stored unshredded: its wrapper carries a residual
+// `value` and no typed_value at all.
+ParquetColumnSchema shredded_object_schema_with_fallback_only_field() {
+    auto schema = shredded_object_schema();
+    auto* field = schema.children.back()->children[0].get();
+    field->children.clear();
+    auto value = std::make_unique<ParquetColumnSchema>();
+    value->name = "value";
+    value->kind = ParquetColumnSchemaKind::PRIMITIVE;
+    value->type = make_nullable(std::make_shared<DataTypeString>());
+    field->children.push_back(std::move(value));
+    return schema;
+}
+
 // Deep object shredding where an ancestor of the requested leaf carries residual keys. Those keys
 // are disjoint from the shredded schema, so they can never supply the requested path.
 ParquetColumnSchema shredded_deep_object_schema_with_ancestor_residual() {
@@ -3818,6 +3832,255 @@ TEST(VariantColumnReaderTest, UnannotatedByteArrayLeafStillNormalizes) {
                       .get_value_ref(0)
                       .get_binary(),
               StringRef("abc"));
+}
+
+TEST(VariantColumnReaderTest, UnshreddedKeySeeksRootResidualWithoutMaterializing) {
+    VariantBatchBuilder residual_builder;
+    {
+        auto row = residual_builder.begin_row();
+        auto object = row.start_object();
+        object.add_key(StringRef("b"));
+        row.add_string(StringRef("hello"));
+        object.finish();
+        row.finish();
+    }
+    const VariantBatchBuilder residual_batch = residual_builder.finish_batch();
+    const VariantRef residual = residual_batch.value_at(0);
+
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(nullable_int64({11}, {0}));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(
+            nullable_strings({StringRef(residual.metadata.data, residual.metadata.size)}, {0}));
+    root_fields.push_back(
+            nullable_strings({StringRef(residual.value.data, residual.value.size)}, {0}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    RuntimeProfile runtime_profile("unshredded-key-root-residual");
+    ParquetProfile parquet_profile;
+    parquet_profile.init(&runtime_profile);
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(shredded_object_schema(), *physical, output,
+                                         parquet_profile.column_reader_profile())
+                        .ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    const auto& variants = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());
+
+    // "b" is not in the shredding schema, so it can only live in the root residual.
+    const std::array path {VariantShreddedPathSegment {
+            .kind = VariantShreddedPathSegment::Kind::OBJECT_KEY, .key = StringRef("b")}};
+    ASSERT_TRUE(variants.find_shredded_typed_value(path).has_value());
+
+    const auto extracted = extract_object_key(nullable, {StringRef("b")});
+    const auto& extracted_nullable = assert_cast<const ColumnNullable&>(*extracted);
+    ASSERT_EQ(extracted_nullable.get_null_map_data()[0], 0);
+    EXPECT_EQ(assert_cast<const ColumnVariantV2&>(extracted_nullable.get_nested_column())
+                      .get_value_ref(0)
+                      .get_string(),
+              StringRef("hello"));
+
+    auto* reconstructed_rows = runtime_profile.get_counter("VariantReconstructedRows");
+    ASSERT_NE(reconstructed_rows, nullptr);
+    EXPECT_EQ(reconstructed_rows->value(), 0);
+    auto* seek_rows = runtime_profile.get_counter("VariantResidualSeekRows");
+    ASSERT_NE(seek_rows, nullptr);
+    EXPECT_EQ(seek_rows->value(), 1);
+}
+
+TEST(VariantColumnReaderTest, KeyAbsentFromShreddingAndResidualResolvesToNull) {
+    VariantBatchBuilder residual_builder;
+    {
+        auto row = residual_builder.begin_row();
+        auto object = row.start_object();
+        object.add_key(StringRef("b"));
+        row.add_string(StringRef("hello"));
+        object.finish();
+        row.finish();
+    }
+    const VariantBatchBuilder residual_batch = residual_builder.finish_batch();
+    const VariantRef residual = residual_batch.value_at(0);
+
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(nullable_int64({11}, {0}));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(
+            nullable_strings({StringRef(residual.metadata.data, residual.metadata.size)}, {0}));
+    root_fields.push_back(
+            nullable_strings({StringRef(residual.value.data, residual.value.size)}, {0}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(shredded_object_schema(), *physical, output).ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+
+    const auto extracted = extract_object_key(nullable, {StringRef("missing")});
+    const auto& extracted_nullable = assert_cast<const ColumnNullable&>(*extracted);
+    EXPECT_EQ(extracted_nullable.get_null_map_data(), (NullMap {1}));
+}
+
+TEST(VariantColumnReaderTest, UnshreddedKeySeeksAncestorResidualBelowAShreddedObject) {
+    VariantBatchBuilder residual_builder;
+    {
+        auto row = residual_builder.begin_row();
+        auto object = row.start_object();
+        object.add_key(StringRef("city"));
+        row.add_string(StringRef("hangzhou"));
+        object.finish();
+        row.finish();
+    }
+    const VariantBatchBuilder residual_batch = residual_builder.finish_batch();
+    const VariantRef residual = residual_batch.value_at(0);
+
+    MutableColumns address_wrapper_fields;
+    address_wrapper_fields.push_back(nullable_int64({5}, {0}));
+    MutableColumns profile_object_fields;
+    profile_object_fields.push_back(ColumnNullable::create(
+            ColumnStruct::create(std::move(address_wrapper_fields)), ColumnUInt8::create(1, 0)));
+    MutableColumns profile_wrapper_fields;
+    profile_wrapper_fields.push_back(
+            nullable_strings({StringRef(residual.value.data, residual.value.size)}, {0}));
+    profile_wrapper_fields.push_back(ColumnNullable::create(
+            ColumnStruct::create(std::move(profile_object_fields)), ColumnUInt8::create(1, 0)));
+    MutableColumns root_object_fields;
+    root_object_fields.push_back(ColumnNullable::create(
+            ColumnStruct::create(std::move(profile_wrapper_fields)), ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(
+            nullable_strings({StringRef(residual.metadata.data, residual.metadata.size)}, {0}));
+    root_fields.push_back(nullable_strings({empty_bytes()}, {1}));
+    root_fields.push_back(ColumnNullable::create(
+            ColumnStruct::create(std::move(root_object_fields)), ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(shredded_deep_object_schema_with_ancestor_residual(),
+                                         *physical, output)
+                        .ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    const auto& variants = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());
+
+    // "profile" is shredded but "city" is not, so the value sits in the residual beside the
+    // shredded "profile" object.
+    const std::array path {
+            VariantShreddedPathSegment {.kind = VariantShreddedPathSegment::Kind::OBJECT_KEY,
+                                        .key = StringRef("profile")},
+            VariantShreddedPathSegment {.kind = VariantShreddedPathSegment::Kind::OBJECT_KEY,
+                                        .key = StringRef("city")}};
+    ASSERT_TRUE(variants.find_shredded_typed_value(path).has_value());
+
+    const auto extracted = extract_object_key(nullable, {StringRef("profile"), StringRef("city")});
+    const auto& extracted_nullable = assert_cast<const ColumnNullable&>(*extracted);
+    ASSERT_EQ(extracted_nullable.get_null_map_data()[0], 0);
+    EXPECT_EQ(assert_cast<const ColumnVariantV2&>(extracted_nullable.get_nested_column())
+                      .get_value_ref(0)
+                      .get_string(),
+              StringRef("hangzhou"));
+}
+
+TEST(VariantColumnReaderTest, ResidualSeekResolvesFieldIdsPerMetadataDictionary) {
+    // Two rows whose dictionaries hold a different key set, so the same key resolves to a different
+    // field id in each. Caching per dictionary rather than per batch is what keeps row 1 correct.
+    const auto encode = [](std::initializer_list<std::pair<std::string_view, int64_t>> keys) {
+        VariantBatchBuilder builder;
+        auto row = builder.begin_row();
+        auto object = row.start_object();
+        for (const auto& [key, value] : keys) {
+            object.add_key(StringRef(key.data(), key.size()));
+            row.add_int(value);
+        }
+        object.finish();
+        row.finish();
+        return builder.finish_batch();
+    };
+    const VariantBatchBuilder first = encode({{"b", 1}});
+    const VariantBatchBuilder second = encode({{"a", 7}, {"b", 2}});
+    const VariantRef first_value = first.value_at(0);
+    const VariantRef second_value = second.value_at(0);
+
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(nullable_int64({11, 22}, {0, 0}));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(2, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(
+            nullable_strings({StringRef(first_value.metadata.data, first_value.metadata.size),
+                              StringRef(second_value.metadata.data, second_value.metadata.size)},
+                             {0, 0}));
+    root_fields.push_back(
+            nullable_strings({StringRef(first_value.value.data, first_value.value.size),
+                              StringRef(second_value.value.data, second_value.value.size)},
+                             {0, 0}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 ColumnUInt8::create(2, 0)));
+    auto physical = root_wrapper(std::move(root_fields), NullMap(2, 0));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(shredded_object_schema(), *physical, output).ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+
+    const auto extracted = extract_object_key(nullable, {StringRef("b")});
+    const auto& extracted_nullable = assert_cast<const ColumnNullable&>(*extracted);
+    const auto& extracted_variant =
+            assert_cast<const ColumnVariantV2&>(extracted_nullable.get_nested_column());
+    EXPECT_EQ(extracted_nullable.get_null_map_data(), (NullMap {0, 0}));
+    EXPECT_EQ(extracted_variant.get_value_ref(0).get_int(), 1);
+    EXPECT_EQ(extracted_variant.get_value_ref(1).get_int(), 2);
+}
+
+TEST(VariantColumnReaderTest, FallbackOnlyFieldResolvesFromItsOwnResidual) {
+    VariantBatchBuilder residual_builder;
+    {
+        auto row = residual_builder.begin_row();
+        row.add_string(StringRef("wrapped"));
+        row.finish();
+    }
+    const VariantBatchBuilder residual_batch = residual_builder.finish_batch();
+    const VariantRef residual = residual_batch.value_at(0);
+
+    MutableColumns wrapper_fields;
+    wrapper_fields.push_back(
+            nullable_strings({StringRef(residual.value.data, residual.value.size)}, {0}));
+    MutableColumns object_fields;
+    object_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(wrapper_fields)),
+                                                   ColumnUInt8::create(1, 0)));
+    MutableColumns root_fields;
+    root_fields.push_back(
+            nullable_strings({StringRef(residual.metadata.data, residual.metadata.size)}, {0}));
+    root_fields.push_back(nullable_strings({empty_bytes()}, {1}));
+    root_fields.push_back(ColumnNullable::create(ColumnStruct::create(std::move(object_fields)),
+                                                 ColumnUInt8::create(1, 0)));
+    auto physical = root_wrapper(std::move(root_fields));
+
+    auto output = make_nullable(std::make_shared<DataTypeVariantV2>())->create_column();
+    ASSERT_TRUE(materialize_variant_rows(shredded_object_schema_with_fallback_only_field(),
+                                         *physical, output)
+                        .ok());
+    const auto& nullable = assert_cast<const ColumnNullable&>(*output);
+    const auto& variants = assert_cast<const ColumnVariantV2&>(nullable.get_nested_column());
+
+    // The wrapper has no typed_value, so its residual holds the complete value of "a".
+    const std::array path {VariantShreddedPathSegment {
+            .kind = VariantShreddedPathSegment::Kind::OBJECT_KEY, .key = StringRef("a")}};
+    ASSERT_TRUE(variants.find_shredded_typed_value(path).has_value());
+
+    const auto extracted = extract_object_key(nullable, {StringRef("a")});
+    const auto& extracted_nullable = assert_cast<const ColumnNullable&>(*extracted);
+    ASSERT_EQ(extracted_nullable.get_null_map_data()[0], 0);
+    EXPECT_EQ(assert_cast<const ColumnVariantV2&>(extracted_nullable.get_nested_column())
+                      .get_value_ref(0)
+                      .get_string(),
+              StringRef("wrapped"));
 }
 
 } // namespace doris::format::parquet

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_variant_read.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_variant_read.groovy
@@ -1803,6 +1803,23 @@ public class AppendVariantEqualityDelete {
     assertTrue(counterSum(positionDeleteProfile, "VariantReconstructedRows") > 0,
                "Position-delete filtering did not reconstruct its Variant rows")
 
+    // A STRING path must build a physical leaf projection rather than falling back to rebuilding
+    // the complete Variant. Reading only the accessed leaves is the entire advantage shredded
+    // storage has over unshredded storage.
+    String stringLeafToken = "iceberg_variant_string_leaf_" + UUID.randomUUID().toString()
+    sql """
+        SELECT '${stringLeafToken}', COUNT(*)
+        FROM variant_values
+        WHERE CAST(v['name'] AS STRING) = 'name-40'
+    """
+    String stringLeafProfile = getProfileByToken(stringLeafToken,
+            ["VariantLeafProjections", "VariantDirectLeafRows",
+             "VariantReconstructedRows"]).toString()
+    assertTrue(counterSum(stringLeafProfile, "VariantLeafProjections") > 0,
+               "A STRING leaf predicate did not build a physical leaf projection")
+    assertTrue(counterSum(stringLeafProfile, "VariantDirectLeafRows") > 0,
+               "A STRING leaf predicate did not evaluate rows from the shredded typed leaf")
+
     // Files written before the Variant field existed have no physical Variant payload. Schema
     // evolution must synthesize NULL instead of rejecting their non-Parquet file format.
     // Metadata-only MODIFY is valid on an existing Iceberg v3 ORC Variant table. Doris still

--- a/regression-test/suites/external_table_p0/iceberg/test_iceberg_variant_read.groovy
+++ b/regression-test/suites/external_table_p0/iceberg/test_iceberg_variant_read.groovy
@@ -1807,18 +1807,30 @@ public class AppendVariantEqualityDelete {
     // the complete Variant. Reading only the accessed leaves is the entire advantage shredded
     // storage has over unshredded storage.
     String stringLeafToken = "iceberg_variant_string_leaf_" + UUID.randomUUID().toString()
-    sql """
+    List<List<Object>> stringLeafRows = sql """
         SELECT '${stringLeafToken}', COUNT(*)
-        FROM variant_values
-        WHERE CAST(v['name'] AS STRING) = 'name-40'
+        FROM variant_page_pruning FOR VERSION AS OF ${shreddedOnlySnapshot}
+        WHERE CAST(v['padding'] AS STRING) IS NOT NULL
     """
-    String stringLeafProfile = getProfileByToken(stringLeafToken,
-            ["VariantLeafProjections", "VariantDirectLeafRows",
-             "VariantReconstructedRows"]).toString()
-    assertTrue(counterSum(stringLeafProfile, "VariantLeafProjections") > 0,
-               "A STRING leaf predicate did not build a physical leaf projection")
+    assertEquals(1, stringLeafRows.size())
+    assertEquals(4096L, ((Number) stringLeafRows[0][1]).longValue(),
+                 "The pinned shredded STRING fixture did not return all padding rows")
+    String stringLeafProfile = profileAction.getProfileBySql(stringLeafToken,
+            ["VariantLeafProjectionRowGroupColumns",
+             "VariantResidualProjectionRowGroupColumns",
+             "VariantFullProjectionRowGroupColumns",
+             "VariantDirectLeafRows", "VariantReconstructedRows"]).toString()
+    assertTrue(counterSum(stringLeafProfile, "VariantLeafProjectionRowGroupColumns") > 0,
+               "A STRING leaf predicate did not retain its physical row-group leaf projection")
+    assertEquals(0L, counterSum(stringLeafProfile,
+                                "VariantResidualProjectionRowGroupColumns"),
+               "The fully shredded STRING fixture unexpectedly retained residual columns")
+    assertEquals(0L, counterSum(stringLeafProfile, "VariantFullProjectionRowGroupColumns"),
+               "A STRING leaf predicate unexpectedly read the complete Variant wrapper")
     assertTrue(counterSum(stringLeafProfile, "VariantDirectLeafRows") > 0,
                "A STRING leaf predicate did not evaluate rows from the shredded typed leaf")
+    assertEquals(0L, counterSum(stringLeafProfile, "VariantReconstructedRows"),
+               "A STRING leaf-only predicate unexpectedly reconstructed complete Variant rows")
 
     // Files written before the Variant field existed have no physical Variant payload. Schema
     // evolution must synthesize NULL instead of rejecting their non-Parquet file format.

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_catalog_variant.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_catalog_variant.groovy
@@ -305,9 +305,9 @@ suite("test_paimon_catalog_variant", "p0,external,doris,external_docker,external
         assertTrue(counterSum(deepProjectionProfile,
                         "VariantLeafProjectionRowGroupColumns") > 0,
                 "Paimon Native did not project the deeply shredded Variant object leaves")
-        assertTrue(counterSum(deepProjectionProfile,
-                        "VariantResidualProjectionRowGroupColumns") > 0,
-                "Paimon Native did not retain the root residual beside deeply shredded leaves")
+        assertEquals(0L, counterSum(deepProjectionProfile,
+                        "VariantResidualProjectionRowGroupColumns"),
+                "Paimon Native unexpectedly read unrelated ancestor residual columns")
         assertEquals(0L, counterSum(deepProjectionProfile,
                         "VariantFullProjectionRowGroupColumns"),
                 "Paimon Native unexpectedly fell back to complete Variant row-group projection")

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_catalog_variant.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_catalog_variant.groovy
@@ -284,7 +284,7 @@ suite("test_paimon_catalog_variant", "p0,external,doris,external_docker,external
         assertEquals(2, deepProjectionRows.size())
         String deepProjectionProfile = new ProfileAction(context).getProfileBySql(
                 deepProjectionToken,
-                ["VariantLeafProjectionRowGroupColumns", "VariantFullProjectionRowGroupColumns"],
+                ["VariantLeafProjectionRowGroupColumns", "VariantResidualProjectionRowGroupColumns"],
                 30000L, 500L)
         def counterSum = { String profile, String counterName ->
             def values = profile =~
@@ -305,8 +305,8 @@ suite("test_paimon_catalog_variant", "p0,external,doris,external_docker,external
                         "VariantLeafProjectionRowGroupColumns") > 0,
                 "Paimon Native did not project the deeply shredded Variant object leaves")
         assertEquals(0L, counterSum(deepProjectionProfile,
-                        "VariantFullProjectionRowGroupColumns"),
-                "Paimon Native unexpectedly fell back to full Variant row-group projection")
+                        "VariantResidualProjectionRowGroupColumns"),
+                "Paimon Native unexpectedly had to read residual columns beside the shredded leaves")
         sql """set enable_profile = false"""
 
         order_qt_native_mixed_us_partitions """

--- a/regression-test/suites/external_table_p0/paimon/test_paimon_catalog_variant.groovy
+++ b/regression-test/suites/external_table_p0/paimon/test_paimon_catalog_variant.groovy
@@ -284,7 +284,8 @@ suite("test_paimon_catalog_variant", "p0,external,doris,external_docker,external
         assertEquals(2, deepProjectionRows.size())
         String deepProjectionProfile = new ProfileAction(context).getProfileBySql(
                 deepProjectionToken,
-                ["VariantLeafProjectionRowGroupColumns", "VariantResidualProjectionRowGroupColumns"],
+                ["VariantLeafProjectionRowGroupColumns", "VariantResidualProjectionRowGroupColumns",
+                 "VariantFullProjectionRowGroupColumns"],
                 30000L, 500L)
         def counterSum = { String profile, String counterName ->
             def values = profile =~
@@ -304,9 +305,12 @@ suite("test_paimon_catalog_variant", "p0,external,doris,external_docker,external
         assertTrue(counterSum(deepProjectionProfile,
                         "VariantLeafProjectionRowGroupColumns") > 0,
                 "Paimon Native did not project the deeply shredded Variant object leaves")
+        assertTrue(counterSum(deepProjectionProfile,
+                        "VariantResidualProjectionRowGroupColumns") > 0,
+                "Paimon Native did not retain the root residual beside deeply shredded leaves")
         assertEquals(0L, counterSum(deepProjectionProfile,
-                        "VariantResidualProjectionRowGroupColumns"),
-                "Paimon Native unexpectedly had to read residual columns beside the shredded leaves")
+                        "VariantFullProjectionRowGroupColumns"),
+                "Paimon Native unexpectedly fell back to complete Variant row-group projection")
         sql """set enable_profile = false"""
 
         order_qt_native_mixed_us_partitions """


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary:
Reading a shredded Iceberg Variant was 2.16x slower than reading the same data unshredded. The shredded scan read 38% fewer bytes but spent all of it back on Variant reconstruction: every requested leaf fell through find_typed_value() to materialized_column(), so VariantReconstructedRows equalled RawRowsRead for the whole scan.

find_typed_value() gave up in three situations it did not have to:

1. A STRING leaf returned nullopt whenever the state was complete, even though normalize_projected_primitive_leaf() already reconstructs exactly that leaf from its ParquetColumnSchema and is used for the same types once a leaf projection exists. Its result is byte-identical to rebuilding the canonical root and extracting the leaf, so the complete-state guard only bought a full reconstruction.

2. A residual beside any ancestor on the path rejected the whole batch. Reaching a path segment proves that key belongs to the shredding schema, and shredding keeps an object's residual keys disjoint from its shredded fields, so an ancestor residual can never supply the requested path. This already is the invariant collect_variant_terminal_fallback_leaf_ids() relies on when it validates row groups.

3. A residual anywhere on the path rejected the whole batch even when a single row carried it. Rows are now resolved individually: the first null typed value on the path hands the row to the encoded residual beside it, everything else keeps the shredded leaf. Rejecting 8192 rows because one of them is stored unshredded is what kept q08 on the slow path even for its BIGINT leaf.

Walking the path per row also closes a correctness gap. find_typed_value() never inspected the root `value`, so a row whose root typed_value is null and whose complete Variant lives in the root residual reported the path as absent, while the materialized fallback returned its real value. The root is now level 0 of the same walk and resolves like every other level.

VariantDirectLeafResidualMergedRows reports how many rows took the merged path.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

