### PR TITLE
[improvement](be) Refactor thread-pool scan scheduling

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -333,9 +333,9 @@ DEFINE_Int32(task_executor_max_concurrency_per_task, "-1");
 DEFINE_Int32(task_executor_initial_max_concurrency_per_task, "-1");
 
 // Enable task executor in internal table scan.
-DEFINE_Bool(enable_task_executor_in_internal_table, "true");
+DEFINE_Bool(enable_task_executor_in_internal_table, "false");
 // Enable task executor in external table scan.
-DEFINE_Bool(enable_task_executor_in_external_table, "true");
+DEFINE_Bool(enable_task_executor_in_external_table, "false");
 
 // number of scanner thread pool size for olap table
 // and the min thread num of remote scanner thread pool

--- a/be/src/exec/scan/scanner_context.cpp
+++ b/be/src/exec/scan/scanner_context.cpp
@@ -641,8 +641,24 @@ bool ScannerContext::can_admit_scan_task(const std::unique_lock<std::mutex>& tra
     // 1. An adaptive or low-memory limit can temporarily reduce effective concurrency to zero.
     // 2. If there are no completed or in-flight tasks, no worker can publish a block or EOS.
     // 3. Admit one scanner in that case so the query can make progress and cannot stall.
+    // This must stay ahead of the shared LIMIT check below. Another instance can exhaust the
+    // limit while this Context's runnable is still queued with nothing in flight; the operator is
+    // then blocked on the dependency, and only the admitted scanner's EOS can wake it so
+    // get_block_from_queue() observes termination.
     const bool has_progressing_task = current_concurrency > 0;
-    return !has_progressing_task || current_concurrency < effective_max_concurrency;
+    if (!has_progressing_task) {
+        return true;
+    }
+
+    // A progressing task will publish a result and wake the operator. Once shared LIMIT is
+    // exhausted, any additional scanner would only complete as EOS, so admitting more is pure
+    // thread-pool round trips. get_block_from_queue() finishes the Context when the last result
+    // is consumed with nothing in flight.
+    if (is_shared_scan_limit_exhausted()) {
+        return false;
+    }
+
+    return current_concurrency < effective_max_concurrency;
 }
 
 std::shared_ptr<ScanTask> ScannerContext::try_get_next_scan_task(

--- a/be/src/exec/scan/scanner_context.cpp
+++ b/be/src/exec/scan/scanner_context.cpp
@@ -184,6 +184,9 @@ Status ScannerContext::init() {
     _scanner_profile = _local_state->_scanner_profile;
     _newly_create_free_blocks_num = _local_state->_newly_create_free_blocks_num;
     _scanner_memory_used_counter = _local_state->_memory_used_counter;
+    // ThreadPool scheduling queues a Context rather than a Scanner. Its queue delay is therefore
+    // meaningful only as Context-level latency; per-scanner delays depend on arbitrary selection.
+    _context_wait_worker_timer = ADD_TIMER(_scanner_profile, "ScannerContextWaitWorkerTime");
 
     // 3. get thread token
     if (!_state->get_query_ctx()) {
@@ -328,9 +331,9 @@ void ScannerContext::return_free_block(BlockUPtr block) {
 Status ScannerContext::submit_scan_task(std::shared_ptr<ScanTask> scan_task,
                                         std::unique_lock<std::mutex>& /*transfer_lock*/) {
     // increase _num_finished_scanners no matter the scan_task is submitted successfully or not.
-    // since if submit failed, it will be added back by ScannerContext::push_back_scan_task
+    // since if submit failed, it will be added back by ScannerContext::push_completed_scan_task
     // and _num_finished_scanners will be reduced.
-    // if submit succeed, it will be also added back by ScannerContext::push_back_scan_task
+    // if submit succeed, it will be also added back by ScannerContext::push_completed_scan_task
     // see ScannerScheduler::_scanner_scan.
     _in_flight_tasks_num++;
     return _scanner_scheduler->submit(shared_from_this(), scan_task);
@@ -340,7 +343,7 @@ void ScannerContext::clear_free_blocks() {
     clear_blocks(_free_blocks);
 }
 
-void ScannerContext::push_back_scan_task(std::shared_ptr<ScanTask> scan_task) {
+void ScannerContext::push_completed_scan_task(std::shared_ptr<ScanTask> scan_task) {
     if (scan_task->status_ok()) {
         if (scan_task->cached_block && scan_task->cached_block->rows() > 0) {
             Status st = validate_block_schema(scan_task->cached_block.get());
@@ -350,6 +353,8 @@ void ScannerContext::push_back_scan_task(std::shared_ptr<ScanTask> scan_task) {
         }
     }
 
+    // Publishing the result and releasing its in-flight slot must be atomic. Otherwise a worker
+    // could observe an available slot before the operator can observe this completed task.
     std::lock_guard<std::mutex> l(_transfer_lock);
     if (!scan_task->status_ok()) {
         _process_status = scan_task->get_status();
@@ -410,15 +415,24 @@ Status ScannerContext::get_block_from_queue(RuntimeState* state, Block* block, b
             _num_finished_scanners++;
             RETURN_IF_ERROR(_scanner_scheduler->schedule_scan_task(shared_from_this(), nullptr, l));
         } else {
-            scan_task->set_state(ScanTask::State::IN_FLIGHT);
+            // A completed non-EOS attempt is still non-terminal. This covers a task whose block
+            // was just consumed above as well as one that produced no block. The scheduler returns
+            // it to PENDING (ThreadPool) or re-admits it (TaskExecutor) for another scan.
             RETURN_IF_ERROR(
                     _scanner_scheduler->schedule_scan_task(shared_from_this(), scan_task, l));
         }
     }
 
+    // A scanner can make shared LIMIT exhausted while it is still producing the final block:
+    // 1. The remaining limit is 5 and an in-flight scanner reads 100 rows.
+    // 2. The scanner decrements the shared limit below zero, then publishes its 100-row block. If not check
+    // _in_flight_tasks_num == 0 here, the operator will find the limit has reached, but actuall it
+    // do not get the cached block yet.
+    // 3. The operator consumes the block and applies the final limit of 5 rows.
+    // Therefore, wait for every worker to publish its block or EOS before completing this Context.
     if (_completed_tasks.empty() &&
         (_num_finished_scanners == _all_scanners.size() ||
-         (_is_shared_scan_limit_exhausted() && _in_flight_tasks_num == 0))) {
+         (is_shared_scan_limit_exhausted() && _in_flight_tasks_num == 0))) {
         _set_scanner_done();
         _is_finished = true;
     }
@@ -559,8 +573,87 @@ void ScannerContext::_set_scanner_done() {
     _dependency->set_always_ready();
 }
 
-bool ScannerContext::_is_shared_scan_limit_exhausted() const {
+bool ScannerContext::is_shared_scan_limit_exhausted() const {
     return limit >= 0 && _shared_scan_limit->load(std::memory_order_acquire) <= 0;
+}
+
+bool ScannerContext::is_context_queued(const std::unique_lock<std::mutex>& transfer_lock) const {
+    DORIS_CHECK(transfer_lock.owns_lock());
+    return _is_context_queued;
+}
+
+void ScannerContext::set_context_queued(bool queued,
+                                        const std::unique_lock<std::mutex>& transfer_lock) {
+    DORIS_CHECK(transfer_lock.owns_lock());
+    DORIS_CHECK(_is_context_queued != queued);
+    if (queued) {
+        // A Context is deduplicated while queued, so this timestamp covers exactly one submitted
+        // runnable rather than the wait time of any particular scanner it may later choose.
+        DORIS_CHECK(_context_wait_worker_start_ns == 0);
+        _context_wait_worker_start_ns = MonotonicNanos();
+    } else {
+        // A worker clears the state immediately after dequeueing the runnable. Record the elapsed
+        // time here so queue-state changes and profiling cannot diverge. Failed submissions never
+        // set this state, and therefore never enter this branch.
+        DORIS_CHECK(_context_wait_worker_start_ns != 0);
+#ifndef BE_TEST
+        DORIS_CHECK(_context_wait_worker_timer != nullptr);
+        COUNTER_UPDATE(_context_wait_worker_timer,
+                       MonotonicNanos() - _context_wait_worker_start_ns);
+#endif
+        _context_wait_worker_start_ns = 0;
+    }
+    _is_context_queued = queued;
+}
+
+void ScannerContext::push_pending_scan_task(std::shared_ptr<ScanTask> scan_task,
+                                            const std::unique_lock<std::mutex>& transfer_lock) {
+    DORIS_CHECK(transfer_lock.owns_lock());
+    DORIS_CHECK(scan_task != nullptr);
+    DORIS_CHECK(scan_task->cached_block == nullptr);
+    DORIS_CHECK(!scan_task->is_eos());
+    // The state transition documents that this is an admission queue, not a completed-result queue.
+    scan_task->set_state(ScanTask::State::PENDING);
+    _pending_tasks.push(std::move(scan_task));
+}
+
+std::shared_ptr<ScanTask> ScannerContext::try_get_next_scan_task(
+        const std::unique_lock<std::mutex>& transfer_lock) {
+    DORIS_CHECK(transfer_lock.owns_lock());
+    if (done() || _pending_tasks.empty()) {
+        return nullptr;
+    }
+
+    int32_t effective_max_concurrency = _max_scan_concurrency;
+    if (_enable_adaptive_scanners) {
+        effective_max_concurrency = _adaptive_processor->expected_scanners > 0
+                                            ? _adaptive_processor->expected_scanners
+                                            : _max_scan_concurrency;
+    }
+    if (low_memory_mode()) {
+        effective_max_concurrency = std::min(effective_max_concurrency, low_memory_mode_scanners());
+    }
+
+    // Completed blocks still occupy a concurrency slot until the operator consumes them. Counting
+    // both collections prevents a fast producer from exceeding the per-Context scanner limit.
+    const int32_t current_concurrency =
+            cast_set<int32_t>(_completed_tasks.size()) + _in_flight_tasks_num;
+    // Keep at least one task progressing whenever a pending scanner exists:
+    // 1. An adaptive or low-memory limit can temporarily reduce effective concurrency to zero.
+    // 2. If there are no completed or in-flight tasks, no worker can publish a block or EOS.
+    // 3. Admit one scanner in that case so the query can make progress and cannot stall.
+    const bool has_progressing_task = current_concurrency > 0;
+    if (has_progressing_task && current_concurrency >= effective_max_concurrency) {
+        return nullptr;
+    }
+
+    // Pop and mark in-flight while holding the same lock used by completion and consumption.
+    // Thus concurrent Context workers cannot admit the same task or both pass the limit check.
+    auto scan_task = _pending_tasks.top();
+    _pending_tasks.pop();
+    scan_task->set_state(ScanTask::State::IN_FLIGHT);
+    ++_in_flight_tasks_num;
+    return scan_task;
 }
 
 void ScannerContext::update_peak_running_scanner(int num) {
@@ -755,13 +848,6 @@ std::shared_ptr<ScanTask> ScannerContext::_pull_next_scan_task(
     }
 
     if (!_pending_tasks.empty()) {
-        // Do not submit more pending scanners after the shared LIMIT is exhausted while
-        // completed or in-flight tasks can still make progress. If neither exists, allow pending
-        // scanners to be submitted so they can report EOS and wake the pipeline task.
-        if (_is_shared_scan_limit_exhausted() &&
-            (_in_flight_tasks_num != 0 || !_completed_tasks.empty())) {
-            return nullptr;
-        }
         std::shared_ptr<ScanTask> next_scan_task;
         next_scan_task = _pending_tasks.top();
         _pending_tasks.pop();

--- a/be/src/exec/scan/scanner_context.cpp
+++ b/be/src/exec/scan/scanner_context.cpp
@@ -617,11 +617,10 @@ void ScannerContext::push_pending_scan_task(std::shared_ptr<ScanTask> scan_task,
     _pending_tasks.push(std::move(scan_task));
 }
 
-std::shared_ptr<ScanTask> ScannerContext::try_get_next_scan_task(
-        const std::unique_lock<std::mutex>& transfer_lock) {
+bool ScannerContext::can_admit_scan_task(const std::unique_lock<std::mutex>& transfer_lock) const {
     DORIS_CHECK(transfer_lock.owns_lock());
     if (done() || _pending_tasks.empty()) {
-        return nullptr;
+        return false;
     }
 
     int32_t effective_max_concurrency = _max_scan_concurrency;
@@ -643,7 +642,12 @@ std::shared_ptr<ScanTask> ScannerContext::try_get_next_scan_task(
     // 2. If there are no completed or in-flight tasks, no worker can publish a block or EOS.
     // 3. Admit one scanner in that case so the query can make progress and cannot stall.
     const bool has_progressing_task = current_concurrency > 0;
-    if (has_progressing_task && current_concurrency >= effective_max_concurrency) {
+    return !has_progressing_task || current_concurrency < effective_max_concurrency;
+}
+
+std::shared_ptr<ScanTask> ScannerContext::try_get_next_scan_task(
+        const std::unique_lock<std::mutex>& transfer_lock) {
+    if (!can_admit_scan_task(transfer_lock)) {
         return nullptr;
     }
 

--- a/be/src/exec/scan/scanner_context.cpp
+++ b/be/src/exec/scan/scanner_context.cpp
@@ -617,6 +617,11 @@ void ScannerContext::push_pending_scan_task(std::shared_ptr<ScanTask> scan_task,
     _pending_tasks.push(std::move(scan_task));
 }
 
+bool ScannerContext::has_progressing_task(const std::unique_lock<std::mutex>& transfer_lock) const {
+    DORIS_CHECK(transfer_lock.owns_lock());
+    return cast_set<int32_t>(_completed_tasks.size()) + _in_flight_tasks_num > 0;
+}
+
 bool ScannerContext::can_admit_scan_task(const std::unique_lock<std::mutex>& transfer_lock) const {
     DORIS_CHECK(transfer_lock.owns_lock());
     if (done() || _pending_tasks.empty()) {
@@ -663,6 +668,12 @@ bool ScannerContext::can_admit_scan_task(const std::unique_lock<std::mutex>& tra
 
 std::shared_ptr<ScanTask> ScannerContext::try_get_next_scan_task(
         const std::unique_lock<std::mutex>& transfer_lock) {
+    if (_enable_adaptive_scanners) {
+        // Refresh expected_scanners and feed current block estimates back to the memory limiter,
+        // exactly as _get_margin() does on the TaskExecutor path. can_admit_scan_task() only reads
+        // the cached value, so ThreadPool admission would otherwise never apply adaptive limits.
+        static_cast<void>(_available_pickup_scanner_count());
+    }
     if (!can_admit_scan_task(transfer_lock)) {
         return nullptr;
     }
@@ -671,6 +682,12 @@ std::shared_ptr<ScanTask> ScannerContext::try_get_next_scan_task(
     // Thus concurrent Context workers cannot admit the same task or both pass the limit check.
     auto scan_task = _pending_tasks.top();
     _pending_tasks.pop();
+    // ThreadPool admission bypasses ScannerScheduler::submit(); restart the per-scanner wait
+    // timer here so it measures admission-to-execution instead of everything since the previous
+    // attempt paused, which would include time the completed block waited for the operator.
+    if (auto scanner_delegate = scan_task->scanner.lock()) {
+        scanner_delegate->_scanner->start_wait_worker_timer();
+    }
     scan_task->set_state(ScanTask::State::IN_FLIGHT);
     ++_in_flight_tasks_num;
     return scan_task;

--- a/be/src/exec/scan/scanner_context.h
+++ b/be/src/exec/scan/scanner_context.h
@@ -283,6 +283,11 @@ public:
     void push_pending_scan_task(std::shared_ptr<ScanTask> scan_task,
                                 const std::unique_lock<std::mutex>& transfer_lock);
 
+    // Return whether a Context worker can currently admit one pending scanner. This check has no
+    // side effects, so the scheduler can avoid submitting a runnable that would immediately exit.
+    // The caller must hold _transfer_lock.
+    bool can_admit_scan_task(const std::unique_lock<std::mutex>& transfer_lock) const;
+
     // Atomically check whether this context can start another scan task, move one task from
     // pending to in-flight, and return it. The caller must hold _transfer_lock.
     std::shared_ptr<ScanTask> try_get_next_scan_task(

--- a/be/src/exec/scan/scanner_context.h
+++ b/be/src/exec/scan/scanner_context.h
@@ -293,6 +293,12 @@ public:
     // _transfer_lock.
     bool can_admit_scan_task(const std::unique_lock<std::mutex>& transfer_lock) const;
 
+    // Return whether at least one task is progressing: in flight on a worker, or completed and
+    // awaiting operator consumption. A progressing task eventually triggers rescheduling, so the
+    // ThreadPool scheduler can tolerate a failed runnable submission while one exists. The caller
+    // must hold _transfer_lock.
+    bool has_progressing_task(const std::unique_lock<std::mutex>& transfer_lock) const;
+
     // Atomically check whether this context can start another scan task, move one task from
     // pending to in-flight, and return it. The caller must hold _transfer_lock.
     std::shared_ptr<ScanTask> try_get_next_scan_task(

--- a/be/src/exec/scan/scanner_context.h
+++ b/be/src/exec/scan/scanner_context.h
@@ -129,7 +129,11 @@ public:
     void set_state(State state) {
         switch (state) {
         case State::PENDING:
-            DCHECK(_state == State::PENDING || _state == State::IN_FLIGHT) << (int)_state;
+            // A task returns to PENDING after the operator consumes its non-EOS cached block.
+            // For example, one scanner may produce several blocks, so COMPLETED is not terminal.
+            DCHECK(_state == State::PENDING || _state == State::IN_FLIGHT ||
+                   _state == State::COMPLETED)
+                    << (int)_state;
             DCHECK(cached_block == nullptr);
             break;
         case State::IN_FLIGHT:
@@ -208,11 +212,17 @@ public:
     // set the `eos` to `ScanTask::eos` if there is no more data in current scanner
     Status submit_scan_task(std::shared_ptr<ScanTask> scan_task, std::unique_lock<std::mutex>&);
 
-    // Push back a scan task.
-    void push_back_scan_task(std::shared_ptr<ScanTask> scan_task);
+    // Publish a task whose current scan attempt has completed. The operator consumes its cached
+    // block and returns a non-EOS task to PENDING for its next scan attempt.
+    void push_completed_scan_task(std::shared_ptr<ScanTask> scan_task);
 
     // Return true if this ScannerContext need no more process
     bool done() const { return _is_finished || _should_stop; }
+
+    // This is checked by ScannerScheduler::_scanner_scan(), rather than task admission, so an
+    // already queued scanner can finish as EOS and release its in-flight slot after shared LIMIT
+    // is reached. The limit is atomic and can therefore be read without _transfer_lock.
+    bool is_shared_scan_limit_exhausted() const;
 
     std::string debug_string();
 
@@ -254,6 +264,30 @@ public:
                               std::unique_lock<std::mutex>& transfer_lock,
                               std::unique_lock<std::shared_mutex>& scheduler_lock);
 
+    // Context scheduling and operator consumption share this lock so queue-state changes and task
+    // admission form one atomic decision. For example, two worker callbacks cannot both admit the
+    // last available concurrency slot.
+    std::mutex& transfer_lock() { return _transfer_lock; }
+
+    // One Context runnable represents many pending scanners in the ThreadPool scheduler. Keeping
+    // this separate from scanner execution prevents duplicate Context runnables from accumulating.
+    bool is_context_queued(const std::unique_lock<std::mutex>& transfer_lock) const;
+    // Transition the Context runnable's queue state and maintain its wait-time interval. Setting
+    // true records enqueue time; clearing false charges that interval to the Context profile.
+    // The scheduler sets true only after submit succeeds, so failed submissions have no interval.
+    // Example: a queue-full submit leaves the state false and contributes no worker-wait time.
+    void set_context_queued(bool queued, const std::unique_lock<std::mutex>& transfer_lock);
+
+    // Return a scanner to the admission queue after its block is consumed. It may not own a cached
+    // block and may not be EOS: EOS scanners are terminal and must not run again.
+    void push_pending_scan_task(std::shared_ptr<ScanTask> scan_task,
+                                const std::unique_lock<std::mutex>& transfer_lock);
+
+    // Atomically check whether this context can start another scan task, move one task from
+    // pending to in-flight, and return it. The caller must hold _transfer_lock.
+    std::shared_ptr<ScanTask> try_get_next_scan_task(
+            const std::unique_lock<std::mutex>& transfer_lock);
+
 protected:
     /// Four criteria to determine whether to increase the parallelism of the scanners
     /// 1. It ran for at least `SCALE_UP_DURATION` ms after last scale up
@@ -261,7 +295,6 @@ protected:
     /// 3. `_free_blocks_memory_usage` < `_max_bytes_in_queue`, remains enough memory to scale up
     /// 4. At most scale up `MAX_SCALE_UP_RATIO` times to `_max_thread_num`
     void _set_scanner_done();
-    bool _is_shared_scan_limit_exhausted() const;
 
     RuntimeState* _state = nullptr;
     ScanLocalStateBase* _local_state = nullptr;
@@ -295,26 +328,37 @@ protected:
     //   current_concurrency = _completed_tasks.size() + _in_flight_tasks_num
     //
     // Lifecycle of a ScanTask:
-    //   _pending_tasks  --(submit_scan_task)--> [thread pool]  --(push_back_scan_task)-->
+    //   _pending_tasks  --(submit_scan_task)--> [thread pool]  --(push_completed_scan_task)-->
     //   _completed_tasks  --(get_block_from_queue)--> operator
     //   After consumption: non-EOS task goes back to _pending_tasks; EOS increments
     //   _num_finished_scanners.
 
     // Completed scan tasks whose cached_block is ready for the operator to consume.
-    // Protected by _transfer_lock.  Written by push_back_scan_task() (scanner thread),
+    // Protected by _transfer_lock.  Written by push_completed_scan_task() (scanner thread),
     // read/popped by get_block_from_queue() (operator thread).
     std::list<std::shared_ptr<ScanTask>> _completed_tasks;
 
-    // Scanners waiting to be submitted to the scheduler thread pool.  Stored as a stack
-    // (LIFO) so that recently-used scanners are re-scheduled first, which is more likely
-    // to be cache-friendly.  Protected by _transfer_lock.  Populated in the constructor
-    // and by schedule_scan_task() when the concurrency limit is reached; drained by
-    // _pull_next_scan_task() during scheduling.
+    // Scanners waiting to be admitted for execution. Stored as a stack (LIFO) so that
+    // recently-used scanners are re-scheduled first, which is more likely to be cache-friendly.
+    // Protected by _transfer_lock. Populated in the constructor and when an operator returns a
+    // non-EOS task; drained by try_get_next_scan_task() or the TaskExecutor scheduler.
     std::stack<std::shared_ptr<ScanTask>> _pending_tasks;
 
+    // True only while one runnable for this context is waiting in the thread pool. It does not
+    // describe scanners currently executing on worker threads. This deduplicates Context
+    // submission: N pending scanners still create exactly one runnable. Protected by _transfer_lock.
+    bool _is_context_queued = false;
+
+    // Start time for one queued Context runnable. This is accounted to the scan operator profile
+    // when the thread-pool worker dequeues the runnable, so the profile reports actual thread-pool
+    // queue latency even though a worker may select any pending scanner. Protected by _transfer_lock.
+    int64_t _context_wait_worker_start_ns = 0;
+    RuntimeProfile::Counter* _context_wait_worker_timer = nullptr;
+
     // Number of scan tasks currently submitted to the scanner scheduler thread pool
-    // (i.e. in-flight).  Incremented by submit_scan_task() before submission and
-    // decremented by push_back_scan_task() when the thread pool returns the task.
+    // (i.e. in-flight). Incremented before a task is submitted or directly admitted for
+    // thread-pool execution, and decremented by push_completed_scan_task() when the worker
+    // returns it.
     // Declared atomic so it can be read without _transfer_lock in non-critical paths,
     // but must be read under _transfer_lock whenever combined with _completed_tasks.size()
     // to form a consistent concurrency snapshot.

--- a/be/src/exec/scan/scanner_context.h
+++ b/be/src/exec/scan/scanner_context.h
@@ -219,9 +219,12 @@ public:
     // Return true if this ScannerContext need no more process
     bool done() const { return _is_finished || _should_stop; }
 
-    // This is checked by ScannerScheduler::_scanner_scan(), rather than task admission, so an
-    // already queued scanner can finish as EOS and release its in-flight slot after shared LIMIT
-    // is reached. The limit is atomic and can therefore be read without _transfer_lock.
+    // Checked in two places after shared LIMIT is reached:
+    // 1. ScannerScheduler::_scanner_scan() finishes an admitted scanner as EOS without opening it,
+    //    so it releases its in-flight slot and wakes the operator.
+    // 2. can_admit_scan_task() stops admitting more scanners while another task is still
+    //    progressing, because the only outcome would be further EOS round trips.
+    // The limit is atomic and can therefore be read without _transfer_lock.
     bool is_shared_scan_limit_exhausted() const;
 
     std::string debug_string();
@@ -285,7 +288,9 @@ public:
 
     // Return whether a Context worker can currently admit one pending scanner. This check has no
     // side effects, so the scheduler can avoid submitting a runnable that would immediately exit.
-    // The caller must hold _transfer_lock.
+    // It always admits one scanner when nothing is progressing, even after shared LIMIT is
+    // exhausted, because that scanner's EOS is what wakes the operator. The caller must hold
+    // _transfer_lock.
     bool can_admit_scan_task(const std::unique_lock<std::mutex>& transfer_lock) const;
 
     // Atomically check whether this context can start another scan task, move one task from

--- a/be/src/exec/scan/scanner_scheduler.cpp
+++ b/be/src/exec/scan/scanner_scheduler.cpp
@@ -75,17 +75,7 @@ Status ScannerScheduler::submit(std::shared_ptr<ScannerContext> ctx,
     TabletStorageType type = scanner_delegate->_scanner->get_storage_type();
     auto sumbit_task = [&]() {
         auto work_func = [scanner_ref = scan_task, ctx]() {
-            auto status = [&] {
-                RETURN_IF_CATCH_EXCEPTION(_scanner_scan(ctx, scanner_ref));
-                return Status::OK();
-            }();
-
-            if (!status.ok()) {
-                scanner_ref->set_status(status);
-                ctx->push_back_scan_task(scanner_ref);
-                return true;
-            }
-            return scanner_ref->is_eos();
+            return execute_scan_task(ctx, scanner_ref);
         };
         SimplifiedScanTask simple_scan_task = {work_func, ctx, scan_task};
         return this->submit_scan_task(simple_scan_task);
@@ -102,6 +92,22 @@ Status ScannerScheduler::submit(std::shared_ptr<ScannerContext> ctx,
     }
 
     return Status::OK();
+}
+
+bool ScannerScheduler::execute_scan_task(const std::shared_ptr<ScannerContext>& ctx,
+                                         const std::shared_ptr<ScanTask>& scan_task) {
+    // Both schedulers admit tasks differently, but exceptions must always become a completed task
+    // so the operator observes the error and releases the task's in-flight concurrency slot.
+    auto status = [&] {
+        RETURN_IF_CATCH_EXCEPTION(_scanner_scan(ctx, scan_task));
+        return Status::OK();
+    }();
+    if (!status.ok()) {
+        scan_task->set_status(status);
+        ctx->push_completed_scan_task(scan_task);
+        return true;
+    }
+    return scan_task->is_eos();
 }
 
 void handle_reserve_memory_failure(RuntimeState* state, std::shared_ptr<ScannerContext> ctx,
@@ -179,6 +185,10 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
 
     ASSIGN_STATUS_IF_CATCH_EXCEPTION(
             RuntimeState* state = ctx->state(); DCHECK(nullptr != state);
+            // Do not suppress admission when shared LIMIT is exhausted. A queued scanner still
+            // needs to complete as EOS so push_completed_scan_task() releases its in-flight slot
+            // and the pipeline can observe completion instead of waiting indefinitely.
+            if (ctx->is_shared_scan_limit_exhausted()) { eos = true; }
             // scanner->open may alloc plenty amount of memory(read blocks of data),
             // so better to also check low memory and clear free blocks here.
             if (ctx->low_memory_mode()) { ctx->clear_free_blocks(); }
@@ -308,7 +318,7 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
             "{}, eos: {}, status: {}",
             ctx->ctx_id, ctx->num_scheduled_scanners(), eos, status.to_string());
 
-    ctx->push_back_scan_task(scan_task);
+    ctx->push_completed_scan_task(scan_task);
 }
 // NOLINTEND(readability-function-cognitive-complexity,readability-function-size)
 

--- a/be/src/exec/scan/scanner_scheduler.h
+++ b/be/src/exec/scan/scanner_scheduler.h
@@ -138,7 +138,11 @@ public:
 protected:
     int _min_active_scan_threads;
 
-private:
+    // Execute one admitted task for both scheduler implementations. The return value is consumed
+    // by TaskExecutor to distinguish terminal EOS/error tasks from scanners that remain runnable.
+    static bool execute_scan_task(const std::shared_ptr<ScannerContext>& ctx,
+                                  const std::shared_ptr<ScanTask>& scan_task);
+
     static void _scanner_scan(std::shared_ptr<ScannerContext> ctx,
                               std::shared_ptr<ScanTask> scan_task);
 
@@ -240,12 +244,13 @@ public:
                               std::unique_lock<std::mutex>& transfer_lock) override;
 
 private:
+    void _run_context(std::shared_ptr<ScannerContext> scanner_ctx);
+
     std::unique_ptr<ThreadPool> _scan_thread_pool;
     std::atomic<bool> _is_stop;
     std::weak_ptr<CgroupCpuCtl> _cgroup_cpu_ctl;
     std::string _sched_name;
     std::string _workload_group;
-    std::shared_mutex _lock;
 };
 
 class TaskExecutorSimplifiedScanScheduler final : public ScannerScheduler {

--- a/be/src/exec/scan/simplified_scan_scheduler.cpp
+++ b/be/src/exec/scan/simplified_scan_scheduler.cpp
@@ -17,6 +17,8 @@
 
 #include <memory>
 
+#include "common/exception.h"
+#include "common/logging.h"
 #include "exec/scan/scanner_context.h"
 #include "exec/scan/scanner_scheduler.h"
 
@@ -34,7 +36,73 @@ Status TaskExecutorSimplifiedScanScheduler::schedule_scan_task(
 Status ThreadPoolSimplifiedScanScheduler::schedule_scan_task(
         std::shared_ptr<ScannerContext> scanner_ctx, std::shared_ptr<ScanTask> current_scan_task,
         std::unique_lock<std::mutex>& transfer_lock) {
-    std::unique_lock<std::shared_mutex> wl(_lock);
-    return scanner_ctx->schedule_scan_task(current_scan_task, transfer_lock, wl);
+    // Unlike TaskExecutor, ThreadPool queues a Context runnable. It later admits one pending task
+    // under transfer_lock. This bounds queue entries to one per Context even when many scanners
+    // become runnable together.
+    DORIS_CHECK(transfer_lock.owns_lock());
+    if (current_scan_task != nullptr) {
+        // The operator has consumed a non-EOS result, making this scanner eligible for another
+        // scan attempt. Queue the scanner first; the Context runnable chooses it later.
+        scanner_ctx->push_pending_scan_task(std::move(current_scan_task), transfer_lock);
+    }
+    if (scanner_ctx->is_context_queued(transfer_lock)) {
+        // A queued runnable will see all pending scanners added before it obtains transfer_lock.
+        // Submitting another runnable would only duplicate work and distort Context queue latency.
+        return Status::OK();
+    }
+
+    // transfer_lock prevents another producer from submitting concurrently. The worker callback
+    // also waits for this lock, so it cannot run between successful submission and marking queued.
+    Status status;
+    if (_is_stop) {
+        status = Status::InternalError<false>("scanner pool {} is shutdown.", _sched_name);
+    } else {
+        status = _scan_thread_pool->submit_func([this, scanner_ctx] { _run_context(scanner_ctx); });
+    }
+    if (status.ok()) {
+        // Start the Context wait interval only after submission succeeds. This excludes failed
+        // submit_func() calls, which never waited for a worker and must not affect the profile.
+        scanner_ctx->set_context_queued(true, transfer_lock);
+    } else {
+        // No worker can dequeue a rejected runnable. The Context remains unqueued, so a later
+        // scheduling attempt can submit it again without clearing state or accounting queue time.
+        LOG(WARNING) << fmt::format("Failed to submit scanner context {}, reason: {}",
+                                    scanner_ctx->debug_string(), status.to_string());
+    }
+    return status;
+}
+
+void ThreadPoolSimplifiedScanScheduler::_run_context(std::shared_ptr<ScannerContext> scanner_ctx) {
+    std::shared_ptr<ScanTask> scan_task;
+    {
+        std::unique_lock<std::mutex> transfer_lock(scanner_ctx->transfer_lock());
+        // The worker has dequeued the Context. Clearing the marker also charges its queue latency:
+        // the interval from successful submit_func() to worker start, not scanner execution time.
+        scanner_ctx->set_context_queued(false, transfer_lock);
+
+        auto task_execution_lock = scanner_ctx->task_exec_ctx();
+        if (task_execution_lock == nullptr) {
+            return;
+        }
+
+        // Admission checks completed results, active tasks, adaptive limits, and shared LIMIT while
+        // holding transfer_lock. A null task means the Context is currently not allowed to run one.
+        scan_task = scanner_ctx->try_get_next_scan_task(transfer_lock);
+        if (scan_task == nullptr) {
+            return;
+        }
+
+        // Queue the next Context runnable before executing this task. Example: with a concurrency
+        // limit of two, the next worker may admit scanner B while this worker scans scanner A.
+        // Releasing transfer_lock only after resubmission keeps the admission decision atomic.
+        Status resubmit_status = schedule_scan_task(scanner_ctx, nullptr, transfer_lock);
+        if (!resubmit_status.ok()) {
+            LOG(WARNING) << fmt::format("Failed to resubmit scanner context {}, reason: {}",
+                                        scanner_ctx->ctx_id, resubmit_status.to_string());
+        }
+    }
+    // The scan runs without transfer_lock so the operator and other Context workers can continue
+    // consuming results and admitting work. Completion reacquires the lock before publishing.
+    execute_scan_task(scanner_ctx, scan_task);
 }
 } // namespace doris

--- a/be/src/exec/scan/simplified_scan_scheduler.cpp
+++ b/be/src/exec/scan/simplified_scan_scheduler.cpp
@@ -21,6 +21,8 @@
 #include "common/logging.h"
 #include "exec/scan/scanner_context.h"
 #include "exec/scan/scanner_scheduler.h"
+#include "runtime/thread_context.h"
+#include "util/debug_points.h"
 
 namespace doris {
 class ScannerDelegate;
@@ -58,28 +60,38 @@ Status ThreadPoolSimplifiedScanScheduler::schedule_scan_task(
 
     // transfer_lock prevents another producer from submitting concurrently. The worker callback
     // also waits for this lock, so it cannot run between successful submission and marking queued.
-    Status status;
     if (_is_stop) {
-        status = Status::InternalError<false>("scanner pool {} is shutdown.", _sched_name);
-    } else {
-        status = _scan_thread_pool->submit_func([this, scanner_ctx] { _run_context(scanner_ctx); });
+        // Shutdown must surface: progressing tasks may never complete on a stopped pool.
+        return Status::InternalError<false>("scanner pool {} is shutdown.", _sched_name);
     }
+    Status status =
+            _scan_thread_pool->submit_func([this, scanner_ctx] { _run_context(scanner_ctx); });
     if (status.ok()) {
         // Start the Context wait interval only after submission succeeds. This excludes failed
         // submit_func() calls, which never waited for a worker and must not affect the profile.
         scanner_ctx->set_context_queued(true, transfer_lock);
-    } else {
-        // No worker can dequeue a rejected runnable. The Context remains unqueued, so a later
-        // scheduling attempt can submit it again without clearing state or accounting queue time.
-        LOG(WARNING) << fmt::format("Failed to submit scanner context {}, reason: {}",
-                                    scanner_ctx->debug_string(), status.to_string());
+        return Status::OK();
     }
-    return status;
+    // No worker can dequeue a rejected runnable. The Context remains unqueued, so a later
+    // scheduling attempt can submit it again without clearing state or accounting queue time.
+    LOG(WARNING) << fmt::format("Failed to submit scanner context {}, reason: {}",
+                                scanner_ctx->debug_string(), status.to_string());
+    if (scanner_ctx->has_progressing_task(transfer_lock) ||
+        scanner_ctx->is_shared_scan_limit_exhausted()) {
+        // Someone will retry: a progressing task completes, the operator consumes its result and
+        // reschedules; after shared LIMIT is exhausted, get_block_from_queue() finishes the
+        // Context on its next call. Pool saturation must not fail a query that still progresses.
+        return Status::OK();
+    }
+    // Nothing will retry this Context. Surface the failure, normalized like
+    // ScannerScheduler::submit() so both schedulers report saturation as TOO_MANY_TASKS.
+    return Status::TooManyTasks("Failed to submit scanner context {} to scanner pool, reason: {}",
+                                scanner_ctx->ctx_id, status.msg());
 }
 
 void ThreadPoolSimplifiedScanScheduler::_run_context(std::shared_ptr<ScannerContext> scanner_ctx) {
     std::shared_ptr<ScanTask> scan_task;
-    {
+    Status admission_status = [&]() -> Status {
         std::unique_lock<std::mutex> transfer_lock(scanner_ctx->transfer_lock());
         // The worker has dequeued the Context. Clearing the marker also charges its queue latency:
         // the interval from successful submit_func() to worker start, not scanner execution time.
@@ -87,24 +99,44 @@ void ThreadPoolSimplifiedScanScheduler::_run_context(std::shared_ptr<ScannerCont
 
         auto task_execution_lock = scanner_ctx->task_exec_ctx();
         if (task_execution_lock == nullptr) {
-            return;
+            return Status::OK();
         }
-
-        // Admission checks completed results, active tasks, adaptive limits, and shared LIMIT while
-        // holding transfer_lock. A null task means the Context is currently not allowed to run one.
-        scan_task = scanner_ctx->try_get_next_scan_task(transfer_lock);
-        if (scan_task == nullptr) {
-            return;
-        }
-
-        // Queue the next Context runnable before executing this task. Example: with a concurrency
-        // limit of two, the next worker may admit scanner B while this worker scans scanner A.
-        // Releasing transfer_lock only after resubmission keeps the admission decision atomic.
-        Status resubmit_status = schedule_scan_task(scanner_ctx, nullptr, transfer_lock);
-        if (!resubmit_status.ok()) {
-            LOG(WARNING) << fmt::format("Failed to resubmit scanner context {}, reason: {}",
-                                        scanner_ctx->ctx_id, resubmit_status.to_string());
-        }
+#ifndef BE_TEST
+        // Attach before admission: allocations below (for example the resubmitted
+        // FunctionRunnable) must charge the query rather than the orphan tracker. Scoped to this
+        // lambda so it detaches before execute_scan_task(), whose _scanner_scan() attaches again.
+        SCOPED_ATTACH_TASK(scanner_ctx->state());
+#endif
+        RETURN_IF_CATCH_EXCEPTION({
+            // Admission checks completed results, active tasks, adaptive limits, and shared LIMIT
+            // while holding transfer_lock. A null task means the Context may not run one now.
+            scan_task = scanner_ctx->try_get_next_scan_task(transfer_lock);
+            if (scan_task != nullptr) {
+                DBUG_EXECUTE_IF("ThreadPoolSimplifiedScanScheduler._run_context.inject_failure", {
+                    throw Exception(ErrorCode::INTERNAL_ERROR, "injected admission failure");
+                });
+                // Queue the next Context runnable before executing this task. Example: with a
+                // concurrency limit of two, the next worker may admit scanner B while this worker
+                // scans scanner A. Holding transfer_lock keeps the admission decision atomic.
+                Status resubmit_status = schedule_scan_task(scanner_ctx, nullptr, transfer_lock);
+                if (!resubmit_status.ok()) {
+                    LOG(WARNING) << fmt::format("Failed to resubmit scanner context {}, reason: {}",
+                                                scanner_ctx->ctx_id, resubmit_status.to_string());
+                }
+            }
+        });
+        return Status::OK();
+    }();
+    if (scan_task == nullptr) {
+        return;
+    }
+    if (!admission_status.ok()) [[unlikely]] {
+        // The scanner was admitted but a later step threw. Publish the failure so the operator
+        // observes the error and the in-flight slot is released; swallowing it would leak the
+        // slot and let dispatch_thread() terminate the process on the escaped exception.
+        scan_task->set_status(admission_status);
+        scanner_ctx->push_completed_scan_task(scan_task);
+        return;
     }
     // The scan runs without transfer_lock so the operator and other Context workers can continue
     // consuming results and admitting work. Completion reacquires the lock before publishing.

--- a/be/src/exec/scan/simplified_scan_scheduler.cpp
+++ b/be/src/exec/scan/simplified_scan_scheduler.cpp
@@ -50,6 +50,11 @@ Status ThreadPoolSimplifiedScanScheduler::schedule_scan_task(
         // Submitting another runnable would only duplicate work and distort Context queue latency.
         return Status::OK();
     }
+    if (!scanner_ctx->can_admit_scan_task(transfer_lock)) {
+        // No runnable is needed when the Context has no pending scanner or its concurrency slots
+        // are occupied. Completion or operator consumption will retry scheduling when state changes.
+        return Status::OK();
+    }
 
     // transfer_lock prevents another producer from submitting concurrently. The worker callback
     // also waits for this lock, so it cannot run between successful submission and marking queued.

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -454,10 +454,12 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
     // We assume that each current inactive thread will grab one item from the
     // queue.  If it seems like we'll need another thread, we create one.
     //
-    // Rather than creating the thread here, while holding the lock, we defer
-    // it to down below. This is because thread creation can be rather slow
-    // (hundreds of milliseconds in some cases) and we'd like to allow the
-    // existing threads to continue to process tasks while we do so.
+    // Rather than creating an additional thread here, while holding the lock,
+    // we defer it to down below. This is because thread creation can be rather
+    // slow (hundreds of milliseconds in some cases) and we'd like to allow the
+    // existing threads to continue to process tasks while we do so. The first
+    // thread is an exception: it must be created before publishing the task so
+    // a failed submission cannot leave a runnable in a pool with no workers.
     //
     // In theory, a currently active thread could finish immediately after this
     // calculation but before our new worker starts running. This would mean we
@@ -471,9 +473,23 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
     int additional_threads =
             static_cast<int>(_queue.size()) + threads_from_this_submit - inactive_threads;
     bool need_a_thread = false;
+    bool create_first_thread = false;
     if (additional_threads > 0 && _num_threads + _num_threads_pending_start < _max_threads) {
+        create_first_thread = _num_threads == 0 && _num_threads_pending_start == 0;
         need_a_thread = true;
         _num_threads_pending_start++;
+    }
+
+    if (create_first_thread) {
+        // Keep the lock until the task is published. A successfully created dispatch thread will
+        // wait for the lock, while a creation failure can return without changing any queue state.
+        Status status = create_thread();
+        if (!status.ok()) {
+            _num_threads_pending_start--;
+            thread_pool_submit_failed->increment(1);
+            return status;
+        }
+        need_a_thread = false;
     }
 
     Task task;
@@ -521,13 +537,14 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
             l.lock();
             _num_threads_pending_start--;
             if (_num_threads + _num_threads_pending_start == 0) {
-                // If we have no threads, we can't do any work.
-                return status;
+                _no_threads_cond.notify_all();
             }
-            // If we failed to create a thread, but there are still some other
-            // worker threads, log a warning message and continue.
-            LOG(WARNING) << "Thread pool " << _name
-                         << " failed to create thread: " << status.to_string();
+            if (_pool_status.ok()) {
+                // The task was published only because another worker can execute it.
+                DORIS_CHECK_GT(_num_threads + _num_threads_pending_start, 0);
+                LOG(WARNING) << "Thread pool " << _name
+                             << " failed to create thread: " << status.to_string();
+            }
         }
     }
 
@@ -687,6 +704,8 @@ void ThreadPool::dispatch_thread() {
 }
 
 Status ThreadPool::create_thread() {
+    DBUG_EXECUTE_IF("ThreadPool.create_thread.inject_failure",
+                    { return Status::RuntimeError("injected thread creation failure"); });
     return Thread::create("thread pool", absl::Substitute("$0 [worker]", _name),
                           &ThreadPool::dispatch_thread, this, nullptr);
 }
@@ -717,6 +736,9 @@ Status ThreadPool::set_min_threads(int min_threads) {
 
 Status ThreadPool::set_max_threads(int max_threads) {
     std::lock_guard<std::mutex> l(_lock);
+    if (max_threads <= 0) {
+        return Status::InvalidArgument("Thread pool {} max_threads must be greater than 0", _name);
+    }
     DBUG_EXECUTE_IF("ThreadPool.set_max_threads.force_set", {
         _max_threads = max_threads;
         return Status::OK();

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -540,8 +540,10 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
                 _no_threads_cond.notify_all();
             }
             if (_pool_status.ok()) {
-                // The task was published only because another worker can execute it.
-                DORIS_CHECK_GT(_num_threads + _num_threads_pending_start, 0);
+                // A published task either already ran or still has a live or pending worker.
+                // The last-worker guard in dispatch_thread() keeps this true; a violation is a
+                // pool logic error.
+                DORIS_CHECK(_queue.empty() || _num_threads + _num_threads_pending_start > 0);
                 LOG(WARNING) << "Thread pool " << _name
                              << " failed to create thread: " << status.to_string();
             }
@@ -580,7 +582,12 @@ void ThreadPool::dispatch_thread() {
             break;
         }
 
-        if (_num_threads + _num_threads_pending_start > _max_threads) {
+        // A runtime shrink may leave more live + pending threads than _max_threads. Excess threads
+        // retire here, but the last live worker must stay while tasks are queued: a pending
+        // replacement may still fail to start, and a pool with queued tasks and no worker can only
+        // recover on the next submit. The excess thread retires once the queue drains.
+        if (_num_threads + _num_threads_pending_start > _max_threads &&
+            (_num_threads > 1 || _queue.empty())) {
             break;
         }
 
@@ -704,6 +711,13 @@ void ThreadPool::dispatch_thread() {
 }
 
 Status ThreadPool::create_thread() {
+    DBUG_EXECUTE_IF("ThreadPool.create_thread.block", {
+        // Hold the caller here until the test removes this debug point. Used to widen the window
+        // between publishing a task and observing the thread-creation result.
+        while (DebugPoints::instance()->is_enable("ThreadPool.create_thread.block")) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    });
     DBUG_EXECUTE_IF("ThreadPool.create_thread.inject_failure",
                     { return Status::RuntimeError("injected thread creation failure"); });
     return Thread::create("thread pool", absl::Substitute("$0 [worker]", _name),

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -305,7 +305,8 @@ private:
     // Create new thread.
     //
     // REQUIRES: caller has incremented '_num_threads_pending_start' ahead of this call.
-    // NOTE: For performance reasons, _lock should not be held.
+    // NOTE: For performance reasons, _lock should normally not be held. The first worker is
+    // created with _lock held so submit() can publish its first task atomically.
     Status create_thread();
 
     // Aborts if the current thread is a member of this thread pool.

--- a/be/test/exec/scan/scanner_context_test.cpp
+++ b/be/test/exec/scan/scanner_context_test.cpp
@@ -23,6 +23,7 @@
 #include <gen_cpp/Types_types.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -44,6 +45,8 @@
 #include "storage/tablet/tablet.h"
 #include "storage/tablet/tablet_meta.h"
 #include "testutil/mock/mock_runtime_state.h"
+#include "util/countdown_latch.h"
+#include "util/defer_op.h"
 
 namespace doris {
 class ScannerContextTest : public testing::Test {
@@ -681,6 +684,8 @@ TEST_F(ScannerContextTest, pull_next_scan_task) {
     // a block or EOS and prevent the Context from stalling.
     scanner_context->_max_scan_concurrency = 0;
 
+    EXPECT_FALSE(scanner_context->can_admit_scan_task(context_transfer_lock));
+
     auto completed_task = std::make_shared<ScanTask>(std::make_shared<ScannerDelegate>(scanner));
     completed_task->set_state(ScanTask::State::IN_FLIGHT);
     completed_task->cached_block = Block::create_unique();
@@ -689,6 +694,7 @@ TEST_F(ScannerContextTest, pull_next_scan_task) {
     // A consumed non-EOS result must be eligible for another Context admission. This also covers
     // the COMPLETED -> PENDING transition used by ThreadPool scheduling.
     scanner_context->push_pending_scan_task(completed_task, context_transfer_lock);
+    EXPECT_TRUE(scanner_context->can_admit_scan_task(context_transfer_lock));
 
     EXPECT_FALSE(scanner_context->is_context_queued(context_transfer_lock));
     scanner_context->set_context_queued(true, context_transfer_lock);
@@ -700,6 +706,10 @@ TEST_F(ScannerContextTest, pull_next_scan_task) {
     EXPECT_EQ(admitted_task, completed_task);
     EXPECT_EQ(admitted_task->_state, ScanTask::State::IN_FLIGHT);
     EXPECT_EQ(scanner_context->_in_flight_tasks_num, 1);
+
+    auto blocked_task = std::make_shared<ScanTask>(std::make_shared<ScannerDelegate>(scanner));
+    scanner_context->push_pending_scan_task(blocked_task, context_transfer_lock);
+    EXPECT_FALSE(scanner_context->can_admit_scan_task(context_transfer_lock));
     EXPECT_EQ(scanner_context->try_get_next_scan_task(context_transfer_lock), nullptr);
 }
 
@@ -1044,6 +1054,66 @@ TEST_F(ScannerContextTest, get_block_from_queue) {
                                                0);
     EXPECT_TRUE(st.ok());
     EXPECT_EQ(scanner_context->_num_finished_scanners, 1);
+}
+
+TEST_F(ScannerContextTest, terminal_eos_skips_context_submission) {
+    const int parallel_tasks = 1;
+    auto scan_operator = std::make_unique<OlapScanOperatorX>(obj_pool.get(), tnode, 0, *descs,
+                                                             parallel_tasks, TQueryCacheParam {});
+    auto olap_scan_local_state =
+            OlapScanLocalState::create_unique(state.get(), scan_operator.get());
+
+    OlapScanner::Params scanner_params;
+    scanner_params.state = state.get();
+    scanner_params.profile = profile.get();
+    scanner_params.limit = 100;
+    scanner_params.key_ranges = std::vector<OlapScanRange*>();
+    std::shared_ptr<Scanner> scanner =
+            OlapScanner::create_shared(olap_scan_local_state.get(), std::move(scanner_params));
+    auto scanner_delegate = std::make_shared<ScannerDelegate>(scanner);
+    std::list<std::shared_ptr<ScannerDelegate>> scanners {scanner_delegate};
+    auto scanner_context = ScannerContext::create_shared(
+            state.get(), olap_scan_local_state.get(), output_tuple_desc, output_row_descriptor,
+            scanners, 100, scan_dependency, &shared_limit, nullptr, nullptr, 0, false,
+            parallel_tasks);
+
+    auto eos_task = std::make_shared<ScanTask>(scanner_delegate);
+    eos_task->set_state(ScanTask::State::IN_FLIGHT);
+    eos_task->set_state(ScanTask::State::EOS);
+    scanner_context->_pending_tasks = std::stack<std::shared_ptr<ScanTask>>();
+    scanner_context->_completed_tasks.push_back(eos_task);
+    scanner_context->_in_flight_tasks_num = 0;
+
+    ThreadPoolSimplifiedScanScheduler scheduler("terminal_eos_test", cgroup_cpu_ctl);
+    ASSERT_TRUE(scheduler.start(1, 1, 0, 1).ok());
+    CountDownLatch task_started(1);
+    CountDownLatch release_task(1);
+    Defer cleanup = [&] {
+        release_task.count_down();
+        scheduler.stop();
+    };
+    ASSERT_TRUE(scheduler
+                        .submit_scan_task(SimplifiedScanTask(
+                                [&] {
+                                    task_started.count_down();
+                                    release_task.wait();
+                                    return true;
+                                },
+                                nullptr, nullptr))
+                        .ok());
+    ASSERT_TRUE(task_started.wait_for(std::chrono::seconds(5)));
+    ASSERT_EQ(scheduler.get_active_threads(), 1);
+    scanner_context->_scanner_scheduler = &scheduler;
+
+    MockRuntimeStateLocal mock_runtime_state;
+    EXPECT_CALL(mock_runtime_state, is_cancelled()).WillRepeatedly(testing::Return(false));
+    Block block;
+    bool eos = false;
+    Status status = scanner_context->get_block_from_queue(&mock_runtime_state, &block, &eos, 0);
+
+    EXPECT_TRUE(status.ok()) << status.to_string();
+    EXPECT_TRUE(eos);
+    EXPECT_EQ(scheduler.get_queue_size(), 0);
 }
 
 /**

--- a/be/test/exec/scan/scanner_context_test.cpp
+++ b/be/test/exec/scan/scanner_context_test.cpp
@@ -28,8 +28,10 @@
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <thread>
 #include <tuple>
 
+#include "common/config.h"
 #include "common/object_pool.h"
 #include "core/block/block.h"
 #include "exec/operator/olap_scan_operator.h"
@@ -40,12 +42,14 @@
 #include "exec/scan/scanner_scheduler.h"
 #include "runtime/descriptors.h"
 #include "runtime/query_context.h"
+#include "runtime/task_execution_context.h"
 #include "storage/options.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet/tablet.h"
 #include "storage/tablet/tablet_meta.h"
 #include "testutil/mock/mock_runtime_state.h"
 #include "util/countdown_latch.h"
+#include "util/debug_points.h"
 #include "util/defer_op.h"
 
 namespace doris {
@@ -780,6 +784,191 @@ TEST_F(ScannerContextTest, can_admit_scan_task_respects_shared_limit) {
     scanner_context->_in_flight_tasks_num = 1;
     EXPECT_TRUE(scanner_context->can_admit_scan_task(transfer_lock));
     scanner_context->_in_flight_tasks_num = 0;
+}
+
+TEST_F(ScannerContextTest, thread_pool_admission_refreshes_adaptive_limit) {
+    const int parallel_tasks = 2;
+    auto scan_operator = std::make_unique<OlapScanOperatorX>(obj_pool.get(), tnode, 0, *descs,
+                                                             parallel_tasks, TQueryCacheParam {});
+    auto olap_scan_local_state =
+            OlapScanLocalState::create_unique(state.get(), scan_operator.get());
+
+    OlapScanner::Params scanner_params;
+    scanner_params.state = state.get();
+    scanner_params.profile = profile.get();
+    scanner_params.limit = -1;
+    scanner_params.key_ranges = std::vector<OlapScanRange*>();
+    std::shared_ptr<Scanner> scanner =
+            OlapScanner::create_shared(olap_scan_local_state.get(), std::move(scanner_params));
+
+    std::list<std::shared_ptr<ScannerDelegate>> scanners;
+    for (int i = 0; i < 5; ++i) {
+        scanners.push_back(std::make_shared<ScannerDelegate>(scanner));
+    }
+
+    TUniqueId query_id = state->get_query_ctx()->query_id();
+    const int64_t query_mem_limit = 1024LL * 1024 * 1024;
+    auto arbitrator = MemShareArbitrator::create_shared(query_id, query_mem_limit, 0.3);
+    auto limiter = MemLimiter::create_shared(query_id, parallel_tasks, false,
+                                             static_cast<int64_t>(query_mem_limit * 0.3));
+    // 200MB budget with 100MB estimated blocks: max_count = 2, so instance 1 gets exactly one
+    // adaptive slot. ins_idx = 1 keeps _available_pickup_scanner_count() away from the
+    // arbitrator-driven limit adjustment, which would overwrite this deterministic setup.
+    limiter->update_open_tasks_count(1);
+    limiter->update_mem_limit(200LL * 1024 * 1024);
+    limiter->reestimated_block_mem_bytes(100LL * 1024 * 1024);
+
+    auto scanner_context = ScannerContext::create_shared(
+            state.get(), olap_scan_local_state.get(), output_tuple_desc, output_row_descriptor,
+            scanners, -1, scan_dependency, &shared_limit, arbitrator, limiter, 1, true,
+            parallel_tasks);
+
+    std::unique_lock<std::mutex> transfer_lock(scanner_context->transfer_lock());
+    ASSERT_TRUE(scanner_context->_enable_adaptive_scanners);
+    ASSERT_LT(1, scanner_context->_max_scan_concurrency);
+    EXPECT_EQ(scanner_context->_adaptive_processor->expected_scanners, 0);
+
+    // Admission refreshes the adaptive limit. Nothing is progressing yet, so the first scanner is
+    // admitted regardless, but expected_scanners must no longer stay at its initial zero.
+    auto first_task = scanner_context->try_get_next_scan_task(transfer_lock);
+    ASSERT_NE(first_task, nullptr);
+    EXPECT_EQ(scanner_context->_adaptive_processor->expected_scanners, 1);
+
+    // One task is in flight and the refreshed adaptive limit is one: admission must refuse the
+    // next scanner even though _max_scan_concurrency would still allow it.
+    EXPECT_FALSE(scanner_context->can_admit_scan_task(transfer_lock));
+    EXPECT_EQ(scanner_context->try_get_next_scan_task(transfer_lock), nullptr);
+}
+
+TEST_F(ScannerContextTest, thread_pool_submit_failure_policy) {
+    const int parallel_tasks = 2;
+    auto scan_operator = std::make_unique<OlapScanOperatorX>(obj_pool.get(), tnode, 0, *descs,
+                                                             parallel_tasks, TQueryCacheParam {});
+    auto olap_scan_local_state =
+            OlapScanLocalState::create_unique(state.get(), scan_operator.get());
+
+    OlapScanner::Params scanner_params;
+    scanner_params.state = state.get();
+    scanner_params.profile = profile.get();
+    scanner_params.limit = -1;
+    scanner_params.key_ranges = std::vector<OlapScanRange*>();
+    std::shared_ptr<Scanner> scanner =
+            OlapScanner::create_shared(olap_scan_local_state.get(), std::move(scanner_params));
+
+    std::list<std::shared_ptr<ScannerDelegate>> scanners;
+    for (int i = 0; i < 2; ++i) {
+        scanners.push_back(std::make_shared<ScannerDelegate>(scanner));
+    }
+    auto scanner_context = ScannerContext::create_shared(
+            state.get(), olap_scan_local_state.get(), output_tuple_desc, output_row_descriptor,
+            scanners, -1, scan_dependency, &shared_limit, nullptr, nullptr, 0, false,
+            parallel_tasks);
+
+    // One worker, zero queue capacity, worker occupied: every submit_func() is rejected.
+    ThreadPoolSimplifiedScanScheduler scheduler("submit_failure_policy_test", cgroup_cpu_ctl);
+    ASSERT_TRUE(scheduler.start(1, 1, 0, 1).ok());
+    CountDownLatch task_started(1);
+    CountDownLatch release_task(1);
+    Defer cleanup = [&] {
+        release_task.count_down();
+        scheduler.stop();
+    };
+    ASSERT_TRUE(scheduler
+                        .submit_scan_task(SimplifiedScanTask(
+                                [&] {
+                                    task_started.count_down();
+                                    release_task.wait();
+                                    return true;
+                                },
+                                nullptr, nullptr))
+                        .ok());
+    ASSERT_TRUE(task_started.wait_for(std::chrono::seconds(5)));
+    scanner_context->_scanner_scheduler = &scheduler;
+
+    std::unique_lock<std::mutex> transfer_lock(scanner_context->transfer_lock());
+    ASSERT_FALSE(scanner_context->_pending_tasks.empty());
+
+    // A progressing task exists: pool saturation is tolerated and must not fail the query. The
+    // progressing task's completion and consumption will reschedule this Context.
+    scanner_context->_in_flight_tasks_num = 1;
+    EXPECT_TRUE(scheduler.schedule_scan_task(scanner_context, nullptr, transfer_lock).ok());
+    EXPECT_FALSE(scanner_context->is_context_queued(transfer_lock));
+
+    // Nothing is progressing and shared LIMIT is not exhausted: nothing will retry, so the
+    // failure must surface, normalized like ScannerScheduler::submit().
+    scanner_context->_in_flight_tasks_num = 0;
+    Status surfaced = scheduler.schedule_scan_task(scanner_context, nullptr, transfer_lock);
+    EXPECT_TRUE(surfaced.is<ErrorCode::TOO_MANY_TASKS>()) << surfaced.to_string();
+    EXPECT_FALSE(scanner_context->is_context_queued(transfer_lock));
+}
+
+TEST_F(ScannerContextTest, run_context_publishes_admission_failure) {
+    const bool old_enable_debug_points = config::enable_debug_points;
+    config::enable_debug_points = true;
+    DebugPoints::instance()->add("ThreadPoolSimplifiedScanScheduler._run_context.inject_failure");
+    Defer cleanup_debug_point = [&] {
+        DebugPoints::instance()->remove(
+                "ThreadPoolSimplifiedScanScheduler._run_context.inject_failure");
+        config::enable_debug_points = old_enable_debug_points;
+    };
+
+    const int parallel_tasks = 2;
+    auto scan_operator = std::make_unique<OlapScanOperatorX>(obj_pool.get(), tnode, 0, *descs,
+                                                             parallel_tasks, TQueryCacheParam {});
+    auto olap_scan_local_state =
+            OlapScanLocalState::create_unique(state.get(), scan_operator.get());
+
+    OlapScanner::Params scanner_params;
+    scanner_params.state = state.get();
+    scanner_params.profile = profile.get();
+    scanner_params.limit = -1;
+    scanner_params.key_ranges = std::vector<OlapScanRange*>();
+    std::shared_ptr<Scanner> scanner =
+            OlapScanner::create_shared(olap_scan_local_state.get(), std::move(scanner_params));
+
+    std::list<std::shared_ptr<ScannerDelegate>> scanners;
+    for (int i = 0; i < 2; ++i) {
+        scanners.push_back(std::make_shared<ScannerDelegate>(scanner));
+    }
+    // The worker's task_exec_ctx() must resolve, otherwise _run_context() exits before admission.
+    // HasTaskExecutionCtx snapshots the weak_ptr at construction, so set it before create_shared.
+    auto task_execution_context = std::make_shared<TaskExecutionContext>();
+    state->set_task_execution_context(task_execution_context);
+    auto scanner_context = ScannerContext::create_shared(
+            state.get(), olap_scan_local_state.get(), output_tuple_desc, output_row_descriptor,
+            scanners, -1, scan_dependency, &shared_limit, nullptr, nullptr, 0, false,
+            parallel_tasks);
+
+    ThreadPoolSimplifiedScanScheduler scheduler("run_context_failure_test", cgroup_cpu_ctl);
+    ASSERT_TRUE(scheduler.start(1, 1, 1, 1).ok());
+    Defer cleanup = [&] { scheduler.stop(); };
+    scanner_context->_scanner_scheduler = &scheduler;
+
+    {
+        std::unique_lock<std::mutex> transfer_lock(scanner_context->transfer_lock());
+        ASSERT_TRUE(scheduler.schedule_scan_task(scanner_context, nullptr, transfer_lock).ok());
+        ASSERT_TRUE(scanner_context->is_context_queued(transfer_lock));
+    }
+
+    // The worker admits a scanner and hits the injected exception. It must publish the failure
+    // as a completed task instead of terminating the process or leaking the in-flight slot.
+    bool published = false;
+    for (int i = 0; i < 10000; ++i) {
+        std::unique_lock<std::mutex> transfer_lock(scanner_context->transfer_lock());
+        if (!scanner_context->_completed_tasks.empty()) {
+            published = true;
+            break;
+        }
+        transfer_lock.unlock();
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(published);
+
+    std::unique_lock<std::mutex> transfer_lock(scanner_context->transfer_lock());
+    ASSERT_EQ(scanner_context->_completed_tasks.size(), 1);
+    EXPECT_FALSE(scanner_context->_completed_tasks.front()->status_ok());
+    EXPECT_EQ(scanner_context->_in_flight_tasks_num, 0);
+    EXPECT_FALSE(scanner_context->is_context_queued(transfer_lock));
 }
 
 TEST_F(ScannerContextTest, schedule_scan_task) {

--- a/be/test/exec/scan/scanner_context_test.cpp
+++ b/be/test/exec/scan/scanner_context_test.cpp
@@ -171,7 +171,10 @@ TEST_F(ScannerContextTest, test_init) {
     state->set_query_options(query_options);
     std::unique_ptr<MockSimplifiedScanScheduler> scheduler =
             std::make_unique<MockSimplifiedScanScheduler>(cgroup_cpu_ctl);
+    // init() is invoked twice below, and each invocation performs one initial scheduling attempt.
+    // Keep this expectation explicit so changing bootstrap scheduling updates this test too.
     EXPECT_CALL(*scheduler, schedule_scan_task(testing::_, testing::_, testing::_))
+            .Times(2)
             .WillRepeatedly(testing::Return(Status::OK()));
     scanner_context->_scanner_scheduler = scheduler.get();
 
@@ -458,7 +461,7 @@ TEST_F(ScannerContextTest, test_max_column_reader_num) {
     ASSERT_EQ(scanner_context->_max_scan_concurrency, 1);
 }
 
-TEST_F(ScannerContextTest, test_push_back_scan_task) {
+TEST_F(ScannerContextTest, test_push_completed_scan_task) {
     const int parallel_tasks = 1;
     auto scan_operator = std::make_unique<OlapScanOperatorX>(obj_pool.get(), tnode, 0, *descs,
                                                              parallel_tasks, TQueryCacheParam {});
@@ -491,7 +494,7 @@ TEST_F(ScannerContextTest, test_push_back_scan_task) {
 
     for (int i = 0; i < 5; ++i) {
         auto scan_task = std::make_shared<ScanTask>(std::make_shared<ScannerDelegate>(scanner));
-        scanner_context->push_back_scan_task(scan_task);
+        scanner_context->push_completed_scan_task(scan_task);
         ASSERT_EQ(scanner_context->_in_flight_tasks_num, 10 - i);
     }
 }
@@ -669,6 +672,35 @@ TEST_F(ScannerContextTest, pull_next_scan_task) {
     pull_scan_task = scanner_context->_pull_next_scan_task(
             nullptr, scanner_context->_max_scan_concurrency - 1);
     EXPECT_NE(pull_scan_task, nullptr);
+
+    std::unique_lock<std::mutex> context_transfer_lock(scanner_context->transfer_lock());
+    scanner_context->_pending_tasks = std::stack<std::shared_ptr<ScanTask>>();
+    scanner_context->_completed_tasks.clear();
+    scanner_context->_in_flight_tasks_num = 0;
+        // Even if the effective limit is temporarily zero, one pending task must run so it can publish
+        // a block or EOS and prevent the Context from stalling.
+        scanner_context->_max_scan_concurrency = 0;
+
+    auto completed_task = std::make_shared<ScanTask>(std::make_shared<ScannerDelegate>(scanner));
+    completed_task->set_state(ScanTask::State::IN_FLIGHT);
+    completed_task->cached_block = Block::create_unique();
+    completed_task->set_state(ScanTask::State::COMPLETED);
+    completed_task->cached_block.reset();
+        // A consumed non-EOS result must be eligible for another Context admission. This also covers
+        // the COMPLETED -> PENDING transition used by ThreadPool scheduling.
+    scanner_context->push_pending_scan_task(completed_task, context_transfer_lock);
+
+    EXPECT_FALSE(scanner_context->is_context_queued(context_transfer_lock));
+    scanner_context->set_context_queued(true, context_transfer_lock);
+    EXPECT_TRUE(scanner_context->is_context_queued(context_transfer_lock));
+    scanner_context->set_context_queued(false, context_transfer_lock);
+
+        // The Context can admit exactly one scanner at its configured concurrency limit.
+    auto admitted_task = scanner_context->try_get_next_scan_task(context_transfer_lock);
+    EXPECT_EQ(admitted_task, completed_task);
+    EXPECT_EQ(admitted_task->_state, ScanTask::State::IN_FLIGHT);
+    EXPECT_EQ(scanner_context->_in_flight_tasks_num, 1);
+    EXPECT_EQ(scanner_context->try_get_next_scan_task(context_transfer_lock), nullptr);
 }
 
 TEST_F(ScannerContextTest, schedule_scan_task) {

--- a/be/test/exec/scan/scanner_context_test.cpp
+++ b/be/test/exec/scan/scanner_context_test.cpp
@@ -677,17 +677,17 @@ TEST_F(ScannerContextTest, pull_next_scan_task) {
     scanner_context->_pending_tasks = std::stack<std::shared_ptr<ScanTask>>();
     scanner_context->_completed_tasks.clear();
     scanner_context->_in_flight_tasks_num = 0;
-        // Even if the effective limit is temporarily zero, one pending task must run so it can publish
-        // a block or EOS and prevent the Context from stalling.
-        scanner_context->_max_scan_concurrency = 0;
+    // Even if the effective limit is temporarily zero, one pending task must run so it can publish
+    // a block or EOS and prevent the Context from stalling.
+    scanner_context->_max_scan_concurrency = 0;
 
     auto completed_task = std::make_shared<ScanTask>(std::make_shared<ScannerDelegate>(scanner));
     completed_task->set_state(ScanTask::State::IN_FLIGHT);
     completed_task->cached_block = Block::create_unique();
     completed_task->set_state(ScanTask::State::COMPLETED);
     completed_task->cached_block.reset();
-        // A consumed non-EOS result must be eligible for another Context admission. This also covers
-        // the COMPLETED -> PENDING transition used by ThreadPool scheduling.
+    // A consumed non-EOS result must be eligible for another Context admission. This also covers
+    // the COMPLETED -> PENDING transition used by ThreadPool scheduling.
     scanner_context->push_pending_scan_task(completed_task, context_transfer_lock);
 
     EXPECT_FALSE(scanner_context->is_context_queued(context_transfer_lock));
@@ -695,7 +695,7 @@ TEST_F(ScannerContextTest, pull_next_scan_task) {
     EXPECT_TRUE(scanner_context->is_context_queued(context_transfer_lock));
     scanner_context->set_context_queued(false, context_transfer_lock);
 
-        // The Context can admit exactly one scanner at its configured concurrency limit.
+    // The Context can admit exactly one scanner at its configured concurrency limit.
     auto admitted_task = scanner_context->try_get_next_scan_task(context_transfer_lock);
     EXPECT_EQ(admitted_task, completed_task);
     EXPECT_EQ(admitted_task->_state, ScanTask::State::IN_FLIGHT);

--- a/be/test/exec/scan/scanner_context_test.cpp
+++ b/be/test/exec/scan/scanner_context_test.cpp
@@ -713,6 +713,75 @@ TEST_F(ScannerContextTest, pull_next_scan_task) {
     EXPECT_EQ(scanner_context->try_get_next_scan_task(context_transfer_lock), nullptr);
 }
 
+TEST_F(ScannerContextTest, can_admit_scan_task_respects_shared_limit) {
+    const int parallel_tasks = 4;
+    auto scan_operator = std::make_unique<OlapScanOperatorX>(obj_pool.get(), tnode, 0, *descs,
+                                                             parallel_tasks, TQueryCacheParam {});
+    auto olap_scan_local_state =
+            OlapScanLocalState::create_unique(state.get(), scan_operator.get());
+
+    const int64_t limit = 100;
+    OlapScanner::Params scanner_params;
+    scanner_params.state = state.get();
+    scanner_params.profile = profile.get();
+    scanner_params.limit = limit;
+    scanner_params.key_ranges = std::vector<OlapScanRange*>();
+    std::shared_ptr<Scanner> scanner =
+            OlapScanner::create_shared(olap_scan_local_state.get(), std::move(scanner_params));
+
+    std::list<std::shared_ptr<ScannerDelegate>> scanners;
+    for (int i = 0; i < 4; ++i) {
+        scanners.push_back(std::make_shared<ScannerDelegate>(scanner));
+    }
+    auto scanner_context = ScannerContext::create_shared(
+            state.get(), olap_scan_local_state.get(), output_tuple_desc, output_row_descriptor,
+            scanners, limit, scan_dependency, &shared_limit, nullptr, nullptr, 0, false,
+            parallel_tasks);
+    scanner_context->_scanner_scheduler = scan_scheduler.get();
+
+    std::unique_lock<std::mutex> transfer_lock(scanner_context->transfer_lock());
+    // Constructor queued all four scanners as pending; nothing is in flight or completed.
+    ASSERT_EQ(scanner_context->_pending_tasks.size(), 4);
+    ASSERT_TRUE(scanner_context->_completed_tasks.empty());
+    ASSERT_EQ(scanner_context->_in_flight_tasks_num, 0);
+
+    // Shared LIMIT exhausted by another instance while nothing is progressing: one scanner must
+    // still be admitted so its EOS can wake the operator. Otherwise a queued Context runnable
+    // would exit without publishing anything and the pipeline task would block forever.
+    shared_limit.store(0);
+    ASSERT_TRUE(scanner_context->is_shared_scan_limit_exhausted());
+    EXPECT_TRUE(scanner_context->can_admit_scan_task(transfer_lock));
+
+    auto admitted_task = scanner_context->try_get_next_scan_task(transfer_lock);
+    ASSERT_NE(admitted_task, nullptr);
+    EXPECT_EQ(admitted_task->_state, ScanTask::State::IN_FLIGHT);
+    EXPECT_EQ(scanner_context->_in_flight_tasks_num, 1);
+
+    // With a task progressing, no further scanner is admitted after shared LIMIT is exhausted
+    // even though concurrency slots remain. This avoids O(pending) EOS round trips.
+    ASSERT_LT(1, scanner_context->_max_scan_concurrency);
+    EXPECT_FALSE(scanner_context->can_admit_scan_task(transfer_lock));
+    EXPECT_EQ(scanner_context->try_get_next_scan_task(transfer_lock), nullptr);
+    EXPECT_EQ(scanner_context->_in_flight_tasks_num, 1);
+    EXPECT_EQ(scanner_context->_pending_tasks.size(), 3);
+
+    // A completed-but-unconsumed result also counts as progressing: the operator will be woken
+    // to consume it and can observe termination there.
+    admitted_task->set_state(ScanTask::State::EOS);
+    scanner_context->_in_flight_tasks_num = 0;
+    scanner_context->_completed_tasks.push_back(admitted_task);
+    EXPECT_FALSE(scanner_context->can_admit_scan_task(transfer_lock));
+    scanner_context->_completed_tasks.clear();
+
+    // While shared LIMIT still has remaining rows, the same state admits normally up to the
+    // concurrency limit.
+    shared_limit.store(limit);
+    ASSERT_FALSE(scanner_context->is_shared_scan_limit_exhausted());
+    scanner_context->_in_flight_tasks_num = 1;
+    EXPECT_TRUE(scanner_context->can_admit_scan_task(transfer_lock));
+    scanner_context->_in_flight_tasks_num = 0;
+}
+
 TEST_F(ScannerContextTest, schedule_scan_task) {
     const int parallel_tasks = 4;
     auto scan_operator = std::make_unique<OlapScanOperatorX>(obj_pool.get(), tnode, 0, *descs,

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -46,6 +46,7 @@
 #include "gtest/gtest.h"
 #include "util/barrier.h"
 #include "util/countdown_latch.h"
+#include "util/debug_points.h"
 #include "util/defer_op.h"
 #include "util/random.h"
 #include "util/time.h"
@@ -132,6 +133,40 @@ TEST_F(ThreadPoolTest, TestSimpleTasks) {
     _pool->wait();
     EXPECT_EQ(10 + 15 + 20 + 15, counter.load());
     _pool->shutdown();
+}
+
+TEST_F(ThreadPoolTest, TestCreateFirstThreadFailureDoesNotEnqueueTask) {
+    const bool old_enable_debug_points = config::enable_debug_points;
+    config::enable_debug_points = true;
+    DebugPoints::instance()->add("ThreadPool.create_thread.inject_failure");
+    Defer cleanup = [&] {
+        DebugPoints::instance()->remove("ThreadPool.create_thread.inject_failure");
+        config::enable_debug_points = old_enable_debug_points;
+    };
+
+    // Initialization deliberately tolerates a thread creation failure so a later submit can retry.
+    EXPECT_TRUE(rebuild_pool_with_min_max(1, 1).ok());
+    EXPECT_EQ(0, _pool->num_threads());
+
+    std::atomic<int> rejected_task_runs = 0;
+    Status submit_status = _pool->submit_func([&] { ++rejected_task_runs; });
+    EXPECT_FALSE(submit_status.ok());
+    EXPECT_EQ(0, _pool->get_queue_size());
+    EXPECT_EQ(0, rejected_task_runs.load());
+
+    DebugPoints::instance()->remove("ThreadPool.create_thread.inject_failure");
+    std::atomic<int> accepted_task_runs = 0;
+    EXPECT_TRUE(_pool->submit_func([&] { ++accepted_task_runs; }).ok());
+    _pool->wait();
+
+    EXPECT_EQ(0, rejected_task_runs.load());
+    EXPECT_EQ(1, accepted_task_runs.load());
+}
+
+TEST_F(ThreadPoolTest, TestRejectNonPositiveMaxThreads) {
+    int old_max_threads = _pool->max_threads();
+    EXPECT_TRUE(_pool->set_max_threads(0).is<INVALID_ARGUMENT>());
+    EXPECT_EQ(old_max_threads, _pool->max_threads());
 }
 
 class SlowTask : public Runnable {

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -169,6 +169,76 @@ TEST_F(ThreadPoolTest, TestRejectNonPositiveMaxThreads) {
     EXPECT_EQ(old_max_threads, _pool->max_threads());
 }
 
+TEST_F(ThreadPoolTest, TestLastWorkerSurvivesShrinkWithQueuedTask) {
+    const bool old_enable_debug_points = config::enable_debug_points;
+    config::enable_debug_points = true;
+    Defer cleanup = [&] {
+        DebugPoints::instance()->remove("ThreadPool.create_thread.block");
+        DebugPoints::instance()->remove("ThreadPool.create_thread.inject_failure");
+        config::enable_debug_points = old_enable_debug_points;
+    };
+
+    // Build the pool before enabling debug points so the initial worker starts normally.
+    EXPECT_TRUE(rebuild_pool_with_min_max(1, 2).ok());
+    ASSERT_EQ(1, _pool->num_threads());
+
+    // Occupy the only worker so the next submission requests an additional thread.
+    CountDownLatch task_a_started(1);
+    CountDownLatch release_task_a(1);
+    ASSERT_TRUE(_pool->submit_func([&] {
+                         task_a_started.count_down();
+                         release_task_a.wait();
+                     }).ok());
+    task_a_started.wait();
+
+    // The next submission publishes task B, then stalls inside create_thread() so a runtime
+    // shrink can interleave before the creation failure is observed.
+    DebugPoints::instance()->add("ThreadPool.create_thread.block");
+    DebugPoints::instance()->add("ThreadPool.create_thread.inject_failure");
+    std::atomic<int> task_b_runs = 0;
+    CountDownLatch task_b_done(1);
+    Status submit_b_status;
+    std::thread submitter([&] {
+        submit_b_status = _pool->submit_func([&] {
+            ++task_b_runs;
+            task_b_done.count_down();
+        });
+    });
+    auto wait_for = [](const std::function<bool()>& pred) {
+        for (int i = 0; i < 10000; ++i) {
+            if (pred()) {
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return false;
+    };
+    ASSERT_TRUE(wait_for([&] { return _pool->get_queue_size() == 1; }));
+    ASSERT_EQ(1, _pool->num_threads_pending_start());
+
+    // Shrink below live + pending. The active worker counts the pending replacement, but it must
+    // not retire while it is the last live worker and task B is still queued: the replacement can
+    // still fail to start.
+    ASSERT_TRUE(_pool->set_max_threads(1).ok());
+    release_task_a.count_down();
+    ASSERT_TRUE(task_b_done.wait_for(std::chrono::seconds(10)));
+
+    // Only after B ran does the stalled creation fail; the failure path must tolerate it.
+    DebugPoints::instance()->remove("ThreadPool.create_thread.block");
+    submitter.join();
+
+    EXPECT_TRUE(submit_b_status.ok()) << submit_b_status.to_string();
+    EXPECT_EQ(1, task_b_runs.load());
+    EXPECT_EQ(0, _pool->get_queue_size());
+
+    // The pool stays usable: the next submission recreates a worker if none is left.
+    DebugPoints::instance()->remove("ThreadPool.create_thread.inject_failure");
+    std::atomic<int> task_c_runs = 0;
+    ASSERT_TRUE(_pool->submit_func([&] { ++task_c_runs; }).ok());
+    _pool->wait();
+    EXPECT_EQ(1, task_c_runs.load());
+}
+
 class SlowTask : public Runnable {
 public:
     explicit SlowTask(CountDownLatch* latch) : _latch(latch) {}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

The ThreadPool scan scheduler (`ThreadPoolSimplifiedScanScheduler`) submitted one
runnable per scanner. A scan operator with many scanners therefore occupied many
thread-pool queue entries at once, every `schedule_scan_task` call went through a
scheduler-wide `shared_mutex`, and the per-Context admission logic (`_get_margin`,
`_pull_next_scan_task`) was shared with the TaskExecutor path even though the two
schedulers have different queueing models.

This PR reworks ThreadPool scan scheduling around **one queued runnable per
ScannerContext**:

- `schedule_scan_task` only returns a consumed non-EOS scanner to `_pending_tasks`
  and submits a Context runnable if none is queued (`_is_context_queued`) and the
  Context can currently admit a scanner (`can_admit_scan_task`). Queue occupancy
  is now bounded by the number of Contexts instead of the number of scanners.
- The runnable (`_run_context`) admits exactly one pending scanner under
  `transfer_lock` (`try_get_next_scan_task`), resubmits itself before releasing
  the lock if more work is admissible, then runs the scan without the lock.
- Admission keeps at least one task progressing whenever a pending scanner exists
  (so adaptive/low-memory limits cannot stall a Context), and stops admitting
  further scanners once shared LIMIT is exhausted while another task is still
  progressing (avoids one EOS round trip per pending scanner). The "admit one when
  idle" rule stays ahead of the LIMIT check so a runnable dequeued after another
  instance exhausted the limit still wakes the blocked operator.
- `ScannerScheduler::_scanner_scan` finishes an admitted scanner as EOS without
  opening it once shared LIMIT is exhausted, so it always releases its in-flight
  slot. `push_back_scan_task` is renamed `push_completed_scan_task` and documented
  as publishing a result and releasing its slot atomically.
- The scheduler-wide `shared_mutex` in `ThreadPoolSimplifiedScanScheduler` is
  removed; all ThreadPool admission decisions are serialized by the Context's
  `transfer_lock` only.
- Profile: new `ScannerContextWaitWorkerTime` counter measuring the interval from
  a successful Context submission to worker start.

Two `ThreadPool` fixes support this model:

- `do_submit` now creates the first worker *before* publishing the task. Previously
  a first-worker creation failure returned an error while leaving the runnable in
  the queue, where it could run after a later recovery. `set_max_threads` rejects
  non-positive values.
- The scan scheduler no longer submits a Context runnable when the Context has no
  pending scanner or no free concurrency slot, so a terminal EOS cannot fail with a
  queue-capacity error after scanning has completed.

### Release note

None

### Check List (For Author)

- Test
    - [x] Unit Test
        - `./run-be-ut.sh --run --filter='ScannerContextTest.*' -j16`
          (32/32 passed, ASAN)
        - `./run-be-ut.sh --run --filter='*ThreadPool*' -j16`
    - [ ] Regression test
    - [ ] Manual test
    - [ ] No need to test or manual test. Explain why:

- Behavior changed:
    - [x] Yes.
        - `enable_task_executor_in_internal_table` and
          `enable_task_executor_in_external_table` default to `false`, so
          internal and external table scans use the ThreadPool scheduler by
          default. This is intentional: the refactored ThreadPool scheduler is the
          default scan scheduling path going forward; the TaskExecutor path remains
          available by setting these configs to `true`.
        - In ThreadPool mode, a Context admits at most one scanner per dequeued
          runnable and keeps at most one runnable queued. `min_scanners_concurrency`
          and `min_active_scan_threads` no longer influence ThreadPool admission
          (they still apply to the TaskExecutor path); per-Context concurrency is
          bounded by `max_scanners_concurrency`, adaptive and low-memory limits.
        - After shared LIMIT is exhausted, no additional scanners are admitted while
          a task is progressing.
        - A thread-pool submission whose first worker cannot be created now returns
          an error without retaining the task.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
