### PR TITLE
[fix](regression) Fix flaky materialized view load-open test

### DIFF
--- a/regression-test/suites/rollup_p0/test_materialized_view_load_open.groovy
+++ b/regression-test/suites/rollup_p0/test_materialized_view_load_open.groovy
@@ -128,10 +128,10 @@ suite("test_materialized_view_load_open", "rollup") {
             );
         """
     
-    createMV("CREATE materialized VIEW test_load_open AS SELECT k1 as a1 FROM ${tbName1} GROUP BY k1;")
-    createMV("CREATE materialized VIEW test_load_open_dynamic_partition AS SELECT k1 as a2 FROM ${tbName2} GROUP BY k1;")
-    createMV("CREATE materialized VIEW test_load_open_schema_change AS SELECT k1 as a3 FROM ${tbName3} GROUP BY k1;")
-    createMV("CREATE materialized VIEW test_load_open_dynamic_partition_schema_change AS SELECT k1 as a4 FROM ${tbName4} GROUP BY k1;")
+    create_sync_mv(context.dbName, tbName1, "test_load_open", "SELECT k1 as a1 FROM ${tbName1} GROUP BY k1;")
+    create_sync_mv(context.dbName, tbName2, "test_load_open_dynamic_partition", "SELECT k1 as a2 FROM ${tbName2} GROUP BY k1;")
+    create_sync_mv(context.dbName, tbName3, "test_load_open_schema_change", "SELECT k1 as a3 FROM ${tbName3} GROUP BY k1;")
+    create_sync_mv(context.dbName, tbName4, "test_load_open_dynamic_partition_schema_change", "SELECT k1 as a4 FROM ${tbName4} GROUP BY k1;")
 
     sql "insert into ${tbName1} values('2000-05-20', 1.5, 'test', 1);"
     sql "insert into ${tbName1} values('2010-05-20', 1.5, 'test', 1);"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

`test_materialized_view_load_open` used `createMV`, which waits for the latest materialized view job in the shared database. Under parallel suite execution, it can observe a concurrent job as `FINISHED` and execute `ADD COLUMN` while its own table is still in `ROLLUP` state.

Replace all four calls with `create_sync_mv` so each materialized view creation waits for the job belonging to its base table.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test
    - [x] No need to test or manual test. Explain why:
        - [x] Other reason: regression-test synchronization-only change; not run per request.

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label