### PR TITLE
[fix](virtual slot) Materialize constant virtual columns before caching

### DIFF
--- a/be/src/storage/segment/segment_iterator.cpp
+++ b/be/src/storage/segment/segment_iterator.cpp
@@ -3591,6 +3591,9 @@ Status SegmentIterator::_materialization_of_virtual_column(Block* block) {
             RETURN_IF_ERROR(column_expr->root()->execute_column(column_expr.get(), block, nullptr,
                                                                 _selected_size, result_column));
 
+            // The materialized value is cached in the block and later consumed as the slot's
+            // concrete column type, so do not let a ColumnConst cross this boundary.
+            result_column = result_column->convert_to_full_column_if_const();
             block->replace_by_position(materialized_pos, std::move(result_column));
         }
     }

--- a/be/test/storage/segment/segment_iterator_virtual_column_test.cpp
+++ b/be/test/storage/segment/segment_iterator_virtual_column_test.cpp
@@ -52,8 +52,8 @@ TabletSchemaSPtr make_tablet_schema() {
 TEST(SegmentIteratorVirtualColumnTest, MaterializationExpandsConstNullableResult) {
     auto tablet_schema = make_tablet_schema();
     auto segment = std::make_shared<Segment>(0, RowsetId(), tablet_schema, InvertedIndexFileInfo());
-    auto schema = std::make_shared<Schema>(tablet_schema->columns(), std::vector<ColumnId> {0});
-    SegmentIterator iterator(segment, schema);
+    auto read_schema = std::make_shared<::doris::ReadSchema>(tablet_schema->columns());
+    SegmentIterator iterator(segment, read_schema);
 
     auto type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeFloat64>());
     auto expr = std::make_shared<VLiteral>(type, Field());

--- a/be/test/storage/segment/segment_iterator_virtual_column_test.cpp
+++ b/be/test/storage/segment/segment_iterator_virtual_column_test.cpp
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "core/column/column_nothing.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_number.h"
+#include "exprs/vexpr_context.h"
+#include "exprs/vliteral.h"
+#include "storage/olap_common.h"
+#include "storage/schema.h"
+#include "storage/segment/segment.h"
+#include "storage/segment/segment_iterator.h"
+#include "storage/tablet/tablet_schema.h"
+
+namespace doris::segment_v2 {
+namespace {
+
+TabletSchemaSPtr make_tablet_schema() {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(KeysType::DUP_KEYS);
+    auto* column = schema_pb.add_column();
+    column->set_unique_id(0);
+    column->set_name("virtual_column");
+    column->set_type("DOUBLE");
+    column->set_is_key(true);
+    column->set_is_nullable(true);
+    auto tablet_schema = std::make_shared<TabletSchema>();
+    tablet_schema->init_from_pb(schema_pb);
+    return tablet_schema;
+}
+
+} // namespace
+
+TEST(SegmentIteratorVirtualColumnTest, MaterializationExpandsConstNullableResult) {
+    auto tablet_schema = make_tablet_schema();
+    auto segment = std::make_shared<Segment>(0, RowsetId(), tablet_schema, InvertedIndexFileInfo());
+    auto schema = std::make_shared<Schema>(tablet_schema->columns(), std::vector<ColumnId> {0});
+    SegmentIterator iterator(segment, schema);
+
+    auto type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeFloat64>());
+    auto expr = std::make_shared<VLiteral>(type, Field());
+    iterator._virtual_column_exprs[0] = std::make_shared<VExprContext>(std::move(expr));
+    iterator._selected_size = 4;
+
+    Block block;
+    block.insert({ColumnNothing::create(0), type, "virtual_column"});
+
+    ASSERT_TRUE(iterator._materialization_of_virtual_column(&block).ok());
+    const auto& result = block.get_by_position(0).column;
+    EXPECT_FALSE(is_column_const(*result));
+    const auto* nullable = check_and_get_column<ColumnNullable>(result.get());
+    ASSERT_NE(nullable, nullptr);
+    EXPECT_EQ(nullable->size(), 4);
+    EXPECT_TRUE(nullable->only_null());
+}
+
+} // namespace doris::segment_v2


### PR DESCRIPTION
Problem Summary:
Virtual-column expressions may return ColumnConst, including all-NULL nullable constants. SegmentIterator previously stored these results directly in the
output block, while downstream consumers expect row-aligned concrete columns. This could cause type assertion failures during CSE virtual-column queries with
short-circuit evaluation.

Solution:
Materialize constant expression results with convert_to_full_column_if_const() before caching them in the virtual-column slot.