### PR TITLE
[fix](load) Make insert cancellation reliable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/manager/QueryProfileAction.java
@@ -148,6 +148,21 @@ public class QueryProfileAction extends RestBaseController {
         return dataList;
     }
 
+    private boolean requestAllFeForKill(String httpPath, Map<String, String> arguments, String authorization) {
+        ImmutableMap<String, String> header = ImmutableMap.<String, String>builder()
+                .put(NodeAction.AUTHORIZATION, authorization).build();
+        for (Pair<String, Integer> ipPort : HttpUtils.getFeList()) {
+            String url = HttpUtils.concatUrl(ipPort, httpPath, arguments);
+            try {
+                HttpUtils.parseResponse(HttpUtils.doPost(url, header, null));
+                return true;
+            } catch (Exception e) {
+                LOG.debug("failed to cancel query through {}", url, e);
+            }
+        }
+        return false;
+    }
+
     @RequestMapping(path = "/query_info", method = RequestMethod.GET)
     public Object queryInfo(HttpServletRequest request, HttpServletResponse response,
                             @RequestParam(value = QUERY_ID_PARA, required = false) String queryId,
@@ -530,12 +545,17 @@ public class QueryProfileAction extends RestBaseController {
             String httpPath = "/rest/v2/manager/query/kill/" + queryId;
             Map<String, String> arguments = Maps.newHashMap();
             arguments.put(IS_ALL_NODE_PARA, "false");
-            requestAllFe(httpPath, arguments, request.getHeader(NodeAction.AUTHORIZATION), HttpMethod.POST);
-            return ResponseEntityBuilder.ok();
+            if (requestAllFeForKill(httpPath, arguments, request.getHeader(NodeAction.AUTHORIZATION))) {
+                return ResponseEntityBuilder.ok();
+            }
+            return ResponseEntityBuilder.badRequest("Query not found or already committing: " + queryId);
         }
 
         ExecuteEnv env = ExecuteEnv.getInstance();
-        env.getScheduler().cancelQuery(queryId, new Status(TStatusCode.CANCELLED, "cancel query by rest api"));
+        if (!env.getScheduler().cancelQuery(
+                queryId, new Status(TStatusCode.CANCELLED, "cancel query by rest api"))) {
+            return ResponseEntityBuilder.badRequest("Query not found or already committing: " + queryId);
+        }
         return ResponseEntityBuilder.ok();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/AbstractInsertExecutor.java
@@ -26,6 +26,7 @@ import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.Status;
 import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.load.loadv2.InsertLoadJob;
@@ -273,6 +274,12 @@ public abstract class AbstractInsertExecutor {
             for (InsertExecutorListener listener : listeners) {
                 listener.beforeComplete(this, executor, jobId);
             }
+            long beforeOnCompleteSleepMs = DebugPointUtil.getDebugParamOrDefault(
+                    "AbstractInsertExecutor.beforeOnComplete.sleep", 0L);
+            if (beforeOnCompleteSleepMs > 0) {
+                Thread.sleep(beforeOnCompleteSleepMs);
+            }
+            executor.beginTransactionCommit();
             onComplete();
             for (InsertExecutorListener listener : listeners) {
                 try {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/InsertIntoTableCommand.java
@@ -29,6 +29,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.profile.ProfileManager.ProfileType;
+import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.datasource.ExternalTable;
@@ -351,6 +352,11 @@ public class InsertIntoTableCommand extends Command implements NeedAuditEncrypti
                 }
                 Throwables.throwIfInstanceOf(e, RuntimeException.class);
                 throw new IllegalStateException(e.getMessage(), e);
+            }
+            long beforeSetCoordinatorSleepMs = DebugPointUtil.getDebugParamOrDefault(
+                    "InsertIntoTableCommand.beforeSetCoordinator.sleep", 0L);
+            if (beforeSetCoordinatorSleepMs > 0) {
+                Thread.sleep(beforeSetCoordinatorSleepMs);
             }
             stmtExecutor.setProfileType(ProfileType.LOAD);
             // We exposed @StmtExecutor#cancel as a unified entry point for statement interruption,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/utils/KillUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/utils/KillUtils.java
@@ -154,7 +154,9 @@ public class KillUtils {
                     && !Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ctx, PrivPredicate.ADMIN)) {
                 ErrorReport.reportDdlException(ErrorCode.ERR_KILL_DENIED_ERROR, queryId);
             }
-            killCtx.kill(false);
+            if (!killCtx.kill(false)) {
+                throw new DdlException("Query " + queryId + " is already committing or finished");
+            }
             ctx.getState().setOk();
             return true;
         }
