### PR TITLE
[fix](test) use Cloud Table Stream read-state hook

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommandTableStreamTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommandTableStreamTest.java
@@ -618,15 +618,17 @@ public class InsertIntoTableCommandTableStreamTest extends TestWithFeService {
                             .build();
                 }).thenAnswer(invocation -> buildReadStateResponse(invocation.getArgument(0)));
 
-                ResolveCloudTableStreamReadState resolver = new ResolveCloudTableStreamReadState();
+                // Read-state installation is a post-analysis invariant, so exercise the hook that
+                // owns this lifecycle instead of the removed generic rewrite rule.
                 org.apache.doris.nereids.exceptions.AnalysisException exception = Assertions.assertThrows(
                         org.apache.doris.nereids.exceptions.AnalysisException.class,
-                        () -> resolver.rewriteRoot(analyzedPlan, null));
+                        () -> Deencapsulation.invoke(
+                                CloudTableStreamReadStateHook.class, "resolve", analyzedPlan));
                 Assertions.assertTrue(exception.getMessage()
                         .contains("did not return all Cloud Table Stream bindings"));
                 Assertions.assertTrue(wrappers.stream().noneMatch(OlapTableStreamWrapper::hasCloudReadStates));
 
-                resolver.rewriteRoot(analyzedPlan, null);
+                Deencapsulation.invoke(CloudTableStreamReadStateHook.class, "resolve", analyzedPlan);
                 Assertions.assertTrue(wrappers.stream().allMatch(OlapTableStreamWrapper::hasCloudReadStates));
                 ArgumentCaptor<Cloud.GetTableStreamOffsetRequest> requestCaptor =
                         ArgumentCaptor.forClass(Cloud.GetTableStreamOffsetRequest.class);


### PR DESCRIPTION
## What problem does this PR solve?

A Cloud Table Stream test still instantiated `ResolveCloudTableStreamReadState` after that generic rewrite rule was removed, causing FE test compilation to fail.

## What is changed?

Invoke `CloudTableStreamReadStateHook.resolve` through the test existing reflection utility. This keeps the partial-response retry coverage on the production post-analysis lifecycle that now owns read-state installation.

## Testing

- `InsertIntoTableCommandTableStreamTest`: 13 tests passed
- FE Checkstyle passed