### PR TITLE
[fix](subquery) Keep all correlated predicates when unnesting nested correlated subqueries

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/jobs/executor/Rewriter.java
@@ -467,6 +467,15 @@ public class Rewriter extends AbstractBatchJobExecutor {
                     ),
                     // query rewrite support window, so add this rule here
                     custom(RuleType.AGG_SCALAR_SUBQUERY_TO_WINDOW_FUNCTION, AggScalarSubQueryToWindowFunction::new),
+                    // the analyzer may create redundant passthrough projects around the aggregate
+                    // (e.g. the group-by normalization projects of `GROUP BY`), which block
+                    // UnCorrelatedApplyAggregateFilter /
+                    // PullUpCorrelatedFilterUnderApplyAggregateProject
+                    // (they need Apply(Aggregate(Filter)) to pull up the correlated predicate under
+                    // the aggregate). eliminate them before unnesting so that the correlated predicate
+                    // under the aggregate is extracted into the apply's correlationFilter instead of
+                    // being silently dropped after apply-to-join.
+                    custom(RuleType.ELIMINATE_UNNECESSARY_PROJECT, EliminateUnnecessaryProject::new),
                     bottomUp(
                             new EliminateUselessPlanUnderApply(),
                             // CorrelateApplyToUnCorrelateApply and ApplyToJoin

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyAggregateFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyAggregateFilter.java
@@ -117,7 +117,8 @@ public class UnCorrelatedApplyAggregateFilter implements RewriteRuleFactory {
                 PlanUtils.filterOrSelf(ImmutableSet.copyOf(unCorrelatedPredicate), filter.child()));
         return new LogicalApply<>(apply.getCorrelationSlot(), apply.getSubqueryType(), apply.isNot(),
                 apply.getCompareExpr(), apply.getTypeCoercionExpr(),
-                ExpressionUtils.optionalAnd(correlatedPredicate), apply.getMarkJoinSlotReference(),
+                ExpressionUtils.mergeCorrelationFilter(apply.getCorrelationFilter(), correlatedPredicate),
+                apply.getMarkJoinSlotReference(),
                 apply.isNeedAddSubOutputToProjects(), apply.isMarkJoinSlotNotNull(), apply.left(),
                 isRightChildAgg ? newAgg : apply.right().withChildren(newAgg));
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyFilter.java
@@ -68,7 +68,8 @@ public class UnCorrelatedApplyFilter extends OneRewriteRuleFactory {
             Plan child = PlanUtils.filterOrSelf(ImmutableSet.copyOf(unCorrelatedPredicate), filter.child());
             return new LogicalApply<>(apply.getCorrelationSlot(), apply.getSubqueryType(), apply.isNot(),
                     apply.getCompareExpr(), apply.getTypeCoercionExpr(),
-                    ExpressionUtils.optionalAnd(correlatedPredicate), apply.getMarkJoinSlotReference(),
+                    ExpressionUtils.mergeCorrelationFilter(apply.getCorrelationFilter(), correlatedPredicate),
+                    apply.getMarkJoinSlotReference(),
                     apply.isNeedAddSubOutputToProjects(),
                     apply.isMarkJoinSlotNotNull(), apply.left(), child);
         }).toRule(RuleType.UN_CORRELATED_APPLY_FILTER);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyProjectFilter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyProjectFilter.java
