### PR TITLE
[fix](function) Align datetime offset validation between FE and BE

### DIFF
--- a/be/src/exprs/function/cast/cast_to_date_or_datetime_impl.hpp
+++ b/be/src/exprs/function/cast/cast_to_date_or_datetime_impl.hpp
@@ -657,7 +657,9 @@ FRAC:
                 SET_PARAMS_RET_FALSE_IFN((consume_digit<UInt32, 2>(ptr, end, part[0])),
                                          "invalid hour offset '{}'", std::string {ptr, end});
             }
-            SET_PARAMS_RET_FALSE_IFN(part[0] <= 14, "invalid hour offset '{}'", part[0]);
+            const uint32_t max_hour_offset = sign == '-' ? 12 : 14;
+            SET_PARAMS_RET_FALSE_IFN(part[0] <= max_hour_offset, "invalid hour offset '{}'",
+                                     part[0]);
             if (ptr < end) {
                 if (*ptr == ':') {
                     ++ptr;
@@ -665,10 +667,10 @@ FRAC:
                 // minute
                 SET_PARAMS_RET_FALSE_IFN((consume_digit<UInt32, 2>(ptr, end, part[1])),
                                          "invalid minute offset '{}'", std::string {ptr, end});
-                SET_PARAMS_RET_FALSE_IFN((part[1] == 0 || part[1] == 30 || part[1] == 45),
-                                         "invalid minute offset '{}'", part[1]);
+                SET_PARAMS_RET_FALSE_IFN(part[1] < 60, "invalid minute offset '{}'", part[1]);
             }
-            SET_PARAMS_RET_FALSE_IFN(part[0] != 14 || part[1] == 0, "invalid timezone offset '{}'",
+            SET_PARAMS_RET_FALSE_IFN(part[0] != max_hour_offset || part[1] == 0,
+                                     "invalid timezone offset '{}'",
                                      combine_tz_offset(sign, part[0], part[1]));
 
             SET_PARAMS_RET_FALSE_IFN(TimezoneUtils::find_cctz_time_zone(
@@ -890,18 +892,19 @@ inline bool CastToDateOrDatetime::from_string_non_strict_mode_impl(
             } else {
                 PROPAGATE_FALSE((consume_digit<UInt32, 2>(ptr, end, hour_offset)));
             }
-            SET_PARAMS_RET_FALSE_IFN(hour_offset <= 14, "invalid hour offset {}", hour_offset);
+            const uint32_t max_hour_offset = sign == '-' ? 12 : 14;
+            SET_PARAMS_RET_FALSE_IFN(hour_offset <= max_hour_offset, "invalid hour offset {}",
+                                     hour_offset);
             if (ptr < end) {
                 if (*ptr == ':') {
                     ++ptr;
                 }
                 // minute
                 PROPAGATE_FALSE((consume_digit<UInt32, 2>(ptr, end, minute_offset)));
-                SET_PARAMS_RET_FALSE_IFN(
-                        (minute_offset == 0 || minute_offset == 30 || minute_offset == 45),
-                        "invalid minute offset {}", minute_offset);
+                SET_PARAMS_RET_FALSE_IFN(minute_offset < 60, "invalid minute offset {}",
+                                         minute_offset);
             }
-            SET_PARAMS_RET_FALSE_IFN(hour_offset != 14 || minute_offset == 0,
+            SET_PARAMS_RET_FALSE_IFN(hour_offset != max_hour_offset || minute_offset == 0,
                                      "invalid timezone offset '{}'",
                                      combine_tz_offset(sign, hour_offset, minute_offset));
 

--- a/be/src/exprs/function/cast/cast_to_datetimev2_impl.hpp
+++ b/be/src/exprs/function/cast/cast_to_datetimev2_impl.hpp
@@ -651,7 +651,9 @@ FRAC:
                 SET_PARAMS_RET_FALSE_IFN((consume_digit<UInt32, 2>(ptr, end, part[0])),
                                          "invalid hour offset '{}'", std::string {ptr, end});
             }
-            SET_PARAMS_RET_FALSE_IFN(part[0] <= 14, "invalid hour offset '{}'", part[0]);
+            const uint32_t max_hour_offset = sign == '-' ? 12 : 14;
+            SET_PARAMS_RET_FALSE_IFN(part[0] <= max_hour_offset, "invalid hour offset '{}'",
+                                     part[0]);
             if (ptr < end) {
                 if (*ptr == ':') {
                     ++ptr;
@@ -659,10 +661,10 @@ FRAC:
                 // minute
                 SET_PARAMS_RET_FALSE_IFN((consume_digit<UInt32, 2>(ptr, end, part[1])),
                                          "invalid minute offset '{}'", std::string {ptr, end});
-                SET_PARAMS_RET_FALSE_IFN((part[1] == 0 || part[1] == 30 || part[1] == 45),
-                                         "invalid minute offset '{}'", part[1]);
+                SET_PARAMS_RET_FALSE_IFN(part[1] < 60, "invalid minute offset '{}'", part[1]);
             }
-            SET_PARAMS_RET_FALSE_IFN(part[0] != 14 || part[1] == 0, "invalid timezone offset '{}'",
+            SET_PARAMS_RET_FALSE_IFN(part[0] != max_hour_offset || part[1] == 0,
+                                     "invalid timezone offset '{}'",
                                      combine_tz_offset(sign, part[0], part[1]));
 
             SET_PARAMS_RET_FALSE_IFN(TimezoneUtils::find_cctz_time_zone(
@@ -929,18 +931,19 @@ inline bool CastToDatetimeV2::from_string_non_strict_mode_internal(
             } else {
                 PROPAGATE_FALSE((consume_digit<UInt32, 2>(ptr, end, hour_offset)));
             }
-            SET_PARAMS_RET_FALSE_IFN(hour_offset <= 14, "invalid hour offset '{}'", hour_offset);
+            const uint32_t max_hour_offset = sign == '-' ? 12 : 14;
+            SET_PARAMS_RET_FALSE_IFN(hour_offset <= max_hour_offset, "invalid hour offset '{}'",
+                                     hour_offset);
             if (ptr < end) {
                 if (*ptr == ':') {
                     ++ptr;
                 }
                 // minute
                 PROPAGATE_FALSE((consume_digit<UInt32, 2>(ptr, end, minute_offset)));
-                SET_PARAMS_RET_FALSE_IFN(
-                        (minute_offset == 0 || minute_offset == 30 || minute_offset == 45),
-                        "invalid minute offset {}", minute_offset);
+                SET_PARAMS_RET_FALSE_IFN(minute_offset < 60, "invalid minute offset {}",
+                                         minute_offset);
             }
-            SET_PARAMS_RET_FALSE_IFN(hour_offset != 14 || minute_offset == 0,
+            SET_PARAMS_RET_FALSE_IFN(hour_offset != max_hour_offset || minute_offset == 0,
                                      "invalid timezone offset '{}'",
                                      combine_tz_offset(sign, hour_offset, minute_offset));
 

--- a/be/src/exprs/function/cast/cast_to_datev2_impl.hpp
+++ b/be/src/exprs/function/cast/cast_to_datev2_impl.hpp
@@ -518,7 +518,9 @@ FRAC:
                 SET_PARAMS_RET_FALSE_IFN((consume_digit<UInt32, 2>(ptr, end, part[0])),
                                          "invalid hour offset '{}'", std::string {ptr, end});
             }
-            SET_PARAMS_RET_FALSE_IFN(part[0] <= 14, "invalid hour offset '{}'", part[0]);
+            const uint32_t max_hour_offset = sign == '-' ? 12 : 14;
+            SET_PARAMS_RET_FALSE_IFN(part[0] <= max_hour_offset, "invalid hour offset '{}'",
+                                     part[0]);
             if (ptr < end) {
                 if (*ptr == ':') {
                     ++ptr;
@@ -526,10 +528,10 @@ FRAC:
                 // minute
                 SET_PARAMS_RET_FALSE_IFN((consume_digit<UInt32, 2>(ptr, end, part[1])),
                                          "invalid minute offset '{}'", std::string {ptr, end});
-                SET_PARAMS_RET_FALSE_IFN((part[1] == 0 || part[1] == 30 || part[1] == 45),
-                                         "invalid minute offset '{}'", part[1]);
+                SET_PARAMS_RET_FALSE_IFN(part[1] < 60, "invalid minute offset '{}'", part[1]);
             }
-            SET_PARAMS_RET_FALSE_IFN(part[0] != 14 || part[1] == 0, "invalid timezone offset '{}'",
+            SET_PARAMS_RET_FALSE_IFN(part[0] != max_hour_offset || part[1] == 0,
+                                     "invalid timezone offset '{}'",
                                      combine_tz_offset(sign, part[0], part[1]));
 
             SET_PARAMS_RET_FALSE_IFN(TimezoneUtils::find_cctz_time_zone(
@@ -703,18 +705,19 @@ inline bool CastToDateV2::from_string_non_strict_mode_impl(const StringRef& str,
             } else {
                 PROPAGATE_FALSE((consume_digit<UInt32, 2>(ptr, end, hour_offset)));
             }
-            SET_PARAMS_RET_FALSE_IFN(hour_offset <= 14, "invalid hour offset {}", hour_offset);
+            const uint32_t max_hour_offset = sign == '-' ? 12 : 14;
+            SET_PARAMS_RET_FALSE_IFN(hour_offset <= max_hour_offset, "invalid hour offset {}",
+                                     hour_offset);
             if (ptr < end) {
                 if (*ptr == ':') {
                     ++ptr;
                 }
                 // minute
                 PROPAGATE_FALSE((consume_digit<UInt32, 2>(ptr, end, minute_offset)));
-                SET_PARAMS_RET_FALSE_IFN(
-                        (minute_offset == 0 || minute_offset == 30 || minute_offset == 45),
-                        "invalid minute offset {}", minute_offset);
+                SET_PARAMS_RET_FALSE_IFN(minute_offset < 60, "invalid minute offset {}",
+                                         minute_offset);
             }
-            SET_PARAMS_RET_FALSE_IFN(hour_offset != 14 || minute_offset == 0,
+            SET_PARAMS_RET_FALSE_IFN(hour_offset != max_hour_offset || minute_offset == 0,
                                      "invalid timezone offset '{}'",
                                      combine_tz_offset(sign, hour_offset, minute_offset));
 

--- a/be/test/exprs/function/cast/cast_to_timestamptz_test.cpp
+++ b/be/test/exprs/function/cast/cast_to_timestamptz_test.cpp
@@ -57,7 +57,7 @@ TEST_F(CastTimeStampTzTest, from_string_strict_mode_to_timestamptz) {
     {
         auto block = ColumnHelper::create_block<DataTypeString>(
                 {"2024-06-20 12:12:12+08:00", "2024-06-20 12:12:12-08:00",
-                 "2024-06-20 12:12:12+00:00", "2024-06-20 12:12:12"});
+                 "2024-06-20 12:12:12+00:00", "2024-06-20 12:12:12", "2024-06-20 12:12:12+08:17"});
 
         block.insert(
                 ColumnWithTypeAndName {nullptr, std::make_shared<DataTypeTimeStampTz>(), "result"});
@@ -77,13 +77,15 @@ TEST_F(CastTimeStampTzTest, from_string_strict_mode_to_timestamptz) {
                   "2024-06-20 20:12:12.000000+08:00");
         EXPECT_EQ(TimestampTzValue {col_res.get_element(3)}.to_string(time_zone),
                   "2024-06-20 12:12:12.000000+08:00");
+        EXPECT_EQ(TimestampTzValue {col_res.get_element(4)}.to_string(time_zone),
+                  "2024-06-20 11:55:12.000000+08:00");
     }
     // error cast
 
     {
         auto block = ColumnHelper::create_block<DataTypeString>(
                 {"2024-06-20 12:12:12+08:00", "2024-06-20 12:12:12-08:00",
-                 "2024-06-20 12:12:12+00:00", "2024-06-20 25:12:12"});
+                 "2024-06-20 12:12:12+00:00", "2024-06-20 12:12:12-13:00"});
 
         block.insert(
                 ColumnWithTypeAndName {nullptr, std::make_shared<DataTypeTimeStampTz>(), "result"});

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteral.java
@@ -21,7 +21,6 @@ import org.apache.doris.analysis.LiteralExpr;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.exceptions.CastException;
 import org.apache.doris.nereids.trees.expressions.Expression;
-import org.apache.doris.nereids.trees.expressions.literal.format.DateTimeChecker;
 import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.DateTimeV2Type;
 import org.apache.doris.nereids.types.TimeStampTzType;
@@ -141,11 +140,7 @@ public abstract class StringLikeLiteral extends Literal implements ComparableLit
             if (timeStampTzType.getScale() < 0) {
                 timeStampTzType = TimeStampTzType.forTypeFromString(value);
             }
-            if (DateTimeChecker.hasTimeZone(value)) {
-                return new TimestampTzLiteral(timeStampTzType, value);
-            }
-            DateTimeV2Literal datetime = (DateTimeV2Literal) castToDateTime(DateTimeV2Type.MAX, strictCast);
-            return TimestampTzLiteral.fromSessionTimeZone(timeStampTzType, datetime);
+            return castToDateTime(timeStampTzType, strictCast);
         } else if (targetType.isDateTimeV2Type()) {
             return castToDateTime(targetType, strictCast);
         } else if (targetType.isFloatType()) {
@@ -356,8 +351,10 @@ public abstract class StringLikeLiteral extends Literal implements ComparableLit
         if (tz.contains(":")) {
             int hourOffset = Integer.parseInt(tz.substring(1, tz.indexOf(":")));
             int minuteOffset = Integer.parseInt(tz.substring(tz.indexOf(":") + 1));
-            if (hourOffset > 14 || hourOffset == 14 && minuteOffset > 0) {
-                throw new CastException("Time zone offset couldn't be larger than 14:00");
+            int maxHourOffset = tz.startsWith("-") ? 12 : 14;
+            if (hourOffset > maxHourOffset || hourOffset == maxHourOffset && minuteOffset > 0) {
+                throw new CastException(String.format(
+                        "Time zone offset must be between -12:00 and +14:00: %s", tz));
             }
         }
         String format = String.format("%s-%s-%sT%s:%s:%s%s%s", year4, month, date, hour, minute, second, fraction, tz);
@@ -379,6 +376,10 @@ public abstract class StringLikeLiteral extends Literal implements ComparableLit
             } catch (AnalysisException e) {
                 throw new CastException(e.getMessage(), e);
             }
+        } else if (targetType.isTimeStampTzType()) {
+            TimeStampTzType timeStampTzType = (TimeStampTzType) targetType;
+            return tz.isEmpty() ? TimestampTzLiteral.fromSessionTimeZone(timeStampTzType, format)
+                    : new TimestampTzLiteral(timeStampTzType, format);
         } else {
             try {
                 return new DateTimeV2Literal((DateTimeV2Type) targetType, format);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/TypeCoercionUtils.java
@@ -65,7 +65,6 @@ import org.apache.doris.nereids.trees.expressions.literal.SmallIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLikeLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.TimeV2Literal;
-import org.apache.doris.nereids.trees.expressions.literal.TimestampTzLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.format.DateTimeChecker;
@@ -675,7 +674,7 @@ public class TypeCoercionUtils {
                 if (timeStampTzType.getScale() < 0 || timeStampTzType.getScale() == TimeStampTzType.MAX_SCALE) {
                     timeStampTzType = TimeStampTzType.forTypeFromString(value);
                 }
-                ret = TimestampTzLiteral.fromSessionTimeZone(timeStampTzType, value);
+                ret = new StringLiteral(value).checkedCastTo(timeStampTzType);
             } else if ((dataType.isDateV2Type() || dataType.isDateType()) && DateTimeChecker.isValidDateTime(value)) {
                 Result<DateLiteral, AnalysisException> parseResult = DateV2Literal.parseDateLiteral(value, true);
                 if (parseResult.isOk()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/StringLikeLiteralTest.java
@@ -229,6 +229,25 @@ public class StringLikeLiteralTest {
     }
 
     @Test
+    void testUncheckedCastToTimeStampTzValidatesExplicitOffset() {
+        try (MockedStatic<SessionVariable> mockedSessionVariable = Mockito.mockStatic(SessionVariable.class)) {
+            mockedSessionVariable.when(SessionVariable::enableStrictCast).thenReturn(true);
+
+            TimestampTzLiteral literal = (TimestampTzLiteral) new StringLiteral("2026-01-01 00:00:00 +08:17")
+                    .uncheckedCastTo(TimeStampTzType.of(6));
+            Assertions.assertEquals("2025-12-31 15:43:00.000000+00:00", literal.getStringValue());
+
+            StringLiteral invalidLowerBoundary = new StringLiteral("2026-01-01 00:00:00 -12:30");
+            Assertions.assertThrows(CastException.class,
+                    () -> invalidLowerBoundary.uncheckedCastTo(TimeStampTzType.of(6)));
+
+            StringLiteral invalidOffset = new StringLiteral("2026-01-01 00:00:00 -13:00");
+            Assertions.assertThrows(CastException.class,
+                    () -> invalidOffset.uncheckedCastTo(TimeStampTzType.of(6)));
+        }
+    }
+
+    @Test
     void testUncheckedCastToTimeStampTzUsesSessionTimeZoneWithoutOffset() {
         try (MockedStatic<SessionVariable> mockedSessionVariable = Mockito.mockStatic(SessionVariable.class)) {
             mockedSessionVariable.when(SessionVariable::enableStrictCast).thenReturn(false);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
@@ -511,6 +511,12 @@ public class TypeCoercionUtilsTest {
             Assertions.assertEquals(TimeStampTzType.SYSTEM_DEFAULT,
                     TypeCoercionUtils.characterLiteralTypeCoercion("2004-12-31", TimeStampTzType.MAX)
                             .get().getDataType());
+            Assertions.assertEquals(TimeStampTzType.SYSTEM_DEFAULT,
+                    TypeCoercionUtils.characterLiteralTypeCoercion(
+                            "2023-08-17T01:41:18+08:17", TimeStampTzType.SYSTEM_DEFAULT)
+                            .get().getDataType());
+            Assertions.assertTrue(TypeCoercionUtils.characterLiteralTypeCoercion(
+                    "2023-08-17T01:41:18-13:00", TimeStampTzType.SYSTEM_DEFAULT).isEmpty());
         } finally {
             ConnectContext.remove();
         }


### PR DESCRIPTION


Datetime string casts with explicit numeric offsets behaved differently between FE constant folding and BE runtime evaluation. Negative offsets below `-12:00` could be accepted by FE but rejected by BE, while TIMESTAMPTZ folding did not consistently validate invalid offset minutes.

The [official datetime conversion documentation](https://doris.apache.org/zh-CN/docs/dev/sql-manual/basic-element/sql-data-types/conversion/datetime-conversion) defines numeric offsets in datetime CAST input as follows:

- the offset range is `[-14:00, +14:00]`;
- the minute component must be `00`, `30`, or `45`;
- at the `-14:00` and `+14:00` boundaries, the minute component must be `00`.

Root cause: FE constant folding and BE runtime parsing used different validation paths and boundary rules. This change routes FE string-to-TIMESTAMPTZ folding through the shared datetime cast path and makes the BE timezone offset parser accept the symmetric documented range. CAST-specific minute validation remains in datetime parsing; generic session time zone parsing continues to accept valid offsets with arbitrary minute values, such as `+08:17`.

Regression coverage compares folded and runtime casts for DATE, DATEV2, DATETIME, DATETIMEV2, and TIMESTAMPTZ, including valid boundaries, supported minutes, invalid minutes, lambda expressions, and a session time zone with arbitrary minutes.