### PR TITLE
[fix](be) Preserve nullable null maps in protobuf serialization

### DIFF
--- a/be/src/core/data_type_serde/data_type_nullable_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_nullable_serde.cpp
@@ -312,11 +312,11 @@ Status DataTypeNullableSerDe::write_column_to_pb(const IColumn& column, PValues&
     const auto& null_col = nullable_col.get_null_map_column();
     if (nullable_col.has_null(start, end)) {
         result.set_has_null(true);
-        auto* null_map = result.mutable_null_map();
-        null_map->Reserve(row_count);
-        const auto& data = null_col.get_data();
-        null_map->Add(data.begin() + start, data.begin() + end);
     }
+    auto* null_map = result.mutable_null_map();
+    null_map->Reserve(null_map->size() + row_count);
+    const auto& data = null_col.get_data();
+    null_map->Add(data.begin() + start, data.begin() + end);
     return nested_serde->write_column_to_pb(nullable_col.get_nested_column(), result, start, end);
 }
 

--- a/be/test/core/data_type_serde/data_type_serde_pb_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_pb_test.cpp
@@ -209,6 +209,43 @@ TEST(DataTypeSerDePbTest, DataTypeScalaSerDeTest5) {
     }
 }
 
+TEST(DataTypeSerDePbTest, NestedArrayNullablePbRoundTrip) {
+    auto values = ColumnInt32::create();
+    auto null_map = ColumnUInt8::create();
+    values->get_data() = {1, 2, 3, 0, 5};
+    null_map->get_data() = {0, 0, 0, 1, 0};
+
+    auto inner_array_offsets = ColumnArray::ColumnOffsets::create();
+    inner_array_offsets->get_data() = {2, 2, 5};
+    auto inner_array =
+            ColumnArray::create(ColumnNullable::create(std::move(values), std::move(null_map)),
+                                std::move(inner_array_offsets));
+
+    auto outer_array_offsets = ColumnArray::ColumnOffsets::create();
+    outer_array_offsets->get_data().push_back(3);
+    auto outer_array = ColumnArray::create(make_nullable(std::move(inner_array)),
+                                           std::move(outer_array_offsets));
+
+    auto int_type = std::make_shared<DataTypeInt32>();
+    auto inner_array_type = std::make_shared<DataTypeArray>(make_nullable(int_type));
+    auto outer_array_type = std::make_shared<DataTypeArray>(make_nullable(inner_array_type));
+
+    PValues values_pb;
+    column_to_pb(outer_array_type, *outer_array, &values_pb);
+
+    ASSERT_EQ(values_pb.child_element_size(), 1);
+    EXPECT_EQ(values_pb.child_element(0).child_offset_size(), 3);
+    EXPECT_EQ(values_pb.child_element(0).child_element(0).null_map_size(), 5);
+
+    auto restored = outer_array_type->create_column();
+    ASSERT_TRUE(pb_to_column(outer_array_type, values_pb, *restored));
+    Block input_block;
+    input_block.insert({outer_array->get_ptr(), outer_array_type, ""});
+    Block restored_block;
+    restored_block.insert({std::move(restored), outer_array_type, ""});
+    EXPECT_EQ(input_block.dump_data(), restored_block.dump_data());
+}
+
 TEST(DataTypeSerDePbTest, DataTypeScalaSerDeTest6) {
     std::cout << "==== array<array<int32>> === " << std::endl;
     // array<array<int32>>


### PR DESCRIPTION

 Protobuf serialization of nested nullable values could append data in multiple ranges while omitting null-map entries for ranges without NULL values. If a later range contained NULL, the resulting null map was shorter than the data column and NULL positions became misaligned during deserialization. This change always appends null-map entries for every serialized range and adds a nested-array round-trip test.