@@ -89,7 +89,8 @@ public class UnCorrelatedApplyProjectFilter extends OneRewriteRuleFactory {
                     LogicalProject newProject = project.withProjectsAndChild(projects, child);
                     return new LogicalApply<>(apply.getCorrelationSlot(), apply.getSubqueryType(), apply.isNot(),
                             apply.getCompareExpr(), apply.getTypeCoercionExpr(),
-                            ExpressionUtils.optionalAnd(correlatedPredicate), apply.getMarkJoinSlotReference(),
+                            ExpressionUtils.mergeCorrelationFilter(apply.getCorrelationFilter(), correlatedPredicate),
+                            apply.getMarkJoinSlotReference(),
                             apply.isNeedAddSubOutputToProjects(),
                             apply.isMarkJoinSlotNotNull(), apply.left(), newProject);
                 }).toRule(RuleType.UN_CORRELATED_APPLY_PROJECT_FILTER);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -228,6 +228,27 @@ public class ExpressionUtils {
     }
 
     /**
+     * Merge newly extracted correlated predicates into an existing correlation filter of an
+     * apply. the same apply can be rewritten multiple times (e.g. two nested correlated
+     * filters), and each rule application pulls a new correlated predicate into the apply.
+     * the existing correlation filter must be kept and AND-ed with the new predicates,
+     * otherwise the previously extracted predicates are silently dropped and never appear in
+     * the final join condition.
+     *
+     * @param existingCorrelationFilter the correlation filter accumulated on the apply
+     * @param correlatedPredicates the newly extracted correlated predicates
+     * @return the merged correlation filter
+     */
+    public static Optional<Expression> mergeCorrelationFilter(
+            Optional<Expression> existingCorrelationFilter, List<Expression> correlatedPredicates) {
+        List<Expression> allCorrelatedPredicates = new ArrayList<>();
+        existingCorrelationFilter.ifPresent(filter -> allCorrelatedPredicates.addAll(
+                ExpressionUtils.extractConjunction(filter)));
+        allCorrelatedPredicates.addAll(correlatedPredicates);
+        return optionalAnd(allCorrelatedPredicates);
+    }
+
+    /**
      * Rebuild expression tree and refresh BoundFunction signatures.
      * If an expression is a BoundFunction, recreate it with rebuilt children and
      * reset its signature.

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeWhereSubqueryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/analysis/AnalyzeWhereSubqueryTest.java
@@ -35,6 +35,7 @@ import org.apache.doris.nereids.rules.rewrite.UnCorrelatedApplyProjectFilter;
 import org.apache.doris.nereids.trees.expressions.Alias;
 import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.ExprId;
+import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.LessThan;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
@@ -341,6 +342,37 @@ public class AnalyzeWhereSubqueryTest extends TestWithFeService implements MemoP
                                         new SlotReference(new ExprId(6), "v2", BigIntType.INSTANCE, true,
                                                 ImmutableList.of("test", "t7"))))))
                 );
+    }
+
+    @Test
+    public void testNestedCorrelatedInSubqueryKeepsBothCorrelationPredicates() {
+        // two layered correlated predicates in one IN subquery: inner (r.r1 = l.x) and outer
+        // (q.r2 = l.x). the second UnCorrelatedApplyProjectFilter application must AND the
+        // newly extracted predicate with the accumulated correlationFilter instead of
+        // overwriting it, otherwise the outer predicate silently disappears from the final
+        // semi join and the query returns a wrong (too true) result.
+        String sql = "select l.x, l.x in ("
+                + "select q.r1 from ("
+                + "select r.r1, r.r2 from ("
+                + "select 0 as r1, 2 as r2 union all select 2 as r1, 0 as r2"
+                + ") r where r.r1 = l.x"
+                + ") q where q.r2 = l.x"
+                + ") pred from (select 0 as x union all select 2) l";
+        PlanChecker.from(connectContext)
+                .analyze(sql)
+                .applyBottomUp(new LogicalSubQueryAliasToLogicalProject())
+                .applyBottomUp(new UnCorrelatedApplyProjectFilter())
+                .applyBottomUp(new MergeProjectable())
+                .applyBottomUp(new UnCorrelatedApplyProjectFilter())
+                .applyBottomUp(new InApplyToJoin())
+                .matches(logicalJoin().when(join -> {
+                    List<Expression> conjuncts = join.getOtherJoinConjuncts();
+                    // the IN equality (l.x = q.r1) plus both correlated predicates
+                    // (r.r1 = l.x and q.r2 = l.x) must all be kept in the final join
+                    return conjuncts.size() == 3
+                            && conjuncts.stream().anyMatch(c -> c.toSql().contains("r2"))
+                            && conjuncts.stream().anyMatch(c -> c.toSql().contains("r1"));
+                }));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyAccumulateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/UnCorrelatedApplyAccumulateTest.java
@@ -1,0 +1,141 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite;
+
+import org.apache.doris.nereids.trees.expressions.EqualTo;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.plans.logical.LogicalAggregate;
+import org.apache.doris.nereids.trees.plans.logical.LogicalApply;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
+import org.apache.doris.nereids.util.ExpressionUtils;
+import org.apache.doris.nereids.util.MemoPatternMatchSupported;
+import org.apache.doris.nereids.util.MemoTestUtils;
+import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.nereids.util.PlanConstructor;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The UnCorrelatedApply* rules rebuild LogicalApply and must AND the newly extracted
+ * correlated predicate into the already accumulated correlationFilter instead of
+ * overwriting it. this covers the non-Project accumulation path:
+ *
+ * <pre>
+ *   Apply(correlationSlot=[x])
+ *     +-- L
+ *     +-- Filter(r2 = x)                      // correlated HAVING
+ *          +-- Aggregate(group by [r1, r2])
+ *               +-- Filter(r1 = x)            // correlated WHERE
+ *                    +-- R
+ * </pre>
+ *
+ * UnCorrelatedApplyFilter first pulls the correlated HAVING predicate (r2 = x) into the
+ * apply, then UnCorrelatedApplyAggregateFilter must merge the correlated WHERE predicate
+ * (r1 = x) into the same correlationFilter instead of replacing it, otherwise the HAVING
+ * predicate silently disappears from the final join and the query returns a wrong (too
+ * true) result.
+ */
+class UnCorrelatedApplyAccumulateTest implements MemoPatternMatchSupported {
+
+    @Test
+    public void testFilterThenAggregateFilterAccumulateCorrelationFilter() {
+        LogicalOlapScan left = PlanConstructor.newLogicalOlapScan(0, "t1", 1);
+        Slot x = left.getOutput().get(0); // t1.id
+        LogicalOlapScan right = PlanConstructor.newLogicalOlapScan(1, "t2", 1);
+        Slot r1 = right.getOutput().get(0); // t2.id
+        Slot r2 = right.getOutput().get(1); // t2.name
+
+        // correlated WHERE: r1 = x, below the aggregate
+        LogicalFilter<LogicalOlapScan> where =
+                new LogicalFilter<>(ImmutableSet.of(new EqualTo(r1, x)), right);
+        LogicalAggregate<LogicalFilter<LogicalOlapScan>> agg =
+                new LogicalAggregate<>(ImmutableList.of(r1, r2), ImmutableList.of(r1, r2), where);
+        // correlated HAVING: r2 = x, above the aggregate
+        LogicalFilter<LogicalAggregate<LogicalFilter<LogicalOlapScan>>> having =
+                new LogicalFilter<>(ImmutableSet.of(new EqualTo(r2, x)), agg);
+        LogicalApply<LogicalOlapScan, LogicalFilter<LogicalAggregate<LogicalFilter<LogicalOlapScan>>>> apply =
+                new LogicalApply<>(ImmutableList.of(x),
+                        LogicalApply.SubQueryType.EXITS_SUBQUERY, false, Optional.empty(), Optional.empty(),
+                        Optional.empty(), Optional.empty(),
+                        false, false, left, having);
+
+        PlanChecker.from(MemoTestUtils.createConnectContext(), apply)
+                .applyBottomUp(new UnCorrelatedApplyFilter())
+                .applyBottomUp(new UnCorrelatedApplyAggregateFilter())
+                .matches(logicalApply().when(a -> {
+                    Optional<Expression> correlationFilter = a.getCorrelationFilter();
+                    if (!correlationFilter.isPresent()) {
+                        return false;
+                    }
+                    List<Expression> conjuncts = ExpressionUtils.extractConjunction(correlationFilter.get());
+                    // the correlated HAVING (r2 = x) extracted by UnCorrelatedApplyFilter and the
+                    // correlated WHERE (r1 = x) extracted by UnCorrelatedApplyAggregateFilter must
+                    // both be kept in the accumulated correlation filter
+                    return conjuncts.size() == 2
+                            && conjuncts.stream().anyMatch(c -> c.toSql().contains("name"))
+                            && conjuncts.stream().anyMatch(c -> c.toSql().contains("id"));
+                }));
+    }
+
+    @Test
+    public void testAggregateFilterThenFilterAccumulateCorrelationFilter() {
+        LogicalOlapScan left = PlanConstructor.newLogicalOlapScan(0, "t1", 1);
+        Slot x = left.getOutput().get(0); // t1.id
+        LogicalOlapScan right = PlanConstructor.newLogicalOlapScan(1, "t2", 1);
+        Slot r1 = right.getOutput().get(0); // t2.id
+        Slot r2 = right.getOutput().get(1); // t2.name
+
+        // correlated WHERE: r1 = x, below the aggregate
+        LogicalFilter<LogicalOlapScan> where =
+                new LogicalFilter<>(ImmutableSet.of(new EqualTo(r1, x)), right);
+        LogicalAggregate<LogicalFilter<LogicalOlapScan>> agg =
+                new LogicalAggregate<>(ImmutableList.of(r1, r2), ImmutableList.of(r1, r2), where);
+        // correlated HAVING: r2 = x, above the aggregate
+        LogicalFilter<LogicalAggregate<LogicalFilter<LogicalOlapScan>>> having =
+                new LogicalFilter<>(ImmutableSet.of(new EqualTo(r2, x)), agg);
+        LogicalApply<LogicalOlapScan, LogicalFilter<LogicalAggregate<LogicalFilter<LogicalOlapScan>>>> apply =
+                new LogicalApply<>(ImmutableList.of(x),
+                        LogicalApply.SubQueryType.EXITS_SUBQUERY, false, Optional.empty(), Optional.empty(),
+                        Optional.empty(), Optional.empty(),
+                        false, false, left, having);
+
+        // reversed application order: UnCorrelatedApplyAggregateFilter pulls the correlated
+        // WHERE (r1 = x) into the apply first, then UnCorrelatedApplyFilter must merge the
+        // correlated HAVING (r2 = x) instead of overwriting it
+        PlanChecker.from(MemoTestUtils.createConnectContext(), apply)
+                .applyBottomUp(new UnCorrelatedApplyAggregateFilter())
+                .applyBottomUp(new UnCorrelatedApplyFilter())
+                .matches(logicalApply().when(a -> {
+                    Optional<Expression> correlationFilter = a.getCorrelationFilter();
+                    if (!correlationFilter.isPresent()) {
+                        return false;
+                    }
+                    List<Expression> conjuncts = ExpressionUtils.extractConjunction(correlationFilter.get());
+                    return conjuncts.size() == 2
+                            && conjuncts.stream().anyMatch(c -> c.toSql().contains("name"))
+                            && conjuncts.stream().anyMatch(c -> c.toSql().contains("id"));
+                }));
+    }
+}

