### PR TITLE
[fix](be) Read strict cast strings by row

### DIFF
--- a/be/src/core/data_type_serde/data_type_decimal_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_decimal_serde.cpp
@@ -680,12 +680,8 @@ Status DataTypeDecimalSerDe<T>::from_string_strict_mode_batch(
     const auto row = str.size();
     column.resize(row);
 
-    const ColumnString::Chars* chars = &str.get_chars();
-    const IColumn::Offsets* offsets = &str.get_offsets();
-
     auto& column_to = assert_cast<ColumnType&>(column);
     auto& vec_to = column_to.get_data();
-    size_t current_offset = 0;
     auto arg_precision = static_cast<UInt32>(precision);
     auto arg_scale = static_cast<UInt32>(scale);
     CastParameters params;
@@ -694,16 +690,10 @@ Status DataTypeDecimalSerDe<T>::from_string_strict_mode_batch(
         if (null_map && null_map[i]) {
             continue;
         }
-        size_t next_offset = (*offsets)[i];
-        size_t string_size = next_offset - current_offset;
-
-        if (!CastToDecimal::from_string(StringRef(&(*chars)[current_offset], string_size),
-                                        vec_to[i], arg_precision, arg_scale, params)) {
-            return Status::InvalidArgument(
-                    "parse number fail, string: '{}'",
-                    std::string((char*)&(*chars)[current_offset], string_size));
+        auto str_ref = str.get_data_at(i);
+        if (!CastToDecimal::from_string(str_ref, vec_to[i], arg_precision, arg_scale, params)) {
+            return Status::InvalidArgument("parse number fail, string: '{}'", str_ref.to_string());
         }
-        current_offset = next_offset;
     }
     return Status::OK();
 }

--- a/be/src/core/data_type_serde/data_type_number_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_number_serde.cpp
@@ -1661,10 +1661,6 @@ Status DataTypeNumberSerDe<T>::from_string_strict_mode_batch(
     const auto size = str.size();
     column.resize(size);
 
-    size_t current_offset = 0;
-    const ColumnString::Chars* chars = &str.get_chars();
-    const IColumn::Offsets* offsets = &str.get_offsets();
-
     auto& column_to = assert_cast<ColumnType&>(column);
     auto& vec_to = column_to.get_data();
     CastParameters params;
@@ -1673,16 +1669,10 @@ Status DataTypeNumberSerDe<T>::from_string_strict_mode_batch(
         if (null_map && null_map[i]) {
             continue;
         }
-        size_t next_offset = (*offsets)[i];
-        size_t string_size = next_offset - current_offset;
-
-        StringRef str_ref(&(*chars)[current_offset], string_size);
+        auto str_ref = str.get_data_at(i);
         if (!try_parse_impl<T, true>(vec_to[i], str_ref, params)) {
-            return Status::InvalidArgument(
-                    "parse number fail, string: '{}'",
-                    std::string((char*)&(*chars)[current_offset], string_size));
+            return Status::InvalidArgument("parse number fail, string: '{}'", str_ref.to_string());
         }
-        current_offset = next_offset;
     }
     return Status::OK();
 }

--- a/be/test/core/data_type_serde/data_type_serde_number_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_number_test.cpp
@@ -32,6 +32,7 @@
 #include "common/status.h"
 #include "core/assert_cast.h"
 #include "core/column/column.h"
+#include "core/column/column_decimal.h"
 #include "core/data_type/common_data_type_serder_test.h"
 #include "core/data_type/common_data_type_test.h"
 #include "core/data_type/data_type.h"
@@ -39,6 +40,7 @@
 #include "core/data_type_serde/data_type_date_or_datetime_serde.h"
 #include "core/data_type_serde/data_type_datetimev2_serde.h"
 #include "core/data_type_serde/data_type_datev2_serde.h"
+#include "core/data_type_serde/data_type_decimal_serde.h"
 #include "core/field.h"
 #include "core/types.h"
 #include "testutil/test_util.h"
@@ -123,6 +125,32 @@ public:
 private:
     bool _old_value;
 };
+
+TEST(DataTypeNumberSerDeStandaloneTest, StrictBatchSkipsNullableStringPayloadByRow) {
+    auto strings = ColumnString::create();
+    strings->insert_data("-", 1);
+    strings->insert_data("-", 1);
+    strings->insert_data("2628", 4);
+    NullMap null_map = {1, 1, 0};
+
+    DataTypeNumberSerDe<TYPE_BIGINT> number_serde;
+    auto number_result = ColumnInt64::create();
+    ASSERT_TRUE(
+            number_serde
+                    .from_string_strict_mode_batch(*strings, *number_result, {}, null_map.data())
+                    .ok());
+    ASSERT_EQ(number_result->size(), 3);
+    EXPECT_EQ(number_result->get_element(2), 2628);
+
+    DataTypeDecimalSerDe<TYPE_DECIMAL64> decimal_serde(18, 0);
+    auto decimal_result = ColumnDecimal64::create(0, 0);
+    ASSERT_TRUE(
+            decimal_serde
+                    .from_string_strict_mode_batch(*strings, *decimal_result, {}, null_map.data())
+                    .ok());
+    ASSERT_EQ(decimal_result->size(), 3);
+    EXPECT_EQ(decimal_result->get_element(2), Decimal64(2628));
+}
 
 TEST_F(DataTypeNumberSerDeTest, serdes) {
     auto test_func = [](const auto& serde, const auto& source_column) {


### PR DESCRIPTION


Problem Summary: Strict string-to-number and string-to-decimal batch conversion could read the wrong bytes after nullable rows with non-empty nested payloads. Root cause: skipped null rows did not advance the manually tracked `ColumnString` offset. This change reads each non-null row with `ColumnString::get_data_at()` and adds a unit test for both conversion paths.


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

