### PR TITLE
[fix](mtmv) skip in-flight MTMVs from Nereids MV rewrite candidates

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/insertoverwrite/InsertOverwriteManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/insertoverwrite/InsertOverwriteManager.java
@@ -361,6 +361,19 @@ public class InsertOverwriteManager extends MasterDaemon implements Writable, Ab
     }
 
     /**
+     * Whether the given MTMV table currently has an INSERT OVERWRITE running on this FE master.
+     */
+    public boolean hasRunningTask(long dbId, long tableId) {
+        runningLock.readLock().lock();
+        try {
+            Set<Long> tables = runningTables.get(dbId);
+            return tables != null && tables.contains(tableId);
+        } finally {
+            runningLock.readLock().unlock();
+        }
+    }
+
+    /**
      * replay logs
      *
      * @param insertOverwriteLog

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CollectRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/CollectRelation.java
@@ -268,6 +268,15 @@ public class CollectRelation implements AnalysisRuleFactory {
                 LOG.debug("table {} related mv set is {}", new BaseTableInfo(table), mtmvSet);
             }
             for (MTMV mtmv : mtmvSet) {
+                // Skip MTMVs that currently have an INSERT OVERWRITE in flight.
+                if (Env.getCurrentEnv().getInsertOverwriteManager()
+                        .hasRunningTask(mtmv.getDatabase().getId(), mtmv.getId())) {
+                    if (isDebugEnabled) {
+                        LOG.debug("skip candidate mtmv {} because an insert overwrite is in flight",
+                                new BaseTableInfo(mtmv));
+                    }
+                    continue;
+                }
                 cascadesContext.getStatementContext().getCandidateMTMVs().add(mtmv);
                 cascadesContext.getStatementContext().getMtmvRelatedTables().put(mtmv.getFullQualifiers(), mtmv);
                 mtmv.readMvLock();


### PR DESCRIPTION
### What problem does this PR solve?

Assume that mtmv A,B,C,D share same base tables.

```
set global enable_dml_materialized_view_rewrite = true (default)
```

We found a lock competition case between them and create new mtmv. Like:

```
T0            T1            T2            T3            T4            T5            T6
  │             │             │             │             │             │             │

  ┌─ Refresh mv_A ────────────────────────────────────────────────┐
  │ plan (holds R on mv_A,B,C,D) │        │ W(A) │  BE run  │ W(A) │
  │ ═══════════════════════════  │        │══════│          │══════│
  └──────────────────────────────┘

       ┌─ Refresh mv_B ────────────────────────────────────────────────┐
       │ plan │        │ W(B) │  BE run  │ W(B) │
       │ ═══  │        │══════│          │══════│
       └──────┘

            ┌─ Refresh mv_C ─────────────────────────────────────────────────┐
            │ plan │        │ W(C) │  BE run  │ W(C) │
            │ ═══  │        │══════│          │══════│
            └──────┘

                 ┌─ Refresh mv_D (arrives here) ──────────────────────────────────┐
                 │ plan: tryReadLock(mv_A) — mv_A currently write-locked          │
                 │       ════════════ waits ════════════ 60s timeout              │
                 │      => throw "Failed to get read lock on table:mv_A"          │
                 └────────────────────────────────────────────────────────────────┘

                                          ┌─ CREATE MATERIALIZED VIEW mv_X ─────────────────────┐
                                          │ base table is the same as A/B/C/D...                │
                                          │ tryReadLock(mv_A) — still contested                 │
                                          │ ══════════════ waits ══════════════ 60s => error     │
                                          └─────────────────────────────────────────────────────┘
```

If there is mv_E,mv_F,mv_G... before create mv_X, the mv_X may be never created and retry until timeout, throwing MySQL socket read timeout (180s).

If the base tables are hive/iceberg table, plan time will often longer than internal table, this case may more likely to happen.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