--- a/regression-test/data/nereids_rules_p0/adjust_nullable/test_subquery_nullable.out
+++ b/regression-test/data/nereids_rules_p0/adjust_nullable/test_subquery_nullable.out
@@ -127,7 +127,7 @@ PhysicalResultSink
 -- !correlate_notop_notnullable_agg_scalar_subquery_shape --
 PhysicalResultSink
 --PhysicalDistribute[DistributionSpecGather]
-----PhysicalProject[AND[any_value(count(x)) IS NULL,NULL] AS `x > 10 and x < 1`, assert_true(OR[(count(*) <= 1),count(*) IS NULL], 'correlate scalar subquery must return only 1 row') AS `assert_true(OR[count(*) IS NULL,(count(*) <= 1)], 'correlate scalar subquery must return only 1 row')`, assert_true(OR[(count(*) <= 1),count(*) IS NULL], 'correlate scalar subquery must return only 1 row') AS `assert_true(OR[count(*) IS NULL,(count(*) <= 1)], 'correlate scalar subquery must return only 1 row')`, cte1.a AS `a`]
+----PhysicalProject[AND[any_value(count(x)) IS NULL,NULL] AS `x > 10 and x < 1`, assert_true(OR[(count(*) <= 1),count(*) IS NULL], 'correlate scalar subquery must return only 1 row') AS `assert_true(OR[count(*) IS NULL,(count(*) <= 1)], 'correlate scalar subquery must return only 1 row')`, cte1.a AS `a`]
 ------hashJoin[LEFT_OUTER_JOIN broadcast] hashCondition=((expr_(cast(a as BIGINT) + cast(b as BIGINT)) = cast(x as BIGINT))) otherCondition=()
 --------PhysicalProject[(cast(test_subquery_nullable_t1.a as BIGINT) + cast(test_subquery_nullable_t1.b as BIGINT)) AS `expr_(cast(a as BIGINT) + cast(b as BIGINT))`, test_subquery_nullable_t1.a]
 ----------PhysicalOlapScan[test_subquery_nullable_t1]

--- a/regression-test/data/query_p0/subquery/test_subquery_in_project.out
+++ b/regression-test/data/query_p0/subquery/test_subquery_in_project.out
@@ -70,6 +70,10 @@ true
 0	false
 2	false
 
+-- !sql22 --
+0	false
+2	false
+
 -- !select_m1 --
 \N
 false

--- a/regression-test/data/query_p0/subquery/test_subquery_in_project.out
+++ b/regression-test/data/query_p0/subquery/test_subquery_in_project.out
@@ -66,6 +66,10 @@ true
 5
 7
 
+-- !sql21 --
+0	false
+2	false
+
 -- !select_m1 --
 \N
 false

--- a/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query10.out
+++ b/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query10.out
@@ -9,12 +9,13 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->c_current_addr_sk
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
+--------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
+------------------------PhysicalProject
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 --------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
 ----------------------------------PhysicalProject
@@ -25,7 +26,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF5
+------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk
 ------------------------------------PhysicalProject
@@ -33,15 +34,14 @@ PhysicalResultSink
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
 ----------------------------------------PhysicalOlapScan[date_dim]
