### PR TITLE
[fix](fe) Check temporary CTAS targets by session name

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateTableCommand.java
@@ -23,6 +23,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.analyzer.UnboundResultSink;
@@ -253,7 +254,11 @@ public class CreateTableCommand extends Command implements NeedAuditEncryption, 
             return false;
         }
         DatabaseIf<?> database = catalog.getDbNullable(qualifiedName.get(1));
-        return database != null && database.isTableExist(qualifiedName.get(2));
+        String tableName = qualifiedName.get(2);
+        if (createTableInfo.isTemp()) {
+            tableName = Util.generateTempTableInnerName(tableName);
+        }
+        return database != null && database.isTableExist(tableName);
     }
 
     private String getAutoRangePartitionNameOrNull() {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateTableCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/CreateTableCommandTest.java
@@ -17,11 +17,16 @@
 
 package org.apache.doris.nereids.trees.plans.commands;
 
+import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.Util;
+import org.apache.doris.datasource.CatalogIf;
+import org.apache.doris.datasource.CatalogMgr;
 import org.apache.doris.nereids.analyzer.UnboundTableSinkCreator;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateTableInfo;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+import org.apache.doris.nereids.util.RelationUtil;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.StmtExecutor;
 
@@ -34,6 +39,41 @@ import java.util.List;
 import java.util.Optional;
 
 class CreateTableCommandTest {
+
+    @Test
+    void temporaryCtasChecksSessionScopedTableName() {
+        CreateTableInfo createTableInfo = Mockito.mock(CreateTableInfo.class);
+        ConnectContext context = Mockito.mock(ConnectContext.class);
+        Env env = Mockito.mock(Env.class);
+        CatalogMgr catalogMgr = Mockito.mock(CatalogMgr.class);
+        CatalogIf<?> catalog = Mockito.mock(CatalogIf.class);
+        DatabaseIf<?> database = Mockito.mock(DatabaseIf.class);
+        List<String> tableNameParts = ImmutableList.of("catalog", "database", "target");
+        List<String> qualifiedName = ImmutableList.of("catalog", "database", "target");
+        String innerTableName = "session-id_#TEMP#_target";
+
+        Mockito.when(createTableInfo.getTableNameParts()).thenReturn(tableNameParts);
+        Mockito.when(createTableInfo.isTemp()).thenReturn(true);
+        Mockito.when(env.getCatalogMgr()).thenReturn(catalogMgr);
+        Mockito.when(catalogMgr.getCatalog("catalog")).thenReturn(catalog);
+        Mockito.when(catalog.getDbNullable("database")).thenReturn(database);
+        Mockito.when(database.isTableExist(innerTableName)).thenReturn(false);
+        CreateTableCommand command = new CreateTableCommand(Optional.empty(), createTableInfo);
+
+        try (MockedStatic<Env> envMock = Mockito.mockStatic(Env.class);
+                MockedStatic<RelationUtil> relationMock = Mockito.mockStatic(RelationUtil.class);
+                MockedStatic<Util> utilMock = Mockito.mockStatic(Util.class)) {
+            envMock.when(Env::getCurrentEnv).thenReturn(env);
+            relationMock.when(() -> RelationUtil.getQualifierName(context, tableNameParts))
+                    .thenReturn(qualifiedName);
+            utilMock.when(() -> Util.generateTempTableInnerName("target")).thenReturn(innerTableName);
+
+            org.junit.jupiter.api.Assertions.assertFalse(command.targetTableExists(context));
+
+            Mockito.verify(database).isTableExist(innerTableName);
+            Mockito.verify(database, Mockito.never()).isTableExist("target");
+        }
+    }
 
     @Test
     void ctasIfNotExistsReturnsBeforeUnsupportedSinkValidation() throws Exception {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #66112

Problem Summary:

`CREATE TEMPORARY TABLE ... AS SELECT` is allowed to use the same display
name as an ordinary table or a temporary table owned by another session.
The target-existence preflight added in #66112 looked up that display name
directly, so it could report `Table already exists` before catalog creation
translated the target to the current session's internal temporary-table
name.

This was observed in the muted Cloud P0 `test_temp_table` occurrence from
[build 1026654](http://43.132.222.7:8111/buildConfiguration/Doris_DorisRegression_CloudP0/1026654?buildTab=tests&status=muted): a second connection could not create
its session-local `t_test_temp_table1` because an ordinary table with that
display name existed.

The fix makes the CTAS preflight use the same session-scoped internal name
as temporary-table creation. A focused FE unit test verifies that the
ordinary display name is not probed for temporary CTAS.

### Release note

None

### Check List (For Author)

- Test
    - [x] Unit Test
      - `./run-fe-ut.sh --run org.apache.doris.nereids.trees.plans.commands.CreateTableCommandTest`
      - 4 tests passed, 0 failures/errors
    - [ ] Regression test
      - The existing `temp_table_p0/test_temp_table.groovy` case covers the exact cross-session flow; no local Doris cluster was available for a runtime rerun.
    - [ ] Manual test
- Behavior changed:
    - [x] Yes. Temporary CTAS now checks only the current session's target,
          allowing same-named ordinary tables and other sessions' temporary
          tables to coexist as designed.
- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
