### PR TITLE
[improvement](workflow) Fence PR checks by SHA and reject stale starts

### DIFF
--- a/.github/workflows/checkstyle.yaml
+++ b/.github/workflows/checkstyle.yaml
@@ -26,6 +26,9 @@ jobs:
   java-checkstyle:
     name: "CheckStyle"
     runs-on: ubuntu-latest
+    concurrency:
+      group: fe-code-style-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: true
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
@@ -56,4 +59,3 @@ jobs:
         if: steps.filter.outputs.fe_changes == 'true'
         run:
           cd fe && mvn clean checkstyle:check
-

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -31,6 +31,9 @@ jobs:
   clang-format:
     name: "Clang Formatter"
     runs-on: ubuntu-latest
+    concurrency:
+      group: code-formatter-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: true
     if: github.event_name == 'pull_request'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"

--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -55,27 +55,19 @@ permissions:
 jobs:
   code-review:
     runs-on: ubuntu-latest
-    concurrency:
-      group: code-review-${{ inputs.pr_number || github.event.issue.number || github.run_id }}
-      cancel-in-progress: true
     # Pre-finalization steps can use 183 minutes and auth sync can use 8 more,
     # leaving 12 minutes for runner setup and post-job cleanup.
     timeout-minutes: 203
-    # Retry with a new /review request so an older workflow rerun cannot replace
-    # the latest review for the same PR.
     if: >-
-      github.run_attempt == 1 &&
+      inputs.pr_number != '' ||
       (
-        inputs.pr_number != '' ||
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/review') &&
         (
-          github.event_name == 'issue_comment' &&
-          github.event.issue.pull_request &&
-          startsWith(github.event.comment.body, '/review') &&
-          (
-            github.event.comment.author_association == 'MEMBER' ||
-            github.event.comment.author_association == 'OWNER' ||
-            github.event.comment.author_association == 'COLLABORATOR'
-          )
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
         )
       )
     steps:

--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -55,19 +55,27 @@ permissions:
 jobs:
   code-review:
     runs-on: ubuntu-latest
+    concurrency:
+      group: code-review-${{ inputs.pr_number || github.event.issue.number || github.run_id }}
+      cancel-in-progress: true
     # Pre-finalization steps can use 183 minutes and auth sync can use 8 more,
     # leaving 12 minutes for runner setup and post-job cleanup.
     timeout-minutes: 203
+    # Retry with a new /review request so an older workflow rerun cannot replace
+    # the latest review for the same PR.
     if: >-
-      inputs.pr_number != '' ||
+      github.run_attempt == 1 &&
       (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        startsWith(github.event.comment.body, '/review') &&
+        inputs.pr_number != '' ||
         (
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'COLLABORATOR'
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          startsWith(github.event.comment.body, '/review') &&
+          (
+            github.event.comment.author_association == 'MEMBER' ||
+            github.event.comment.author_association == 'OWNER' ||
+            github.event.comment.author_association == 'COLLABORATOR'
+          )
         )
       )
     steps:

--- a/.github/workflows/gitleaks-pr-check.yml
+++ b/.github/workflows/gitleaks-pr-check.yml
@@ -28,6 +28,9 @@ jobs:
   gitleaks:
     name: Check for secrets
     runs-on: ubuntu-latest
+    concurrency:
+      group: gitleaks-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: true
     env:
       GITLEAKS_VERSION: 8.30.0
       GITLEAKS_SHA256: 79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e

--- a/.github/workflows/license-eyes.yml
+++ b/.github/workflows/license-eyes.yml
@@ -32,6 +32,9 @@ jobs:
   license-check:
     name: "License Check"
     runs-on: ubuntu-latest
+    concurrency:
+      group: license-check-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: true
     if: |
       (github.event_name == 'pull_request') ||
       (github.event_name == 'push' && github.ref == 'refs/heads/master')


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

Four frequent PR workflows originally used only the PR number as a job concurrency key. GitHub does not guarantee that jobs enter a concurrency group in the same order as PR events. A delayed old event or a manual rerun of an old validation could therefore cancel the newer check.

This PR changes FE Code Style Checker, Code Formatter, Gitleaks PR Check, and License Check to:

- isolate cancellation by workflow, PR number, and the immutable GitHub validation SHA;
- read the current PR head SHA through the Pulls API as the first step, before checkout or other costly work;
- fail an obsolete event explicitly if its recorded head SHA no longer matches the current PR head.

Checkstyle and Gitleaks receive read-only Pull requests permission for this check. License Check runs on master push remain independent and do not perform the PR preflight. Code Review Runner is intentionally outside this PR because its cancellation path also controls review status, comments, and session state.

Repeated events or reruns for the same validation SHA still coalesce. Different validation SHAs no longer cancel each other, so this is not cross-SHA latest-only: an old job already running can finish, while an old job that starts after the PR has advanced fails before checkout. The one-time preflight does not guarantee that a PR stays current throughout a long-running job.

#### Historical usage data and expected effect

The August 20, 21, and 24 sample contained 1,727 jobs across these four workflows. Forty old jobs overlapped later same-PR events, representing about 61.5 runner minutes under a PR-only cancellation estimate. That figure is an upper bound for the earlier design, not a saving claimed for this SHA-isolated design. The new design prevents reverse-order cancellation and avoids the substantive work of stale jobs that start after a PR update; it still consumes runner startup and the preflight call.

### Release note

None

### Check List (For Author)

- Test: Manual test. Ran actionlint on the four workflows with only the pre-existing Checkstyle checkout v3 warning excluded, checked the scoped diff, and read back the PR head through the same Pulls API endpoint. The new SHA checks were queued at the time of this edit; remote terminal validation is not yet claimed.
- Behavior changed: Yes. Cancellation is scoped to the same PR and validation SHA, and stale starts fail before checkout.
- Does this need documentation: No

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label