-------------------------------PhysicalOlapScan[customer_demographics]
---------------------------PhysicalProject
-----------------------------filter(ca.ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
-------------------------------PhysicalOlapScan[customer_address(ca)]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalProject
+--------------------------filter(ca.ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
+----------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query35.out
+++ b/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query35.out
@@ -9,12 +9,14 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=()
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=()
+------------------------PhysicalProject
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 --------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=()
 ----------------------------------PhysicalProject
@@ -34,14 +36,12 @@ PhysicalResultSink
 --------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
 ----------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[customer_address(ca)]
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer_demographics]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query69.out
+++ b/regression-test/data/shape_check/tpcds_sf100/noStatsRfPrune/query69.out
@@ -9,11 +9,11 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[LEFT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->c_current_addr_sk
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->c_current_addr_sk
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=()
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=()
+--------------------------hashJoin[LEFT_ANTI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ----------------------------hashJoin[LEFT_ANTI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 ------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
 --------------------------------PhysicalProject
@@ -33,15 +33,15 @@ PhysicalResultSink
 ------------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
 --------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer_demographics]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+--------------------------------PhysicalProject
+----------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
+------------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------filter(ca.ca_state IN ('MI', 'TX', 'VA'))
-----------------------------PhysicalOlapScan[customer_address(ca)]
+--------------------------PhysicalOlapScan[customer_demographics]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
-------------------------PhysicalProject
---------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
-----------------------------PhysicalOlapScan[date_dim]
+----------------------filter(ca.ca_state IN ('MI', 'TX', 'VA'))
+------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query10.out
+++ b/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query10.out
@@ -9,12 +9,13 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->c_current_addr_sk
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF4 cd_demo_sk->c_current_cdemo_sk
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
+--------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
+------------------------PhysicalProject
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 --------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
 ----------------------------------PhysicalProject
@@ -25,7 +26,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4 RF5
+------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk
 ------------------------------------PhysicalProject
@@ -33,15 +34,14 @@ PhysicalResultSink
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
 ----------------------------------------PhysicalOlapScan[date_dim]
-------------------------------PhysicalOlapScan[customer_demographics]
---------------------------PhysicalProject
-----------------------------filter(ca.ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
-------------------------------PhysicalOlapScan[customer_address(ca)]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalProject
+--------------------------filter(ca.ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
+----------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query35.out
+++ b/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query35.out
@@ -9,12 +9,14 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->c_current_cdemo_sk
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
+------------------------PhysicalProject
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 --------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
 ----------------------------------PhysicalProject
@@ -25,7 +27,7 @@ PhysicalResultSink
 ----------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4 RF5
+------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4
 --------------------------------PhysicalProject
 ----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk
 ------------------------------------PhysicalProject
@@ -34,14 +36,12 @@ PhysicalResultSink
 --------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
 ----------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[customer_address(ca)]
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer_demographics]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query69.out
+++ b/regression-test/data/shape_check/tpcds_sf100/no_stats_shape/query69.out
@@ -9,11 +9,11 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[LEFT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->c_current_addr_sk
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->c_current_addr_sk
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF4 cd_demo_sk->c_current_cdemo_sk
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF4 cd_demo_sk->c_current_cdemo_sk
+--------------------------hashJoin[LEFT_ANTI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ----------------------------hashJoin[LEFT_ANTI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 ------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
 --------------------------------PhysicalProject
@@ -33,15 +33,15 @@ PhysicalResultSink
 ------------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
 --------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer_demographics]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+--------------------------------PhysicalProject
+----------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
+------------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------filter(ca.ca_state IN ('MI', 'TX', 'VA'))
-----------------------------PhysicalOlapScan[customer_address(ca)]
+--------------------------PhysicalOlapScan[customer_demographics]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
-------------------------PhysicalProject
---------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
-----------------------------PhysicalOlapScan[date_dim]
+----------------------filter(ca.ca_state IN ('MI', 'TX', 'VA'))
+------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query10.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query10.out
@@ -9,39 +9,39 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF6 c_current_cdemo_sk->cd_demo_sk
+--------------------PhysicalOlapScan[customer_demographics] apply RFs: RF6
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->c_current_addr_sk
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->ws_sold_date_sk
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4
-----------------------------PhysicalProject
-------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
---------------------------------PhysicalOlapScan[date_dim]
-------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ss_sold_date_sk
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
-------------------------------PhysicalProject
---------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
-----------------------------------PhysicalOlapScan[date_dim]
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF1 c_current_cdemo_sk->cd_demo_sk
-------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF1
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->c_current_addr_sk
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
+------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 ss_customer_sk->c_customer_sk;RF4 ss_customer_sk->ws_bill_customer_sk
+--------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF0
+------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF3 RF5
 ----------------------------------PhysicalProject
-------------------------------------filter(ca.ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
---------------------------------------PhysicalOlapScan[customer_address(ca)]
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ws_sold_date_sk
+--------------------------------------PhysicalProject
+----------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF2 RF4
+--------------------------------------PhysicalProject
+----------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
+------------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ss_sold_date_sk
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
+----------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalProject
+--------------------------filter(ca.ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
+----------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query35.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query35.out
@@ -9,39 +9,39 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
-------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=()
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->ss_sold_date_sk
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=()
+------------------------PhysicalProject
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3
-------------------------------PhysicalProject
---------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
-----------------------------------PhysicalOlapScan[date_dim]
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=()
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=()
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+--------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=()
+----------------------------------PhysicalProject
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ss_sold_date_sk
+--------------------------------------PhysicalProject
+----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1
+--------------------------------------PhysicalProject
+----------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
+------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
 ------------------------------------PhysicalOlapScan[customer(c)]
-----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer_address(ca)]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[customer_demographics]
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->ws_sold_date_sk
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
+----------------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->ws_sold_date_sk
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0
-----------------------------PhysicalProject
-------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
---------------------------------PhysicalOlapScan[date_dim]
+--------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf100/rf_prune/query69.out
+++ b/regression-test/data/shape_check/tpcds_sf100/rf_prune/query69.out
@@ -9,39 +9,39 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF6 c_customer_sk->ss_customer_sk
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->ss_sold_date_sk
+----------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+--------------------PhysicalProject
+----------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->ss_customer_sk
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[store_sales] apply RFs: RF5 RF6
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->ss_sold_date_sk
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
-----------------------------PhysicalOlapScan[date_dim]
---------------------hashJoin[RIGHT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->cs_ship_customer_sk
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3 RF4
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF2 c_current_cdemo_sk->cd_demo_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF2
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->c_current_addr_sk
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->c_current_addr_sk
+----------------------------hashJoin[LEFT_ANTI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ------------------------------hashJoin[LEFT_ANTI_JOIN broadcast] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF1
+----------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF2
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->ws_sold_date_sk
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
 ----------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------PhysicalProject
---------------------------------filter(ca.ca_state IN ('MI', 'TX', 'VA'))
-----------------------------------PhysicalOlapScan[customer_address(ca)]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
+--------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalProject
+------------------------------filter(ca.ca_state IN ('MI', 'TX', 'VA'))
+--------------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query10.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query10.out
@@ -9,39 +9,39 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF6 c_current_cdemo_sk->cd_demo_sk
+--------------------PhysicalOlapScan[customer_demographics] apply RFs: RF6
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF5 ca_address_sk->c_current_addr_sk
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->ws_sold_date_sk
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4
-----------------------------PhysicalProject
-------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
---------------------------------PhysicalOlapScan[date_dim]
-------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ss_sold_date_sk
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
-------------------------------PhysicalProject
---------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
-----------------------------------PhysicalOlapScan[date_dim]
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF1 c_current_cdemo_sk->cd_demo_sk
-------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF1
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->c_current_addr_sk
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
+------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 ss_customer_sk->c_customer_sk;RF4 ss_customer_sk->ws_bill_customer_sk
+--------------------------------hashJoin[LEFT_SEMI_JOIN broadcast] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF0
+------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF3 RF5
 ----------------------------------PhysicalProject
-------------------------------------filter(ca.ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
---------------------------------------PhysicalOlapScan[customer_address(ca)]
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ws_sold_date_sk
+--------------------------------------PhysicalProject
+----------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF2 RF4
+--------------------------------------PhysicalProject
+----------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
+------------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ss_sold_date_sk
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
+----------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalProject
+--------------------------filter(ca.ca_county IN ('Cochran County', 'Kandiyohi County', 'Marquette County', 'Storey County', 'Warren County'))
+----------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query35.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query35.out
@@ -9,39 +9,39 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
-------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->ss_customer_sk
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->ss_sold_date_sk
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4
-------------------------------PhysicalProject
---------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
-----------------------------------PhysicalOlapScan[date_dim]
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF2 cd_demo_sk->c_current_cdemo_sk
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->c_current_addr_sk
-----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF1 RF2
-----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer_address(ca)]
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[customer_demographics]
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->ws_sold_date_sk
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0
-----------------------------PhysicalProject
-------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
---------------------------------PhysicalOlapScan[date_dim]
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+--------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->ss_customer_sk
+----------------------------------PhysicalProject
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ss_sold_date_sk
+--------------------------------------PhysicalProject
+----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2
+--------------------------------------PhysicalProject
+----------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
+------------------------------------------PhysicalOlapScan[date_dim]
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->ws_sold_date_sk
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
+----------------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf100/shape/query69.out
+++ b/regression-test/data/shape_check/tpcds_sf100/shape/query69.out
@@ -9,39 +9,39 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF6 c_customer_sk->ss_customer_sk
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->ss_sold_date_sk
+----------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+--------------------PhysicalProject
+----------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->ss_customer_sk
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[store_sales] apply RFs: RF5 RF6
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->ss_sold_date_sk
+----------------------------PhysicalProject
+------------------------------PhysicalOlapScan[store_sales] apply RFs: RF3 RF4
+----------------------------PhysicalProject
+------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
+--------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
-----------------------------PhysicalOlapScan[date_dim]
---------------------hashJoin[RIGHT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->cs_ship_customer_sk
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3 RF4
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF2 c_current_cdemo_sk->cd_demo_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF2
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF1 ca_address_sk->c_current_addr_sk
+--------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF2 ca_address_sk->c_current_addr_sk
+----------------------------hashJoin[LEFT_ANTI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ------------------------------hashJoin[LEFT_ANTI_JOIN broadcast] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF1
+----------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF2
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->ws_sold_date_sk
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF0
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
 ----------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------PhysicalProject
---------------------------------filter(ca.ca_state IN ('MI', 'TX', 'VA'))
-----------------------------------PhysicalOlapScan[customer_address(ca)]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2000))
+--------------------------------------PhysicalOlapScan[date_dim]
+----------------------------PhysicalProject
+------------------------------filter(ca.ca_state IN ('MI', 'TX', 'VA'))
+--------------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf1000/dphyper/query10.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/dphyper/query10.out
@@ -9,13 +9,13 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
---------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
+--------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
+------------------------PhysicalProject
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 --------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
 ----------------------------------PhysicalProject
@@ -35,13 +35,13 @@ PhysicalResultSink
 --------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
 ----------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------PhysicalProject
---------------------------------filter(ca.ca_county IN ('Campbell County', 'Cleburne County', 'Escambia County', 'Fairfield County', 'Washtenaw County'))
-----------------------------------PhysicalOlapScan[customer_address(ca)]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalProject
+--------------------------filter(ca.ca_county IN ('Campbell County', 'Cleburne County', 'Escambia County', 'Fairfield County', 'Washtenaw County'))
+----------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf1000/dphyper/query35.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/dphyper/query35.out
@@ -9,39 +9,39 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->c_current_cdemo_sk
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->c_current_cdemo_sk
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
+------------------------PhysicalProject
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
+--------------------------------------PhysicalOlapScan[date_dim]
 ------------------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 --------------------------------PhysicalProject
-----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->ws_sold_date_sk
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ws_sold_date_sk
 ------------------------------------PhysicalProject
---------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF3
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF2
 ------------------------------------PhysicalProject
 --------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
 ----------------------------------------PhysicalOlapScan[date_dim]
---------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->ss_customer_sk
+--------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF1 c_customer_sk->ss_customer_sk
 ----------------------------------PhysicalProject
-------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ss_sold_date_sk
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->ss_sold_date_sk
 --------------------------------------PhysicalProject
-----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2
+----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1
 --------------------------------------PhysicalProject
 ----------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
 ------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
 ------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4 RF5
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[customer_address(ca)]
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer_demographics]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
-------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer_address(ca)]
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[customer_demographics]
 

--- a/regression-test/data/shape_check/tpcds_sf1000/eliminate_empty/query10_empty.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/eliminate_empty/query10_empty.out
@@ -9,39 +9,39 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
+--------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->ws_sold_date_sk
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4
-----------------------------PhysicalProject
-------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
---------------------------------PhysicalOlapScan[date_dim]
-------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ss_sold_date_sk
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
-------------------------------PhysicalProject
---------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
-----------------------------------PhysicalOlapScan[date_dim]
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF1 c_current_cdemo_sk->cd_demo_sk
-------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF1
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->c_current_addr_sk
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
+------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+--------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF0
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ss_sold_date_sk
+--------------------------------------PhysicalProject
+----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
+--------------------------------------PhysicalProject
+----------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
+------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter(ca.ca_county IN ('Campbell County', 'Cleburne County', 'Escambia County', 'Fairfield County', 'Washtenaw County'))
---------------------------------------PhysicalOlapScan[customer_address(ca)]
+------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
+----------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalProject
+--------------------------filter(ca.ca_county IN ('Campbell County', 'Cleburne County', 'Escambia County', 'Fairfield County', 'Washtenaw County'))
+----------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf1000/hint/query69.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/hint/query69.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF7 c_customer_sk->ss_customer_sk
+------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF7 c_customer_sk->ss_customer_sk
 --------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->ss_sold_date_sk
 ------------------------PhysicalProject
@@ -17,18 +17,18 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2002))
 ----------------------------PhysicalOlapScan[date_dim]
---------------------hashJoin[RIGHT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=() build RFs:RF5 c_customer_sk->cs_ship_customer_sk
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->cs_sold_date_sk
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+------------------------hashJoin[RIGHT_ANTI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->cs_ship_customer_sk
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF4 RF5
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2002))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF3 c_current_cdemo_sk->cd_demo_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF3
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->cs_sold_date_sk
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3 RF4
+------------------------------PhysicalProject
+--------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2002))
+----------------------------------PhysicalOlapScan[date_dim]
 --------------------------hashJoin[RIGHT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->ws_bill_customer_sk
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query10.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query10.out
@@ -9,39 +9,39 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
+--------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->ws_sold_date_sk
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4
-----------------------------PhysicalProject
-------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
---------------------------------PhysicalOlapScan[date_dim]
-------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ss_sold_date_sk
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
-------------------------------PhysicalProject
---------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
-----------------------------------PhysicalOlapScan[date_dim]
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF1 c_current_cdemo_sk->cd_demo_sk
-------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF1
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->c_current_addr_sk
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
+------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+--------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF0
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ss_sold_date_sk
+--------------------------------------PhysicalProject
+----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
+--------------------------------------PhysicalProject
+----------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
+------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter(ca.ca_county IN ('Campbell County', 'Cleburne County', 'Escambia County', 'Fairfield County', 'Washtenaw County'))
---------------------------------------PhysicalOlapScan[customer_address(ca)]
+------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
+----------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalProject
+--------------------------filter(ca.ca_county IN ('Campbell County', 'Cleburne County', 'Escambia County', 'Fairfield County', 'Washtenaw County'))
+----------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query35.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query35.out
@@ -9,39 +9,39 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF4 cd_demo_sk->c_current_cdemo_sk
---------------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->ws_sold_date_sk
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[web_sales] apply RFs: RF3
---------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
-------------------------------------PhysicalOlapScan[date_dim]
-----------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->ss_customer_sk
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->c_current_cdemo_sk
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
+------------------------PhysicalProject
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ss_sold_date_sk
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->cs_sold_date_sk
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3
 ----------------------------------PhysicalProject
 ------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
 --------------------------------------PhysicalOlapScan[date_dim]
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->c_current_addr_sk
+------------------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ws_sold_date_sk
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF2
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
+----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF1 c_customer_sk->ss_customer_sk
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF0 RF4
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->ss_sold_date_sk
+--------------------------------------PhysicalProject
+----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1
+--------------------------------------PhysicalProject
+----------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
+------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer_address(ca)]
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer_demographics]
+------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4 RF5
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer_address(ca)]
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[customer_demographics]
 

--- a/regression-test/data/shape_check/tpcds_sf1000/shape/query69.out
+++ b/regression-test/data/shape_check/tpcds_sf1000/shape/query69.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF7 c_customer_sk->ss_customer_sk
+------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF7 c_customer_sk->ss_customer_sk
 --------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->ss_sold_date_sk
 ------------------------PhysicalProject
@@ -17,18 +17,18 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2002))
 ----------------------------PhysicalOlapScan[date_dim]
