### PR TITLE
[fix](spill) Spread spill files across equally empty disks

### DIFF
--- a/be/src/exec/spill/spill_file_manager.cpp
+++ b/be/src/exec/spill/spill_file_manager.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <memory>
+#include <random>
 #include <string>
 #include <utility>
 
@@ -148,11 +149,36 @@ std::vector<SpillDataDir*> SpillFileManager::_get_stores_for_spill(
 
     std::ranges::sort(stores_with_usage, [](auto&& a, auto&& b) { return a.second < b.second; });
 
+    // Shuffle the disks that are effectively as empty as the emptiest one, so concurrent
+    // callers do not all land on the same disk.
+    //
+    // _get_disk_usage() is derived from SpillDataDir::_available_bytes, which is only
+    // refreshed by the GC thread every config::spill_gc_interval_ms (2s by default). Within
+    // that window every caller computes an identical usage vector, sorts it identically and
+    // would otherwise pick an identical winner -- so all spill files created during those
+    // two seconds pile onto one disk while the others stay idle. Randomizing among the
+    // near-equal head of the list keeps the "prefer the emptiest disk" intent (a disk that
+    // is genuinely emptier by more than the band still wins outright) while spreading load
+    // across disks whose usage only differs by sampling noise.
+    const double lowest_usage = stores_with_usage.front().second;
+    auto equally_empty_end =
+            std::ranges::find_if(stores_with_usage, [lowest_usage](const auto& entry) {
+                return entry.second > lowest_usage + USAGE_EQUIVALENCE_BAND;
+            });
+    std::shuffle(stores_with_usage.begin(), equally_empty_end, _rng_for_store_selection());
+
     std::vector<SpillDataDir*> stores;
     for (const auto& [store, _] : stores_with_usage) {
         stores.emplace_back(store);
     }
     return stores;
+}
+
+std::mt19937& SpillFileManager::_rng_for_store_selection() {
+    // Thread-local so concurrent callers draw independent permutations without contending
+    // on a shared generator.
+    static thread_local std::mt19937 rng(std::random_device {}());
+    return rng;
 }
 
 Status SpillFileManager::create_spill_file(const std::string& relative_path,
@@ -166,7 +192,8 @@ Status SpillFileManager::create_spill_file(const std::string& relative_path,
                 "no available disk can be used for spill.");
     }
 
-    // Select the first available data dir (sorted by usage ascending)
+    // Select the first available data dir (sorted by usage ascending, with the
+    // equally-empty head shuffled -- see _get_stores_for_spill)
     SpillDataDir* data_dir = data_dirs.front();
     spill_file = std::make_shared<SpillFile>(data_dir, relative_path);
     return Status::OK();

--- a/be/src/exec/spill/spill_file_manager.h
+++ b/be/src/exec/spill/spill_file_manager.h
@@ -20,6 +20,7 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include <random>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -148,6 +149,14 @@ private:
         int failed_count {0};
         std::string query_dir;
     };
+
+    // Disks whose usage differs by no more than this are treated as equally empty and
+    // shuffled, so a stale usage snapshot cannot funnel every concurrent caller onto one
+    // disk. 2% of capacity is well below any real imbalance worth reacting to and well
+    // above the drift a 2s-old snapshot can accumulate.
+    static constexpr double USAGE_EQUIVALENCE_BAND = 0.02;
+
+    static std::mt19937& _rng_for_store_selection();
 
     void _init_metrics();
     Status _init_spill_store_map();

--- a/be/test/vec/spill/spill_file_test.cpp
+++ b/be/test/vec/spill/spill_file_test.cpp
@@ -1621,4 +1621,73 @@ TEST_F(SpillFileTest, DataDirCapacityTracking) {
     ASSERT_GT(after_write_bytes, initial_bytes);
 }
 
