### PR TITLE
[fix](fe) Mask FE TLS private key and key store passwords in config dumps

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -362,7 +362,7 @@ public class Config extends ConfigBase {
     @ConfField(description = "Path to the FE TLS private key.")
     public static String tls_private_key_path = "";
 
-    @ConfField(description = "Password for the FE TLS private key.")
+    @ConfField(sensitive = true, description = "Password for the FE TLS private key.")
     public static String tls_private_key_password = "";
 
     @ConfField(description = "Path to the FE TLS CA certificate.")
@@ -393,7 +393,7 @@ public class Config extends ConfigBase {
     public static String key_store_path =  EnvUtils.getDorisHome()
             + "/conf/ssl/doris_ssl_certificate.keystore";
 
-    @ConfField(description = "The key store password of FE https service")
+    @ConfField(sensitive = true, description = "The key store password of FE https service")
     public static String key_store_password = "";
 
     @ConfField(description = "The key store type of FE https service")

--- a/fe/fe-common/src/test/java/org/apache/doris/common/ConfigTest.java
+++ b/fe/fe-common/src/test/java/org/apache/doris/common/ConfigTest.java
@@ -70,6 +70,29 @@ public class ConfigTest {
         }
     }
 
+    // The FE TLS private-key password and the FE HTTPS key-store password are operator-supplied
+    // secrets in fe.conf, so every config dump API must mask them exactly like the tokens above.
+    // The BE counterpart of tls_private_key_password is masked at its own export point.
+    @Test
+    public void testTlsAndKeyStorePasswordsAreMaskedWhenSet() {
+        String oldTlsPassword = Config.tls_private_key_password;
+        String oldKeyStorePassword = Config.key_store_password;
+        try {
+            Config.tls_private_key_password = "super-secret-tls-password";
+            Config.key_store_password = "super-secret-key-store-password";
+
+            Map<String, String> dumped = ConfigBase.dump();
+            Assert.assertEquals(ConfigBase.SENSITIVE_CONF_MASK, dumped.get("tls_private_key_password"));
+            Assert.assertEquals(ConfigBase.SENSITIVE_CONF_MASK, dumped.get("key_store_password"));
+
+            Assert.assertEquals(ConfigBase.SENSITIVE_CONF_MASK, configInfoValue("tls_private_key_password"));
+            Assert.assertEquals(ConfigBase.SENSITIVE_CONF_MASK, configInfoValue("key_store_password"));
+        } finally {
+            Config.tls_private_key_password = oldTlsPassword;
+            Config.key_store_password = oldKeyStorePassword;
+        }
+    }
+
     // An empty sensitive config is left as-is (no secret to hide), so "unset" stays visible.
     @Test
     public void testEmptySensitiveConfigIsNotMasked() {


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #66836

Problem Summary:

#66836 masked `tls_private_key_password` at the BE's shared configuration export point, because the value was returned in plaintext. The FE declares the same configuration key verbatim in `Config.java`, and it was not masked there.

The FE already has the facility this needs: `ConfField.sensitive()` drives `ConfigBase.maskIfSensitive()`, which is applied by both `ConfigBase.dump()` and `ConfigBase.getConfigInfo()` — the two accessors behind `SHOW FRONTEND CONFIG`, `/rest/v1/config/fe`, and `/rest/v2/manager/node/configuration_info`. Only `auth_token` and `fe_meta_auth_token` set the flag, so `tls_private_key_password` was returned verbatim by all three.

`key_store_password` is masked in the same commit. It is the password for the FE HTTPS service key store, it is read by `DorisFE.setKeyStorePassword` and `InternalHttpsUtils`, and it leaks through exactly the same three dump paths. Grouping the two avoids leaving a second plaintext secret one line away from the one being fixed.

Deliberately **not** masked, to keep this change narrow and reviewable:

- `mysql_ssl_default_ca_certificate_password` and `mysql_ssl_default_server_certificate_password` default to the documented literal `doris`. Masking them would permanently hide a published default rather than a secret.
- `initial_root_password` is documented as a 2-staged SHA-1 hash, not a plaintext password.

Neither value is round-tripped by any caller: `ConfigBase.dump()` and `getConfigInfo()` feed rendering paths only (`ConfigController`, `NodeAction`, `ShowConfigCommand`), and runtime mutation goes through `ConfigBase.setMutableConfig`, so masking cannot affect configuration behaviour.

### Release note

`SHOW FRONTEND CONFIG` and the FE configuration REST endpoints now return `********` instead of the configured value for `tls_private_key_password` and `key_store_password`, matching the existing behaviour for `auth_token` and `fe_meta_auth_token`.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

Added `ConfigTest.testTlsAndKeyStorePasswordsAreMaskedWhenSet`, next to the existing `testAuthTokenIsMaskedWhenSet`, asserting both keys are masked in `ConfigBase.dump()` and `ConfigBase.getConfigInfo()`.

```
mvn -f fe/pom.xml -pl :fe-common -am test -Dtest=ConfigTest
  -> Tests run: 7, Failures: 0, Errors: 0, Skipped: 0

cd fe && mvn clean checkstyle:check
  -> BUILD SUCCESS
```

I also confirmed the test fails without the `Config.java` change, so it genuinely covers the behaviour:

```
testTlsAndKeyStorePasswordsAreMaskedWhenSet
  expected:<[********]> but was:<[super-secret-tls-password]>
```

No regression test was added: config masking needs no running cluster, and the existing unit test file already covers this behaviour for the other sensitive configs.

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

The two configuration values are now reported as `********` by the config dump APIs when set. An empty value is still shown as empty, so "unset" remains visible.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