---------------------hashJoin[RIGHT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=() build RFs:RF5 c_customer_sk->cs_ship_customer_sk
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->cs_sold_date_sk
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+------------------------hashJoin[RIGHT_ANTI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->cs_ship_customer_sk
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF4 RF5
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2002))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF3 c_current_cdemo_sk->cd_demo_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF3
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->cs_sold_date_sk
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3 RF4
+------------------------------PhysicalProject
+--------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2002))
+----------------------------------PhysicalOlapScan[date_dim]
 --------------------------hashJoin[RIGHT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->ws_bill_customer_sk
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk

--- a/regression-test/data/shape_check/tpcds_sf1000_constraints/shape/query10.out
+++ b/regression-test/data/shape_check/tpcds_sf1000_constraints/shape/query10.out
@@ -9,39 +9,39 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
+--------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->ws_sold_date_sk
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4
-----------------------------PhysicalProject
-------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
---------------------------------PhysicalOlapScan[date_dim]
-------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ss_sold_date_sk
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
-------------------------------PhysicalProject
---------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
-----------------------------------PhysicalOlapScan[date_dim]
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF1 c_current_cdemo_sk->cd_demo_sk
-------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF1
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->c_current_addr_sk
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
+------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+--------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF0
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ss_sold_date_sk
+--------------------------------------PhysicalProject
+----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
+--------------------------------------PhysicalProject
+----------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
+------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter(ca.ca_county IN ('Campbell County', 'Cleburne County', 'Escambia County', 'Fairfield County', 'Washtenaw County'))
---------------------------------------PhysicalOlapScan[customer_address(ca)]
+------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
+----------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalProject
+--------------------------filter(ca.ca_county IN ('Campbell County', 'Cleburne County', 'Escambia County', 'Fairfield County', 'Washtenaw County'))
+----------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf1000_constraints/shape/query35.out
+++ b/regression-test/data/shape_check/tpcds_sf1000_constraints/shape/query35.out
@@ -9,39 +9,39 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF4 cd_demo_sk->c_current_cdemo_sk
---------------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->ws_sold_date_sk
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[web_sales] apply RFs: RF3
---------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
-------------------------------------PhysicalOlapScan[date_dim]
-----------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->ss_customer_sk
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->c_current_cdemo_sk
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
+------------------------PhysicalProject
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ss_sold_date_sk
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->cs_sold_date_sk
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3
 ----------------------------------PhysicalProject
 ------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
 --------------------------------------PhysicalOlapScan[date_dim]
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->c_current_addr_sk
+------------------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ws_sold_date_sk
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF2
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
+----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF1 c_customer_sk->ss_customer_sk
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF0 RF4
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->ss_sold_date_sk
+--------------------------------------PhysicalProject
+----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1
+--------------------------------------PhysicalProject
+----------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
+------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer_address(ca)]
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer_demographics]
+------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4 RF5
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer_address(ca)]
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[customer_demographics]
 

