### PR TITLE
[fix](fe) Exclude ordered distinct aggregates from bucketed fusion

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -93,6 +93,7 @@ import org.apache.doris.nereids.trees.expressions.functions.Udf;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateParam;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregatePhase;
+import org.apache.doris.nereids.trees.expressions.functions.agg.MultiDistinction;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.GroupingScalarFunction;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.UniqueFunction;
 import org.apache.doris.nereids.trees.plans.AbstractPlan;
@@ -3253,7 +3254,9 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
                 }
                 if (c instanceof AggregateExpression) {
                     AggregateFunction func = ((AggregateExpression) c).getFunction();
-                    if (!func.supportAggregatePhase(AggregatePhase.TWO)) {
+                    if (!func.supportAggregatePhase(AggregatePhase.TWO)
+                            || func instanceof MultiDistinction
+                            || func.children().stream().anyMatch(OrderExpression.class::isInstance)) {
                         foundOnePhaseOnly.set(true);
                     }
                     return true;

--- a/regression-test/suites/nereids_rules_p0/agg_strategy/bucketed_hash_agg.groovy
+++ b/regression-test/suites/nereids_rules_p0/agg_strategy/bucketed_hash_agg.groovy
@@ -159,4 +159,20 @@ suite("bucketed_hash_agg") {
     GROUP BY grp
     ORDER BY grp;
     """
+
+    // ============================================================
+    // Test 6: Negative — multi-distinct GROUP_CONCAT with ORDER BY
+    //          BucketedAggregationNode does not carry aggregate sort info.
+    // ============================================================
+    sql "set agg_phase=1"
+    String groupConcatQuery = """
+        SELECT grp, GROUP_CONCAT(DISTINCT CAST(id AS STRING) ORDER BY val)
+        FROM bucketed_agg_reg_test
+        GROUP BY grp;
+    """
+    explain {
+        sql(groupConcatQuery)
+        notContains("BUCKETED AGGREGATE")
+    }
+    sql "set agg_phase=0"
 }


### PR DESCRIPTION
Bucketed aggregation fusion accepted `multi_distinct_group_concat` expressions with an internal `ORDER BY`. `BucketedAggregationNode` does not carry aggregate sort metadata, so finalizing the distinct state could read the order column as a string argument and abort the BE. This change excludes multi-distinct aggregates and aggregate functions with `OrderExpression` children from bucketed fusion.