### PR TITLE
[improvement](be) Separate local tablet schemas from metadata

### DIFF
--- a/be/src/cloud/pb_convert.cpp
+++ b/be/src/cloud/pb_convert.cpp
@@ -805,6 +805,7 @@ void doris_tablet_meta_to_cloud(TabletMetaCloudPB* out, const TabletMetaPB& in) 
     if (in.has_inverted_index_storage_format()) {
         out->set_inverted_index_storage_format(in.inverted_index_storage_format());
     }
+    out->set_tablet_schema_saved(in.tablet_schema_saved());
 }
 
 void doris_tablet_meta_to_cloud(TabletMetaCloudPB* out, TabletMetaPB&& in) {
@@ -893,6 +894,7 @@ void doris_tablet_meta_to_cloud(TabletMetaCloudPB* out, TabletMetaPB&& in) {
     if (in.has_inverted_index_storage_format()) {
         out->set_inverted_index_storage_format(in.inverted_index_storage_format());
     }
+    out->set_tablet_schema_saved(in.tablet_schema_saved());
 }
 
 TabletMetaPB cloud_tablet_meta_to_doris(const TabletMetaCloudPB& in) {
@@ -988,6 +990,7 @@ void cloud_tablet_meta_to_doris(TabletMetaPB* out, const TabletMetaCloudPB& in) 
     if (in.has_inverted_index_storage_format()) {
         out->set_inverted_index_storage_format(in.inverted_index_storage_format());
     }
+    out->set_tablet_schema_saved(in.tablet_schema_saved());
 }
 
 void cloud_tablet_meta_to_doris(TabletMetaPB* out, TabletMetaCloudPB&& in) {
@@ -1076,6 +1079,7 @@ void cloud_tablet_meta_to_doris(TabletMetaPB* out, TabletMetaCloudPB&& in) {
     if (in.has_inverted_index_storage_format()) {
         out->set_inverted_index_storage_format(in.inverted_index_storage_format());
     }
+    out->set_tablet_schema_saved(in.tablet_schema_saved());
 }
 
 } // namespace doris::cloud

--- a/be/src/format_v2/json/json_reader.cpp
+++ b/be/src/format_v2/json/json_reader.cpp
@@ -1137,7 +1137,7 @@ size_t JsonReader::_column_index(std::string_view key, size_t key_index) {
         const auto previous = _previous_positions[key_index];
         if (previous < _requested_columns.size()) {
             const auto previous_name = _requested_columns[previous].slot_desc->col_name();
-            if ((_is_hive_table && CaseInsensitiveStringEqual {}(previous_name, key)) ||
+            if ((_is_hive_table&& CaseInsensitiveStringEqual {}(previous_name, key)) ||
                 (!_is_hive_table && previous_name == key)) {
                 return previous;
             }

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -361,7 +361,7 @@ Status DataDir::load() {
     auto load_rowset_func = [&dir_rowset_metas, this](TabletUid tablet_uid, RowsetId rowset_id,
                                                       std::string_view meta_str) -> bool {
         RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
-        bool parsed = rowset_meta->init(meta_str);
+        bool parsed = rowset_meta->init(meta_str, _meta);
         if (!parsed) {
             LOG(WARNING) << "parse rowset meta string failed for rowset_id:" << rowset_id;
             // return false will break meta iterator, return true to skip this error
@@ -599,11 +599,10 @@ Status DataDir::load() {
         }
 
         std::optional<BinlogFormatPB> binlog_format = std::nullopt;
-        std::optional<RowsetMetaPB> attach_row_binlog_rowset_meta;
+        const RowsetMeta* attach_row_binlog_rowset_meta = nullptr;
         if (attach_row_binlog.rowset != nullptr) {
             binlog_format = BinlogFormatPB::ROW;
-            attach_row_binlog_rowset_meta =
-                    attach_row_binlog.rowset->rowset_meta()->get_rowset_pb();
+            attach_row_binlog_rowset_meta = attach_row_binlog.rowset->rowset_meta().get();
         }
 
         std::string attach_binlog_rowset_id =
@@ -615,10 +614,9 @@ Status DataDir::load() {
             rowset_meta->tablet_uid() == tablet->tablet_uid()) {
             if (!rowset_meta->tablet_schema()) {
                 rowset_meta->set_tablet_schema(tablet->tablet_schema());
-                RETURN_IF_ERROR(RowsetMetaManager::save(_meta, rowset_meta->tablet_uid(),
-                                                        rowset_meta->rowset_id(),
-                                                        rowset_meta->get_rowset_pb(), binlog_format,
-                                                        attach_row_binlog_rowset_meta));
+                RETURN_IF_ERROR(RowsetMetaManager::save(
+                        _meta, rowset_meta->tablet_uid(), rowset_meta->rowset_id(), *rowset_meta,
+                        binlog_format, attach_row_binlog_rowset_meta));
             }
             std::vector<RowsetId> rowset_ids {rowset_meta->rowset_id()};
             if (attach_row_binlog.rowset != nullptr) {
@@ -654,10 +652,10 @@ Status DataDir::load() {
                    rowset_meta->tablet_uid() == tablet->tablet_uid()) {
             if (!rowset_meta->tablet_schema()) {
                 rowset_meta->set_tablet_schema(tablet->tablet_schema());
-                RETURN_IF_ERROR(RowsetMetaManager::save(_meta, rowset_meta->tablet_uid(),
-                                                        rowset_meta->rowset_id(),
-                                                        rowset_meta->get_rowset_pb(), binlog_format,
-                                                        attach_row_binlog_rowset_meta));
+                rowset_meta->set_persist_schema(true);
+                RETURN_IF_ERROR(RowsetMetaManager::save(
+                        _meta, rowset_meta->tablet_uid(), rowset_meta->rowset_id(), *rowset_meta,
+                        binlog_format, attach_row_binlog_rowset_meta));
             }
             Status publish_status = tablet->add_rowset(rowset);
             if (!publish_status && !publish_status.is<PUSH_VERSION_ALREADY_EXIST>()) {

--- a/be/src/storage/olap_define.h
+++ b/be/src/storage/olap_define.h
@@ -154,6 +154,8 @@ const std::string TABLE_ID_KEY = "table_id";
 const std::string ENABLE_BYTE_TO_BASE64 = "byte_to_base64";
 const std::string TABLET_ID_PREFIX = "t_";
 const std::string ROWSET_ID_PREFIX = "s_";
+const std::string TABLET_SCHEMA_PREFIX = "ts_";
+const std::string ROWSET_SCHEMA_PREFIX = "rs_";
 const std::string REMOTE_ROWSET_GC_PREFIX = "gc_";
 const std::string REMOTE_TABLET_GC_PREFIX = "tgc_";
 

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -378,6 +378,7 @@ Status BaseBetaRowsetWriter::init(const RowsetWriterContext& rowset_writer_conte
     _rowset_meta->set_rowset_type(_context.rowset_type);
     _rowset_meta->set_rowset_state(_context.rowset_state);
     _rowset_meta->set_segments_overlap(_context.segments_overlap);
+    _rowset_meta->set_persist_schema(_context.persist_current_schema);
     if (_context.rowset_state == PREPARED || _context.rowset_state == COMMITTED) {
         _is_pending = true;
         _rowset_meta->set_txn_id(_context.txn_id);

--- a/be/src/storage/rowset/rowset_meta.cpp
+++ b/be/src/storage/rowset/rowset_meta.cpp
@@ -39,6 +39,7 @@
 #include "json2pb/pb_to_json.h"
 #include "runtime/exec_env.h"
 #include "storage/olap_common.h"
+#include "storage/rowset/rowset_meta_manager.h"
 #include "storage/storage_policy.h"
 #include "storage/tablet/base_tablet.h"
 #include "storage/tablet/tablet_fwd.h"
@@ -54,8 +55,8 @@ RowsetMeta::~RowsetMeta() {
     }
 }
 
-bool RowsetMeta::init(std::string_view pb_rowset_meta) {
-    bool ret = _deserialize_from_pb(pb_rowset_meta);
+bool RowsetMeta::init(std::string_view pb_rowset_meta, OlapMeta* meta) {
+    bool ret = _deserialize_from_pb(pb_rowset_meta, meta);
     if (!ret) {
         return false;
     }
@@ -69,9 +70,19 @@ bool RowsetMeta::init(const RowsetMeta* rowset_meta) {
     return init_from_pb(rowset_meta_pb);
 }
 
-bool RowsetMeta::init_from_pb(const RowsetMetaPB& rowset_meta_pb) {
+bool RowsetMeta::init_from_pb(const RowsetMetaPB& rowset_meta_pb,
+                              const std::map<int32_t, std::string>* version_to_schema) {
     if (rowset_meta_pb.has_tablet_schema()) {
         set_tablet_schema(rowset_meta_pb.tablet_schema());
+    } else if (version_to_schema != nullptr && rowset_meta_pb.has_schema_version()) {
+        auto schema_it = version_to_schema->find(rowset_meta_pb.schema_version());
+        if (schema_it == version_to_schema->end()) {
+            LOG(WARNING) << "no rowset schema available. tablet_id=" << rowset_meta_pb.tablet_id()
+                         << ", schema_version=" << rowset_meta_pb.schema_version()
+                         << ", rowset_id=" << rowset_meta_pb.rowset_id_v2();
+            return false;
+        }
+        _set_tablet_schema_from_binary(schema_it->second);
     }
     // Release ownership of TabletSchemaPB from `rowset_meta_pb` and then set it back to `rowset_meta_pb`,
     // this won't break const semantics of `rowset_meta_pb`, because `rowset_meta_pb` is not changed
@@ -206,9 +217,12 @@ void RowsetMeta::to_rowset_pb(RowsetMetaPB* rs_meta_pb, bool skip_schema) const 
     *rs_meta_pb = _rowset_meta_pb;
     if (_schema) [[likely]] {
         rs_meta_pb->set_schema_version(_schema->schema_version());
-        if (!skip_schema) {
-            // For cloud, separate tablet schema from rowset meta to reduce persistent size.
+        // Variant rowsets with the same schema version may contain different extracted columns,
+        // so their schemas cannot be shared by schema version.
+        if (!skip_schema || has_variant_type_in_schema()) {
             _schema->to_schema_pb(rs_meta_pb->mutable_tablet_schema());
+        } else {
+            rs_meta_pb->clear_tablet_schema();
         }
     }
     rs_meta_pb->set_has_variant_type_in_schema(has_variant_type_in_schema());
@@ -221,25 +235,23 @@ RowsetMetaPB RowsetMeta::get_rowset_pb(bool skip_schema) const {
 }
 
 void RowsetMeta::set_tablet_schema(const TabletSchemaSPtr& tablet_schema) {
-    if (_handle) {
-        TabletSchemaCache::instance()->release(_handle);
-    }
-    auto pair = TabletSchemaCache::instance()->insert(tablet_schema->to_key());
-    _handle = pair.first;
-    _schema = pair.second;
+    _set_tablet_schema_from_binary(tablet_schema->to_key());
 }
 
 void RowsetMeta::set_tablet_schema(const TabletSchemaPB& tablet_schema) {
+    _set_tablet_schema_from_binary(TabletSchema::deterministic_string_serialize(tablet_schema));
+}
+
+void RowsetMeta::_set_tablet_schema_from_binary(const std::string& schema_binary) {
     if (_handle) {
         TabletSchemaCache::instance()->release(_handle);
     }
-    auto pair = TabletSchemaCache::instance()->insert(
-            TabletSchema::deterministic_string_serialize(tablet_schema));
+    auto pair = TabletSchemaCache::instance()->insert(schema_binary);
     _handle = pair.first;
     _schema = pair.second;
 }
 
-bool RowsetMeta::_deserialize_from_pb(std::string_view value) {
+bool RowsetMeta::_deserialize_from_pb(std::string_view value, OlapMeta* meta) {
     if (!_rowset_meta_pb.ParseFromArray(value.data(), cast_set<int32_t>(value.size()))) {
         _rowset_meta_pb.Clear();
         return false;
@@ -247,6 +259,16 @@ bool RowsetMeta::_deserialize_from_pb(std::string_view value) {
     if (_rowset_meta_pb.has_tablet_schema()) {
         set_tablet_schema(_rowset_meta_pb.tablet_schema());
         _rowset_meta_pb.set_allocated_tablet_schema(nullptr);
+    } else if (meta != nullptr && _rowset_meta_pb.has_schema_version()) {
+        std::string schema_binary;
+        Status status = RowsetMetaManager::get_rowset_schema(
+                meta, _rowset_meta_pb.tablet_id(), TabletUid(_rowset_meta_pb.tablet_uid()),
+                _rowset_meta_pb.tablet_schema_hash(), _rowset_meta_pb.schema_version(),
+                &schema_binary);
+        if (!status.ok()) {
+            return false;
+        }
+        _set_tablet_schema_from_binary(schema_binary);
     }
     return true;
 }
@@ -257,6 +279,7 @@ bool RowsetMeta::_serialize_to_pb(std::string* value) {
     }
     RowsetMetaPB rowset_meta_pb = _rowset_meta_pb;
     if (_schema) {
+        rowset_meta_pb.set_schema_version(_schema->schema_version());
         _schema->to_schema_pb(rowset_meta_pb.mutable_tablet_schema());
     }
     return rowset_meta_pb.SerializeToString(value);

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -24,6 +24,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -43,16 +44,19 @@
 
 namespace doris {
 
+class OlapMeta;
+
 class RowsetMeta : public MetadataAdder<RowsetMeta> {
 public:
     RowsetMeta() = default;
     ~RowsetMeta();
 
-    bool init(std::string_view pb_rowset_meta);
+    bool init(std::string_view pb_rowset_meta, OlapMeta* meta = nullptr);
 
     bool init(const RowsetMeta* rowset_meta);
 
-    bool init_from_pb(const RowsetMetaPB& rowset_meta_pb);
+    bool init_from_pb(const RowsetMetaPB& rowset_meta_pb,
+                      const std::map<int32_t, std::string>* version_to_schema = nullptr);
 
     bool init_from_json(const std::string& json_rowset_meta);
 
@@ -430,6 +434,10 @@ public:
 
     const TabletSchemaSPtr& tablet_schema() const { return _schema; }
 
+    void set_persist_schema(bool persist) { _persist_current_schema = persist; }
+
+    bool need_persist_schema() const { return _persist_current_schema; }
+
     void set_txn_expiration(int64_t expiration) { _rowset_meta_pb.set_txn_expiration(expiration); }
 
     void set_compaction_level(int64_t compaction_level) {
@@ -512,7 +520,9 @@ public:
     }
 
 private:
-    bool _deserialize_from_pb(std::string_view value);
+    void _set_tablet_schema_from_binary(const std::string& schema_binary);
+
+    bool _deserialize_from_pb(std::string_view value, OlapMeta* meta);
 
     bool _serialize_to_pb(std::string* value);
 
@@ -529,6 +539,7 @@ private:
     RowsetId _rowset_id;
     StorageResource _storage_resource;
     bool _is_removed_from_rowset_meta = false;
+    bool _persist_current_schema = true;
     DorisCallOnce<Result<EncryptionAlgorithmPB>> _determine_encryption_once;
     std::atomic<int64_t> _stale_at_s {0};
 };

--- a/be/src/storage/rowset/rowset_meta_manager.cpp
+++ b/be/src/storage/rowset/rowset_meta_manager.cpp
@@ -29,10 +29,12 @@
 #include <string_view>
 #include <vector>
 
+#include "common/check.h"
 #include "common/logging.h"
 #include "storage/binlog.h"
 #include "storage/olap_define.h"
 #include "storage/olap_meta.h"
+#include "storage/tablet/tablet_schema.h"
 #include "storage/utils.h"
 #include "util/debug_points.h"
 
@@ -63,7 +65,7 @@ Status RowsetMetaManager::get_rowset_meta(OlapMeta* meta, TabletUid tablet_uid,
     } else if (!s.ok()) {
         return Status::Error<IO_ERROR>("load rowset id: {} failed.", key);
     }
-    bool ret = rowset_meta->init(value);
+    bool ret = rowset_meta->init(value, meta);
     if (!ret) {
         return Status::Error<SERIALIZE_PROTOBUF_ERROR>("parse rowset meta failed. rowset id: {}",
                                                        key);
@@ -72,9 +74,12 @@ Status RowsetMetaManager::get_rowset_meta(OlapMeta* meta, TabletUid tablet_uid,
 }
 
 Status RowsetMetaManager::save(OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id,
-                               const RowsetMetaPB& rowset_meta_pb,
+                               const RowsetMeta& rowset_meta,
                                std::optional<BinlogFormatPB> binlog_format,
-                               const std::optional<RowsetMetaPB>& attach_row_binlog_rowset_meta) {
+                               const RowsetMeta* attach_row_binlog_rowset_meta) {
+    const auto& tablet_schema = rowset_meta.tablet_schema();
+    DORIS_CHECK(tablet_schema != nullptr);
+    RowsetMetaPB rowset_meta_pb = rowset_meta.get_rowset_pb(true);
     if (rowset_meta_pb.partition_id() <= 0) {
         LOG(WARNING) << "invalid partition id " << rowset_meta_pb.partition_id() << " tablet "
                      << rowset_meta_pb.tablet_id();
@@ -84,21 +89,108 @@ Status RowsetMetaManager::save(OlapMeta* meta, TabletUid tablet_uid, const Rowse
     }
     DBUG_EXECUTE_IF("RowsetMetaManager::save::zero_partition_id", {
         long partition_id = rowset_meta_pb.partition_id();
-        auto& rs_pb = const_cast<std::decay_t<decltype(rowset_meta_pb)>&>(rowset_meta_pb);
-        rs_pb.set_partition_id(0);
+        rowset_meta_pb.set_partition_id(0);
         LOG(WARNING) << "set debug point RowsetMetaManager::save::zero_partition_id old="
                      << partition_id << " new=" << rowset_meta_pb.DebugString();
     });
+    if (rowset_meta.need_persist_schema()) {
+        RETURN_IF_ERROR(save_schema(meta, rowset_meta.tablet_id(), tablet_uid,
+                                    rowset_meta.tablet_schema_hash(), tablet_schema));
+    }
     if (!binlog_format.has_value()) {
         return _save(meta, tablet_uid, rowset_id, rowset_meta_pb);
     }
     if (*binlog_format == BinlogFormatPB::STATEMENT_AND_SNAPSHOT) {
         return _save_with_ccr_binlog(meta, tablet_uid, rowset_id, rowset_meta_pb);
     }
-    DCHECK_EQ(*binlog_format, BinlogFormatPB::ROW);
-    DCHECK(attach_row_binlog_rowset_meta.has_value());
+    DORIS_CHECK(*binlog_format == BinlogFormatPB::ROW);
+    DORIS_CHECK(attach_row_binlog_rowset_meta != nullptr);
+    const auto& attach_row_binlog_tablet_schema = attach_row_binlog_rowset_meta->tablet_schema();
+    DORIS_CHECK(attach_row_binlog_tablet_schema != nullptr);
+    if (attach_row_binlog_rowset_meta->need_persist_schema()) {
+        RETURN_IF_ERROR(save_schema(meta, attach_row_binlog_rowset_meta->tablet_id(),
+                                    attach_row_binlog_rowset_meta->tablet_uid(),
+                                    attach_row_binlog_rowset_meta->tablet_schema_hash(),
+                                    attach_row_binlog_tablet_schema));
+    }
+    RowsetMetaPB attach_row_binlog_rowset_pb = attach_row_binlog_rowset_meta->get_rowset_pb(true);
     return _save_with_row_binlog(meta, tablet_uid, rowset_id, rowset_meta_pb,
-                                 *attach_row_binlog_rowset_meta);
+                                 attach_row_binlog_rowset_pb);
+}
+
+bool RowsetMetaManager::schema_exists(OlapMeta* meta, TabletUid tablet_uid, int32_t schema_hash,
+                                      int32_t schema_version) {
+    std::string schema_key = fmt::format("{}{}_{}_{}", ROWSET_SCHEMA_PREFIX, tablet_uid.to_string(),
+                                         schema_hash, schema_version);
+    std::string value;
+    return meta->key_may_exist(META_COLUMN_FAMILY_INDEX, schema_key, &value) &&
+           meta->get(META_COLUMN_FAMILY_INDEX, schema_key, &value).ok();
+}
+
+Status RowsetMetaManager::save_schema(OlapMeta* meta, TTabletId tablet_id, TabletUid tablet_uid,
+                                      int32_t schema_hash, const TabletSchemaSPtr& schema) {
+    DORIS_CHECK(schema != nullptr);
+    // Variant rowsets keep their rowset-specific schemas inline.
+    if (schema->num_variant_columns() > 0) {
+        return Status::OK();
+    }
+    const int32_t schema_version = schema->schema_version();
+    std::string schema_key = fmt::format("{}{}_{}_{}", ROWSET_SCHEMA_PREFIX, tablet_uid.to_string(),
+                                         schema_hash, schema_version);
+    if (schema_exists(meta, tablet_uid, schema_hash, schema_version)) {
+        return Status::OK();
+    }
+
+    TabletSchemaPB schema_pb;
+    schema->to_schema_pb(&schema_pb);
+    std::string schema_binary = TabletSchema::deterministic_string_serialize(schema_pb);
+    Status status = meta->put(META_COLUMN_FAMILY_INDEX, schema_key, schema_binary);
+    if (!status.ok()) {
+        LOG(WARNING) << "failed to save rowset schema. tablet=" << tablet_id
+                     << ", key=" << schema_key << ", status=" << status;
+    }
+    return status;
+}
+
+Status RowsetMetaManager::get_rowset_schema(OlapMeta* meta, TTabletId tablet_id,
+                                            TabletUid tablet_uid, int32_t schema_hash,
+                                            int32_t schema_version,
+                                            std::string* binary_rowset_schema) {
+    std::string schema_key = fmt::format("{}{}_{}_{}", ROWSET_SCHEMA_PREFIX, tablet_uid.to_string(),
+                                         schema_hash, schema_version);
+    Status status = meta->get(META_COLUMN_FAMILY_INDEX, schema_key, binary_rowset_schema);
+    if (!status.ok()) {
+        LOG(WARNING) << "failed to get rowset schema. tablet=" << tablet_id
+                     << ", key=" << schema_key << ", status=" << status;
+    }
+    return status;
+}
+
+Status RowsetMetaManager::remove_schemas(OlapMeta* meta, TTabletId tablet_id, TabletUid tablet_uid,
+                                         int32_t schema_hash) {
+    const std::string schema_key_prefix =
+            fmt::format("{}{}_{}_", ROWSET_SCHEMA_PREFIX, tablet_uid.to_string(), schema_hash);
+    std::vector<std::string> schema_keys;
+    RETURN_IF_ERROR(
+            meta->iterate(META_COLUMN_FAMILY_INDEX, schema_key_prefix,
+                          [&schema_keys](std::string_view key, std::string_view /* value */) {
+                              schema_keys.emplace_back(key);
+                              return true;
+                          }));
+    if (schema_keys.empty()) {
+        return Status::OK();
+    }
+
+    Status status = meta->remove(META_COLUMN_FAMILY_INDEX, schema_keys);
+    if (!status.ok()) {
+        LOG(WARNING) << "failed to remove rowset schemas. tablet=" << tablet_id
+                     << ", tablet_uid=" << tablet_uid << ", schema_hash=" << schema_hash
+                     << ", status=" << status;
+        return status;
+    }
+    LOG(INFO) << "removed rowset schemas. tablet=" << tablet_id << ", tablet_uid=" << tablet_uid
+              << ", schema_hash=" << schema_hash << ", count=" << schema_keys.size();
+    return Status::OK();
 }
 
 Status RowsetMetaManager::_save(OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id,
@@ -125,7 +217,6 @@ Status RowsetMetaManager::_save_with_ccr_binlog(OlapMeta* meta, TabletUid tablet
         return Status::Error<SERIALIZE_PROTOBUF_ERROR>("serialize rowset pb failed. rowset id:{}",
                                                        rowset_key);
     }
-
     // create binlog write data
     // binlog_meta_key format: {kBinlogPrefix}meta_{tablet_uid}_{version}_{rowset_id}
     // binlog_data_key format: {kBinlogPrefix}data_{tablet_uid}_{version}_{rowset_id}
@@ -298,7 +389,7 @@ std::string RowsetMetaManager::get_rowset_binlog_meta(OlapMeta* meta, TabletUid 
     VLOG_DEBUG << fmt::format("get binlog_meta_key:{}", binlog_data_key);
 
     std::string binlog_meta_value;
-    Status status = meta->get(META_COLUMN_FAMILY_INDEX, binlog_data_key, &binlog_meta_value);
+    Status status = _get_binlog_data_with_schema(meta, binlog_data_key, &binlog_meta_value);
     if (!status.ok()) {
         LOG(WARNING) << fmt::format(
                 "fail to get binlog meta. tablet uid:{}, binlog version:{}, "
@@ -307,6 +398,39 @@ std::string RowsetMetaManager::get_rowset_binlog_meta(OlapMeta* meta, TabletUid 
         return "";
     }
     return binlog_meta_value;
+}
+
+Status RowsetMetaManager::_get_binlog_data_with_schema(OlapMeta* meta,
+                                                       const std::string& binlog_data_key,
+                                                       std::string* binlog_data) {
+    RETURN_IF_ERROR(meta->get(META_COLUMN_FAMILY_INDEX, binlog_data_key, binlog_data));
+
+    RowsetMetaPB rowset_meta_pb;
+    if (!rowset_meta_pb.ParseFromString(*binlog_data)) {
+        return Status::Error<SERIALIZE_PROTOBUF_ERROR>("failed to parse binlog rowset meta. key={}",
+                                                       binlog_data_key);
+    }
+    if (rowset_meta_pb.has_tablet_schema()) {
+        return Status::OK();
+    }
+    if (!rowset_meta_pb.has_schema_version()) {
+        return Status::Error<SERIALIZE_PROTOBUF_ERROR>(
+                "schema version is missing from binlog rowset meta. key={}", binlog_data_key);
+    }
+
+    std::string schema_binary;
+    RETURN_IF_ERROR(get_rowset_schema(
+            meta, rowset_meta_pb.tablet_id(), TabletUid(rowset_meta_pb.tablet_uid()),
+            rowset_meta_pb.tablet_schema_hash(), rowset_meta_pb.schema_version(), &schema_binary));
+    if (!rowset_meta_pb.mutable_tablet_schema()->ParseFromString(schema_binary)) {
+        return Status::Error<SERIALIZE_PROTOBUF_ERROR>(
+                "failed to parse schema for binlog rowset meta. key={}", binlog_data_key);
+    }
+    if (!rowset_meta_pb.SerializeToString(binlog_data)) {
+        return Status::Error<SERIALIZE_PROTOBUF_ERROR>(
+                "failed to serialize binlog rowset meta. key={}", binlog_data_key);
+    }
+    return Status::OK();
 }
 
 Status RowsetMetaManager::get_rowset_binlog_metas(OlapMeta* meta, const TabletUid tablet_uid,
@@ -353,7 +477,7 @@ Status RowsetMetaManager::_get_rowset_binlog_metas(OlapMeta* meta, const TabletU
         auto binlog_data_key =
                 make_binlog_data_key(tablet_uid_str, binlog_meta_entry_pb.version(), rowset_id);
         std::string binlog_data;
-        status = meta->get(META_COLUMN_FAMILY_INDEX, binlog_data_key, &binlog_data);
+        status = _get_binlog_data_with_schema(meta, binlog_data_key, &binlog_data);
         if (!status.ok()) {
             LOG(WARNING) << status.to_string();
             return false;
@@ -420,7 +544,7 @@ Status RowsetMetaManager::get_rowset_binlog_metas(OlapMeta* meta, TabletUid tabl
         auto binlog_data_key =
                 make_binlog_data_key(tablet_uid_str, binlog_meta_entry_pb.version(), rowset_id);
         std::string binlog_data;
-        status = meta->get(META_COLUMN_FAMILY_INDEX, binlog_data_key, &binlog_data);
+        status = _get_binlog_data_with_schema(meta, binlog_data_key, &binlog_data);
         if (!status.ok()) {
             LOG(WARNING) << status.to_string();
             return false;
@@ -480,7 +604,7 @@ Status RowsetMetaManager::_get_all_rowset_binlog_metas(OlapMeta* meta, const Tab
         auto binlog_data_key =
                 make_binlog_data_key(tablet_uid_str, binlog_meta_entry_pb.version(), rowset_id);
         std::string binlog_data;
-        status = meta->get(META_COLUMN_FAMILY_INDEX, binlog_data_key, &binlog_data);
+        status = _get_binlog_data_with_schema(meta, binlog_data_key, &binlog_data);
         if (!status.ok()) {
             LOG(WARNING) << status;
             return false;

--- a/be/src/storage/rowset/rowset_meta_manager.h
+++ b/be/src/storage/rowset/rowset_meta_manager.h
@@ -24,7 +24,6 @@
 #include <functional>
 #include <map>
 #include <optional>
-#include <set>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -56,21 +55,20 @@ public:
 
     static Status get_rowset_meta(OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id,
                                   RowsetMetaSharedPtr rowset_meta);
-    // TODO(Drogon): refactor save && _save_with_binlog to one, adapt to ut temperately
-    static Status save(
-            OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id,
-            const RowsetMetaPB& rowset_meta_pb,
-            std::optional<BinlogFormatPB> binlog_format = std::nullopt,
-            const std::optional<RowsetMetaPB>& attach_row_binlog_rowset_meta = std::nullopt);
-
-    // STATEMENT_AND_SNAPSHOT
     static Status save(OlapMeta* meta, TabletUid tablet_uid, const RowsetId& rowset_id,
-                       const RowsetMetaPB& rowset_meta_pb, bool enable_binlog) {
-        return save(meta, tablet_uid, rowset_id, rowset_meta_pb,
-                    enable_binlog
-                            ? std::optional<BinlogFormatPB>(BinlogFormatPB::STATEMENT_AND_SNAPSHOT)
-                            : std::nullopt);
-    }
+                       const RowsetMeta& rowset_meta,
+                       std::optional<BinlogFormatPB> binlog_format = std::nullopt,
+                       const RowsetMeta* attach_row_binlog_rowset_meta = nullptr);
+
+    static bool schema_exists(OlapMeta* meta, TabletUid tablet_uid, int32_t schema_hash,
+                              int32_t schema_version);
+    static Status save_schema(OlapMeta* meta, TTabletId tablet_id, TabletUid tablet_uid,
+                              int32_t schema_hash, const TabletSchemaSPtr& schema);
+    static Status get_rowset_schema(OlapMeta* meta, TTabletId tablet_id, TabletUid tablet_uid,
+                                    int32_t schema_hash, int32_t schema_version,
+                                    std::string* binary_rowset_schema);
+    static Status remove_schemas(OlapMeta* meta, TTabletId tablet_id, TabletUid tablet_uid,
+                                 int32_t schema_hash);
 
     static std::vector<std::string> get_binlog_filenames(OlapMeta* meta, TabletUid tablet_uid,
                                                          std::string_view binlog_version,
@@ -124,6 +122,8 @@ private:
                                         const RowsetId& rowset_id,
                                         const RowsetMetaPB& rowset_meta_pb,
                                         const RowsetMetaPB& attach_row_binlog_rowset_meta);
+    static Status _get_binlog_data_with_schema(OlapMeta* meta, const std::string& binlog_data_key,
+                                               std::string* binlog_data);
     static Status _get_rowset_binlog_metas(OlapMeta* meta, const TabletUid tablet_uid,
                                            const std::vector<int64_t>& binlog_versions,
                                            RowsetBinlogMetasPB* metas_pb);

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -131,6 +131,8 @@ struct RowsetWriterContext {
 
     std::shared_ptr<PartialUpdateInfo> partial_update_info;
 
+    bool persist_current_schema = false;
+
     bool is_transient_rowset_writer = false;
 
     segment_v2::HistoricalRowRetrieverContext make_historical_row_retriever_context();

--- a/be/src/storage/rowset_builder.cpp
+++ b/be/src/storage/rowset_builder.cpp
@@ -265,6 +265,14 @@ Status RowsetBuilder::init() {
 Status BaseRowsetBuilder::_init_context_common_fields(RowsetWriterContext& context) {
     _tablet = DORIS_TRY(ExecEnv::get_tablet(_req.tablet_id));
 
+    // Persist the request schema while migrating a legacy tablet or before building with a newer
+    // schema, because building can update the tablet's maximum schema version.
+    if (!_tablet->tablet_meta()->tablet_schema_saved() ||
+        _req.table_schema_param->version() > _tablet->tablet_schema()->schema_version() ||
+        _req.table_schema_param->version() == 0) {
+        context.persist_current_schema = true;
+    }
+
     context.txn_id = _req.txn_id;
     context.load_id = _req.load_id;
     context.db_id = _req.table_schema_param->db_id();

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -50,6 +50,7 @@
 
 #include "agent/task_worker_pool.h"
 #include "cloud/cloud_storage_engine.h"
+#include "common/check.h"
 #include "common/config.h"
 #include "common/logging.h"
 #include "common/metrics/doris_metrics.h"
@@ -939,11 +940,14 @@ Status StorageEngine::start_trash_sweep(double* usage, bool ignore_guard) {
 
 void StorageEngine::_clean_unused_rowset_metas() {
     std::vector<RowsetMetaSharedPtr> invalid_rowset_metas;
-    auto clean_rowset_func = [this, &invalid_rowset_metas](TabletUid tablet_uid, RowsetId rowset_id,
-                                                           std::string_view meta_str) -> bool {
+    OlapMeta* current_meta = nullptr;
+    auto clean_rowset_func = [this, &invalid_rowset_metas, &current_meta](
+                                     TabletUid tablet_uid, RowsetId rowset_id,
+                                     std::string_view meta_str) -> bool {
         // return false will break meta iterator, return true to skip this error
+        DORIS_CHECK(current_meta != nullptr);
         RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
-        bool parsed = rowset_meta->init(meta_str);
+        bool parsed = rowset_meta->init(meta_str, current_meta);
         if (!parsed) {
             LOG(WARNING) << "parse rowset meta string failed for rowset_id:" << rowset_id;
             rowset_meta->set_rowset_id(rowset_id);
@@ -995,8 +999,9 @@ void StorageEngine::_clean_unused_rowset_metas() {
     };
     auto data_dirs = get_stores();
     for (auto data_dir : data_dirs) {
+        current_meta = data_dir->get_meta();
         static_cast<void>(
-                RowsetMetaManager::traverse_rowset_metas(data_dir->get_meta(), clean_rowset_func));
+                RowsetMetaManager::traverse_rowset_metas(current_meta, clean_rowset_func));
         // 1. delete delete_bitmap
         std::set<int64_t> tablets_to_save_meta;
         for (auto& rowset_meta : invalid_rowset_metas) {

--- a/be/src/storage/tablet/tablet.cpp
+++ b/be/src/storage/tablet/tablet.cpp
@@ -276,6 +276,12 @@ bool Tablet::set_tablet_schema_into_rowset_meta() {
             flag = true;
         }
     }
+    for (const auto& [_, rowset_meta] : _tablet_meta->all_stale_rs_metas()) {
+        if (!rowset_meta->tablet_schema()) {
+            rowset_meta->set_tablet_schema(_tablet_meta->tablet_schema());
+            flag = true;
+        }
+    }
     return flag;
 }
 
@@ -475,6 +481,12 @@ Status Tablet::revise_tablet_meta(const std::vector<RowsetSharedPtr>& to_add,
         }
     }
 
+    for (const auto& rowset : to_add) {
+        RETURN_IF_ERROR(RowsetMetaManager::save_schema(data_dir()->get_meta(), tablet_id(),
+                                                       tablet_uid(), schema_hash(),
+                                                       rowset->rowset_meta()->tablet_schema()));
+    }
+
     // clear stale rowset
     for (auto& [v, rs] : _stale_rs_version_map) {
         _engine.add_unused_rowset(rs);
@@ -564,6 +576,12 @@ Status Tablet::modify_rowsets(std::vector<RowsetSharedPtr>& to_add,
                         it->second->rowset_id().to_string());
             }
         }
+    }
+
+    for (const auto& rowset : to_add) {
+        RETURN_IF_ERROR(RowsetMetaManager::save_schema(data_dir()->get_meta(), tablet_id(),
+                                                       tablet_uid(), schema_hash(),
+                                                       rowset->rowset_meta()->tablet_schema()));
     }
 
     bool same_version = true;

--- a/be/src/storage/tablet/tablet_manager.cpp
+++ b/be/src/storage/tablet/tablet_manager.cpp
@@ -32,6 +32,7 @@
 #include <mutex>
 #include <optional>
 #include <ostream>
+#include <set>
 #include <string_view>
 
 #include "absl/strings/substitute.h"
@@ -442,6 +443,8 @@ TabletSharedPtr TabletManager::_internal_create_tablet_unlocked(
     } else {
         tablet->delete_all_files();
         static_cast<void>(TabletMetaManager::remove(data_dir, new_tablet_id, new_schema_hash));
+        static_cast<void>(RowsetMetaManager::remove_schemas(data_dir->get_meta(), new_tablet_id,
+                                                            tablet->tablet_uid(), new_schema_hash));
         COUNTER_UPDATE(ADD_CHILD_TIMER(profile, "RemoveTabletFiles", parent_timer_name),
                        static_cast<int64_t>(watch.reset()));
     }
@@ -883,9 +886,9 @@ std::vector<TabletCompactionContext> TabletManager::find_best_tablets_to_compact
 Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_id,
                                             TSchemaHash schema_hash, std::string_view meta_binary,
                                             bool update_meta, bool force, bool restore,
-                                            bool check_path) {
+                                            bool check_path, bool need_persist_schema) {
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
-    Status status = tablet_meta->deserialize(meta_binary);
+    Status status = tablet_meta->deserialize(data_dir, meta_binary);
     if (!status.ok()) {
         return Status::Error<HEADER_PB_PARSE_FAILED>(
                 "fail to load tablet because can not parse meta_binary string. tablet_id={}, "
@@ -956,6 +959,12 @@ Status TabletManager::load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_
     RETURN_NOT_OK_STATUS_WITH_WARN(
             tablet->init(), absl::Substitute("tablet init failed. tablet=$0", tablet->tablet_id()));
 
+    // Clone and restore replace the tablet uid. Backfill schemas missing from legacy rowset metas
+    // before _add_tablet_unlocked() persists them under the new uid via TabletMeta::_save_meta().
+    if (need_persist_schema) {
+        static_cast<void>(tablet->set_tablet_schema_into_rowset_meta());
+    }
+
     RuntimeProfile profile("CreateTablet");
     std::lock_guard<std::shared_mutex> wrlock(_get_tablets_shard_lock(tablet_id));
     RETURN_NOT_OK_STATUS_WITH_WARN(
@@ -989,6 +998,10 @@ Status TabletManager::load_tablet_from_dir(DataDir* store, TTabletId tablet_id,
     if (!tablet_meta->create_from_file(header_path).ok()) {
         return Status::Error<ENGINE_LOAD_INDEX_TABLE_ERROR>(
                 "fail to load tablet_meta. file_path={}", header_path);
+    }
+    if (tablet_meta->tablet_schema_saved()) {
+        return Status::Error<ENGINE_LOAD_INDEX_TABLE_ERROR>(
+                "tablet header is not self-contained. tablet={}", tablet_id);
     }
     TabletUid tablet_uid = TabletUid::gen_uid();
 
@@ -1054,10 +1067,10 @@ Status TabletManager::load_tablet_from_dir(DataDir* store, TTabletId tablet_id,
     // should change tablet uid when tablet object changed
     tablet_meta->set_tablet_uid(std::move(tablet_uid));
     std::string meta_binary;
-    tablet_meta->serialize(&meta_binary);
+    tablet_meta->serialize(&meta_binary, false);
     RETURN_NOT_OK_STATUS_WITH_WARN(
             load_tablet_from_meta(store, tablet_id, schema_hash, meta_binary, true, force, restore,
-                                  true),
+                                  true, true),
             absl::Substitute("fail to load tablet. header_path=$0", header_path));
 
     return Status::OK();
@@ -1236,6 +1249,27 @@ bool TabletManager::_move_tablet_to_trash(const TabletSharedPtr& tablet) {
     RETURN_IF_ERROR(register_transition_tablet(tablet->tablet_id(), "move to trash"));
     Defer defer {[&]() { unregister_transition_tablet(tablet->tablet_id(), "move to trash"); }};
 
+    auto remove_rowset_schemas = [&tablet]() {
+        Status status = RowsetMetaManager::remove_schemas(tablet->data_dir()->get_meta(),
+                                                          tablet->tablet_id(), tablet->tablet_uid(),
+                                                          tablet->schema_hash());
+        if (!status.ok()) {
+            LOG(WARNING) << "failed to remove rowset schemas while dropping tablet. tablet="
+                         << tablet->tablet_id() << ", tablet_uid=" << tablet->tablet_uid()
+                         << ", status=" << status;
+            return false;
+        }
+        return true;
+    };
+    auto remove_separated_schemas = [&tablet, &remove_rowset_schemas]() {
+        Status status = TabletMetaManager::remove_schema(tablet->data_dir(), tablet->tablet_id(),
+                                                         tablet->schema_hash());
+        if (!status.ok() && !status.is<META_KEY_NOT_FOUND>()) {
+            return false;
+        }
+        return remove_rowset_schemas();
+    };
+
     TabletSharedPtr tablet_in_not_shutdown = get_tablet(tablet->tablet_id());
     if (tablet_in_not_shutdown) {
         TSchemaHash schema_hash_not_shutdown = tablet_in_not_shutdown->schema_hash();
@@ -1249,14 +1283,17 @@ bool TabletManager::_move_tablet_to_trash(const TabletSharedPtr& tablet) {
                           << tablet_in_not_shutdown->tablet_id()
                           << ", mem manager tablet path=" << tablet_in_not_shutdown->tablet_path()
                           << ", shutdown tablet path=" << tablet->tablet_path();
-                return tablet->data_dir()->move_to_trash(tablet->tablet_path());
+                if (!tablet->data_dir()->move_to_trash(tablet->tablet_path())) {
+                    return false;
+                }
             } else {
                 LOG(INFO) << "tablet path eq shutdown tablet path, not move to trash, tablet_id="
                           << tablet_in_not_shutdown->tablet_id()
                           << ", mem manager tablet path=" << tablet_in_not_shutdown->tablet_path()
                           << ", shutdown tablet path=" << tablet->tablet_path();
-                return true;
             }
+            return tablet_in_not_shutdown->tablet_uid() == tablet->tablet_uid() ||
+                   remove_rowset_schemas();
         }
     }
 
@@ -1272,7 +1309,7 @@ bool TabletManager::_move_tablet_to_trash(const TabletSharedPtr& tablet) {
                          << " schema hash = " << tablet_meta->schema_hash()
                          << " old tablet_uid=" << tablet->tablet_uid()
                          << " cur tablet_uid=" << tablet_meta->tablet_uid();
-            return true;
+            return tablet_meta->tablet_uid() == tablet->tablet_uid() || remove_rowset_schemas();
         }
 
         tablet->clear_cache();
@@ -1313,6 +1350,10 @@ bool TabletManager::_move_tablet_to_trash(const TabletSharedPtr& tablet) {
                          << ", tablet_uid=" << tablet_meta->tablet_uid() << ", error=" << remove_st;
             return false;
         }
+
+        if (!remove_rowset_schemas()) {
+            return false;
+        }
         LOG(INFO) << "successfully move tablet to trash. "
                   << "tablet_id=" << tablet->tablet_id()
                   << ", schema_hash=" << tablet->schema_hash() << ", tablet_path=" << tablet_path;
@@ -1334,7 +1375,7 @@ bool TabletManager::_move_tablet_to_trash(const TabletSharedPtr& tablet) {
                           << ", delete tablet_path=" << tablet_path;
                 RETURN_IF_ERROR(io::global_local_filesystem()->delete_directory(tablet_path));
                 RETURN_IF_ERROR(DataDir::delete_tablet_parent_path_if_empty(tablet_path));
-                return true;
+                return remove_separated_schemas();
             }
             LOG(WARNING) << "errors while load meta from store, skip this tablet. "
                          << "tablet_id=" << tablet->tablet_id()
@@ -1345,7 +1386,7 @@ bool TabletManager::_move_tablet_to_trash(const TabletSharedPtr& tablet) {
                       << "tablet_id=" << tablet->tablet_id()
                       << ", schema_hash=" << tablet->schema_hash()
                       << ", tablet_path=" << tablet_path;
-            return true;
+            return !check_st.is<META_KEY_NOT_FOUND>() || remove_separated_schemas();
         }
     }
 }

--- a/be/src/storage/tablet/tablet_manager.h
+++ b/be/src/storage/tablet/tablet_manager.h
@@ -128,7 +128,8 @@ public:
     //   where we should change tablet status from shutdown back to running
     Status load_tablet_from_meta(DataDir* data_dir, TTabletId tablet_id, TSchemaHash schema_hash,
                                  std::string_view header, bool update_meta, bool force = false,
-                                 bool restore = false, bool check_path = true);
+                                 bool restore = false, bool check_path = true,
+                                 bool need_persist_schema = false);
 
     Status load_tablet_from_dir(DataDir* data_dir, TTabletId tablet_id, SchemaHash schema_hash,
                                 const std::string& schema_hash_path, bool force = false,

--- a/be/src/storage/tablet/tablet_meta.cpp
+++ b/be/src/storage/tablet/tablet_meta.cpp
@@ -29,6 +29,7 @@
 #include <time.h>
 
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <random>
 #include <ranges>
@@ -38,6 +39,7 @@
 #include "cloud/cloud_meta_mgr.h"
 #include "cloud/cloud_storage_engine.h"
 #include "cloud/config.h"
+#include "common/check.h"
 #include "common/config.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
@@ -712,10 +714,35 @@ Status TabletMeta::_save_meta(DataDir* data_dir) {
         LOG(FATAL) << "tablet_uid is invalid"
                    << " tablet=" << tablet_id() << " _tablet_uid=" << _tablet_uid.to_string();
     }
+
+    if (!_tablet_schema_saved) {
+        std::map<int32_t, TabletSchemaSPtr> rowset_schemas;
+        for (const auto& [_, rowset_meta] : _rs_metas) {
+            DORIS_CHECK(rowset_meta->tablet_schema() != nullptr);
+            rowset_schemas[rowset_meta->tablet_schema()->schema_version()] =
+                    rowset_meta->tablet_schema();
+        }
+        for (const auto& [_, rowset_meta] : _stale_rs_metas) {
+            DORIS_CHECK(rowset_meta->tablet_schema() != nullptr);
+            rowset_schemas[rowset_meta->tablet_schema()->schema_version()] =
+                    rowset_meta->tablet_schema();
+        }
+        for (const auto& [_, schema] : rowset_schemas) {
+            RETURN_IF_ERROR(RowsetMetaManager::save_schema(data_dir->get_meta(), tablet_id(),
+                                                           tablet_uid(), schema_hash(), schema));
+        }
+
+        TabletSchemaPB schema_pb;
+        _schema->to_schema_pb(&schema_pb);
+        RETURN_IF_ERROR(TabletMetaManager::save_schema(
+                data_dir, tablet_id(), schema_hash(),
+                TabletSchema::deterministic_string_serialize(schema_pb)));
+        _tablet_schema_saved = true;
+    }
     string meta_binary;
 
     auto t1 = MonotonicMicros();
-    serialize(&meta_binary);
+    serialize(&meta_binary, true);
     auto t2 = MonotonicMicros();
     Status status = TabletMetaManager::save(data_dir, tablet_id(), schema_hash(), meta_binary);
     if (!status.ok()) {
@@ -732,9 +759,9 @@ Status TabletMeta::_save_meta(DataDir* data_dir) {
     return status;
 }
 
-void TabletMeta::serialize(string* meta_binary) {
+void TabletMeta::serialize(string* meta_binary, bool skip_schema) {
     TabletMetaPB tablet_meta_pb;
-    to_meta_pb(&tablet_meta_pb, false);
+    to_meta_pb(&tablet_meta_pb, false, skip_schema);
     if (tablet_meta_pb.partition_id() <= 0) {
         LOG(WARNING) << "invalid partition id " << tablet_meta_pb.partition_id() << " tablet "
                      << tablet_meta_pb.tablet_id();
@@ -770,18 +797,71 @@ void TabletMeta::serialize(string* meta_binary) {
     }
 }
 
-Status TabletMeta::deserialize(std::string_view meta_binary) {
+Status TabletMeta::deserialize(DataDir* data_dir, std::string_view meta_binary) {
     TabletMetaPB tablet_meta_pb;
     bool parsed = tablet_meta_pb.ParseFromArray(meta_binary.data(),
                                                 static_cast<int32_t>(meta_binary.size()));
     if (!parsed) {
         return Status::Error<INIT_FAILED>("parse tablet meta failed");
     }
-    init_from_pb(tablet_meta_pb);
+    std::map<int32_t, std::string> version_to_schema;
+    if (tablet_meta_pb.tablet_schema_saved()) {
+        if (data_dir == nullptr) {
+            return Status::Error<INIT_FAILED>(
+                    "data dir is required to load separated tablet schema. tablet={}",
+                    tablet_meta_pb.tablet_id());
+        }
+
+        std::string tablet_schema_binary;
+        RETURN_IF_ERROR(TabletMetaManager::get_schema(data_dir, tablet_meta_pb.tablet_id(),
+                                                      tablet_meta_pb.schema_hash(),
+                                                      &tablet_schema_binary));
+        if (!tablet_meta_pb.mutable_schema()->ParseFromString(tablet_schema_binary)) {
+            return Status::Error<INIT_FAILED>("parse separated tablet schema failed. tablet={}",
+                                              tablet_meta_pb.tablet_id());
+        }
+
+        // Reuse the tablet schema while loading TabletMeta. The rowset-schema key is still kept
+        // because standalone rowset metas are recovered without a TabletMeta context.
+        version_to_schema[tablet_meta_pb.schema().schema_version()] = tablet_schema_binary;
+
+        auto load_rowset_schema = [&](const RowsetMetaPB& rowset_meta_pb) -> Status {
+            if (rowset_meta_pb.has_tablet_schema()) {
+                return Status::OK();
+            }
+            if (!rowset_meta_pb.has_schema_version()) {
+                return Status::Error<INIT_FAILED>(
+                        "schema version is missing from separated rowset meta. tablet={}, "
+                        "rowset={}",
+                        tablet_meta_pb.tablet_id(), rowset_meta_pb.rowset_id_v2());
+            }
+            if (version_to_schema.contains(rowset_meta_pb.schema_version())) {
+                return Status::OK();
+            }
+            std::string rowset_schema_binary;
+            RETURN_IF_ERROR(RowsetMetaManager::get_rowset_schema(
+                    data_dir->get_meta(), tablet_meta_pb.tablet_id(),
+                    TabletUid(tablet_meta_pb.tablet_uid()), tablet_meta_pb.schema_hash(),
+                    rowset_meta_pb.schema_version(), &rowset_schema_binary));
+            version_to_schema.emplace(rowset_meta_pb.schema_version(),
+                                      std::move(rowset_schema_binary));
+            return Status::OK();
+        };
+        for (const auto& rowset_meta_pb : tablet_meta_pb.rs_metas()) {
+            RETURN_IF_ERROR(load_rowset_schema(rowset_meta_pb));
+        }
+        for (const auto& rowset_meta_pb : tablet_meta_pb.stale_rs_metas()) {
+            RETURN_IF_ERROR(load_rowset_schema(rowset_meta_pb));
+        }
+    }
+
+    init_from_pb(tablet_meta_pb,
+                 tablet_meta_pb.tablet_schema_saved() ? &version_to_schema : nullptr);
     return Status::OK();
 }
 
-void TabletMeta::init_from_pb(const TabletMetaPB& tablet_meta_pb) {
+void TabletMeta::init_from_pb(const TabletMetaPB& tablet_meta_pb,
+                              const std::map<int32_t, std::string>* version_to_schema) {
     _table_id = tablet_meta_pb.table_id();
     _index_id = tablet_meta_pb.index_id();
     _partition_id = tablet_meta_pb.partition_id();
@@ -792,6 +872,7 @@ void TabletMeta::init_from_pb(const TabletMetaPB& tablet_meta_pb) {
     _creation_time = tablet_meta_pb.creation_time();
     _cumulative_layer_point = tablet_meta_pb.cumulative_layer_point();
     _tablet_uid = TabletUid(tablet_meta_pb.tablet_uid());
+    _tablet_schema_saved = tablet_meta_pb.tablet_schema_saved();
     _ttl_seconds = tablet_meta_pb.ttl_seconds();
     if (tablet_meta_pb.has_tablet_type()) {
         _tablet_type = tablet_meta_pb.tablet_type();
@@ -839,7 +920,7 @@ void TabletMeta::init_from_pb(const TabletMetaPB& tablet_meta_pb) {
     // init _rs_metas
     for (auto& it : tablet_meta_pb.rs_metas()) {
         RowsetMetaSharedPtr rs_meta(new RowsetMeta());
-        rs_meta->init_from_pb(it);
+        rs_meta->init_from_pb(it, version_to_schema);
         _rs_metas.emplace(rs_meta->version(), rs_meta);
     }
 
@@ -849,7 +930,7 @@ void TabletMeta::init_from_pb(const TabletMetaPB& tablet_meta_pb) {
     if (!config::skip_loading_stale_rowset_meta && !_enable_unique_key_merge_on_write) {
         for (auto& it : tablet_meta_pb.stale_rs_metas()) {
             RowsetMetaSharedPtr rs_meta(new RowsetMeta());
-            rs_meta->init_from_pb(it);
+            rs_meta->init_from_pb(it, version_to_schema);
             _stale_rs_metas.emplace(rs_meta->version(), rs_meta);
         }
     }
@@ -907,7 +988,9 @@ void TabletMeta::init_from_pb(const TabletMetaPB& tablet_meta_pb) {
     }
 }
 
-void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb, bool cloud_get_rowset_meta) {
+void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb, bool cloud_get_rowset_meta,
+                            bool skip_schema) {
+    DORIS_CHECK(!skip_schema || _tablet_schema_saved);
     tablet_meta_pb->set_table_id(table_id());
     tablet_meta_pb->set_index_id(index_id());
     tablet_meta_pb->set_partition_id(partition_id());
@@ -920,6 +1003,7 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb, bool cloud_get_rowset_
     *(tablet_meta_pb->mutable_tablet_uid()) = tablet_uid().to_proto();
     tablet_meta_pb->set_tablet_type(_tablet_type);
     tablet_meta_pb->set_ttl_seconds(_ttl_seconds);
+    tablet_meta_pb->set_tablet_schema_saved(skip_schema && _tablet_schema_saved);
     switch (tablet_state()) {
     case TABLET_NOTREADY:
         tablet_meta_pb->set_tablet_state(PB_NOTREADY);
@@ -941,14 +1025,16 @@ void TabletMeta::to_meta_pb(TabletMetaPB* tablet_meta_pb, bool cloud_get_rowset_
     // RowsetMetaPB is separated from TabletMetaPB
     if (!config::is_cloud_mode() || cloud_get_rowset_meta) {
         for (const auto& [_, rs] : _rs_metas) {
-            rs->to_rowset_pb(tablet_meta_pb->add_rs_metas());
+            rs->to_rowset_pb(tablet_meta_pb->add_rs_metas(), skip_schema);
         }
         for (const auto& [_, rs] : _stale_rs_metas) {
-            rs->to_rowset_pb(tablet_meta_pb->add_stale_rs_metas());
+            rs->to_rowset_pb(tablet_meta_pb->add_stale_rs_metas(), skip_schema);
         }
     }
 
-    _schema->to_schema_pb(tablet_meta_pb->mutable_schema());
+    if (!_tablet_schema_saved || !skip_schema) {
+        _schema->to_schema_pb(tablet_meta_pb->mutable_schema());
+    }
 
     tablet_meta_pb->set_in_restore_mode(in_restore_mode());
 

--- a/be/src/storage/tablet/tablet_meta.h
+++ b/be/src/storage/tablet/tablet_meta.h
@@ -142,11 +142,14 @@ public:
                                                   int64_t tablet_id);
     Status save_meta(DataDir* data_dir);
 
-    void serialize(std::string* meta_binary);
-    Status deserialize(std::string_view meta_binary);
-    void init_from_pb(const TabletMetaPB& tablet_meta_pb);
+    void serialize(std::string* meta_binary, bool skip_schema = false);
+    Status deserialize(DataDir* data_dir, std::string_view meta_binary);
+    Status deserialize(std::string_view meta_binary) { return deserialize(nullptr, meta_binary); }
+    void init_from_pb(const TabletMetaPB& tablet_meta_pb,
+                      const std::map<int32_t, std::string>* version_to_schema = nullptr);
 
-    void to_meta_pb(TabletMetaPB* tablet_meta_pb, bool cloud_get_rowset_meta);
+    void to_meta_pb(TabletMetaPB* tablet_meta_pb, bool cloud_get_rowset_meta,
+                    bool skip_schema = false);
     void to_json(std::string* json_string, json2pb::Pb2JsonOptions& options);
     size_t tablet_columns_num() const { return _schema->num_columns(); }
 
@@ -332,6 +335,10 @@ public:
 
     int64_t avg_rs_meta_serialize_size() const { return _avg_rs_meta_serialize_size; }
 
+    bool tablet_schema_saved() const { return _tablet_schema_saved.load(); }
+
+    void set_tablet_schema_saved(bool schema_saved) { _tablet_schema_saved.store(schema_saved); }
+
     EncryptionAlgorithmPB encryption_algorithm() const { return _encryption_algorithm; }
 
 private:
@@ -394,6 +401,8 @@ private:
     int32_t _vertical_compaction_num_columns_per_group = 5;
 
     int64_t _avg_rs_meta_serialize_size = 0;
+
+    std::atomic_bool _tablet_schema_saved = false;
 
     // cloud
     int64_t _ttl_seconds = 0;

--- a/be/src/storage/tablet/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet/tablet_meta_manager.cpp
@@ -28,6 +28,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "common/check.h"
 #include "common/logging.h"
 #include "common/status.h"
 #include "json2pb/json_to_pb.h"
@@ -35,6 +36,7 @@
 #include "storage/data_dir.h"
 #include "storage/olap_define.h"
 #include "storage/olap_meta.h"
+#include "storage/rowset/rowset_meta_manager.h"
 #include "storage/utils.h"
 
 namespace rocksdb {
@@ -68,7 +70,7 @@ Status TabletMetaManager::get_meta(DataDir* store, TTabletId tablet_id, TSchemaH
                      << " failed.";
         return s;
     }
-    return tablet_meta->deserialize(value);
+    return tablet_meta->deserialize(store, value);
 }
 
 Status TabletMetaManager::get_json_meta(DataDir* store, TTabletId tablet_id,
@@ -89,9 +91,30 @@ Status TabletMetaManager::get_json_meta(DataDir* store, TTabletId tablet_id,
 // 2. save to local meta store
 Status TabletMetaManager::save(DataDir* store, TTabletId tablet_id, TSchemaHash schema_hash,
                                TabletMetaSharedPtr tablet_meta, std::string_view header_prefix) {
+    for (const auto& [_, rowset_meta] : tablet_meta->all_rs_metas()) {
+        DORIS_CHECK(rowset_meta->tablet_schema() != nullptr);
+        RETURN_IF_ERROR(RowsetMetaManager::save_schema(store->get_meta(), tablet_id,
+                                                       tablet_meta->tablet_uid(), schema_hash,
+                                                       rowset_meta->tablet_schema()));
+    }
+    for (const auto& [_, rowset_meta] : tablet_meta->all_stale_rs_metas()) {
+        DORIS_CHECK(rowset_meta->tablet_schema() != nullptr);
+        RETURN_IF_ERROR(RowsetMetaManager::save_schema(store->get_meta(), tablet_id,
+                                                       tablet_meta->tablet_uid(), schema_hash,
+                                                       rowset_meta->tablet_schema()));
+    }
+
+    if (!tablet_meta->tablet_schema_saved()) {
+        TabletSchemaPB schema_pb;
+        tablet_meta->tablet_schema()->to_schema_pb(&schema_pb);
+        RETURN_IF_ERROR(save_schema(store, tablet_id, schema_hash,
+                                    TabletSchema::deterministic_string_serialize(schema_pb)));
+        tablet_meta->set_tablet_schema_saved(true);
+    }
+
     std::string key = fmt::format("{}{}_{}", header_prefix, tablet_id, schema_hash);
     std::string value;
-    tablet_meta->serialize(&value);
+    tablet_meta->serialize(&value, true);
     if (tablet_meta->partition_id() <= 0) {
         LOG(WARNING) << "invalid partition id " << tablet_meta->partition_id() << " tablet "
                      << tablet_meta->tablet_id();
@@ -114,6 +137,34 @@ Status TabletMetaManager::save(DataDir* store, TTabletId tablet_id, TSchemaHash 
     return meta->put(META_COLUMN_FAMILY_INDEX, key, meta_binary);
 }
 
+Status TabletMetaManager::save_schema(DataDir* store, TTabletId tablet_id, TSchemaHash schema_hash,
+                                      const std::string& schema_binary) {
+    std::string key = fmt::format("{}{}_{}", TABLET_SCHEMA_PREFIX, tablet_id, schema_hash);
+    return store->get_meta()->put(META_COLUMN_FAMILY_INDEX, key, schema_binary);
+}
+
+Status TabletMetaManager::get_schema(DataDir* store, TTabletId tablet_id, TSchemaHash schema_hash,
+                                     std::string* schema_binary) {
+    std::string key = fmt::format("{}{}_{}", TABLET_SCHEMA_PREFIX, tablet_id, schema_hash);
+    Status status = store->get_meta()->get(META_COLUMN_FAMILY_INDEX, key, schema_binary);
+    if (!status.ok()) {
+        LOG(WARNING) << "failed to get tablet schema. tablet=" << tablet_id << ", key=" << key
+                     << ", status=" << status;
+    }
+    return status;
+}
+
+Status TabletMetaManager::remove_schema(DataDir* store, TTabletId tablet_id,
+                                        TSchemaHash schema_hash) {
+    const std::string key = fmt::format("{}{}_{}", TABLET_SCHEMA_PREFIX, tablet_id, schema_hash);
+    Status status = store->get_meta()->remove(META_COLUMN_FAMILY_INDEX, key);
+    if (!status.ok() && !status.is<META_KEY_NOT_FOUND>()) {
+        LOG(WARNING) << "failed to remove tablet schema. tablet=" << tablet_id << ", key=" << key
+                     << ", status=" << status;
+    }
+    return status;
+}
+
 // TODO(ygl):
 // 1. remove load data first
 // 2. remove from load meta store using term if term > 0
@@ -123,6 +174,12 @@ Status TabletMetaManager::remove(DataDir* store, TTabletId tablet_id, TSchemaHas
     OlapMeta* meta = store->get_meta();
     Status res = meta->remove(META_COLUMN_FAMILY_INDEX, key);
     VLOG_NOTICE << "remove tablet_meta, key:" << key << ", res:" << res;
+    if (res.ok() && header_prefix == HEADER_PREFIX) {
+        Status schema_status = remove_schema(store, tablet_id, schema_hash);
+        if (!schema_status.ok() && !schema_status.is<META_KEY_NOT_FOUND>()) {
+            return schema_status;
+        }
+    }
     return res;
 }
 

--- a/be/src/storage/tablet/tablet_meta_manager.h
+++ b/be/src/storage/tablet/tablet_meta_manager.h
@@ -53,6 +53,12 @@ public:
                        const std::string& meta_binary,
                        std::string_view header_prefix = HEADER_PREFIX);
 
+    static Status save_schema(DataDir* store, TTabletId tablet_id, TSchemaHash schema_hash,
+                              const std::string& schema_binary);
+    static Status get_schema(DataDir* store, TTabletId tablet_id, TSchemaHash schema_hash,
+                             std::string* schema_binary);
+    static Status remove_schema(DataDir* store, TTabletId tablet_id, TSchemaHash schema_hash);
+
     static Status remove(DataDir* store, TTabletId tablet_id, TSchemaHash schema_hash,
                          std::string_view header_prefix = HEADER_PREFIX);
 

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -748,6 +748,10 @@ Status EngineCloneTask::_finish_clone(Tablet* tablet, const std::string& clone_d
     auto cloned_tablet_meta_file = fmt::format("{}/{}.hdr", clone_dir, tablet->tablet_id());
     auto cloned_tablet_meta = std::make_shared<TabletMeta>();
     RETURN_IF_ERROR(cloned_tablet_meta->create_from_file(cloned_tablet_meta_file));
+    if (cloned_tablet_meta->tablet_schema_saved()) {
+        return Status::Error<ENGINE_LOAD_INDEX_TABLE_ERROR>(
+                "cloned tablet header is not self-contained. tablet={}", tablet->tablet_id());
+    }
 
     // remove the cloned meta file
     RETURN_IF_ERROR(io::global_local_filesystem()->delete_file(cloned_tablet_meta_file));

--- a/be/src/storage/txn/txn_manager.cpp
+++ b/be/src/storage/txn/txn_manager.cpp
@@ -378,15 +378,14 @@ Status TxnManager::commit_txn(OlapMeta* meta, TPartitionId partition_id,
     // it is under a single txn lock
     if (!is_recovery) {
         std::optional<BinlogFormatPB> binlog_format;
-        std::optional<RowsetMetaPB> attach_row_binlog_rowset_meta;
+        const RowsetMeta* attach_row_binlog_rowset_meta = nullptr;
         if (attach_row_binlog.rowset != nullptr) {
-            attach_row_binlog_rowset_meta =
-                    attach_row_binlog.rowset->rowset_meta()->get_rowset_pb();
+            attach_row_binlog_rowset_meta = attach_row_binlog.rowset->rowset_meta().get();
             binlog_format = BinlogFormatPB::ROW;
         }
         Status save_status = RowsetMetaManager::save(meta, tablet_uid, rowset_ptr->rowset_id(),
-                                                     rowset_ptr->rowset_meta()->get_rowset_pb(),
-                                                     binlog_format, attach_row_binlog_rowset_meta);
+                                                     *rowset_ptr->rowset_meta(), binlog_format,
+                                                     attach_row_binlog_rowset_meta);
         DBUG_EXECUTE_IF("TxnManager.RowsetMetaManager.save_wait", {
             if (auto wait = dp->param<int>("duration", 0); wait > 0) {
                 LOG_WARNING("TxnManager.RowsetMetaManager.save_wait")
@@ -628,18 +627,18 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
         }
     }
 
-    std::optional<RowsetMetaPB> attach_row_binlog_rowset_meta;
+    const RowsetMeta* attach_row_binlog_rowset_meta = nullptr;
     if (tablet_txn_info->attach_row_binlog.rowset != nullptr) {
         attach_row_binlog_rowset_meta =
-                tablet_txn_info->attach_row_binlog.rowset->rowset_meta()->get_rowset_pb();
+                tablet_txn_info->attach_row_binlog.rowset->rowset_meta().get();
         binlog_format = BinlogFormatPB::ROW;
     }
 
     /// Step 4: save meta
     int64_t t5 = MonotonicMicros();
-    auto status = RowsetMetaManager::save(meta, tablet_uid, rowset->rowset_id(),
-                                          rowset->rowset_meta()->get_rowset_pb(), binlog_format,
-                                          attach_row_binlog_rowset_meta);
+    auto status =
+            RowsetMetaManager::save(meta, tablet_uid, rowset->rowset_id(), *rowset->rowset_meta(),
+                                    binlog_format, attach_row_binlog_rowset_meta);
     stats->save_meta_time_us += MonotonicMicros() - t5;
     if (!status.ok()) {
         status.append(fmt::format(", txn id: {}", transaction_id));

--- a/be/test/storage/index/inverted/common/inverted_index_gc_binlogs_test.cpp
+++ b/be/test/storage/index/inverted/common/inverted_index_gc_binlogs_test.cpp
@@ -163,8 +163,8 @@ TEST_F(IndexGcBinglogsTest, gc_binlogs_test) {
         EXPECT_TRUE(rowset->add_to_binlog().ok());
         EXPECT_TRUE(_tablet->add_rowset(rowset).ok());
         EXPECT_TRUE(RowsetMetaManager::save(_data_dir->get_meta(), _tablet->tablet_uid(),
-                                            rowset->rowset_id(),
-                                            rowset->rowset_meta()->get_rowset_pb(), true)
+                                            rowset->rowset_id(), *rowset->rowset_meta(),
+                                            BinlogFormatPB::STATEMENT_AND_SNAPSHOT)
                             .ok());
         _tablet->save_meta();
         _tablet->gc_binlogs(0);

--- a/be/test/storage/path_gc_test.cpp
+++ b/be/test/storage/path_gc_test.cpp
@@ -158,7 +158,7 @@ TEST(PathGcTest, GcTabletAndRowset) {
         st = create_rowset_files(*rs, false);
         ASSERT_TRUE(st.ok()) << st;
         st = RowsetMetaManager::save(data_dir.get_meta(), rs->rowset_meta()->tablet_uid(),
-                                     rs->rowset_id(), rs->rowset_meta()->get_rowset_pb(), false);
+                                     rs->rowset_id(), *rs->rowset_meta());
         ASSERT_TRUE(st.ok()) << st;
     }
     // Prepare garbage rowset files

--- a/be/test/storage/rowset/rowset_meta_manager_test.cpp
+++ b/be/test/storage/rowset/rowset_meta_manager_test.cpp
@@ -28,8 +28,8 @@
 #include <filesystem>
 #include <fstream>
 #include <map>
+#include <memory>
 #include <new>
-#include <set>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -37,10 +37,12 @@
 #include "common/config.h"
 #include "gtest/gtest_pred_impl.h"
 #include "runtime/exec_env.h"
+#include "storage/binlog.h"
 #include "storage/olap_define.h"
 #include "storage/olap_meta.h"
 #include "storage/options.h"
 #include "storage/storage_engine.h"
+#include "storage/tablet/tablet_schema.h"
 #include "util/uid_util.h"
 
 using ::testing::_;
@@ -84,6 +86,30 @@ public:
     }
 
 protected:
+    TabletSchemaSPtr create_tablet_schema(bool with_variant = false, int32_t schema_version = 1) {
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(KeysType::DUP_KEYS);
+        schema_pb.set_schema_version(schema_version);
+
+        auto* key_column = schema_pb.add_column();
+        key_column->set_unique_id(0);
+        key_column->set_name("k");
+        key_column->set_type("INT");
+        key_column->set_is_key(true);
+        key_column->set_is_nullable(false);
+
+        auto* value_column = schema_pb.add_column();
+        value_column->set_unique_id(1);
+        value_column->set_name("v");
+        value_column->set_type(with_variant ? "VARIANT" : "INT");
+        value_column->set_is_key(false);
+        value_column->set_is_nullable(true);
+
+        auto schema = std::make_shared<TabletSchema>();
+        schema->init_from_pb(schema_pb);
+        return schema;
+    }
+
     RowsetMetaSharedPtr create_rowset_meta(int64_t rowset_id, RowsetStatePB state, Version version,
                                            bool is_row_binlog = false) {
         auto rowset_meta = std::make_shared<RowsetMeta>();
@@ -94,18 +120,11 @@ protected:
         rowset_meta->set_tablet_uid(_tablet_uid);
         rowset_meta->set_rowset_state(state);
         rowset_meta->set_version(version);
+        rowset_meta->set_tablet_schema(create_tablet_schema());
         if (is_row_binlog) {
             rowset_meta->mark_row_binlog();
         }
         return rowset_meta;
-    }
-
-    RowsetMetaPB to_rowset_meta_pb(const RowsetMetaSharedPtr& rowset_meta) {
-        std::string serialized;
-        EXPECT_TRUE(rowset_meta->serialize(&serialized));
-        RowsetMetaPB rowset_meta_pb;
-        EXPECT_TRUE(rowset_meta_pb.ParseFromString(serialized));
-        return rowset_meta_pb;
     }
 
     OlapMeta* meta() { return _meta; }
@@ -123,8 +142,8 @@ TEST_F(RowsetMetaManagerTest, SaveAndLoad) {
             create_rowset_meta(20001, RowsetStatePB::COMMITTED, Version {7, 7}, true);
 
     auto st = RowsetMetaManager::save(meta(), tablet_uid(), base_rowset_meta->rowset_id(),
-                                      to_rowset_meta_pb(base_rowset_meta), BinlogFormatPB::ROW,
-                                      to_rowset_meta_pb(attach_rowset_meta));
+                                      *base_rowset_meta, BinlogFormatPB::ROW,
+                                      attach_rowset_meta.get());
     ASSERT_TRUE(st.ok()) << st;
 
     RowsetMetaSharedPtr loaded_base_meta = std::make_shared<RowsetMeta>();
@@ -145,14 +164,41 @@ TEST_F(RowsetMetaManagerTest, SaveAndLoad) {
     EXPECT_TRUE(loaded_attach_meta->is_row_binlog());
 }
 
+TEST_F(RowsetMetaManagerTest, VariantSchemaRemainsInline) {
+    auto rowset_meta = create_rowset_meta(20002, RowsetStatePB::VISIBLE, Version {8, 8});
+    rowset_meta->set_tablet_schema(create_tablet_schema(true, 10));
+
+    RowsetMetaPB rowset_meta_pb = rowset_meta->get_rowset_pb(true);
+    EXPECT_TRUE(rowset_meta_pb.has_tablet_schema());
+    EXPECT_TRUE(rowset_meta_pb.has_variant_type_in_schema());
+    EXPECT_EQ(rowset_meta_pb.schema_version(), 10);
+}
+
+TEST_F(RowsetMetaManagerTest, VariantSchemaIsNotPersistedSeparately) {
+    auto rowset_meta = create_rowset_meta(20003, RowsetStatePB::VISIBLE, Version {9, 9});
+    rowset_meta->set_tablet_schema(create_tablet_schema(true, 11));
+
+    auto st = RowsetMetaManager::save(meta(), tablet_uid(), rowset_meta->rowset_id(), *rowset_meta);
+    ASSERT_TRUE(st.ok()) << st;
+    EXPECT_FALSE(RowsetMetaManager::schema_exists(meta(), tablet_uid(),
+                                                  rowset_meta->tablet_schema_hash(), 11));
+
+    RowsetMetaSharedPtr loaded_rowset_meta = std::make_shared<RowsetMeta>();
+    st = RowsetMetaManager::get_rowset_meta(meta(), tablet_uid(), rowset_meta->rowset_id(),
+                                            loaded_rowset_meta);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_NE(loaded_rowset_meta->tablet_schema(), nullptr);
+    EXPECT_EQ(loaded_rowset_meta->tablet_schema()->num_variant_columns(), 1U);
+}
+
 TEST_F(RowsetMetaManagerTest, Remove) {
     auto base_rowset_meta = create_rowset_meta(20010, RowsetStatePB::VISIBLE, Version {9, 9});
     auto attach_rowset_meta =
             create_rowset_meta(20011, RowsetStatePB::VISIBLE, Version {9, 9}, true);
 
     auto st = RowsetMetaManager::save(meta(), tablet_uid(), base_rowset_meta->rowset_id(),
-                                      to_rowset_meta_pb(base_rowset_meta), BinlogFormatPB::ROW,
-                                      to_rowset_meta_pb(attach_rowset_meta));
+                                      *base_rowset_meta, BinlogFormatPB::ROW,
+                                      attach_rowset_meta.get());
     ASSERT_TRUE(st.ok()) << st;
 
     st = RowsetMetaManager::exists(meta(), tablet_uid(), attach_rowset_meta->rowset_id());
@@ -167,14 +213,66 @@ TEST_F(RowsetMetaManagerTest, Remove) {
     auto attach_rowset_meta_2 =
             create_rowset_meta(20013, RowsetStatePB::VISIBLE, Version {10, 10}, true);
     st = RowsetMetaManager::save(meta(), tablet_uid(), base_rowset_meta_2->rowset_id(),
-                                 to_rowset_meta_pb(base_rowset_meta_2), BinlogFormatPB::ROW,
-                                 to_rowset_meta_pb(attach_rowset_meta_2));
+                                 *base_rowset_meta_2, BinlogFormatPB::ROW,
+                                 attach_rowset_meta_2.get());
     ASSERT_TRUE(st.ok()) << st;
 
     st = RowsetMetaManager::remove(meta(), tablet_uid(), attach_rowset_meta_2->rowset_id());
     ASSERT_TRUE(st.ok()) << st;
     EXPECT_TRUE(RowsetMetaManager::exists(meta(), tablet_uid(), attach_rowset_meta_2->rowset_id())
                         .is<ErrorCode::META_KEY_NOT_FOUND>());
+}
+
+TEST_F(RowsetMetaManagerTest, CcrBinlogDataAddsSchemaOnExport) {
+    auto rowset_meta = create_rowset_meta(20014, RowsetStatePB::VISIBLE, Version {11, 11});
+    ASSERT_TRUE(RowsetMetaManager::save(meta(), tablet_uid(), rowset_meta->rowset_id(),
+                                        *rowset_meta, BinlogFormatPB::STATEMENT_AND_SNAPSHOT)
+                        .ok());
+
+    const std::string binlog_data_key =
+            make_binlog_data_key(tablet_uid(), 11, rowset_meta->rowset_id());
+    std::string stored_binlog_data;
+    ASSERT_TRUE(meta()->get(META_COLUMN_FAMILY_INDEX, binlog_data_key, &stored_binlog_data).ok());
+    RowsetMetaPB stored_binlog_rowset_meta_pb;
+    ASSERT_TRUE(stored_binlog_rowset_meta_pb.ParseFromString(stored_binlog_data));
+    EXPECT_FALSE(stored_binlog_rowset_meta_pb.has_tablet_schema());
+
+    ASSERT_TRUE(RowsetMetaManager::remove(meta(), tablet_uid(), rowset_meta->rowset_id()).ok());
+    std::string binlog_data = RowsetMetaManager::get_rowset_binlog_meta(
+            meta(), tablet_uid(), "11", rowset_meta->rowset_id().to_string());
+    RowsetMetaPB binlog_rowset_meta_pb;
+    ASSERT_TRUE(binlog_rowset_meta_pb.ParseFromString(binlog_data));
+    EXPECT_TRUE(binlog_rowset_meta_pb.has_tablet_schema());
+
+    RowsetBinlogMetasPB binlog_metas_pb;
+    ASSERT_TRUE(
+            RowsetMetaManager::get_rowset_binlog_metas(meta(), tablet_uid(), {11}, &binlog_metas_pb)
+                    .ok());
+    ASSERT_EQ(binlog_metas_pb.rowset_binlog_metas_size(), 1);
+    RowsetMetaPB snapshot_binlog_rowset_meta_pb;
+    ASSERT_TRUE(snapshot_binlog_rowset_meta_pb.ParseFromString(
+            binlog_metas_pb.rowset_binlog_metas(0).data()));
+    EXPECT_TRUE(snapshot_binlog_rowset_meta_pb.has_tablet_schema());
+}
+
+TEST_F(RowsetMetaManagerTest, RemoveSchemas) {
+    auto rowset_meta = create_rowset_meta(20020, RowsetStatePB::VISIBLE, Version {11, 11});
+    const auto tablet_id = rowset_meta->tablet_id();
+    const auto schema_hash = rowset_meta->tablet_schema_hash();
+    for (int32_t schema_version : {1, 2, 3}) {
+        auto tablet_schema = std::make_shared<TabletSchema>();
+        tablet_schema->copy_from(*rowset_meta->tablet_schema());
+        tablet_schema->set_schema_version(schema_version);
+        ASSERT_TRUE(RowsetMetaManager::save_schema(meta(), tablet_id, tablet_uid(), schema_hash,
+                                                   tablet_schema)
+                            .ok());
+    }
+
+    ASSERT_TRUE(
+            RowsetMetaManager::remove_schemas(meta(), tablet_id, tablet_uid(), schema_hash).ok());
+    EXPECT_FALSE(RowsetMetaManager::schema_exists(meta(), tablet_uid(), schema_hash, 1));
+    EXPECT_FALSE(RowsetMetaManager::schema_exists(meta(), tablet_uid(), schema_hash, 2));
+    EXPECT_FALSE(RowsetMetaManager::schema_exists(meta(), tablet_uid(), schema_hash, 3));
 }
 
 } // namespace doris

--- a/be/test/storage/rowset/rowset_meta_test.cpp
+++ b/be/test/storage/rowset/rowset_meta_test.cpp
@@ -25,6 +25,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <memory>
 #include <new>
 #include <string>
 
@@ -33,6 +34,7 @@
 #include "gtest/gtest_pred_impl.h"
 #include "storage/olap_common.h"
 #include "storage/olap_meta.h"
+#include "storage/tablet/tablet_schema.h"
 
 using ::testing::_;
 using ::testing::Return;

--- a/be/test/storage/tablet/tablet_meta_manager_test.cpp
+++ b/be/test/storage/tablet/tablet_meta_manager_test.cpp
@@ -17,6 +17,7 @@
 
 #include "storage/tablet/tablet_meta_manager.h"
 
+#include <fmt/format.h>
 #include <gen_cpp/olap_file.pb.h>
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
@@ -33,6 +34,9 @@
 
 #include "gtest/gtest_pred_impl.h"
 #include "storage/data_dir.h"
+#include "storage/olap_define.h"
+#include "storage/olap_meta.h"
+#include "storage/rowset/rowset_meta_manager.h"
 #include "storage/storage_engine.h"
 using std::string;
 
@@ -86,14 +90,64 @@ TEST_F(TabletMetaManagerTest, TestSaveAndGetAndRemove) {
     TabletMetaSharedPtr tablet_meta(new TabletMeta());
     Status s = tablet_meta->deserialize(meta_binary);
     EXPECT_EQ(Status::OK(), s);
+    TabletSchemaPB rowset_schema_pb;
+    tablet_meta->tablet_schema()->to_schema_pb(&rowset_schema_pb);
+    rowset_schema_pb.set_schema_version(7);
+    auto rowset_schema = std::make_shared<TabletSchema>();
+    rowset_schema->init_from_pb(rowset_schema_pb);
+    for (auto& [_, rowset_meta] : tablet_meta->all_mutable_rs_metas()) {
+        rowset_meta->set_tablet_schema(rowset_schema);
+    }
 
     s = TabletMetaManager::save(_data_dir, tablet_id, schema_hash, tablet_meta);
     EXPECT_EQ(Status::OK(), s);
+
+    std::string stored_meta_binary;
+    s = _data_dir->get_meta()->get(META_COLUMN_FAMILY_INDEX,
+                                   fmt::format("{}{}_{}", HEADER_PREFIX, tablet_id, schema_hash),
+                                   &stored_meta_binary);
+    ASSERT_EQ(Status::OK(), s);
+    TabletMetaPB stored_meta_pb;
+    ASSERT_TRUE(stored_meta_pb.ParseFromString(stored_meta_binary));
+    EXPECT_TRUE(stored_meta_pb.tablet_schema_saved());
+    EXPECT_FALSE(stored_meta_pb.has_schema());
+    for (const auto& rowset_meta_pb : stored_meta_pb.rs_metas()) {
+        EXPECT_FALSE(rowset_meta_pb.has_tablet_schema());
+        EXPECT_TRUE(rowset_meta_pb.has_schema_version());
+    }
+
+    std::string stored_tablet_schema;
+    EXPECT_EQ(Status::OK(), TabletMetaManager::get_schema(_data_dir, tablet_id, schema_hash,
+                                                          &stored_tablet_schema));
+    std::string stored_rowset_schema;
+    EXPECT_EQ(Status::OK(),
+              RowsetMetaManager::get_rowset_schema(
+                      _data_dir->get_meta(), tablet_id, tablet_meta->tablet_uid(), schema_hash,
+                      rowset_schema->schema_version(), &stored_rowset_schema));
+
+    TabletMetaSharedPtr separated_meta(new TabletMeta());
+    ASSERT_EQ(Status::OK(),
+              TabletMetaManager::get_meta(_data_dir, tablet_id, schema_hash, separated_meta));
+    for (const auto& [_, rowset_meta] : separated_meta->all_rs_metas()) {
+        EXPECT_NE(nullptr, rowset_meta->tablet_schema());
+        EXPECT_EQ(7, rowset_meta->tablet_schema()->schema_version());
+    }
+
     std::string json_meta_read;
     s = TabletMetaManager::get_json_meta(_data_dir, tablet_id, schema_hash, &json_meta_read);
     EXPECT_EQ(Status::OK(), s);
     // FIXME(Drogon): adapt for BinlogConfig default
     // EXPECT_EQ(_json_header, json_meta_read);
+
+    const std::string rowset_schema_key =
+            fmt::format("{}{}_{}_{}", ROWSET_SCHEMA_PREFIX, tablet_meta->tablet_uid().to_string(),
+                        schema_hash, rowset_schema->schema_version());
+    ASSERT_EQ(Status::OK(),
+              _data_dir->get_meta()->remove(META_COLUMN_FAMILY_INDEX, rowset_schema_key));
+    TabletMetaSharedPtr incomplete_meta(new TabletMeta());
+    EXPECT_FALSE(
+            TabletMetaManager::get_meta(_data_dir, tablet_id, schema_hash, incomplete_meta).ok());
+
     s = TabletMetaManager::remove(_data_dir, tablet_id, schema_hash);
     EXPECT_EQ(Status::OK(), s);
     TabletMetaSharedPtr meta_read(new TabletMeta());

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -731,6 +731,8 @@ message TabletMetaPB {
     optional TabletRolePB tablet_role = 36 [default = TABLET_ROLE_DATA];
     // Used by a base tablet to find its paired row-binlog tablet.
     optional int64 binlog_tablet_id = 37;
+    // Whether tablet schema has been persisted separately from tablet meta.
+    optional bool tablet_schema_saved = 99 [default = false];
 
     // For cloud
     optional int64 index_id = 1000;
@@ -795,6 +797,8 @@ message TabletMetaCloudPB {
     optional TabletRolePB tablet_role = 41 [default = TABLET_ROLE_DATA];
     // Used by a base tablet to find its paired row-binlog tablet.
     optional int64 binlog_tablet_id = 42;
+    // Whether tablet schema has been persisted separately from tablet meta.
+    optional bool tablet_schema_saved = 99 [default = false];
 
     // Use for selectdb-cloud
     optional string table_name = 101;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

Reduce local metadata size by storing reusable tablet and rowset schemas separately. Keep variant rowset schemas inline.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes.  local tablet and rowset schema persistence and loading now use separated metadata

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

