### PR TITLE
[fix](regression) Align connector TLS regression settings

### DIFF
--- a/regression-test/conf/regression-conf.groovy
+++ b/regression-test/conf/regression-conf.groovy
@@ -306,8 +306,6 @@ icebergS3TablesCatalogGlueRest=""
 // The path of the cert configuration file for the testing framework
 // is consistent with the path of the cert file for the cluster
 enableTLS=false
-// Comma-separated Doris connector protocols that remain plaintext when TLS is enabled
-tlsExcludedProtocols=""
 tlsVerifyMode="strict"
 keyStorePath="/your/keystore.p12"
 keyStorePassword="yourPwd"

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/Suite.groovy
@@ -135,14 +135,10 @@ class Suite implements GroovyInterceptable {
             return Collections.emptyList()
         }
 
-        String tlsVerifyMode = getConf("tlsVerifyMode", "strict")
-        boolean skipHostnameVerification = !tlsVerifyMode.equalsIgnoreCase("strict")
-        String excludedProtocols = getConf("tlsExcludedProtocols", "")
         return [
                 "--doris-enable-tls", "true",
                 "--doris-tls-ca-certificate-path", getConf("trustCACert"),
-                "--doris-tls-skip-hostname-verification", skipHostnameVerification.toString(),
-                "--doris-tls-excluded-protocols", excludedProtocols
+                "--doris-tls-skip-hostname-verification", "false"
         ]
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: https://github.com/apache/doris/pull/66658

Problem Summary:

Connector regression cases derived hostname verification and excluded protocols from framework TLS settings. This could disable Arrow Flight TLS coverage or skip hostname verification unintentionally. When TLS is enabled, pass the CA certificate and require hostname verification for every connector protocol.

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test
        - Flink connector TLS: 3 suites passed
        - Spark connector TLS: 2 suites passed
    - [x] Unit Test
        - Regression framework: 4 tests passed
    - [ ] Manual test
    - [ ] No need to test or manual test.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Connector TLS regression cases now verify hostnames and exercise all protocols.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label