### PR TITLE
branch-4.1: [fix](test) Stabilize Paimon external path regression case

### DIFF
--- a/regression-test/suites/external_table_p0/paimon/write/test_paimon_write_external_paths.groovy
+++ b/regression-test/suites/external_table_p0/paimon/write/test_paimon_write_external_paths.groovy
@@ -122,8 +122,7 @@ suite("test_paimon_write_external_paths", "p0,external,paimon") {
             assertSparkDorisResultEquals(sparkRows, dorisRows)
         }
 
-        // Separate statements force separate writer lifecycles. The selected
-        // path must therefore be refreshed for every Doris commit.
+        // Separate statements force separate writer lifecycles.
         sql """INSERT INTO t_round_robin VALUES ('p1', 1, 'one')"""
         sql """INSERT INTO t_round_robin VALUES ('p1', 2, 'two')"""
         sql """INSERT INTO t_round_robin VALUES ('p2', 3, 'three')"""
@@ -134,8 +133,13 @@ suite("test_paimon_write_external_paths", "p0,external,paimon") {
             FROM numbers("number" = "16")
         """
         def oldRoundFiles = dataFiles("t_round_robin")
-        assertTrue(oldRoundFiles.any { it.startsWith("${pathRoot}/round-a/") })
-        assertTrue(oldRoundFiles.any { it.startsWith("${pathRoot}/round-b/") })
+        assertFalse(oldRoundFiles.isEmpty())
+        // Each lifecycle randomly initializes its round-robin position, so independent
+        // statements need not hit both paths. Only membership in the configured set is stable.
+        assertTrue(oldRoundFiles.every {
+            it.startsWith("${pathRoot}/round-a/") ||
+                    it.startsWith("${pathRoot}/round-b/")
+        })
         assertDorisSparkRows("external_round_robin_initial", "t_round_robin",
                 "pt, id, length(payload)", "ORDER BY pt, id")
 


### PR DESCRIPTION
## Proposed changes
- Replace the probabilistic requirement that both round-robin roots appear with the stable path-set contract.
- Keep an explicit non-empty assertion so an empty metadata result cannot pass vacuously.
- Document why independent writer lifecycles do not guarantee coverage of both roots.

## Problem summary
Paimon randomly initializes the round-robin position for each writer lifecycle. The regression case uses independent insert statements, so a valid finite run can select only one configured root and fail even though every file uses the configured path set.

## Testing
- Compiled the changed suite with the repository Groovy 4.0.19 dependency.
- Verified the path predicate for one configured root, both roots, an empty list, and an unexpected root.
- Ran git diff --check.
- Not run: the focused external Paimon regression suite requires JDK 8 and an external Paimon test environment, which are not available in the isolated worktree.