### PR TITLE
branch-4.1: [improvement](fe) Enable safe Iceberg MTMV rewrite by default

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mtmv/MTMVUtil.java
@@ -28,6 +28,8 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.datasource.CatalogMgr;
+import org.apache.doris.datasource.mvcc.MvccSnapshot;
+import org.apache.doris.datasource.mvcc.MvccUtil;
 import org.apache.doris.job.common.JobType;
 import org.apache.doris.job.common.TaskStatus;
 import org.apache.doris.job.task.AbstractTask;
@@ -118,6 +120,39 @@ public class MTMVUtil {
         Set<BaseTableInfo> baseTables = mtmv.getRelation().getBaseTablesOneLevelAndFromView();
         for (BaseTableInfo baseTableInfo : baseTables) {
             if (!baseTableInfo.isInternalTable()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Whether an MTMV contains an external table whose changes cannot be identified by the
+     * statement snapshot. Snapshot-id based tables, such as Iceberg, can safely participate in
+     * rewrite freshness checks because both query planning and MTMV validation use the same pinned
+     * snapshot. Timestamp based tables still require the explicit data-unawareness session switch.
+     */
+    public static boolean mtmvContainsExternalTableWithDataUnawareness(MTMV mtmv) {
+        Set<BaseTableInfo> baseTables = mtmv.getRelation().getBaseTablesOneLevelAndFromView();
+        for (BaseTableInfo baseTableInfo : baseTables) {
+            if (baseTableInfo.isInternalTable()) {
+                continue;
+            }
+            try {
+                TableIf table = getTable(baseTableInfo);
+                if (!(table instanceof MTMVRelatedTableIf)) {
+                    return true;
+                }
+                Optional<MvccSnapshot> statementSnapshot = MvccUtil.getSnapshotFromContext(table);
+                if (!statementSnapshot.isPresent()) {
+                    return true;
+                }
+                MTMVSnapshotIf tableSnapshot = ((MTMVRelatedTableIf) table)
+                        .getTableSnapshot(statementSnapshot);
+                if (!(tableSnapshot instanceof MTMVSnapshotIdSnapshot)) {
+                    return true;
+                }
+            } catch (AnalysisException e) {
                 return true;
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitConsistentMaterializationContextHook.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitConsistentMaterializationContextHook.java
@@ -50,7 +50,8 @@ public class InitConsistentMaterializationContextHook extends InitMaterializatio
                 .getAvailableMTMVs(cascadesContext.getStatementContext().getCandidateMTMVs(),
                         cascadesContext.getConnectContext(),
                         true, ((connectContext, mtmv) -> {
-                            return MTMVUtil.mtmvContainsExternalTable(mtmv) && (!connectContext.getSessionVariable()
+                            return MTMVUtil.mtmvContainsExternalTableWithDataUnawareness(mtmv)
+                                    && (!connectContext.getSessionVariable()
                                     .isEnableDmlMaterializedViewRewriteWhenBaseTableUnawareness());
                         }));
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/InitMaterializationContextHook.java
@@ -184,7 +184,8 @@ public class InitMaterializationContextHook implements PlannerHook {
                 .getAvailableMTMVs(cascadesContext.getStatementContext().getCandidateMTMVs(),
                         cascadesContext.getConnectContext(),
                         false, ((connectContext, mtmv) -> {
-                            return MTMVUtil.mtmvContainsExternalTable(mtmv) && (!connectContext.getSessionVariable()
+                            return MTMVUtil.mtmvContainsExternalTableWithDataUnawareness(mtmv)
+                                    && (!connectContext.getSessionVariable()
                                     .isEnableMaterializedViewRewriteWhenBaseTableUnawareness());
                         }));
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVUtilTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/MTMVUtilTest.java
@@ -21,15 +21,95 @@ import org.apache.doris.analysis.DateLiteral;
 import org.apache.doris.analysis.IntLiteral;
 import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.analysis.StringLiteral;
+import org.apache.doris.catalog.MTMV;
+import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.datasource.mvcc.MvccSnapshot;
+import org.apache.doris.datasource.mvcc.MvccUtil;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.Optional;
 
 public class MTMVUtilTest {
+    @Test
+    public void testExternalTableWithSnapshotIdIsDataChangeAware() throws AnalysisException {
+        MTMV mtmv = Mockito.mock(MTMV.class);
+        MTMVRelation relation = Mockito.mock(MTMVRelation.class);
+        BaseTableInfo externalTableInfo = Mockito.mock(BaseTableInfo.class);
+        TableIf externalTable = Mockito.mock(TableIf.class,
+                Mockito.withSettings().extraInterfaces(MTMVRelatedTableIf.class));
+        MTMVRelatedTableIf relatedTable = (MTMVRelatedTableIf) externalTable;
+        MvccSnapshot statementSnapshot = Mockito.mock(MvccSnapshot.class);
+
+        Mockito.when(mtmv.getRelation()).thenReturn(relation);
+        Mockito.when(relation.getBaseTablesOneLevelAndFromView()).thenReturn(ImmutableSet.of(externalTableInfo));
+        Mockito.when(externalTableInfo.isInternalTable()).thenReturn(false);
+        Mockito.when(relatedTable.getTableSnapshot(Optional.of(statementSnapshot)))
+                .thenReturn(new MTMVSnapshotIdSnapshot(7L));
+
+        try (MockedStatic<MTMVUtil> mtmvUtil = Mockito.mockStatic(MTMVUtil.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<MvccUtil> mvccUtil = Mockito.mockStatic(MvccUtil.class)) {
+            mtmvUtil.when(() -> MTMVUtil.getTable(externalTableInfo)).thenReturn(externalTable);
+            mvccUtil.when(() -> MvccUtil.getSnapshotFromContext(externalTable))
+                    .thenReturn(Optional.of(statementSnapshot));
+
+            Assert.assertFalse(MTMVUtil.mtmvContainsExternalTableWithDataUnawareness(mtmv));
+        }
+    }
+
+    @Test
+    public void testExternalTableWithoutSnapshotIdHasDataUnawareness() throws AnalysisException {
+        MTMV mtmv = Mockito.mock(MTMV.class);
+        MTMVRelation relation = Mockito.mock(MTMVRelation.class);
+        BaseTableInfo externalTableInfo = Mockito.mock(BaseTableInfo.class);
+        TableIf externalTable = Mockito.mock(TableIf.class,
+                Mockito.withSettings().extraInterfaces(MTMVRelatedTableIf.class));
+        MTMVRelatedTableIf relatedTable = (MTMVRelatedTableIf) externalTable;
+        MvccSnapshot statementSnapshot = Mockito.mock(MvccSnapshot.class);
+
+        Mockito.when(mtmv.getRelation()).thenReturn(relation);
+        Mockito.when(relation.getBaseTablesOneLevelAndFromView()).thenReturn(ImmutableSet.of(externalTableInfo));
+        Mockito.when(externalTableInfo.isInternalTable()).thenReturn(false);
+        Mockito.when(relatedTable.getTableSnapshot(Optional.of(statementSnapshot)))
+                .thenReturn(new MTMVTimestampSnapshot(7L));
+
+        try (MockedStatic<MTMVUtil> mtmvUtil = Mockito.mockStatic(MTMVUtil.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<MvccUtil> mvccUtil = Mockito.mockStatic(MvccUtil.class)) {
+            mtmvUtil.when(() -> MTMVUtil.getTable(externalTableInfo)).thenReturn(externalTable);
+            mvccUtil.when(() -> MvccUtil.getSnapshotFromContext(externalTable))
+                    .thenReturn(Optional.of(statementSnapshot));
+
+            Assert.assertTrue(MTMVUtil.mtmvContainsExternalTableWithDataUnawareness(mtmv));
+        }
+    }
+
+    @Test
+    public void testExternalTableWithoutStatementSnapshotHasDataUnawareness() throws AnalysisException {
+        MTMV mtmv = Mockito.mock(MTMV.class);
+        MTMVRelation relation = Mockito.mock(MTMVRelation.class);
+        BaseTableInfo externalTableInfo = Mockito.mock(BaseTableInfo.class);
+        TableIf externalTable = Mockito.mock(TableIf.class,
+                Mockito.withSettings().extraInterfaces(MTMVRelatedTableIf.class));
+
+        Mockito.when(mtmv.getRelation()).thenReturn(relation);
+        Mockito.when(relation.getBaseTablesOneLevelAndFromView()).thenReturn(ImmutableSet.of(externalTableInfo));
+        Mockito.when(externalTableInfo.isInternalTable()).thenReturn(false);
+
+        try (MockedStatic<MTMVUtil> mtmvUtil = Mockito.mockStatic(MTMVUtil.class, Mockito.CALLS_REAL_METHODS);
+                MockedStatic<MvccUtil> mvccUtil = Mockito.mockStatic(MvccUtil.class)) {
+            mtmvUtil.when(() -> MTMVUtil.getTable(externalTableInfo)).thenReturn(externalTable);
+            mvccUtil.when(() -> MvccUtil.getSnapshotFromContext(externalTable)).thenReturn(Optional.empty());
+
+            Assert.assertTrue(MTMVUtil.mtmvContainsExternalTableWithDataUnawareness(mtmv));
+        }
+    }
+
     @Test
     public void testGetExprTimeSec() throws AnalysisException {
         LiteralExpr expr = new DateLiteral("2020-01-01");

--- a/regression-test/suites/mtmv_p0/test_iceberg_mtmv.groovy
+++ b/regression-test/suites/mtmv_p0/test_iceberg_mtmv.groovy
@@ -210,7 +210,9 @@ suite("test_iceberg_mtmv", "p0,external,iceberg,external_docker,external_docker_
         sql """drop table if exists ${catalog_name}.${icebergDb}.${icebergTable2}"""
 
         // Test rewrite and union partitions
-        sql """set materialized_view_rewrite_enable_contain_external_table=true;"""
+        // Iceberg has a statement-pinned snapshot id, so rewrite does not require the
+        // data-unawareness opt-in used by external tables without exact snapshot tracking.
+        sql """set materialized_view_rewrite_enable_contain_external_table=false;"""
         String mvSql = "SELECT par,count(*) as num FROM ${catalog_name}.${icebergDb}.${icebergTable3} group by par"
         String mvName = "union_mv"
         sql """drop table if exists ${catalog_name}.${icebergDb}.${icebergTable3}"""
@@ -322,4 +324,3 @@ suite("test_iceberg_mtmv", "p0,external,iceberg,external_docker,external_docker_
         sql """ drop catalog if exists ${catalog_name} """
     }
 }
-


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

Q5 and Q6 of the Spark-written unshredded Iceberg c-benchmark create and refresh a 480-row MTMV. With the default `materialized_view_rewrite_enable_contain_external_table=false`, Doris rejected every materialized view containing an external table before checking whether that table had an exact statement-pinned snapshot. Q5 and Q6 therefore missed the refreshed MTMV and scanned all 180 million Iceberg rows.

This PR changes only FE materialized-view candidate filtering. It recognizes external tables whose statement snapshot is exact and data-change aware, currently snapshot-id-based Iceberg and Paimon tables. Query planning and MTMV validation use the same pinned statement snapshot id. Timestamp-based, unpinned, unsupported, and unresolved external tables remain behind the existing explicit data-unawareness opt-in.

The performance A/B used identical `fb41a26081f` BE code on both sides and added only this FE change. The formal profile confirms that both queries choose `mv_truewatch_spark_unshredded` and scan 480 rows instead of 180 million rows:

| Query | Before cold / hot-min | With FE fix cold / hot-min | Reduction |
|---|---:|---:|---:|
| Q5 | 4.308s / 4.194s | 0.084s / 0.057s | 98.1% / 98.6% |
| Q6 | 5.327s / 5.288s | 0.071s / 0.070s | 98.7% / 98.7% |

Q5 scans 6.88 KB and Q6 scans 11.19 KB after rewrite. The final PR branch is rebased directly on `branch-4.1` and contains no BE or Variant-reader changes.

Evidence from the controlled A/B workflow:

- Fixed-run dashboard: http://172.20.48.32:8111/dashboard/benchmark?workflowUid=1pLsUhu8PrZqkogjoXyNaC
- Fixed-run profile/plan/result artifact: https://qa-build.oss-cn-beijing.aliyuncs.com/performance/benchmark-results/_all/1SaxOOYsSPV9FEL0Wij18i/outputs.tar.gz
- Exact pre-fix dashboard (`fb41a26081f`): http://172.20.48.32:8111/dashboard/benchmark?workflowUid=156zdVjTP0YrkKjaxrJFN

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test
        - Existing Iceberg MTMV rewrite case now validates rewrite with the data-unawareness opt-in disabled.
    - [x] Unit Test
        - `./run-fe-ut.sh --run 'org.apache.doris.mtmv.MTMVUtilTest,org.apache.doris.mtmv.MTMVRewriteUtilTest'` (16 passed on the final FE-only head)
    - [x] Manual test
        - `git diff --check upstream-apache/branch-4.1...HEAD`
        - Formal EXPLAIN/profile and Q5/Q6 timing against the 180-million-row Spark unshredded Iceberg data
    - [ ] No need to test or manual test.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Snapshot-id-aware external tables can use fresh MTMVs without enabling the data-unawareness opt-in.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
