### PR TITLE
[fix](be) Release query context after runtime filters publish

### DIFF
--- a/be/src/exec/runtime_filter/runtime_filter_mgr.cpp
+++ b/be/src/exec/runtime_filter/runtime_filter_mgr.cpp
@@ -412,6 +412,9 @@ Status RuntimeFilterMergeControllerEntity::init(std::shared_ptr<QueryContext> qu
     SCOPED_CONSUME_MEM_TRACKER(_mem_tracker.get());
     if (runtime_filter_params.__isset.rid_to_runtime_filter) {
         for (const auto& filterid_to_desc : runtime_filter_params.rid_to_runtime_filter) {
+            if (!filterid_to_desc.second.has_remote_targets) {
+                continue;
+            }
             int filter_id = filterid_to_desc.first;
             const auto& targetv2_iter = runtime_filter_params.rid_to_target_paramv2.find(filter_id);
             const auto& build_iter =
@@ -432,6 +435,16 @@ Status RuntimeFilterMergeControllerEntity::init(std::shared_ptr<QueryContext> qu
         }
     }
     return Status::OK();
+}
+
+bool RuntimeFilterMergeControllerEntity::all_filters_published() {
+    SharedLockGuard guard(_filter_map_mutex);
+    for (const auto& filter : _filter_map) {
+        if (!filter.second.done.load()) {
+            return false;
+        }
+    }
+    return true;
 }
 
 Status RuntimeFilterMergeControllerEntity::send_filter_size(std::shared_ptr<QueryContext> query_ctx,

--- a/be/src/exec/runtime_filter/runtime_filter_mgr.h
+++ b/be/src/exec/runtime_filter/runtime_filter_mgr.h
@@ -206,6 +206,8 @@ public:
         return _filter_map.empty();
     }
 
+    bool all_filters_published();
+
     Status reset_global_rf(QueryContext* query_ctx,
                            const google::protobuf::RepeatedField<int32_t>& filter_ids);
 

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -328,7 +328,7 @@ FragmentMgr::FragmentMgr(ExecEnv* exec_env)
     REGISTER_ENTITY_HOOK_METRIC(_entity, this, query_ctx_delay_delete_count,
                                 [this]() { return _query_ctx_map_delay_delete.num_items(); });
     REGISTER_ENTITY_HOOK_METRIC(_entity, this, query_ctx_delay_delete_oldest_age_seconds, [this]() {
-        return get_query_ctx_map_delay_delete_stats().oldest_retained_millis / MILLIS_PER_SEC;
+        return get_query_ctx_map_delay_delete_oldest_retained_millis() / MILLIS_PER_SEC;
     });
 
     auto s = Thread::create(
@@ -653,7 +653,8 @@ std::string FragmentMgr::dump_pipeline_tasks(TUniqueId& query_id) {
 RuntimeFilterQueryContextStats FragmentMgr::get_query_ctx_map_delay_delete_stats() {
     const int64_t now_millis = MonotonicMillis();
     RuntimeFilterQueryContextStats stats;
-    _query_ctx_map_delay_delete.apply(
+    stats.contexts.reserve(_query_ctx_map_delay_delete.num_items());
+    _query_ctx_map_delay_delete.apply_readonly(
             [&](const phmap::flat_hash_map<TUniqueId, std::shared_ptr<QueryContext>>& map) {
                 for (const auto& [query_id, query_ctx] : map) {
                     const int64_t retained_millis = std::max<int64_t>(
@@ -664,9 +665,25 @@ RuntimeFilterQueryContextStats FragmentMgr::get_query_ctx_map_delay_delete_stats
                                               .retained_millis = retained_millis,
                                               .cancelled = query_ctx->is_cancelled()});
                 }
-                return Status::OK();
             });
     return stats;
+}
+
+int64_t FragmentMgr::get_query_ctx_map_delay_delete_oldest_retained_millis() const {
+    const int64_t now_millis = MonotonicMillis();
+    int64_t oldest_retained_millis = 0;
+    _query_ctx_map_delay_delete.apply_readonly(
+            [&](const phmap::flat_hash_map<TUniqueId, std::shared_ptr<QueryContext>>& map) {
+                for (const auto& entry : map) {
+                    const auto& query_ctx = entry.second;
+                    oldest_retained_millis = std::max(
+                            oldest_retained_millis,
+                            std::max<int64_t>(
+                                    0,
+                                    now_millis - query_ctx->runtime_filter_retained_at_millis()));
+                }
+            });
+    return oldest_retained_millis;
 }
 
 std::string FragmentMgr::dump_query_ctx_map_delay_delete() {
@@ -1242,15 +1259,35 @@ Status FragmentMgr::merge_filter(const PMergeFilterRequest* request,
             return Status::InternalError("Merge filter failed: Merge controller handler is null");
         }
         auto status = handler->merge(q_ctx, request, attach_data);
-        if (handler->all_filters_published()) {
-            _query_ctx_map_delay_delete.erase(query_id);
-        }
+        _release_query_context_if_runtime_filters_published(query_id, handler);
         return status;
     } else {
         return Status::EndOfFile(
                 "Merge filter size failed: Query context (query-id: {}) already finished",
                 queryid.to_string());
     }
+}
+
+void FragmentMgr::_release_query_context_if_runtime_filters_published(
+        const TUniqueId& query_id,
+        const std::shared_ptr<RuntimeFilterMergeControllerEntity>& handler) {
+    if (!handler->all_filters_published()) {
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(_rerunnable_params_lock);
+        // all_filters_published() is scoped to one recursive CTE round. Rerunnable entries
+        // survive reset_global_rf() and are removed only by FINAL_CLOSE, so their absence is the
+        // explicit signal that no later runtime-filter generation can be started.
+        const auto query_has_rerunnable_fragment = std::ranges::any_of(
+                _rerunnable_params_map,
+                [&](const auto& entry) { return entry.first.first == query_id; });
+        if (query_has_rerunnable_fragment) {
+            return;
+        }
+    }
+    _query_ctx_map_delay_delete.erase(query_id);
 }
 
 void FragmentMgr::get_runtime_query_info(
@@ -1365,6 +1402,9 @@ Status FragmentMgr::rerun_fragment(const std::shared_ptr<brpc::ClosureGuard>& gu
             {
                 std::lock_guard<std::mutex> lk(_rerunnable_params_lock);
                 final_close_info = _rerunnable_params_map.extract({query_id, fragment_id});
+            }
+            if (auto handler = query_ctx->get_merge_controller_handler()) {
+                _release_query_context_if_runtime_filters_published(query_id, handler);
             }
         }
         fragment_ctx->notify_close();

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -90,12 +90,15 @@
 #include "util/thread.h"
 #include "util/threadpool.h"
 #include "util/thrift_util.h"
+#include "util/time.h"
 #include "util/uid_util.h"
 
 namespace doris {
 
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(fragment_instance_count, MetricUnit::NOUNIT);
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(timeout_canceled_fragment_count, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(query_ctx_delay_delete_count, MetricUnit::NOUNIT);
+DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(query_ctx_delay_delete_oldest_age_seconds, MetricUnit::SECONDS);
 
 bvar::LatencyRecorder g_fragmentmgr_prepare_latency("doris_FragmentMgr", "prepare");
 
@@ -322,6 +325,11 @@ FragmentMgr::FragmentMgr(ExecEnv* exec_env)
         : _exec_env(exec_env), _stop_background_threads_latch(1) {
     _entity = DorisMetrics::instance()->metric_registry()->register_entity("FragmentMgr");
     INT_UGAUGE_METRIC_REGISTER(_entity, timeout_canceled_fragment_count);
+    REGISTER_ENTITY_HOOK_METRIC(_entity, this, query_ctx_delay_delete_count,
+                                [this]() { return _query_ctx_map_delay_delete.num_items(); });
+    REGISTER_ENTITY_HOOK_METRIC(_entity, this, query_ctx_delay_delete_oldest_age_seconds, [this]() {
+        return get_query_ctx_map_delay_delete_stats().oldest_retained_millis / MILLIS_PER_SEC;
+    });
 
     auto s = Thread::create(
             "FragmentMgr", "cancel_timeout_plan_fragment", [this]() { this->cancel_worker(); },
@@ -340,6 +348,8 @@ FragmentMgr::~FragmentMgr() = default;
 
 void FragmentMgr::stop() {
     DEREGISTER_HOOK_METRIC(fragment_instance_count);
+    DEREGISTER_ENTITY_HOOK_METRIC(_entity, query_ctx_delay_delete_count);
+    DEREGISTER_ENTITY_HOOK_METRIC(_entity, query_ctx_delay_delete_oldest_age_seconds);
     _stop_background_threads_latch.count_down();
     if (_cancel_thread) {
         _cancel_thread->join();
@@ -456,6 +466,12 @@ void FragmentMgr::remove_query_context(const TUniqueId& key) {
 #endif
 }
 
+void FragmentMgr::_retain_query_context_for_runtime_filter(
+        const TUniqueId& query_id, std::shared_ptr<QueryContext> query_ctx) {
+    query_ctx->set_runtime_filter_retained_at_millis(MonotonicMillis());
+    _query_ctx_map_delay_delete.insert(query_id, std::move(query_ctx));
+}
+
 std::shared_ptr<QueryContext> FragmentMgr::get_query_ctx(const TUniqueId& query_id) {
     auto val = _query_ctx_map.find(query_id);
     if (auto q_ctx = val.lock()) {
@@ -557,7 +573,7 @@ Status FragmentMgr::_get_or_create_query_ctx(const TPipelineFragmentParams& para
                                 query_ctx->runtime_filter_mgr()->set_runtime_filter_params(
                                         info.runtime_filter_params);
                                 if (!handler->empty()) {
-                                    _query_ctx_map_delay_delete.insert(query_id, query_ctx);
+                                    _retain_query_context_for_runtime_filter(query_id, query_ctx);
                                 }
                             }
                             if (info.__isset.topn_filter_descs) {
@@ -632,6 +648,39 @@ std::string FragmentMgr::dump_pipeline_tasks(TUniqueId& query_id) {
                 "Dump pipeline tasks failed: Query context (query id = {}) not found. \n",
                 print_id(query_id));
     }
+}
+
+RuntimeFilterQueryContextStats FragmentMgr::get_query_ctx_map_delay_delete_stats() {
+    const int64_t now_millis = MonotonicMillis();
+    RuntimeFilterQueryContextStats stats;
+    _query_ctx_map_delay_delete.apply(
+            [&](const phmap::flat_hash_map<TUniqueId, std::shared_ptr<QueryContext>>& map) {
+                for (const auto& [query_id, query_ctx] : map) {
+                    const int64_t retained_millis = std::max<int64_t>(
+                            0, now_millis - query_ctx->runtime_filter_retained_at_millis());
+                    stats.oldest_retained_millis =
+                            std::max(stats.oldest_retained_millis, retained_millis);
+                    stats.contexts.push_back({.query_id = query_id,
+                                              .retained_millis = retained_millis,
+                                              .cancelled = query_ctx->is_cancelled()});
+                }
+                return Status::OK();
+            });
+    return stats;
+}
+
+std::string FragmentMgr::dump_query_ctx_map_delay_delete() {
+    const auto stats = get_query_ctx_map_delay_delete_stats();
+    fmt::memory_buffer buffer;
+    fmt::format_to(buffer, "query_ctx_delay_delete_size: {}\noldest_retained_seconds: {}\n",
+                   stats.contexts.size(), stats.oldest_retained_millis / MILLIS_PER_SEC);
+    for (size_t i = 0; i < stats.contexts.size(); ++i) {
+        const auto& context = stats.contexts[i];
+        fmt::format_to(buffer, "No.{} QueryId: {}, retained_seconds={}, state={}\n", i,
+                       print_id(context.query_id), context.retained_millis / MILLIS_PER_SEC,
+                       context.cancelled ? "cancelled" : "waiting_runtime_filters");
+    }
+    return fmt::to_string(buffer);
 }
 
 Status FragmentMgr::exec_plan_fragment(const TPipelineFragmentParams& params,
@@ -755,7 +804,6 @@ void FragmentMgr::cancel_worker() {
 
         timespec now;
         clock_gettime(CLOCK_MONOTONIC, &now);
-
         if (config::enable_pipeline_task_leakage_detect &&
             now.tv_sec - check_invalid_query_last_timestamp.tv_sec >
                     config::pipeline_task_leakage_detect_period_secs) {
@@ -1189,10 +1237,15 @@ Status FragmentMgr::merge_filter(const PMergeFilterRequest* request,
     query_id.__set_lo(queryid.lo);
     if (auto q_ctx = get_query_ctx(query_id)) {
         SCOPED_ATTACH_TASK(q_ctx.get());
-        if (!q_ctx->get_merge_controller_handler()) {
+        auto handler = q_ctx->get_merge_controller_handler();
+        if (!handler) {
             return Status::InternalError("Merge filter failed: Merge controller handler is null");
         }
-        return q_ctx->get_merge_controller_handler()->merge(q_ctx, request, attach_data);
+        auto status = handler->merge(q_ctx, request, attach_data);
+        if (handler->all_filters_published()) {
+            _query_ctx_map_delay_delete.erase(query_id);
+        }
+        return status;
     } else {
         return Status::EndOfFile(
                 "Merge filter size failed: Query context (query-id: {}) already finished",

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -95,6 +95,13 @@ public:
             static_cast<void>(function(pair.second));
         }
     }
+    template <typename Function>
+    void apply_readonly(Function&& function) const {
+        for (const auto& pair : _internal_map) {
+            std::shared_lock lock(*pair.first);
+            function(pair.second);
+        }
+    }
 
     Status apply_if_not_exists(const Key& query_id, std::shared_ptr<ValueType>& query_ctx,
                                ApplyFunction&& function);
@@ -181,6 +188,7 @@ public:
 
     std::string dump_pipeline_tasks(int64_t duration = 0);
     std::string dump_pipeline_tasks(TUniqueId& query_id);
+    int64_t get_query_ctx_map_delay_delete_oldest_retained_millis() const;
     RuntimeFilterQueryContextStats get_query_ctx_map_delay_delete_stats();
     std::string dump_query_ctx_map_delay_delete();
 
@@ -218,6 +226,9 @@ private:
 
     void _retain_query_context_for_runtime_filter(const TUniqueId& query_id,
                                                   std::shared_ptr<QueryContext> query_ctx);
+    void _release_query_context_if_runtime_filters_published(
+            const TUniqueId& query_id,
+            const std::shared_ptr<RuntimeFilterMergeControllerEntity>& handler);
 
     void _collect_timeout_queries_and_brpc_items(
             std::vector<TUniqueId>& queries_timeout,

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -109,6 +109,17 @@ private:
             _internal_map;
 };
 
+struct RuntimeFilterQueryContextInfo {
+    TUniqueId query_id;
+    int64_t retained_millis = 0;
+    bool cancelled = false;
+};
+
+struct RuntimeFilterQueryContextStats {
+    int64_t oldest_retained_millis = 0;
+    std::vector<RuntimeFilterQueryContextInfo> contexts;
+};
+
 // This class used to manage all the fragment execute in this instance
 class FragmentMgr : public RestMonitorIface {
 public:
@@ -170,6 +181,8 @@ public:
 
     std::string dump_pipeline_tasks(int64_t duration = 0);
     std::string dump_pipeline_tasks(TUniqueId& query_id);
+    RuntimeFilterQueryContextStats get_query_ctx_map_delay_delete_stats();
+    std::string dump_query_ctx_map_delay_delete();
 
     void get_runtime_query_info(std::vector<std::weak_ptr<ResourceContext>>* _resource_ctx_list);
 
@@ -202,6 +215,9 @@ private:
                                     const TPipelineFragmentParamsList& parent,
                                     QuerySource query_type,
                                     std::shared_ptr<QueryContext>& query_ctx);
+
+    void _retain_query_context_for_runtime_filter(const TUniqueId& query_id,
+                                                  std::shared_ptr<QueryContext> query_ctx);
 
     void _collect_timeout_queries_and_brpc_items(
             std::vector<TUniqueId>& queries_timeout,
@@ -251,7 +267,8 @@ private:
 
     // query id -> QueryContext
     ConcurrentContextMap<TUniqueId, std::weak_ptr<QueryContext>, QueryContext> _query_ctx_map;
-    // keep query ctx do not delete immediately to make rf coordinator merge filter work well after query eos
+    // Keep query ctx alive after query EOS until all remote runtime filters are published or the
+    // query is cancelled.
     ConcurrentContextMap<TUniqueId, std::shared_ptr<QueryContext>, QueryContext>
             _query_ctx_map_delay_delete;
 
@@ -262,6 +279,8 @@ private:
 
     std::shared_ptr<MetricEntity> _entity;
     UIntGauge* timeout_canceled_fragment_count = nullptr;
+    UIntGauge* query_ctx_delay_delete_count = nullptr;
+    UIntGauge* query_ctx_delay_delete_oldest_age_seconds = nullptr;
 };
 
 uint64_t get_fragment_executing_count();

--- a/be/src/runtime/query_context.cpp
+++ b/be/src/runtime/query_context.cpp
@@ -344,6 +344,10 @@ void QueryContext::cancel(Status new_status, int fragment_id) {
 
     set_ready_to_execute(new_status);
     cancel_all_pipeline_context(new_status, fragment_id);
+    // fragment_mgr is nullptr in unit tests that create QueryContext in isolation.
+    if (_exec_env->fragment_mgr()) {
+        _exec_env->fragment_mgr()->remove_query_context(_query_id);
+    }
 }
 
 void QueryContext::set_load_error_url(std::string error_url) {

--- a/be/src/runtime/query_context.h
+++ b/be/src/runtime/query_context.h
@@ -229,6 +229,10 @@ public:
     std::shared_ptr<RuntimeFilterMergeControllerEntity> get_merge_controller_handler() const {
         return _merge_controller_handler;
     }
+    void set_runtime_filter_retained_at_millis(int64_t retained_at_millis) {
+        _runtime_filter_retained_at_millis = retained_at_millis;
+    }
+    int64_t runtime_filter_retained_at_millis() const { return _runtime_filter_retained_at_millis; }
 
     bool is_nereids() const { return _is_nereids; }
     std::shared_ptr<MemShareArbitrator> mem_arb() const { return _mem_arb; }
@@ -362,6 +366,7 @@ private:
     // This shared ptr is never used. It is just a reference to hold the object.
     // There is a weak ptr in runtime filter manager to reference this object.
     std::shared_ptr<RuntimeFilterMergeControllerEntity> _merge_controller_handler;
+    int64_t _runtime_filter_retained_at_millis = 0;
 
     std::map<int, std::weak_ptr<PipelineFragmentContext>> _fragment_id_to_pipeline_ctx;
     std::mutex _pipeline_map_write_lock;

--- a/be/src/service/http/action/pipeline_task_action.cpp
+++ b/be/src/service/http/action/pipeline_task_action.cpp
@@ -84,4 +84,11 @@ void QueryPipelineTaskAction::handle(HttpRequest* req) {
                             ExecEnv::GetInstance()->fragment_mgr()->dump_pipeline_tasks(query_id));
 }
 
+void QueryContextDelayDeleteAction::handle(HttpRequest* req) {
+    req->add_output_header(HttpHeaders::CONTENT_TYPE, "text/plain; charset=utf-8");
+    HttpChannel::send_reply(
+            req, HttpStatus::OK,
+            ExecEnv::GetInstance()->fragment_mgr()->dump_query_ctx_map_delay_delete());
+}
+
 } // end namespace doris

--- a/be/src/service/http/action/pipeline_task_action.h
+++ b/be/src/service/http/action/pipeline_task_action.h
@@ -51,4 +51,13 @@ public:
     void handle(HttpRequest* req) override;
 };
 
+class QueryContextDelayDeleteAction : public HttpHandlerWithAuth {
+public:
+    QueryContextDelayDeleteAction(ExecEnv* exec_env) : HttpHandlerWithAuth(exec_env) {}
+
+    ~QueryContextDelayDeleteAction() override = default;
+
+    void handle(HttpRequest* req) override;
+};
+
 } // end namespace doris

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -193,6 +193,12 @@ Status HttpService::start() {
     _ev_http_server->register_handler(HttpMethod::GET, "/api/query_pipeline_tasks/{query_id}",
                                       query_pipeline_task_action);
 
+    // Inspect QueryContexts retained for runtime-filter merging.
+    QueryContextDelayDeleteAction* query_ctx_delay_delete_action =
+            _pool.add(new QueryContextDelayDeleteAction(_env));
+    _ev_http_server->register_handler(HttpMethod::GET, "/api/query_context_delay_delete",
+                                      query_ctx_delay_delete_action);
+
     // Dump all be process thread num
     BeProcThreadAction* be_proc_thread_action = _pool.add(new BeProcThreadAction(_env));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/be_process_thread_num",

--- a/be/test/exec/runtime_filter/runtime_filter_mgr_test.cpp
+++ b/be/test/exec/runtime_filter/runtime_filter_mgr_test.cpp
@@ -193,21 +193,37 @@ TEST_F(RuntimeFilterMgrTest, TestRuntimeFilterMergeControllerEntity) {
         // Init
         TRuntimeFilterParams param =
                 TRuntimeFilterParamsBuilder()
-                        .add_rid_to_runtime_filter(
-                                rid,
-                                TRuntimeFilterDescBuilder().add_planId_to_target_expr(0).build())
+                        .add_rid_to_runtime_filter(rid, TRuntimeFilterDescBuilder()
+                                                                .set_mode(false)
+                                                                .add_planId_to_target_expr(0)
+                                                                .build())
                         .add_rid_to_target_paramv2(rid, {TRuntimeFilterTargetParamsV2()})
                         .build();
         EXPECT_FALSE(entity->init(ctx, param).ok());
 
         param = TRuntimeFilterParamsBuilder()
-                        .add_rid_to_runtime_filter(
-                                rid,
-                                TRuntimeFilterDescBuilder().add_planId_to_target_expr(0).build())
+                        .add_rid_to_runtime_filter(rid, TRuntimeFilterDescBuilder()
+                                                                .set_mode(false)
+                                                                .add_planId_to_target_expr(0)
+                                                                .build())
                         .add_runtime_filter_builder_num(rid, 1)
                         .add_rid_to_target_paramv2(rid, {TRuntimeFilterTargetParamsV2()})
                         .build();
         EXPECT_TRUE(entity->init(ctx, param).ok());
+        EXPECT_FALSE(entity->empty());
+    }
+
+    {
+        auto local_entity = std::make_shared<RuntimeFilterMergeControllerEntity>();
+        auto local_param =
+                TRuntimeFilterParamsBuilder()
+                        .add_rid_to_runtime_filter(
+                                rid,
+                                TRuntimeFilterDescBuilder().add_planId_to_target_expr(0).build())
+                        .add_runtime_filter_builder_num(rid, 1)
+                        .build();
+        EXPECT_TRUE(local_entity->init(ctx, local_param).ok());
+        EXPECT_TRUE(local_entity->empty());
     }
 }
 

--- a/be/test/runtime/fragment_mgr_cross_cluster_cancel_test.cpp
+++ b/be/test/runtime/fragment_mgr_cross_cluster_cancel_test.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include "common/config.h"
+#include "exec/pipeline/thrift_builder.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/exec_env.h"
 #include "runtime/fragment_mgr.h"
@@ -188,7 +189,7 @@ TEST(FragmentMgrDelayDeleteMapTest, ClearShouldNotAbortWhenReleasingLastQueryCon
     exec_env->_fragment_mgr = previous_fragment_mgr;
 }
 
-TEST(FragmentMgrDelayDeleteMapTest, ReleaseQueryContextAfterAllRuntimeFiltersPublished) {
+TEST(FragmentMgrDelayDeleteMapTest, ReleaseQueryContextAfterFinalRecursiveRuntimeFilterRound) {
     auto* exec_env = ExecEnv::GetInstance();
     auto* previous_fragment_mgr = exec_env->_fragment_mgr;
     exec_env->_fragment_mgr = new FragmentMgr(exec_env);
@@ -210,14 +211,17 @@ TEST(FragmentMgrDelayDeleteMapTest, ReleaseQueryContextAfterAllRuntimeFiltersPub
             QueryContext::create(query_id, exec_env, query_options, fe_addr,
                                  /*is_nereids*/ true, fe_addr, QuerySource::INTERNAL_FRONTEND);
     auto handler = std::make_shared<RuntimeFilterMergeControllerEntity>();
-    TRuntimeFilterParams runtime_filter_params;
-    ASSERT_TRUE(handler->init(query_ctx, runtime_filter_params).ok());
     constexpr int filter_id = 1;
-    {
-        LockGuard guard(handler->_filter_map_mutex);
-        auto [filter, inserted] = handler->_filter_map.try_emplace(filter_id);
-        ASSERT_TRUE(inserted);
-    }
+    auto runtime_filter_params =
+            TRuntimeFilterParamsBuilder()
+                    .add_rid_to_runtime_filter(filter_id, TRuntimeFilterDescBuilder(filter_id)
+                                                                  .set_mode(false)
+                                                                  .add_planId_to_target_expr(0)
+                                                                  .build())
+                    .add_runtime_filter_builder_num(filter_id, 1)
+                    .add_rid_to_target_paramv2(filter_id, {TRuntimeFilterTargetParamsV2()})
+                    .build();
+    ASSERT_TRUE(handler->init(query_ctx, runtime_filter_params).ok());
     query_ctx->set_merge_controller_handler(handler);
 
     std::shared_ptr<QueryContext> existing_query_ctx;
@@ -229,32 +233,68 @@ TEST(FragmentMgrDelayDeleteMapTest, ReleaseQueryContextAfterAllRuntimeFiltersPub
                                              })
                         .ok());
     exec_env->_fragment_mgr->_retain_query_context_for_runtime_filter(query_id, query_ctx);
+    {
+        std::lock_guard<std::mutex> lock(exec_env->_fragment_mgr->_rerunnable_params_lock);
+        exec_env->_fragment_mgr->_rerunnable_params_map[{query_id, 1}].query_ctx = query_ctx;
+    }
 
     PMergeFilterRequest request;
     request.mutable_query_id()->set_hi(query_id.hi);
     request.mutable_query_id()->set_lo(query_id.lo);
     request.set_filter_id(filter_id);
+    // The ownership test drives done explicitly; a different stage makes merge() skip payload
+    // deserialization while still exercising FragmentMgr's post-merge release decision.
     request.set_stage(1);
 
-    ASSERT_TRUE(exec_env->_fragment_mgr->merge_filter(&request, nullptr).ok());
-    EXPECT_EQ(exec_env->_fragment_mgr->_query_ctx_map_delay_delete.num_items(), 1);
-
-    auto stats = exec_env->_fragment_mgr->get_query_ctx_map_delay_delete_stats();
-    ASSERT_EQ(stats.contexts.size(), 1);
-    EXPECT_EQ(stats.contexts[0].query_id, query_id);
-    auto dump = exec_env->_fragment_mgr->dump_query_ctx_map_delay_delete();
-    EXPECT_NE(dump.find(print_id(query_id)), std::string::npos);
-    EXPECT_NE(dump.find("state=waiting_runtime_filters"), std::string::npos);
-
+    // Round 0 is complete, but the rerunnable entry proves another generation may follow.
     {
         LockGuard guard(handler->_filter_map_mutex);
         handler->_filter_map.at(filter_id).done = true;
     }
     ASSERT_TRUE(exec_env->_fragment_mgr->merge_filter(&request, nullptr).ok());
-    EXPECT_EQ(exec_env->_fragment_mgr->_query_ctx_map_delay_delete.num_items(), 0);
+    EXPECT_EQ(exec_env->_fragment_mgr->_query_ctx_map_delay_delete.num_items(), 1);
+
+    google::protobuf::RepeatedField<int32_t> filter_ids;
+    filter_ids.Add(filter_id);
+    ASSERT_TRUE(exec_env->_fragment_mgr->reset_global_rf(query_id, filter_ids).ok());
+    {
+        LockGuard guard(handler->_filter_map_mutex);
+        EXPECT_FALSE(handler->_filter_map.at(filter_id).done);
+        EXPECT_EQ(handler->_filter_map.at(filter_id).stage, 1);
+    }
+
+    auto stats = exec_env->_fragment_mgr->get_query_ctx_map_delay_delete_stats();
+    ASSERT_EQ(stats.contexts.size(), 1);
+    EXPECT_EQ(stats.contexts[0].query_id, query_id);
+    EXPECT_GE(exec_env->_fragment_mgr->get_query_ctx_map_delay_delete_oldest_retained_millis(),
+              stats.oldest_retained_millis);
+    auto dump = exec_env->_fragment_mgr->dump_query_ctx_map_delay_delete();
+    EXPECT_NE(dump.find(print_id(query_id)), std::string::npos);
+    EXPECT_NE(dump.find("state=waiting_runtime_filters"), std::string::npos);
 
     std::weak_ptr<QueryContext> weak_query_ctx = query_ctx;
+    {
+        decltype(exec_env->_fragment_mgr->_rerunnable_params_map)::node_type final_close_info;
+        {
+            std::lock_guard<std::mutex> lock(exec_env->_fragment_mgr->_rerunnable_params_lock);
+            final_close_info =
+                    exec_env->_fragment_mgr->_rerunnable_params_map.extract({query_id, 1});
+        }
+        ASSERT_FALSE(final_close_info.empty());
+    }
+    exec_env->_fragment_mgr->_release_query_context_if_runtime_filters_published(query_id, handler);
+    EXPECT_EQ(exec_env->_fragment_mgr->_query_ctx_map_delay_delete.num_items(), 1);
     query_ctx.reset();
+    EXPECT_FALSE(weak_query_ctx.expired());
+
+    // The final generation's merge arrives after FINAL_CLOSE and still finds QueryContext.
+    {
+        LockGuard guard(handler->_filter_map_mutex);
+        handler->_filter_map.at(filter_id).done = true;
+    }
+    request.set_stage(2);
+    ASSERT_TRUE(exec_env->_fragment_mgr->merge_filter(&request, nullptr).ok());
+    EXPECT_EQ(exec_env->_fragment_mgr->_query_ctx_map_delay_delete.num_items(), 0);
     EXPECT_TRUE(weak_query_ctx.expired());
 
     exec_env->_fragment_mgr->stop();

--- a/be/test/runtime/fragment_mgr_cross_cluster_cancel_test.cpp
+++ b/be/test/runtime/fragment_mgr_cross_cluster_cancel_test.cpp
@@ -179,10 +179,119 @@ TEST(FragmentMgrDelayDeleteMapTest, ClearShouldNotAbortWhenReleasingLastQueryCon
     auto query_ctx =
             QueryContext::create(query_id, exec_env, query_options, fe_addr,
                                  /*is_nereids*/ true, fe_addr, QuerySource::INTERNAL_FRONTEND);
-    exec_env->_fragment_mgr->_query_ctx_map_delay_delete.insert(query_id, query_ctx);
+    exec_env->_fragment_mgr->_retain_query_context_for_runtime_filter(query_id, query_ctx);
     query_ctx.reset();
 
     exec_env->_fragment_mgr->_query_ctx_map_delay_delete.clear();
+    exec_env->_fragment_mgr->stop();
+    delete exec_env->_fragment_mgr;
+    exec_env->_fragment_mgr = previous_fragment_mgr;
+}
+
+TEST(FragmentMgrDelayDeleteMapTest, ReleaseQueryContextAfterAllRuntimeFiltersPublished) {
+    auto* exec_env = ExecEnv::GetInstance();
+    auto* previous_fragment_mgr = exec_env->_fragment_mgr;
+    exec_env->_fragment_mgr = new FragmentMgr(exec_env);
+
+    TUniqueId query_id;
+    query_id.__set_hi(203);
+    query_id.__set_lo(304);
+
+    TQueryOptions query_options;
+    query_options.__set_query_type(TQueryType::LOAD);
+    query_options.__set_execution_timeout(60);
+    query_options.__set_mem_limit(64L * 1024 * 1024);
+
+    TNetworkAddress fe_addr;
+    fe_addr.hostname = "127.0.0.1";
+    fe_addr.port = 9030;
+
+    auto query_ctx =
+            QueryContext::create(query_id, exec_env, query_options, fe_addr,
+                                 /*is_nereids*/ true, fe_addr, QuerySource::INTERNAL_FRONTEND);
+    auto handler = std::make_shared<RuntimeFilterMergeControllerEntity>();
+    TRuntimeFilterParams runtime_filter_params;
+    ASSERT_TRUE(handler->init(query_ctx, runtime_filter_params).ok());
+    constexpr int filter_id = 1;
+    {
+        LockGuard guard(handler->_filter_map_mutex);
+        auto [filter, inserted] = handler->_filter_map.try_emplace(filter_id);
+        ASSERT_TRUE(inserted);
+    }
+    query_ctx->set_merge_controller_handler(handler);
+
+    std::shared_ptr<QueryContext> existing_query_ctx;
+    ASSERT_TRUE(exec_env->_fragment_mgr->_query_ctx_map
+                        .apply_if_not_exists(query_id, existing_query_ctx,
+                                             [&](auto& map) {
+                                                 map.insert({query_id, query_ctx});
+                                                 return Status::OK();
+                                             })
+                        .ok());
+    exec_env->_fragment_mgr->_retain_query_context_for_runtime_filter(query_id, query_ctx);
+
+    PMergeFilterRequest request;
+    request.mutable_query_id()->set_hi(query_id.hi);
+    request.mutable_query_id()->set_lo(query_id.lo);
+    request.set_filter_id(filter_id);
+    request.set_stage(1);
+
+    ASSERT_TRUE(exec_env->_fragment_mgr->merge_filter(&request, nullptr).ok());
+    EXPECT_EQ(exec_env->_fragment_mgr->_query_ctx_map_delay_delete.num_items(), 1);
+
+    auto stats = exec_env->_fragment_mgr->get_query_ctx_map_delay_delete_stats();
+    ASSERT_EQ(stats.contexts.size(), 1);
+    EXPECT_EQ(stats.contexts[0].query_id, query_id);
+    auto dump = exec_env->_fragment_mgr->dump_query_ctx_map_delay_delete();
+    EXPECT_NE(dump.find(print_id(query_id)), std::string::npos);
+    EXPECT_NE(dump.find("state=waiting_runtime_filters"), std::string::npos);
+
+    {
+        LockGuard guard(handler->_filter_map_mutex);
+        handler->_filter_map.at(filter_id).done = true;
+    }
+    ASSERT_TRUE(exec_env->_fragment_mgr->merge_filter(&request, nullptr).ok());
+    EXPECT_EQ(exec_env->_fragment_mgr->_query_ctx_map_delay_delete.num_items(), 0);
+
+    std::weak_ptr<QueryContext> weak_query_ctx = query_ctx;
+    query_ctx.reset();
+    EXPECT_TRUE(weak_query_ctx.expired());
+
+    exec_env->_fragment_mgr->stop();
+    delete exec_env->_fragment_mgr;
+    exec_env->_fragment_mgr = previous_fragment_mgr;
+}
+
+TEST(FragmentMgrDelayDeleteMapTest, CancellationReleasesQueryContext) {
+    auto* exec_env = ExecEnv::GetInstance();
+    auto* previous_fragment_mgr = exec_env->_fragment_mgr;
+    exec_env->_fragment_mgr = new FragmentMgr(exec_env);
+
+    TQueryOptions query_options;
+    query_options.__set_query_type(TQueryType::LOAD);
+    query_options.__set_execution_timeout(60);
+    query_options.__set_mem_limit(64L * 1024 * 1024);
+
+    TNetworkAddress fe_addr;
+    fe_addr.hostname = "127.0.0.1";
+    fe_addr.port = 9030;
+
+    TUniqueId cancelled_query_id;
+    cancelled_query_id.__set_hi(607);
+    cancelled_query_id.__set_lo(708);
+    auto cancelled_query_ctx =
+            QueryContext::create(cancelled_query_id, exec_env, query_options, fe_addr,
+                                 /*is_nereids*/ true, fe_addr, QuerySource::INTERNAL_FRONTEND);
+    exec_env->_fragment_mgr->_retain_query_context_for_runtime_filter(cancelled_query_id,
+                                                                      cancelled_query_ctx);
+    std::weak_ptr<QueryContext> weak_query_ctx = cancelled_query_ctx;
+    cancelled_query_ctx->cancel(Status::Cancelled("unit test"));
+    EXPECT_EQ(exec_env->_fragment_mgr->_query_ctx_map_delay_delete.num_items(), 0);
+    EXPECT_TRUE(exec_env->_fragment_mgr->get_query_ctx_map_delay_delete_stats().contexts.empty());
+    EXPECT_FALSE(weak_query_ctx.expired());
+    cancelled_query_ctx.reset();
+    EXPECT_TRUE(weak_query_ctx.expired());
+
     exec_env->_fragment_mgr->stop();
     delete exec_env->_fragment_mgr;
     exec_env->_fragment_mgr = previous_fragment_mgr;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Runtime-filter merge backends retained QueryContext objects indefinitely after successful queries finished because the delay-delete map held a strong reference. Cancel paths that bypassed FragmentMgr::cancel_query could retain the same reference as well. Keep the existing ConcurrentContextMap, retain only queries with remote filters, release the reference after every remote filter is published, and synchronously remove cancelled queries from QueryContext::cancel. Preserve delay-map size, oldest-retention, and Query ID observability without adding a custom map or background GC.

### Release note

Fix retained query tasks and runtime-filter memory on runtime-filter merge backends.

### Check List (For Author)

- Test: Unit Test
    - RuntimeFilterMgrTest.* and FragmentMgrDelayDeleteMapTest.*
    - ASAN BE build
- Behavior changed: Yes. Completed and cancelled queries release runtime-filter delay-delete references promptly.
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

