### PR TITLE
[fix](be) Fix crash on duplicate txn commit

### DIFF
--- a/be/src/storage/rowset/pending_rowset_helper.h
+++ b/be/src/storage/rowset/pending_rowset_helper.h
@@ -43,6 +43,8 @@ public:
     // guarded rowset is indeed no longer in use.
     void drop();
 
+    bool is_initialized() const { return _pending_rowset_set != nullptr; }
+
 private:
     friend class PendingRowsetSet;
     explicit PendingRowsetGuard(const std::vector<RowsetId>& rowset_ids, PendingRowsetSet* set);

--- a/be/src/storage/txn/txn_manager.cpp
+++ b/be/src/storage/txn/txn_manager.cpp
@@ -360,7 +360,9 @@ Status TxnManager::commit_txn(OlapMeta* meta, TPartitionId partition_id,
                       << ", tablet: " << tablet_info.to_string()
                       << ", rowset_id: " << load_info->rowset->rowset_id();
             // Should not remove this rowset from pending rowsets
-            load_info->pending_rs_guard = std::move(guard);
+            if (guard.is_initialized()) {
+                load_info->pending_rs_guard = std::move(guard);
+            }
             return Status::OK();
         }
 

--- a/be/test/storage/txn/txn_manager_test.cpp
+++ b/be/test/storage/txn/txn_manager_test.cpp
@@ -323,6 +323,20 @@ TEST_F(TxnManagerTest, CommitTxnTwiceWithSameRowsetId) {
     EXPECT_TRUE(k_engine->pending_local_rowsets().contains(_rowset->rowset_id()));
 }
 
+TEST_F(TxnManagerTest, CommitTxnTwiceWithMovedFromPendingRowsetGuard) {
+    auto guard = k_engine->pending_local_rowsets().add(_rowset->rowset_id());
+    auto st = k_engine->txn_manager()->commit_txn(_meta.get(), partition_id, transaction_id,
+                                                  tablet_id, _tablet_uid, load_id, _rowset,
+                                                  std::move(guard), false);
+    ASSERT_TRUE(st.ok()) << st;
+
+    st = k_engine->txn_manager()->commit_txn(_meta.get(), partition_id, transaction_id, tablet_id,
+                                             _tablet_uid, load_id, _rowset_same_id,
+                                             std::move(guard), false);
+    ASSERT_TRUE(st.ok()) << st;
+    EXPECT_TRUE(k_engine->pending_local_rowsets().contains(_rowset->rowset_id()));
+}
+
 // 1. prepare twice should be success
 TEST_F(TxnManagerTest, PrepareNewTxnTwice) {
     auto st = k_engine->txn_manager()->prepare_txn(partition_id, transaction_id, tablet_id,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67048

Related PR: N/A

Problem Summary: 
The first successful commit moves PendingRowsetGuard into TabletTxnInfo,
leaving the caller-owned guard uninitialized. LoadStreamWriter::close() can be
replayed after a timeout and calls RowsetBuilder::commit_txn() again, passing
the same moved-from guard.

The duplicate-rowset branch previously move-assigned that uninitialized guard
over the initialized guard stored in TabletTxnInfo, triggering the
PendingRowsetGuard move-assignment CHECK.

This change skips replacement only when the incoming guard is uninitialized.
The stored guard is preserved, while the existing fresh-guard behavior and
move-assignment invariant remain unchanged.

### Release note

Fix a BE crash when retrying a transaction commit after a timeout.

### Check List (For Author)

- Test: Unit Test
    - `TxnManagerTest.CommitTxnTwiceWithMovedFromPendingRowsetGuard`
    - `TxnManagerTest.CommitTxnTwiceWithSameRowsetId`
- Behavior changed: Yes. Duplicate commit retries with a moved-from pending rowset guard now preserve the stored guard and return success.
- Does this need documentation: No.

