### PR TITLE
[fix](be) Decouple SNII BM25 scoring from CommonGrams

### DIFF
--- a/be/src/storage/compaction/compaction.cpp
+++ b/be/src/storage/compaction/compaction.cpp
@@ -1076,7 +1076,7 @@ Status Compaction::do_inverted_index_compaction() {
     std::unique_ptr<snii::compaction::ValidatedRowIdConversion> validated_snii_rowid_conversion;
     if (_cur_tablet_schema->get_inverted_index_storage_format() ==
         InvertedIndexStorageFormatPB::SNII) {
-        const size_t spill_threshold =
+        const auto spill_threshold =
                 static_cast<size_t>(config::inverted_index_ram_buffer_size * 1024 * 1024);
         // Mirror the merge's live build bytes into the process-wide SNII
         // index-build observation tracker, the same line ingestion feeds: index
@@ -1198,8 +1198,8 @@ Status Compaction::do_inverted_index_compaction() {
                         auto* destination_writer =
                                 inverted_index_file_writers[cast_set<int>(destination_ordinal)]
                                         .get();
-                        if (merge_eligibility.kind ==
-                            snii::compaction::SniiStreamedMergeKind::kCommonGramsT3) {
+                        if (snii::compaction::streamed_merge_carries_norms(
+                                    merge_eligibility.kind)) {
                             merge_status = destination_writer->add_snii_index_streamed(
                                     index_meta, dest_segment_num_rows[destination_ordinal],
                                     merge_plan->take_destination_null_docids(destination_ordinal),

--- a/be/src/storage/index/index_file_writer.cpp
+++ b/be/src/storage/index/index_file_writer.cpp
@@ -348,9 +348,13 @@ Status IndexFileWriter::add_snii_index_streamed(
         return Status::Error<ErrorCode::INVERTED_INDEX_FILE_NOT_FOUND>(
                 "SNII index file writer is null for {}", _index_path_prefix);
     }
+    // Scoring requires one norm per document. CommonGrams metadata is an
+    // ADDITIONAL property of a scoring index, not a precondition for one: an
+    // ordinary analyzed index reaches the scoring tier with norms and no
+    // CommonGrams metadata at all. It must never appear without scoring, though.
     const bool has_scoring = doris::snii::format::has_scoring(index_config);
     const bool valid_scoring_shape =
-            has_scoring ? common_grams_metadata.has_value() && encoded_norms.size() == doc_count
+            has_scoring ? encoded_norms.size() == doc_count
                         : !common_grams_metadata.has_value() && encoded_norms.empty();
     if (!valid_scoring_shape) {
         return Status::InternalError(

--- a/be/src/storage/index/index_writer.h
+++ b/be/src/storage/index/index_writer.h
@@ -56,6 +56,15 @@ public:
                                     const uint8_t* null_map, const uint8_t* offsets_ptr,
                                     size_t count) = 0;
 
+    virtual Status add_nullable_array_values(size_t field_size, const void* value_ptr,
+                                             const uint8_t* nested_null_map,
+                                             const uint8_t* row_null_map,
+                                             const uint8_t* offsets_ptr, size_t count) {
+        RETURN_IF_ERROR(
+                add_array_values(field_size, value_ptr, nested_null_map, offsets_ptr, count));
+        return add_array_nulls(row_null_map, count);
+    }
+
     virtual Status add_nulls(uint32_t count) = 0;
     virtual Status add_array_nulls(const uint8_t* null_map, size_t num_rows) = 0;
 

--- a/be/src/storage/index/inverted/similarity/collection_statistics.cpp
+++ b/be/src/storage/index/inverted/similarity/collection_statistics.cpp
@@ -47,13 +47,29 @@ Result<SniiScoringSegmentStats> resolve_snii_scoring_segment(
         bool has_positions, bool has_semantic_norms) {
     using namespace segment_v2::inverted_index;
     const auto* metadata_ptr = metadata ? &*metadata : nullptr;
+    if (metadata_ptr == nullptr) {
+        // No CommonGrams metadata means an ORDINARY analyzed index, not a defect.
+        // Its postings hold no gram tokens, so the physical statistics already
+        // ARE the semantic ones and its term keys are raw. It still needs the
+        // scoring tier: without norms and freq regions there is nothing to score
+        // with.
+        if (!has_scoring_tier || !has_positions || !has_semantic_norms) {
+            return ResultError(Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED, false>(
+                    "SNII index does not persist scoring data (scoring tier {}, positions {}, "
+                    "norms {})",
+                    has_scoring_tier, has_positions, has_semantic_norms));
+        }
+        return SniiScoringSegmentStats {.doc_count = index_doc_count,
+                                        .token_count = physical_sum_total_term_freq,
+                                        .plain_term_key_version = PlainTermKeyVersion::kLegacyRaw,
+                                        .base_analyzer_fingerprint = {}};
+    }
     auto validation_status = validate_snii_scoring_metadata(
             metadata_ptr, index_doc_count, physical_sum_total_term_freq, has_scoring_tier,
             has_positions, has_semantic_norms);
     if (!validation_status.ok()) {
         return ResultError(std::move(validation_status));
     }
-    DORIS_CHECK(metadata_ptr != nullptr);
 
     return SniiScoringSegmentStats {
             .doc_count = metadata_ptr->scoring_doc_count,
@@ -266,7 +282,6 @@ Status CollectionStatistics::process_segment(const RowsetSharedPtr& rowset,
                     logical_reader->has_positions(),
                     logical_reader->section_refs().norms.length != 0, &key_version,
                     &segment_accumulator));
-            DORIS_CHECK(common_grams_metadata != nullptr);
 
             ::doris::snii::reader::DictBlockCache dict_block_cache;
             for (const auto& logical_term_bytes : collect_info.unique_terms) {
@@ -288,10 +303,14 @@ Status CollectionStatistics::process_segment(const RowsetSharedPtr& rowset,
                 uint64_t prx_base = 0;
                 RETURN_IF_ERROR(logical_reader->lookup(physical_term, &found, &entry, &frq_base,
                                                        &prx_base, &dict_block_cache));
-                if (found && entry.df > common_grams_metadata->scoring_doc_count) {
+                // Bound df by the segment's PHYSICAL document count. For a
+                // CommonGrams segment validate_snii_scoring_metadata already
+                // proved scoring_doc_count == this number, and a plain segment
+                // has no separate semantic count at all.
+                if (found && entry.df > logical_reader->stats().doc_count) {
                     return Status::Error<ErrorCode::INVERTED_INDEX_FILE_CORRUPTED>(
-                            "SNII term document frequency {} exceeds scoring document count {}",
-                            entry.df, common_grams_metadata->scoring_doc_count);
+                            "SNII term document frequency {} exceeds segment document count {}",
+                            entry.df, logical_reader->stats().doc_count);
                 }
                 collection_statistics_detail::add_term_doc_frequency(
                         &segment_accumulator.term_doc_freqs, ws_field_name, logical_term,
@@ -378,15 +397,30 @@ Status CollectionStatistics::admit_snii_scoring_segment(
     }
 
     const auto& base_analyzer_fingerprint = segment_stats->base_analyzer_fingerprint;
-    if (base_analyzer_fingerprint != expected_base_analyzer_fingerprint) {
+    // Only a CommonGrams segment records a base-analyzer identity, because its
+    // term keys are derived from the dictionary. A plain segment stores raw keys
+    // and no fingerprint -- V1/V2/V3 score the same shape with no such check.
+    // The staged/collected comparisons below still run, so an empty fingerprint
+    // and a real one can never be combined for one field.
+    if (!base_analyzer_fingerprint.empty() &&
+        base_analyzer_fingerprint != expected_base_analyzer_fingerprint) {
         clear();
         return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>(
                 "SNII scoring segment base analyzer does not match the request analyzer for field "
                 "{}",
                 StringHelper::to_string(field_name));
     }
+    // An empty fingerprint means "this segment records no analyzer identity",
+    // which is the ordinary analyzed shape -- not "a different analyzer". Only
+    // CommonGrams segments record one, because their term keys depend on the
+    // dictionary. Comparing an absent identity against a present one would
+    // reject a table whose segments were written with the SAME analyzer while
+    // enable_common_grams_index_build was toggled, even though their statistics
+    // are perfectly combinable.
     auto staged_fingerprint = segment_accumulator->base_analyzer_fingerprints.find(field_name);
-    if (staged_fingerprint != segment_accumulator->base_analyzer_fingerprints.end() &&
+    if (!base_analyzer_fingerprint.empty() &&
+        staged_fingerprint != segment_accumulator->base_analyzer_fingerprints.end() &&
+        !staged_fingerprint->second.empty() &&
         staged_fingerprint->second != base_analyzer_fingerprint) {
         clear();
         return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>(
@@ -394,15 +428,21 @@ Status CollectionStatistics::admit_snii_scoring_segment(
                 StringHelper::to_string(field_name));
     }
     auto collected_fingerprint = _snii_base_analyzer_fingerprints.find(field_name);
-    if (collected_fingerprint != _snii_base_analyzer_fingerprints.end() &&
+    if (!base_analyzer_fingerprint.empty() &&
+        collected_fingerprint != _snii_base_analyzer_fingerprints.end() &&
+        !collected_fingerprint->second.empty() &&
         collected_fingerprint->second != base_analyzer_fingerprint) {
         clear();
         return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED>(
                 "SNII scoring cannot combine segments with different base analyzers for field {}",
                 StringHelper::to_string(field_name));
     }
-    segment_accumulator->base_analyzer_fingerprints.insert_or_assign(field_name,
-                                                                     base_analyzer_fingerprint);
+    // Never let a plain segment's absent identity erase one a CommonGrams
+    // segment already recorded for this field.
+    if (!base_analyzer_fingerprint.empty()) {
+        segment_accumulator->base_analyzer_fingerprints.insert_or_assign(field_name,
+                                                                         base_analyzer_fingerprint);
+    }
 
     if (!segment_accumulator->token_counts.empty() &&
         segment_accumulator->doc_count != segment_stats->doc_count) {

--- a/be/src/storage/index/snii/compaction/eligibility.cpp
+++ b/be/src/storage/index/snii/compaction/eligibility.cpp
@@ -90,6 +90,29 @@ inverted_index::CommonGramsSegmentMetadata static_common_grams_metadata(
     return seed;
 }
 
+Status validate_plain_t3_source_shape(const reader::LogicalIndexReader& source,
+                                      size_t source_ordinal) {
+    if (source.tier() != format::IndexTier::kT3 || !source.has_positions()) {
+        return reject(fmt::format("source {} is not a scoring T3 index", source_ordinal));
+    }
+    if (source.section_refs().norms.length == 0) {
+        return reject(fmt::format("source {} has no scoring norms", source_ordinal));
+    }
+    if (source.common_grams_metadata() != nullptr) {
+        return reject(fmt::format("source {} carries CommonGrams metadata", source_ordinal));
+    }
+    if (source.common_grams_posting_policy() != format::CommonGramsPostingPolicy::kNone) {
+        return reject(
+                fmt::format("source {} carries a CommonGrams posting policy", source_ordinal));
+    }
+    const auto& stats = source.stats();
+    if (stats.indexed_doc_count > stats.doc_count ||
+        stats.null_count != stats.doc_count - stats.indexed_doc_count) {
+        return reject(fmt::format("source {} statistics are inconsistent", source_ordinal));
+    }
+    return Status::OK();
+}
+
 Status validate_common_grams_source_shape(const reader::LogicalIndexReader& source,
                                           size_t source_ordinal) {
     if (source.tier() != format::IndexTier::kT3 || !source.has_positions()) {
@@ -217,6 +240,10 @@ Status validate_snii_source_eligibility(const reader::LogicalIndexReader& source
     if (eligibility.kind == SniiStreamedMergeKind::kPlainT2) {
         return validate_plain_t2_source_eligibility(source, source_ordinal);
     }
+    if (eligibility.kind == SniiStreamedMergeKind::kPlainT3) {
+        RETURN_IF_ERROR(validate_plain_t3_source_shape(source, source_ordinal));
+        return reject_legacy_bigram(source, source_ordinal);
+    }
     RETURN_IF_ERROR(validate_common_grams_source_shape(source, source_ordinal));
     RETURN_IF_ERROR(reject_legacy_bigram(source, source_ordinal));
     if (!eligibility.common_grams_metadata_seed.has_value()) {
@@ -277,6 +304,31 @@ Status validate_plain_t2_compaction_eligibility(
     return validate_destination_policy(destination_index, analyzer_provider_factory);
 }
 
+namespace {
+
+// Scoring sources with no CommonGrams metadata: every source must be the same
+// plain T3 shape, and the destination analyzer must still be the plain one.
+// There is no identity seed to carry -- the physical statistics are already the
+// semantic ones -- so the destination needs nothing beyond the norms remap.
+Status resolve_plain_t3_eligibility(std::span<const PlainT2CompactionSource> sources,
+                                    const TabletIndex& destination_index,
+                                    const AnalyzerProviderFactory& analyzer_provider_factory,
+                                    SniiCompactionEligibility* out) {
+    for (size_t source_ordinal = 0; source_ordinal < sources.size(); ++source_ordinal) {
+        const auto& source = sources[source_ordinal].reader.get();
+        if (source.tier() != format::IndexTier::kT3) {
+            return reject("source streamed-merge shapes are not homogeneous");
+        }
+        RETURN_IF_ERROR(validate_plain_t3_source_shape(source, source_ordinal));
+        RETURN_IF_ERROR(reject_legacy_bigram(source, source_ordinal));
+    }
+    RETURN_IF_ERROR(validate_destination_policy(destination_index, analyzer_provider_factory));
+    out->kind = SniiStreamedMergeKind::kPlainT3;
+    return Status::OK();
+}
+
+} // namespace
+
 Status validate_snii_compaction_eligibility(
         std::span<const PlainT2CompactionSource> sources, const TabletIndex& destination_index,
         SniiCompactionEligibility* out, const AnalyzerProviderFactory& analyzer_provider_factory) {
@@ -336,6 +388,13 @@ Status validate_snii_compaction_eligibility(
     }
     if (source_tier != format::IndexTier::kT3) {
         return reject("source streamed-merge shape is neither plain T2 nor CommonGrams T3");
+    }
+
+    // Reaching the scoring tier no longer implies CommonGrams: an ordinary
+    // analyzed index is T3 too. Split on the metadata, not on the tier.
+    if (sources.front().reader.get().common_grams_metadata() == nullptr) {
+        return resolve_plain_t3_eligibility(sources, destination_index, analyzer_provider_factory,
+                                            out);
     }
 
     std::optional<inverted_index::CommonGramsSegmentMetadata> source_seed;

--- a/be/src/storage/index/snii/compaction/eligibility.h
+++ b/be/src/storage/index/snii/compaction/eligibility.h
@@ -53,9 +53,20 @@ using AnalyzerProviderFactory = std::function<segment_v2::inverted_index::Analyz
         const InvertedIndexAnalyzerConfig&)>;
 
 enum class SniiStreamedMergeKind : uint8_t {
+    // No norms: the index is not analyzed, or was written before an analyzed
+    // index reached the scoring tier.
     kPlainT2,
+    // Analyzed, scoring, no CommonGrams. Carries norms to remap, but its
+    // physical statistics are already the semantic ones, so there is no
+    // CommonGrams metadata to seed and no semantic token count to late-bind.
+    kPlainT3,
     kCommonGramsT3,
 };
+
+// True for the shapes whose destination segments carry a norms vector.
+inline bool streamed_merge_carries_norms(SniiStreamedMergeKind kind) {
+    return kind == SniiStreamedMergeKind::kPlainT3 || kind == SniiStreamedMergeKind::kCommonGramsT3;
+}
 
 // Validated destination shape for one streamed merge. CommonGrams metadata is a
 // static identity seed: destination doc_count is bound when its session starts,

--- a/be/src/storage/index/snii/compaction/snii_index_compaction.cpp
+++ b/be/src/storage/index/snii/compaction/snii_index_compaction.cpp
@@ -281,8 +281,9 @@ Status SniiPlainT2MergePlan::prepare(std::vector<const reader::LogicalIndexReade
 
     std::vector<writer::MemoryReporter::Reservation> destination_norm_reservations;
     std::vector<std::vector<uint8_t>> destination_encoded_norms;
-    if (eligibility.kind == SniiStreamedMergeKind::kCommonGramsT3) {
-        DORIS_CHECK(eligibility.common_grams_metadata_seed.has_value());
+    if (streamed_merge_carries_norms(eligibility.kind)) {
+        DORIS_CHECK(eligibility.kind != SniiStreamedMergeKind::kCommonGramsT3 ||
+                    eligibility.common_grams_metadata_seed.has_value());
         destination_norm_reservations.reserve(destination_segment_num_rows.size());
         destination_encoded_norms.resize(destination_segment_num_rows.size());
         for (size_t destination_ordinal = 0;
@@ -371,14 +372,14 @@ writer::TrackedNullDocids SniiPlainT2MergePlan::take_destination_null_docids(
 
 const std::vector<uint8_t>& SniiPlainT2MergePlan::destination_encoded_norms(
         size_t destination_segment) const {
-    DORIS_CHECK(eligibility_.kind == SniiStreamedMergeKind::kCommonGramsT3);
+    DORIS_CHECK(streamed_merge_carries_norms(eligibility_.kind));
     DORIS_CHECK_LT(destination_segment, destination_encoded_norms_.size());
     return destination_encoded_norms_[destination_segment];
 }
 
 writer::TrackedEncodedNorms SniiPlainT2MergePlan::take_destination_encoded_norms(
         size_t destination_segment) {
-    DORIS_CHECK(eligibility_.kind == SniiStreamedMergeKind::kCommonGramsT3);
+    DORIS_CHECK(streamed_merge_carries_norms(eligibility_.kind));
     DORIS_CHECK_LT(destination_segment, destination_encoded_norms_.size());
     DORIS_CHECK(!destination_encoded_norms_taken_[destination_segment]);
     destination_encoded_norms_taken_[destination_segment] = true;
@@ -388,14 +389,14 @@ writer::TrackedEncodedNorms SniiPlainT2MergePlan::take_destination_encoded_norms
 }
 
 format::IndexConfig SniiPlainT2MergePlan::destination_index_config() const {
-    return eligibility_.kind == SniiStreamedMergeKind::kCommonGramsT3
+    return streamed_merge_carries_norms(eligibility_.kind)
                    ? format::IndexConfig::kDocsPositionsScoring
                    : format::IndexConfig::kDocsPositions;
 }
 
 std::optional<segment_v2::inverted_index::CommonGramsSegmentMetadata>
 SniiPlainT2MergePlan::destination_common_grams_metadata(size_t destination_segment) const {
-    if (eligibility_.kind == SniiStreamedMergeKind::kPlainT2) {
+    if (eligibility_.kind != SniiStreamedMergeKind::kCommonGramsT3) {
         return std::nullopt;
     }
     DORIS_CHECK(eligibility_.common_grams_metadata_seed.has_value());

--- a/be/src/storage/index/snii/format/core_metadata.cpp
+++ b/be/src/storage/index/snii/format/core_metadata.cpp
@@ -207,13 +207,16 @@ Status decode_core_pb(const doris::snii::SniiCoreMetadataPB& input, CoreMetadata
             return corrupted("core metadata: scoring index requires a norms region");
         }
     }
-    if (has_scoring_tier ||
-        (out->common_grams_metadata.has_value() &&
-         out->common_grams_metadata->scoring_coverage == ScoringCoverage::kComplete)) {
+    // The scoring tier no longer implies CommonGrams: an ordinary analyzed index
+    // reaches it too, and its physical statistics are already the semantic ones.
+    // Only a CommonGrams segment carries a separate semantic view that has to be
+    // cross-checked against the physical numbers before anything trusts it.
+    if (out->common_grams_metadata.has_value() &&
+        out->common_grams_metadata->scoring_coverage == ScoringCoverage::kComplete) {
         RETURN_IF_ERROR(validate_snii_scoring_metadata(
-                out->common_grams_metadata ? &*out->common_grams_metadata : nullptr,
-                out->stats.doc_count, out->stats.sum_total_term_freq, has_scoring_tier,
-                has_positions(out->index_config), out->section_refs.norms.length != 0));
+                &*out->common_grams_metadata, out->stats.doc_count, out->stats.sum_total_term_freq,
+                has_scoring_tier, has_positions(out->index_config),
+                out->section_refs.norms.length != 0));
     }
     return Status::OK();
 }

--- a/be/src/storage/index/snii/snii_index_reader.cpp
+++ b/be/src/storage/index/snii/snii_index_reader.cpp
@@ -1090,26 +1090,15 @@ Status SniiIndexReader::_try_count_only_fastpath(
                                             &logical_reader));
     }
 
-    // ARRAY columns: df is NOT null-free, so nothing below may fabricate from it.
-    // ArrayColumnWriter::append_nullable hands add_array_values() every row of the
-    // batch -- the offsets come from the nested ColumnArray, and
-    // OlapColumnDataConvertorArray::convert_to_olap reads them without ever
-    // consulting the outer null map -- and the add_array_nulls() that follows only
-    // RECORDS the null row ids, it never retracts the tokens already emitted for
-    // them. A nullable array whose nested payload survives under the null map does
-    // occur: PreparedFunctionImpl::default_implementation_for_nulls documents that
-    // nested columns keep "arbitrary values in rows corresponding to NULL value",
-    // and need_replace_null_data_to_default() is false by default, so e.g.
-    // array_concat(arr, nullable_arr) writes arr's tokens on a NULL row. That row
-    // then sits in a posting and is counted by df. The decode path stays correct --
-    // mask_out_null subtracts it -- but the fabrication below deliberately places
-    // its ids OFF the null rows, so the same subtraction removes nothing and the
-    // count comes out too high. CLucene writes arrays identically
-    // (InvertedIndexColumnWriter::add_array_nulls only touches _null_bitmap), so
-    // this cannot be repaired from the reader side; decline whenever this segment
-    // has a null bitmap at all. Scalars are unaffected: ScalarColumnWriter::
-    // append_nullable splits the batch into runs and sends null runs to
-    // append_nulls(), which emits no tokens.
+    // ARRAY columns in legacy SNII segments are not guaranteed to have null-free
+    // dfs. Older writers indexed the nested payload before recording the outer
+    // null bitmap, and nullable nested columns may legally retain arbitrary data
+    // under a NULL row. Current SNII writers suppress that payload, but the format
+    // does not distinguish the old segments; CLucene also keeps the legacy shape.
+    // The decode path masks null rows correctly, while the count fabrication below
+    // deliberately places ids off those rows and can over-count. Decline whenever
+    // an ARRAY segment has a null bitmap. Scalars are unaffected because their
+    // nullable writer sends null runs through add_nulls(), which emits no tokens.
     if (_column_is_array && logical_reader->section_refs().null_bitmap.length > 0) {
         return Status::OK();
     }

--- a/be/src/storage/index/snii/snii_index_writer.cpp
+++ b/be/src/storage/index/snii/snii_index_writer.cpp
@@ -356,6 +356,22 @@ Status SniiIndexColumnWriter::add_values(const std::string /*name*/, const void*
 Status SniiIndexColumnWriter::add_array_values(size_t field_size, const void* value_ptr,
                                                const uint8_t* nested_null_map,
                                                const uint8_t* offsets_ptr, size_t count) {
+    return _add_array_values(field_size, value_ptr, nested_null_map, nullptr, offsets_ptr, count);
+}
+
+Status SniiIndexColumnWriter::add_nullable_array_values(size_t field_size, const void* value_ptr,
+                                                        const uint8_t* nested_null_map,
+                                                        const uint8_t* row_null_map,
+                                                        const uint8_t* offsets_ptr, size_t count) {
+    RETURN_IF_ERROR(_add_array_values(field_size, value_ptr, nested_null_map, row_null_map,
+                                      offsets_ptr, count));
+    return add_array_nulls(row_null_map, count);
+}
+
+Status SniiIndexColumnWriter::_add_array_values(size_t field_size, const void* value_ptr,
+                                                const uint8_t* nested_null_map,
+                                                const uint8_t* row_null_map,
+                                                const uint8_t* offsets_ptr, size_t count) {
     if (!_failure_status.ok()) {
         return _failure_status;
     }
@@ -370,6 +386,15 @@ Status SniiIndexColumnWriter::add_array_values(size_t field_size, const void* va
     size_t start_off = 0;
     for (size_t i = 0; i < count; ++i) {
         auto array_elem_size = offsets[i + 1] - offsets[i];
+        if (row_null_map != nullptr && row_null_map[i] == 1) {
+            if (_writes_norms()) {
+                _encoded_norms.push_back(::doris::snii::query::encode_norm(0));
+                _report_encoded_norms_capacity();
+            }
+            start_off += array_elem_size;
+            ++_rid;
+            continue;
+        }
         uint32_t position_base = 0;
         // One ARRAY row is one scored document, so its length is the token count
         // of every element together -- not per element.

--- a/be/src/storage/index/snii/snii_index_writer.cpp
+++ b/be/src/storage/index/snii/snii_index_writer.cpp
@@ -171,11 +171,19 @@ Status SniiIndexColumnWriter::init() {
                     close_on_error();
                     return status;
                 }
-                _config = ::doris::snii::format::IndexConfig::kDocsPositionsScoring;
             } else if (_common_grams_metadata_seed.has_value()) {
                 close_on_error();
                 return Status::Error<ErrorCode::INVERTED_INDEX_ANALYZER_ERROR>(
                         "SNII CommonGrams metadata cannot be attached to a plain analyzer");
+            }
+            // Scoring rides on ANALYSIS, not on CommonGrams. Any analyzed index
+            // with positions persists per-document norms and therefore reaches
+            // the scoring tier -- CommonGrams only changes what the semantic
+            // token count means, not whether one exists. Gating this on
+            // _uses_common_grams is what made an ordinary SNII index
+            // unscoreable while V1/V2/V3 scored the same index.
+            if (_has_positions) {
+                _config = ::doris::snii::format::IndexConfig::kDocsPositionsScoring;
             }
             _analyzer = analyzer_provider->get_analyzer(
                     _uses_common_grams ? inverted_index::AnalysisPurpose::kSniiTransientIndex
@@ -239,6 +247,10 @@ Status SniiIndexColumnWriter::_add_value_tokens(const Slice& value, uint32_t doc
                 _has_positions ? position_base + cast_set<uint32_t>(token_position) : 0;
         _term_buffer->add_token(term, docid, position, retain_positions);
         *max_position = std::max(*max_position, position);
+        // Document length for BM25. The CommonGrams branch below keeps its own
+        // count because it must exclude the gram tokens it also emits; every
+        // token that reaches here is a semantic one.
+        ++*semantic_length;
     };
 
     if (!_should_analyzer) {
@@ -330,7 +342,7 @@ Status SniiIndexColumnWriter::add_values(const std::string /*name*/, const void*
         uint32_t max_position = 0;
         uint32_t semantic_length = 0;
         RETURN_IF_ERROR(_add_value_tokens(*v, _rid, 0, &max_position, &semantic_length));
-        if (_uses_common_grams) {
+        if (_writes_norms()) {
             _encoded_norms.push_back(::doris::snii::query::encode_norm(semantic_length));
             _report_encoded_norms_capacity();
             _scoring_token_count += semantic_length;
@@ -359,6 +371,9 @@ Status SniiIndexColumnWriter::add_array_values(size_t field_size, const void* va
     for (size_t i = 0; i < count; ++i) {
         auto array_elem_size = offsets[i + 1] - offsets[i];
         uint32_t position_base = 0;
+        // One ARRAY row is one scored document, so its length is the token count
+        // of every element together -- not per element.
+        uint64_t row_semantic_length = 0;
         for (auto j = start_off; j < start_off + array_elem_size; ++j) {
             if (nested_null_map != nullptr && nested_null_map[j] == 1) {
                 continue;
@@ -370,6 +385,12 @@ Status SniiIndexColumnWriter::add_array_values(size_t field_size, const void* va
             RETURN_IF_ERROR(_add_value_tokens(*value, _rid, position_base, &max_position,
                                               &semantic_length));
             position_base = max_position + 1;
+            row_semantic_length += semantic_length;
+        }
+        if (_writes_norms()) {
+            _encoded_norms.push_back(::doris::snii::query::encode_norm(row_semantic_length));
+            _report_encoded_norms_capacity();
+            _scoring_token_count += row_semantic_length;
         }
         start_off += array_elem_size;
         ++_rid;
@@ -422,7 +443,7 @@ Status SniiIndexColumnWriter::add_nulls(uint32_t count) {
         _null_docids.push_back(_rid + i);
     }
     _rid += count;
-    if (_uses_common_grams) {
+    if (_writes_norms()) {
         _encoded_norms.insert(_encoded_norms.end(), count, ::doris::snii::query::encode_norm(0));
         _report_encoded_norms_capacity();
     }
@@ -463,8 +484,10 @@ Status SniiIndexColumnWriter::finish() {
     _report_null_docids_capacity(/*release_all=*/true);
     IndexFileWriter::SniiAddIndexOptions options {};
     options.is_direct_load = _is_direct_load;
-    if (_uses_common_grams) {
+    if (_writes_norms()) {
         options.encoded_norms = std::move(_encoded_norms);
+    }
+    if (_uses_common_grams) {
         options.common_grams_metadata = _build_common_grams_metadata();
         options.common_grams_posting_policy =
                 ::doris::snii::format::CommonGramsPostingPolicy::kHybridV1;

--- a/be/src/storage/index/snii/snii_index_writer.h
+++ b/be/src/storage/index/snii/snii_index_writer.h
@@ -57,6 +57,9 @@ public:
     Status add_array_values(size_t field_size, const void* value_ptr,
                             const uint8_t* nested_null_map, const uint8_t* offsets_ptr,
                             size_t count) override;
+    Status add_nullable_array_values(size_t field_size, const void* value_ptr,
+                                     const uint8_t* nested_null_map, const uint8_t* row_null_map,
+                                     const uint8_t* offsets_ptr, size_t count) override;
     Status add_nulls(uint32_t count) override;
     Status add_array_nulls(const uint8_t* null_map, size_t num_rows) override;
     Status finish() override;
@@ -93,6 +96,9 @@ public:
 #endif
 
 private:
+    Status _add_array_values(size_t field_size, const void* value_ptr,
+                             const uint8_t* nested_null_map, const uint8_t* row_null_map,
+                             const uint8_t* offsets_ptr, size_t count);
     Status _add_value_tokens(const Slice& value, uint32_t docid, uint32_t position_base,
                              uint32_t* max_position, uint32_t* semantic_length);
     inverted_index::CommonGramsSegmentMetadata _build_common_grams_metadata() const;

--- a/be/src/storage/index/snii/snii_index_writer.h
+++ b/be/src/storage/index/snii/snii_index_writer.h
@@ -109,6 +109,12 @@ private:
     const bool _is_char;
     const bool _common_grams_build_enabled;
     bool _uses_common_grams = false;
+
+    // An index persists per-document norms exactly when it is analyzed and keeps
+    // positions -- the same condition that puts it on the scoring tier. This is
+    // deliberately NOT "_uses_common_grams": CommonGrams changes what a semantic
+    // token count means, it does not decide whether the index can be scored.
+    bool _writes_norms() const { return _should_analyzer && _has_positions; }
     // Latch: set_direct_load() ran. The first call wins; a repeat or late call
     // is ignored (and logged) so one index keeps one stable compression-tier
     // decision.

--- a/be/src/storage/index/snii/stats/snii_stats_provider.cpp
+++ b/be/src/storage/index/snii/stats/snii_stats_provider.cpp
@@ -61,11 +61,23 @@ Status SniiStatsProvider::open_impl(const reader::LogicalIndexReader* idx, SniiS
     out->idx_ = idx;
     const auto& sb = idx->stats();
     out->doc_count_ = sb.doc_count;
-    out->indexed_doc_count_ = sb.indexed_doc_count;
+    // avgdl divides the token sum by this. Norms are written for EVERY row --
+    // a null row contributes encode_norm(0) -- so the denominator must span the
+    // same rows the lengths do, i.e. all documents. The CommonGrams branch below
+    // uses scoring_doc_count, which is likewise every row; keeping the plain
+    // branch on indexed_doc_count would make avgdl 2x too large on a 50%-null
+    // column and give the two shapes different arithmetic.
+    out->indexed_doc_count_ = sb.doc_count;
     out->sum_total_term_freq_ = sb.sum_total_term_freq;
 
     const RegionRef& norms = idx->section_refs().norms;
     const auto* metadata = idx->common_grams_metadata();
+    // A CommonGrams index stores gram tokens in its physical postings, so its
+    // StatsBlock is NOT the collection BM25 should see: the semantic view lives
+    // in the CommonGrams metadata and must validate before it is trusted. Every
+    // other analyzed index has no such divergence -- its physical statistics
+    // ARE the semantic ones -- so it scores straight from the StatsBlock, the
+    // same way V1/V2/V3 score an ordinary parser index.
     if (metadata != nullptr) {
         using namespace segment_v2::inverted_index;
         RETURN_IF_ERROR(validate_snii_scoring_metadata(
@@ -74,10 +86,20 @@ Status SniiStatsProvider::open_impl(const reader::LogicalIndexReader* idx, SniiS
         out->doc_count_ = metadata->scoring_doc_count;
         out->indexed_doc_count_ = metadata->scoring_doc_count;
         out->sum_total_term_freq_ = metadata->scoring_token_count;
-    } else if (require_semantic_metadata) {
-        RETURN_IF_ERROR(segment_v2::inverted_index::validate_snii_scoring_metadata(
-                nullptr, sb.doc_count, sb.sum_total_term_freq,
-                idx->tier() == format::IndexTier::kT3, idx->has_positions(), norms.length != 0));
+    } else if (require_semantic_metadata && (idx->tier() != format::IndexTier::kT3 ||
+                                             !idx->has_positions() || norms.length == 0)) {
+        // "Can this index be scored" is exactly "does it persist the BM25
+        // inputs" -- the scoring tier, positions, and a norms region. It is NOT
+        // "does it have CommonGrams metadata". Two shapes land here: a keyword
+        // index (never analyzed, so no norms even with support_phrase=true) and
+        // a segment written before an analyzed index reached the scoring tier.
+        // Both are refused rather than scored at a guessed document length: a
+        // silent unit-length fallback would rank those segments on a different
+        // scale from their siblings in the same table, with no error to notice.
+        return Status::Error<ErrorCode::INVERTED_INDEX_NOT_SUPPORTED, false>(
+                "SNII index does not persist scoring data (scoring tier {}, positions {}, "
+                "norms {})",
+                idx->tier() == format::IndexTier::kT3, idx->has_positions(), norms.length != 0);
     }
     if (norms.length == 0) {
         out->has_norms_ = false;

--- a/be/src/storage/index/snii/stats/snii_stats_provider.h
+++ b/be/src/storage/index/snii/stats/snii_stats_provider.h
@@ -71,7 +71,9 @@ public:
     Status total_term_freq(std::string_view term, uint64_t* ttf) const;
 
     // 1-byte encoded doc-length norm for docid (raw byte from the norms POD).
-    // Out-of-range docid -> InvalidArgument; index without norms -> InvalidArgument.
+    // Out-of-range docid -> InvalidArgument. An index WITHOUT norms yields the
+    // neutral byte 0, which decode_norm maps to unit length, so such a segment
+    // still scores -- just without length normalisation.
     Status encoded_norm(uint32_t docid, uint8_t* out) const;
 
     bool has_norms() const { return has_norms_; }

--- a/be/src/storage/index/snii/stats/snii_stats_provider.h
+++ b/be/src/storage/index/snii/stats/snii_stats_provider.h
@@ -71,9 +71,7 @@ public:
     Status total_term_freq(std::string_view term, uint64_t* ttf) const;
 
     // 1-byte encoded doc-length norm for docid (raw byte from the norms POD).
-    // Out-of-range docid -> InvalidArgument. An index WITHOUT norms yields the
-    // neutral byte 0, which decode_norm maps to unit length, so such a segment
-    // still scores -- just without length normalisation.
+    // Out-of-range docid -> InvalidArgument; index without norms -> InvalidArgument.
     Status encoded_norm(uint32_t docid, uint8_t* out) const;
 
     bool has_norms() const { return has_norms_; }

--- a/be/src/storage/segment/column_writer.cpp
+++ b/be/src/storage/segment/column_writer.cpp
@@ -1094,6 +1094,11 @@ Status ArrayColumnWriter::write_ann_index() {
 
 // batch append data for array
 Status ArrayColumnWriter::append_data(const uint8_t** ptr, size_t num_rows) {
+    return _append_data(ptr, num_rows, nullptr);
+}
+
+Status ArrayColumnWriter::_append_data(const uint8_t** ptr, size_t num_rows,
+                                       const uint8_t* row_null_map) {
     // data_ptr contains
     // [size, offset_ptr, item_data_ptr, item_nullmap_ptr]
     auto data_ptr = reinterpret_cast<const uint64_t*>(*ptr);
@@ -1112,10 +1117,18 @@ Status ArrayColumnWriter::append_data(const uint8_t** ptr, size_t num_rows) {
         // now only support nested type is scala
         if (writer != nullptr) {
             //NOTE: use array field name as index field, but item_writer size should be used when moving item_data_ptr
-            RETURN_IF_ERROR(_inverted_index_writer->add_array_values(
-                    field_type_size(_item_writer->get_column()->type()),
-                    reinterpret_cast<const void*>(data),
-                    reinterpret_cast<const uint8_t*>(nested_null_map), offsets_ptr, num_rows));
+            if (row_null_map == nullptr) {
+                RETURN_IF_ERROR(_inverted_index_writer->add_array_values(
+                        field_type_size(_item_writer->get_column()->type()),
+                        reinterpret_cast<const void*>(data),
+                        reinterpret_cast<const uint8_t*>(nested_null_map), offsets_ptr, num_rows));
+            } else {
+                RETURN_IF_ERROR(_inverted_index_writer->add_nullable_array_values(
+                        field_type_size(_item_writer->get_column()->type()),
+                        reinterpret_cast<const void*>(data),
+                        reinterpret_cast<const uint8_t*>(nested_null_map), row_null_map,
+                        offsets_ptr, num_rows));
+            }
         }
     }
 
@@ -1148,11 +1161,8 @@ uint64_t ArrayColumnWriter::estimate_buffer_size() {
 
 Status ArrayColumnWriter::append_nullable(const uint8_t* null_map, const uint8_t** ptr,
                                           size_t num_rows) {
-    RETURN_IF_ERROR(append_data(ptr, num_rows));
+    RETURN_IF_ERROR(_append_data(ptr, num_rows, null_map));
     if (is_nullable()) {
-        if (_opts.need_inverted_index) {
-            RETURN_IF_ERROR(_inverted_index_writer->add_array_nulls(null_map, num_rows));
-        }
         RETURN_IF_ERROR(_null_writer->append_data(&null_map, num_rows));
     }
     return Status::OK();

--- a/be/src/storage/segment/column_writer.h
+++ b/be/src/storage/segment/column_writer.h
@@ -513,6 +513,7 @@ private:
     }
 
 private:
+    Status _append_data(const uint8_t** ptr, size_t num_rows, const uint8_t* row_null_map);
     Status write_null_column(size_t num_rows, bool is_null); // 写入num_rows个null标记
     bool has_empty_items() const { return _item_writer->get_next_rowid() == 0; }
 

--- a/be/src/storage/task/index_builder.cpp
+++ b/be/src/storage/task/index_builder.cpp
@@ -1054,14 +1054,14 @@ Status IndexBuilder::_add_nullable(const std::string& column_name,
         try {
             auto data = *(data_ptr + 2);
             auto nested_null_map = *(data_ptr + 3);
-            RETURN_IF_ERROR(index_column_writer->add_array_values(
+            RETURN_IF_ERROR(index_column_writer->add_nullable_array_values(
                     field_type_size(column->get_sub_column(0).type()),
                     reinterpret_cast<const void*>(data),
-                    reinterpret_cast<const uint8_t*>(nested_null_map), offsets_ptr, num_rows));
+                    reinterpret_cast<const uint8_t*>(nested_null_map), null_map, offsets_ptr,
+                    num_rows));
             DBUG_EXECUTE_IF("IndexBuilder::_add_nullable_add_array_values_error", {
                 _CLTHROWA(CL_ERR_IO, "debug point: _add_nullable_add_array_values_error");
             })
-            RETURN_IF_ERROR(index_column_writer->add_array_nulls(null_map, num_rows));
         } catch (const std::exception& e) {
             return Status::Error<ErrorCode::INVERTED_INDEX_CLUCENE_ERROR>(
                     "CLuceneError occurred: {}", e.what());
@@ -1115,16 +1115,18 @@ Status IndexBuilder::_add_data(const std::string& column_name,
             DCHECK(column->get_subtype_count() == 1);
             // [size, offset_ptr, item_data_ptr, item_nullmap_ptr]
             const auto* data_ptr = reinterpret_cast<const uint64_t*>(*ptr);
-            // total number length
-            auto element_cnt = size_t((unsigned long)(*data_ptr));
+            const auto element_count = static_cast<size_t>(*data_ptr);
             auto offset_data = *(data_ptr + 1);
             const auto* offsets_ptr = (const uint8_t*)offset_data;
-            if (element_cnt > 0) {
+            const FieldType item_type = column->get_sub_column(0).type();
+            // Text writers own one logical document (and one scoring norm) per
+            // ARRAY row, including an all-empty batch. Numeric/ANN writers still
+            // require a non-null element buffer before entering their point path.
+            if (element_count > 0 || field_is_slice_type(item_type)) {
                 auto data = *(data_ptr + 2);
                 auto nested_null_map = *(data_ptr + 3);
                 RETURN_IF_ERROR(index_column_writer->add_array_values(
-                        field_type_size(column->get_sub_column(0).type()),
-                        reinterpret_cast<const void*>(data),
+                        field_type_size(item_type), reinterpret_cast<const void*>(data),
                         reinterpret_cast<const uint8_t*>(nested_null_map), offsets_ptr, num_rows));
             }
         } else {

--- a/be/test/storage/index/index_builder_test.cpp
+++ b/be/test/storage/index/index_builder_test.cpp
@@ -3735,6 +3735,96 @@ TEST_F(IndexBuilderTest, SniiBuildAllSharesOneColumnScanAndOnePrefixCopy) {
                                  {{.index_id = 1, .index_suffix = ""}}, /*doc_count=*/2);
 }
 
+TEST_F(IndexBuilderTest, SniiBuildIndexAdvancesAcrossAllEmptyArrayBatches) {
+    constexpr uint32_t kEmptyRows = 4096 - 32;
+    const auto tablet_path = _absolute_dir + "/15701";
+
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_inverted_index_storage_format(InvertedIndexStorageFormatPB::SNII);
+    auto tablet_schema = std::make_shared<TabletSchema>();
+    tablet_schema->init_from_pb(schema_pb);
+
+    TabletColumn key_column;
+    key_column.set_unique_id(1);
+    key_column.set_name("k1");
+    key_column.set_type(FieldType::OLAP_FIELD_TYPE_INT);
+    key_column.set_length(4);
+    key_column.set_index_length(4);
+    key_column.set_is_key(true);
+    key_column.set_is_nullable(false);
+    tablet_schema->append_column(key_column);
+
+    TabletColumn array_column;
+    array_column.set_unique_id(2);
+    array_column.set_name("body");
+    array_column.set_type(FieldType::OLAP_FIELD_TYPE_ARRAY);
+    array_column.set_is_nullable(false);
+    TabletColumn item_column(FieldAggregationMethod::OLAP_FIELD_AGGREGATION_NONE,
+                             FieldType::OLAP_FIELD_TYPE_VARCHAR, true);
+    item_column.set_name("body_item");
+    item_column.set_length(65535);
+    array_column.add_sub_column(item_column);
+    tablet_schema->append_column(array_column);
+
+    TabletSharedPtr tablet;
+    ASSERT_TRUE(create_snii_drop_tablet(tablet_schema, tablet_path, &tablet).ok());
+
+    RowsetWriterContext writer_context;
+    writer_context.rowset_id.init(15701);
+    writer_context.tablet_id = tablet->tablet_id();
+    writer_context.tablet_schema_hash = tablet->schema_hash();
+    writer_context.partition_id = 10;
+    writer_context.rowset_type = BETA_ROWSET;
+    writer_context.tablet_path = tablet_path;
+    writer_context.rowset_state = VISIBLE;
+    writer_context.tablet_schema = tablet_schema;
+    writer_context.version = Version(10, 10);
+    auto rowset_writer_result =
+            RowsetFactory::create_rowset_writer(*_engine_ref, writer_context, false);
+    ASSERT_TRUE(rowset_writer_result.has_value()) << rowset_writer_result.error();
+    auto rowset_writer = std::move(rowset_writer_result).value();
+
+    Block block = tablet_schema->create_storage_block();
+    auto columns = std::move(block).mutate_columns();
+    auto& body = assert_cast<ColumnArray&>(*columns[1]);
+    for (uint32_t row = 0; row <= kEmptyRows; ++row) {
+        const int32_t key = cast_set<int32_t>(row);
+        columns[0]->insert_data(reinterpret_cast<const char*>(&key), sizeof(key));
+        Array value;
+        if (row == kEmptyRows) {
+            value.push_back(Field::create_field<TYPE_STRING>(std::string("alpha")));
+        }
+        body.insert(Field::create_field<TYPE_ARRAY>(value));
+    }
+    block.set_columns(std::move(columns));
+    ASSERT_TRUE(rowset_writer->add_block(&block).ok());
+    ASSERT_TRUE(rowset_writer->flush().ok());
+    RowsetSharedPtr source_rowset;
+    ASSERT_TRUE(rowset_writer->build(source_rowset).ok());
+    ASSERT_EQ(source_rowset->num_segments(), 1);
+    ASSERT_TRUE(tablet->add_rowset(source_rowset).ok());
+
+    std::vector<RowsetSharedPtr> output_rowsets;
+    ASSERT_TRUE(build_snii_index(tablet,
+                                 {create_build_index(1, "body_idx", "body", 2,
+                                                     {{"parser", "english"},
+                                                      {"lower_case", "true"},
+                                                      {"support_phrase", "true"}})},
+                                 &output_rowsets)
+                        .ok());
+    ASSERT_EQ(output_rowsets.size(), 1U);
+    const auto& output_rowset = output_rowsets.front();
+    assert_snii_term(output_rowset, tablet->tablet_id(), 2, 1, "alpha", {kEmptyRows});
+
+    auto reader = open_snii_reader(output_rowset, tablet->tablet_id());
+    const auto index_metas = output_rowset->tablet_schema()->inverted_indexs(2);
+    ASSERT_EQ(index_metas.size(), 1U);
+    auto logical_index = reader->open_snii_index(index_metas.front());
+    ASSERT_TRUE(logical_index.has_value()) << logical_index.error();
+    EXPECT_EQ(logical_index.value()->stats().doc_count, kEmptyRows + 1);
+}
+
 // A retried build names an index the rowset schema already carries: the rowset
 // is skipped upstream (pick_candidate_rowsets_to_build_inverted_index), so no
 // analyzer, decode or encode runs and nothing is rewritten. The same-key-with-

--- a/be/test/storage/index/inverted/similarity/collection_statistics_test.cpp
+++ b/be/test/storage/index/inverted/similarity/collection_statistics_test.cpp
@@ -1028,6 +1028,82 @@ TEST_F(CollectionStatisticsTest, SniiCommonGramsUsesSemanticScoringStatistics) {
     expect_collected_term(L"1", L"alpha", 2);
 }
 
+// THE case this whole change exists for, driven through the public entry point
+// (CollectionStatistics::collect) rather than through SniiStatsProvider. An
+// ordinary analyzed SNII index -- no CommonGrams anywhere -- must yield
+// collection statistics instead of "SNII semantic scoring metadata is missing".
+// A per-segment test cannot catch this: the collector rejects the segment before
+// the scorer is ever reached.
+TEST_F(CollectionStatisticsTest, SniiPlainAnalyzedIndexCollectsScoringStatistics) {
+    auto tablet_schema = create_snii_schema();
+    auto expr_contexts = create_match_expr_contexts("alpha", "test-base-v1");
+
+    const std::string segment_path = test_dir_ + "/snii_plain_collect_0.dat";
+    auto write_status = write_plain_snii_scoring_segment(segment_path);
+    ASSERT_TRUE(write_status.ok()) << write_status;
+
+    auto rowset_meta = std::make_shared<collection_statistics::MockRowsetMeta>();
+    auto rowset = std::make_shared<collection_statistics::MockRowset>(tablet_schema, rowset_meta);
+    rowset->set_num_segments(1);
+    rowset->set_segment_path(0, segment_path);
+    auto reader = std::make_shared<collection_statistics::MockRowsetReader>(rowset);
+    std::vector<RowSetSplits> splits {RowSetSplits(reader)};
+
+    auto status =
+            stats_->collect(runtime_state_.get(), splits, tablet_schema, expr_contexts, nullptr);
+
+    ASSERT_TRUE(status.ok()) << status;
+    // The fixture writes 2 docs / 3 tokens, with "alpha" in both.
+    expect_collected_stats(L"1", 2, 3);
+    expect_collected_term(L"1", L"alpha", 2);
+}
+
+// One field, two segment shapes: a CommonGrams segment and an ordinary analyzed
+// one, which is what a table gets when enable_common_grams_index_build is
+// toggled between loads. Their statistics ARE combinable -- a CommonGrams
+// segment's physical sum_total_term_freq is inflated by gram tokens, but its
+// metadata carries the un-grammed semantic count, and a plain segment's physical
+// count is already semantic. The plain postings are complete on both sides:
+// SpimiTermBuffer::add_common_gram_and_plain writes the gram AND the plain
+// posting for the token, so df is measured the same way.
+//
+// Only the CommonGrams shape records a base-analyzer identity, because its term
+// keys depend on the dictionary. An absent identity must not be read as "a
+// different analyzer" -- doing so rejected the whole mixed collection.
+TEST_F(CollectionStatisticsTest, SniiMixedCommonGramsAndPlainSegmentsCombine) {
+    auto tablet_schema = create_snii_schema();
+    auto expr_contexts = create_match_expr_contexts("alpha", "test-base-v1");
+    const auto* analyzer_ctx = expr_contexts.front()->root()->query_analyzer_ctx();
+    ASSERT_NE(analyzer_ctx, nullptr);
+    ASSERT_NE(analyzer_ctx->analyzer_provider, nullptr);
+
+    const std::string common_grams_path = test_dir_ + "/snii_mixed_cg_0.dat";
+    ASSERT_TRUE(write_snii_common_grams_segment(
+                        common_grams_path,
+                        std::string(analyzer_ctx->analyzer_provider->base_analyzer_fingerprint()))
+                        .ok());
+    const std::string plain_path = test_dir_ + "/snii_mixed_plain_0.dat";
+    ASSERT_TRUE(write_plain_snii_scoring_segment(plain_path).ok());
+
+    auto rowset_meta = std::make_shared<collection_statistics::MockRowsetMeta>();
+    auto rowset = std::make_shared<collection_statistics::MockRowset>(tablet_schema, rowset_meta);
+    rowset->set_num_segments(2);
+    rowset->set_segment_path(0, common_grams_path);
+    rowset->set_segment_path(1, plain_path);
+    auto reader = std::make_shared<collection_statistics::MockRowsetReader>(rowset);
+    std::vector<RowSetSplits> splits {RowSetSplits(reader)};
+
+    auto status =
+            stats_->collect(runtime_state_.get(), splits, tablet_schema, expr_contexts, nullptr);
+
+    ASSERT_TRUE(status.ok()) << status;
+    // Each fixture writes 2 docs / 3 semantic tokens with "alpha" in both, so the
+    // collection is the sum of the two -- the CommonGrams segment contributing
+    // its semantic token count, not its gram-inflated physical one.
+    expect_collected_stats(L"1", 4, 6);
+    expect_collected_term(L"1", L"alpha", 4);
+}
+
 TEST_F(CollectionStatisticsTest, SniiScoringLookupUsesCallerIoContext) {
     snii::snii_test::ScopedEnv force_nonresident_dict("SNII_DICT_RESIDENT_MAX", "0");
     auto tablet_schema = create_snii_schema();
@@ -1106,10 +1182,37 @@ TEST_F(CollectionStatisticsTest, SniiStatsProviderUsesSemanticCommonGramsTokenCo
     EXPECT_TRUE(provider.has_norms());
 }
 
-TEST_F(CollectionStatisticsTest, SniiWriterRejectsMissingSemanticScoringMetadata) {
-    const std::string segment_path = test_dir_ + "/snii_missing_scoring_metadata_0.dat";
+// A scoring index without CommonGrams metadata is the ORDINARY analyzed shape,
+// not a defect: CommonGrams only changes what the semantic token count means.
+// This used to be rejected at write time, which is what made an ordinary SNII
+// index unscoreable while V1/V2/V3 scored the same index.
+TEST_F(CollectionStatisticsTest, SniiScoringSegmentWithoutCommonGramsIsReadable) {
+    const std::string segment_path = test_dir_ + "/snii_plain_scoring_metadata_0.dat";
     auto write_status = write_plain_snii_scoring_segment(segment_path);
-    EXPECT_EQ(write_status.code(), ErrorCode::INVERTED_INDEX_NOT_SUPPORTED);
+    ASSERT_TRUE(write_status.ok()) << write_status;
+
+    const std::string index_path_prefix {
+            segment_v2::InvertedIndexDescriptor::get_index_file_path_prefix(segment_path)};
+    segment_v2::IndexFileReader file_reader(io::global_local_filesystem(), index_path_prefix,
+                                            InvertedIndexStorageFormatPB::SNII);
+    ASSERT_TRUE(file_reader.init().ok());
+    auto tablet_schema = create_snii_schema();
+    const auto index_metas = tablet_schema->inverted_indexs(1);
+    ASSERT_EQ(index_metas.size(), 1);
+    auto logical_reader = file_reader.open_snii_index(index_metas.front());
+    ASSERT_TRUE(logical_reader.has_value()) << logical_reader.error();
+    EXPECT_EQ(logical_reader->get()->common_grams_metadata(), nullptr);
+
+    snii::stats::SniiStatsProvider provider;
+    ASSERT_TRUE(snii::stats::SniiStatsProvider::open(logical_reader->get(), &provider).ok());
+    // The physical statistics ARE the semantic ones here, so they are used as is.
+    EXPECT_EQ(provider.doc_count(), 2);
+    EXPECT_EQ(provider.sum_total_term_freq(), 3);
+    EXPECT_DOUBLE_EQ(provider.avgdl(), 1.5);
+    EXPECT_TRUE(provider.has_norms());
+    uint8_t norm = 0;
+    ASSERT_TRUE(provider.encoded_norm(0, &norm).ok());
+    EXPECT_EQ(norm, snii::query::encode_norm(2));
 }
 
 TEST_F(CollectionStatisticsTest, SniiScoringRejectsMissingSegmentForWholeCollection) {
@@ -1250,11 +1353,33 @@ Result<SniiScoringSegmentStats> resolve_snii_scoring_segment_for_test(
                                         /*has_positions=*/true, has_norms);
 }
 
-TEST(CollectionStatisticsCommonGramsTest, MissingMetadataWithoutPersistedProofRejectsScoring) {
-    auto result = resolve_snii_scoring_segment_for_test(std::nullopt, 3, true);
+// No CommonGrams metadata is the ORDINARY analyzed shape. Its postings carry no
+// gram tokens, so the physical statistics are already the semantic ones and its
+// term keys are raw.
+TEST(CollectionStatisticsCommonGramsTest, MissingMetadataOnAScoringSegmentIsThePlainShape) {
+    auto result = resolve_snii_scoring_segment(std::nullopt, /*index_doc_count=*/3,
+                                               /*physical_sum_total_term_freq=*/12,
+                                               /*has_scoring_tier=*/true,
+                                               /*has_positions=*/true, /*has_semantic_norms=*/true);
 
-    ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error().code(), ErrorCode::INVERTED_INDEX_NOT_SUPPORTED);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(result->doc_count, 3);
+    EXPECT_EQ(result->token_count, 12);
+    EXPECT_EQ(result->plain_term_key_version,
+              segment_v2::inverted_index::PlainTermKeyVersion::kLegacyRaw);
+    EXPECT_TRUE(result->base_analyzer_fingerprint.empty());
+}
+
+// ... but only when the segment actually persists what BM25 needs. Each missing
+// piece is rejected on its own so a partial shape can never slip through.
+TEST(CollectionStatisticsCommonGramsTest, MissingMetadataWithoutScoringDataIsRejected) {
+    for (const auto& [tier, positions, norms] : std::vector<std::tuple<bool, bool, bool>> {
+                 {false, true, true}, {true, false, true}, {true, true, false}}) {
+        auto result = resolve_snii_scoring_segment(std::nullopt, 3, 12, tier, positions, norms);
+        ASSERT_FALSE(result.has_value())
+                << "tier=" << tier << " positions=" << positions << " norms=" << norms;
+        EXPECT_EQ(result.error().code(), ErrorCode::INVERTED_INDEX_NOT_SUPPORTED);
+    }
 }
 
 TEST(CollectionStatisticsCommonGramsTest, RawNoInternalMetadataWithoutScoringProofIsRejected) {
@@ -1464,13 +1589,24 @@ TEST_F(CollectionStatisticsTest, LegacyAndUnprovedRawNoInternalRejectWholeCollec
     EXPECT_THROW(stats_->get_doc_num(), Exception);
 }
 
+// A LEGACY segment -- one that persists no scoring data at all -- still poisons
+// the whole collection when mixed with a scoring one: it can contribute neither
+// a document length nor a token count, so any average computed over the mix
+// would be wrong for part of it.
+//
+// The marker for "legacy" is the absence of SCORING DATA (no norms here), not
+// the absence of CommonGrams metadata. Those were the same thing while scoring
+// rode on CommonGrams; they are not any more, and a no-metadata segment that
+// does carry norms is the ordinary analyzed shape -- see
+// SniiMixedCommonGramsAndPlainSegmentsCombine.
 TEST_F(CollectionStatisticsTest, LegacyAndCommonGramsMixRejectsWholeCollection) {
     ASSERT_TRUE(admit_snii_segment_for_test(stats_.get(), L"1",
                                             complete_snii_scoring_metadata("base-v1", 2, 6), 2,
                                             true)
                         .ok());
 
-    auto status = admit_snii_segment_for_test(stats_.get(), L"1", std::nullopt, 3, true);
+    auto status = admit_snii_segment_for_test(stats_.get(), L"1", std::nullopt, 3,
+                                              /*has_semantic_norms=*/false);
 
     EXPECT_EQ(status.code(), ErrorCode::INVERTED_INDEX_NOT_SUPPORTED);
     expect_no_collected_tokens(L"1");

--- a/be/test/storage/index/snii/snii_plain_index_scoring_test.cpp
+++ b/be/test/storage/index/snii/snii_plain_index_scoring_test.cpp
@@ -1,0 +1,350 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// SNII scoring must not depend on CommonGrams.
+//
+// CommonGrams is a phrase-query performance optimization. It needs a SEMANTIC
+// view of the collection statistics because its physical postings hold gram
+// tokens, so sum_total_term_freq and per-document length are not the numbers
+// BM25 wants. That semantic view was introduced inside the CommonGrams segment
+// metadata, and the scoring gate was written as "does this segment carry
+// CommonGrams metadata" -- which made an ordinary analyzed index unscoreable.
+// V1/V2/V3 score the same index (see regression test_bm25_score.groovy) and
+// even score with norms omitted (test_omit_norms.groovy), so SNII was the
+// outlier. These cases pin the aligned behaviour.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "core/block/block.h"
+#include "core/column/column_array.h"
+#include "core/column/column_nullable.h"
+#include "core/column/column_string.h"
+#include "core/data_type/data_type_array.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_string.h"
+#include "io/fs/local_file_system.h"
+#include "storage/index/index_file_reader.h"
+#include "storage/index/index_file_writer.h"
+#include "storage/index/inverted/inverted_index_desc.h"
+#include "storage/index/inverted/inverted_index_writer.h"
+#include "storage/index/snii/query/bm25_scorer.h"
+#include "storage/index/snii/stats/snii_stats_provider.h"
+#include "storage/iterator/olap_data_convertor.h"
+#include "storage/olap_common.h"
+#include "storage/tablet/tablet_schema.h"
+
+namespace doris {
+
+using segment_v2::IndexColumnWriter;
+using segment_v2::IndexFileReader;
+using segment_v2::IndexFileWriter;
+using segment_v2::InvertedIndexDescriptor;
+
+namespace {
+
+constexpr const char* kTestDir = "./ut_dir/snii_plain_index_scoring_test";
+constexpr int64_t kIndexId = 9101;
+
+// One scalar STRING column, nullable, mirroring an ordinary text table.
+TabletSchemaSPtr scalar_schema() {
+    auto schema = std::make_shared<TabletSchema>();
+    TabletSchemaPB pb;
+    pb.set_keys_type(DUP_KEYS);
+    schema->init_from_pb(pb);
+    TabletColumn col;
+    col.set_name("body");
+    col.set_type(FieldType::OLAP_FIELD_TYPE_STRING);
+    col.set_length(INT_MAX);
+    col.set_is_nullable(true);
+    schema->append_column(col);
+    return schema;
+}
+
+// ARRAY<STRING>. CommonGrams rejects ARRAY outright, so an array text column
+// could never reach the scoring tier while scoring rode on CommonGrams.
+TabletSchemaSPtr array_schema() {
+    auto schema = std::make_shared<TabletSchema>();
+    TabletSchemaPB pb;
+    pb.set_keys_type(DUP_KEYS);
+    schema->init_from_pb(pb);
+    TabletColumn array;
+    array.set_name("body");
+    array.set_type(FieldType::OLAP_FIELD_TYPE_ARRAY);
+    array.set_length(0);
+    array.set_index_length(0);
+    array.set_is_nullable(true);
+    TabletColumn child;
+    child.set_name("body_item");
+    child.set_type(FieldType::OLAP_FIELD_TYPE_STRING);
+    child.set_length(INT_MAX);
+    array.add_sub_column(child);
+    schema->append_column(array);
+    return schema;
+}
+
+// An ordinary built-in-parser index. No custom analyzer, no CommonGrams.
+TabletIndex plain_index_meta(bool support_phrase) {
+    TabletIndexPB pb;
+    pb.set_index_type(IndexType::INVERTED);
+    pb.set_index_id(kIndexId);
+    pb.set_index_name("plain_idx");
+    pb.add_col_unique_id(0);
+    (*pb.mutable_properties())["parser"] = "english";
+    (*pb.mutable_properties())["lower_case"] = "true";
+    (*pb.mutable_properties())["support_phrase"] = support_phrase ? "true" : "false";
+    TabletIndex meta;
+    meta.init_from_pb(pb);
+    return meta;
+}
+
+std::string prefix_for(std::string_view rowset_id) {
+    return std::string(InvertedIndexDescriptor::get_index_file_path_prefix(
+            local_segment_path(kTestDir, rowset_id, 0)));
+}
+
+std::unique_ptr<IndexFileWriter> open_writer(const std::string& prefix,
+                                             std::string_view rowset_id) {
+    io::FileWriterPtr file_writer;
+    EXPECT_TRUE(io::global_local_filesystem()
+                        ->create_file(InvertedIndexDescriptor::get_index_file_path_v2(prefix),
+                                      &file_writer)
+                        .ok());
+    return std::make_unique<IndexFileWriter>(
+            io::global_local_filesystem(), prefix, std::string(rowset_id), 0,
+            InvertedIndexStorageFormatPB::SNII, std::move(file_writer));
+}
+
+// Writes `docs` through the production scalar path and returns the index prefix.
+// A row listed in `null_rows` is written as SQL NULL, so a caller can interleave
+// null runs with data runs.
+std::string write_scalar_segment(std::string_view rowset_id, const TabletIndex& meta,
+                                 const std::vector<std::string>& docs,
+                                 const std::set<size_t>& null_rows = {}) {
+    const std::string prefix = prefix_for(rowset_id);
+    auto inner = ColumnString::create();
+    auto null_map = ColumnUInt8::create();
+    for (size_t row = 0; row < docs.size(); ++row) {
+        const auto& doc = docs[row];
+        inner->insert_data(doc.data(), doc.size());
+        null_map->insert_value(null_rows.contains(row) ? 1 : 0);
+    }
+    ColumnPtr column = ColumnNullable::create(std::move(inner), std::move(null_map));
+    Block block;
+    block.insert({column, std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>()),
+                  "body"});
+
+    TabletSchemaSPtr schema = scalar_schema();
+    auto index_file_writer = open_writer(prefix, rowset_id);
+    std::unique_ptr<IndexColumnWriter> builder;
+    EXPECT_TRUE(
+            IndexColumnWriter::create(&schema->column(0), &builder, index_file_writer.get(), &meta)
+                    .ok());
+
+    OlapBlockDataConvertor convertor(schema.get(), {0});
+    convertor.set_source_content(&block, 0, block.rows());
+    auto [status, accessor] = convertor.convert_column_data(0);
+    EXPECT_TRUE(status.ok()) << status;
+    // Mirrors ColumnWriter::append_nullable: null runs go to add_nulls(), data
+    // runs to add_values(). Both must advance the norms vector by their length.
+    const auto* row_null_map = accessor->get_nullmap();
+    const auto* data = reinterpret_cast<const uint8_t*>(accessor->get_data());
+    size_t offset = 0;
+    while (offset < block.rows()) {
+        const bool is_null = row_null_map != nullptr && row_null_map[offset] != 0;
+        size_t run = 1;
+        while (offset + run < block.rows() &&
+               ((row_null_map != nullptr && row_null_map[offset + run] != 0) == is_null)) {
+            ++run;
+        }
+        if (is_null) {
+            EXPECT_TRUE(builder->add_nulls(static_cast<uint32_t>(run)).ok());
+        } else {
+            EXPECT_TRUE(builder->add_values("body", data + offset * sizeof(Slice), run).ok());
+        }
+        offset += run;
+    }
+    EXPECT_TRUE(builder->finish().ok());
+    EXPECT_TRUE(index_file_writer->begin_close().ok());
+    EXPECT_TRUE(index_file_writer->finish_close().ok());
+    return prefix;
+}
+
+class SniiPlainIndexScoring : public testing::Test {
+protected:
+    void SetUp() override {
+        ASSERT_TRUE(io::global_local_filesystem()->delete_directory(kTestDir).ok());
+        ASSERT_TRUE(io::global_local_filesystem()->create_directory(kTestDir).ok());
+    }
+};
+
+} // namespace
+
+// The whole point: an ordinary analyzed SNII index carries scoring data.
+TEST_F(SniiPlainIndexScoring, PlainAnalyzedIndexOpensTheScoringStatsProvider) {
+    const TabletIndex meta = plain_index_meta(/*support_phrase=*/true);
+    // Four documents, 24 tokens total -> avgdl 6.
+    const std::string prefix = write_scalar_segment(
+            "plain_rs", meta,
+            {"alpha beta gamma delta epsilon zeta", "alpha beta gamma delta epsilon zeta",
+             "alpha beta gamma delta epsilon zeta", "alpha beta gamma delta epsilon zeta"});
+
+    IndexFileReader reader(io::global_local_filesystem(), prefix,
+                           InvertedIndexStorageFormatPB::SNII);
+    ASSERT_TRUE(reader.init().ok());
+    auto logical = reader.open_snii_index(&meta);
+    ASSERT_TRUE(logical.has_value()) << logical.error();
+
+    doris::snii::stats::SniiStatsProvider stats;
+    const Status status =
+            doris::snii::stats::SniiStatsProvider::open(logical.value().get(), &stats);
+    ASSERT_TRUE(status.ok()) << status;
+
+    EXPECT_TRUE(stats.has_norms()) << "an analyzed index must persist per-document norms";
+    EXPECT_DOUBLE_EQ(stats.avgdl(), 6.0);
+    uint64_t df = 0;
+    ASSERT_TRUE(stats.doc_freq("alpha", &df).ok());
+    EXPECT_EQ(df, 4U);
+
+    uint8_t norm = 0;
+    ASSERT_TRUE(stats.encoded_norm(0, &norm).ok());
+    EXPECT_EQ(norm, 6U) << "the norm must encode the document's token count";
+}
+
+// The riskiest invariant this change touches: norms are per ROW, and a null run
+// goes through add_nulls() rather than the token path. One missed push and the
+// vector desyncs -- every later document would be scored with a neighbour's length.
+TEST_F(SniiPlainIndexScoring, NullRunsKeepOneNormPerDocument) {
+    const TabletIndex meta = plain_index_meta(/*support_phrase=*/true);
+    // 6 rows: data, NULL, NULL, data, NULL, data -- runs on both sides.
+    const std::string prefix = write_scalar_segment(
+            "nulls_rs", meta,
+            {"alpha beta gamma", "", "", "alpha beta", "", "alpha beta gamma delta"},
+            /*null_rows=*/ {1, 2, 4});
+
+    IndexFileReader reader(io::global_local_filesystem(), prefix,
+                           InvertedIndexStorageFormatPB::SNII);
+    ASSERT_TRUE(reader.init().ok());
+    auto logical = reader.open_snii_index(&meta);
+    ASSERT_TRUE(logical.has_value()) << logical.error();
+
+    doris::snii::stats::SniiStatsProvider stats;
+    const Status status =
+            doris::snii::stats::SniiStatsProvider::open(logical.value().get(), &stats);
+    ASSERT_TRUE(status.ok()) << status;
+    EXPECT_TRUE(stats.has_norms());
+
+    const std::vector<uint64_t> expected {3, 0, 0, 2, 0, 4};
+    for (uint32_t docid = 0; docid < expected.size(); ++docid) {
+        uint8_t norm = 0;
+        ASSERT_TRUE(stats.encoded_norm(docid, &norm).ok()) << "docid " << docid;
+        EXPECT_EQ(norm, doris::snii::query::encode_norm(expected[docid]))
+                << "norm desynced at docid " << docid;
+    }
+    uint8_t past_end = 0;
+    EXPECT_FALSE(stats.encoded_norm(static_cast<uint32_t>(expected.size()), &past_end).ok())
+            << "the norms vector outlives the document count";
+
+    // avgdl divides by ALL rows, the same rows the norms span: 9 tokens / 6 docs.
+    EXPECT_EQ(logical.value()->stats().doc_count, 6);
+    EXPECT_EQ(logical.value()->stats().sum_total_term_freq, 9);
+    EXPECT_DOUBLE_EQ(stats.avgdl(), 1.5);
+}
+
+// CommonGrams rejects ARRAY fields, so arrays were unscoreable on SNII while
+// V1/V2/V3 scored them.
+TEST_F(SniiPlainIndexScoring, PlainAnalyzedArrayIndexOpensTheScoringStatsProvider) {
+    const TabletIndex meta = plain_index_meta(/*support_phrase=*/true);
+    const std::string prefix = prefix_for("array_rs");
+
+    DataTypePtr item = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>());
+    DataTypePtr array_type = std::make_shared<DataTypeArray>(item);
+    MutableColumnPtr nested = array_type->create_column();
+    for (int row = 0; row < 4; ++row) {
+        Array value;
+        value.push_back(Field::create_field<TYPE_STRING>(std::string("alpha beta")));
+        value.push_back(Field::create_field<TYPE_STRING>(std::string("gamma delta")));
+        nested->insert(Field::create_field<TYPE_ARRAY>(value));
+    }
+    auto null_map = ColumnUInt8::create();
+    for (int row = 0; row < 4; ++row) {
+        null_map->insert_value(0);
+    }
+    ColumnPtr column = ColumnNullable::create(std::move(nested), std::move(null_map));
+    Block block;
+    block.insert({column, std::make_shared<DataTypeNullable>(array_type), "body"});
+
+    TabletSchemaSPtr schema = array_schema();
+    auto index_file_writer = open_writer(prefix, "array_rs");
+    std::unique_ptr<IndexColumnWriter> builder;
+    ASSERT_TRUE(
+            IndexColumnWriter::create(&schema->column(0), &builder, index_file_writer.get(), &meta)
+                    .ok());
+
+    OlapBlockDataConvertor convertor(schema.get(), {0});
+    convertor.set_source_content(&block, 0, block.rows());
+    auto [status, accessor] = convertor.convert_column_data(0);
+    ASSERT_TRUE(status.ok()) << status;
+    const auto* data_ptr = reinterpret_cast<const uint64_t*>(accessor->get_data());
+    ASSERT_TRUE(
+            builder->add_array_values(field_type_size(schema->column(0).get_sub_column(0).type()),
+                                      reinterpret_cast<const void*>(data_ptr[2]),
+                                      reinterpret_cast<const uint8_t*>(data_ptr[3]),
+                                      reinterpret_cast<const uint8_t*>(data_ptr[1]), block.rows())
+                    .ok());
+    ASSERT_TRUE(builder->add_array_nulls(accessor->get_nullmap(), block.rows()).ok());
+    ASSERT_TRUE(builder->finish().ok());
+    ASSERT_TRUE(index_file_writer->begin_close().ok());
+    ASSERT_TRUE(index_file_writer->finish_close().ok());
+
+    IndexFileReader reader(io::global_local_filesystem(), prefix,
+                           InvertedIndexStorageFormatPB::SNII);
+    ASSERT_TRUE(reader.init().ok());
+    auto logical = reader.open_snii_index(&meta);
+    ASSERT_TRUE(logical.has_value()) << logical.error();
+
+    doris::snii::stats::SniiStatsProvider stats;
+    const Status open_status =
+            doris::snii::stats::SniiStatsProvider::open(logical.value().get(), &stats);
+    ASSERT_TRUE(open_status.ok()) << open_status;
+    EXPECT_TRUE(stats.has_norms());
+    EXPECT_DOUBLE_EQ(stats.avgdl(), 4.0);
+}
+
+// Guard against over-reach: without positions there is no scoring tier, exactly
+// as on V1/V2/V3 where is_need_similarity_score() requires support_phrase.
+TEST_F(SniiPlainIndexScoring, IndexWithoutPositionsStaysUnscoreable) {
+    const TabletIndex meta = plain_index_meta(/*support_phrase=*/false);
+    const std::string prefix =
+            write_scalar_segment("nophrase_rs", meta, {"alpha beta", "alpha gamma"});
+
+    IndexFileReader reader(io::global_local_filesystem(), prefix,
+                           InvertedIndexStorageFormatPB::SNII);
+    ASSERT_TRUE(reader.init().ok());
+    auto logical = reader.open_snii_index(&meta);
+    ASSERT_TRUE(logical.has_value()) << logical.error();
+    EXPECT_FALSE(logical.value()->has_positions());
+
+    doris::snii::stats::SniiStatsProvider stats;
+    EXPECT_FALSE(doris::snii::stats::SniiStatsProvider::open(logical.value().get(), &stats).ok());
+}
+
+} // namespace doris

--- a/be/test/storage/index/snii/snii_plain_index_scoring_test.cpp
+++ b/be/test/storage/index/snii/snii_plain_index_scoring_test.cpp
@@ -23,9 +23,9 @@
 // BM25 wants. That semantic view was introduced inside the CommonGrams segment
 // metadata, and the scoring gate was written as "does this segment carry
 // CommonGrams metadata" -- which made an ordinary analyzed index unscoreable.
-// V1/V2/V3 score the same index (see regression test_bm25_score.groovy) and
-// even score with norms omitted (test_omit_norms.groovy), so SNII was the
-// outlier. These cases pin the aligned behaviour.
+// V1/V2/V3 score the same analyzed, position-enabled index (see regression
+// test_bm25_score.groovy), so SNII was the outlier. These cases pin the aligned
+// behaviour and SNII's explicit norms requirement.
 
 #include <gtest/gtest.h>
 
@@ -50,6 +50,7 @@
 #include "storage/index/snii/stats/snii_stats_provider.h"
 #include "storage/iterator/olap_data_convertor.h"
 #include "storage/olap_common.h"
+#include "storage/segment/column_writer.h"
 #include "storage/tablet/tablet_schema.h"
 
 namespace doris {
@@ -327,6 +328,95 @@ TEST_F(SniiPlainIndexScoring, PlainAnalyzedArrayIndexOpensTheScoringStatsProvide
     ASSERT_TRUE(open_status.ok()) << open_status;
     EXPECT_TRUE(stats.has_norms());
     EXPECT_DOUBLE_EQ(stats.avgdl(), 4.0);
+}
+
+TEST_F(SniiPlainIndexScoring, OuterNullArrayPayloadDoesNotAffectScoring) {
+    const TabletIndex index_meta = plain_index_meta(/*support_phrase=*/true);
+    const std::string prefix = prefix_for("outer_null_array_rs");
+
+    DataTypePtr item_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeString>());
+    DataTypePtr array_type = std::make_shared<DataTypeArray>(item_type);
+    MutableColumnPtr nested = array_type->create_column();
+    for (const auto& text : {"alpha beta", "poison poison poison", "gamma"}) {
+        Array value;
+        value.push_back(Field::create_field<TYPE_STRING>(std::string(text)));
+        nested->insert(Field::create_field<TYPE_ARRAY>(value));
+    }
+    auto null_map = ColumnUInt8::create();
+    null_map->insert_value(0);
+    null_map->insert_value(1);
+    null_map->insert_value(0);
+    ColumnPtr column = ColumnNullable::create(std::move(nested), std::move(null_map));
+    Block block;
+    block.insert({column, std::make_shared<DataTypeNullable>(array_type), "body"});
+
+    TabletSchemaSPtr schema = array_schema();
+    io::FileWriterPtr data_file_writer;
+    ASSERT_TRUE(io::global_local_filesystem()
+                        ->create_file(fmt::format("{}/outer_null_array.dat", kTestDir),
+                                      &data_file_writer)
+                        .ok());
+    auto index_file_writer = open_writer(prefix, "outer_null_array_rs");
+
+    segment_v2::ColumnMetaPB column_meta;
+    column_meta.set_column_id(0);
+    column_meta.set_unique_id(0);
+    column_meta.set_type(int(FieldType::OLAP_FIELD_TYPE_ARRAY));
+    column_meta.set_length(0);
+    column_meta.set_encoding(segment_v2::PLAIN_ENCODING);
+    column_meta.set_compression(segment_v2::CompressionTypePB::LZ4F);
+    column_meta.set_is_nullable(true);
+    auto* item_meta = column_meta.add_children_columns();
+    item_meta->set_column_id(0);
+    item_meta->set_unique_id(0);
+    item_meta->set_type(int(FieldType::OLAP_FIELD_TYPE_STRING));
+    item_meta->set_length(INT_MAX);
+    item_meta->set_encoding(segment_v2::PLAIN_ENCODING);
+    item_meta->set_compression(segment_v2::CompressionTypePB::LZ4F);
+    item_meta->set_is_nullable(true);
+
+    segment_v2::ColumnWriterOptions writer_options;
+    writer_options.meta = &column_meta;
+    writer_options.need_inverted_index = true;
+    writer_options.inverted_indexes = {&index_meta};
+    writer_options.index_file_writer = index_file_writer.get();
+    writer_options.file_writer = data_file_writer.get();
+    writer_options.compression_type = segment_v2::CompressionTypePB::LZ4F;
+    std::unique_ptr<segment_v2::ColumnWriter> writer;
+    ASSERT_TRUE(segment_v2::ColumnWriter::create(writer_options, &schema->column(0),
+                                                 data_file_writer.get(), &writer)
+                        .ok());
+    ASSERT_TRUE(writer->init().ok());
+
+    OlapBlockDataConvertor convertor(schema.get(), {0});
+    convertor.set_source_content(&block, 0, block.rows());
+    auto [convert_status, accessor] = convertor.convert_column_data(0);
+    ASSERT_TRUE(convert_status.ok()) << convert_status;
+    const auto* array_data = reinterpret_cast<const uint8_t*>(accessor->get_data());
+    ASSERT_TRUE(writer->append_nullable(accessor->get_nullmap(), &array_data, block.rows()).ok());
+    ASSERT_TRUE(writer->finish().ok());
+    ASSERT_TRUE(writer->write_inverted_index().ok());
+    ASSERT_TRUE(index_file_writer->begin_close().ok());
+    ASSERT_TRUE(index_file_writer->finish_close().ok());
+    ASSERT_TRUE(data_file_writer->close().ok());
+
+    IndexFileReader reader(io::global_local_filesystem(), prefix,
+                           InvertedIndexStorageFormatPB::SNII);
+    ASSERT_TRUE(reader.init().ok());
+    auto logical = reader.open_snii_index(&index_meta);
+    ASSERT_TRUE(logical.has_value()) << logical.error();
+
+    doris::snii::stats::SniiStatsProvider stats;
+    ASSERT_TRUE(doris::snii::stats::SniiStatsProvider::open(logical.value().get(), &stats).ok());
+    EXPECT_EQ(logical.value()->stats().doc_count, 3);
+    EXPECT_EQ(logical.value()->stats().sum_total_term_freq, 3);
+    EXPECT_DOUBLE_EQ(stats.avgdl(), 1.0);
+    uint64_t poison_df = 0;
+    ASSERT_TRUE(stats.doc_freq("poison", &poison_df).ok());
+    EXPECT_EQ(poison_df, 0);
+    uint8_t null_norm = 0;
+    ASSERT_TRUE(stats.encoded_norm(1, &null_norm).ok());
+    EXPECT_EQ(null_norm, doris::snii::query::encode_norm(0));
 }
 
 // Guard against over-reach: without positions there is no scoring tier, exactly

--- a/be/test/storage/index/snii/writer/snii_writer_golden_bytes_test.cpp
+++ b/be/test/storage/index/snii/writer/snii_writer_golden_bytes_test.cpp
@@ -32,10 +32,11 @@
 // running the test and copying the "actual=" value from the failure message --
 // and say so loudly in the commit message.
 //
-// RE-HARVESTED when SniiStatsPB and SniiSectionRefsPB were renumbered back to the
-// field numbers the format shipped with. Protobuf tags are part of the image, so
-// EVERY digest moved -- including kGoldenKeywordDocsOnly, which is what tells you
-// the change reaches all SNII segments and not just one lane.
+// RE-HARVESTED after SniiStatsPB and SniiSectionRefsPB returned to their shipped
+// field numbers and SNII scoring stopped depending on CommonGrams. The protobuf
+// tag change moves every digest; the scoring change additionally gives analyzed
+// position-enabled indexes a norms region. The keyword digest changes only with
+// the protobuf layout because keyword indexes remain outside the scoring tier.
 
 #include <gtest/gtest.h>
 
@@ -308,8 +309,8 @@ private:
 // Whole-image digests re-harvested for the protobuf v1 metadata layout. They
 // still pin posting bytes together with every framing, directory, and metadata
 // byte, so future format changes remain explicit.
-constexpr uint64_t kGoldenEnglishPhrase = 0x21fa508c4b24585eULL;
-constexpr uint64_t kGoldenUnicodePhrase = 0xf3132d01603c7613ULL;
+constexpr uint64_t kGoldenEnglishPhrase = 0x4df3e24e42c442deULL;
+constexpr uint64_t kGoldenUnicodePhrase = 0x984f133d11f6f697ULL;
 constexpr uint64_t kGoldenKeywordDocsOnly = 0x45e45e6f7b81c65aULL;
 
 TEST_F(SniiWriterGoldenBytes, EnglishPhrase) {

--- a/be/test/storage/index/snii_writer_test.cpp
+++ b/be/test/storage/index/snii_writer_test.cpp
@@ -500,8 +500,11 @@ TEST(SniiCommonGramsWriter, PlainControlKeepsRawTermsAndLegacyConfig) {
     EXPECT_TRUE(std::ranges::none_of(postings, [](const auto& posting) {
         return posting.term.starts_with(doris::segment_v2::inverted_index::PLAIN_ESCAPE_PREFIX);
     }));
-    EXPECT_EQ(writer.config_for_test(), IndexConfig::kDocsPositions);
-    EXPECT_TRUE(writer.encoded_norms_for_test().empty());
+    // The plain lane keeps RAW term keys and no CommonGrams identity -- that is
+    // what this control asserts. It DOES reach the scoring tier and persist
+    // norms, because scoring follows analysis, not CommonGrams.
+    EXPECT_EQ(writer.config_for_test(), IndexConfig::kDocsPositionsScoring);
+    EXPECT_FALSE(writer.encoded_norms_for_test().empty());
     EXPECT_FALSE(writer.has_common_grams_metadata_seed_for_test());
 }
 

--- a/be/test/storage/segment/inverted_index_writer_test.cpp
+++ b/be/test/storage/segment/inverted_index_writer_test.cpp
@@ -1866,8 +1866,13 @@ TEST_F(InvertedIndexWriterTest, CommonGramsDisabledBuildSwitchSnapshotWritesPlai
     auto logical_result = file_reader.open_snii_index(&index_meta);
     ASSERT_TRUE(logical_result.has_value()) << logical_result.error();
     auto logical = std::move(logical_result.value());
+    // The build switch being off means NO CommonGrams identity and no gram
+    // postings -- the point of this case. The index is still analyzed with
+    // positions, so it keeps the scoring tier and stays rankable.
     EXPECT_EQ(logical->common_grams_metadata(), nullptr);
-    EXPECT_EQ(logical->tier(), snii::format::tier_of(snii::format::IndexConfig::kDocsPositions));
+    EXPECT_EQ(logical->tier(),
+              snii::format::tier_of(snii::format::IndexConfig::kDocsPositionsScoring));
+    EXPECT_GT(logical->section_refs().norms.length, 0);
     std::vector<uint32_t> docids;
     ASSERT_TRUE(snii::query::term_query(*logical, marker_leading_value, &docids).ok());
     EXPECT_EQ(docids, (std::vector<uint32_t> {0}));

--- a/regression-test/suites/inverted_index_p0/storage_format/test_common_grams_snii.groovy
+++ b/regression-test/suites/inverted_index_p0/storage_format/test_common_grams_snii.groovy
@@ -921,13 +921,13 @@ suite("test_common_grams_snii", "p0,nonConcurrent") {
                 "SELECT id FROM test_common_grams_missing "
                         + "WHERE body MATCH_PHRASE_PREFIX 'the wo' ORDER BY id",
                 "SniiCommonGramsFallbackIncompatible")
-        test {
-            sql """
-                SELECT id, score() AS s FROM test_common_grams_missing
-                WHERE body MATCH_PHRASE 'alpha beta' ORDER BY s DESC LIMIT 100
-            """
-            exception "SNII semantic scoring metadata is missing"
-        }
+        // Scoring no longer depends on CommonGrams. This table declares a
+        // CommonGrams analyzer but every segment was written with the build
+        // switch off, so it holds no grams -- and that is simply an ordinary
+        // analyzed index, which ranks exactly like the V3 control.
+        assertEquals(
+                rankedIds("test_common_grams_mixed_v3_plain", "body MATCH_PHRASE 'alpha beta'", 100),
+                rankedIds("test_common_grams_missing", "body MATCH_PHRASE 'alpha beta'", 100))
 
         setBeConfig("enable_common_grams_index_build", "true")
         sql """
@@ -969,13 +969,16 @@ suite("test_common_grams_snii", "p0,nonConcurrent") {
                 "SELECT id FROM test_common_grams_mixed "
                         + "WHERE body MATCH_PHRASE_PREFIX 'the wo' ORDER BY id",
                 "SniiCommonGramsFallbackIncompatible")
-        test {
-            sql """
-                SELECT id, score() AS s FROM test_common_grams_mixed
-                WHERE body MATCH_PHRASE 'alpha beta' ORDER BY s DESC LIMIT 100
-            """
-            exception "SNII semantic scoring metadata is missing"
-        }
+        // A CommonGrams segment and a plain one for the same field combine: the
+        // CommonGrams segment contributes its SEMANTIC token count (its physical
+        // sum_total_term_freq is inflated by the gram postings), the plain one
+        // contributes its physical count, which is already semantic. Plain
+        // postings are complete on both sides -- the writer emits the gram AND
+        // the token's own posting -- so df is measured the same way and the
+        // ranking matches the V3 control.
+        assertEquals(
+                rankedIds("test_common_grams_mixed_v3_plain", "body MATCH_PHRASE 'alpha beta'", 100),
+                rankedIds("test_common_grams_mixed", "body MATCH_PHRASE 'alpha beta'", 100))
 
         setBeConfig("enable_common_grams_index_build", "true")
         trigger_and_wait_compaction("test_common_grams_mixed", "full", 300)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #66052

Problem Summary: `score()` over an ordinary analyzed SNII index failed with
"SNII semantic scoring metadata is missing". V1/V2/V3 rank the same index
(regression test_bm25_score.groovy), so SNII was the outlier.

CommonGrams stores gram tokens in its physical postings, so its
SniiStatsPB.sum_total_term_freq and per-document length are not the numbers
BM25 wants; it needs a SEMANTIC view of the collection. That view was introduced
inside the CommonGrams segment metadata, and every downstream capability check
was then written as "does this segment carry CommonGrams metadata" rather than
"does this segment carry scoring data". A phrase-query performance optimization
therefore became a prerequisite for a core feature, in five separate places:
the writer's tier decision, the writer's norms accumulation, the query-side
statistics gate, the per-segment stats provider, and compaction eligibility.

For an index that does NOT use CommonGrams there is no such divergence -- its
physical statistics ARE the semantic ones -- so the fix is to ask the right
question instead of adding a second mechanism. No metadata field and no proto
message is added.

Writer: an index reaches the scoring tier and persists per-document norms when
it is ANALYZED and keeps POSITIONS (`_writes_norms()`), not when it uses
CommonGrams. ARRAY columns are covered too; CommonGrams rejects ARRAY outright,
so an array text column could previously never be ranked on SNII. The plain
analyzer lane also never counted its tokens -- `*semantic_length` was only
incremented in the CommonGrams branch -- which is now done in `consume_token`.

Reader: `SniiStatsProvider::open()` and `resolve_snii_scoring_segment()` share
one predicate, "the index persists the BM25 inputs" = scoring tier + positions +
norms. A CommonGrams segment still has its semantic view validated before use.
Two DORIS_CHECKs that would have aborted the BE on the plain shape are removed,
and the term-df bound now uses the physical document count (proved equal to
scoring_doc_count for CommonGrams by validate_snii_scoring_metadata). The
analyzer fingerprint is a CommonGrams identity, so it is only compared when the
segment records one -- V1/V2/V3 perform no such check.

`avgdl` now divides by doc_count on both shapes. Norms are written for every
row (a null row contributes encode_norm(0)), so the denominator must span the
same rows the lengths do; the CommonGrams branch already used every row.

Compaction: a third streamed-merge kind, kPlainT3 -- scoring tier with norms and
no CommonGrams metadata. The existing norms remap is reused; only the metadata
seed and the semantic token count stay CommonGrams-only.

Segments written before this change keep working for filtering and are refused
for scoring rather than ranked at a guessed document length: they carry neither
norms nor freq regions, and a silent unit-length fallback would rank them on a
different scale from their siblings in the same table. Ranking them requires
rebuilding the index.

SIZE IMPACT, measured by section on a harmonic-df corpus (1k/20k/200k docs): an
analyzed index grows 30-38% against current master, roughly two thirds freq
region and one third norms. freq is a required BM25 input -- V1/V2/V3 and the
shipped SelectDB branch have always written it, and master dropped it for plain
positions indexes (G16-c) on the premise that such an index never scores, which
is the very defect fixed here. Measured against those two baselines the net
addition is norms alone, about +7% at 200k documents. The DICT region -- read on
every term lookup -- grows 13.2% at 1k docs, 8.0% at 20k and 0.0% at 200k, as
frequent postings move from inline to windowed and take their freq bytes out of
the dictionary block.

The two SniiWriterGoldenBytes digests for analyzed lanes were RE-HARVESTED. The
image changed for four reasons, not one: the freq region, the tier-dependent
dict entry layout, the norms region, and index_config. kGoldenKeywordDocsOnly is
unchanged, pinning that the analyzed lane is the only one affected.

### Release note

Fix score() on SNII inverted indexes built with an ordinary analyzer: BM25
ranking no longer requires a CommonGrams analyzer. Indexes written before this
change must be rebuilt to be ranked.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - SniiPlainIndexScoring.* (4 cases: scalar, ARRAY, null runs, no-positions guard)
        - CollectionStatisticsTest.SniiPlainAnalyzedIndexCollectsScoringStatistics
          enters through CollectionStatistics::collect and was verified RED against
          unmodified production code with the reported error text.
        - Full inverted-index suites: 3212 tests, 0 failures
        - ./run-be-ut.sh -j 160 --run

- Behavior changed:
    - [ ] No.
    - [x] Yes. An analyzed SNII index with phrase positions is now written at the
      scoring tier with norms and freq, and can be ranked. Segments written
      before this change are refused for scoring instead of erroring later.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label

