### PR TITLE
[fix](be) Skip CHAR payload checks for NULL rows

### DIFF
--- a/be/src/storage/iterator/olap_data_convertor.cpp
+++ b/be/src/storage/iterator/olap_data_convertor.cpp
@@ -549,7 +549,7 @@ Status OlapBlockDataConvertor::OlapColumnDataConvertorChar::convert_to_olap() {
 
     // If column_string is not padded to full, we should do padding here.
     if (should_padding(column_string, _length)) {
-        _column = clone_and_padding(column_string, _length);
+        _column = clone_and_padding(column_string, _length, _nullmap);
         column_string = assert_cast<const ColumnString*>(_column.get());
     }
 

--- a/be/src/storage/iterator/olap_data_convertor.h
+++ b/be/src/storage/iterator/olap_data_convertor.h
@@ -180,7 +180,8 @@ private:
             return column->size() * padding_length != column->chars.size();
         }
 
-        static ColumnPtr clone_and_padding(const ColumnString* input, size_t padding_length) {
+        static ColumnPtr clone_and_padding(const ColumnString* input, size_t padding_length,
+                                           const UInt8* null_map = nullptr) {
             auto column = ColumnString::create();
 
             column->offsets.resize(input->size());
@@ -191,6 +192,10 @@ private:
                 column->offsets[i] = cast_set<uint32_t, size_t, false>((i + 1) * padding_length);
 
                 auto str = input->get_data_at(i);
+
+                if (null_map && null_map[i]) {
+                    continue;
+                }
 
                 DCHECK(str.size <= padding_length)
                         << "char type data length over limit, padding_length=" << padding_length


### PR DESCRIPTION
Nullable CHAR columns can carry a non-empty nested string payload for rows whose logical value is NULL. The CHAR storage converter previously validated that payload against the CHAR length even though the row was NULL, causing an unnecessary DCHECK during INSERT. This change passes the null map into CHAR padding and skips validation and copying for NULL rows while preserving the existing checks for non-NULL rows.