### PR TITLE
[fix](fe) Support constant expressions in bracket array literal

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -572,6 +572,7 @@ import org.apache.doris.nereids.trees.expressions.Regexp;
 import org.apache.doris.nereids.trees.expressions.ScalarSubquery;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
+import org.apache.doris.nereids.trees.expressions.SubqueryExpr;
 import org.apache.doris.nereids.trees.expressions.Subtract;
 import org.apache.doris.nereids.trees.expressions.TryCast;
 import org.apache.doris.nereids.trees.expressions.WhenClause;
@@ -3793,12 +3794,30 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
     }
 
     @Override
-    public ArrayLiteral visitArrayLiteral(ArrayLiteralContext ctx) {
-        List<Literal> items = ctx.items.stream().<Literal>map(this::typedVisit).collect(Collectors.toList());
+    public Expression visitArrayLiteral(ArrayLiteralContext ctx) {
+        List<Expression> items = ctx.items.stream().<Expression>map(this::typedVisit).collect(Collectors.toList());
         if (items.isEmpty()) {
-            return new ArrayLiteral(items);
+            return new ArrayLiteral(ImmutableList.of());
         }
-        return new ArrayLiteral(typeCoercionItems(items));
+        for (Expression item : items) {
+            if (!item.isConstant()) {
+                throw new ParseException("Array literal '[...]' only supports constant expressions, "
+                        + "but got non-constant expression: " + displaySql(item), ctx);
+            }
+        }
+        if (items.stream().allMatch(Literal.class::isInstance)) {
+            List<Literal> literals = items.stream().map(Literal.class::cast).collect(Collectors.toList());
+            return new ArrayLiteral(typeCoercionItems(literals));
+        }
+        // array literal contains constant but non-literal expressions (e.g. cast), build array function instead
+        return new Array(items);
+    }
+
+    private String displaySql(Expression item) {
+        if (item instanceof SubqueryExpr) {
+            return "subquery";
+        }
+        return item.toSql();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -533,6 +533,7 @@ import org.apache.doris.nereids.trees.expressions.BitAnd;
 import org.apache.doris.nereids.trees.expressions.BitNot;
 import org.apache.doris.nereids.trees.expressions.BitOr;
 import org.apache.doris.nereids.trees.expressions.BitXor;
+import org.apache.doris.nereids.trees.expressions.BracketArray;
 import org.apache.doris.nereids.trees.expressions.CaseWhen;
 import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.Default;
@@ -3809,8 +3810,10 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
             List<Literal> literals = items.stream().map(Literal.class::cast).collect(Collectors.toList());
             return new ArrayLiteral(typeCoercionItems(literals));
         }
-        // array literal contains constant but non-literal expressions (e.g. cast), build array function instead
-        return new Array(items);
+        // array literal contains constant but non-literal expressions (e.g. cast), preserve the
+        // bracket-array origin through analysis: unbound function calls look constant at parse time,
+        // so bound items are re-validated before lowering to the array function (see BracketArray).
+        return new BracketArray(items);
     }
 
     private String displaySql(Expression item) {
@@ -3822,17 +3825,24 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
 
     @Override
     public MapLiteral visitMapLiteral(MapLiteralContext ctx) {
-        List<Literal> items = ctx.items.stream().<Literal>map(this::typedVisit).collect(Collectors.toList());
+        List<Expression> items = ctx.items.stream().<Expression>map(this::typedVisit).collect(Collectors.toList());
         if (items.size() % 2 != 0) {
             throw new ParseException("map can't be odd parameters, need even parameters", ctx);
         }
+        for (Expression item : items) {
+            if (!(item instanceof Literal)) {
+                throw new ParseException("Map literal '{...}' only supports literal key and value, "
+                        + "but got non-literal expression: " + item.toSql(), ctx);
+            }
+        }
+        List<Literal> literalItems = items.stream().map(Literal.class::cast).collect(Collectors.toList());
         List<Literal> keys = Lists.newArrayList();
         List<Literal> values = Lists.newArrayList();
-        for (int i = 0; i < items.size(); i++) {
+        for (int i = 0; i < literalItems.size(); i++) {
             if (i % 2 == 0) {
-                keys.add(items.get(i));
+                keys.add(literalItems.get(i));
             } else {
-                values.add(items.get(i));
+                values.add(literalItems.get(i));
             }
         }
         List<Literal> castKeys = typeCoercionItems(keys);
@@ -3845,8 +3855,14 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
 
     @Override
     public Object visitStructLiteral(StructLiteralContext ctx) {
-        List<Literal> fields = ctx.items.stream().<Literal>map(this::typedVisit).collect(Collectors.toList());
-        return new StructLiteral(fields);
+        List<Expression> fields = ctx.items.stream().<Expression>map(this::typedVisit).collect(Collectors.toList());
+        for (Expression field : fields) {
+            if (!(field instanceof Literal)) {
+                throw new ParseException("Struct literal '{...}' only supports literal fields, "
+                        + "but got non-literal expression: " + field.toSql(), ctx);
+            }
+        }
+        return new StructLiteral(fields.stream().map(Literal.class::cast).collect(Collectors.toList()));
     }
 
     @Override
@@ -4494,7 +4510,12 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
         if (ctx.propertyClause() != null) {
             properties = visitPropertyClause(ctx.propertyClause());
         }
-        Literal filePath = (Literal) visit(ctx.filePath);
+        Object filePathObj = visit(ctx.filePath);
+        if (!(filePathObj instanceof Literal)) {
+            throw new ParseException("OUTFILE only supports a literal file path, "
+                    + "but got expression: " + ctx.filePath.getText(), ctx.filePath);
+        }
+        Literal filePath = (Literal) filePathObj;
         return new LogicalFileSink<>(filePath.getStringValue(), format, properties, ImmutableList.of(), plan);
     }
 
@@ -4819,7 +4840,13 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
                                     String parameterName = visitIdentifierOrText(kv.key);
                                     Optional<String> value = Optional.empty();
                                     if (kv.constantValue != null) {
-                                        Literal literal = (Literal) visit(kv.constantValue);
+                                        Object constant = visit(kv.constantValue);
+                                        if (!(constant instanceof Literal)) {
+                                            throw new ParseException("SET_VAR hint only supports a literal value, "
+                                                    + "but got expression: " + kv.constantValue.getText(),
+                                                    kv.constantValue);
+                                        }
+                                        Literal literal = (Literal) constant;
                                         value = Optional.ofNullable(literal.toLegacyLiteral().getStringValue());
                                     } else if (kv.identifierValue != null) {
                                         // maybe we should throw exception when the identifierValue is quoted identifier

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/ExpressionAnalyzer.java
@@ -45,6 +45,7 @@ import org.apache.doris.nereids.trees.expressions.Between;
 import org.apache.doris.nereids.trees.expressions.BinaryArithmetic;
 import org.apache.doris.nereids.trees.expressions.BitNot;
 import org.apache.doris.nereids.trees.expressions.BoundStar;
+import org.apache.doris.nereids.trees.expressions.BracketArray;
 import org.apache.doris.nereids.trees.expressions.CaseWhen;
 import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.ComparisonPredicate;
@@ -78,6 +79,7 @@ import org.apache.doris.nereids.trees.expressions.functions.Udf;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
 import org.apache.doris.nereids.trees.expressions.functions.agg.NullableAggregateFunction;
 import org.apache.doris.nereids.trees.expressions.functions.agg.SupportMultiDistinct;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Array;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.ElementAt;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Lambda;
 import org.apache.doris.nereids.trees.expressions.functions.udf.AliasUdfBuilder;
@@ -614,6 +616,26 @@ public class ExpressionAnalyzer extends SubExprAnalyzer<ExpressionRewriteContext
             }
             return castFunction;
         }
+    }
+
+    @Override
+    public Expression visitBracketArray(BracketArray bracketArray, ExpressionRewriteContext context) {
+        // at parse time the items may still be UnboundFunction, which defaults to deterministic and
+        // is neither an aggregate nor a table generating function, so they look constant. Bind the
+        // items first, then re-validate constantness, e.g. [random()] becomes volatile and [sum(1)]
+        // becomes an aggregate after binding, and both must be rejected before lowering to array().
+        List<Expression> boundItems = bracketArray.children().stream()
+                .map(item -> item.accept(this, context))
+                .collect(ImmutableList.toImmutableList());
+        for (Expression item : boundItems) {
+            if (!item.isConstant()) {
+                throw new AnalysisException("Array literal '[...]' only supports constant expressions, "
+                        + "but got non-constant expression: " + item.toSql());
+            }
+        }
+        Array array = new Array(boundItems);
+        array.checkLegalityBeforeTypeCoercion();
+        return array;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/BracketArray.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/BracketArray.java
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions;
+
+import org.apache.doris.nereids.exceptions.UnboundException;
+import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * A bracket array literal '[e1, e2, ...]' whose items are constant expressions that
+ * cannot be folded to a literal at parse time (e.g. cast or arithmetic over literals).
+ *
+ * <p>Unlike {@link org.apache.doris.nereids.trees.expressions.literal.ArrayLiteral}, the items
+ * are still unbound constant expressions, so whether they stay constant must be
+ * re-validated after function binding. For example '[random()]' and '[sum(1)]' look
+ * constant while they are {@link org.apache.doris.nereids.analyzer.UnboundFunction}
+ * (which defaults to deterministic and is neither an aggregate nor a table generating
+ * function), but become volatile / aggregate after binding.
+ *
+ * <p>This node preserves the bracket-array origin through analysis. During analysis it is
+ * lowered to the scalar 'array' function after all bound items are validated to be constant.
+ */
+public class BracketArray extends Expression {
+
+    public BracketArray(List<Expression> items) {
+        super(ImmutableList.copyOf(Objects.requireNonNull(items, "items should not null")));
+    }
+
+    public BracketArray(Expression... items) {
+        this(ImmutableList.copyOf(items));
+    }
+
+    @Override
+    public <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
+        return visitor.visitBracketArray(this, context);
+    }
+
+    @Override
+    public boolean nullable() {
+        // lowered to the array() function during analysis, which is AlwaysNotNullable
+        return false;
+    }
+
+    @Override
+    public String computeToSql() throws UnboundException {
+        return children().stream()
+                .map(Expression::toSql)
+                .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    @Override
+    public String toString() {
+        return children().stream()
+                .map(Object::toString)
+                .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    @Override
+    public String toDigest() {
+        return children().stream()
+                .map(Expression::toDigest)
+                .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    @Override
+    public BracketArray withChildren(List<Expression> children) {
+        return new BracketArray(children);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/ExpressionVisitor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/visitor/ExpressionVisitor.java
@@ -36,6 +36,7 @@ import org.apache.doris.nereids.trees.expressions.BitNot;
 import org.apache.doris.nereids.trees.expressions.BitOr;
 import org.apache.doris.nereids.trees.expressions.BitXor;
 import org.apache.doris.nereids.trees.expressions.BoundStar;
+import org.apache.doris.nereids.trees.expressions.BracketArray;
 import org.apache.doris.nereids.trees.expressions.CaseWhen;
 import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.ComparisonPredicate;
@@ -351,6 +352,10 @@ public abstract class ExpressionVisitor<R, C>
 
     public R visitArrayLiteral(ArrayLiteral arrayLiteral, C context) {
         return visitLiteral(arrayLiteral, context);
+    }
+
+    public R visitBracketArray(BracketArray bracketArray, C context) {
+        return visit(bracketArray, context);
     }
 
     public R visitMapLiteral(MapLiteral mapLiteral, C context) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/LogicalPlanBuilderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/LogicalPlanBuilderTest.java
@@ -17,7 +17,13 @@
 
 package org.apache.doris.nereids.parser;
 
+import org.apache.doris.nereids.analyzer.UnboundOneRowRelation;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
+import org.apache.doris.nereids.exceptions.ParseException;
+import org.apache.doris.nereids.trees.expressions.Cast;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.functions.scalar.Array;
+import org.apache.doris.nereids.trees.expressions.literal.ArrayLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLikeLiteral;
 import org.apache.doris.nereids.trees.plans.commands.DeleteFromCommand;
 import org.apache.doris.nereids.trees.plans.commands.DeleteFromUsingCommand;
@@ -247,5 +253,54 @@ public class LogicalPlanBuilderTest {
         Assertions.assertInstanceOf(UnboundSlot.class, sort.getOrderKeys().get(0).getExpr());
         // Second key: column name remains as UnboundSlot
         Assertions.assertInstanceOf(UnboundSlot.class, sort.getOrderKeys().get(1).getExpr());
+    }
+
+    @Test
+    public void testArrayLiteralWithCastExpression() {
+        // bracket array literal should accept valid expressions (e.g. TIMESTAMPTZ cast),
+        // consistent with ARRAY(...) and other element types
+        String sql = "SELECT CAST(["
+                + "CAST('2026-08-18 12:34:56 +08:00' AS TIMESTAMPTZ(6)),"
+                + "CAST('2026-08-18 04:34:56 +00:00' AS TIMESTAMPTZ(6))"
+                + "] AS ARRAY<TIMESTAMPTZ>)";
+        LogicalPlan plan = parser.parseSingle(sql);
+        UnboundOneRowRelation one = (UnboundOneRowRelation) plan.child(0);
+        Expression expr = one.getProjects().get(0).child(0);
+        // outer cast: CAST(array_expr AS ARRAY<TIMESTAMPTZ>)
+        Assertions.assertInstanceOf(Cast.class, expr);
+        Expression child = ((Cast) expr).child();
+        // non-literal elements -> built as array() function instead of ArrayLiteral
+        Assertions.assertInstanceOf(Array.class, child);
+        Array array = (Array) child;
+        Assertions.assertEquals(2, array.arity());
+        array.getArguments().forEach(arg -> Assertions.assertInstanceOf(Cast.class, arg));
+    }
+
+    @Test
+    public void testArrayLiteralAllLiteralStillProducesArrayLiteral() {
+        String sql = "SELECT CAST([1, 2, 3] AS ARRAY<INT>)";
+        LogicalPlan plan = parser.parseSingle(sql);
+        UnboundOneRowRelation one = (UnboundOneRowRelation) plan.child(0);
+        Expression expr = one.getProjects().get(0).child(0);
+        Assertions.assertInstanceOf(Cast.class, expr);
+        // all-literal elements keep the ArrayLiteral node, no behavior regression
+        Assertions.assertInstanceOf(ArrayLiteral.class, ((Cast) expr).child());
+    }
+
+    @Test
+    public void testArrayLiteralWithColumnReferenceThrowsParseException() {
+        // bracket array literal only supports constant expressions, a column reference
+        // cannot be folded to a constant and should report a reasonable error
+        String sql = "SELECT [c1, c2]";
+        ParseException exception = Assertions.assertThrows(ParseException.class, () -> parser.parseSingle(sql));
+        Assertions.assertTrue(exception.getMessage().contains("constant"));
+    }
+
+    @Test
+    public void testArrayLiteralWithSubqueryThrowsParseException() {
+        // a subquery cannot be folded to a constant and should report a reasonable error
+        String sql = "SELECT [(SELECT 1)]";
+        ParseException exception = Assertions.assertThrows(ParseException.class, () -> parser.parseSingle(sql));
+        Assertions.assertTrue(exception.getMessage().contains("constant"));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/LogicalPlanBuilderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/LogicalPlanBuilderTest.java
@@ -20,9 +20,9 @@ package org.apache.doris.nereids.parser;
 import org.apache.doris.nereids.analyzer.UnboundOneRowRelation;
 import org.apache.doris.nereids.analyzer.UnboundSlot;
 import org.apache.doris.nereids.exceptions.ParseException;
+import org.apache.doris.nereids.trees.expressions.BracketArray;
 import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.functions.scalar.Array;
 import org.apache.doris.nereids.trees.expressions.literal.ArrayLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.IntegerLikeLiteral;
 import org.apache.doris.nereids.trees.plans.commands.DeleteFromCommand;
@@ -269,11 +269,12 @@ public class LogicalPlanBuilderTest {
         // outer cast: CAST(array_expr AS ARRAY<TIMESTAMPTZ>)
         Assertions.assertInstanceOf(Cast.class, expr);
         Expression child = ((Cast) expr).child();
-        // non-literal elements -> built as array() function instead of ArrayLiteral
-        Assertions.assertInstanceOf(Array.class, child);
-        Array array = (Array) child;
-        Assertions.assertEquals(2, array.arity());
-        array.getArguments().forEach(arg -> Assertions.assertInstanceOf(Cast.class, arg));
+        // non-literal elements are kept as a bracket array, which is later lowered to the
+        // array() function during analysis after the bound items are validated to be constant
+        Assertions.assertInstanceOf(BracketArray.class, child);
+        BracketArray bracketArray = (BracketArray) child;
+        Assertions.assertEquals(2, bracketArray.arity());
+        bracketArray.children().forEach(arg -> Assertions.assertInstanceOf(Cast.class, arg));
     }
 
     @Test
@@ -302,5 +303,43 @@ public class LogicalPlanBuilderTest {
         String sql = "SELECT [(SELECT 1)]";
         ParseException exception = Assertions.assertThrows(ParseException.class, () -> parser.parseSingle(sql));
         Assertions.assertTrue(exception.getMessage().contains("constant"));
+    }
+
+    @Test
+    public void testMapLiteralWithArrayOfCastThrowsParseException() {
+        // a nested bracket array with a cast item is a constant expression, but map literal
+        // consumes its children as literal only, so it must be rejected with a controlled error
+        // instead of failing with an internal runtime cast error
+        String sql = "SELECT {1: [CAST(2 AS INT)]}";
+        ParseException exception = Assertions.assertThrows(ParseException.class, () -> parser.parseSingle(sql));
+        Assertions.assertTrue(exception.getMessage().contains("literal"));
+    }
+
+    @Test
+    public void testStructLiteralWithCastThrowsParseException() {
+        // a struct literal only supports literal fields, a nested bracket array whose items are
+        // expressions must be rejected with a controlled error instead of failing with an
+        // internal runtime cast error
+        String sql = "SELECT {[CAST(1 AS INT)], 2}";
+        ParseException exception = Assertions.assertThrows(ParseException.class, () -> parser.parseSingle(sql));
+        Assertions.assertTrue(exception.getMessage().contains("literal"));
+    }
+
+    @Test
+    public void testOutFileWithArrayExpressionThrowsParseException() {
+        // OUTFILE consumes the file path constant as literal only, a non-literal constant
+        // expression must be rejected with a controlled error
+        String sql = "SELECT 1 INTO OUTFILE [CAST('x' AS CHAR)]";
+        ParseException exception = Assertions.assertThrows(ParseException.class, () -> parser.parseSingle(sql));
+        Assertions.assertTrue(exception.getMessage().contains("literal"));
+    }
+
+    @Test
+    public void testSetVarHintWithArrayExpressionThrowsParseException() {
+        // SET_VAR hint consumes the constant value as literal only, a non-literal constant
+        // expression must be rejected with a controlled error
+        String sql = "SELECT /*+ SET_VAR(parallel_fragment_exec_instance_num=[CAST(1 AS INT)]) */ 1";
+        ParseException exception = Assertions.assertThrows(ParseException.class, () -> parser.parseSingle(sql));
+        Assertions.assertTrue(exception.getMessage().contains("literal"));
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/ArrayLiteralAnalysisTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/ArrayLiteralAnalysisTest.java
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.analysis;
+
+import org.apache.doris.common.ExceptionChecker;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.util.MemoTestUtils;
+import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.qe.ConnectContext;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that bracket array literals validate constantness of their items after
+ * function binding, since unbound function calls look constant at parse time.
+ */
+public class ArrayLiteralAnalysisTest {
+
+    @Test
+    public void testArrayLiteralWithVolatileFunctionFails() {
+        // [random()] looks constant at parse time because an unbound function defaults to
+        // deterministic, but binding turns it into a volatile function, so the bracket array
+        // literal must be rejected during analysis
+        ConnectContext connectContext = MemoTestUtils.createConnectContext();
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "constant", () -> {
+            PlanChecker.from(connectContext).analyze("SELECT [random()]");
+        });
+    }
+
+    @Test
+    public void testArrayLiteralWithAggregateFunctionFails() {
+        // [sum(1)] looks constant at parse time because an unbound function is neither an
+        // aggregate nor a table generating function, but binding turns it into an aggregate,
+        // so the bracket array literal must be rejected during analysis
+        ConnectContext connectContext = MemoTestUtils.createConnectContext();
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "constant", () -> {
+            PlanChecker.from(connectContext).analyze("SELECT [sum(1)]");
+        });
+    }
+
+    @Test
+    public void testArrayLiteralWithColumnReferenceFails() {
+        // a column reference is not constant and must be rejected during analysis as well
+        ConnectContext connectContext = MemoTestUtils.createConnectContext();
+        ExceptionChecker.expectThrowsWithMsg(AnalysisException.class, "constant", () -> {
+            PlanChecker.from(connectContext).analyze(
+                    "SELECT [id] FROM (SELECT 1 AS id) t");
+        });
+    }
+
+    @Test
+    public void testArrayLiteralWithConstantExpressionAnalyzes() {
+        // genuinely constant expressions (arithmetic, cast) stay constant after binding,
+        // so the bracket array literal is lowered to the array function and analyzed fine
+        ConnectContext connectContext = MemoTestUtils.createConnectContext();
+        PlanChecker.from(connectContext).analyze("SELECT [1 + 2, 3 + 4]");
+    }
+}

--- a/fe/fe-sql-parser/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-sql-parser/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -1836,7 +1836,7 @@ constant
     | booleanValue                                                                             #booleanLiteral
     | BINARY? STRING_LITERAL                                                                   #stringLiteral
     | VARBINARY_LITERAL                                                                        #varbinaryLiteral
-    | LEFT_BRACKET (items+=constant)? (COMMA items+=constant)* RIGHT_BRACKET                   #arrayLiteral
+    | LEFT_BRACKET (items+=expression)? (COMMA items+=expression)* RIGHT_BRACKET               #arrayLiteral
     | LEFT_BRACE (items+=constant COLON items+=constant)?
        (COMMA items+=constant COLON items+=constant)* RIGHT_BRACE                              #mapLiteral
     | LEFT_BRACE items+=constant (COMMA items+=constant)* RIGHT_BRACE                          #structLiteral


### PR DESCRIPTION

Problem Summary:
The bracket array literal `[...]` only accepted `constant` elements at the
grammar level, so expressions such as `CAST(...)` were rejected with a confusing
parse error. For example, the following query failed with
`missing ']' at '('`, pointing at the first `(` of the first `TIMESTAMPTZ` cast:

```
SELECT CAST([
    CAST('2026-08-18 12:34:56 +08:00' AS TIMESTAMPTZ(6)),
    CAST('2026-08-18 04:34:56 +00:00' AS TIMESTAMPTZ(6))
] AS ARRAY<TIMESTAMPTZ>);
```

This PR relaxes the arrayLiteral rule to accept arbitrary expression items
(consistent with ARRAY(...) and Spark semantics), and updates
LogicalPlanBuilder#visitArrayLiteral accordingly

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

