### PR TITLE
[fix](spill) Account unsubmitted tasks when revoke_memory submit fails

### DIFF
--- a/be/src/runtime/workload_management/query_task_controller.cpp
+++ b/be/src/runtime/workload_management/query_task_controller.cpp
@@ -203,8 +203,19 @@ Status QueryTaskController::revoke_memory() {
             ((void*)spill_context.get()), PrettyPrinter::print_bytes(revoked_size),
             PrettyPrinter::print_bytes(total_revokable_size), chosen_tasks.size(), tasks.size());
 
-    for (auto* task : chosen_tasks) {
-        RETURN_IF_ERROR(task->revoke_memory(spill_context));
+    for (size_t i = 0; i < chosen_tasks.size(); ++i) {
+        auto status = chosen_tasks[i]->revoke_memory(spill_context);
+        if (!status.ok()) {
+            // A failed submit never reaches do_revoke_memory, so neither the failed
+            // task nor the unsubmitted remainder would ever call on_task_finished().
+            // Without accounting for them here the SpillContext never completes, its
+            // callback never fires set_memory_sufficient(true), and the query waits
+            // on _memory_sufficient_dependency forever.
+            for (size_t j = i; j < chosen_tasks.size(); ++j) {
+                spill_context->on_task_finished();
+            }
+            return status;
+        }
     }
     return Status::OK();
 }

--- a/be/test/exec/pipeline/pipeline_task_test.cpp
+++ b/be/test/exec/pipeline/pipeline_task_test.cpp
@@ -1992,4 +1992,21 @@ TEST_F(PipelineTaskTest, TEST_TERMINATE_RACE_FIX) {
     config::enable_debug_points = false;
 }
 
+TEST_F(PipelineTaskTest, TEST_SPILL_CONTEXT_REQUIRES_FULL_ACCOUNTING) {
+    // Contract behind QueryTaskController::revoke_memory's error path: the completion
+    // callback (which resumes the paused query via set_memory_sufficient(true)) fires only
+    // after on_task_finished() has been called once per counted task. A submit error means
+    // the failed task and the unsubmitted remainder never reach do_revoke_memory, so the
+    // caller must account for them itself or the query blocks forever.
+    bool fired = false;
+    auto ctx =
+            std::make_shared<SpillContext>(3, TUniqueId {}, [&](SpillContext*) { fired = true; });
+    ctx->on_task_finished(); // one task finished normally
+    EXPECT_FALSE(fired);
+    // two tasks failed to submit: the caller accounts for them
+    ctx->on_task_finished();
+    ctx->on_task_finished();
+    EXPECT_TRUE(fired);
+}
+
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67031

Related PR: #67032

Problem Summary:

`QueryTaskController::revoke_memory` sizes its `SpillContext` to the number of chosen tasks and relies on every task eventually calling `on_task_finished()`. If `PipelineTask::revoke_memory` fails to submit the `RevokableTask` for the Nth chosen task, the old `RETURN_IF_ERROR` aborted the loop: the failed task and the unsubmitted remainder never reach `do_revoke_memory`, so the `SpillContext` never completes, its completion callback never fires `set_memory_sufficient(true)`, and the query blocks on `_memory_sufficient_dependency` forever — a silent per-query hang whose piled-up sessions can starve the BE.

On a submit error, call `on_task_finished()` for the failed task and every remaining unsubmitted task before returning the error; the caller (`handle_single_query_`) still cancels the query on the returned status.

Adds `TEST_SPILL_CONTEXT_REQUIRES_FULL_ACCOUNTING` documenting the completion contract.

### Release note

Fix a permanent query hang when a spill revocation task fails to submit.

### Check List (For Author)

- Test
    - [x] Unit Test

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.
