### PR TITLE
[fix](be) Propagate CCR delete bitmap calculation errors

### DIFF
--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -275,8 +275,13 @@ void _ingest_binlog(StorageEngine& engine, IngestBinlogArg* arg) {
                 paths.emplace_back(file);
                 LOG(WARNING) << "will delete downloaded success file " << file << " due to error";
             }
-            static_cast<void>(io::global_local_filesystem()->batch_delete(paths));
-            LOG(WARNING) << "done delete downloaded success files due to error " << tstatus;
+            auto cleanup_status = io::global_local_filesystem()->batch_delete(paths);
+            if (!cleanup_status.ok()) {
+                LOG(WARNING) << "failed to delete downloaded success files due to error " << tstatus
+                             << ", cleanup status: " << cleanup_status;
+            } else {
+                LOG(WARNING) << "done delete downloaded success files due to error " << tstatus;
+            }
         }
 
         if (ingest_binlog_tstatus) {

--- a/be/src/service/backend_service.cpp
+++ b/be/src/service/backend_service.cpp
@@ -242,7 +242,8 @@ void _ingest_binlog(StorageEngine& engine, IngestBinlogArg* arg) {
     std::vector<std::string> download_success_files;
     std::unordered_map<std::string_view, uint64_t> elapsed_time_map;
     Defer defer {[=, &engine, &tstatus, ingest_binlog_tstatus = arg->tstatus, &watch,
-                  &total_download_bytes, &total_download_files, &elapsed_time_map]() {
+                  &total_download_bytes, &total_download_files, &download_success_files,
+                  &elapsed_time_map]() {
         g_ingest_binlog_latency << watch.elapsed_time_microseconds();
         auto elapsed_time_ms = watch.elapsed_time_milliseconds();
         double copy_rate = 0.0;
@@ -640,13 +641,24 @@ void _ingest_binlog(StorageEngine& engine, IngestBinlogArg* arg) {
             elapsed_time_map.emplace("calc_delete_bitmap", watch.elapsed_time_microseconds());
         }
 
-        static_cast<void>(BaseTablet::commit_phase_update_delete_bitmap(
+        status = BaseTablet::commit_phase_update_delete_bitmap(
                 local_tablet, rowset, pre_rowset_ids, delete_bitmap, segments, txn_id,
-                calc_delete_bitmap_token.get(), nullptr));
+                calc_delete_bitmap_token.get(), nullptr);
         elapsed_time_map.emplace("commit_phase_update_delete_bitmap",
                                  watch.elapsed_time_microseconds());
-        static_cast<void>(calc_delete_bitmap_token->wait());
+        auto wait_status = calc_delete_bitmap_token->wait();
         elapsed_time_map.emplace("wait_delete_bitmap", watch.elapsed_time_microseconds());
+        if (status.ok()) {
+            status = wait_status;
+        }
+        if (!status.ok()) {
+            LOG(WARNING) << "failed to calculate delete bitmap for ingest binlog"
+                         << ", tablet_id=" << local_tablet_id
+                         << ", rowset_id=" << rowset->rowset_id() << ", txn_id=" << txn_id
+                         << ", status=" << status;
+            status.to_thrift(&tstatus);
+            return;
+        }
     }
 
     // Step 7.3: commit txn

--- a/regression-test/suites/ccr_mow_syncer_p0/test_ingest_binlog.groovy
+++ b/regression-test/suites/ccr_mow_syncer_p0/test_ingest_binlog.groovy
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import org.apache.doris.regression.util.DebugPoint
+import org.apache.doris.regression.util.NodeType
+
 suite("test_mow_ingest_binlog") {
 
     def syncer = getSyncer()
@@ -123,5 +126,40 @@ suite("test_mow_ingest_binlog") {
 
 
     // End Test 2
+    syncer.closeBackendClients()
+
+    logger.info("=== Test 3: Delete bitmap calculation failure case ===")
+    sql """
+            INSERT INTO ${tableName} VALUES (1, 0)
+        """
+    assertTrue(syncer.getBinlog("${tableName}"))
+    assertTrue(syncer.beginTxn("${tableName}"))
+    assertTrue(syncer.getBackendClients())
+
+    def debugPointName = "BaseTablet::calc_segment_delete_bitmap.inject_err"
+    def targetBackends = target_sql "SHOW PROC '/backends'"
+    try {
+        targetBackends.each { backend ->
+            DebugPoint.enableDebugPoint(backend[1] as String, backend[4] as int, NodeType.BE,
+                    debugPointName, [percent: "1.0"])
+        }
+        assertFalse(syncer.ingestBinlog())
+        assertFalse(syncer.checkTargetVersion())
+        target_sql " sync "
+        res = target_sql """SELECT * FROM ${tableName} WHERE test=1"""
+        assertEquals(res.size(), insert_num)
+    } finally {
+        targetBackends.each { backend ->
+            DebugPoint.disableDebugPoint(backend[1] as String, backend[4] as int, NodeType.BE,
+                    debugPointName)
+        }
+    }
+
+    assertTrue(syncer.ingestBinlog())
+    assertTrue(syncer.commitTxn())
+    assertTrue(syncer.checkTargetVersion())
+    target_sql " sync "
+    res = target_sql """SELECT * FROM ${tableName} WHERE test=1"""
+    assertEquals(res.size(), insert_num)
     syncer.closeBackendClients()
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67120

Related PR: None

Problem Summary:

In Shared-Nothing CCR incremental replication, `IngestBinlog` discarded both the status returned by `BaseTablet::commit_phase_update_delete_bitmap()` and the asynchronous delete bitmap token's `wait()` status.

For UNIQUE KEY merge-on-write tablets, a delete bitmap calculation failure could therefore be logged but not propagated. The downloaded rowset could still be committed and published with an incomplete delete bitmap, exposing historical rows and producing duplicate unique keys.

The failure cleanup also captured `download_success_files` by value before downloads occurred, so downloaded segment and index files were not removed. Additionally, the result of `batch_delete()` was discarded and cleanup could be logged as successful even when deletion failed.

This PR:

- preserves and propagates synchronous task-submission failures;
- waits for already-submitted delete bitmap tasks and propagates asynchronous worker failures;
- returns before `commit_txn()` so the prepared tablet transaction is aborted;
- captures downloaded files by reference for failure cleanup;
- reports `batch_delete()` failures without replacing the original ingest error;
- adds a CCR MOW fault-injection regression case that verifies asynchronous worker failures keep the failed version invisible and allow the same binlog to be retried safely.

### Release note

Fix CCR replay for MOW tables so delete bitmap calculation failures abort `IngestBinlog` instead of publishing a rowset with an incomplete delete bitmap.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
        - `test_mow_ingest_binlog`, including the new asynchronous delete bitmap worker failure case, passed.
        - The test injects `BaseTablet::calc_segment_delete_bitmap.inject_err` on the target BE.
        - It verifies that `IngestBinlog` returns an error from the delete bitmap failure branch before reaching the rowset commit step, the failed version remains invisible, no duplicate key becomes visible, and retrying the same binlog succeeds.
        - CCR P0 cases covering MOW and non-MOW `_ingest_binlog` paths passed.
    - [ ] Unit Test
    - [x] Manual test
        - Full FE and BE ASAN build passed with clang 20.1.7.
        - A Docker two-cluster CCR environment was used, with separate source and target clusters and binlog enabled.
        - `build-support/clang-format.sh` and `build-support/check-format.sh` passed with clang-format 16.
        - Changed-lines clang-tidy completed with zero warnings.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

Known test coverage limitations:

- The regression test covers an asynchronous delete bitmap worker failure, but does not inject a synchronous task-submission failure from `commit_phase_update_delete_bitmap()`.
- It does not directly inspect the BE transaction manager to confirm the local transaction state; the result is supported by the executed error path, version invisibility, absence of duplicate keys, and successful retry.
- It does not inspect the tablet directory before and after failure to verify deletion of downloaded segment or index files.
- A filesystem `batch_delete()` failure was not injected, so the cleanup failure logging branch is not covered by a runtime test.

Known environment-only failures unrelated to this change:

- Two `test_create_table_with_binlog_config` cases conflict with the Docker image's forced `force_enable_feature_binlog` setting.
- `test_is_being_synced` requires an unavailable external S3 bucket.
- clang-tidy 20 reports a pre-existing orphan `NOLINTEND` at `types.h:576`; no warning was reported on the lines changed by this PR.

- Behavior changed:
    - [ ] No.
    - [x] Yes. CCR `IngestBinlog` now returns delete bitmap calculation errors and aborts before committing the rowset. Cleanup failures are also reported accurately.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
