### PR TITLE
[test](fuzzy) Keep FileScannerV2 enabled

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1133,7 +1133,8 @@ public class SessionVariable implements Serializable, Writable {
             "FileScanNode 扫描数据的最大并发，默认为 16", "The max threads to read data of FileScanNode, default 16"})
     public int maxFileScannersConcurrency = 16;
 
-    @VariableMgr.VarAttr(name = ENABLE_FILE_SCANNER_V2, needForward = true, fuzzy = true, description = {
+    // Fuzzy regression tests only cover the default FileScannerV2 path.
+    @VariableMgr.VarAttr(name = ENABLE_FILE_SCANNER_V2, needForward = true, description = {
             "开启后 FileScanNode 会在支持的查询场景使用 FileScannerV2，默认开启",
             "When enabled, FileScanNode uses FileScannerV2 for supported query scans. Enabled by default."})
     public boolean enableFileScannerV2 = true;
@@ -3791,10 +3792,6 @@ public class SessionVariable implements Serializable, Writable {
         this.useSerialExchange = random.nextBoolean();
         this.enableCommonExpPushDownForInvertedIndex = random.nextBoolean();
         this.enableExprZonemapFilter = Config.pull_request_id % 2 == 0;
-        // Randomize the external file scanner engine (FileScannerV2 vs the legacy V1 path). Kept
-        // here rather than in setFuzzyForCatalog() so it also runs in the external regression
-        // pipeline, which enables fuzzy sessions with fuzzy_test_type=p1 (not "external").
-        this.enableFileScannerV2 = random.nextBoolean();
         this.disableStreamPreaggregations = random.nextBoolean();
         this.enableStreamingAggHashJoinForcePassthrough = random.nextBoolean();
         this.enableLocalExchangeBeforeAgg = random.nextBoolean();

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
@@ -196,6 +196,19 @@ public class SessionVariablesTest extends TestWithFeService {
     }
 
     @Test
+    public void testFileScannerV2StaysEnabledInFuzzyMode() throws Exception {
+        SessionVariable sessionVar = new SessionVariable();
+        Assertions.assertTrue(sessionVar.enableFileScannerV2);
+
+        Field field = SessionVariable.class.getDeclaredField("enableFileScannerV2");
+        VariableMgr.VarAttr varAttr = field.getAnnotation(VariableMgr.VarAttr.class);
+        Assertions.assertFalse(varAttr.fuzzy());
+
+        sessionVar.initFuzzyModeVariables();
+        Assertions.assertTrue(sessionVar.enableFileScannerV2);
+    }
+
+    @Test
     public void testForceEagerAggHintParseWhenSetSessionVariable() throws Exception {
         SessionVariable sessionVar = new SessionVariable();
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Fuzzy session initialization currently randomizes `enable_file_scanner_v2`, so regression runs may use either FileScannerV2 or the legacy V1 path. Going forward, fuzzy regression testing should cover only the default FileScannerV2-enabled path.

This change removes the variable from fuzzy randomization and adds a unit test that protects the enabled invariant.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test
    - [ ] No need to test or manual test.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Fuzzy sessions keep `enable_file_scanner_v2` enabled instead of randomizing it.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label