### PR TITLE
[fix](load) Respect Kafka isolation level when fetching offsets

### DIFF
--- a/be/src/load/routine_load/data_consumer.cpp
+++ b/be/src/load/routine_load/data_consumer.cpp
@@ -17,9 +17,11 @@
 
 #include "load/routine_load/data_consumer.h"
 
+#include <absl/strings/match.h>
 #include <absl/strings/str_split.h>
 #include <gen_cpp/Types_types.h>
 #include <gen_cpp/internal_service.pb.h>
+#include <librdkafka/rdkafka.h>
 #include <librdkafka/rdkafkacpp.h>
 
 // AWS Kinesis SDK includes
@@ -475,6 +477,89 @@ Status KafkaDataConsumer::get_offsets_for_times(const std::vector<PIntegerPair>&
     return Status::OK();
 }
 
+Status KafkaDataConsumer::_get_offsets_for_partitions(
+        const std::vector<std::pair<int32_t, int64_t>>& partition_offset_specs,
+        std::vector<PIntegerPair>* offsets, int timeout) {
+    DCHECK(!partition_offset_specs.empty());
+    rd_kafka_topic_partition_list_t* topic_partitions =
+            rd_kafka_topic_partition_list_new(static_cast<int>(partition_offset_specs.size()));
+    Defer delete_topic_partitions {
+            [topic_partitions]() { rd_kafka_topic_partition_list_destroy(topic_partitions); }};
+    for (const auto& [partition_id, offset_spec] : partition_offset_specs) {
+        rd_kafka_topic_partition_t* topic_partition =
+                rd_kafka_topic_partition_list_add(topic_partitions, _topic.c_str(), partition_id);
+        topic_partition->offset = offset_spec;
+    }
+
+    rd_kafka_t* kafka_handle = _k_consumer->c_ptr();
+    rd_kafka_AdminOptions_t* options =
+            rd_kafka_AdminOptions_new(kafka_handle, RD_KAFKA_ADMIN_OP_LISTOFFSETS);
+    Defer delete_options {[options]() { rd_kafka_AdminOptions_destroy(options); }};
+
+    char errstr[512];
+    rd_kafka_resp_err_t err =
+            rd_kafka_AdminOptions_set_request_timeout(options, timeout, errstr, sizeof(errstr));
+    if (UNLIKELY(err != RD_KAFKA_RESP_ERR_NO_ERROR)) {
+        return Status::InternalError("failed to set timeout for getting kafka offsets: {}", errstr);
+    }
+
+    auto isolation_level = RD_KAFKA_ISOLATION_LEVEL_READ_UNCOMMITTED;
+    auto isolation_level_property = _custom_properties.find("isolation.level");
+    if (isolation_level_property != _custom_properties.end() &&
+        absl::EqualsIgnoreCase(isolation_level_property->second, "read_committed")) {
+        isolation_level = RD_KAFKA_ISOLATION_LEVEL_READ_COMMITTED;
+    }
+    rd_kafka_error_t* isolation_level_error =
+            rd_kafka_AdminOptions_set_isolation_level(options, isolation_level);
+    if (UNLIKELY(isolation_level_error != nullptr)) {
+        std::string error_message = rd_kafka_error_string(isolation_level_error);
+        rd_kafka_error_destroy(isolation_level_error);
+        return Status::InternalError("failed to set isolation level for getting kafka offsets: {}",
+                                     error_message);
+    }
+
+    rd_kafka_queue_t* queue = rd_kafka_queue_new(kafka_handle);
+    Defer delete_queue {[queue]() { rd_kafka_queue_destroy(queue); }};
+    rd_kafka_ListOffsets(kafka_handle, topic_partitions, options, queue);
+
+    rd_kafka_event_t* event = rd_kafka_queue_poll(queue, timeout);
+    if (UNLIKELY(event == nullptr)) {
+        return Status::InternalError("get kafka offsets for partitions timeout");
+    }
+    Defer delete_event {[event]() { rd_kafka_event_destroy(event); }};
+
+    if (UNLIKELY(rd_kafka_event_error(event) != RD_KAFKA_RESP_ERR_NO_ERROR)) {
+        return Status::InternalError("failed to get kafka offsets for partitions: {}",
+                                     rd_kafka_event_error_string(event));
+    }
+    const rd_kafka_ListOffsets_result_t* result = rd_kafka_event_ListOffsets_result(event);
+    if (UNLIKELY(result == nullptr)) {
+        return Status::InternalError(
+                "failed to get kafka offsets for partitions: invalid response");
+    }
+
+    size_t result_info_count = 0;
+    const rd_kafka_ListOffsetsResultInfo_t** result_infos =
+            rd_kafka_ListOffsets_result_infos(result, &result_info_count);
+    if (UNLIKELY(result_info_count != partition_offset_specs.size())) {
+        return Status::InternalError("failed to get kafka offsets for all partitions");
+    }
+    for (size_t i = 0; i < result_info_count; ++i) {
+        const rd_kafka_topic_partition_t* topic_partition =
+                rd_kafka_ListOffsetsResultInfo_topic_partition(result_infos[i]);
+        if (UNLIKELY(topic_partition->err != RD_KAFKA_RESP_ERR_NO_ERROR)) {
+            return Status::InternalError("failed to get kafka offset for partition {}: {}",
+                                         topic_partition->partition,
+                                         rd_kafka_err2str(topic_partition->err));
+        }
+        PIntegerPair pair;
+        pair.set_key(topic_partition->partition);
+        pair.set_val(topic_partition->offset);
+        offsets->push_back(std::move(pair));
+    }
+    return Status::OK();
+}
+
 // get latest offsets for given partitions
 Status KafkaDataConsumer::get_latest_offsets_for_partitions(
         const std::vector<int32_t>& partition_ids, std::vector<PIntegerPair>* offsets,
@@ -483,33 +568,12 @@ Status KafkaDataConsumer::get_latest_offsets_for_partitions(
         // sleep 61s
         std::this_thread::sleep_for(std::chrono::seconds(61));
     });
