### PR TITLE
[fix](cloud) Validate server config before starting services

### DIFF
--- a/cloud/src/main.cpp
+++ b/cloud/src/main.cpp
@@ -252,6 +252,13 @@ int main(int argc, char** argv) {
     brpc::FLAGS_max_body_size = config::brpc_max_body_size;
     brpc::FLAGS_socket_max_unwritten_bytes = config::brpc_socket_max_unwritten_bytes;
 
+    std::unique_ptr<ICloudServerStarter> meta_brpc_starter;
+    int port = config::brpc_listen_port;
+    if (!create_meta_brpc_starter(&server, port, &meta_brpc_starter) ||
+        !meta_brpc_starter->validate_config()) {
+        return -1;
+    }
+
     std::shared_ptr<TxnKv> txn_kv;
     if (config::use_mem_kv) {
         // MUST NOT be used in production environment
@@ -326,10 +333,7 @@ int main(int argc, char** argv) {
         pthread_setname_np(periodiccally_log_thread.native_handle(), "recycler_periodically_log");
     }
 
-    std::unique_ptr<ICloudServerStarter> meta_brpc_starter;
-    int port = config::brpc_listen_port;
-    if (!create_meta_brpc_starter(&server, port, &meta_brpc_starter) ||
-        !meta_brpc_starter->start()) {
+    if (!meta_brpc_starter->start()) {
         return -1;
     }
     end = steady_clock::now();

--- a/cloud/src/server/cloud_server_starter_factory.h
+++ b/cloud/src/server/cloud_server_starter_factory.h
@@ -30,6 +30,7 @@ namespace doris::cloud {
 class ICloudServerStarter {
 public:
     virtual ~ICloudServerStarter() = default;
+    virtual bool validate_config() = 0;
     virtual bool start() = 0;
     virtual void stop() = 0;
     virtual void join() = 0;

--- a/cloud/src/server/oss/cloud_server_starter_factory.cpp
+++ b/cloud/src/server/oss/cloud_server_starter_factory.cpp
@@ -34,13 +34,20 @@ class OssMetaBrpcServerStarter final : public ICloudServerStarter {
 public:
     OssMetaBrpcServerStarter(brpc::Server* server, int port) : _server(server), _port(port) {}
 
-    bool start() override {
+    bool validate_config() override {
         if (_server == nullptr) {
             LOG(ERROR) << "meta brpc server is null";
             return false;
         }
         if (config::enable_tls) {
             LOG(ERROR) << "Cloud TLS requires TLS module";
+            return false;
+        }
+        return true;
+    }
+
+    bool start() override {
+        if (!validate_config()) {
             return false;
         }
 

--- a/cloud/test/CMakeLists.txt
+++ b/cloud/test/CMakeLists.txt
@@ -104,6 +104,8 @@ add_executable(util_test util_test.cpp)
 
 add_executable(network_util_test network_util_test.cpp)
 
+add_executable(cloud_server_starter_factory_test cloud_server_starter_factory_test.cpp)
+
 set(TLS_UT_TARGETS)
 if (ENABLE_TLS)
     file(GLOB_RECURSE TLS_UT_FILES CONFIGURE_DEPENDS
@@ -183,6 +185,8 @@ target_link_libraries(stopwatch_test ${TEST_LINK_LIBS})
 target_link_libraries(util_test ${TEST_LINK_LIBS})
 
 target_link_libraries(network_util_test ${TEST_LINK_LIBS})
+
+target_link_libraries(cloud_server_starter_factory_test ${TEST_LINK_LIBS})
 
 foreach(TLS_UT_TARGET ${TLS_UT_TARGETS})
     target_link_libraries(${TLS_UT_TARGET} ${TEST_LINK_LIBS})

--- a/cloud/test/cloud_server_starter_factory_test.cpp
+++ b/cloud/test/cloud_server_starter_factory_test.cpp
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "server/cloud_server_starter_factory.h"
+
+#include <brpc/server.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "common/config.h"
+
+namespace doris::cloud {
+
+class CloudServerStarterFactoryTest : public testing::Test {
+protected:
+    void SetUp() override { original_enable_tls = config::enable_tls; }
+
+    void TearDown() override { config::enable_tls = original_enable_tls; }
+
+    bool original_enable_tls = false;
+};
+
+TEST_F(CloudServerStarterFactoryTest, PlaintextConfigIsValid) {
+    brpc::Server server;
+    std::unique_ptr<ICloudServerStarter> starter;
+    ASSERT_TRUE(create_meta_brpc_starter(&server, 0, &starter));
+
+    config::enable_tls = false;
+    EXPECT_TRUE(starter->validate_config());
+}
+
+TEST_F(CloudServerStarterFactoryTest, TlsConfigIsRejected) {
+    brpc::Server server;
+    std::unique_ptr<ICloudServerStarter> starter;
+    ASSERT_TRUE(create_meta_brpc_starter(&server, 0, &starter));
+
+    config::enable_tls = true;
+    EXPECT_FALSE(starter->validate_config());
+}
+
+TEST_F(CloudServerStarterFactoryTest, NullServerIsRejected) {
+    std::unique_ptr<ICloudServerStarter> starter;
+    ASSERT_TRUE(create_meta_brpc_starter(nullptr, 0, &starter));
+
+    config::enable_tls = false;
+    EXPECT_FALSE(starter->validate_config());
+}
+
+} // namespace doris::cloud


### PR DESCRIPTION
## Proposed changes

- Validate Cloud server configuration before initializing TxnKv, MetaService, Recycler, or background threads.
- Keep start-time validation as a defensive check.
- Add OSS starter unit coverage for plaintext, unsupported TLS, and null-server configurations.

## Problem

Cloud server validation currently runs after MetaService, Recycler, and the Recycler logging thread have started. If validation rejects the configuration, `main` returns through partially initialized resources, and the joinable Recycler thread can terminate the process during stack unwinding.