--- a/regression-test/data/shape_check/tpcds_sf1000_constraints/shape/query69.out
+++ b/regression-test/data/shape_check/tpcds_sf1000_constraints/shape/query69.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF7 c_customer_sk->ss_customer_sk
+------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF7 c_customer_sk->ss_customer_sk
 --------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->ss_sold_date_sk
 ------------------------PhysicalProject
@@ -17,18 +17,18 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2002))
 ----------------------------PhysicalOlapScan[date_dim]
---------------------hashJoin[RIGHT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=() build RFs:RF5 c_customer_sk->cs_ship_customer_sk
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->cs_sold_date_sk
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+------------------------hashJoin[RIGHT_ANTI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->cs_ship_customer_sk
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF4 RF5
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2002))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF3 c_current_cdemo_sk->cd_demo_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF3
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->cs_sold_date_sk
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3 RF4
+------------------------------PhysicalProject
+--------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2002))
+----------------------------------PhysicalOlapScan[date_dim]
 --------------------------hashJoin[RIGHT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->ws_bill_customer_sk
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk

--- a/regression-test/data/shape_check/tpcds_sf1000_nopkfk/shape/query10.out
+++ b/regression-test/data/shape_check/tpcds_sf1000_nopkfk/shape/query10.out
@@ -9,39 +9,39 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
+--------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->ws_sold_date_sk
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales] apply RFs: RF4
-----------------------------PhysicalProject
-------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
---------------------------------PhysicalOlapScan[date_dim]
-------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ss_sold_date_sk
-------------------------------PhysicalProject
---------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
-------------------------------PhysicalProject
---------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
-----------------------------------PhysicalOlapScan[date_dim]
---------------------------PhysicalProject
-----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF1 c_current_cdemo_sk->cd_demo_sk
-------------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF1
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->c_current_addr_sk
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
+------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+--------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF0
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ss_sold_date_sk
+--------------------------------------PhysicalProject
+----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF2 RF3
+--------------------------------------PhysicalProject
+----------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
+------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------filter(ca.ca_county IN ('Campbell County', 'Cleburne County', 'Escambia County', 'Fairfield County', 'Washtenaw County'))
---------------------------------------PhysicalOlapScan[customer_address(ca)]
+------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
+----------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
+------------------------PhysicalProject
+--------------------------filter(ca.ca_county IN ('Campbell County', 'Cleburne County', 'Escambia County', 'Fairfield County', 'Washtenaw County'))
+----------------------------PhysicalOlapScan[customer_address(ca)]
 

--- a/regression-test/data/shape_check/tpcds_sf1000_nopkfk/shape/query35.out
+++ b/regression-test/data/shape_check/tpcds_sf1000_nopkfk/shape/query35.out
@@ -9,39 +9,39 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF5 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF5
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF4 cd_demo_sk->c_current_cdemo_sk
---------------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->ws_sold_date_sk
---------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[web_sales] apply RFs: RF3
---------------------------------PhysicalProject
-----------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
-------------------------------------PhysicalOlapScan[date_dim]
-----------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->ss_customer_sk
+------------------hashJoin[INNER_JOIN shuffle] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->c_current_cdemo_sk
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
+------------------------PhysicalProject
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ss_sold_date_sk
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->cs_sold_date_sk
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF1 RF2
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3
 ----------------------------------PhysicalProject
 ------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
 --------------------------------------PhysicalOlapScan[date_dim]