-    MonotonicStopWatch watch;
-    watch.start();
+    std::vector<std::pair<int32_t, int64_t>> partition_offset_specs;
+    partition_offset_specs.reserve(partition_ids.size());
     for (int32_t partition_id : partition_ids) {
-        int64_t low = 0;
-        int64_t high = 0;
-        auto timeout_ms = timeout - static_cast<int>(watch.elapsed_time() / 1000 / 1000);
-        if (UNLIKELY(timeout_ms <= 0)) {
-            return Status::InternalError("get kafka latest offsets for partitions timeout");
-        }
-
-        RdKafka::ErrorCode err =
-                _k_consumer->query_watermark_offsets(_topic, partition_id, &low, &high, timeout_ms);
-        if (UNLIKELY(err != RdKafka::ERR_NO_ERROR)) {
-            std::stringstream ss;
-            ss << "failed to get latest offset for partition: " << partition_id
-               << ", err: " << RdKafka::err2str(err);
-            LOG(WARNING) << ss.str();
-            return Status::InternalError(ss.str());
-        }
-
-        PIntegerPair pair;
-        pair.set_key(partition_id);
-        pair.set_val(high);
-        offsets->push_back(std::move(pair));
+        partition_offset_specs.emplace_back(partition_id, RD_KAFKA_OFFSET_SPEC_LATEST);
     }
-
-    return Status::OK();
+    return _get_offsets_for_partitions(partition_offset_specs, offsets, timeout);
 }
 
 Status KafkaDataConsumer::get_real_offsets_for_partitions(
@@ -519,8 +583,7 @@ Status KafkaDataConsumer::get_real_offsets_for_partitions(
         // sleep 61s
         std::this_thread::sleep_for(std::chrono::seconds(61));
     });
-    MonotonicStopWatch watch;
-    watch.start();
+    std::vector<std::pair<int32_t, int64_t>> partition_offset_specs;
     for (const auto& entry : offset_flags) {
         PIntegerPair pair;
         if (UNLIKELY(entry.val() >= 0)) {
@@ -530,35 +593,19 @@ Status KafkaDataConsumer::get_real_offsets_for_partitions(
             continue;
         }
 
-        int64_t low = 0;
-        int64_t high = 0;
-        auto timeout_ms = timeout - static_cast<int>(watch.elapsed_time() / 1000 / 1000);
-        if (UNLIKELY(timeout_ms <= 0)) {
-            return Status::InternalError("get kafka real offsets for partitions timeout");
-        }
-
-        RdKafka::ErrorCode err =
-                _k_consumer->query_watermark_offsets(_topic, entry.key(), &low, &high, timeout_ms);
-        if (UNLIKELY(err != RdKafka::ERR_NO_ERROR)) {
-            std::stringstream ss;
-            ss << "failed to get latest offset for partition: " << entry.key()
-               << ", err: " << RdKafka::err2str(err);
-            LOG(WARNING) << ss.str();
-            return Status::InternalError(ss.str());
-        }
-
-        pair.set_key(entry.key());
+        DCHECK(entry.val() == -1 || entry.val() == -2);
         if (entry.val() == -1) {
             // OFFSET_END_VAL = -1
-            pair.set_val(high);
+            partition_offset_specs.emplace_back(entry.key(), RD_KAFKA_OFFSET_SPEC_LATEST);
         } else if (entry.val() == -2) {
             // OFFSET_BEGINNING_VAL = -2
-            pair.set_val(low);
+            partition_offset_specs.emplace_back(entry.key(), RD_KAFKA_OFFSET_SPEC_EARLIEST);
         }
-        offsets->push_back(std::move(pair));
     }
-
-    return Status::OK();
+    if (partition_offset_specs.empty()) {
+        return Status::OK();
+    }
+    return _get_offsets_for_partitions(partition_offset_specs, offsets, timeout);
 }
 
 Status KafkaDataConsumer::cancel(std::shared_ptr<StreamLoadContext> ctx) {

--- a/be/src/load/routine_load/data_consumer.h
+++ b/be/src/load/routine_load/data_consumer.h
@@ -32,6 +32,7 @@
 #include <ostream>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "common/logging.h"
@@ -168,6 +169,10 @@ public:
                                            std::vector<PIntegerPair>* offsets, int timeout);
 
 private:
+    Status _get_offsets_for_partitions(
+            const std::vector<std::pair<int32_t, int64_t>>& partition_offset_specs,
+            std::vector<PIntegerPair>* offsets, int timeout);
+
     std::string _brokers;
     std::string _topic;
     std::unordered_map<std::string, std::string> _custom_properties;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kafka/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kafka/KafkaRoutineLoadJob.java
@@ -955,9 +955,9 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                     && entry.getValue() < cachedPartitionWithLatestOffsets.get(entry.getKey())) {
                 // "entry.getValue()" is the offset to be consumed.
                 // "cachedPartitionWithLatestOffsets.get(entry.getKey())" is the "next" offset of this partition.
-                // (because librdkafa's query_watermark_offsets() will return the next offset.
+                // (because Kafka's ListOffsets API will return the next offset.
                 //  For example, there 4 msg in partition with offset 0,1,2,3,
-                //  query_watermark_offsets() will return 4.)
+                //  ListOffsets will return 4.)
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("has more data to consume. offsets to be consumed: {}, "
                                     + "latest offsets: {}, task {}, job {}",

--- a/regression-test/suites/load_p0/routine_load/test_routine_load_isolation_level_offset.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_routine_load_isolation_level_offset.groovy
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.util.RoutineLoadTestUtils
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.clients.producer.ProducerRecord
+
+suite("test_routine_load_isolation_level_offset", "nonConcurrent") {
+    if (!RoutineLoadTestUtils.isKafkaTestEnabled(context)) {
+        return
+    }
+
+    def kafkaBroker = RoutineLoadTestUtils.getKafkaBroker(context)
+    def kafkaTopic = "test_routine_load_isolation_level_offset_${System.currentTimeMillis()}"
+    def readCommittedJob = "test_isolation_offset_read_committed"
+    def readUncommittedJob = "test_isolation_offset_read_uncommitted"
+
+    sql "DROP TABLE IF EXISTS test_routine_load_isolation_level_offset"
+    sql """
+        CREATE TABLE test_routine_load_isolation_level_offset (
+            k1 INT
+        )
+        DUPLICATE KEY(k1)
+        DISTRIBUTED BY HASH(k1) BUCKETS 1
+        PROPERTIES ("replication_num" = "1")
+    """
+
+    def adminProperties = new Properties()
+    adminProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBroker)
+    def adminClient = AdminClient.create(adminProperties)
+    try {
+        adminClient.createTopics([new NewTopic(kafkaTopic, 1, (short) 1)]).all().get()
+    } finally {
+        adminClient.close()
+    }
+
+    def producerProperties = new Properties()
+    producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaBroker)
+    producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+            "org.apache.kafka.common.serialization.StringSerializer")
+    producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+            "org.apache.kafka.common.serialization.StringSerializer")
+    producerProperties.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG,
+            "${kafkaTopic}_transaction")
+    producerProperties.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "10000")
+    producerProperties.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, "10000")
+
+    def producer = new KafkaProducer<>(producerProperties)
+    try {
+        producer.initTransactions()
+        producer.beginTransaction()
+        producer.send(new ProducerRecord<>(kafkaTopic, null, "1")).get()
+        producer.flush()
+
+        def createJob = { jobName, isolationLevel ->
+            sql """
+                CREATE ROUTINE LOAD ${jobName}
+                ON test_routine_load_isolation_level_offset
+                COLUMNS TERMINATED BY ","
+                PROPERTIES ("desired_concurrent_number" = "1")
+                FROM KAFKA (
+                    "kafka_broker_list" = "${kafkaBroker}",
+                    "kafka_topic" = "${kafkaTopic}",
+                    "property.kafka_default_offsets" = "OFFSET_END",
+                    "property.isolation.level" = "${isolationLevel}"
+                )
+            """
+        }
+
+        createJob(readCommittedJob, "read_committed")
+        createJob(readUncommittedJob, "read_uncommitted")
+        sql "PAUSE ROUTINE LOAD FOR ${readCommittedJob}"
+        sql "PAUSE ROUTINE LOAD FOR ${readUncommittedJob}"
+
+        def readCommittedInfo = sql "SHOW ROUTINE LOAD FOR ${readCommittedJob}"
+        def readUncommittedInfo = sql "SHOW ROUTINE LOAD FOR ${readUncommittedJob}"
+        assertEquals("OFFSET_ZERO", parseJson(readCommittedInfo[0][15])["0"])
+        assertEquals("0", parseJson(readUncommittedInfo[0][15])["0"])
+
+        sql """
+            ALTER ROUTINE LOAD FOR ${readCommittedJob}
+            FROM KAFKA ("kafka_partitions" = "0", "kafka_offsets" = "0")
+        """
+        sql """
+            ALTER ROUTINE LOAD FOR ${readUncommittedJob}
+            FROM KAFKA ("kafka_partitions" = "0", "kafka_offsets" = "0")
+        """
+
+        def attempts = 0
+        while (true) {
+            readCommittedInfo = sql "SHOW ROUTINE LOAD FOR ${readCommittedJob}"
+            readUncommittedInfo = sql "SHOW ROUTINE LOAD FOR ${readUncommittedJob}"
+            def readCommittedLag = parseJson(readCommittedInfo[0][16])["0"]
+            def readUncommittedLag = parseJson(readUncommittedInfo[0][16])["0"]
+            if (readCommittedLag == 0 && readUncommittedLag == 1) {
+                break
+            }
+            if (attempts++ >= 60) {
+                assertEquals(0, readCommittedLag)
+                assertEquals(1, readUncommittedLag)
+            }
+            sleep(1000)
+        }
+    } finally {
+        try_sql "STOP ROUTINE LOAD FOR ${readCommittedJob}"
+        try_sql "STOP ROUTINE LOAD FOR ${readUncommittedJob}"
+        try {
+            producer.abortTransaction()
+        } finally {
+            producer.close()
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

Routine load used `query_watermark_offsets()` when resolving `OFFSET_END` and refreshing latest offsets. The high watermark is the log end offset and includes records from open Kafka transactions, so `isolation.level=read_committed` did not affect routine load progress, lag, or scheduling decisions.

This change uses Kafka’s `ListOffsets` Admin API and passes the job isolation level explicitly. `read_committed` now returns the last stable offset, while `read_uncommitted` continues to return the log end offset. Both periodic latest-offset refresh and `OFFSET_END` resolution share the same implementation.

A transactional Kafka regression case covers the different initial offsets and lag values for `read_committed` and `read_uncommitted` jobs.

### Release note

Kafka routine load offset queries now respect `property.isolation.level`.

### Check List (For Author)

- Test: Not run (skipped at requester direction)
- Behavior changed: Yes. `read_committed` offset and lag exclude records in open transactions.
- Does this need documentation: No