### PR TITLE
[improvement](cloud) Limit retained instance tombstone scheduling

### DIFF
--- a/cloud/src/recycler/recycler.cpp
+++ b/cloud/src/recycler/recycler.cpp
@@ -38,6 +38,7 @@
 #include <numeric>
 #include <optional>
 #include <random>
+#include <ranges>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -87,6 +88,7 @@ using namespace std::chrono;
 namespace {
 
 constexpr size_t kRowsetBatchGetSize = 256;
+constexpr size_t kRecentCompletedInstanceCount = 5;
 
 int64_t packed_file_retry_sleep_ms() {
     const int64_t min_ms = std::max<int64_t>(0, config::packed_file_txn_retry_sleep_min_ms);
@@ -113,6 +115,12 @@ void add_file_to_delete_if_not_packed(const doris::RowsetMetaCloudPB& rowset,
     if (!is_packed_slice_path(rowset, path)) {
         file_paths->push_back(path);
     }
+}
+
+bool should_retain_deleted_instance_tombstone(const InstanceInfoPB& instance) {
+    return config::retain_deleted_instance_tombstone &&
+           instance.status() == InstanceInfoPB::DELETED &&
+           instance.recycle_state() == INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED;
 }
 
 bool filter_out_instance(const std::string& instance_id) {
@@ -288,8 +296,28 @@ void Recycler::instance_scanner_callback() {
             if (!instances.empty()) {
                 // enqueue instances
                 std::lock_guard lock(mtx_);
+                std::vector<InstanceInfoPB> completed_instances;
                 for (auto& instance : instances) {
                     if (filter_out_instance(instance.instance_id())) continue;
+                    if (should_retain_deleted_instance_tombstone(instance)) {
+                        completed_instances.push_back(instance);
+                        continue;
+                    }
+                    auto [_, success] = pending_instance_set_.insert(instance.instance_id());
+                    // skip instance already in pending queue
+                    if (success) {
+                        pending_instance_queue_.push_back(std::move(instance));
+                    }
+                }
+                std::ranges::sort(completed_instances, [&](const auto& l, const auto& r) {
+                    if (l.recycle_state_update_time_ms() != r.recycle_state_update_time_ms()) {
+                        return l.recycle_state_update_time_ms() > r.recycle_state_update_time_ms();
+                    }
+                    return l.instance_id() < r.instance_id();
+                });
+                auto recent_completed_instances =
+                        completed_instances | std::views::take(kRecentCompletedInstanceCount);
+                for (auto& instance : recent_completed_instances) {
                     auto [_, success] = pending_instance_set_.insert(instance.instance_id());
                     // skip instance already in pending queue
                     if (success) {
@@ -858,8 +886,11 @@ int InstanceRecycler::recycle_deleted_instance() {
     auto start_time = steady_clock::now();
     const auto recycle_state = instance_info_.recycle_state();
 
-    if (config::retain_deleted_instance_tombstone &&
-        recycle_state == InstanceRecycleState::INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED) {
+    if (should_retain_deleted_instance_tombstone(instance_info_)) {
+        LOG_WARNING("instance recycle completed, retain deleted instance key")
+                .tag("instance_id", instance_id_)
+                .tag("recycle_state", InstanceRecycleState_Name(recycle_state))
+                .tag("recycle_state_update_time_ms", instance_info_.recycle_state_update_time_ms());
         return 0;
     }
 

--- a/cloud/test/recycler_test.cpp
+++ b/cloud/test/recycler_test.cpp
@@ -11364,6 +11364,72 @@ TEST(RecyclerTest, enable_recycler_skip_instance_scanner) {
     EXPECT_TRUE(recycler.pending_instance_queue_.empty());
 }
 
+TEST(RecyclerTest, instance_scanner_enqueues_recent_completed_instances) {
+    auto txn_kv = std::make_shared<MemTxnKv>();
+    ASSERT_EQ(txn_kv->init(), 0);
+
+    const auto old_whitelist = config::recycle_whitelist;
+    const auto old_blacklist = config::recycle_blacklist;
+    const bool old_retain_deleted_instance_tombstone = config::retain_deleted_instance_tombstone;
+    const int64_t old_recycle_interval = config::recycle_interval_seconds;
+    const int64_t old_sleep = config::recycler_sleep_before_scheduling_seconds;
+    DORIS_CLOUD_DEFER {
+        config::recycle_whitelist = old_whitelist;
+        config::recycle_blacklist = old_blacklist;
+        config::retain_deleted_instance_tombstone = old_retain_deleted_instance_tombstone;
+        config::recycle_interval_seconds = old_recycle_interval;
+        config::recycler_sleep_before_scheduling_seconds = old_sleep;
+    };
+    config::recycle_whitelist.clear();
+    config::recycle_blacklist.clear();
+    config::retain_deleted_instance_tombstone = true;
+    config::recycle_interval_seconds = 3600;
+    config::recycler_sleep_before_scheduling_seconds = 0;
+
+    for (int i = 0; i < 7; ++i) {
+        InstanceInfoPB instance;
+        instance.set_instance_id(fmt::format("completed_{}", i));
+        instance.set_status(InstanceInfoPB::DELETED);
+        instance.set_recycle_state(INSTANCE_RECYCLE_STATE_CLEANUP_COMPLETED);
+        instance.set_recycle_state_update_time_ms(100 + i);
+        if (i == 1) {
+            instance.set_recycle_state_update_time_ms(102);
+        }
+        put_instance_info(txn_kv.get(), instance);
+    }
+    for (int i = 0; i < 7; ++i) {
+        InstanceInfoPB instance;
+        instance.set_instance_id(fmt::format("normal_{}", i));
+        instance.set_status(InstanceInfoPB::NORMAL);
+        put_instance_info(txn_kv.get(), instance);
+    }
+
+    Recycler recycler(txn_kv);
+    std::thread scanner([&]() { recycler.instance_scanner_callback(); });
+
+    std::vector<std::string> actual_instance_ids;
+    bool scan_completed = false;
+    {
+        std::unique_lock lock(recycler.mtx_);
+        scan_completed = recycler.pending_instance_cond_.wait_for(
+                lock, std::chrono::seconds(5),
+                [&]() { return recycler.pending_instance_queue_.size() >= 12; });
+        for (const auto& instance : recycler.pending_instance_queue_) {
+            actual_instance_ids.push_back(instance.instance_id());
+        }
+    }
+    recycler.stopped_ = true;
+    recycler.notifier_.notify_all();
+    scanner.join();
+
+    ASSERT_TRUE(scan_completed);
+    std::ranges::sort(actual_instance_ids);
+    std::vector<std::string> expected_instance_ids {
+            "completed_1", "completed_3", "completed_4", "completed_5", "completed_6", "normal_0",
+            "normal_1",    "normal_2",    "normal_3",    "normal_4",    "normal_5",    "normal_6"};
+    EXPECT_EQ(actual_instance_ids, expected_instance_ids);
+}
+
 TEST(RecyclerTest, enable_recycler_skip_recycle_callback) {
     auto txn_kv = std::make_shared<MemTxnKv>();
     ASSERT_EQ(txn_kv->init(), 0);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary: 
Completed deleted-instance tombstones were scheduled during every recycler scan, producing repeated warning logs without additional cleanup work. Limit scheduling to the five most recently updated completed tombstones while leaving normal instances unrestricted. Log the recycle state and update time for retained tombstones.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

