### PR TITLE
[refactor](be) Narrow scanner scheduling refactor scope

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -333,9 +333,9 @@ DEFINE_Int32(task_executor_max_concurrency_per_task, "-1");
 DEFINE_Int32(task_executor_initial_max_concurrency_per_task, "-1");
 
 // Enable task executor in internal table scan.
-DEFINE_Bool(enable_task_executor_in_internal_table, "false");
+DEFINE_Bool(enable_task_executor_in_internal_table, "true");
 // Enable task executor in external table scan.
-DEFINE_Bool(enable_task_executor_in_external_table, "false");
+DEFINE_Bool(enable_task_executor_in_external_table, "true");
 
 // number of scanner thread pool size for olap table
 // and the min thread num of remote scanner thread pool

--- a/be/src/exec/scan/scanner_context.cpp
+++ b/be/src/exec/scan/scanner_context.cpp
@@ -48,7 +48,6 @@
 #include "runtime/thread_context.h"
 #include "runtime/workload_management/resource_context.h"
 #include "storage/tablet/tablet.h"
-#include "util/time.h"
 #include "util/uid_util.h"
 
 namespace doris {
@@ -184,10 +183,6 @@ Status ScannerContext::init() {
     _scanner_profile = _local_state->_scanner_profile;
     _newly_create_free_blocks_num = _local_state->_newly_create_free_blocks_num;
     _scanner_memory_used_counter = _local_state->_memory_used_counter;
-    // ThreadPool scheduling queues a Context rather than a Scanner. Its queue delay is therefore
-    // meaningful only as Context-level latency; per-scanner delays depend on arbitrary selection.
-    _context_wait_worker_timer = ADD_TIMER(_scanner_profile, "ScannerContextWaitWorkerTime");
-
     // 3. get thread token
     if (!_state->get_query_ctx()) {
         return Status::InternalError("Query context of {} is not set",
@@ -586,24 +581,16 @@ void ScannerContext::set_context_queued(bool queued,
                                         const std::unique_lock<std::mutex>& transfer_lock) {
     DORIS_CHECK(transfer_lock.owns_lock());
     DORIS_CHECK(_is_context_queued != queued);
-    if (queued) {
-        // A Context is deduplicated while queued, so this timestamp covers exactly one submitted
-        // runnable rather than the wait time of any particular scanner it may later choose.
-        DORIS_CHECK(_context_wait_worker_start_ns == 0);
-        _context_wait_worker_start_ns = MonotonicNanos();
-    } else {
-        // A worker clears the state immediately after dequeueing the runnable. Record the elapsed
-        // time here so queue-state changes and profiling cannot diverge. Failed submissions never
-        // set this state, and therefore never enter this branch.
-        DORIS_CHECK(_context_wait_worker_start_ns != 0);
-#ifndef BE_TEST
-        DORIS_CHECK(_context_wait_worker_timer != nullptr);
-        COUNTER_UPDATE(_context_wait_worker_timer,
-                       MonotonicNanos() - _context_wait_worker_start_ns);
-#endif
-        _context_wait_worker_start_ns = 0;
-    }
     _is_context_queued = queued;
+}
+
+void ScannerContext::set_context_failure(const Status& failure,
+                                         const std::unique_lock<std::mutex>& transfer_lock) {
+    DORIS_CHECK(transfer_lock.owns_lock());
+    DORIS_CHECK(!failure.ok());
+    _process_status = failure;
+    _is_finished = true;
+    _set_scanner_done();
 }
 
 void ScannerContext::push_pending_scan_task(std::shared_ptr<ScanTask> scan_task,
@@ -615,11 +602,6 @@ void ScannerContext::push_pending_scan_task(std::shared_ptr<ScanTask> scan_task,
     // The state transition documents that this is an admission queue, not a completed-result queue.
     scan_task->set_state(ScanTask::State::PENDING);
     _pending_tasks.push(std::move(scan_task));
-}
-
-bool ScannerContext::has_progressing_task(const std::unique_lock<std::mutex>& transfer_lock) const {
-    DORIS_CHECK(transfer_lock.owns_lock());
-    return cast_set<int32_t>(_completed_tasks.size()) + _in_flight_tasks_num > 0;
 }
 
 bool ScannerContext::can_admit_scan_task(const std::unique_lock<std::mutex>& transfer_lock) const {
@@ -885,6 +867,13 @@ std::shared_ptr<ScanTask> ScannerContext::_pull_next_scan_task(
     }
 
     if (!_pending_tasks.empty()) {
+        // Do not submit more pending scanners after the shared LIMIT is exhausted while
+        // completed or in-flight tasks can still make progress. If neither exists, allow one
+        // scanner to report EOS and wake the pipeline task.
+        if (is_shared_scan_limit_exhausted() &&
+            (_in_flight_tasks_num != 0 || !_completed_tasks.empty())) {
+            return nullptr;
+        }
         std::shared_ptr<ScanTask> next_scan_task;
         next_scan_task = _pending_tasks.top();
         _pending_tasks.pop();

--- a/be/src/exec/scan/scanner_context.cpp
+++ b/be/src/exec/scan/scanner_context.cpp
@@ -408,28 +408,20 @@ Status ScannerContext::get_block_from_queue(RuntimeState* state, Block* block, b
         if (scan_task->is_eos()) {
             // 1. if eos, record a finished scanner.
             _num_finished_scanners++;
-            RETURN_IF_ERROR(_scanner_scheduler->schedule_scan_task(shared_from_this(), nullptr, l));
-        } else {
-            // A completed non-EOS attempt is still non-terminal. This covers a task whose block
-            // was just consumed above as well as one that produced no block. The scheduler returns
-            // it to PENDING (ThreadPool) or re-admits it (TaskExecutor) for another scan.
-            RETURN_IF_ERROR(
-                    _scanner_scheduler->schedule_scan_task(shared_from_this(), scan_task, l));
         }
     }
 
-    // A scanner can make shared LIMIT exhausted while it is still producing the final block:
-    // 1. The remaining limit is 5 and an in-flight scanner reads 100 rows.
-    // 2. The scanner decrements the shared limit below zero, then publishes its 100-row block. If not check
-    // _in_flight_tasks_num == 0 here, the operator will find the limit has reached, but actuall it
-    // do not get the cached block yet.
-    // 3. The operator consumes the block and applies the final limit of 5 rows.
-    // Therefore, wait for every worker to publish its block or EOS before completing this Context.
     if (_completed_tasks.empty() &&
         (_num_finished_scanners == _all_scanners.size() ||
-         (is_shared_scan_limit_exhausted() && _in_flight_tasks_num == 0))) {
+         (_is_shared_scan_limit_exhausted() && _in_flight_tasks_num == 0))) {
         _set_scanner_done();
         _is_finished = true;
+    } else if (scan_task != nullptr) {
+        // Check the terminal state before scheduling more work. In particular, after the shared
+        // LIMIT is exhausted, submitting another Context runnable can turn a completed query into
+        // a queue-capacity error even though there is no result left to drain.
+        RETURN_IF_ERROR(_scanner_scheduler->schedule_scan_task(
+                shared_from_this(), scan_task->is_eos() ? nullptr : scan_task, l));
     }
 
     *eos = done();
@@ -568,7 +560,7 @@ void ScannerContext::_set_scanner_done() {
     _dependency->set_always_ready();
 }
 
-bool ScannerContext::is_shared_scan_limit_exhausted() const {
+bool ScannerContext::_is_shared_scan_limit_exhausted() const {
     return limit >= 0 && _shared_scan_limit->load(std::memory_order_acquire) <= 0;
 }
 
@@ -624,28 +616,9 @@ bool ScannerContext::can_admit_scan_task(const std::unique_lock<std::mutex>& tra
     // both collections prevents a fast producer from exceeding the per-Context scanner limit.
     const int32_t current_concurrency =
             cast_set<int32_t>(_completed_tasks.size()) + _in_flight_tasks_num;
-    // Keep at least one task progressing whenever a pending scanner exists:
-    // 1. An adaptive or low-memory limit can temporarily reduce effective concurrency to zero.
-    // 2. If there are no completed or in-flight tasks, no worker can publish a block or EOS.
-    // 3. Admit one scanner in that case so the query can make progress and cannot stall.
-    // This must stay ahead of the shared LIMIT check below. Another instance can exhaust the
-    // limit while this Context's runnable is still queued with nothing in flight; the operator is
-    // then blocked on the dependency, and only the admitted scanner's EOS can wake it so
-    // get_block_from_queue() observes termination.
-    const bool has_progressing_task = current_concurrency > 0;
-    if (!has_progressing_task) {
-        return true;
-    }
-
-    // A progressing task will publish a result and wake the operator. Once shared LIMIT is
-    // exhausted, any additional scanner would only complete as EOS, so admitting more is pure
-    // thread-pool round trips. get_block_from_queue() finishes the Context when the last result
-    // is consumed with nothing in flight.
-    if (is_shared_scan_limit_exhausted()) {
-        return false;
-    }
-
-    return current_concurrency < effective_max_concurrency;
+    // Keep one task progressing even if an adaptive limit temporarily reaches zero. Otherwise no
+    // worker can publish a result and wake the operator to make another scheduling decision.
+    return current_concurrency == 0 || current_concurrency < effective_max_concurrency;
 }
 
 std::shared_ptr<ScanTask> ScannerContext::try_get_next_scan_task(
@@ -868,9 +841,9 @@ std::shared_ptr<ScanTask> ScannerContext::_pull_next_scan_task(
 
     if (!_pending_tasks.empty()) {
         // Do not submit more pending scanners after the shared LIMIT is exhausted while
-        // completed or in-flight tasks can still make progress. If neither exists, allow one
-        // scanner to report EOS and wake the pipeline task.
-        if (is_shared_scan_limit_exhausted() &&
+        // completed or in-flight tasks can still make progress. If neither exists, allow pending
+        // scanners to be submitted so they can report EOS and wake the pipeline task.
+        if (_is_shared_scan_limit_exhausted() &&
             (_in_flight_tasks_num != 0 || !_completed_tasks.empty())) {
             return nullptr;
         }

--- a/be/src/exec/scan/scanner_context.h
+++ b/be/src/exec/scan/scanner_context.h
@@ -272,14 +272,16 @@ public:
     // last available concurrency slot.
     std::mutex& transfer_lock() { return _transfer_lock; }
 
-    // One Context runnable represents many pending scanners in the ThreadPool scheduler. Keeping
-    // this separate from scanner execution prevents duplicate Context runnables from accumulating.
+    // One Context submission represents many pending scanners in the ThreadPool scheduler.
+    // Keeping this separate from scanner execution prevents duplicate runnables from accumulating.
     bool is_context_queued(const std::unique_lock<std::mutex>& transfer_lock) const;
-    // Transition the Context runnable's queue state and maintain its wait-time interval. Setting
-    // true records enqueue time; clearing false charges that interval to the Context profile.
-    // The scheduler sets true only after submit succeeds, so failed submissions have no interval.
-    // Example: a queue-full submit leaves the state false and contributes no worker-wait time.
+    // Transition the Context runnable's queue state. The caller must hold _transfer_lock.
     void set_context_queued(bool queued, const std::unique_lock<std::mutex>& transfer_lock);
+
+    // Publish a scheduler failure and make the Context terminal. The caller must hold
+    // _transfer_lock so a retained ThreadPool callback cannot admit another scanner concurrently.
+    void set_context_failure(const Status& failure,
+                             const std::unique_lock<std::mutex>& transfer_lock);
 
     // Return a scanner to the admission queue after its block is consumed. It may not own a cached
     // block and may not be EOS: EOS scanners are terminal and must not run again.
@@ -292,12 +294,6 @@ public:
     // exhausted, because that scanner's EOS is what wakes the operator. The caller must hold
     // _transfer_lock.
     bool can_admit_scan_task(const std::unique_lock<std::mutex>& transfer_lock) const;
-
-    // Return whether at least one task is progressing: in flight on a worker, or completed and
-    // awaiting operator consumption. A progressing task eventually triggers rescheduling, so the
-    // ThreadPool scheduler can tolerate a failed runnable submission while one exists. The caller
-    // must hold _transfer_lock.
-    bool has_progressing_task(const std::unique_lock<std::mutex>& transfer_lock) const;
 
     // Atomically check whether this context can start another scan task, move one task from
     // pending to in-flight, and return it. The caller must hold _transfer_lock.
@@ -360,16 +356,10 @@ protected:
     // non-EOS task; drained by try_get_next_scan_task() or the TaskExecutor scheduler.
     std::stack<std::shared_ptr<ScanTask>> _pending_tasks;
 
-    // True only while one runnable for this context is waiting in the thread pool. It does not
-    // describe scanners currently executing on worker threads. This deduplicates Context
-    // submission: N pending scanners still create exactly one runnable. Protected by _transfer_lock.
+    // True from the start of one Context submission until its runnable starts. A failed submission
+    // also makes the Context terminal, so the marker may remain true when no runnable was retained.
+    // It does not describe scanners executing on workers. Protected by _transfer_lock.
     bool _is_context_queued = false;
-
-    // Start time for one queued Context runnable. This is accounted to the scan operator profile
-    // when the thread-pool worker dequeues the runnable, so the profile reports actual thread-pool
-    // queue latency even though a worker may select any pending scanner. Protected by _transfer_lock.
-    int64_t _context_wait_worker_start_ns = 0;
-    RuntimeProfile::Counter* _context_wait_worker_timer = nullptr;
 
     // Number of scan tasks currently submitted to the scanner scheduler thread pool
     // (i.e. in-flight). Incremented before a task is submitted or directly admitted for

--- a/be/src/exec/scan/scanner_context.h
+++ b/be/src/exec/scan/scanner_context.h
@@ -219,14 +219,6 @@ public:
     // Return true if this ScannerContext need no more process
     bool done() const { return _is_finished || _should_stop; }
 
-    // Checked in two places after shared LIMIT is reached:
-    // 1. ScannerScheduler::_scanner_scan() finishes an admitted scanner as EOS without opening it,
-    //    so it releases its in-flight slot and wakes the operator.
-    // 2. can_admit_scan_task() stops admitting more scanners while another task is still
-    //    progressing, because the only outcome would be further EOS round trips.
-    // The limit is atomic and can therefore be read without _transfer_lock.
-    bool is_shared_scan_limit_exhausted() const;
-
     std::string debug_string();
 
     std::shared_ptr<TaskHandle> task_handle() const { return _task_handle; }
@@ -290,9 +282,8 @@ public:
 
     // Return whether a Context worker can currently admit one pending scanner. This check has no
     // side effects, so the scheduler can avoid submitting a runnable that would immediately exit.
-    // It always admits one scanner when nothing is progressing, even after shared LIMIT is
-    // exhausted, because that scanner's EOS is what wakes the operator. The caller must hold
-    // _transfer_lock.
+    // It always admits one scanner when nothing is progressing so the operator can be woken. The
+    // caller must hold _transfer_lock.
     bool can_admit_scan_task(const std::unique_lock<std::mutex>& transfer_lock) const;
 
     // Atomically check whether this context can start another scan task, move one task from
@@ -307,6 +298,7 @@ protected:
     /// 3. `_free_blocks_memory_usage` < `_max_bytes_in_queue`, remains enough memory to scale up
     /// 4. At most scale up `MAX_SCALE_UP_RATIO` times to `_max_thread_num`
     void _set_scanner_done();
+    bool _is_shared_scan_limit_exhausted() const;
 
     RuntimeState* _state = nullptr;
     ScanLocalStateBase* _local_state = nullptr;

--- a/be/src/exec/scan/scanner_scheduler.cpp
+++ b/be/src/exec/scan/scanner_scheduler.cpp
@@ -185,10 +185,6 @@ void ScannerScheduler::_scanner_scan(std::shared_ptr<ScannerContext> ctx,
 
     ASSIGN_STATUS_IF_CATCH_EXCEPTION(
             RuntimeState* state = ctx->state(); DCHECK(nullptr != state);
-            // Do not suppress admission when shared LIMIT is exhausted. A queued scanner still
-            // needs to complete as EOS so push_completed_scan_task() releases its in-flight slot
-            // and the pipeline can observe completion instead of waiting indefinitely.
-            if (ctx->is_shared_scan_limit_exhausted()) { eos = true; }
             // scanner->open may alloc plenty amount of memory(read blocks of data),
             // so better to also check low memory and clear free blocks here.
             if (ctx->low_memory_mode()) { ctx->clear_free_blocks(); }

--- a/be/src/exec/scan/simplified_scan_scheduler.cpp
+++ b/be/src/exec/scan/simplified_scan_scheduler.cpp
@@ -49,7 +49,7 @@ Status ThreadPoolSimplifiedScanScheduler::schedule_scan_task(
     }
     if (scanner_ctx->is_context_queued(transfer_lock)) {
         // A queued runnable will see all pending scanners added before it obtains transfer_lock.
-        // Submitting another runnable would only duplicate work and distort Context queue latency.
+        // Submitting another runnable would only duplicate work.
         return Status::OK();
     }
     if (!scanner_ctx->can_admit_scan_task(transfer_lock)) {
@@ -58,43 +58,32 @@ Status ThreadPoolSimplifiedScanScheduler::schedule_scan_task(
         return Status::OK();
     }
 
-    // transfer_lock prevents another producer from submitting concurrently. The worker callback
-    // also waits for this lock, so it cannot run between successful submission and marking queued.
     if (_is_stop) {
-        // Shutdown must surface: progressing tasks may never complete on a stopped pool.
-        return Status::InternalError<false>("scanner pool {} is shutdown.", _sched_name);
+        Status failure = Status::InternalError<false>("scanner pool {} is shutdown.", _sched_name);
+        scanner_ctx->set_context_failure(failure, transfer_lock);
+        return failure;
     }
+
+    // ThreadPool::submit_func() may return an error after retaining the runnable. Set the marker
+    // before submission so either outcome is safe: a retained callback clears it, while a truly
+    // rejected callback leaves a terminal Context that no longer needs rescheduling.
+    scanner_ctx->set_context_queued(true, transfer_lock);
     Status status =
             _scan_thread_pool->submit_func([this, scanner_ctx] { _run_context(scanner_ctx); });
     if (status.ok()) {
-        // Start the Context wait interval only after submission succeeds. This excludes failed
-        // submit_func() calls, which never waited for a worker and must not affect the profile.
-        scanner_ctx->set_context_queued(true, transfer_lock);
         return Status::OK();
     }
-    // No worker can dequeue a rejected runnable. The Context remains unqueued, so a later
-    // scheduling attempt can submit it again without clearing state or accounting queue time.
-    LOG(WARNING) << fmt::format("Failed to submit scanner context {}, reason: {}",
-                                scanner_ctx->debug_string(), status.to_string());
-    if (scanner_ctx->has_progressing_task(transfer_lock) ||
-        scanner_ctx->is_shared_scan_limit_exhausted()) {
-        // Someone will retry: a progressing task completes, the operator consumes its result and
-        // reschedules; after shared LIMIT is exhausted, get_block_from_queue() finishes the
-        // Context on its next call. Pool saturation must not fail a query that still progresses.
-        return Status::OK();
-    }
-    // Nothing will retry this Context. Surface the failure, normalized like
-    // ScannerScheduler::submit() so both schedulers report saturation as TOO_MANY_TASKS.
-    return Status::TooManyTasks("Failed to submit scanner context {} to scanner pool, reason: {}",
-                                scanner_ctx->ctx_id, status.msg());
+    Status failure =
+            Status::TooManyTasks("Failed to submit scanner context {} to scanner pool, reason: {}",
+                                 scanner_ctx->ctx_id, status.msg());
+    scanner_ctx->set_context_failure(failure, transfer_lock);
+    return failure;
 }
 
 void ThreadPoolSimplifiedScanScheduler::_run_context(std::shared_ptr<ScannerContext> scanner_ctx) {
     std::shared_ptr<ScanTask> scan_task;
     Status admission_status = [&]() -> Status {
         std::unique_lock<std::mutex> transfer_lock(scanner_ctx->transfer_lock());
-        // The worker has dequeued the Context. Clearing the marker also charges its queue latency:
-        // the interval from successful submit_func() to worker start, not scanner execution time.
         scanner_ctx->set_context_queued(false, transfer_lock);
 
         auto task_execution_lock = scanner_ctx->task_exec_ctx();
@@ -107,35 +96,39 @@ void ThreadPoolSimplifiedScanScheduler::_run_context(std::shared_ptr<ScannerCont
         // lambda so it detaches before execute_scan_task(), whose _scanner_scan() attaches again.
         SCOPED_ATTACH_TASK(scanner_ctx->state());
 #endif
-        RETURN_IF_CATCH_EXCEPTION({
-            // Admission checks completed results, active tasks, adaptive limits, and shared LIMIT
-            // while holding transfer_lock. A null task means the Context may not run one now.
-            scan_task = scanner_ctx->try_get_next_scan_task(transfer_lock);
-            if (scan_task != nullptr) {
-                DBUG_EXECUTE_IF("ThreadPoolSimplifiedScanScheduler._run_context.inject_failure", {
-                    throw Exception(ErrorCode::INTERNAL_ERROR, "injected admission failure");
-                });
-                // Queue the next Context runnable before executing this task. Example: with a
-                // concurrency limit of two, the next worker may admit scanner B while this worker
-                // scans scanner A. Holding transfer_lock keeps the admission decision atomic.
-                Status resubmit_status = schedule_scan_task(scanner_ctx, nullptr, transfer_lock);
-                if (!resubmit_status.ok()) {
-                    LOG(WARNING) << fmt::format("Failed to resubmit scanner context {}, reason: {}",
-                                                scanner_ctx->ctx_id, resubmit_status.to_string());
+        Status status = [&]() -> Status {
+            RETURN_IF_CATCH_EXCEPTION({
+                // Admission checks completed results, active tasks, adaptive limits, and shared
+                // LIMIT while holding transfer_lock.
+                scan_task = scanner_ctx->try_get_next_scan_task(transfer_lock);
+                if (scan_task != nullptr) {
+                    DBUG_EXECUTE_IF("ThreadPoolSimplifiedScanScheduler._run_context.inject_failure",
+                                    {
+                                        throw Exception(ErrorCode::INTERNAL_ERROR,
+                                                        "injected admission failure");
+                                    });
+                    // Queue the next Context runnable before executing this task. Holding
+                    // transfer_lock keeps the admission decision atomic.
+                    RETURN_IF_ERROR(schedule_scan_task(scanner_ctx, nullptr, transfer_lock));
                 }
-            }
-        });
-        return Status::OK();
+            });
+            return Status::OK();
+        }();
+        if (!status.ok() && scan_task == nullptr) {
+            scanner_ctx->set_context_failure(status, transfer_lock);
+        }
+        return status;
     }();
-    if (scan_task == nullptr) {
+    if (!admission_status.ok()) [[unlikely]] {
+        if (scan_task != nullptr) {
+            // The scanner was admitted before the failure. Publish it to release the in-flight
+            // slot and make the error observable by the operator.
+            scan_task->set_status(admission_status);
+            scanner_ctx->push_completed_scan_task(scan_task);
+        }
         return;
     }
-    if (!admission_status.ok()) [[unlikely]] {
-        // The scanner was admitted but a later step threw. Publish the failure so the operator
-        // observes the error and the in-flight slot is released; swallowing it would leak the
-        // slot and let dispatch_thread() terminate the process on the escaped exception.
-        scan_task->set_status(admission_status);
-        scanner_ctx->push_completed_scan_task(scan_task);
+    if (scan_task == nullptr) {
         return;
     }
     // The scan runs without transfer_lock so the operator and other Context workers can continue

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -454,12 +454,10 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
     // We assume that each current inactive thread will grab one item from the
     // queue.  If it seems like we'll need another thread, we create one.
     //
-    // Rather than creating an additional thread here, while holding the lock,
-    // we defer it to down below. This is because thread creation can be rather
-    // slow (hundreds of milliseconds in some cases) and we'd like to allow the
-    // existing threads to continue to process tasks while we do so. The first
-    // thread is an exception: it must be created before publishing the task so
-    // a failed submission cannot leave a runnable in a pool with no workers.
+    // Rather than creating the thread here, while holding the lock, we defer
+    // it to down below. This is because thread creation can be rather slow
+    // (hundreds of milliseconds in some cases) and we'd like to allow the
+    // existing threads to continue to process tasks while we do so.
     //
     // In theory, a currently active thread could finish immediately after this
     // calculation but before our new worker starts running. This would mean we
@@ -473,23 +471,9 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
     int additional_threads =
             static_cast<int>(_queue.size()) + threads_from_this_submit - inactive_threads;
     bool need_a_thread = false;
-    bool create_first_thread = false;
     if (additional_threads > 0 && _num_threads + _num_threads_pending_start < _max_threads) {
-        create_first_thread = _num_threads == 0 && _num_threads_pending_start == 0;
         need_a_thread = true;
         _num_threads_pending_start++;
-    }
-
-    if (create_first_thread) {
-        // Keep the lock until the task is published. A successfully created dispatch thread will
-        // wait for the lock, while a creation failure can return without changing any queue state.
-        Status status = create_thread();
-        if (!status.ok()) {
-            _num_threads_pending_start--;
-            thread_pool_submit_failed->increment(1);
-            return status;
-        }
-        need_a_thread = false;
     }
 
     Task task;
@@ -537,16 +521,13 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
             l.lock();
             _num_threads_pending_start--;
             if (_num_threads + _num_threads_pending_start == 0) {
-                _no_threads_cond.notify_all();
+                // If we have no threads, we can't do any work.
+                return status;
             }
-            if (_pool_status.ok()) {
-                // A published task either already ran or still has a live or pending worker.
-                // The last-worker guard in dispatch_thread() keeps this true; a violation is a
-                // pool logic error.
-                DORIS_CHECK(_queue.empty() || _num_threads + _num_threads_pending_start > 0);
-                LOG(WARNING) << "Thread pool " << _name
-                             << " failed to create thread: " << status.to_string();
-            }
+            // If we failed to create a thread, but there are still some other
+            // worker threads, log a warning message and continue.
+            LOG(WARNING) << "Thread pool " << _name
+                         << " failed to create thread: " << status.to_string();
         }
     }
 
@@ -582,12 +563,7 @@ void ThreadPool::dispatch_thread() {
             break;
         }
 
-        // A runtime shrink may leave more live + pending threads than _max_threads. Excess threads
-        // retire here, but the last live worker must stay while tasks are queued: a pending
-        // replacement may still fail to start, and a pool with queued tasks and no worker can only
-        // recover on the next submit. The excess thread retires once the queue drains.
-        if (_num_threads + _num_threads_pending_start > _max_threads &&
-            (_num_threads > 1 || _queue.empty())) {
+        if (_num_threads + _num_threads_pending_start > _max_threads) {
             break;
         }
 
@@ -711,15 +687,6 @@ void ThreadPool::dispatch_thread() {
 }
 
 Status ThreadPool::create_thread() {
-    DBUG_EXECUTE_IF("ThreadPool.create_thread.block", {
-        // Hold the caller here until the test removes this debug point. Used to widen the window
-        // between publishing a task and observing the thread-creation result.
-        while (DebugPoints::instance()->is_enable("ThreadPool.create_thread.block")) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        }
-    });
-    DBUG_EXECUTE_IF("ThreadPool.create_thread.inject_failure",
-                    { return Status::RuntimeError("injected thread creation failure"); });
     return Thread::create("thread pool", absl::Substitute("$0 [worker]", _name),
                           &ThreadPool::dispatch_thread, this, nullptr);
 }
@@ -750,9 +717,6 @@ Status ThreadPool::set_min_threads(int min_threads) {
 
 Status ThreadPool::set_max_threads(int max_threads) {
     std::lock_guard<std::mutex> l(_lock);
-    if (max_threads <= 0) {
-        return Status::InvalidArgument("Thread pool {} max_threads must be greater than 0", _name);
-    }
     DBUG_EXECUTE_IF("ThreadPool.set_max_threads.force_set", {
         _max_threads = max_threads;
         return Status::OK();

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -305,8 +305,7 @@ private:
     // Create new thread.
     //
     // REQUIRES: caller has incremented '_num_threads_pending_start' ahead of this call.
-    // NOTE: For performance reasons, _lock should normally not be held. The first worker is
-    // created with _lock held so submit() can publish its first task atomically.
+    // NOTE: For performance reasons, _lock should not be held.
     Status create_thread();
 
     // Aborts if the current thread is a member of this thread pool.

--- a/be/test/exec/scan/scanner_context_test.cpp
+++ b/be/test/exec/scan/scanner_context_test.cpp
@@ -631,6 +631,7 @@ TEST_F(ScannerContextTest, pull_next_scan_task) {
             state.get(), olap_scan_local_state.get(), output_tuple_desc, output_row_descriptor,
             scanners, limit, scan_dependency, &shared_limit, nullptr, nullptr, 0, false,
             parallel_tasks);
+    shared_limit.store(limit);
 
     std::mutex transfer_mutex;
     std::unique_lock<std::mutex> transfer_lock(transfer_mutex);
@@ -888,18 +889,16 @@ TEST_F(ScannerContextTest, thread_pool_submit_failure_policy) {
     std::unique_lock<std::mutex> transfer_lock(scanner_context->transfer_lock());
     ASSERT_FALSE(scanner_context->_pending_tasks.empty());
 
-    // A progressing task exists: pool saturation is tolerated and must not fail the query. The
-    // progressing task's completion and consumption will reschedule this Context.
-    scanner_context->_in_flight_tasks_num = 1;
-    EXPECT_TRUE(scheduler.schedule_scan_task(scanner_context, nullptr, transfer_lock).ok());
-    EXPECT_FALSE(scanner_context->is_context_queued(transfer_lock));
-
-    // Nothing is progressing and shared LIMIT is not exhausted: nothing will retry, so the
-    // failure must surface, normalized like ScannerScheduler::submit().
-    scanner_context->_in_flight_tasks_num = 0;
+    // Context submission is fail-fast regardless of other progress. Retrying here would couple
+    // the scanner scheduler to ThreadPool's internal rejection/retention behavior.
     Status surfaced = scheduler.schedule_scan_task(scanner_context, nullptr, transfer_lock);
     EXPECT_TRUE(surfaced.is<ErrorCode::TOO_MANY_TASKS>()) << surfaced.to_string();
-    EXPECT_FALSE(scanner_context->is_context_queued(transfer_lock));
+    EXPECT_TRUE(scanner_context->done());
+    EXPECT_FALSE(scanner_context->_process_status.ok());
+    EXPECT_TRUE(scan_dependency->ready());
+    // The marker is set before submit_func(). This rejected runnable was not retained, but the
+    // terminal Context no longer needs the marker cleared or another submission attempted.
+    EXPECT_TRUE(scanner_context->is_context_queued(transfer_lock));
 }
 
 TEST_F(ScannerContextTest, run_context_publishes_admission_failure) {
@@ -999,6 +998,7 @@ TEST_F(ScannerContextTest, schedule_scan_task) {
             state.get(), olap_scan_local_state.get(), output_tuple_desc, output_row_descriptor,
             scanners, limit, scan_dependency, &shared_limit, nullptr, nullptr, 0, false,
             parallel_tasks);
+    shared_limit.store(limit);
 
     std::mutex transfer_mutex;
     std::unique_lock<std::mutex> transfer_lock(transfer_mutex);

--- a/be/test/exec/scan/scanner_context_test.cpp
+++ b/be/test/exec/scan/scanner_context_test.cpp
@@ -718,75 +718,6 @@ TEST_F(ScannerContextTest, pull_next_scan_task) {
     EXPECT_EQ(scanner_context->try_get_next_scan_task(context_transfer_lock), nullptr);
 }
 
-TEST_F(ScannerContextTest, can_admit_scan_task_respects_shared_limit) {
-    const int parallel_tasks = 4;
-    auto scan_operator = std::make_unique<OlapScanOperatorX>(obj_pool.get(), tnode, 0, *descs,
-                                                             parallel_tasks, TQueryCacheParam {});
-    auto olap_scan_local_state =
-            OlapScanLocalState::create_unique(state.get(), scan_operator.get());
-
-    const int64_t limit = 100;
-    OlapScanner::Params scanner_params;
-    scanner_params.state = state.get();
-    scanner_params.profile = profile.get();
-    scanner_params.limit = limit;
-    scanner_params.key_ranges = std::vector<OlapScanRange*>();
-    std::shared_ptr<Scanner> scanner =
-            OlapScanner::create_shared(olap_scan_local_state.get(), std::move(scanner_params));
-
-    std::list<std::shared_ptr<ScannerDelegate>> scanners;
-    for (int i = 0; i < 4; ++i) {
-        scanners.push_back(std::make_shared<ScannerDelegate>(scanner));
-    }
-    auto scanner_context = ScannerContext::create_shared(
-            state.get(), olap_scan_local_state.get(), output_tuple_desc, output_row_descriptor,
-            scanners, limit, scan_dependency, &shared_limit, nullptr, nullptr, 0, false,
-            parallel_tasks);
-    scanner_context->_scanner_scheduler = scan_scheduler.get();
-
-    std::unique_lock<std::mutex> transfer_lock(scanner_context->transfer_lock());
-    // Constructor queued all four scanners as pending; nothing is in flight or completed.
-    ASSERT_EQ(scanner_context->_pending_tasks.size(), 4);
-    ASSERT_TRUE(scanner_context->_completed_tasks.empty());
-    ASSERT_EQ(scanner_context->_in_flight_tasks_num, 0);
-
-    // Shared LIMIT exhausted by another instance while nothing is progressing: one scanner must
-    // still be admitted so its EOS can wake the operator. Otherwise a queued Context runnable
-    // would exit without publishing anything and the pipeline task would block forever.
-    shared_limit.store(0);
-    ASSERT_TRUE(scanner_context->is_shared_scan_limit_exhausted());
-    EXPECT_TRUE(scanner_context->can_admit_scan_task(transfer_lock));
-
-    auto admitted_task = scanner_context->try_get_next_scan_task(transfer_lock);
-    ASSERT_NE(admitted_task, nullptr);
-    EXPECT_EQ(admitted_task->_state, ScanTask::State::IN_FLIGHT);
-    EXPECT_EQ(scanner_context->_in_flight_tasks_num, 1);
-
-    // With a task progressing, no further scanner is admitted after shared LIMIT is exhausted
-    // even though concurrency slots remain. This avoids O(pending) EOS round trips.
-    ASSERT_LT(1, scanner_context->_max_scan_concurrency);
-    EXPECT_FALSE(scanner_context->can_admit_scan_task(transfer_lock));
-    EXPECT_EQ(scanner_context->try_get_next_scan_task(transfer_lock), nullptr);
-    EXPECT_EQ(scanner_context->_in_flight_tasks_num, 1);
-    EXPECT_EQ(scanner_context->_pending_tasks.size(), 3);
-
-    // A completed-but-unconsumed result also counts as progressing: the operator will be woken
-    // to consume it and can observe termination there.
-    admitted_task->set_state(ScanTask::State::EOS);
-    scanner_context->_in_flight_tasks_num = 0;
-    scanner_context->_completed_tasks.push_back(admitted_task);
-    EXPECT_FALSE(scanner_context->can_admit_scan_task(transfer_lock));
-    scanner_context->_completed_tasks.clear();
-
-    // While shared LIMIT still has remaining rows, the same state admits normally up to the
-    // concurrency limit.
-    shared_limit.store(limit);
-    ASSERT_FALSE(scanner_context->is_shared_scan_limit_exhausted());
-    scanner_context->_in_flight_tasks_num = 1;
-    EXPECT_TRUE(scanner_context->can_admit_scan_task(transfer_lock));
-    scanner_context->_in_flight_tasks_num = 0;
-}
-
 TEST_F(ScannerContextTest, thread_pool_admission_refreshes_adaptive_limit) {
     const int parallel_tasks = 2;
     auto scan_operator = std::make_unique<OlapScanOperatorX>(obj_pool.get(), tnode, 0, *descs,
@@ -1265,6 +1196,7 @@ TEST_F(ScannerContextTest, get_block_from_queue) {
             state.get(), olap_scan_local_state.get(), output_tuple_desc, output_row_descriptor,
             scanners, limit, scan_dependency, &shared_limit, nullptr, nullptr, 0, false,
             parallel_tasks);
+    shared_limit.store(limit);
     scanner_context->_newly_create_free_blocks_num = newly_create_free_blocks_num.get();
     scanner_context->_scanner_memory_used_counter = scanner_memory_used_counter.get();
     scanner_context->_max_bytes_in_queue = 200;
@@ -1315,33 +1247,6 @@ TEST_F(ScannerContextTest, get_block_from_queue) {
 }
 
 TEST_F(ScannerContextTest, terminal_eos_skips_context_submission) {
-    const int parallel_tasks = 1;
-    auto scan_operator = std::make_unique<OlapScanOperatorX>(obj_pool.get(), tnode, 0, *descs,
-                                                             parallel_tasks, TQueryCacheParam {});
-    auto olap_scan_local_state =
-            OlapScanLocalState::create_unique(state.get(), scan_operator.get());
-
-    OlapScanner::Params scanner_params;
-    scanner_params.state = state.get();
-    scanner_params.profile = profile.get();
-    scanner_params.limit = 100;
-    scanner_params.key_ranges = std::vector<OlapScanRange*>();
-    std::shared_ptr<Scanner> scanner =
-            OlapScanner::create_shared(olap_scan_local_state.get(), std::move(scanner_params));
-    auto scanner_delegate = std::make_shared<ScannerDelegate>(scanner);
-    std::list<std::shared_ptr<ScannerDelegate>> scanners {scanner_delegate};
-    auto scanner_context = ScannerContext::create_shared(
-            state.get(), olap_scan_local_state.get(), output_tuple_desc, output_row_descriptor,
-            scanners, 100, scan_dependency, &shared_limit, nullptr, nullptr, 0, false,
-            parallel_tasks);
-
-    auto eos_task = std::make_shared<ScanTask>(scanner_delegate);
-    eos_task->set_state(ScanTask::State::IN_FLIGHT);
-    eos_task->set_state(ScanTask::State::EOS);
-    scanner_context->_pending_tasks = std::stack<std::shared_ptr<ScanTask>>();
-    scanner_context->_completed_tasks.push_back(eos_task);
-    scanner_context->_in_flight_tasks_num = 0;
-
     ThreadPoolSimplifiedScanScheduler scheduler("terminal_eos_test", cgroup_cpu_ctl);
     ASSERT_TRUE(scheduler.start(1, 1, 0, 1).ok());
     CountDownLatch task_started(1);
@@ -1361,17 +1266,60 @@ TEST_F(ScannerContextTest, terminal_eos_skips_context_submission) {
                         .ok());
     ASSERT_TRUE(task_started.wait_for(std::chrono::seconds(5)));
     ASSERT_EQ(scheduler.get_active_threads(), 1);
-    scanner_context->_scanner_scheduler = &scheduler;
 
-    MockRuntimeStateLocal mock_runtime_state;
-    EXPECT_CALL(mock_runtime_state, is_cancelled()).WillRepeatedly(testing::Return(false));
-    Block block;
-    bool eos = false;
-    Status status = scanner_context->get_block_from_queue(&mock_runtime_state, &block, &eos, 0);
+    auto verify_terminal_context = [&](int scanner_count, int64_t remaining_limit) {
+        const int parallel_tasks = 1;
+        auto scan_operator = std::make_unique<OlapScanOperatorX>(
+                obj_pool.get(), tnode, 0, *descs, parallel_tasks, TQueryCacheParam {});
+        auto olap_scan_local_state =
+                OlapScanLocalState::create_unique(state.get(), scan_operator.get());
 
-    EXPECT_TRUE(status.ok()) << status.to_string();
-    EXPECT_TRUE(eos);
-    EXPECT_EQ(scheduler.get_queue_size(), 0);
+        OlapScanner::Params scanner_params;
+        scanner_params.state = state.get();
+        scanner_params.profile = profile.get();
+        scanner_params.limit = 100;
+        scanner_params.key_ranges = std::vector<OlapScanRange*>();
+        std::shared_ptr<Scanner> scanner =
+                OlapScanner::create_shared(olap_scan_local_state.get(), std::move(scanner_params));
+
+        std::list<std::shared_ptr<ScannerDelegate>> scanners;
+        for (int i = 0; i < scanner_count; ++i) {
+            scanners.push_back(std::make_shared<ScannerDelegate>(scanner));
+        }
+        auto scanner_context = ScannerContext::create_shared(
+                state.get(), olap_scan_local_state.get(), output_tuple_desc, output_row_descriptor,
+                scanners, 100, scan_dependency, &shared_limit, nullptr, nullptr, 0, false,
+                parallel_tasks);
+        scanner_context->_scanner_scheduler = &scheduler;
+
+        scanner_context->_pending_tasks = std::stack<std::shared_ptr<ScanTask>>();
+        auto scanner_iter = scanners.begin();
+        auto eos_task = std::make_shared<ScanTask>(*scanner_iter++);
+        eos_task->set_state(ScanTask::State::IN_FLIGHT);
+        eos_task->set_state(ScanTask::State::EOS);
+        scanner_context->_completed_tasks.push_back(eos_task);
+        while (scanner_iter != scanners.end()) {
+            scanner_context->_pending_tasks.push(std::make_shared<ScanTask>(*scanner_iter++));
+        }
+        scanner_context->_in_flight_tasks_num = 0;
+        shared_limit.store(remaining_limit);
+
+        MockRuntimeStateLocal mock_runtime_state;
+        EXPECT_CALL(mock_runtime_state, is_cancelled()).WillRepeatedly(testing::Return(false));
+        Block block;
+        bool eos = false;
+        Status status = scanner_context->get_block_from_queue(&mock_runtime_state, &block, &eos, 0);
+
+        EXPECT_TRUE(status.ok()) << status.to_string();
+        EXPECT_TRUE(eos);
+        EXPECT_EQ(scheduler.get_queue_size(), 0);
+    };
+
+    // All scanners completed: no runnable is needed even if the pool cannot accept one.
+    verify_terminal_context(1, 100);
+    // Shared LIMIT completed the Context while another scanner is pending. Check terminal state
+    // before rescheduling so the full pool cannot turn successful EOS into TOO_MANY_TASKS.
+    verify_terminal_context(2, 0);
 }
 
 /**

--- a/be/test/util/threadpool_test.cpp
+++ b/be/test/util/threadpool_test.cpp
@@ -46,7 +46,6 @@
 #include "gtest/gtest.h"
 #include "util/barrier.h"
 #include "util/countdown_latch.h"
-#include "util/debug_points.h"
 #include "util/defer_op.h"
 #include "util/random.h"
 #include "util/time.h"
@@ -133,110 +132,6 @@ TEST_F(ThreadPoolTest, TestSimpleTasks) {
     _pool->wait();
     EXPECT_EQ(10 + 15 + 20 + 15, counter.load());
     _pool->shutdown();
-}
-
-TEST_F(ThreadPoolTest, TestCreateFirstThreadFailureDoesNotEnqueueTask) {
-    const bool old_enable_debug_points = config::enable_debug_points;
-    config::enable_debug_points = true;
-    DebugPoints::instance()->add("ThreadPool.create_thread.inject_failure");
-    Defer cleanup = [&] {
-        DebugPoints::instance()->remove("ThreadPool.create_thread.inject_failure");
-        config::enable_debug_points = old_enable_debug_points;
-    };
-
-    // Initialization deliberately tolerates a thread creation failure so a later submit can retry.
-    EXPECT_TRUE(rebuild_pool_with_min_max(1, 1).ok());
-    EXPECT_EQ(0, _pool->num_threads());
-
-    std::atomic<int> rejected_task_runs = 0;
-    Status submit_status = _pool->submit_func([&] { ++rejected_task_runs; });
-    EXPECT_FALSE(submit_status.ok());
-    EXPECT_EQ(0, _pool->get_queue_size());
-    EXPECT_EQ(0, rejected_task_runs.load());
-
-    DebugPoints::instance()->remove("ThreadPool.create_thread.inject_failure");
-    std::atomic<int> accepted_task_runs = 0;
-    EXPECT_TRUE(_pool->submit_func([&] { ++accepted_task_runs; }).ok());
-    _pool->wait();
-
-    EXPECT_EQ(0, rejected_task_runs.load());
-    EXPECT_EQ(1, accepted_task_runs.load());
-}
-
-TEST_F(ThreadPoolTest, TestRejectNonPositiveMaxThreads) {
-    int old_max_threads = _pool->max_threads();
-    EXPECT_TRUE(_pool->set_max_threads(0).is<INVALID_ARGUMENT>());
-    EXPECT_EQ(old_max_threads, _pool->max_threads());
-}
-
-TEST_F(ThreadPoolTest, TestLastWorkerSurvivesShrinkWithQueuedTask) {
-    const bool old_enable_debug_points = config::enable_debug_points;
-    config::enable_debug_points = true;
-    Defer cleanup = [&] {
-        DebugPoints::instance()->remove("ThreadPool.create_thread.block");
-        DebugPoints::instance()->remove("ThreadPool.create_thread.inject_failure");
-        config::enable_debug_points = old_enable_debug_points;
-    };
-
-    // Build the pool before enabling debug points so the initial worker starts normally.
-    EXPECT_TRUE(rebuild_pool_with_min_max(1, 2).ok());
-    ASSERT_EQ(1, _pool->num_threads());
-
-    // Occupy the only worker so the next submission requests an additional thread.
-    CountDownLatch task_a_started(1);
-    CountDownLatch release_task_a(1);
-    ASSERT_TRUE(_pool->submit_func([&] {
-                         task_a_started.count_down();
-                         release_task_a.wait();
-                     }).ok());
-    task_a_started.wait();
-
-    // The next submission publishes task B, then stalls inside create_thread() so a runtime
-    // shrink can interleave before the creation failure is observed.
-    DebugPoints::instance()->add("ThreadPool.create_thread.block");
-    DebugPoints::instance()->add("ThreadPool.create_thread.inject_failure");
-    std::atomic<int> task_b_runs = 0;
-    CountDownLatch task_b_done(1);
-    Status submit_b_status;
-    std::thread submitter([&] {
-        submit_b_status = _pool->submit_func([&] {
-            ++task_b_runs;
-            task_b_done.count_down();
-        });
-    });
-    auto wait_for = [](const std::function<bool()>& pred) {
-        for (int i = 0; i < 10000; ++i) {
-            if (pred()) {
-                return true;
-            }
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        }
-        return false;
-    };
-    ASSERT_TRUE(wait_for([&] { return _pool->get_queue_size() == 1; }));
-    ASSERT_EQ(1, _pool->num_threads_pending_start());
-
-    // Shrink below live + pending. The active worker counts the pending replacement, but it must
-    // not retire while it is the last live worker and task B is still queued: the replacement can
-    // still fail to start.
-    ASSERT_TRUE(_pool->set_max_threads(1).ok());
-    release_task_a.count_down();
-    ASSERT_TRUE(task_b_done.wait_for(std::chrono::seconds(10)));
-
-    // Only after B ran does the stalled creation fail; the failure path must tolerate it.
-    DebugPoints::instance()->remove("ThreadPool.create_thread.block");
-    submitter.join();
-
-    EXPECT_TRUE(submit_b_status.ok()) << submit_b_status.to_string();
-    EXPECT_EQ(1, task_b_runs.load());
-    EXPECT_EQ(0, _pool->get_queue_size());
-
-    // The pool stays usable: the next submission recreates a worker if none is left.
-    DebugPoints::instance()->remove("ThreadPool.create_thread.inject_failure");
-    std::atomic<int> task_c_runs = 0;
-    ASSERT_TRUE(_pool->submit_func([&] { ++task_c_runs; }).ok());
-    _pool->wait();
-    EXPECT_EQ(1, task_c_runs.load());
 }
 
 class SlowTask : public Runnable {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #66985

Problem Summary:

Review follow-ups on #66985 expanded the Context-level scan scheduling refactor into generic `ThreadPool` lifecycle changes, changed the default scan scheduler, and added Context-level profiling, retry policy, and shared-LIMIT-specific admission behavior. Those changes are not required by the core Context scheduling model and make the refactor harder to reason about.

This PR narrows the follow-up scope:

- Keep TaskExecutor as the default scheduler and leave the new ThreadPool Context scheduler opt-in.
- Restore the generic `ThreadPool` implementation and its tests instead of changing worker lifecycle behavior in this PR.
- Keep submission failures local to the new Context scheduling path and publish them as terminal Context failures.
- Remove the newly added shared-LIMIT admission and pre-open execution shortcuts. Existing Scanner early-EOS and TaskExecutor behavior remain responsible for that lifecycle.
- Check terminal Context state before rescheduling, so completed EOS cannot be converted into a thread-pool queue-capacity error.

### Release note

None

### Check List (For Author)

- Test
    - [x] Unit Test
        - `./run-be-ut.sh --run --filter='ScannerContextTest.*' -j16` (34/34 passed, ASAN)
        - `./run-be-ut.sh --run --filter='ThreadPoolTest.*' -j16` (18/18 passed, ASAN)
    - [ ] Regression test
    - [ ] Manual test
    - [ ] No need to test or manual test. Explain why:
- Static and style checks
    - [x] `./build-support/check-format.sh`
    - [x] `./build-support/check-build-hygiene.sh`
    - [x] `git diff --check`
    - [ ] `./build-support/run-clang-tidy.sh --base HEAD --build-dir be/ut_build_ASAN` could not complete analysis because the local toolchain could not find `stddef.h` and also emitted pre-existing whole-file diagnostics.
- Behavior changed:
    - [x] Yes. TaskExecutor remains the default; the Context ThreadPool scheduler no longer adds shared-LIMIT-specific admission or scanner-open behavior, and terminal Contexts are recognized before rescheduling.
- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