@@ -184,7 +186,10 @@ public class KillUtils {
                     && !Env.getCurrentEnv().getAccessManager().checkGlobalPriv(ctx, PrivPredicate.ADMIN)) {
                 ErrorReport.reportDdlException(ErrorCode.ERR_KILL_DENIED_ERROR, connectionId);
             }
-            killCtx.kill(killConnection);
+            if (!killCtx.kill(killConnection)) {
+                throw new DdlException("Query on connection " + connectionId
+                        + " is already committing or finished");
+            }
         }
         ctx.getState().setOk();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -1253,7 +1253,7 @@ public class ConnectContext {
     }
 
     // kill operation with no protect.
-    public void kill(boolean killConnection) {
+    public boolean kill(boolean killConnection) {
         LOG.warn("kill query from {}, kill {} connection: {}", getRemoteHostPortString(), getConnectType(),
                 killConnection);
 
@@ -1261,7 +1261,9 @@ public class ConnectContext {
             killConnection();
         }
         // Now, cancel running query.
-        cancelQuery(new Status(TStatusCode.CANCELLED, "cancel query by user from " + getRemoteHostPortString()));
+        boolean queryCancelled = cancelQuery(
+                new Status(TStatusCode.CANCELLED, "cancel query by user from " + getRemoteHostPortString()));
+        return killConnection || queryCancelled;
     }
 
     // kill operation with no protect by timeout.
@@ -1285,11 +1287,12 @@ public class ConnectContext {
         }
     }
 