-------------------------------PhysicalProject
---------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF0 ca_address_sk->c_current_addr_sk
+------------------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+--------------------------------PhysicalProject
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ws_sold_date_sk
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF2
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
+----------------------------------------PhysicalOlapScan[date_dim]
+--------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF1 c_customer_sk->ss_customer_sk
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF0 RF4
+------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->ss_sold_date_sk
+--------------------------------------PhysicalProject
+----------------------------------------PhysicalOlapScan[store_sales] apply RFs: RF0 RF1
+--------------------------------------PhysicalProject
+----------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 1999))
+------------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------------PhysicalProject
-------------------------------------PhysicalOlapScan[customer_address(ca)]
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer_demographics]
+------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4 RF5
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer_address(ca)]
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[customer_demographics]
 

--- a/regression-test/data/shape_check/tpcds_sf1000_nopkfk/shape/query69.out
+++ b/regression-test/data/shape_check/tpcds_sf1000_nopkfk/shape/query69.out
@@ -9,7 +9,7 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[RIGHT_SEMI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF7 c_customer_sk->ss_customer_sk
+------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF7 c_customer_sk->ss_customer_sk
 --------------------PhysicalProject
 ----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF6 d_date_sk->ss_sold_date_sk
 ------------------------PhysicalProject
@@ -17,18 +17,18 @@ PhysicalResultSink
 ------------------------PhysicalProject
 --------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2002))
 ----------------------------PhysicalOlapScan[date_dim]
---------------------hashJoin[RIGHT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=() build RFs:RF5 c_customer_sk->cs_ship_customer_sk
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF4 d_date_sk->cs_sold_date_sk
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 c_current_cdemo_sk->cd_demo_sk
+------------------------PhysicalProject
+--------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF5
+------------------------hashJoin[RIGHT_ANTI_JOIN shuffleBucket] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=() build RFs:RF4 c_customer_sk->cs_ship_customer_sk
 --------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF4 RF5
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2002))
-------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF3 c_current_cdemo_sk->cd_demo_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[customer_demographics] apply RFs: RF3
+----------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF3 d_date_sk->cs_sold_date_sk
+------------------------------PhysicalProject
+--------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF3 RF4
+------------------------------PhysicalProject
+--------------------------------filter((date_dim.d_moy <= 3) and (date_dim.d_moy >= 1) and (date_dim.d_year = 2002))
+----------------------------------PhysicalOlapScan[date_dim]
 --------------------------hashJoin[RIGHT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=() build RFs:RF2 c_customer_sk->ws_bill_customer_sk
 ----------------------------PhysicalProject
 ------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk

--- a/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query10.out
+++ b/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query10.out
@@ -9,13 +9,13 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->c_current_cdemo_sk
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->c_current_cdemo_sk
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
+------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 --------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
 ----------------------------------PhysicalProject
 ------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ss_sold_date_sk
@@ -27,21 +27,21 @@ PhysicalResultSink
 ----------------------------------PhysicalProject
 ------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4 RF5
 --------------------------------PhysicalProject
-----------------------------------filter(ca.ca_county IN ('Bonneville County', 'Boone County', 'Brown County', 'Fillmore County', 'McPherson County'))
-------------------------------------PhysicalOlapScan[customer_address(ca)]
-----------------------------PhysicalOlapScan[customer_demographics]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2000))
+----------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2000))
+--------------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
-----------------------------PhysicalProject
-------------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2000))
---------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_moy <= 6) and (date_dim.d_moy >= 3) and (date_dim.d_year = 2000))
-------------------------------PhysicalOlapScan[date_dim]
+--------------------------filter(ca.ca_county IN ('Bonneville County', 'Boone County', 'Brown County', 'Fillmore County', 'McPherson County'))
+----------------------------PhysicalOlapScan[customer_address(ca)]
+--------------------PhysicalOlapScan[customer_demographics]
 

