### PR TITLE
[fix](inverted index) Handle deleted documents in score TopN

### DIFF
--- a/be/src/exprs/function/function_search.cpp
+++ b/be/src/exprs/function/function_search.cpp
@@ -474,9 +474,10 @@ Status FunctionSearch::evaluate_inverted_index_with_search_param(
             bool use_wand = index_query_context->runtime_state != nullptr &&
                             index_query_context->runtime_state->query_options()
                                     .enable_inverted_index_wand_query;
-            query_v2::collect_multi_segment_top_k(
-                    weight, exec_ctx, root_binding_key, top_k, roaring,
-                    index_query_context->collection_similarity, use_wand);
+            query_v2::collect_multi_segment_top_k(weight, exec_ctx, root_binding_key, top_k,
+                                                  roaring,
+                                                  index_query_context->collection_similarity,
+                                                  use_wand, index_query_context->delete_bitmap);
         } else {
             query_v2::collect_multi_segment_doc_set(
                     weight, exec_ctx, root_binding_key, roaring,

--- a/be/src/storage/index/index_query_context.h
+++ b/be/src/storage/index/index_query_context.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include <memory>
+#include <roaring/roaring.hh>
+
 #include "storage/compaction/collection_similarity.h"
 #include "storage/index/inverted/similarity/collection_statistics.h"
 
@@ -29,6 +32,7 @@ struct IndexQueryContext {
 
     CollectionStatisticsPtr collection_statistics;
     CollectionSimilarityPtr collection_similarity;
+    std::shared_ptr<const roaring::Roaring> delete_bitmap;
 
     size_t query_limit = 0;
     bool is_asc = false;

--- a/be/src/storage/index/inverted/query_v2/collect/top_k_collector.cpp
+++ b/be/src/storage/index/inverted/query_v2/collect/top_k_collector.cpp
@@ -24,7 +24,8 @@ namespace doris::segment_v2::inverted_index::query_v2 {
 void collect_multi_segment_top_k(const WeightPtr& weight, const QueryExecutionContext& context,
                                  const std::string& binding_key, size_t k,
                                  const std::shared_ptr<roaring::Roaring>& roaring,
-                                 const CollectionSimilarityPtr& similarity, bool use_wand) {
+                                 const CollectionSimilarityPtr& similarity, bool use_wand,
+                                 const std::shared_ptr<const roaring::Roaring>& delete_bitmap) {
     TopKCollector final_collector(k);
 
     for_each_index_segment(
@@ -32,8 +33,13 @@ void collect_multi_segment_top_k(const WeightPtr& weight, const QueryExecutionCo
                 float initial_threshold = final_collector.threshold();
 
                 TopKCollector seg_collector(k);
-                auto callback = [&seg_collector](uint32_t doc_id, float score) -> float {
-                    return seg_collector.collect(doc_id, score);
+                float threshold = initial_threshold;
+                auto callback = [&](uint32_t doc_id, float score) -> float {
+                    if (delete_bitmap != nullptr && delete_bitmap->contains(doc_id + seg_base)) {
+                        return threshold;
+                    }
+                    threshold = seg_collector.collect(doc_id, score);
+                    return threshold;
                 };
 
                 if (use_wand) {

--- a/be/src/storage/index/inverted/query_v2/collect/top_k_collector.h
+++ b/be/src/storage/index/inverted/query_v2/collect/top_k_collector.h
@@ -98,9 +98,10 @@ private:
     std::vector<ScoredDoc> _buffer;
 };
 
-void collect_multi_segment_top_k(const WeightPtr& weight, const QueryExecutionContext& context,
-                                 const std::string& binding_key, size_t k,
-                                 const std::shared_ptr<roaring::Roaring>& roaring,
-                                 const CollectionSimilarityPtr& similarity, bool use_wand = true);
+void collect_multi_segment_top_k(
+        const WeightPtr& weight, const QueryExecutionContext& context,
+        const std::string& binding_key, size_t k, const std::shared_ptr<roaring::Roaring>& roaring,
+        const CollectionSimilarityPtr& similarity, bool use_wand = true,
+        const std::shared_ptr<const roaring::Roaring>& delete_bitmap = nullptr);
 
 } // namespace doris::segment_v2::inverted_index::query_v2

--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -1786,11 +1786,17 @@ Status SegmentIterator::_init_index_iterators() {
     _index_query_context->io_ctx = &_opts.io_ctx;
     _index_query_context->stats = _opts.stats;
     _index_query_context->runtime_state = _opts.runtime_state;
+    if (auto it = _opts.delete_bitmap.find(segment_id()); it != _opts.delete_bitmap.end()) {
+        _index_query_context->delete_bitmap = it->second;
+    }
 
     if (_score_runtime) {
         _index_query_context->collection_statistics = _opts.collection_statistics;
         _index_query_context->collection_similarity = std::make_shared<CollectionSimilarity>();
-        _index_query_context->query_limit = _score_runtime->get_limit();
+        _index_query_context->query_limit =
+                _opts.delete_condition_predicates->num_of_column_predicate() == 0
+                        ? _score_runtime->get_limit()
+                        : 0;
         _index_query_context->is_asc = _score_runtime->is_asc();
     }
 
@@ -3806,7 +3812,8 @@ void SegmentIterator::_prepare_score_column_materialization() {
 
     IColumn::MutablePtr result_column;
     auto result_row_ids = std::make_unique<std::vector<uint64_t>>();
-    if (_score_runtime->get_limit() > 0 && _col_predicates.empty() &&
+    if (_opts.delete_condition_predicates->num_of_column_predicate() == 0 &&
+        _score_runtime->get_limit() > 0 && _col_predicates.empty() &&
         _common_expr_ctxs_push_down.empty()) {
         OrderType order_type = _score_runtime->is_asc() ? OrderType::ASC : OrderType::DESC;
         _index_query_context->collection_similarity->get_topn_bm25_scores(

--- a/be/test/storage/index/inverted/query_v2/multi_segment_collector_test.cpp
+++ b/be/test/storage/index/inverted/query_v2/multi_segment_collector_test.cpp
@@ -29,6 +29,7 @@
 #include "storage/index/inverted/analyzer/custom_analyzer.h"
 #include "storage/index/inverted/query_v2/collect/doc_set_collector.h"
 #include "storage/index/inverted/query_v2/collect/multi_segment_util.h"
+#include "storage/index/inverted/query_v2/collect/top_k_collector.h"
 #include "storage/index/inverted/query_v2/term_query/term_query.h"
 #include "storage/index/inverted/util/string_helper.h"
 
@@ -137,6 +138,41 @@ TEST_F(MultiSegmentCollectorTest, CollectDocSetWithMultiReader) {
     EXPECT_EQ(roaring->cardinality(), 2);
     EXPECT_TRUE(roaring->contains(0));
     EXPECT_TRUE(roaring->contains(3));
+
+    _CLDECDELETE(dir0);
+    _CLDECDELETE(dir1);
+}
+
+TEST_F(MultiSegmentCollectorTest, CollectTopKExcludesDeletedDocs) {
+    auto* dir0 = FSDirectory::getDirectory((kTestDir + "/segment0").c_str());
+    auto* dir1 = FSDirectory::getDirectory((kTestDir + "/segment1").c_str());
+
+    ValueArray<lucene::index::IndexReader*> readers(2);
+    readers[0] = lucene::index::IndexReader::open(dir0, true);
+    readers[1] = lucene::index::IndexReader::open(dir1, true);
+    auto reader = make_shared_reader(_CLNEW lucene::index::MultiReader(&readers, true));
+
+    auto index_query_context = std::make_shared<IndexQueryContext>();
+    auto field = StringHelper::to_wstring("title");
+    TermQuery query(index_query_context, field, StringHelper::to_wstring("fleabag"));
+    auto weight = query.weight(false);
+
+    QueryExecutionContext exec_ctx;
+    exec_ctx.segment_num_rows = reader->maxDoc();
+    exec_ctx.readers = {reader};
+    exec_ctx.field_reader_bindings.emplace(field, reader);
+
+    auto mutable_deleted_docs = std::make_shared<roaring::Roaring>();
+    mutable_deleted_docs->add(0);
+    std::shared_ptr<const roaring::Roaring> deleted_docs = std::move(mutable_deleted_docs);
+    for (bool use_wand : {false, true}) {
+        auto roaring = std::make_shared<roaring::Roaring>();
+        ASSERT_NO_THROW(collect_multi_segment_top_k(weight, exec_ctx, "", 1, roaring, nullptr,
+                                                    use_wand, deleted_docs));
+
+        EXPECT_EQ(roaring->cardinality(), 1);
+        EXPECT_TRUE(roaring->contains(3));
+    }
 
     _CLDECDELETE(dir0);
     _CLDECDELETE(dir1);

--- a/regression-test/suites/search/test_search_score_topn_delete_predicate.groovy
+++ b/regression-test/suites/search/test_search_score_topn_delete_predicate.groovy
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_search_score_topn_delete_predicate", "p0") {
+    def insertRows = { tableName, rows ->
+        sql "INSERT INTO ${tableName} VALUES ${rows}"
+        sql "SYNC"
+    }
+
+    def assertScoreTopN = { tableName, predicate, expectedId ->
+        assertEquals(expectedId, sql("""
+        SELECT id
+        FROM ${tableName}
+        WHERE ${predicate}
+        ORDER BY score() DESC
+        LIMIT 1
+        """)[0][0] as int)
+    }
+
+    sql "DROP TABLE IF EXISTS test_search_score_topn_delete_predicate"
+    sql """
+        CREATE TABLE test_search_score_topn_delete_predicate (
+            id INT,
+            title TEXT,
+            INDEX idx_title (title) USING INVERTED PROPERTIES("parser" = "english")
+        ) ENGINE=OLAP
+        DUPLICATE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "disable_auto_compaction" = "true"
+        )
+    """
+    insertRows("test_search_score_topn_delete_predicate",
+            "(1, 'alpha alpha alpha alpha alpha alpha'), (2, 'alpha')")
+    assertScoreTopN("test_search_score_topn_delete_predicate", "SEARCH('title:alpha')", 1)
+    assertScoreTopN("test_search_score_topn_delete_predicate", "title MATCH_ANY 'alpha'", 1)
+
+    sql "DELETE FROM test_search_score_topn_delete_predicate WHERE id = 1"
+
+    assertScoreTopN("test_search_score_topn_delete_predicate", "SEARCH('title:alpha')", 2)
+    assertScoreTopN("test_search_score_topn_delete_predicate", "title MATCH_ANY 'alpha'", 2)
+
+    // A delete predicate only applies to data rowsets older than the delete rowset.
+    sql "INSERT INTO test_search_score_topn_delete_predicate VALUES (1, 'beta beta')"
+    sql "SYNC"
+
+    assertScoreTopN("test_search_score_topn_delete_predicate", "title MATCH_ANY 'beta'", 1)
+
+    sql "DROP TABLE IF EXISTS test_search_score_topn_delete_mow_light"
+    sql """
+        CREATE TABLE test_search_score_topn_delete_mow_light (
+            id INT,
+            title TEXT,
+            INDEX idx_title (title) USING INVERTED PROPERTIES("parser" = "english")
+        ) ENGINE=OLAP
+        UNIQUE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "disable_auto_compaction" = "true",
+            "enable_unique_key_merge_on_write" = "true",
+            "enable_mow_light_delete" = "true"
+        )
+    """
+    insertRows("test_search_score_topn_delete_mow_light",
+            "(1, 'alpha alpha alpha alpha alpha alpha'), (2, 'alpha')")
+    assertScoreTopN("test_search_score_topn_delete_mow_light", "SEARCH('title:alpha')", 1)
+
+    sql "DELETE FROM test_search_score_topn_delete_mow_light WHERE id = 1"
+
+    assertScoreTopN("test_search_score_topn_delete_mow_light", "SEARCH('title:alpha')", 2)
+
+    sql "DROP TABLE IF EXISTS test_search_score_topn_delete_bitmap"
+    sql """
+        CREATE TABLE test_search_score_topn_delete_bitmap (
+            id INT,
+            title TEXT,
+            INDEX idx_title (title) USING INVERTED PROPERTIES("parser" = "english")
+        ) ENGINE=OLAP
+        UNIQUE KEY(id)
+        DISTRIBUTED BY HASH(id) BUCKETS 1
+        PROPERTIES (
+            "replication_allocation" = "tag.location.default: 1",
+            "disable_auto_compaction" = "true",
+            "enable_unique_key_merge_on_write" = "true",
+            "enable_mow_light_delete" = "false"
+        )
+    """
+    insertRows("test_search_score_topn_delete_bitmap",
+            "(1, 'alpha alpha alpha alpha alpha alpha'), (2, 'alpha')")
+    assertScoreTopN("test_search_score_topn_delete_bitmap", "SEARCH('title:alpha')", 1)
+
+    sql "DELETE FROM test_search_score_topn_delete_bitmap WHERE id = 1"
+
+    assertScoreTopN("test_search_score_topn_delete_bitmap", "SEARCH('title:alpha')", 2)
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

A score-sorted inverted-index `SEARCH` query can return an empty result when its highest-scoring hit has already been deleted. The scan applies deletion visibility after the score TopN collector has consumed the query `LIMIT`; if the collector retains only a deleted document, the lower-scoring visible document has already been discarded.

Reproduction:

```sql
CREATE TABLE test_search_score_topn_delete_predicate (
    id INT,
    title TEXT,
    INDEX idx_title (title) USING INVERTED PROPERTIES("parser" = "english")
) ENGINE=OLAP
DUPLICATE KEY(id)
DISTRIBUTED BY HASH(id) BUCKETS 1
PROPERTIES ("replication_allocation" = "tag.location.default: 1");

INSERT INTO test_search_score_topn_delete_predicate VALUES
    (1, "alpha alpha alpha alpha alpha alpha"),
    (2, "alpha");
SYNC;
DELETE FROM test_search_score_topn_delete_predicate WHERE id = 1;

SELECT id
FROM test_search_score_topn_delete_predicate
WHERE SEARCH("title:alpha")
ORDER BY score() DESC
LIMIT 1;
```

Before this change, the score collector keeps only deleted `id = 1`; the later visibility filtering removes it, so the actual result is:

```text
Empty set
```

The expected result is:

```text
+----+
| id |
+----+
|  2 |
+----+
```

There are two deletion mechanisms with different handling requirements:

1. **Delete predicate**

   DUP tables and Unique MOW tables with `enable_mow_light_delete = true` use delete predicates. A delete predicate is evaluated during scan after the inverted-index score collector and BM25 score materialization. Therefore, for a segment with delete predicates, this change disables both early score TopN truncation points: the index query receives no score limit, and score materialization does not keep only the query TopN. The scan evaluates the delete predicate first and applies the final query limit only to visible rows. Segments without delete predicates retain the existing fast path.

2. **Delete bitmap**

   Unique MOW tables with `enable_mow_light_delete = false` mark obsolete physical rows in a delete bitmap. These rows are also filtered later in scan, so they can occupy a score TopN slot for the same reason. Unlike delete predicates, delete bitmaps are common for key-overwrite imports as well as deletes, so disabling TopN whenever one exists would unnecessarily lose the optimization. This change passes the segment delete bitmap to `collect_multi_segment_top_k` and excludes deleted document IDs while collecting TopK candidates. The collector can therefore retain the highest-scoring visible document.

`MATCH_ANY` does not call `collect_multi_segment_top_k`; it reads the inverted-index bitmap through `FunctionMatchBase::evaluate_inverted_index()`. It is not part of the score TopN path fixed here.

The regression covers the delete-predicate path for a DUP table and MOW light-delete table, and the delete-bitmap path for a Unique MOW table. The BE unit test verifies that multi-segment TopK collection skips entries present in the delete bitmap.

### Release note

Fixes incorrect empty results for score-sorted inverted-index `SEARCH` queries when deleted documents would otherwise occupy the TopN candidates.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
        - `./run-regression-test.sh --conf /tmp/doris-topn-regression.hNbTTJ/regression-conf.groovy --run -g p0 -d search -s test_search_score_topn_delete_predicate`
    - [x] Unit test
        - `./run-be-ut.sh --run --filter=MultiSegmentCollectorTest.CollectTopKExcludesDeletedDocs -j 192`

- Behavior changed:
    - [ ] No.
    - [x] Yes. Deleted documents no longer consume score TopN candidates. Delete-predicate segments defer score TopN truncation until after visibility filtering; delete bitmap entries are excluded during TopK collection.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->