-    public void cancelQuery(Status cancelReason) {
+    public boolean cancelQuery(Status cancelReason) {
         StmtExecutor executorRef = executor;
         if (executorRef != null) {
-            executorRef.cancel(cancelReason);
+            return executorRef.cancel(cancelReason);
         }
+        return false;
     }
 
     public void checkTimeout(long now) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectPoolMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectPoolMgr.java
@@ -113,8 +113,7 @@ public class ConnectPoolMgr {
         for (ConnectContext ctx : connectionMap.values()) {
             TUniqueId qid = ctx.queryId();
             if (qid != null && DebugUtil.printId(qid).equals(queryId)) {
-                ctx.cancelQuery(cancelReason);
-                return true;
+                return ctx.cancelQuery(cancelReason);
             }
         }
         return false;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/FEOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/FEOpExecutor.java
@@ -91,10 +91,10 @@ public class FEOpExecutor {
         }
     }
 
-    public void cancel() throws Exception {
+    public boolean cancel() throws Exception {
         TUniqueId queryId = ctx.queryId();
         if (queryId == null) {
-            return;
+            return false;
         }
         Preconditions.checkNotNull(feAddr, "query with id %s is not forwarded to fe", queryId);
         TMasterOpRequest request = new TMasterOpRequest();
@@ -107,6 +107,7 @@ public class FEOpExecutor {
         // just make the protocol happy
         request.setSql("");
         result = forward(request);
+        return result.getStatusCode() == 0;
     }
 
     // Send request to specific fe

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -64,9 +64,10 @@ public class MasterOpExecutor extends FEOpExecutor {
     }
 
     @Override
-    public void cancel() throws Exception {
-        super.cancel();
+    public boolean cancel() throws Exception {
+        boolean cancelled = super.cancel();
         waitOnReplaying();
+        return cancelled;
     }
 
     private void waitOnReplaying() throws DdlException {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -155,7 +155,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.protobuf.ByteString;
-import lombok.Setter;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -199,8 +198,10 @@ public class StmtExecutor {
     private List<List<String>> changedSessionVarsForAudit;
     private ProfileType profileType = ProfileType.QUERY;
 
-    @Setter
     private volatile Coordinator coord = null;
+    private final Object cancellationLock = new Object();
+    private Status cancelReason = null;
+    private boolean transactionCommitStarted = false;
     // Arrow Flight SQL: when true, this query's coordinator is kept alive past GetFlightInfo and
     // is finalized later by ConnectContext (see #62259), so the eager close in executeAndSendResult
     // is skipped.
@@ -1284,15 +1285,54 @@ public class StmtExecutor {
         }
     }
 
+    /**
+     * Publish the coordinator used by this statement.
+     *
+     * <p>Cancellation can arrive while an INSERT is still planning or initializing its transaction.
+     * Remembering the cancellation and applying it here prevents the later coordinator from escaping it.</p>
+     */
+    public void setCoord(Coordinator coord) {
+        Status pendingCancelReason;
+        synchronized (cancellationLock) {
+            this.coord = coord;
+            pendingCancelReason = cancelReason;
+        }
+        if (pendingCancelReason != null) {
+            coord.cancel(pendingCancelReason);
+        }
+    }
+
+    /**
+     * Establish the linearization point between cancelling a statement and committing its transaction.
+     */
+    public void beginTransactionCommit() throws UserException {
+        Status pendingCancelReason;
+        synchronized (cancellationLock) {
+            pendingCancelReason = cancelReason;
+            if (pendingCancelReason == null) {
+                transactionCommitStarted = true;
+                return;
+            }
+        }
+        throw new UserException(pendingCancelReason.getErrorMsg());
+    }
+
     // Because this is called by other thread
-    public void cancel(Status cancelReason, boolean needWaitCancelComplete) {
+    public boolean cancel(Status cancelReason, boolean needWaitCancelComplete) {
+        synchronized (cancellationLock) {
+            if (transactionCommitStarted) {
+                return false;
+            }
+            if (this.cancelReason == null) {
+                this.cancelReason = cancelReason;
+            }
+        }
         if (masterOpExecutor != null) {
             try {
-                masterOpExecutor.cancel();
+                return masterOpExecutor.cancel();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
-            return;
         }
         Optional<InsertOverwriteTableCommand> insertOverwriteTableCommand = getInsertOverwriteTableCommand();
         if (insertOverwriteTableCommand.isPresent()) {
@@ -1310,10 +1350,11 @@ public class StmtExecutor {
             // Wait for the command to run or cancel completion
             insertOverwriteTableCommand.get().waitNotRunning();
         }
+        return true;
     }
 
-    public void cancel(Status cancelReason) {
-        cancel(cancelReason, true);
+    public boolean cancel(Status cancelReason) {
+        return cancel(cancelReason, true);
     }
 
     private Optional<InsertOverwriteTableCommand> getInsertOverwriteTableCommand() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/PipelineExecutionTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/PipelineExecutionTask.java
@@ -93,6 +93,10 @@ public class PipelineExecutionTask extends AbstractRuntimeTask<BackendWorker, Mu
     @Override
     public void execute() throws Exception {
         coordinatorContext.withLock(() -> {
+            Status status = coordinatorContext.readCloneStatus();
+            if (!status.ok()) {
+                throw new UserException(status.getErrorMsg());
+            }
             sendAndWaitPhaseOneRpc();
             if (coordinatorContext.twoPhaseExecution()) {
                 sendAndWaitPhaseTwoRpc();

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -85,6 +85,7 @@ import org.apache.doris.common.Version;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.DebugPointUtil.DebugPoint;
+import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.PropertyAnalyzer;
 import org.apache.doris.common.util.ThriftLogHelper;
 import org.apache.doris.common.util.Util;
@@ -1243,11 +1244,13 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             throw new TException("a query id is needed to cancel a query");
         }
         ConnectContext context = proxyQueryIdToConnCtx.get(params.getQueryId());
-        if (context != null) {
-            context.cancelQuery(new Status(TStatusCode.CANCELLED, "cancel query by forward request."));
-        }
+        boolean cancelled = context != null && context.cancelQuery(
+                new Status(TStatusCode.CANCELLED, "cancel query by forward request."));
         TMasterOpResult result = createForwardResultWithJournalSync();
-        result.setStatusCode(0);
+        result.setStatusCode(cancelled ? 0 : 1);
+        if (!cancelled) {
+            result.setErrMessage("Query not found or already committing: " + DebugUtil.printId(params.getQueryId()));
+        }
         return result;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSqlConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/sessions/FlightSqlConnectContext.java
@@ -67,14 +67,16 @@ public class FlightSqlConnectContext extends ConnectContext {
 
     // kill operation with no protect.
     @Override
-    public void kill(boolean killConnection) {
+    public boolean kill(boolean killConnection) {
         LOG.warn("kill query from {}, kill flight sql connection: {}", getRemoteHostPortString(), killConnection);
 
         if (killConnection) {
             killConnection();
         }
         // Now, cancel running query.
-        cancelQuery(new Status(TStatusCode.CANCELLED, "arrow flight query killed by user"));
+        boolean queryCancelled = cancelQuery(
+                new Status(TStatusCode.CANCELLED, "arrow flight query killed by user"));
+        return killConnection || queryCancelled;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -24,6 +24,8 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ResourceMgr;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.Status;
+import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.authenticate.TestLogAppender;
@@ -33,6 +35,7 @@ import org.apache.doris.planner.ResultFileSink;
 import org.apache.doris.qe.CommonResultSet.CommonResultSetMetaData;
 import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.thrift.TQueryOptions;
+import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.utframe.TestWithFeService;
 
@@ -117,6 +120,37 @@ public class StmtExecutorTest extends TestWithFeService {
         StmtExecutor stmtExecutor = new StmtExecutor(connectContext, "");
         stmtExecutor.execute();
         Assert.assertEquals(QueryState.MysqlStateType.OK, connectContext.getState().getStateType());
+    }
+
+    @Test
+    public void testCancelBeforeCoordinatorIsPublished() {
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, "");
+        Coordinator coordinator = Mockito.mock(Coordinator.class);
+        Status cancelReason = new Status(TStatusCode.CANCELLED, "cancel before coordinator");
+
+        Assert.assertTrue(stmtExecutor.cancel(cancelReason));
+        stmtExecutor.setCoord(coordinator);
+
+        Mockito.verify(coordinator).cancel(cancelReason);
+    }
+
+    @Test
+    public void testCancelWinsBeforeTransactionCommit() {
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, "");
+        Status cancelReason = new Status(TStatusCode.CANCELLED, "cancel before commit");
+
+        Assert.assertTrue(stmtExecutor.cancel(cancelReason));
+        UserException exception = Assertions.assertThrows(UserException.class,
+                stmtExecutor::beginTransactionCommit);
+        Assert.assertTrue(exception.getMessage().contains("cancel before commit"));
+    }
+
+    @Test
+    public void testTransactionCommitRejectsLateCancel() throws Exception {
+        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, "");
+
+        stmtExecutor.beginTransactionCommit();
+        Assert.assertFalse(stmtExecutor.cancel(new Status(TStatusCode.CANCELLED, "late cancel")));
     }
 
     @Test

--- a/regression-test/suites/insert_p0/test_cancel_nereids_insert_query.groovy
+++ b/regression-test/suites/insert_p0/test_cancel_nereids_insert_query.groovy
@@ -1,0 +1,132 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+suite("test_cancel_nereids_insert_query", "nonConcurrent") {
+    sql "DROP TABLE IF EXISTS test_cancel_nereids_insert_query"
+    sql "DROP TABLE IF EXISTS test_cancel_nereids_ctas"
+    sql """
+        CREATE TABLE test_cancel_nereids_insert_query (
+            k BIGINT
+        )
+        DUPLICATE KEY(k)
+        DISTRIBUTED BY HASH(k) BUCKETS 1
+        PROPERTIES ("replication_num" = "1")
+    """
+
+    def waitQueryId = { String connectionId, String statementPrefix, String marker ->
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10)
+        while (System.currentTimeMillis() < deadline) {
+            def process = sql_return_maparray("SHOW FULL PROCESSLIST").find {
+                it.Id.toString() == connectionId
+                        && it.Info != null
+                        && it.Info.toString().toUpperCase().contains(statementPrefix)
+                        && it.Info.toString().contains(marker)
+            }
+            if (process != null) {
+                return process.QueryId.toString()
+            }
+            sleep(50)
+        }
+        throw new IllegalStateException("Query did not appear in processlist: ${marker}")
+    }
+
+    def runAndCancel = { String debugPoint, String labelPrefix ->
+        String label = "${labelPrefix}_${System.nanoTime()}"
+        GetDebugPoint().enableDebugPointForAllFEs(debugPoint, [value: 3000])
+        def insertError = new AtomicReference<Throwable>()
+        def insertConnectionId = new AtomicReference<String>()
+        def connectionReady = new CountDownLatch(1)
+        def insertFuture = thread {
+            try {
+                insertConnectionId.set("${sql('SELECT CONNECTION_ID()')[0][0]}")
+                connectionReady.countDown()
+                sql """
+                    INSERT INTO test_cancel_nereids_insert_query WITH LABEL ${label}
+                    SELECT number FROM numbers("number" = "1")
+                """
+            } catch (Throwable t) {
+                insertError.set(t)
+            } finally {
+                connectionReady.countDown()
+            }
+        }
+
+        try {
+            assertTrue(connectionReady.await(10, TimeUnit.SECONDS), "INSERT connection was not ready")
+            String queryId = waitQueryId.call(insertConnectionId.get(), "INSERT", label)
+            sql "KILL QUERY \"${queryId}\""
+            insertFuture.get(15, TimeUnit.SECONDS)
+
+            assertNotNull(insertError.get(), "The cancelled INSERT unexpectedly succeeded")
+            assertTrue(insertError.get().getMessage().contains("cancel query by user"))
+            assertEquals(0L, sql("SELECT COUNT(*) FROM test_cancel_nereids_insert_query")[0][0].toLong())
+
+            def transaction = sql_return_maparray """
+                    SHOW TRANSACTION FROM ${context.dbName} WHERE LABEL = '${label}'
+                """
+            assertEquals(1, transaction.size())
+            assertEquals("ABORTED", transaction[0].TransactionStatus.toString())
+        } finally {
+            GetDebugPoint().disableDebugPointForAllFEs(debugPoint)
+        }
+    }
+
+    runAndCancel.call("InsertIntoTableCommand.beforeSetCoordinator.sleep",
+            "test_cancel_before_coordinator")
+    runAndCancel.call("AbstractInsertExecutor.beforeOnComplete.sleep",
+            "test_cancel_before_commit")
+
+    GetDebugPoint().enableDebugPointForAllFEs(
+            "InsertIntoTableCommand.beforeSetCoordinator.sleep", [value: 3000])
+    def ctasError = new AtomicReference<Throwable>()
+    def ctasConnectionId = new AtomicReference<String>()
+    def ctasConnectionReady = new CountDownLatch(1)
+    def ctasFuture = thread {
+        try {
+            ctasConnectionId.set("${sql('SELECT CONNECTION_ID()')[0][0]}")
+            ctasConnectionReady.countDown()
+            sql """
+                CREATE TABLE test_cancel_nereids_ctas
+                PROPERTIES ("replication_num" = "1")
+                AS SELECT number AS k FROM numbers("number" = "1")
+            """
+        } catch (Throwable t) {
+            ctasError.set(t)
+        } finally {
+            ctasConnectionReady.countDown()
+        }
+    }
+
+    try {
+        assertTrue(ctasConnectionReady.await(10, TimeUnit.SECONDS), "CTAS connection was not ready")
+        String queryId = waitQueryId.call(
+                ctasConnectionId.get(), "CREATE TABLE", "test_cancel_nereids_ctas")
+        sql "KILL QUERY \"${queryId}\""
+        ctasFuture.get(15, TimeUnit.SECONDS)
+
+        assertNotNull(ctasError.get(), "The cancelled CTAS unexpectedly succeeded")
+        assertTrue(ctasError.get().getMessage().contains("cancel query by user"))
+        assertEquals(0, sql("SHOW TABLES LIKE 'test_cancel_nereids_ctas'").size())
+    } finally {
+        GetDebugPoint().disableDebugPointForAllFEs(
+                "InsertIntoTableCommand.beforeSetCoordinator.sleep")
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

INSERT INTO SELECT and CTAS expose two query cancellation races:

1. The insert coordinator is created before transaction initialization, but is published to StmtExecutor only after beginTransaction and sink finalization. A KILL QUERY, JDBC Statement.cancel(), or REST kill request received before publication finds the connection but no coordinator. The old path reports success and loses the cancellation, so the coordinator can later dispatch fragments and commit.
2. After coordinator.join() reports success, there is a window before onComplete() starts transaction commit. A cancellation in this window only targets an already completed coordinator, reports success, and does not prevent commit.

The same false-success behavior exists in local REST cancellation and follower-to-master forwarding because those layers do not propagate whether the statement accepted cancellation.

This PR:

- remembers cancellation in StmtExecutor and replays it when an INSERT or CTAS coordinator is published;
- checks coordinator cancellation while holding the dispatch lock before sending fragments to BEs;
- establishes a linearization point between cancellation and transaction commit: cancellation wins and aborts the transaction, or commit wins and the cancellation request is rejected;
- propagates the accepted or rejected result through ConnectContext, local schedulers, SQL KILL, JDBC cancellation, REST kill, Arrow Flight SQL, and forwarded FE cancellation;
- adds deterministic unit and regression coverage for cancellation before coordinator publication, cancellation before commit, and CTAS cancellation.

Scope: CANCEL LOAD is not changed by this PR. Running InsertLoadJob transaction/query binding is an independent load-job lifecycle issue.

### Release note

KILL QUERY, JDBC Statement.cancel(), and the REST query kill API now reliably cancel Nereids INSERT INTO SELECT and CTAS before transaction commit, including coordinator-publication races. Cancellation attempted after commit begins returns an error instead of a false success.

### Check List (For Author)

- Test
    - [x] Regression test
        - ./run-regression-test.sh --run -d insert_p0 -s test_cancel_nereids_insert_query
    - [x] Unit Test
        - ./run-fe-ut.sh --run org.apache.doris.qe.StmtExecutorTest
    - [x] Manual test
        - Built FE with ./build.sh --fe -j48.
        - Verified the regression suite against FE version doris-0.0.0-1731787677f on query port 24030 and HTTP port 23030.

- Behavior changed:
    - [x] Yes. Query cancellation is sticky until coordinator publication, cancellation is serialized against INSERT commit, and cancellation that arrives after commit begins returns failure.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label