+// ═══════════════════════════════════════════════════════════════════════
+// Disk selection
+// ═══════════════════════════════════════════════════════════════════════
+
+namespace {
+
+// Build a manager over `count` same-medium dirs whose reported usage is driven purely by
+// the values we set here, so the selection policy can be exercised without touching real
+// disks. Usage is 1 - available/capacity, see SpillDataDir::_get_disk_usage.
+std::unique_ptr<SpillFileManager> make_manager_with_dirs(
+        const std::string& root, size_t count,
+        const std::function<int64_t(size_t)>& available_bytes_of) {
+    constexpr int64_t kCapacity = 1024L * 1024 * 1024;
+    std::unordered_map<std::string, std::unique_ptr<SpillDataDir>> data_map;
+    for (size_t i = 0; i < count; ++i) {
+        auto path = fmt::format("{}/disk_{}", root, i);
+        auto dir = std::make_unique<SpillDataDir>(path, kCapacity, TStorageMedium::SSD);
+        // Bypass init(): it would stat a real filesystem. The selection path only reads
+        // these three fields (-fno-access-control lets the test set them directly).
+        dir->_disk_capacity_bytes = kCapacity;
+        dir->_available_bytes = available_bytes_of(i);
+        dir->_spill_data_limit_bytes = kCapacity;
+        data_map.emplace(path, std::move(dir));
+    }
+    return std::make_unique<SpillFileManager>(std::move(data_map));
+}
+
+} // namespace
+
+// A stale usage snapshot must not funnel every caller onto one disk. _get_disk_usage() is
+// derived from _available_bytes, which the GC thread only refreshes every
+// config::spill_gc_interval_ms (2s), so without shuffling every call inside that window
+// sorts identically and returns the same winner.
+TEST_F(SpillFileTest, EquallyEmptyDisksAreSelectedInVaryingOrder) {
+    constexpr size_t kDirCount = 4;
+    constexpr int kDraws = 200;
+    auto mgr = make_manager_with_dirs("./ut_dir/spill_select_equal", kDirCount,
+                                      [](size_t) { return 1024L * 1024 * 1024; });
+
+    std::set<std::string> chosen;
+    for (int i = 0; i < kDraws; ++i) {
+        auto dirs = mgr->_get_stores_for_spill(TStorageMedium::SSD);
+        ASSERT_EQ(dirs.size(), kDirCount);
+        chosen.insert(dirs.front()->path());
+    }
+
+    // Every equally-empty disk must be reachable. With a uniform draw over 4 disks the
+    // odds of missing one across 200 draws are ~1e-25, so this cannot flake; the old
+    // deterministic policy yields exactly one distinct winner.
+    ASSERT_EQ(chosen.size(), kDirCount);
+}
+
+// Shuffling must stay confined to the near-equal head: a disk that is genuinely emptier
+// than the rest still has to win every time.
+TEST_F(SpillFileTest, ClearlyEmptiestDiskAlwaysWins) {
+    constexpr int64_t kCapacity = 1024L * 1024 * 1024;
+    // disk_0 is ~10% used, the others ~60% -- far beyond USAGE_EQUIVALENCE_BAND.
+    auto mgr = make_manager_with_dirs("./ut_dir/spill_select_skewed", 3, [](size_t i) {
+        return i == 0 ? static_cast<int64_t>(kCapacity * 0.9)
+                      : static_cast<int64_t>(kCapacity * 0.4);
+    });
+
+    for (int i = 0; i < 50; ++i) {
+        auto dirs = mgr->_get_stores_for_spill(TStorageMedium::SSD);
+        ASSERT_EQ(dirs.size(), 3);
+        ASSERT_EQ(dirs.front()->path(), "./ut_dir/spill_select_skewed/disk_0");
+    }
+}
+
 } // namespace doris::vectorized


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67062

Problem Summary:

On a backend with several spill disks, every spill file created within a two-second window lands on the same disk while the others stay idle. Spill throughput is capped at one disk's bandwidth and that disk reaches its capacity limit first.

The selection is deterministic *and* the input it sorts on is stale:

- `_get_stores_for_spill()` sorts candidates by usage ascending, and `create_spill_file()` always takes `data_dirs.front()`.
- The usage comes from `SpillDataDir::_get_disk_usage()`, which reads `_available_bytes`.
- `_available_bytes` is only refreshed by `SpillDataDir::update_capacity()`, called from the GC thread once per `config::spill_gc_interval_ms` (2s by default).
- `_spill_data_bytes`, which *is* updated on every write, does not feed into `_get_disk_usage()`.

So nothing the manager hands out during those two seconds changes the ordering: every caller computes the same usage vector, sorts it the same way, and picks the same winner. A single spilling query creates one spill file per partition per pipeline task, so hundreds of calls easily fall inside one refresh window.

This PR shuffles the head of the sorted list. Disks whose usage is within `USAGE_EQUIVALENCE_BAND` (2% of capacity) of the emptiest one are treated as equally empty and drawn from at random; a disk that is genuinely emptier by more than the band still wins outright, so the existing "prefer the emptiest disk" intent is preserved. Only ties that a stale snapshot cannot distinguish get spread out. The generator is `thread_local`, so concurrent callers draw independent permutations without contending on a shared generator.

StarRocks addresses the same problem by picking a random start index and walking the directory list from there (`be/src/compute_env/spill/dir_manager.cpp`); randomizing only within the near-equal band keeps Doris's usage-aware preference rather than replacing it with plain round-robin.

### Release note

Fix spill files all landing on a single disk when multiple spill disks are configured.

### Check List (For Author)

- Test
    - [x] Unit Test

      Two tests in `spill_file_test.cpp`:
      - `EquallyEmptyDisksAreSelectedInVaryingOrder` — with four equally empty disks, 200
        draws must reach all four. The previous deterministic policy yields exactly one
        distinct winner, so this fails before the change. With a uniform draw the odds of
        missing a disk are ~1e-25, so it cannot flake.
      - `ClearlyEmptiestDiskAlwaysWins` — with one disk far emptier than the rest (well
        beyond the band), it must win all 50 draws. This guards the preference that the
        shuffle must not destroy.

- Behavior changed:
    - [x] Yes.

      Which spill disk a given spill file lands on is no longer deterministic when several
      disks are equally empty. Disk preference is unchanged whenever one disk is more than
      2% of capacity emptier than the others. No configuration, format or interface change.

- Does this need documentation?
    - [x] No.
