### PR TITLE
[fix](paimon) recover JNI writes after OOM

### DIFF
--- a/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
+++ b/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
@@ -46,51 +46,61 @@ namespace doris {
 namespace {
 constexpr std::string_view PAIMON_JNI_WRITER_IO_TMP_DIR = "paimon_jni_writer_io_tmp";
 
-struct QuarantinedPaimonJniWriter {
+struct PaimonJniCloseState {
+    // The global writer reference keeps both the Java object and its defining class alive. The
+    // cached method ID therefore remains valid until release_writer_ref() deletes this reference.
     jobject writer_obj = nullptr;
-    jclass writer_cls = nullptr;
     jmethodID close_id = nullptr;
     std::unique_ptr<PaimonJniMemoryManager> memory_manager;
+
+    Status retry_close(JNIEnv* env) const {
+        if (writer_obj == nullptr) {
+            return Status::OK();
+        }
+        if (close_id == nullptr) {
+            return Status::InternalError("PaimonJniWriter.close method is unavailable");
+        }
+        env->CallVoidMethod(writer_obj, close_id);
+        return Jni::Env::GetJniExceptionMsg(env, true,
+                                            "JNI exception retrying PaimonJniWriter.close: ");
+    }
+
+    void release_writer_ref(JNIEnv* env) {
+        if (writer_obj != nullptr) {
+            env->DeleteGlobalRef(writer_obj);
+            writer_obj = nullptr;
+        }
+    }
 };
 
-std::mutex& quarantined_writers_mutex() {
+std::mutex& quarantined_close_states_mutex() {
     static auto* mutex = new std::mutex();
     return *mutex;
 }
 
-std::vector<QuarantinedPaimonJniWriter>& quarantined_writers() {
-    // Deliberately process-lifetime storage: if cleanup never succeeds, leaking the JNI references
-    // and native pages at process exit is safer than destroying memory still used by Java tasks.
-    static auto* writers = new std::vector<QuarantinedPaimonJniWriter>();
-    return *writers;
+std::vector<PaimonJniCloseState>& quarantined_close_states() {
+    // Deliberately process-lifetime storage: if cleanup never succeeds, retaining the writer and
+    // native pages at process exit is safer than destroying memory still used by Java tasks.
+    static auto* states = new std::vector<PaimonJniCloseState>();
+    return *states;
 }
 
-void quarantine_failed_writer(jobject writer_obj, jclass writer_cls, jmethodID close_id,
-                              std::unique_ptr<PaimonJniMemoryManager> memory_manager) {
+void quarantine_failed_close(jobject writer_obj, jmethodID close_id,
+                             std::unique_ptr<PaimonJniMemoryManager> memory_manager) {
     // An unconfirmed Java close means a background Paimon task may still reference this manager's
     // native pages. Keep the Java writer reachable as well, so a later open can retry close before
     // admitting more writers instead of requiring a BE restart.
-    std::lock_guard<std::mutex> lock(quarantined_writers_mutex());
-    quarantined_writers().push_back({writer_obj, writer_cls, close_id, std::move(memory_manager)});
+    std::lock_guard<std::mutex> lock(quarantined_close_states_mutex());
+    quarantined_close_states().push_back({writer_obj, close_id, std::move(memory_manager)});
 }
 
 Status recover_quarantined_writers(JNIEnv* env) {
-    std::lock_guard<std::mutex> lock(quarantined_writers_mutex());
+    std::lock_guard<std::mutex> lock(quarantined_close_states_mutex());
     Status first_failure = Status::OK();
     size_t recovered = 0;
-    auto& writers = quarantined_writers();
-    for (auto it = writers.begin(); it != writers.end();) {
-        Status close_status = Status::OK();
-        if (it->writer_obj != nullptr) {
-            if (it->close_id == nullptr) {
-                close_status = Status::InternalError("PaimonJniWriter.close method is unavailable");
-            } else {
-                env->CallVoidMethod(it->writer_obj, it->close_id);
-                close_status = Jni::Env::GetJniExceptionMsg(
-                        env, true, "JNI exception retrying PaimonJniWriter.close: ");
-            }
-        }
-
+    auto& close_states = quarantined_close_states();
+    for (auto it = close_states.begin(); it != close_states.end();) {
+        Status close_status = it->retry_close(env);
         if (!close_status.ok()) {
             if (first_failure.ok()) {
                 first_failure = close_status;
@@ -99,13 +109,8 @@ Status recover_quarantined_writers(JNIEnv* env) {
             continue;
         }
 
-        if (it->writer_obj != nullptr) {
-            env->DeleteGlobalRef(it->writer_obj);
-        }
-        if (it->writer_cls != nullptr) {
-            env->DeleteGlobalRef(it->writer_cls);
-        }
-        it = writers.erase(it);
+        it->release_writer_ref(env);
+        it = close_states.erase(it);
         ++recovered;
     }
 
@@ -113,12 +118,12 @@ Status recover_quarantined_writers(JNIEnv* env) {
         LOG(INFO) << "Recovered " << recovered
                   << " quarantined Paimon JNI writer(s); retained native memory was released";
     }
-    if (!writers.empty()) {
+    if (!close_states.empty()) {
         return Status::InternalError(
                 "Paimon JNI writes are temporarily unavailable because {} previous Java writer "
                 "close operation(s) still cannot be confirmed; cleanup will be retried by the "
                 "next write. Last cleanup error: {}",
-                writers.size(), first_failure.to_string());
+                close_states.size(), first_failure.to_string());
     }
     return Status::OK();
 }
@@ -151,7 +156,7 @@ JniPaimonWriteBackend::~JniPaimonWriteBackend() {
 }
 
 Status JniPaimonWriteBackend::close() {
-    if (_jni_writer_obj == nullptr && _jni_writer_cls == nullptr) {
+    if (_jni_writer_obj == nullptr) {
         _memory_manager.reset();
         _arrow_schema.reset();
         _opened = false;
@@ -161,11 +166,9 @@ Status JniPaimonWriteBackend::close() {
     JNIEnv* env = nullptr;
     Status env_status = Jni::Env::Get(&env);
     if (!env_status.ok()) {
-        // JNI global references cannot be released without an environment.
-        // Preserve the handles and manager so a later open can finish cleanup safely.
-        quarantine_failed_writer(std::exchange(_jni_writer_obj, nullptr),
-                                 std::exchange(_jni_writer_cls, nullptr), _close_id,
-                                 std::move(_memory_manager));
+        // Preserve the writer and manager so a later open can finish cleanup safely.
+        quarantine_failed_close(std::exchange(_jni_writer_obj, nullptr), _close_id,
+                                std::move(_memory_manager));
         _arrow_schema.reset();
         _opened = false;
         return env_status;
@@ -187,10 +190,6 @@ Status JniPaimonWriteBackend::close() {
             env->DeleteGlobalRef(_jni_writer_obj);
             _jni_writer_obj = nullptr;
         }
-        if (_jni_writer_cls != nullptr) {
-            env->DeleteGlobalRef(_jni_writer_cls);
-            _jni_writer_cls = nullptr;
-        }
         _memory_manager.reset();
     } else {
         if (_memory_manager != nullptr) {
@@ -202,9 +201,8 @@ Status JniPaimonWriteBackend::close() {
         // Paimon may still have asynchronous flush or compaction tasks using MemorySegments backed
         // by these pages. Preserve both Java and native ownership to prevent UAF. A subsequent open
         // retries this same Java close and releases everything only after it succeeds.
-        quarantine_failed_writer(std::exchange(_jni_writer_obj, nullptr),
-                                 std::exchange(_jni_writer_cls, nullptr), _close_id,
-                                 std::move(_memory_manager));
+        quarantine_failed_close(std::exchange(_jni_writer_obj, nullptr), _close_id,
+                                std::move(_memory_manager));
     }
     _arrow_schema.reset();
     _opened = false;
@@ -317,27 +315,30 @@ Status JniPaimonWriteBackend::open(const TPaimonTableSink& sink, RuntimeState* s
 
     // Step 1: Load PaimonJniWriter class through ScannerLoader (Paimon jars are
     // not on the default application classpath, so FindClass won't work).
-    jclass local_cls = nullptr;
-    RETURN_IF_ERROR(_load_writer_class(env, &local_cls));
-    _jni_writer_cls = static_cast<jclass>(env->NewGlobalRef(local_cls));
-    env->DeleteLocalRef(local_cls);
-    RETURN_IF_ERROR(PaimonJniMemoryManager::register_natives(env, _jni_writer_cls));
+    jclass writer_cls = nullptr;
+    RETURN_IF_ERROR(_load_writer_class(env, &writer_cls));
+    Defer release_writer_cls {[&] { env->DeleteLocalRef(writer_cls); }};
+    RETURN_IF_ERROR(PaimonJniMemoryManager::register_natives(env, writer_cls));
 
     // Step 2: Cache JNI method IDs for write, prepareCommit, abort, close.
-    jmethodID open_id = env->GetMethodID(_jni_writer_cls, "open", PAIMON_JNI_WRITER_OPEN_SIGNATURE);
-    jmethodID get_arrow_schema_id = env->GetMethodID(_jni_writer_cls, "getArrowSchema", "()[B");
-    _write_id = env->GetMethodID(_jni_writer_cls, "writeArrow", "(JJ)V");
-    _prepare_commit_id = env->GetMethodID(_jni_writer_cls, "prepareCommit", "()[[B");
-    _abort_id = env->GetMethodID(_jni_writer_cls, "abort", "()V");
-    _close_id = env->GetMethodID(_jni_writer_cls, "close", "()V");
+    jmethodID open_id = env->GetMethodID(writer_cls, "open", PAIMON_JNI_WRITER_OPEN_SIGNATURE);
+    jmethodID get_arrow_schema_id = env->GetMethodID(writer_cls, "getArrowSchema", "()[B");
+    _write_id = env->GetMethodID(writer_cls, "writeArrow", "(JJ)V");
+    _prepare_commit_id = env->GetMethodID(writer_cls, "prepareCommit", "()[[B");
+    _abort_id = env->GetMethodID(writer_cls, "abort", "()V");
+    _close_id = env->GetMethodID(writer_cls, "close", "()V");
+    jmethodID ctor_id = env->GetMethodID(writer_cls, "<init>", "()V");
     RETURN_IF_ERROR(_check_jni_exception(env, "GetMethodID"));
 
     // Step 3: Create the Java PaimonJniWriter instance.
-    jmethodID ctor_id = env->GetMethodID(_jni_writer_cls, "<init>", "()V");
-    jobject local_obj = env->NewObject(_jni_writer_cls, ctor_id);
+    jobject local_obj = env->NewObject(writer_cls, ctor_id);
     RETURN_IF_ERROR(_check_jni_exception(env, "NewObject"));
     _jni_writer_obj = env->NewGlobalRef(local_obj);
     env->DeleteLocalRef(local_obj);
+    RETURN_IF_ERROR(_check_jni_exception(env, "NewGlobalRef PaimonJniWriter"));
+    if (_jni_writer_obj == nullptr) {
+        return Status::InternalError("NewGlobalRef PaimonJniWriter returned null");
+    }
 
     // Step 4: Build Java arguments and call PaimonJniWriter.open().
     const std::map<std::string, std::string> empty_config;

--- a/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
+++ b/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
@@ -24,10 +24,10 @@
 #include <arrow/record_batch.h>
 
 #include <algorithm>
-#include <atomic>
 #include <map>
 #include <mutex>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "common/check.h"
@@ -46,31 +46,81 @@ namespace doris {
 namespace {
 constexpr std::string_view PAIMON_JNI_WRITER_IO_TMP_DIR = "paimon_jni_writer_io_tmp";
 
-std::atomic<bool>& paimon_jni_close_failed() {
-    static std::atomic<bool> failed {false};
-    return failed;
-}
+struct QuarantinedPaimonJniWriter {
+    jobject writer_obj = nullptr;
+    jclass writer_cls = nullptr;
+    jmethodID close_id = nullptr;
+    std::unique_ptr<PaimonJniMemoryManager> memory_manager;
+};
 
-std::mutex& retained_memory_managers_mutex() {
+std::mutex& quarantined_writers_mutex() {
     static auto* mutex = new std::mutex();
     return *mutex;
 }
 
-std::vector<std::unique_ptr<PaimonJniMemoryManager>>& retained_memory_managers() {
-    static auto* managers = new std::vector<std::unique_ptr<PaimonJniMemoryManager>>();
-    return *managers;
+std::vector<QuarantinedPaimonJniWriter>& quarantined_writers() {
+    // Deliberately process-lifetime storage: if cleanup never succeeds, leaking the JNI references
+    // and native pages at process exit is safer than destroying memory still used by Java tasks.
+    static auto* writers = new std::vector<QuarantinedPaimonJniWriter>();
+    return *writers;
 }
 
-void retain_memory_after_failed_close(std::unique_ptr<PaimonJniMemoryManager> manager) {
+void quarantine_failed_writer(jobject writer_obj, jclass writer_cls, jmethodID close_id,
+                              std::unique_ptr<PaimonJniMemoryManager> memory_manager) {
     // An unconfirmed Java close means a background Paimon task may still reference this manager's
-    // native pages. Quarantine the manager and stop admitting new writers so repeated failures
-    // cannot accumulate process-lifetime native memory without a bound.
-    paimon_jni_close_failed().store(true, std::memory_order_release);
-    if (manager == nullptr) {
-        return;
+    // native pages. Keep the Java writer reachable as well, so a later open can retry close before
+    // admitting more writers instead of requiring a BE restart.
+    std::lock_guard<std::mutex> lock(quarantined_writers_mutex());
+    quarantined_writers().push_back({writer_obj, writer_cls, close_id, std::move(memory_manager)});
+}
+
+Status recover_quarantined_writers(JNIEnv* env) {
+    std::lock_guard<std::mutex> lock(quarantined_writers_mutex());
+    Status first_failure = Status::OK();
+    size_t recovered = 0;
+    auto& writers = quarantined_writers();
+    for (auto it = writers.begin(); it != writers.end();) {
+        Status close_status = Status::OK();
+        if (it->writer_obj != nullptr) {
+            if (it->close_id == nullptr) {
+                close_status = Status::InternalError("PaimonJniWriter.close method is unavailable");
+            } else {
+                env->CallVoidMethod(it->writer_obj, it->close_id);
+                close_status = Jni::Env::GetJniExceptionMsg(
+                        env, true, "JNI exception retrying PaimonJniWriter.close: ");
+            }
+        }
+
+        if (!close_status.ok()) {
+            if (first_failure.ok()) {
+                first_failure = close_status;
+            }
+            ++it;
+            continue;
+        }
+
+        if (it->writer_obj != nullptr) {
+            env->DeleteGlobalRef(it->writer_obj);
+        }
+        if (it->writer_cls != nullptr) {
+            env->DeleteGlobalRef(it->writer_cls);
+        }
+        it = writers.erase(it);
+        ++recovered;
     }
-    std::lock_guard<std::mutex> lock(retained_memory_managers_mutex());
-    retained_memory_managers().emplace_back(std::move(manager));
+
+    if (recovered > 0) {
+        LOG(INFO) << "Recovered " << recovered
+                  << " quarantined Paimon JNI writer(s); retained native memory was released";
+    }
+    if (!writers.empty()) {
+        return Status::InternalError(
+                "Paimon JNI writes are temporarily unavailable because {} previous Java writer "
+                "close operation(s) still cannot be confirmed; cleanup will be retried by the "
+                "next write. Last cleanup error: {}",
+                writers.size(), first_failure.to_string());
+    }
+    return Status::OK();
 }
 
 } // namespace
@@ -111,16 +161,11 @@ Status JniPaimonWriteBackend::close() {
     JNIEnv* env = nullptr;
     Status env_status = Jni::Env::Get(&env);
     if (!env_status.ok()) {
-        bool java_users_may_exist = _jni_writer_obj != nullptr;
         // JNI global references cannot be released without an environment.
-        // Deliberately abandon the handles so the Java writer remains alive.
-        _jni_writer_obj = nullptr;
-        _jni_writer_cls = nullptr;
-        if (java_users_may_exist) {
-            retain_memory_after_failed_close(std::move(_memory_manager));
-        } else {
-            _memory_manager.reset();
-        }
+        // Preserve the handles and manager so a later open can finish cleanup safely.
+        quarantine_failed_writer(std::exchange(_jni_writer_obj, nullptr),
+                                 std::exchange(_jni_writer_cls, nullptr), _close_id,
+                                 std::move(_memory_manager));
         _arrow_schema.reset();
         _opened = false;
         return env_status;
@@ -135,15 +180,17 @@ Status JniPaimonWriteBackend::close() {
             env->CallVoidMethod(_jni_writer_obj, _close_id);
             close_status = _check_jni_exception(env, "close PaimonJniWriter");
         }
-        env->DeleteGlobalRef(_jni_writer_obj);
-        _jni_writer_obj = nullptr;
-    }
-    if (_jni_writer_cls != nullptr) {
-        env->DeleteGlobalRef(_jni_writer_cls);
-        _jni_writer_cls = nullptr;
     }
 
     if (close_status.ok()) {
+        if (_jni_writer_obj != nullptr) {
+            env->DeleteGlobalRef(_jni_writer_obj);
+            _jni_writer_obj = nullptr;
+        }
+        if (_jni_writer_cls != nullptr) {
+            env->DeleteGlobalRef(_jni_writer_cls);
+            _jni_writer_cls = nullptr;
+        }
         _memory_manager.reset();
     } else {
         if (_memory_manager != nullptr) {
@@ -153,9 +200,11 @@ Status JniPaimonWriteBackend::close() {
                     << PrettyPrinter::print_bytes(_memory_manager->native_peak_allocated_bytes());
         }
         // Paimon may still have asynchronous flush or compaction tasks using MemorySegments backed
-        // by these pages. Retain this failed writer's ownership until process exit to prevent UAF;
-        // retain_memory_after_failed_close also fences subsequent Paimon JNI writer admission.
-        retain_memory_after_failed_close(std::move(_memory_manager));
+        // by these pages. Preserve both Java and native ownership to prevent UAF. A subsequent open
+        // retries this same Java close and releases everything only after it succeeds.
+        quarantine_failed_writer(std::exchange(_jni_writer_obj, nullptr),
+                                 std::exchange(_jni_writer_cls, nullptr), _close_id,
+                                 std::move(_memory_manager));
     }
     _arrow_schema.reset();
     _opened = false;
@@ -246,11 +295,10 @@ static Status _get_paimon_arrow_schema(JNIEnv* env, jobject writer, jmethodID ge
 
 Status JniPaimonWriteBackend::open(const TPaimonTableSink& sink, RuntimeState* state,
                                    RuntimeProfile* profile) {
-    if (paimon_jni_close_failed().load(std::memory_order_acquire)) {
-        return Status::InternalError(
-                "Paimon JNI writes are disabled on this BE because a previous Java writer close "
-                "could not be confirmed; restart the BE to reclaim retained native memory safely");
-    }
+    JNIEnv* env = nullptr;
+    RETURN_IF_ERROR(Jni::Env::Get(&env));
+    RETURN_IF_ERROR(recover_quarantined_writers(env));
+
     _arrow_schema.reset();
     DORIS_CHECK(sink.__isset.column_names);
     DORIS_CHECK(sink.__isset.write_mode);
@@ -266,9 +314,6 @@ Status JniPaimonWriteBackend::open(const TPaimonTableSink& sink, RuntimeState* s
     RuntimeProfile* jni_profile = profile->create_child("JniPaimonWriteBackend", true, true);
     _native_page_memory_limit = ADD_COUNTER(jni_profile, "NativePageMemoryLimit", TUnit::BYTES);
     _native_page_memory_peak = ADD_COUNTER(jni_profile, "NativePageMemoryPeak", TUnit::BYTES);
-
-    JNIEnv* env = nullptr;
-    RETURN_IF_ERROR(Jni::Env::Get(&env));
 
     // Step 1: Load PaimonJniWriter class through ScannerLoader (Paimon jars are
     // not on the default application classpath, so FindClass won't work).

--- a/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
+++ b/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.cpp
@@ -50,19 +50,25 @@ struct PaimonJniCloseState {
     // The global writer reference keeps both the Java object and its defining class alive. The
     // cached method ID therefore remains valid until release_writer_ref() deletes this reference.
     jobject writer_obj = nullptr;
-    jmethodID close_id = nullptr;
+    jmethodID recover_and_close_id = nullptr;
     std::unique_ptr<PaimonJniMemoryManager> memory_manager;
 
-    Status retry_close(JNIEnv* env) const {
+    Status retry_cleanup(JNIEnv* env) const {
         if (writer_obj == nullptr) {
             return Status::OK();
         }
-        if (close_id == nullptr) {
-            return Status::InternalError("PaimonJniWriter.close method is unavailable");
+        if (recover_and_close_id == nullptr) {
+            return Status::InternalError("PaimonJniWriter.recoverAndClose method is unavailable");
         }
-        env->CallVoidMethod(writer_obj, close_id);
-        return Jni::Env::GetJniExceptionMsg(env, true,
-                                            "JNI exception retrying PaimonJniWriter.close: ");
+
+        if (env->PushLocalFrame(16) != JNI_OK) {
+            env->ExceptionClear();
+            return Status::InternalError(
+                    "Failed to create a JNI local frame for Paimon cleanup recovery");
+        }
+        Defer pop_local_frame {[&] { env->PopLocalFrame(nullptr); }};
+        env->CallVoidMethod(writer_obj, recover_and_close_id);
+        return Jni::Env::GetJniExceptionMsg(env, true, "JNI exception retrying Paimon cleanup: ");
     }
 
     void release_writer_ref(JNIEnv* env) {
@@ -85,13 +91,14 @@ std::vector<PaimonJniCloseState>& quarantined_close_states() {
     return *states;
 }
 
-void quarantine_failed_close(jobject writer_obj, jmethodID close_id,
+void quarantine_failed_close(jobject writer_obj, jmethodID recover_and_close_id,
                              std::unique_ptr<PaimonJniMemoryManager> memory_manager) {
     // An unconfirmed Java close means a background Paimon task may still reference this manager's
-    // native pages. Keep the Java writer reachable as well, so a later open can retry close before
-    // admitting more writers instead of requiring a BE restart.
+    // native pages. Keep the Java writer reachable as well, so a later open can finish deferred
+    // abort and close cleanup before admitting more writers instead of requiring a BE restart.
     std::lock_guard<std::mutex> lock(quarantined_close_states_mutex());
-    quarantined_close_states().push_back({writer_obj, close_id, std::move(memory_manager)});
+    quarantined_close_states().push_back(
+            {writer_obj, recover_and_close_id, std::move(memory_manager)});
 }
 
 Status recover_quarantined_writers(JNIEnv* env) {
@@ -100,7 +107,7 @@ Status recover_quarantined_writers(JNIEnv* env) {
     size_t recovered = 0;
     auto& close_states = quarantined_close_states();
     for (auto it = close_states.begin(); it != close_states.end();) {
-        Status close_status = it->retry_close(env);
+        Status close_status = it->retry_cleanup(env);
         if (!close_status.ok()) {
             if (first_failure.ok()) {
                 first_failure = close_status;
@@ -167,7 +174,7 @@ Status JniPaimonWriteBackend::close() {
     Status env_status = Jni::Env::Get(&env);
     if (!env_status.ok()) {
         // Preserve the writer and manager so a later open can finish cleanup safely.
-        quarantine_failed_close(std::exchange(_jni_writer_obj, nullptr), _close_id,
+        quarantine_failed_close(std::exchange(_jni_writer_obj, nullptr), _recover_and_close_id,
                                 std::move(_memory_manager));
         _arrow_schema.reset();
         _opened = false;
@@ -200,8 +207,8 @@ Status JniPaimonWriteBackend::close() {
         }
         // Paimon may still have asynchronous flush or compaction tasks using MemorySegments backed
         // by these pages. Preserve both Java and native ownership to prevent UAF. A subsequent open
-        // retries this same Java close and releases everything only after it succeeds.
-        quarantine_failed_close(std::exchange(_jni_writer_obj, nullptr), _close_id,
+        // retries Java abort/close cleanup and releases everything only after it succeeds.
+        quarantine_failed_close(std::exchange(_jni_writer_obj, nullptr), _recover_and_close_id,
                                 std::move(_memory_manager));
     }
     _arrow_schema.reset();
@@ -327,6 +334,7 @@ Status JniPaimonWriteBackend::open(const TPaimonTableSink& sink, RuntimeState* s
     _prepare_commit_id = env->GetMethodID(writer_cls, "prepareCommit", "()[[B");
     _abort_id = env->GetMethodID(writer_cls, "abort", "()V");
     _close_id = env->GetMethodID(writer_cls, "close", "()V");
+    _recover_and_close_id = env->GetMethodID(writer_cls, "recoverAndClose", "()V");
     jmethodID ctor_id = env->GetMethodID(writer_cls, "<init>", "()V");
     RETURN_IF_ERROR(_check_jni_exception(env, "GetMethodID"));
 

--- a/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.h
+++ b/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.h
@@ -78,6 +78,7 @@ private:
     jmethodID _prepare_commit_id = nullptr;
     jmethodID _abort_id = nullptr;
     jmethodID _close_id = nullptr;
+    jmethodID _recover_and_close_id = nullptr;
 
     std::unique_ptr<PaimonJniMemoryManager> _memory_manager;
     std::shared_ptr<arrow::Schema> _arrow_schema;

--- a/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.h
+++ b/be/src/exec/sink/writer/paimon/jni_paimon_write_backend.h
@@ -70,11 +70,10 @@ private:
     Status _load_writer_class(JNIEnv* env, jclass* writer_class);
     void _refresh_memory_profile();
 
-    // JNI global references — live for the duration of this backend.
-    jclass _jni_writer_cls = nullptr;
+    // JNI global writer reference — also keeps its defining class loaded.
     jobject _jni_writer_obj = nullptr;
 
-    // Cached JNI method IDs for the PaimonJniWriter Java methods.
+    // Cached method IDs remain valid while _jni_writer_obj keeps the defining class loaded.
     jmethodID _write_id = nullptr;
     jmethodID _prepare_commit_id = nullptr;
     jmethodID _abort_id = nullptr;

--- a/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/PaimonJniWriter.java
+++ b/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/PaimonJniWriter.java
@@ -111,7 +111,6 @@ public class PaimonJniWriter {
     private boolean fullCompactionChangelog;
     private final Set<PartitionBucket> fullCompactionBuckets = new HashSet<>();
     private List<CommitMessage> preparedCommitMessages = Collections.emptyList();
-    private boolean sdkCloseFailed;
 
     public PaimonJniWriter() {
         // Imported C Data vectors reference Doris-owned buffers; this allocator owns only Arrow's
@@ -196,7 +195,7 @@ public class PaimonJniWriter {
                     try {
                         closeResources();
                     } catch (Throwable closeFailure) {
-                        t.addSuppressed(closeFailure);
+                        mergeFailure(t, closeFailure);
                     }
                     throw new RuntimeException("PaimonJniWriter open failed", t);
                 }
@@ -265,8 +264,12 @@ public class PaimonJniWriter {
     }
 
     /**
-     * Abort: discard all written data files and close the SDK writer.
+     * Abort an already prepared commit, if present, and close the SDK writer.
      * Called from C++ when write or prepareCommit fails.
+     *
+     * <p>Do not call prepareCommit from this error path: preparing may flush and compact data,
+     * which needs more heap precisely when the caller is recovering from an OOM. Files without a
+     * prepared commit message remain uncommitted and are handled by Paimon's orphan cleanup.
      */
     public void abort() throws Exception {
         try (ThreadClassLoaderContext ignored = new ThreadClassLoaderContext(classLoader)) {
@@ -526,16 +529,24 @@ public class PaimonJniWriter {
     // ────────────────────────────────────────────────────────────
 
     private void closeResources() throws Exception {
+        Throwable failure = null;
         try {
             closeWriter();
-        } finally {
-            writeSchema = null;
-            arrowAdapter = null;
-            if (allocator != null) {
-                allocator.close();
+        } catch (Throwable closeFailure) {
+            failure = closeFailure;
+        }
+
+        writeSchema = null;
+        arrowAdapter = null;
+        if (allocator != null) {
+            Throwable allocatorFailure = closeResource(allocator);
+            if (allocatorFailure == null) {
                 allocator = null;
+            } else {
+                failure = mergeFailure(failure, allocatorFailure);
             }
         }
+        throwIfFailed(failure);
     }
 
     private List<CommitMessage> prepareCommitMessages() throws Exception {
@@ -572,33 +583,74 @@ public class PaimonJniWriter {
     }
 
     private void closeWriter() throws Exception {
-        if (sdkCloseFailed) {
-            throw new IllegalStateException(
-                    "A previous Paimon SDK close failed; native memory cannot be released safely");
+        Throwable failure = null;
+
+        Throwable writerFailure = closeResource(writer);
+        if (writerFailure == null) {
+            writer = null;
+        } else {
+            failure = writerFailure;
         }
-        Exception failure = closeResource(writer, null);
-        failure = closeResource(globalIndexAssigner, failure);
-        failure = closeResource(ioManager, failure);
-        clearWriterState();
-        if (failure != null) {
-            sdkCloseFailed = true;
-            throw failure;
+
+        Throwable indexAssignerFailure = closeResource(globalIndexAssigner);
+        if (indexAssignerFailure == null) {
+            globalIndexAssigner = null;
+        } else {
+            failure = mergeFailure(failure, indexAssignerFailure);
         }
+
+        Throwable ioManagerFailure = closeResource(ioManager);
+        if (ioManagerFailure == null) {
+            ioManager = null;
+        } else {
+            failure = mergeFailure(failure, ioManagerFailure);
+        }
+
+        if (writer == null && globalIndexAssigner == null && ioManager == null) {
+            clearWriterState();
+        }
+        throwIfFailed(failure);
     }
 
-    private static Exception closeResource(AutoCloseable resource, Exception previousFailure) {
+    static Throwable closeResource(AutoCloseable resource) {
         if (resource == null) {
-            return previousFailure;
+            return null;
         }
         try {
             resource.close();
-        } catch (Exception closeFailure) {
-            if (previousFailure == null) {
-                return closeFailure;
+            return null;
+        } catch (Throwable closeFailure) {
+            return closeFailure;
+        }
+    }
+
+    private static Throwable mergeFailure(Throwable previousFailure, Throwable closeFailure) {
+        if (previousFailure == null) {
+            return closeFailure;
+        }
+        // Adding a suppressed exception may itself allocate. Do not turn an OOM cleanup path into
+        // another allocation failure; the first failure remains the most useful one to propagate.
+        if (!(previousFailure instanceof OutOfMemoryError)) {
+            try {
+                previousFailure.addSuppressed(closeFailure);
+            } catch (Throwable ignored) {
+                // Best-effort diagnostics only.
             }
-            previousFailure.addSuppressed(closeFailure);
         }
         return previousFailure;
+    }
+
+    private static void throwIfFailed(Throwable failure) throws Exception {
+        if (failure == null) {
+            return;
+        }
+        if (failure instanceof Error) {
+            throw (Error) failure;
+        }
+        if (failure instanceof Exception) {
+            throw (Exception) failure;
+        }
+        throw new RuntimeException(failure);
     }
 
     private void clearWriterState() {
@@ -617,11 +669,9 @@ public class PaimonJniWriter {
     }
 
     private void abortWriter() throws Exception {
+        Throwable failure = null;
         try {
             List<CommitMessage> messages = preparedCommitMessages;
-            if (messages.isEmpty() && writer != null) {
-                messages = prepareCommitMessages();
-            }
             if (!messages.isEmpty()) {
                 InnerTableCommit committer = table.newCommit(commitUser);
                 try {
@@ -630,9 +680,15 @@ public class PaimonJniWriter {
                     committer.close();
                 }
             }
-        } finally {
-            closeWriter();
+        } catch (Throwable abortFailure) {
+            failure = abortFailure;
         }
+        try {
+            closeWriter();
+        } catch (Throwable closeFailure) {
+            failure = mergeFailure(failure, closeFailure);
+        }
+        throwIfFailed(failure);
     }
 
     // ────────────────────────────────────────────────────────────

--- a/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/PaimonJniWriter.java
+++ b/fe/be-java-extensions/paimon-connector/src/main/java/org/apache/doris/paimon/PaimonJniWriter.java
@@ -26,8 +26,10 @@ import org.apache.arrow.c.ArrowSchema;
 import org.apache.arrow.c.CDataDictionaryProvider;
 import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.crosspartition.IndexBootstrap;
 import org.apache.paimon.data.BinaryRow;
@@ -111,6 +113,9 @@ public class PaimonJniWriter {
     private boolean fullCompactionChangelog;
     private final Set<PartitionBucket> fullCompactionBuckets = new HashSet<>();
     private List<CommitMessage> preparedCommitMessages = Collections.emptyList();
+    private boolean abortPending;
+    private boolean deferAbortAfterOutOfMemory;
+    private Throwable allocatorCloseFailure;
 
     public PaimonJniWriter() {
         // Imported C Data vectors reference Doris-owned buffers; this allocator owns only Arrow's
@@ -223,12 +228,17 @@ public class PaimonJniWriter {
             preExecutionAuthenticator.execute(() -> {
                 try (ArrowArray array = ArrowArray.wrap(arrayAddress);
                         ArrowSchema schema = ArrowSchema.wrap(schemaAddress);
-                        CDataDictionaryProvider dictionaries = new CDataDictionaryProvider();
-                        VectorSchemaRoot root = Data.importVectorSchemaRoot(
-                                allocator, array, schema, dictionaries)) {
-                    writeBatch(root);
-                    return null;
+                        CDataDictionaryProvider dictionaries = new CDataDictionaryProvider()) {
+                    Schema importedSchema = Data.importSchema(allocator, schema, dictionaries);
+                    try (VectorSchemaRoot root =
+                                 VectorSchemaRoot.create(importedSchema, allocator)) {
+                        Data.importIntoVectorSchemaRoot(
+                                allocator, array, root, dictionaries);
+                        writeBatch(root);
+                        return null;
+                    }
                 } catch (Throwable t) {
+                    recordOutOfMemoryFailure(t);
                     throw new RuntimeException("PaimonJniWriter C Data write failed", t);
                 }
             });
@@ -257,6 +267,7 @@ public class PaimonJniWriter {
                     LOG.info("PaimonJniWriter prepareCommit: {} messages", messages.size());
                     return commitCodec.encode(messages);
                 } catch (Throwable t) {
+                    recordOutOfMemoryFailure(t);
                     throw new RuntimeException("PaimonJniWriter prepareCommit failed", t);
                 }
             });
@@ -264,12 +275,11 @@ public class PaimonJniWriter {
     }
 
     /**
-     * Abort an already prepared commit, if present, and close the SDK writer.
-     * Called from C++ when write or prepareCommit fails.
+     * Abort uncommitted files and close the SDK writer after a write or prepare failure.
      *
-     * <p>Do not call prepareCommit from this error path: preparing may flush and compact data,
-     * which needs more heap precisely when the caller is recovering from an OOM. Files without a
-     * prepared commit message remain uncommitted and are handled by Paimon's orphan cleanup.
+     * <p>For ordinary failures, prepare commit messages before aborting so files already flushed by
+     * Paimon can be deleted. After an OOM, defer that allocation-heavy work until a later recovery
+     * attempt has enough memory.
      */
     public void abort() throws Exception {
         try (ThreadClassLoaderContext ignored = new ThreadClassLoaderContext(classLoader)) {
@@ -282,9 +292,10 @@ public class PaimonJniWriter {
                 } else {
                     abortWriter();
                 }
-            } catch (Exception e) {
-                LOG.error("PaimonJniWriter abort failed", e);
-                throw e;
+            } catch (Throwable t) {
+                recordOutOfMemoryFailure(t);
+                LOG.error("PaimonJniWriter abort failed", t);
+                throwIfFailed(t);
             }
         }
     }
@@ -306,6 +317,28 @@ public class PaimonJniWriter {
             } catch (Exception e) {
                 LOG.warn("PaimonJniWriter close error", e);
                 throw e;
+            }
+        }
+    }
+
+    /** Retry deferred abort cleanup and close all resources after memory pressure subsides. */
+    public void recoverAndClose() throws Exception {
+        try (ThreadClassLoaderContext ignored = new ThreadClassLoaderContext(classLoader)) {
+            try {
+                if (preExecutionAuthenticator != null) {
+                    preExecutionAuthenticator.execute(() -> {
+                        finishPendingAbort();
+                        closeResources();
+                        return null;
+                    });
+                } else {
+                    finishPendingAbort();
+                    closeResources();
+                }
+            } catch (Throwable t) {
+                recordOutOfMemoryFailure(t);
+                LOG.warn("PaimonJniWriter recovery cleanup error", t);
+                throwIfFailed(t);
             }
         }
     }
@@ -529,24 +562,15 @@ public class PaimonJniWriter {
     // ────────────────────────────────────────────────────────────
 
     private void closeResources() throws Exception {
-        Throwable failure = null;
-        try {
-            closeWriter();
-        } catch (Throwable closeFailure) {
-            failure = closeFailure;
+        if (abortPending) {
+            throw new IllegalStateException(
+                    "Paimon writer abort cleanup is pending; recovery must finish abort before close");
         }
 
+        closeWriter();
         writeSchema = null;
         arrowAdapter = null;
-        if (allocator != null) {
-            Throwable allocatorFailure = closeResource(allocator);
-            if (allocatorFailure == null) {
-                allocator = null;
-            } else {
-                failure = mergeFailure(failure, allocatorFailure);
-            }
-        }
-        throwIfFailed(failure);
+        closeAllocator();
     }
 
     private List<CommitMessage> prepareCommitMessages() throws Exception {
@@ -582,34 +606,59 @@ public class PaimonJniWriter {
         }
     }
 
-    private void closeWriter() throws Exception {
-        Throwable failure = null;
-
+    void closeWriter() throws Exception {
         Throwable writerFailure = closeResource(writer);
-        if (writerFailure == null) {
-            writer = null;
-        } else {
-            failure = writerFailure;
+        if (writerFailure != null) {
+            throwIfFailed(writerFailure);
         }
+        writer = null;
 
         Throwable indexAssignerFailure = closeResource(globalIndexAssigner);
-        if (indexAssignerFailure == null) {
-            globalIndexAssigner = null;
-        } else {
-            failure = mergeFailure(failure, indexAssignerFailure);
+        if (indexAssignerFailure != null) {
+            throwIfFailed(indexAssignerFailure);
         }
+        globalIndexAssigner = null;
 
+        // Paimon writers may still need spill files while close is in progress. Close the shared
+        // IOManager only after every writer has stopped successfully.
         Throwable ioManagerFailure = closeResource(ioManager);
-        if (ioManagerFailure == null) {
-            ioManager = null;
-        } else {
-            failure = mergeFailure(failure, ioManagerFailure);
+        if (ioManagerFailure != null) {
+            throwIfFailed(ioManagerFailure);
+        }
+        ioManager = null;
+
+        clearWriterState();
+    }
+
+    private void closeAllocator() throws Exception {
+        if (allocator == null) {
+            return;
+        }
+        if (allocatorCloseFailure != null) {
+            throw new IllegalStateException(
+                    "Arrow allocator entered a terminal failed-close state",
+                    allocatorCloseFailure);
         }
 
-        if (writer == null && globalIndexAssigner == null && ioManager == null) {
-            clearWriterState();
+        verifyAllocatorHasNoOutstandingMemory(allocator);
+        try {
+            allocator.close();
+            allocator = null;
+        } catch (Throwable closeFailure) {
+            // Arrow 19 marks BaseAllocator closed before validating all resources. Retrying close
+            // would return successfully without proving cleanup, so remember this terminal failure.
+            allocatorCloseFailure = closeFailure;
+            throwIfFailed(closeFailure);
         }
-        throwIfFailed(failure);
+    }
+
+    static void verifyAllocatorHasNoOutstandingMemory(BufferAllocator allocator) {
+        long allocatedMemory = allocator.getAllocatedMemory();
+        if (allocatedMemory != 0) {
+            throw new IllegalStateException(
+                    "Arrow allocator still owns " + allocatedMemory
+                            + " bytes; defer terminal close until imported resources are released");
+        }
     }
 
     static Throwable closeResource(AutoCloseable resource) {
@@ -669,26 +718,63 @@ public class PaimonJniWriter {
     }
 
     private void abortWriter() throws Exception {
-        Throwable failure = null;
-        try {
-            List<CommitMessage> messages = preparedCommitMessages;
-            if (!messages.isEmpty()) {
-                InnerTableCommit committer = table.newCommit(commitUser);
-                try {
-                    committer.abort(messages);
-                } finally {
-                    committer.close();
-                }
+        if (writer == null && preparedCommitMessages.isEmpty()) {
+            abortPending = false;
+            deferAbortAfterOutOfMemory = false;
+            return;
+        }
+
+        abortPending = true;
+        if (deferAbortAfterOutOfMemory && preparedCommitMessages.isEmpty()) {
+            LOG.warn("Deferring Paimon prepare-and-abort cleanup after OOM");
+            return;
+        }
+        finishPendingAbort();
+        closeWriter();
+    }
+
+    private void finishPendingAbort() throws Exception {
+        if (!abortPending) {
+            return;
+        }
+
+        List<CommitMessage> messages = preparedCommitMessages;
+        if (messages.isEmpty() && writer != null) {
+            messages = prepareCommitMessages();
+        }
+        if (!messages.isEmpty()) {
+            InnerTableCommit committer = table.newCommit(commitUser);
+            try {
+                committer.abort(messages);
+            } finally {
+                committer.close();
             }
-        } catch (Throwable abortFailure) {
-            failure = abortFailure;
         }
-        try {
-            closeWriter();
-        } catch (Throwable closeFailure) {
-            failure = mergeFailure(failure, closeFailure);
+
+        preparedCommitMessages = Collections.emptyList();
+        abortPending = false;
+        deferAbortAfterOutOfMemory = false;
+    }
+
+    private void recordOutOfMemoryFailure(Throwable failure) {
+        if (containsOutOfMemory(failure)) {
+            deferAbortAfterOutOfMemory = true;
         }
-        throwIfFailed(failure);
+    }
+
+    static boolean containsOutOfMemory(Throwable failure) {
+        Throwable current = failure;
+        for (int depth = 0; current != null && depth < 32; depth++) {
+            if (current instanceof OutOfMemoryError || current instanceof OutOfMemoryException) {
+                return true;
+            }
+            Throwable cause = current.getCause();
+            if (cause == current) {
+                break;
+            }
+            current = cause;
+        }
+        return false;
     }
 
     // ────────────────────────────────────────────────────────────

--- a/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/PaimonJniWriterTest.java
+++ b/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/PaimonJniWriterTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class PaimonJniWriterTest {
 
@@ -117,5 +118,20 @@ public class PaimonJniWriterTest {
             thread.setContextClassLoader(originalClassLoader);
             testClassLoader.close();
         }
+    }
+
+    @Test
+    public void testCloseResourceCanRetryAfterOutOfMemoryError() {
+        AtomicInteger closeAttempts = new AtomicInteger();
+        OutOfMemoryError firstFailure = new OutOfMemoryError("test OOM during close");
+        AutoCloseable resource = () -> {
+            if (closeAttempts.getAndIncrement() == 0) {
+                throw firstFailure;
+            }
+        };
+
+        Assertions.assertSame(firstFailure, PaimonJniWriter.closeResource(resource));
+        Assertions.assertNull(PaimonJniWriter.closeResource(resource));
+        Assertions.assertEquals(2, closeAttempts.get());
     }
 }

--- a/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/PaimonJniWriterTest.java
+++ b/fe/be-java-extensions/paimon-connector/src/test/java/org/apache/doris/paimon/PaimonJniWriterTest.java
@@ -17,9 +17,17 @@
 
 package org.apache.doris.paimon;
 
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.paimon.disk.IOManager;
+import org.apache.paimon.operation.FileStoreWrite;
+import org.apache.paimon.table.sink.TableWriteImpl;
+import org.apache.paimon.types.RowType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collections;
@@ -133,5 +141,144 @@ public class PaimonJniWriterTest {
         Assertions.assertSame(firstFailure, PaimonJniWriter.closeResource(resource));
         Assertions.assertNull(PaimonJniWriter.closeResource(resource));
         Assertions.assertEquals(2, closeAttempts.get());
+    }
+
+    @Test
+    public void testDetectNestedOutOfMemoryFailure() {
+        RuntimeException wrapped = new RuntimeException(
+                "write failed", new IllegalStateException(new OutOfMemoryError("test OOM")));
+        Assertions.assertTrue(PaimonJniWriter.containsOutOfMemory(wrapped));
+        Assertions.assertFalse(PaimonJniWriter.containsOutOfMemory(
+                new RuntimeException("not an OOM")));
+    }
+
+    @Test
+    public void testAllocatorCloseWaitsForOutstandingBuffers() {
+        RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        try {
+            try (ArrowBuf ignored = allocator.buffer(8)) {
+                IllegalStateException exception = Assertions.assertThrows(
+                        IllegalStateException.class,
+                        () -> PaimonJniWriter.verifyAllocatorHasNoOutstandingMemory(allocator));
+                Assertions.assertTrue(exception.getMessage().contains("still owns 8 bytes"));
+            }
+
+            Assertions.assertDoesNotThrow(
+                    () -> PaimonJniWriter.verifyAllocatorHasNoOutstandingMemory(allocator));
+        } finally {
+            allocator.close();
+        }
+    }
+
+    @Test
+    public void testWriterCloseFailureKeepsIoManagerForRetry() throws Exception {
+        AtomicInteger writerCloseAttempts = new AtomicInteger();
+        AtomicInteger ioManagerCloseAttempts = new AtomicInteger();
+        FileStoreWrite<?> fileStoreWrite = (FileStoreWrite<?>) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {FileStoreWrite.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("close")
+                            && writerCloseAttempts.getAndIncrement() == 0) {
+                        throw new OutOfMemoryError("test writer close OOM");
+                    }
+                    return null;
+                });
+        TableWriteImpl<?> tableWrite = new TableWriteImpl<>(
+                RowType.of(), fileStoreWrite, null, null, null, null);
+        IOManager ioManager = (IOManager) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {IOManager.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("close")) {
+                        ioManagerCloseAttempts.incrementAndGet();
+                    }
+                    return null;
+                });
+
+        PaimonJniWriter writer = new PaimonJniWriter();
+        setField(writer, "writer", tableWrite);
+        setField(writer, "ioManager", ioManager);
+        try {
+            Assertions.assertThrows(OutOfMemoryError.class, writer::closeWriter);
+            Assertions.assertEquals(1, writerCloseAttempts.get());
+            Assertions.assertEquals(0, ioManagerCloseAttempts.get());
+
+            Assertions.assertDoesNotThrow(writer::closeWriter);
+            Assertions.assertEquals(2, writerCloseAttempts.get());
+            Assertions.assertEquals(1, ioManagerCloseAttempts.get());
+        } finally {
+            writer.close();
+        }
+    }
+
+    @Test
+    public void testOutOfMemoryAbortDefersPrepareUntilRecovery() throws Exception {
+        AtomicInteger prepareAttempts = new AtomicInteger();
+        AtomicInteger writerCloseAttempts = new AtomicInteger();
+        FileStoreWrite<?> fileStoreWrite = (FileStoreWrite<?>) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {FileStoreWrite.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("prepareCommit")) {
+                        prepareAttempts.incrementAndGet();
+                        return Collections.emptyList();
+                    }
+                    if (method.getName().equals("close")) {
+                        writerCloseAttempts.incrementAndGet();
+                    }
+                    return null;
+                });
+        TableWriteImpl<?> tableWrite = new TableWriteImpl<>(
+                RowType.of(), fileStoreWrite, null, null, null, null);
+
+        PaimonJniWriter writer = new PaimonJniWriter();
+        setField(writer, "writer", tableWrite);
+        setField(writer, "deferAbortAfterOutOfMemory", true);
+
+        writer.abort();
+        Assertions.assertEquals(0, prepareAttempts.get());
+        Assertions.assertEquals(0, writerCloseAttempts.get());
+        Assertions.assertThrows(IllegalStateException.class, writer::close);
+
+        writer.recoverAndClose();
+        Assertions.assertEquals(1, prepareAttempts.get());
+        Assertions.assertEquals(1, writerCloseAttempts.get());
+        Assertions.assertDoesNotThrow(writer::close);
+    }
+
+    @Test
+    public void testOrdinaryAbortPreparesAndClosesWriterImmediately() throws Exception {
+        AtomicInteger prepareAttempts = new AtomicInteger();
+        AtomicInteger writerCloseAttempts = new AtomicInteger();
+        FileStoreWrite<?> fileStoreWrite = (FileStoreWrite<?>) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {FileStoreWrite.class},
+                (proxy, method, args) -> {
+                    if (method.getName().equals("prepareCommit")) {
+                        prepareAttempts.incrementAndGet();
+                        return Collections.emptyList();
+                    }
+                    if (method.getName().equals("close")) {
+                        writerCloseAttempts.incrementAndGet();
+                    }
+                    return null;
+                });
+        TableWriteImpl<?> tableWrite = new TableWriteImpl<>(
+                RowType.of(), fileStoreWrite, null, null, null, null);
+
+        PaimonJniWriter writer = new PaimonJniWriter();
+        setField(writer, "writer", tableWrite);
+
+        writer.abort();
+        Assertions.assertEquals(1, prepareAttempts.get());
+        Assertions.assertEquals(1, writerCloseAttempts.get());
+        Assertions.assertDoesNotThrow(writer::close);
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = PaimonJniWriter.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

When a Paimon JNI writer hits an OOM while flushing or closing, Java cleanup can fail while asynchronous SDK tasks still reference Doris-owned native pages. The failed writer then cannot be safely released, and subsequent writes remain unavailable until the BE is restarted.

This PR:

- makes Java resource cleanup retryable after Throwable, including OutOfMemoryError, and retains only resources whose close did not succeed;
- avoids prepareCommit from the abort/OOM path because it can trigger more flushing and compaction allocation;
- quarantines the Java writer together with PaimonJniMemoryManager when close cannot be confirmed;
- retries quarantined close operations before admitting a later writer, releasing JNI ownership and native pages only after close succeeds;
- keeps the JNI close state minimal: the writer global reference keeps its defining class loaded, so no separate class global reference is needed.

While cleanup still fails, new Paimon JNI writes fail fast instead of risking use-after-free. Once cleanup succeeds, later writes can proceed without restarting the BE.

### Release note

Fix Paimon JNI writes remaining unavailable after an OOM during writer cleanup.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test
    - [ ] No need to test or manual test.
- Behavior changed:
    - [ ] No.
    - [x] Yes. Paimon JNI writer cleanup can be retried after OOM, allowing later writes to recover without a BE restart.
- Does this need documentation?
    - [x] No.
    - [ ] Yes.

Validation:

- FE/BE-Java build: 27 modules passed, Checkstyle 0 violations.
- PaimonJniWriterTest: 6 tests passed.
- clang-format 16 dry-run and git diff --check passed.
- BE C++ compilation and BE unit tests were intentionally not run for this change.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label