### PR TITLE
[improvement](be) Avoid temporary strings in float serialization

### DIFF
--- a/be/src/core/data_type_serde/data_type_number_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_number_serde.cpp
@@ -914,8 +914,7 @@ Status DataTypeNumberSerDe<T>::serialize_one_cell_to_json(const IColumn& column,
         std::string hex = CastToString::from_uint128(data);
         bw.write(hex.data(), hex.size());
     } else if constexpr (T == TYPE_FLOAT || T == TYPE_DOUBLE) {
-        auto str = CastToString::from_number(data);
-        bw.write(str.data(), str.size());
+        CastToString::push_number(data, bw);
     } else if constexpr (is_int_or_bool(T) ||
                          std::numeric_limits<typename PrimitiveTypeTraits<T>::CppType>::is_iec559) {
         bw.write_number(data);


### PR DESCRIPTION
 FLOAT and DOUBLE JSON serialization created a temporary std::string for every value before copying it into BufferWritable. Write the formatted value directly to BufferWritable to avoid the temporary allocation while preserving the existing floating-point representation