### PR TITLE
[fix](be) Use ICU root locale in case conversion paths

### DIFF
--- a/be/src/exprs/function/function_string.cpp
+++ b/be/src/exprs/function/function_string.cpp
@@ -576,33 +576,36 @@ struct TransferImpl {
     static void execute_utf8(const ColumnString::Chars& data, const ColumnString::Offsets& offsets,
                              ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets) {
         std::string result;
+        const auto& root_locale = icu::Locale::getRoot();
         for (int64_t i = 0; i < offsets.size(); ++i) {
             const char* begin = reinterpret_cast<const char*>(&data[offsets[i - 1]]);
             uint32_t size = offsets[i] - offsets[i - 1];
 
             result.clear();
             if constexpr (std::is_same_v<OpName, NameToUpper>) {
-                to_upper_utf8(begin, size, result);
+                to_upper_utf8(begin, size, root_locale, result);
             } else if constexpr (std::is_same_v<OpName, NameToLower>) {
-                to_lower_utf8(begin, size, result);
+                to_lower_utf8(begin, size, root_locale, result);
             }
             StringOP::push_value_string(result, i, res_data, res_offsets);
         }
     }
 
-    static void to_upper_utf8(const char* data, uint32_t size, std::string& result) {
+    static void to_upper_utf8(const char* data, uint32_t size, const icu::Locale& locale,
+                              std::string& result) {
         icu::StringPiece sp;
         sp.set(data, size);
         icu::UnicodeString unicode_str = icu::UnicodeString::fromUTF8(sp);
-        unicode_str.toUpper(icu::Locale::getRoot());
+        unicode_str.toUpper(locale);
         unicode_str.toUTF8String(result);
     }
 
-    static void to_lower_utf8(const char* data, uint32_t size, std::string& result) {
+    static void to_lower_utf8(const char* data, uint32_t size, const icu::Locale& locale,
+                              std::string& result) {
         icu::StringPiece sp;
         sp.set(data, size);
         icu::UnicodeString unicode_str = icu::UnicodeString::fromUTF8(sp);
-        unicode_str.toLower(icu::Locale::getRoot());
+        unicode_str.toLower(locale);
         unicode_str.toUTF8String(result);
     }
 };
@@ -671,20 +674,22 @@ struct InitcapImpl {
                                   ColumnString::Chars& res_data,
                                   ColumnString::Offsets& res_offsets) {
         std::string result;
+        const auto& root_locale = icu::Locale::getRoot();
         for (int64_t i = 0; i < offsets.size(); ++i) {
             const char* begin = reinterpret_cast<const char*>(&data[offsets[i - 1]]);
             uint32_t size = offsets[i] - offsets[i - 1];
             result.clear();
-            to_initcap_utf8(begin, size, result);
+            to_initcap_utf8(begin, size, root_locale, result);
             StringOP::push_value_string(result, i, res_data, res_offsets);
         }
     }
 
-    static void to_initcap_utf8(const char* data, uint32_t size, std::string& result) {
+    static void to_initcap_utf8(const char* data, uint32_t size, const icu::Locale& locale,
+                                std::string& result) {
         icu::StringPiece sp;
         sp.set(data, size);
         icu::UnicodeString unicode_str = icu::UnicodeString::fromUTF8(sp);
-        unicode_str.toLower(icu::Locale::getRoot());
+        unicode_str.toLower(locale);
         icu::UnicodeString output_str;
         bool need_capitalize = true;
         icu::StringCharacterIterator iter(unicode_str);

--- a/be/src/storage/index/inverted/tokenizer/icu/icu_tokenizer.cpp
+++ b/be/src/storage/index/inverted/tokenizer/icu/icu_tokenizer.cpp
@@ -56,7 +56,7 @@ Token* ICUTokenizer::next(Token* token) {
     int32_t length = std::min(end - start, LUCENE_MAX_WORD_LEN);
     auto subString = buffer_.tempSubString(start, length);
     if (this->lowercase) {
-        subString.toLower().toUTF8String(utf8Str_);
+        subString.toLower(icu::Locale::getRoot()).toUTF8String(utf8Str_);
     } else {
         subString.toUTF8String(utf8Str_);
     }

--- a/be/test/storage/index/inverted/analyzer/icu_analyzer_test.cpp
+++ b/be/test/storage/index/inverted/analyzer/icu_analyzer_test.cpp
@@ -18,14 +18,23 @@
 #include "storage/index/inverted/analyzer/icu/icu_analyzer.h"
 
 #include <gtest/gtest.h>
+#include <unicode/locid.h>
+#include <unicode/utypes.h>
 
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "util/defer_op.h"
+
 using namespace lucene::analysis;
 
 namespace doris::segment_v2 {
+
+class LowercaseICUTokenizer : public inverted_index::ICUTokenizer {
+public:
+    LowercaseICUTokenizer() { lowercase = true; }
+};
 
 class ICUTokenizerTest : public ::testing::Test {
 protected:
@@ -599,6 +608,32 @@ TEST_F(ICUTokenizerTest, TestICUAnalyzerCreateComponentsWithLowercase) {
     }
 
     delete token_stream;
+}
+
+TEST_F(ICUTokenizerTest, TestICUTokenizerLowercaseUsesRootLocale) {
+    UErrorCode status = U_ZERO_ERROR;
+    const icu::Locale saved_default = icu::Locale::getDefault();
+    icu::Locale::setDefault(icu::Locale("tr", "TR"), status);
+    ASSERT_TRUE(U_SUCCESS(status));
+    Defer restore_default {[&]() {
+        UErrorCode restore_status = U_ZERO_ERROR;
+        icu::Locale::setDefault(saved_default, restore_status);
+    }};
+
+    std::string text = "I KIZILAY";
+    auto reader = std::make_shared<lucene::util::SStringReader<char>>();
+    reader->init(text.data(), text.size(), false);
+    LowercaseICUTokenizer tokenizer;
+    tokenizer.initialize("./be/dict/icu");
+    tokenizer.set_reader(reader);
+    tokenizer.reset();
+
+    std::vector<std::string> tokens;
+    Token token;
+    while (tokenizer.next(&token)) {
+        tokens.emplace_back(token.termBuffer<char>(), token.termLength<char>());
+    }
+    EXPECT_EQ(tokens, (std::vector<std::string> {"i", "kizilay"}));
 }
 
 TEST_F(ICUTokenizerTest, TestICUAnalyzerTokenStreamThrowsException) {


### PR DESCRIPTION

ICU tokenizer lowercasing still used the process default locale, while `LOWER`, `UPPER`, and `INITCAP` fetched the root locale for every UTF-8 row. This PR makes tokenizer lowercasing deterministic by explicitly using the ICU root locale and moves root-locale lookup outside the vectorized row loops.
