### PR TITLE
branch-4.1: [improvement](github-actions) Reduce macOS BE UT trigger load

### DIFF
--- a/.github/workflows/be-ut-mac.yml
+++ b/.github/workflows/be-ut-mac.yml
@@ -18,9 +18,11 @@
 name: BE UT (macOS)
 
 on:
-  pull_request:
+  push:
+    branches:
+      - branch-4.1
   schedule:
-    - cron: '0 4,10,16,22 * * *'    # schedule it periodically to share the cache
+    - cron: '0 4 * * *'    # daily cache warm-up; PR-level runs moved out to relieve the macOS runner queue
 
 concurrency:
   group: ${{ github.ref }} (BE UT macOS)
@@ -30,6 +32,7 @@ jobs:
   run-ut:
     name: BE UT (macOS)
     runs-on: macos-13
+    timeout-minutes: 360
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -37,33 +40,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
 
-      - name: Paths Filter
-        if: ${{ github.event_name != 'schedule' }}
-        uses: ./.github/actions/paths-filter
-        id: filter
-        with:
-          filters: |
-            be_changes:
-              - 'be/**'
-              - 'gensrc/proto/**'
-              - 'gensrc/thrift/**'
-            arrow_paimon_changes:
-              - '.github/workflows/be-ut-mac.yml'
-              - 'build.sh'
-              - 'env.sh'
-              - 'thirdparty/arrow-paimon-vars.sh'
-              - 'thirdparty/vars.sh'
-              - 'thirdparty/download-thirdparty.sh'
-              - 'thirdparty/build-thirdparty.sh'
-              - 'thirdparty/paimon-cpp-cache.cmake'
-              - 'thirdparty/patches/apache-arrow-*.patch'
-              - 'thirdparty/patches/paimon-cpp-*.patch'
-
       - name: Ccache ${{ github.ref }}
-        if: |
-          github.event_name == 'schedule' ||
-          steps.filter.outputs.be_changes == 'true' ||
-          steps.filter.outputs.arrow_paimon_changes == 'true'
         uses: ./.github/actions/ccache-action
         with:
           key: BE-UT-macOS
@@ -71,10 +48,6 @@ jobs:
           restore-keys: BE-UT-macOS-
 
       - name: Run UT ${{ github.ref }}
-        if: |
-          github.event_name == 'schedule' ||
-          steps.filter.outputs.be_changes == 'true' ||
-          steps.filter.outputs.arrow_paimon_changes == 'true'
         run: |
           cellars=(
             'm4'
@@ -111,7 +84,7 @@ jobs:
           export CUSTOM_CMAKE=/usr/local/bin/cmake
           "${CUSTOM_CMAKE}" --version
           pushd thirdparty
-          branch="${{ github.base_ref }}"
+          branch="${{ github.base_ref || github.ref_name }}"
           if [[ -z "${branch}" ]] || [[ "${branch}" == 'master' ]]; then
             curl -L https://github.com/apache/doris-thirdparty/releases/download/automation/doris-thirdparty-prebuilt-darwin-x86_64.tar.xz \
               -o doris-thirdparty-prebuilt-darwin-x86_64.tar.xz
@@ -121,18 +94,15 @@ jobs:
           fi
           tar -xvf doris-thirdparty-prebuilt-darwin-x86_64.tar.xz
 
-          # Rebuild the Arrow/Paimon stack when its inputs change or the shared
-          # prebuilt predates the selected Arrow version/component closure.
-          # The artifact check also covers scheduled and later BE-only builds,
-          # where Paths Filter is skipped or reports no Arrow/Paimon changes.
+          # Rebuild the Arrow/Paimon stack when the shared prebuilt predates the
+          # selected Arrow version/component closure.
           # shellcheck source=thirdparty/arrow-paimon-vars.sh
           . ./arrow-paimon-vars.sh
           arrow_paimon_prebuilt_is_valid=false
           if arrow_paimon_prebuilt_valid installed; then
             arrow_paimon_prebuilt_is_valid=true
           fi
-          if [[ "${{ steps.filter.outputs.arrow_paimon_changes }}" == "true" ||
-                "${arrow_paimon_prebuilt_is_valid}" != "true" ]]; then
+          if [[ "${arrow_paimon_prebuilt_is_valid}" != "true" ]]; then
             curl -L https://github.com/apache/doris-thirdparty/releases/download/automation/doris-thirdparty-source.tgz \
               -o doris-thirdparty-source.tgz
             tar -zxvf doris-thirdparty-source.tgz


### PR DESCRIPTION
## Summary

Backport the trigger policy from #66958 to `branch-4.1`:

- stop running `BE UT (macOS)` for every pull request
- run it on pushes to `branch-4.1`
- reduce the cache warm-up schedule from four times per day to once per day
- remove the PR-only paths filter and add a 6-hour timeout
- fall back to `github.ref_name` on push so the workflow selects the `automation-4.1` x86_64 thirdparty package instead of the master package

## Motivation

A live queue snapshot on 2026-08-24 showed 17 queued and 1 pending `BE UT (macOS)` pull-request runs. All identifiable queued runs targeted `branch-4.1`; the oldest had waited about 70 hours. Master no longer creates these PR runs after #66958.

## Validation

- `actionlint` passed after excluding the two pre-existing branch warnings below
- embedded `run` script passed `bash -n`
- `git diff --check` passed
- verified `branch-4.1` resolves to the `automation-4.1` thirdparty release suffix on push

## Existing branch issues

`branch-4.1` still uses the retired `macos-13` label and `actions/checkout@v3`. Those pre-existing issues are handled separately by Draft PR #66248. This PR intentionally changes only trigger volume and branch selection; it does not claim a terminal macOS canary until the runner migration is resolved.

Original change: #66958