### PR TITLE
fix: ThreadPool idle workers never shrink due to pthread_cond_timedwait returning no_timeout on timeout

### DIFF
--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -580,21 +580,23 @@ void ThreadPool::dispatch_thread() {
                     _idle_threads.erase(_idle_threads.iterator_to(me));
                 }
             };
-            if (me.not_empty.wait_for(l, _idle_timeout) == std::cv_status::timeout) {
-                // After much investigation, it appears that pthread condition variables have
-                // a weird behavior in which they can return ETIMEDOUT from timed_wait even if
-                // another thread did in fact signal. Apparently after a timeout there is some
-                // brief period during which another thread may actually grab the internal mutex
-                // protecting the state, signal, and release again before we get the mutex. So,
-                // we'll recheck the empty queue case regardless.
-                if (_queue.empty() && _num_threads + _num_threads_pending_start > _min_threads) {
-                    VLOG_NOTICE << "Releasing worker thread from pool " << _name << " after "
-                                << std::chrono::duration_cast<std::chrono::milliseconds>(
-                                           _idle_timeout)
-                                           .count()
-                                << "ms of idle time.";
-                    break;
-                }
+            me.not_empty.wait_for(l, _idle_timeout);
+            // After much investigation, it appears that pthread condition variables have
+            // a weird behavior in which they can return ETIMEDOUT from timed_wait even if
+            // another thread did in fact signal. Apparently after a timeout there is some
+            // brief period during which another thread may actually grab the internal mutex
+            // protecting the state, signal, and release again before we get the mutex. So,
+            // we'll recheck the empty queue case regardless. Moreover, we check the shrink
+            // condition unconditionally (not only on timeout) because on some platforms
+            // pthread_cond_timedwait may return success (no_timeout) even when the timeout
+            // has expired, causing idle workers to never shrink.
+            if (_queue.empty() && _num_threads + _num_threads_pending_start > _min_threads) {
+                VLOG_NOTICE << "Releasing worker thread from pool " << _name << " after "
+                            << std::chrono::duration_cast<std::chrono::milliseconds>(
+                                       _idle_timeout)
+                                       .count()
+                            << "ms of idle time.";
+                break;
             }
             continue;
         }


### PR DESCRIPTION
## Proposed changes

Fix #66997: RScan_normal ThreadPool idle workers never shrink, OS threads accumulate beyond max_threads and eventually crash BE.

### Root Cause

The `ThreadPool::dispatch_thread()` shrink logic was only checking the shrink condition (`queue empty && num_threads > min_threads`) when `std::condition_variable::wait_for()` returned `std::cv_status::timeout`.

However, on some platforms (observed in Doris cloud deployments with compute-storage separation), `pthread_cond_timedwait` may return success (no_timeout) even when the timeout has expired. This causes idle workers to never check the shrink condition, re-enter the idle loop, and never exit.

Over time, remote scan jobs (RScan_normal) create batches of ~80-110 workers per run that accumulate to 20k+ OS threads, exceeding cgroup pids.max and causing BE abort with 'Could not create thread (error 11)'.

### Fix

Always check the shrink condition after `wait_for` returns, regardless of the `cv_status`. The queue-empty guard ensures workers woken for legitimate tasks will not exit prematurely.

### Changes

- `be/src/util/threadpool.cpp`: Remove the `cv_status::timeout` guard around the shrink check, so idle workers always evaluate the shrink condition after `wait_for` returns.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have created an issue and described the bug in detail
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings