### PR TITLE
[test](be) Use storage block creation in bloom filter FPP writer test

### DIFF
--- a/be/test/storage/segment/bloom_filter_fpp_writer_test.cpp
+++ b/be/test/storage/segment/bloom_filter_fpp_writer_test.cpp
@@ -154,7 +154,7 @@ const std::vector<ScalarBloomFilterTypeCase> kSegmentWriterCompatibleBloomFilter
         create_segment_writer_compatible_type_cases();
 
 Block create_single_row_default_block(const TabletSchemaSPtr& schema) {
-    Block block = schema->create_block();
+    Block block = schema->create_storage_block();
     for (uint32_t cid = 0; cid < schema->num_columns(); ++cid) {
         auto column = block.get_by_position(cid).column->assert_mutable();
         column->insert_default();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #66472; #64652

Problem Summary: TabletSchema::create_block() was removed during the read schema refactor, leaving bloom_filter_fpp_writer_test unable to compile. This updates the test to use create_storage_block(), which constructs the same physical schema columns, data types, and names required before default values are inserted.

### Release note

None

### Check List (For Author)

- Test
    - [x] Unit Test
        - ./run-be-ut.sh --run --filter='*BloomFilterFppWriterTest*' -j 192

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label