### PR TITLE
[fix](be) Avoid relying on null string payloads

### DIFF
--- a/be/src/core/block/block.cpp
+++ b/be/src/core/block/block.cpp
@@ -42,6 +42,7 @@
 #include "core/column/column_const.h"
 #include "core/column/column_nothing.h"
 #include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
 #include "core/column/column_vector.h"
 #include "core/data_type/data_type_factory.hpp"
 #include "core/data_type/data_type_nullable.h"
@@ -368,6 +369,38 @@ Status Block::check_no_column_string64() const {
     }
     return Status::OK();
 }
+
+#ifndef NDEBUG
+void Block::debug_inject_nonempty_string_payload_for_null_rows() {
+    for (size_t column_index = 0; column_index < data.size(); ++column_index) {
+        const auto* nullable =
+                check_and_get_column<ColumnNullable>(data[column_index].column.get());
+        if (nullable == nullptr || check_and_get_column<ColumnString>(
+                                           nullable->get_nested_column_ptr().get()) == nullptr) {
+            continue;
+        }
+
+        auto column_guard = mutate_column_scoped(column_index);
+        auto& mutable_nullable = assert_cast<ColumnNullable&>(*column_guard.mutable_column());
+        const auto& nested_string =
+                assert_cast<const ColumnString&>(mutable_nullable.get_nested_column());
+        const auto& null_map = mutable_nullable.get_null_map_data();
+        auto injected_string = ColumnString::create();
+        injected_string->reserve(nested_string.size());
+        for (size_t row = 0; row < nested_string.size(); ++row) {
+            if (null_map[row]) {
+                const auto payload = fmt::format("__DORIS_NULL_PAYLOAD_{}__", row);
+                injected_string->insert_data(payload.data(), payload.size());
+            } else {
+                const auto value = nested_string.get_data_at(row);
+                injected_string->insert_data(value.data, value.size);
+            }
+        }
+        ColumnPtr null_map_column = mutable_nullable.get_null_map_column_ptr();
+        mutable_nullable.replace_columns(std::move(injected_string), std::move(null_map_column));
+    }
+}
+#endif
 
 size_t Block::rows() const {
     for (const auto& elem : data) {

--- a/be/src/core/block/block.h
+++ b/be/src/core/block/block.h
@@ -187,6 +187,10 @@ public:
 
     Status check_no_column_string64() const;
 
+#ifndef NDEBUG
+    void debug_inject_nonempty_string_payload_for_null_rows();
+#endif
+
     /// Approximate number of bytes used by column data in memory.
     /// This reflects the actual data footprint (e.g. string contents, numeric arrays)
     /// and is the metric used by adaptive batch size byte budgets.

--- a/be/src/core/data_type_serde/data_type_decimal_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_decimal_serde.cpp
@@ -680,12 +680,8 @@ Status DataTypeDecimalSerDe<T>::from_string_strict_mode_batch(
     const auto row = str.size();
     column.resize(row);
 
-    const ColumnString::Chars* chars = &str.get_chars();
-    const IColumn::Offsets* offsets = &str.get_offsets();
-
     auto& column_to = assert_cast<ColumnType&>(column);
     auto& vec_to = column_to.get_data();
-    size_t current_offset = 0;
     auto arg_precision = static_cast<UInt32>(precision);
     auto arg_scale = static_cast<UInt32>(scale);
     CastParameters params;
@@ -694,16 +690,10 @@ Status DataTypeDecimalSerDe<T>::from_string_strict_mode_batch(
         if (null_map && null_map[i]) {
             continue;
         }
-        size_t next_offset = (*offsets)[i];
-        size_t string_size = next_offset - current_offset;
-
-        if (!CastToDecimal::from_string(StringRef(&(*chars)[current_offset], string_size),
-                                        vec_to[i], arg_precision, arg_scale, params)) {
-            return Status::InvalidArgument(
-                    "parse number fail, string: '{}'",
-                    std::string((char*)&(*chars)[current_offset], string_size));
+        auto str_ref = str.get_data_at(i);
+        if (!CastToDecimal::from_string(str_ref, vec_to[i], arg_precision, arg_scale, params)) {
+            return Status::InvalidArgument("parse number fail, string: '{}'", str_ref.to_string());
         }
-        current_offset = next_offset;
     }
     return Status::OK();
 }

--- a/be/src/core/data_type_serde/data_type_number_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_number_serde.cpp
@@ -1661,10 +1661,6 @@ Status DataTypeNumberSerDe<T>::from_string_strict_mode_batch(
     const auto size = str.size();
     column.resize(size);
 
-    size_t current_offset = 0;
-    const ColumnString::Chars* chars = &str.get_chars();
-    const IColumn::Offsets* offsets = &str.get_offsets();
-
     auto& column_to = assert_cast<ColumnType&>(column);
     auto& vec_to = column_to.get_data();
     CastParameters params;
@@ -1673,16 +1669,10 @@ Status DataTypeNumberSerDe<T>::from_string_strict_mode_batch(
         if (null_map && null_map[i]) {
             continue;
         }
-        size_t next_offset = (*offsets)[i];
-        size_t string_size = next_offset - current_offset;
-
-        StringRef str_ref(&(*chars)[current_offset], string_size);
+        auto str_ref = str.get_data_at(i);
         if (!try_parse_impl<T, true>(vec_to[i], str_ref, params)) {
-            return Status::InvalidArgument(
-                    "parse number fail, string: '{}'",
-                    std::string((char*)&(*chars)[current_offset], string_size));
+            return Status::InvalidArgument("parse number fail, string: '{}'", str_ref.to_string());
         }
-        current_offset = next_offset;
     }
     return Status::OK();
 }

--- a/be/src/exec/operator/operator.h
+++ b/be/src/exec/operator/operator.h
@@ -616,6 +616,9 @@ public:
 
     [[nodiscard]] Status sink(RuntimeState* state, Block* block, bool eos) {
         RETURN_IF_ERROR(block->check_column_and_type_not_null());
+#ifndef NDEBUG
+        block->debug_inject_nonempty_string_payload_for_null_rows();
+#endif
         RETURN_IF_ERROR(block->check_no_column_string64());
         RETURN_IF_ERROR(block->check_type_and_column());
         return sink_impl(state, block, eos);
@@ -879,6 +882,9 @@ public:
     [[nodiscard]] Status get_block(RuntimeState* state, Block* block, bool* eos) {
         RETURN_IF_ERROR(get_block_impl(state, block, eos));
         RETURN_IF_ERROR(block->check_column_and_type_not_null());
+#ifndef NDEBUG
+        block->debug_inject_nonempty_string_payload_for_null_rows();
+#endif
         RETURN_IF_ERROR(block->check_no_column_string64());
         RETURN_IF_ERROR(block->check_type_and_column());
         return Status::OK();

--- a/be/src/exprs/aggregate/aggregate_function_null_v2.h
+++ b/be/src/exprs/aggregate/aggregate_function_null_v2.h
@@ -97,6 +97,32 @@ protected:
         return num;
     }
 
+    template <bool only_selected>
+    void deserialize_and_merge_vec_with_nulls(const AggregateDataPtr* places, size_t offset,
+                                              AggregateDataPtr rhs, const IColumn& nested_column,
+                                              const UInt8* null_map, Arena& arena,
+                                              size_t num_rows) const {
+        IColumn::Filter non_null_filter(num_rows, 0);
+        std::vector<AggregateDataPtr> non_null_places;
+        non_null_places.reserve(num_rows);
+        for (size_t i = 0; i < num_rows; ++i) {
+            if (!null_map[i] && (!only_selected || places[i] != nullptr)) {
+                *(places[i] + offset) |= 1;
+                non_null_filter[i] = 1;
+                non_null_places.push_back(places[i]);
+            }
+        }
+
+        if (non_null_places.empty()) {
+            return;
+        }
+
+        auto non_null_column = nested_column.filter(non_null_filter, non_null_places.size());
+        nested_function->deserialize_and_merge_vec(non_null_places.data(), offset + prefix_size,
+                                                   rhs, non_null_column.get(), arena,
+                                                   non_null_places.size());
+    }
+
 public:
     AggregateFunctionNullBaseInlineV2(IAggregateFunction* nested_function_,
                                       const DataTypes& arguments, bool is_window_function_)
@@ -310,8 +336,14 @@ public:
             const auto& nested_col = nullable_col.get_nested_column();
             const auto* __restrict null_map_data = nullable_col.get_null_map_data().data();
 
+            if (nullable_col.has_null()) {
+                deserialize_and_merge_vec_with_nulls<false>(places, offset, rhs, nested_col,
+                                                            null_map_data, arena, num_rows);
+                return;
+            }
+
             for (size_t i = 0; i < num_rows; ++i) {
-                *(places[i] + offset) |= (!null_map_data[i]);
+                *(places[i] + offset) |= 1;
             }
             nested_function->deserialize_and_merge_vec(places, offset + prefix_size, rhs,
                                                        &nested_col, arena, num_rows);
@@ -329,9 +361,15 @@ public:
             const auto& nested_col = nullable_col.get_nested_column();
             const auto* __restrict null_map_data = nullable_col.get_null_map_data().data();
 
+            if (nullable_col.has_null()) {
+                deserialize_and_merge_vec_with_nulls<true>(places, offset, rhs, nested_col,
+                                                           null_map_data, arena, num_rows);
+                return;
+            }
+
             for (size_t i = 0; i < num_rows; ++i) {
                 if (places[i]) {
-                    *(places[i] + offset) |= (!null_map_data[i]);
+                    *(places[i] + offset) |= 1;
                 }
             }
             nested_function->deserialize_and_merge_vec_selected(places, offset + prefix_size, rhs,

--- a/be/src/storage/iterator/olap_data_convertor.cpp
+++ b/be/src/storage/iterator/olap_data_convertor.cpp
@@ -549,7 +549,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorChar::convert_to_olap() {
 
     // If column_string is not padded to full, we should do padding here.
     if (should_padding(column_string, _length)) {
-        _column = clone_and_padding(column_string, _length);
+        _column = clone_and_padding(column_string, _length, _nullmap);
         column_string = assert_cast<const ColumnString*>(_column.get());
     }
 

--- a/be/src/storage/iterator/olap_data_convertor.h
+++ b/be/src/storage/iterator/olap_data_convertor.h
@@ -178,7 +178,8 @@ private:
             return column->size() * padding_length != column->chars.size();
         }
 
-        static ColumnPtr clone_and_padding(const ColumnString* input, size_t padding_length) {
+        static ColumnPtr clone_and_padding(const ColumnString* input, size_t padding_length,
+                                           const UInt8* null_map) {
             auto column = ColumnString::create();
 
             column->offsets.resize(input->size());
@@ -187,6 +188,10 @@ private:
 
             for (size_t i = 0; i < input->size(); i++) {
                 column->offsets[i] = cast_set<uint32_t, size_t, false>((i + 1) * padding_length);
+
+                if (null_map != nullptr && null_map[i]) {
+                    continue;
+                }
 
                 auto str = input->get_data_at(i);
 

--- a/be/test/core/block/block_test.cpp
+++ b/be/test/core/block/block_test.cpp
@@ -1061,6 +1061,30 @@ TEST(BlockTest, replace_by_position) {
     ASSERT_EQ(block.get_by_position(0).column->get_int(2), 6);
 }
 
+#ifndef NDEBUG
+TEST(BlockTest, InjectsNonemptyPayloadForNullStringRows) {
+    auto column = ColumnHelper::create_nullable_column<DataTypeString>({"", "existing", "value"},
+                                                                       {1, 1, 0});
+    auto original_column = column;
+    Block block({ColumnWithTypeAndName {
+            column, std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>()),
+            "nullable_string"}});
+
+    block.debug_inject_nonempty_string_payload_for_null_rows();
+    block.debug_inject_nonempty_string_payload_for_null_rows();
+
+    const auto& nullable = assert_cast<const ColumnNullable&>(*block.get_by_position(0).column);
+    EXPECT_EQ(nullable.get_null_map_data(), (NullMap {1, 1, 0}));
+    EXPECT_EQ(nullable.get_nested_column().get_data_at(0).to_string(), "__DORIS_NULL_PAYLOAD_0__");
+    EXPECT_EQ(nullable.get_nested_column().get_data_at(1).to_string(), "__DORIS_NULL_PAYLOAD_1__");
+    EXPECT_EQ(nullable.get_nested_column().get_data_at(2).to_string(), "value");
+
+    const auto& original_nullable = assert_cast<const ColumnNullable&>(*original_column);
+    EXPECT_EQ(original_nullable.get_nested_column().get_data_at(0).to_string(), "");
+    EXPECT_EQ(original_nullable.get_nested_column().get_data_at(1).to_string(), "existing");
+}
+#endif
+
 TEST(BlockTest, compare_at) {
     auto block = ColumnHelper::create_block<DataTypeInt32>({1, 2, 3});
     auto ret = block.compare_at(0, 0, block, -1);

--- a/be/test/core/data_type_serde/data_type_serde_number_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_number_test.cpp
@@ -32,6 +32,7 @@
 #include "common/status.h"
 #include "core/assert_cast.h"
 #include "core/column/column.h"
+#include "core/column/column_decimal.h"
 #include "core/data_type/common_data_type_serder_test.h"
 #include "core/data_type/common_data_type_test.h"
 #include "core/data_type/data_type.h"
@@ -39,6 +40,7 @@
 #include "core/data_type_serde/data_type_date_or_datetime_serde.h"
 #include "core/data_type_serde/data_type_datetimev2_serde.h"
 #include "core/data_type_serde/data_type_datev2_serde.h"
+#include "core/data_type_serde/data_type_decimal_serde.h"
 #include "core/field.h"
 #include "core/types.h"
 #include "testutil/test_util.h"
@@ -123,6 +125,32 @@ public:
 private:
     bool _old_value;
 };
+
+TEST(DataTypeNumberSerDeStandaloneTest, StrictBatchSkipsNullableStringPayloadByRow) {
+    auto strings = ColumnString::create();
+    strings->insert_data("-", 1);
+    strings->insert_data("-", 1);
+    strings->insert_data("2628", 4);
+    NullMap null_map = {1, 1, 0};
+
+    DataTypeNumberSerDe<TYPE_BIGINT> number_serde;
+    auto number_result = ColumnInt64::create();
+    ASSERT_TRUE(
+            number_serde
+                    .from_string_strict_mode_batch(*strings, *number_result, {}, null_map.data())
+                    .ok());
+    ASSERT_EQ(number_result->size(), 3);
+    EXPECT_EQ(number_result->get_element(2), 2628);
+
+    DataTypeDecimalSerDe<TYPE_DECIMAL64> decimal_serde(18, 0);
+    auto decimal_result = ColumnDecimal64::create(0, 0);
+    ASSERT_TRUE(
+            decimal_serde
+                    .from_string_strict_mode_batch(*strings, *decimal_result, {}, null_map.data())
+                    .ok());
+    ASSERT_EQ(decimal_result->size(), 3);
+    EXPECT_EQ(decimal_result->get_element(2), Decimal64(2628));
+}
 
 TEST_F(DataTypeNumberSerDeTest, serdes) {
     auto test_func = [](const auto& serde, const auto& source_column) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #66955

Problem Summary: Nullable string rows may retain arbitrary nested payloads. Strict string-to-number and string-to-decimal batch conversion incorrectly tracked offsets across skipped null rows, and other execution paths may accidentally rely on null rows containing empty strings. Read strict conversions by row and inject identifiable non-empty payloads for null string rows at operator boundaries in non-release builds.

### Release note

None

### Check List (For Author)

- Test: Unit tests added; not run before this commit
- Behavior changed: No. Null row nested payloads remain semantically inaccessible
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

