### PR TITLE
[improvement](github-actions) Run BE UT (macOS) on master pushes only, once a day

### DIFF
--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -18,10 +18,11 @@
 name: BE UT (macOS)
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  push:
+    branches:
+      - master
   schedule:
-    - cron: '0 4,10,16,22 * * *'    # schedule it periodically to share the cache
+    - cron: '0 4 * * *'    # daily cache warm-up; PR-level runs moved out to relieve the macOS runner queue
 
 concurrency:
   group: ${{ github.ref }} (BE UT macOS)
@@ -31,6 +32,7 @@ jobs:
   run-ut:
     name: BE UT (macOS)
     runs-on: macos-15
+    timeout-minutes: 360
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -38,33 +40,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-      - name: Paths Filter
-        if: ${{ github.event_name != 'schedule' }}
-        uses: ./.github/actions/paths-filter
-        id: filter
-        with:
-          filters: |
-            be_changes:
-              - 'be/**'
-              - 'gensrc/proto/**'
-              - 'gensrc/thrift/**'
-            arrow_paimon_changes:
-              - '.github/workflows/be-ut-mac.yml'
-              - 'build.sh'
-              - 'env.sh'
-              - 'thirdparty/arrow-paimon-vars.sh'
-              - 'thirdparty/vars.sh'
-              - 'thirdparty/download-thirdparty.sh'
-              - 'thirdparty/build-thirdparty.sh'
-              - 'thirdparty/paimon-cpp-cache.cmake'
-              - 'thirdparty/patches/apache-arrow-*.patch'
-              - 'thirdparty/patches/paimon-cpp-*.patch'
-
       - name: Ccache ${{ github.ref }}
-        if: |
-          github.event_name == 'schedule' ||
-          steps.filter.outputs.be_changes == 'true' ||
-          steps.filter.outputs.arrow_paimon_changes == 'true'
         uses: ./.github/actions/ccache-action
         with:
           key: BE-UT-macOS
@@ -72,10 +48,6 @@ jobs:
           restore-keys: BE-UT-macOS-
 
       - name: Build BE ${{ github.ref }}
-        if: |
-          github.event_name == 'schedule' ||
-          steps.filter.outputs.be_changes == 'true' ||
-          steps.filter.outputs.arrow_paimon_changes == 'true'
         run: |
           cellars=(
             'm4'
@@ -129,18 +101,15 @@ jobs:
           fi
           tar -xvf doris-thirdparty-prebuilt-darwin-arm64.tar.xz
 
-          # Rebuild the Arrow/Paimon stack when its inputs change or the shared
-          # prebuilt predates the selected Arrow version/component closure.
-          # The artifact check also covers scheduled and later BE-only builds,
-          # where Paths Filter is skipped or reports no Arrow/Paimon changes.
+          # Rebuild the Arrow/Paimon stack when the shared prebuilt predates the
+          # selected Arrow version/component closure.
           # shellcheck source=thirdparty/arrow-paimon-vars.sh
           . ./arrow-paimon-vars.sh
           arrow_paimon_prebuilt_is_valid=false
           if arrow_paimon_prebuilt_valid installed; then
             arrow_paimon_prebuilt_is_valid=true
           fi
-          if [[ "${{ steps.filter.outputs.arrow_paimon_changes }}" == "true" ||
-                "${arrow_paimon_prebuilt_is_valid}" != "true" ]]; then
+          if [[ "${arrow_paimon_prebuilt_is_valid}" != "true" ]]; then
             curl -L https://github.com/apache/doris-thirdparty/releases/download/automation/doris-thirdparty-source.tgz \
               -o doris-thirdparty-source.tgz
             tar -zxvf doris-thirdparty-source.tgz


### PR DESCRIPTION
## Background

`BE UT (macOS)` is the largest consumer of the GitHub Actions queue: in a recent 48h sample it used 1112h of runner wall-clock (44% of all workflows, ~23 concurrent slots against the 5-slot macOS concurrency limit) and spent 355h queued, with a max queue wait of 41.7h. 496 runs were created (486 from PRs), of which 228 did no work (paths filter mismatch) and ~195 did a full BE build.

This workflow only verifies that the BE compiles on macOS — it does not run unit tests (see the comment in the workflow). Running it on every PR push is far beyond what the macOS pool can absorb.

## Changes

1. **Trigger change**: run on `push` to `master` (~18 merges/day) instead of every `pull_request` synchronize (~100 builds/day).
2. **Schedule reduced**: `0 4,10,16,22 * * *` → `0 4 * * *` (one daily cache warm-up instead of four).
3. **Paths filter removed**: with only `push`/`schedule` triggers left, the job-level paths filter has nothing to filter and is deleted; the build step now always runs.
4. **`timeout-minutes: 360` added**: some runs were observed to hang for up to 24h.

## Behavior change

PRs no longer get a macOS compile check during development; failures surface on the master branch after merge. This trades PR-level macOS coverage for queue relief. If PR-level coverage is wanted again later, it can be re-added selectively (e.g. label-triggered or sampled) within the ~5-slot macOS capacity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
