### PR TITLE
[fix](backup) Preserve backup table references across replay

### DIFF
--- a/fe/fe-catalog/src/main/java/org/apache/doris/catalog/info/TableNameInfo.java
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/catalog/info/TableNameInfo.java
@@ -35,11 +35,11 @@ import java.util.stream.Stream;
  * table name info
  */
 public class TableNameInfo {
-    @SerializedName(value = "c")
+    @SerializedName(value = "c", alternate = {"ctl"})
     private String ctl;
-    @SerializedName(value = "t")
+    @SerializedName(value = "t", alternate = {"tbl"})
     private String tbl;
-    @SerializedName(value = "d")
+    @SerializedName(value = "d", alternate = {"db"})
     private String db;
 
     public TableNameInfo() {

--- a/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/backup/BackupJob.java
@@ -454,6 +454,17 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
             return;
         }
 
+        // TableRefInfo fields were not persisted by some earlier versions. A PENDING job cannot
+        // reconstruct the requested tables after replay, so cancel it with an actionable error
+        // instead of repeatedly failing while preparing snapshot tasks.
+        if (state == BackupJobState.PENDING && hasMissingTableReference()) {
+            status = new Status(ErrCode.COMMON_ERROR,
+                    "failed to resume backup job because table reference metadata is missing from the edit log; "
+                            + "submit the backup again");
+            cancelInternal();
+            return;
+        }
+
         // check timeout
         if (System.currentTimeMillis() - createTime > timeoutMs) {
             status = new Status(ErrCode.TIMEOUT, "");
@@ -513,6 +524,10 @@ public class BackupJob extends AbstractJob implements GsonPostProcessable {
         if (!status.ok() && state != BackupJobState.UPLOAD_INFO) {
             cancelInternal();
         }
+    }
+
+    private boolean hasMissingTableReference() {
+        return tableRefs.stream().anyMatch(tableRef -> tableRef.getTableNameInfo() == null);
     }
 
     // cancel by user

--- a/fe/fe-core/src/main/java/org/apache/doris/info/TableRefInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/info/TableRefInfo.java
@@ -27,6 +27,8 @@ import org.apache.doris.catalog.info.PartitionNamesInfo;
 import org.apache.doris.common.UserException;
 import org.apache.doris.nereids.trees.TableSample;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -43,9 +45,11 @@ public class TableRefInfo {
     protected JoinOperator joinOp;
     protected String tableAlias;
     protected boolean isMark;
+    @SerializedName("n")
     protected org.apache.doris.catalog.info.TableNameInfo tableNameInfo;
     private final TableScanParams scanParams;
     private final TableSnapshot tableSnapShot;
+    @SerializedName("p")
     private final PartitionNamesInfo partitionNamesInfo;
     private final List<Long> sampleTabletIds;
     private final TableSample tableSample;

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupHandlerTest.java
@@ -41,6 +41,7 @@ import org.apache.doris.nereids.trees.plans.commands.CreateRepositoryCommand;
 import org.apache.doris.nereids.trees.plans.commands.RestoreCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.LabelNameInfo;
 import org.apache.doris.persist.EditLog;
+import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.task.DirMoveTask;
 import org.apache.doris.task.DownloadTask;
 import org.apache.doris.task.SnapshotTask;
@@ -51,6 +52,9 @@ import org.apache.doris.thrift.TStatusCode;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -59,6 +63,10 @@ import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitOption;
@@ -136,6 +144,48 @@ public class BackupHandlerTest {
 
         File backupDir = new File(BackupHandler.BACKUP_ROOT_DIR.toString());
         Assert.assertTrue(backupDir.exists());
+    }
+
+    @Test
+    public void testReplayPendingJobWithMissingTableReference() throws IOException {
+        List<TableRefInfo> tableRefs = Lists.newArrayList();
+        tableRefs.add(new TableRefInfo(new TableNameInfo(InternalCatalog.INTERNAL_CATALOG_NAME,
+                CatalogMocker.TEST_DB_NAME, CatalogMocker.TEST_TBL_NAME), null));
+        BackupJob backupJob = new BackupJob("legacy_missing_ref", CatalogMocker.TEST_DB_ID,
+                CatalogMocker.TEST_DB_NAME, tableRefs, 600_000, BackupCommand.BackupContent.ALL,
+                env, Repository.KEEP_ON_LOCAL_REPO_ID, 0);
+
+        JsonObject pendingJobJson = JsonParser.parseString(GsonUtils.GSON.toJson(backupJob)).getAsJsonObject();
+        JsonArray corruptedTableRefs = new JsonArray();
+        corruptedTableRefs.add(new JsonObject());
+        pendingJobJson.add("ref", corruptedTableRefs);
+        String corruptedPendingJobJson = pendingJobJson.toString();
+
+        BackupJob replayedPendingJob = GsonUtils.GSON.fromJson(corruptedPendingJobJson, BackupJob.class);
+        handler = new BackupHandler(env);
+        handler.replayAddJob(replayedPendingJob);
+        handler.runAfterCatalogReady();
+
+        BackupJob cancelledJob = (BackupJob) handler.getJob(CatalogMocker.TEST_DB_ID);
+        Assert.assertTrue(cancelledJob.isCancelled());
+        Assert.assertTrue(cancelledJob.getStatus().getErrMsg().contains("submit the backup again"));
+        Mockito.verify(editLog, Mockito.times(1)).logBackupJob(cancelledJob);
+
+        BackupHandler restartedHandler = new BackupHandler(env);
+        restartedHandler.replayAddJob(GsonUtils.GSON.fromJson(corruptedPendingJobJson, BackupJob.class));
+        restartedHandler.replayAddJob(writeAndRead(cancelledJob));
+        Assert.assertTrue(restartedHandler.getJob(CatalogMocker.TEST_DB_ID).isCancelled());
+    }
+
+    private BackupJob writeAndRead(BackupJob backupJob) throws IOException {
+        ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
+        try (DataOutputStream output = new DataOutputStream(outputBytes)) {
+            backupJob.write(output);
+        }
+        try (DataInputStream input = new DataInputStream(
+                new ByteArrayInputStream(outputBytes.toByteArray()))) {
+            return BackupJob.read(input);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -26,6 +26,7 @@ import org.apache.doris.catalog.FsBroker;
 import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.TableProperty;
+import org.apache.doris.catalog.info.PartitionNamesInfo;
 import org.apache.doris.catalog.info.TableNameInfo;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
@@ -38,6 +39,7 @@ import org.apache.doris.fs.FileSystemDescriptor;
 import org.apache.doris.info.TableRefInfo;
 import org.apache.doris.nereids.trees.plans.commands.BackupCommand;
 import org.apache.doris.persist.EditLog;
+import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.task.AgentTask;
 import org.apache.doris.task.AgentTaskExecutor;
 import org.apache.doris.task.AgentTaskQueue;
@@ -625,12 +627,13 @@ public class BackupJobTest {
         DataOutputStream out = new DataOutputStream(Files.newOutputStream(path));
 
         List<TableRefInfo> tableRefs = Lists.newArrayList();
+        PartitionNamesInfo partitionNames = new PartitionNamesInfo(false, Lists.newArrayList("p1", "p2"));
         tableRefs.add(
                 new TableRefInfo(
                         new TableNameInfo(InternalCatalog.INTERNAL_CATALOG_NAME, UnitTestUtil.DB_NAME, UnitTestUtil.TABLE_NAME),
                         null,
                         null,
-                        null,
+                        partitionNames,
                         new ArrayList<>(),
                         null,
                         null,
@@ -652,9 +655,26 @@ public class BackupJobTest {
         Assert.assertEquals(job.getCreateTime(), job2.getCreateTime());
         Assert.assertEquals(job.getType(), job2.getType());
         Assert.assertEquals(job.getCommitSeq(), job2.getCommitSeq());
+        Assert.assertTrue(job2.getInfo().get(4).contains(UnitTestUtil.TABLE_NAME));
+        Assert.assertTrue(job2.getInfo().get(4).contains("p1"));
+        Assert.assertTrue(job2.getInfo().get(4).contains("p2"));
 
         // 3. delete files
         in.close();
         Files.delete(path);
+    }
+
+    @Test
+    public void testDeserializeLegacyTableRefInfoNames() {
+        TableRefInfo tableRef = GsonUtils.GSON.fromJson(
+                "{\"n\":{\"ctl\":\"internal\",\"db\":\"db\",\"tbl\":\"tbl\"},"
+                        + "\"p\":{\"partitionNames\":[\"p1\",\"p2\"],\"isTemp\":false}}",
+                TableRefInfo.class);
+
+        Assert.assertEquals("internal", tableRef.getTableNameInfo().getCtl());
+        Assert.assertEquals("db", tableRef.getTableNameInfo().getDb());
+        Assert.assertEquals("tbl", tableRef.getTableNameInfo().getTbl());
+        Assert.assertEquals(Lists.newArrayList("p1", "p2"),
+                tableRef.getPartitionNamesInfo().getPartitionNames());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/backup/BackupJobTest.java
@@ -53,6 +53,9 @@ import org.apache.doris.thrift.TTaskType;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -64,6 +67,8 @@ import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -676,5 +681,51 @@ public class BackupJobTest {
         Assert.assertEquals("tbl", tableRef.getTableNameInfo().getTbl());
         Assert.assertEquals(Lists.newArrayList("p1", "p2"),
                 tableRef.getPartitionNamesInfo().getPartitionNames());
+    }
+
+    @Test
+    public void testCancelPendingJobWithMissingPersistedTableReference() throws IOException {
+        JsonObject jobJson = JsonParser.parseString(GsonUtils.GSON.toJson(job)).getAsJsonObject();
+        // This is the exact shape written while TableRefInfo lacked @SerializedName annotations.
+        JsonArray corruptedTableRefs = new JsonArray();
+        corruptedTableRefs.add(new JsonObject());
+        jobJson.add("ref", corruptedTableRefs);
+        String corruptedJobJson = jobJson.toString();
+
+        BackupJob replayedJob = GsonUtils.GSON.fromJson(corruptedJobJson, BackupJob.class);
+        replayedJob.setEnv(env);
+        Assert.assertEquals(BackupJobState.PENDING.name(), replayedJob.getInfo().get(3));
+        replayedJob.run();
+
+        Assert.assertTrue(replayedJob.isCancelled());
+        Assert.assertEquals(BackupJobState.CANCELLED.name(), replayedJob.getInfo().get(3));
+        Assert.assertTrue(replayedJob.getStatus().getErrMsg().contains(
+                "table reference metadata is missing from the edit log"));
+
+        BackupJob replayedCancelledJob = writeAndRead(replayedJob);
+        replayedCancelledJob.setEnv(env);
+        replayedCancelledJob.run();
+        Assert.assertTrue(replayedCancelledJob.isCancelled());
+
+        JsonObject finishedJobJson = JsonParser.parseString(corruptedJobJson).getAsJsonObject();
+        finishedJobJson.addProperty("st", BackupJobState.FINISHED.name());
+        BackupJob replayedFinishedJob = GsonUtils.GSON.fromJson(finishedJobJson.toString(), BackupJob.class);
+        replayedFinishedJob.setEnv(env);
+        replayedFinishedJob.run();
+        Assert.assertTrue(replayedFinishedJob.isFinished());
+
+        Mockito.verify(editLog, Mockito.times(1)).logBackupJob(ArgumentMatchers.any(BackupJob.class));
+        mockedAgentTaskExecutor.verifyNoInteractions();
+    }
+
+    private BackupJob writeAndRead(BackupJob backupJob) throws IOException {
+        ByteArrayOutputStream outputBytes = new ByteArrayOutputStream();
+        try (DataOutputStream output = new DataOutputStream(outputBytes)) {
+            backupJob.write(output);
+        }
+        try (DataInputStream input = new DataInputStream(
+                new ByteArrayInputStream(outputBytes.toByteArray()))) {
+            return BackupJob.read(input);
+        }
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #66982

Related PR: none (first of a serial PR0–PR5 series)

Problem Summary:

`BackupJob` persists the tables and partitions selected by a BACKUP statement in the FE edit log.
After `TableRef` was migrated to `TableRefInfo` (#56095), the replacement fields did not retain the
serialized names used by the historical payload. Because Doris' Gson configuration only serializes
fields annotated with `@SerializedName`, affected FE versions wrote each table reference as an empty
JSON object (`"ref": [{}]`). After an FE restart, a PENDING job was replayed successfully but
repeatedly threw a `NullPointerException` with no business context while preparing snapshot tasks.

This change restores stable serialized names (`"n"`/`"p"` on `TableRefInfo`) and accepts the
historical table-name keys (`"ctl"`/`"db"`/`"tbl"`) as alternates of the canonical short keys, so
payloads written both before and after the migration replay correctly.

For already-corrupted PENDING journals, the originally requested scope cannot be reconstructed safely:
treating an empty reference as a whole-database request could back up data the user did not select.
Such jobs are therefore cancelled once, before any repository access, snapshot task creation, or
catalog mutation, with an actionable resubmission error. The cancellation is persisted to the edit
log so a second replay does not re-trigger it. Jobs that already moved past PENDING are left untouched
because later states no longer depend on `tableRefs`.

### Release note

Fix Backup job replay after FE restart when the edit log lost table references. Unrecoverable
historical PENDING jobs are now cancelled once with a clear resubmission error instead of failing
repeatedly with `NullPointerException`.

### Check List (For Author)

- Test:
    - [x] Unit Test
        - `./run-fe-ut.sh --run org.apache.doris.backup.BackupJobTest,org.apache.doris.backup.BackupHandlerTest`
        - 12 tests passed: `BackupJobTest` 9, `BackupHandlerTest` 3; 0 failures/errors/skips.
    - [x] FE build
        - `./build.sh --fe -j 1`
        - Build success; all 73 Maven modules passed and Checkstyle reported 0 violations.
- Behavior changed:
    - [x] Yes. A historical PENDING Backup job whose journal has already lost its table references is
      cancelled and must be resubmitted. All other jobs are unaffected.
- Does this need documentation?
    - [x] No.

Validated on `apache/doris:master@b3b1eab90ca`; PR head: `dcb6d575e4b`.
