### PR TITLE
[opt](expr) Cache predicate mask data pointers for vectorization

### DIFF
--- a/be/benchmark/benchmark_main.cpp
+++ b/be/benchmark/benchmark_main.cpp
@@ -32,6 +32,7 @@
 #include "benchmark_hll_merge.hpp"
 #include "benchmark_hybrid_set.hpp"
 #include "benchmark_json_extract.hpp"
+#include "benchmark_predicate_vectorization.hpp"
 #include "benchmark_variant_segment.hpp"
 #include "benchmark_zone_map_index.hpp"
 #include "binary_cast_benchmark.hpp"

--- a/be/benchmark/benchmark_predicate_vectorization.hpp
+++ b/be/benchmark/benchmark_predicate_vectorization.hpp
@@ -1,0 +1,117 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <benchmark/benchmark.h>
+
+#include <cstdint>
+
+#include "common/compiler_util.h"
+#include "core/pod_array.h"
+
+namespace doris {
+namespace {
+
+using ByteVector = PaddedPODArray<uint8_t>;
+
+NO_INLINE void raw_or_current(ByteVector& combined, const ByteVector& child) {
+    for (size_t row = 0; row < combined.size(); ++row) {
+        combined[row] |= child[row];
+    }
+}
+
+NO_INLINE void raw_or_optimized(ByteVector& combined, const ByteVector& child) {
+    auto* combined_data = combined.data();
+    const auto* child_data = child.data();
+    const size_t rows = combined.size();
+    for (size_t row = 0; row < rows; ++row) {
+        combined_data[row] |= child_data[row];
+    }
+}
+
+NO_INLINE void topn_current(ByteVector& values, const ByteVector& null_map, uint8_t nulls_first) {
+    for (size_t row = 0; row < values.size(); ++row) {
+        values[row] = null_map[row] ? nulls_first : values[row];
+    }
+}
+
+NO_INLINE void topn_optimized(ByteVector& values, const ByteVector& null_map, uint8_t nulls_first) {
+    auto* value_data = values.data();
+    const auto* null_data = null_map.data();
+    const size_t rows = values.size();
+    for (size_t row = 0; row < rows; ++row) {
+        value_data[row] = null_data[row] ? nulls_first : value_data[row];
+    }
+}
+
+template <typename Func>
+void run_kernel(benchmark::State& state, Func&& func) {
+    const auto rows = static_cast<size_t>(state.range(0));
+    ByteVector values(rows, 1);
+    ByteVector null_map(rows, 0);
+    for (size_t row = 0; row < rows; row += 17) {
+        null_map[row] = 1;
+    }
+    for (auto _ : state) {
+        func(values, null_map);
+        auto* values_data = values.data();
+        benchmark::DoNotOptimize(values_data);
+        benchmark::ClobberMemory();
+    }
+    state.SetBytesProcessed(static_cast<int64_t>(state.iterations() * rows));
+}
+
+void BM_PredicateRawMaskCurrent(benchmark::State& state) {
+    run_kernel(state, [](ByteVector& values, const ByteVector& null_map) {
+        raw_or_current(values, null_map);
+    });
+}
+
+void BM_PredicateRawMaskOptimized(benchmark::State& state) {
+    run_kernel(state, [](ByteVector& values, const ByteVector& null_map) {
+        raw_or_optimized(values, null_map);
+    });
+}
+
+void BM_PredicateTopNCurrent(benchmark::State& state) {
+    run_kernel(state, [](ByteVector& values, const ByteVector& null_map) {
+        topn_current(values, null_map, 1);
+    });
+}
+
+void BM_PredicateTopNOptimized(benchmark::State& state) {
+    run_kernel(state, [](ByteVector& values, const ByteVector& null_map) {
+        topn_optimized(values, null_map, 1);
+    });
+}
+
+#define REGISTER_PREDICATE_BENCHMARK(name) \
+    BENCHMARK(name)                        \
+            ->Unit(benchmark::kNanosecond) \
+            ->Args({4096})                 \
+            ->Args({8192})                 \
+            ->Repetitions(5)               \
+            ->DisplayAggregatesOnly()
+
+REGISTER_PREDICATE_BENCHMARK(BM_PredicateRawMaskCurrent);
+REGISTER_PREDICATE_BENCHMARK(BM_PredicateRawMaskOptimized);
+REGISTER_PREDICATE_BENCHMARK(BM_PredicateTopNCurrent);
+REGISTER_PREDICATE_BENCHMARK(BM_PredicateTopNOptimized);
+
+#undef REGISTER_PREDICATE_BENCHMARK
+
+} // namespace
+} // namespace doris

--- a/be/src/exprs/vcompound_pred.h
+++ b/be/src/exprs/vcompound_pred.h
@@ -574,20 +574,22 @@ private:
         // independent buffers and therefore cannot overwrite their parent's in-flight state.
         _raw_combined_scratch.resize(num_values);
         std::ranges::fill(_raw_combined_scratch, 0);
+        auto* combined_data = _raw_combined_scratch.data();
         for (const auto& child : _children) {
             // resize_fill() initializes only newly appended bytes; explicitly reset a reused mask
             // so matches from an earlier page fragment cannot leak into this OR evaluation.
             _raw_child_scratch.resize(num_values);
             std::ranges::fill(_raw_child_scratch, 1);
             RETURN_IF_ERROR(execute_child(child, _raw_child_scratch.data()));
+            const auto* child_data = _raw_child_scratch.data();
             for (size_t row = 0; row < num_values; ++row) {
-                _raw_combined_scratch[row] |= _raw_child_scratch[row];
+                combined_data[row] |= child_data[row];
             }
         }
         // Raw kernels receive an existing selection mask, so composition must preserve rows that
         // an earlier conjunct already rejected instead of replacing the caller's mask.
         for (size_t row = 0; row < num_values; ++row) {
-            matches[row] &= _raw_combined_scratch[row];
+            matches[row] &= combined_data[row];
         }
         constexpr size_t MAX_RETAINED_RAW_MASK_BYTES = 1UL << 20;
         if (_raw_combined_scratch.capacity() > MAX_RETAINED_RAW_MASK_BYTES) {

--- a/be/src/exprs/vtopn_pred.h
+++ b/be/src/exprs/vtopn_pred.h
@@ -283,11 +283,14 @@ private:
         if (auto* nullable = check_and_get_column<ColumnNullable>(*mutable_column)) {
             auto& values = assert_cast<ColumnUInt8&>(*nullable->get_nested_column_ptr()).get_data();
             auto& null_map = nullable->get_null_map_data();
+            auto* values_data = values.data();
+            const auto* null_map_data = null_map.data();
             // Collapse SQL NULL to the filter decision: NULLS FIRST keeps it, while NULLS LAST
             // rejects it. Preserve the nullable wrapper so strict block execution still matches
             // the expression's declared Nullable(Boolean) type.
-            for (size_t row = 0; row < values.size(); ++row) {
-                values[row] = null_map[row] ? _predicate->nulls_first() : values[row];
+            for (size_t row = 0; row < rows; ++row) {
+                values_data[row] =
+                        null_map_data[row] ? _predicate->nulls_first() : values_data[row];
             }
             nullable->fill_false_to_nullmap(rows);
             return mutable_column;


### PR DESCRIPTION


Problem Summary: Predicate hot loops repeatedly access `PaddedPODArray` through container indexing, which prevents Clang from recognizing a stable contiguous loop in compound raw-mask composition and nullable TopN normalization. The fix caches data pointers and the row count before entering each loop, preserving behavior while enabling AVX2 code generation where applicable.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