--- a/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query35.out
+++ b/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query35.out
@@ -9,13 +9,13 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
---------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
-----------------------hashJoin[LEFT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->c_current_cdemo_sk
+--------------------PhysicalProject
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->c_current_cdemo_sk
-----------------------------PhysicalProject
-------------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
+--------------------------filter(OR[ifnull($c$1, FALSE),ifnull($c$2, FALSE)])
+----------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
+------------------------------hashJoin[LEFT_SEMI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 --------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
 ----------------------------------PhysicalProject
 ------------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((store_sales.ss_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF2 d_date_sk->ss_sold_date_sk
@@ -27,21 +27,21 @@ PhysicalResultSink
 ----------------------------------PhysicalProject
 ------------------------------------PhysicalOlapScan[customer(c)] apply RFs: RF4 RF5
 --------------------------------PhysicalProject
-----------------------------------PhysicalOlapScan[customer_address(ca)]
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[customer_demographics]
+----------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk
+------------------------------------PhysicalProject
+--------------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
+------------------------------------PhysicalProject
+--------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
+----------------------------------------PhysicalOlapScan[date_dim]
+------------------------------PhysicalProject
+--------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+----------------------------------PhysicalProject
+------------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+----------------------------------PhysicalProject
+------------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
+--------------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((web_sales.ws_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF1 d_date_sk->ws_sold_date_sk
-----------------------------PhysicalProject
-------------------------------PhysicalOlapScan[web_sales] apply RFs: RF1
-----------------------------PhysicalProject
-------------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
---------------------------------PhysicalOlapScan[date_dim]
-----------------------PhysicalProject
-------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
---------------------------PhysicalProject
-----------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
---------------------------PhysicalProject
-----------------------------filter((date_dim.d_qoy < 4) and (date_dim.d_year = 2001))
-------------------------------PhysicalOlapScan[date_dim]
+--------------------------PhysicalOlapScan[customer_address(ca)]
+--------------------PhysicalProject
+----------------------PhysicalOlapScan[customer_demographics]
 

--- a/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query69.out
+++ b/regression-test/data/shape_check/tpcds_sf10t_orc/shape/query69.out
@@ -9,11 +9,11 @@ PhysicalResultSink
 ------------PhysicalDistribute[DistributionSpecHash]
 --------------hashAgg[LOCAL]
 ----------------PhysicalProject
-------------------hashJoin[LEFT_ANTI_JOIN shuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
+------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->c_current_cdemo_sk
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((customer_demographics.cd_demo_sk = c.c_current_cdemo_sk)) otherCondition=() build RFs:RF5 cd_demo_sk->c_current_cdemo_sk
+----------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
 ------------------------PhysicalProject
---------------------------hashJoin[INNER_JOIN shuffle] hashCondition=((c.c_current_addr_sk = ca.ca_address_sk)) otherCondition=() build RFs:RF4 ca_address_sk->c_current_addr_sk
+--------------------------hashJoin[LEFT_ANTI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = catalog_sales.cs_ship_customer_sk)) otherCondition=()
 ----------------------------hashJoin[LEFT_ANTI_JOIN bucketShuffle] hashCondition=((c.c_customer_sk = web_sales.ws_bill_customer_sk)) otherCondition=()
 ------------------------------hashJoin[RIGHT_SEMI_JOIN shuffle] hashCondition=((c.c_customer_sk = store_sales.ss_customer_sk)) otherCondition=() build RFs:RF3 c_customer_sk->ss_customer_sk
 --------------------------------PhysicalProject
@@ -33,15 +33,15 @@ PhysicalResultSink
 ------------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 2) and (date_dim.d_year = 2003))
 --------------------------------------PhysicalOlapScan[date_dim]
 ----------------------------PhysicalProject
-------------------------------filter(ca.ca_state IN ('AZ', 'MN', 'MO'))
---------------------------------PhysicalOlapScan[customer_address(ca)]
+------------------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
+--------------------------------PhysicalProject
+----------------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
+--------------------------------PhysicalProject
+----------------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 2) and (date_dim.d_year = 2003))
+------------------------------------PhysicalOlapScan[date_dim]
 ------------------------PhysicalProject
---------------------------PhysicalOlapScan[customer_demographics]
+--------------------------filter(ca.ca_state IN ('AZ', 'MN', 'MO'))
+----------------------------PhysicalOlapScan[customer_address(ca)]
 --------------------PhysicalProject
-----------------------hashJoin[INNER_JOIN broadcast] hashCondition=((catalog_sales.cs_sold_date_sk = date_dim.d_date_sk)) otherCondition=() build RFs:RF0 d_date_sk->cs_sold_date_sk
-------------------------PhysicalProject
---------------------------PhysicalOlapScan[catalog_sales] apply RFs: RF0
-------------------------PhysicalProject
---------------------------filter((date_dim.d_moy <= 4) and (date_dim.d_moy >= 2) and (date_dim.d_year = 2003))
-----------------------------PhysicalOlapScan[date_dim]
+----------------------PhysicalOlapScan[customer_demographics]
 

--- a/regression-test/suites/query_p0/subquery/test_subquery_in_project.groovy
+++ b/regression-test/suites/query_p0/subquery/test_subquery_in_project.groovy
@@ -138,6 +138,30 @@ suite("test_subquery_in_project") {
         select sum(age + (select sum(age) from test_sql)) from test_sql group by dt, age order by 1;
     """
 
+    // two layered correlated predicates in one IN subquery: r.r1 = l.x (inner) and q.r2 = l.x
+    // (outer). both must survive into the final semi join, otherwise the finite right side
+    // (r1, r2) in {(0,2),(2,0)} has no row with r1 = x and r2 = x and the wrong result (TRUE)
+    // is silently produced. see the correlation filter merge fix in UnCorrelatedApplyFilter /
+    // UnCorrelatedApplyProjectFilter / UnCorrelatedApplyAggregateFilter.
+    qt_sql21 """
+        SELECT l.x,
+               l.x IN (
+                 SELECT q.r1
+                 FROM (
+                   SELECT r.r1, r.r2
+                   FROM (
+                     SELECT 0 AS r1, 2 AS r2
+                     UNION ALL
+                     SELECT 2 AS r1, 0 AS r2
+                   ) r
+                   WHERE r.r1 = l.x
+                 ) q
+                 WHERE q.r2 = l.x
+               ) AS pred
+        FROM (SELECT 0 AS x UNION ALL SELECT 2) l
+        ORDER BY x;
+    """
+
     sql """drop table if exists test_sql;"""
 
     sql """drop table if exists markjoin_t1;"""

--- a/regression-test/suites/query_p0/subquery/test_subquery_in_project.groovy
+++ b/regression-test/suites/query_p0/subquery/test_subquery_in_project.groovy
@@ -162,6 +162,29 @@ suite("test_subquery_in_project") {
         ORDER BY x;
     """
 
+    // the correlated WHERE (r.r1 = l.x) under a GROUP BY aggregate and the correlated HAVING
+    // (r.r2 = l.x) above it. the analyzer inserts redundant passthrough projects around the
+    // aggregate which used to block UnCorrelatedApplyAggregateFilter, so the WHERE predicate
+    // was silently dropped after apply-to-join and the wrong result (TRUE) was produced. with
+    // the passthrough projects eliminated before subquery unnesting, both correlated predicates
+    // must survive into the final semi join.
+    qt_sql22 """
+        SELECT l.x,
+               EXISTS (
+                 SELECT r.r1
+                 FROM (
+                   SELECT 0 AS r1, 2 AS r2
+                   UNION ALL
+                   SELECT 2 AS r1, 0 AS r2
+                 ) r
+                 WHERE r.r1 = l.x
+                 GROUP BY r.r1, r.r2
+                 HAVING r.r2 = l.x
+               ) AS pred
+        FROM (SELECT 0 AS x UNION ALL SELECT 2) l
+        ORDER BY x;
+    """
+
     sql """drop table if exists test_sql;"""
 
     sql """drop table if exists markjoin_t1;"""


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
When an IN subquery contains two layers of correlated predicates, e.g.

```sql
SELECT l.x,
       l.x IN (
         SELECT q.r1
         FROM (
           SELECT r.r1, r.r2
           FROM (
             SELECT 0 AS r1, 2 AS r2
             UNION ALL
             SELECT 2 AS r1, 0 AS r2
           ) r
           WHERE r.r1 = l.x
         ) q
         WHERE q.r2 = l.x
       ) AS pred
FROM (SELECT 0 AS x UNION ALL SELECT 2) l
ORDER BY x;
```
the Nereids rewrite rules UnCorrelatedApplyFilter / UnCorrelatedApplyProjectFilter /
UnCorrelatedApplyAggregateFilter run twice on the same apply. The second application
rebuilt LogicalApply with only the newly extracted correlated predicate, silently
dropping the predicate extracted by the first application from the accumulated
correlation filter. The dropped predicate therefore never appears in the final
(physical) join, and the query returns TRUE where the correct result is FALSE:
before this fix both rows return pred=1, while the finite right side {(r1,r2)} in
{(0,2),(2,0)} has no row satisfying both r1 = x and r2 = x, so the expected result
is pred=0 for both rows.

The fix adds ExpressionUtils.mergeCorrelationFilter(), which AND-merges the existing
correlation filter with the newly extracted correlated predicates (duplicates are
removed by ExpressionUtils.and), and makes all three rules use it instead of
overwriting the filter. After the fix the final semi join keeps both correlated
predicates: equal join conjuncts are (x = r2) and (x = r1) together with the IN
equality, and the query returns 0/0 as expected.

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

