### PR TITLE
[feature](lance) Support OSS storage provider

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceExternalCatalog.java
@@ -78,7 +78,9 @@ public class LanceExternalCatalog extends ExternalCatalog {
     private static final long ALLOCATOR_LIMIT = 256L * 1024 * 1024;
     private static final int MAX_PROVIDER_MESSAGE_BYTES = 1024;
     private static final String[] RUNTIME_SENSITIVE_OPTION_KEYS = {
-            "aws_access_key_id", "aws_secret_access_key", "aws_session_token"
+            "aws_access_key_id", "aws_secret_access_key", "aws_session_token",
+            "oss_access_key_id", "oss_secret_access_key", "oss_security_token",
+            "access_key_id", "access_key_secret", "security_token"
     };
 
     private transient LanceNamespace namespace;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceExternalCatalog.java
@@ -34,6 +34,8 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.lance.namespace.LanceNamespace;
 import org.lance.namespace.errors.NamespaceNotFoundException;
 import org.lance.namespace.errors.TableNotFoundException;
@@ -60,6 +62,7 @@ import java.util.Set;
 
 /** Read-only Lance Directory or REST Namespace catalog. */
 public class LanceExternalCatalog extends ExternalCatalog {
+    private static final Logger LOG = LogManager.getLogger(LanceExternalCatalog.class);
     public static final String LANCE_CATALOG_TYPE = AbstractLanceProperties.LANCE_CATALOG_TYPE;
     public static final String LANCE_FILESYSTEM = AbstractLanceProperties.LANCE_FILESYSTEM;
     public static final String LANCE_REST = AbstractLanceProperties.LANCE_REST;
@@ -145,9 +148,10 @@ public class LanceExternalCatalog extends ExternalCatalog {
             }
         } catch (Exception e) {
             // The catalog is not initialized yet, so the namespace options this test just built are
-            // the only ones the sanitizer can see.
-            String sanitizedMessage = sanitizedRootCauseMessage(
-                    e, properties.getNamespaceStorageUri(), storageOptions);
+            // the only ones the sanitizer can see. The warehouse is deliberately not passed as the
+            // dataset URI: it came from this very DDL, and blanking it would hide the mistyped
+            // bucket the operator needs to see.
+            String sanitizedMessage = sanitizedRootCauseMessage(e, null, storageOptions);
             throw new DdlException("Lance " + type + " catalog connectivity test failed: "
                     + sanitizedMessage, sanitizedCause(e, sanitizedMessage));
         }
@@ -527,8 +531,9 @@ public class LanceExternalCatalog extends ExternalCatalog {
         List<String> sensitiveValues = new ArrayList<>();
         sensitiveValues.add(catalogProperty.getOrDefault(REST_BEARER_TOKEN, ""));
         sensitiveValues.add(catalogProperty.getOrDefault(REST_API_KEY, ""));
-        // Lance also accepts these options scoped to one base, as base_<id>.oss_secret_access_key,
-        // so match on the suffix rather than looking each bare key up exactly.
+        // Match on a trailing dotted segment as well as the bare key, so any namespace that scopes
+        // an option to one store still has its secret redacted. Over-redaction costs nothing here,
+        // while an exact-key lookup would print a secret it did not recognize.
         nonNullStorageOptions.forEach((key, value) -> {
             if (key == null) {
                 return;
@@ -559,6 +564,13 @@ public class LanceExternalCatalog extends ExternalCatalog {
     }
 
     private static Throwable sanitizedCause(Throwable throwable, String sanitizedMessage) {
+        // The rebuilt cause keeps the provider's credentials out of the user-visible error, but it
+        // also drops the original type, stack and suppressed exceptions. Keep them at debug level:
+        // the untouched text can hold those same credentials, so it must not reach the log by
+        // default, and an operator debugging a provider failure can turn it on deliberately.
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Lance provider failure, replaced by a redacted cause", throwable);
+        }
         return throwable instanceof IllegalArgumentException
                 ? new IllegalArgumentException(sanitizedMessage)
                 : new RuntimeException(sanitizedMessage);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceExternalCatalog.java
@@ -106,7 +106,7 @@ public class LanceExternalCatalog extends ExternalCatalog {
             rootDatabase = properties.getRootDatabase();
             parentNamespace = LanceNamespaceName.parseParentNamespace(
                     properties.getNamespaceParent(), properties.getNamespaceDelimiter());
-            namespaceStorageOptions = LanceStorageOptions.forUri(
+            namespaceStorageOptions = LanceStorageOptions.fromDorisStorageProperties(
                     properties.getNamespaceStorageUri(),
                     catalogProperty.getOrderedStoragePropertiesList());
 
@@ -129,7 +129,7 @@ public class LanceExternalCatalog extends ExternalCatalog {
         }
 
         AbstractLanceProperties properties = getLanceProperties();
-        Map<String, String> storageOptions = LanceStorageOptions.forUri(
+        Map<String, String> storageOptions = LanceStorageOptions.fromDorisStorageProperties(
                 properties.getNamespaceStorageUri(),
                 catalogProperty.getOrderedStoragePropertiesList());
         List<String> parent = LanceNamespaceName.parseParentNamespace(
@@ -438,7 +438,7 @@ public class LanceExternalCatalog extends ExternalCatalog {
         // One option map serves both readers: the FE opens the dataset through the Lance Java SDK
         // and the BE through lance-c, so neither can end up with credentials the other lacks. The
         // dataset URL picks the option vocabulary, the same way Lance picks a provider from it.
-        Map<String, String> storageOptions = LanceStorageOptions.forVendedTable(datasetUri,
+        Map<String, String> storageOptions = LanceStorageOptions.fromDorisAndVendedStorageOptions(datasetUri,
                 catalogProperty.getOrderedStoragePropertiesList(), table.getStorageOptions());
         return new ResolvedTableAccess(datasetUri, storageOptions);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceExternalCatalog.java
@@ -144,8 +144,12 @@ public class LanceExternalCatalog extends ExternalCatalog {
                 closeNamespace(testNamespace);
             }
         } catch (Exception e) {
+            // The catalog is not initialized yet, so the namespace options this test just built are
+            // the only ones the sanitizer can see.
+            String sanitizedMessage = sanitizedRootCauseMessage(
+                    e, properties.getNamespaceStorageUri(), storageOptions);
             throw new DdlException("Lance " + type + " catalog connectivity test failed: "
-                    + sanitizedRootCauseMessage(e), safeCause(e));
+                    + sanitizedMessage, sanitizedCause(e, sanitizedMessage));
         }
     }
 
@@ -330,8 +334,10 @@ public class LanceExternalCatalog extends ExternalCatalog {
                     : LanceMetadataLoader.loadLatest(
                             tableAccess.datasetUri, tableAccess.storageOptions, allocator);
         } catch (Exception e) {
+            String sanitizedMessage = sanitizedRootCauseMessage(
+                    e, tableAccess.datasetUri, tableAccess.storageOptions);
             throw new RuntimeException("Failed to load Lance table metadata for " + dbName + "." + tableName
-                    + ": " + sanitizedRootCauseMessage(e), safeCause(e));
+                    + ": " + sanitizedMessage, sanitizedCause(e, sanitizedMessage));
         }
     }
 
@@ -415,11 +421,8 @@ public class LanceExternalCatalog extends ExternalCatalog {
             Throwable throwable, String datasetUri, Map<String, String> runtimeStorageOptions) {
         String sanitizedMessage = sanitizedRootCauseMessage(
                 throwable, datasetUri, runtimeStorageOptions);
-        Throwable sanitizedCause = throwable instanceof IllegalArgumentException
-                ? new IllegalArgumentException(sanitizedMessage)
-                : new RuntimeException(sanitizedMessage);
         return new RuntimeException("Failed to load Lance index metadata for " + dbName + "." + tableName
-                + ": " + sanitizedMessage, sanitizedCause);
+                + ": " + sanitizedMessage, sanitizedCause(throwable, sanitizedMessage));
     }
 
     private ResolvedTableAccess resolveTableAccess(String dbName, String tableName) {
@@ -506,15 +509,13 @@ public class LanceExternalCatalog extends ExternalCatalog {
         }
     }
 
+    /**
+     * Every provider-facing failure has at least the namespace's own storage options behind it, so
+     * default to those rather than redacting only the REST secrets. Callers holding a resolved
+     * table pass its dataset URI and options to the overload below instead.
+     */
     private String sanitizedRootCauseMessage(Throwable throwable) {
-        String message = ExceptionUtils.getRootCauseMessage(throwable);
-        for (String sensitiveKey : new String[] {REST_BEARER_TOKEN, REST_API_KEY}) {
-            String sensitiveValue = catalogProperty.getOrDefault(sensitiveKey, "");
-            if (StringUtils.isNotEmpty(sensitiveValue)) {
-                message = message.replace(sensitiveValue, "***");
-            }
-        }
-        return message;
+        return sanitizedRootCauseMessage(throwable, null, namespaceStorageOptions);
     }
 
     @VisibleForTesting
@@ -526,9 +527,19 @@ public class LanceExternalCatalog extends ExternalCatalog {
         List<String> sensitiveValues = new ArrayList<>();
         sensitiveValues.add(catalogProperty.getOrDefault(REST_BEARER_TOKEN, ""));
         sensitiveValues.add(catalogProperty.getOrDefault(REST_API_KEY, ""));
-        for (String sensitiveKey : RUNTIME_SENSITIVE_OPTION_KEYS) {
-            sensitiveValues.add(nonNullStorageOptions.getOrDefault(sensitiveKey, ""));
-        }
+        // Lance also accepts these options scoped to one base, as base_<id>.oss_secret_access_key,
+        // so match on the suffix rather than looking each bare key up exactly.
+        nonNullStorageOptions.forEach((key, value) -> {
+            if (key == null) {
+                return;
+            }
+            for (String sensitiveKey : RUNTIME_SENSITIVE_OPTION_KEYS) {
+                if (key.equals(sensitiveKey) || key.endsWith("." + sensitiveKey)) {
+                    sensitiveValues.add(value);
+                    return;
+                }
+            }
+        });
         sensitiveValues.add(datasetUri);
         sensitiveValues.removeIf(StringUtils::isEmpty);
         sensitiveValues.sort((left, right) -> Integer.compare(right.length(), left.length()));
@@ -538,12 +549,19 @@ public class LanceExternalCatalog extends ExternalCatalog {
         return truncateUtf8(removeControlCharacters(message), MAX_PROVIDER_MESSAGE_BYTES);
     }
 
+    /**
+     * Always hand back a rebuilt cause. Returning the original once left every catalog without REST
+     * auth - a directory namespace on OSS, say - free to carry provider text holding its
+     * credentials, which the message beside it had just redacted.
+     */
     private Throwable safeCause(Throwable throwable) {
-        if (StringUtils.isNotEmpty(catalogProperty.getOrDefault(REST_BEARER_TOKEN, ""))
-                || StringUtils.isNotEmpty(catalogProperty.getOrDefault(REST_API_KEY, ""))) {
-            return new RuntimeException(sanitizedRootCauseMessage(throwable));
-        }
-        return throwable;
+        return sanitizedCause(throwable, sanitizedRootCauseMessage(throwable));
+    }
+
+    private static Throwable sanitizedCause(Throwable throwable, String sanitizedMessage) {
+        return throwable instanceof IllegalArgumentException
+                ? new IllegalArgumentException(sanitizedMessage)
+                : new RuntimeException(sanitizedMessage);
     }
 
     private static String removeControlCharacters(String value) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceExternalCatalog.java
@@ -79,6 +79,9 @@ public class LanceExternalCatalog extends ExternalCatalog {
     private static final int MAX_PROVIDER_MESSAGE_BYTES = 1024;
     private static final String[] RUNTIME_SENSITIVE_OPTION_KEYS = {
             "aws_access_key_id", "aws_secret_access_key", "aws_session_token",
+            // This PR is what lets OSS credentials reach these options in the first place, so
+            // they have to be recognized here or the change would introduce a way for them to
+            // surface in an error. Both spellings: a namespace may vend either.
             "oss_access_key_id", "oss_secret_access_key", "oss_security_token",
             "access_key_id", "access_key_secret", "security_token"
     };
@@ -144,11 +147,8 @@ public class LanceExternalCatalog extends ExternalCatalog {
                 closeNamespace(testNamespace);
             }
         } catch (Exception e) {
-            // No dataset URI: the warehouse came from this very DDL, and redacting it would hide
-            // the mistyped bucket the operator needs to see.
-            String sanitizedMessage = sanitizedRootCauseMessage(e, null, storageOptions);
             throw new DdlException("Lance " + type + " catalog connectivity test failed: "
-                    + sanitizedMessage, sanitizedCause(e, sanitizedMessage));
+                    + sanitizedRootCauseMessage(e), safeCause(e));
         }
     }
 
@@ -333,10 +333,8 @@ public class LanceExternalCatalog extends ExternalCatalog {
                     : LanceMetadataLoader.loadLatest(
                             tableAccess.datasetUri, tableAccess.storageOptions, allocator);
         } catch (Exception e) {
-            String sanitizedMessage = sanitizedRootCauseMessage(
-                    e, tableAccess.datasetUri, tableAccess.storageOptions);
             throw new RuntimeException("Failed to load Lance table metadata for " + dbName + "." + tableName
-                    + ": " + sanitizedMessage, sanitizedCause(e, sanitizedMessage));
+                    + ": " + sanitizedRootCauseMessage(e), safeCause(e));
         }
     }
 
@@ -420,8 +418,11 @@ public class LanceExternalCatalog extends ExternalCatalog {
             Throwable throwable, String datasetUri, Map<String, String> runtimeStorageOptions) {
         String sanitizedMessage = sanitizedRootCauseMessage(
                 throwable, datasetUri, runtimeStorageOptions);
+        Throwable sanitizedCause = throwable instanceof IllegalArgumentException
+                ? new IllegalArgumentException(sanitizedMessage)
+                : new RuntimeException(sanitizedMessage);
         return new RuntimeException("Failed to load Lance index metadata for " + dbName + "." + tableName
-                + ": " + sanitizedMessage, sanitizedCause(throwable, sanitizedMessage));
+                + ": " + sanitizedMessage, sanitizedCause);
     }
 
     private ResolvedTableAccess resolveTableAccess(String dbName, String tableName) {
@@ -509,7 +510,14 @@ public class LanceExternalCatalog extends ExternalCatalog {
     }
 
     private String sanitizedRootCauseMessage(Throwable throwable) {
-        return sanitizedRootCauseMessage(throwable, null, namespaceStorageOptions);
+        String message = ExceptionUtils.getRootCauseMessage(throwable);
+        for (String sensitiveKey : new String[] {REST_BEARER_TOKEN, REST_API_KEY}) {
+            String sensitiveValue = catalogProperty.getOrDefault(sensitiveKey, "");
+            if (StringUtils.isNotEmpty(sensitiveValue)) {
+                message = message.replace(sensitiveValue, "***");
+            }
+        }
+        return message;
     }
 
     @VisibleForTesting
@@ -521,19 +529,9 @@ public class LanceExternalCatalog extends ExternalCatalog {
         List<String> sensitiveValues = new ArrayList<>();
         sensitiveValues.add(catalogProperty.getOrDefault(REST_BEARER_TOKEN, ""));
         sensitiveValues.add(catalogProperty.getOrDefault(REST_API_KEY, ""));
-        // Suffix match as well as exact: defensive, so a namespace scoping an option to one store
-        // cannot print a secret this list would otherwise have recognized.
-        nonNullStorageOptions.forEach((key, value) -> {
-            if (key == null) {
-                return;
-            }
-            for (String sensitiveKey : RUNTIME_SENSITIVE_OPTION_KEYS) {
-                if (key.equals(sensitiveKey) || key.endsWith("." + sensitiveKey)) {
-                    sensitiveValues.add(value);
-                    return;
-                }
-            }
-        });
+        for (String sensitiveKey : RUNTIME_SENSITIVE_OPTION_KEYS) {
+            sensitiveValues.add(nonNullStorageOptions.getOrDefault(sensitiveKey, ""));
+        }
         sensitiveValues.add(datasetUri);
         sensitiveValues.removeIf(StringUtils::isEmpty);
         sensitiveValues.sort((left, right) -> Integer.compare(right.length(), left.length()));
@@ -544,19 +542,11 @@ public class LanceExternalCatalog extends ExternalCatalog {
     }
 
     private Throwable safeCause(Throwable throwable) {
-        return sanitizedCause(throwable, sanitizedRootCauseMessage(throwable));
-    }
-
-    private static Throwable sanitizedCause(Throwable throwable, String sanitizedMessage) {
-        Throwable sanitized = throwable instanceof IllegalArgumentException
-                ? new IllegalArgumentException(sanitizedMessage)
-                : new RuntimeException(sanitizedMessage);
-        // The message comes from the root cause, so the stack must too - the wrapper's frames
-        // would point somewhere the message never describes. A stack holds only class, method,
-        // file and line, so unlike the message it cannot carry a credential.
-        Throwable rootCause = ExceptionUtils.getRootCause(throwable);
-        sanitized.setStackTrace((rootCause == null ? throwable : rootCause).getStackTrace());
-        return sanitized;
+        if (StringUtils.isNotEmpty(catalogProperty.getOrDefault(REST_BEARER_TOKEN, ""))
+                || StringUtils.isNotEmpty(catalogProperty.getOrDefault(REST_API_KEY, ""))) {
+            return new RuntimeException(sanitizedRootCauseMessage(throwable));
+        }
+        return throwable;
     }
 
     private static String removeControlCharacters(String value) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceExternalCatalog.java
@@ -79,11 +79,10 @@ public class LanceExternalCatalog extends ExternalCatalog {
     private static final int MAX_PROVIDER_MESSAGE_BYTES = 1024;
     private static final String[] RUNTIME_SENSITIVE_OPTION_KEYS = {
             "aws_access_key_id", "aws_secret_access_key", "aws_session_token",
-            // This PR is what lets OSS credentials reach these options in the first place, so
-            // they have to be recognized here or the change would introduce a way for them to
-            // surface in an error. Both spellings: a namespace may vend either.
-            "oss_access_key_id", "oss_secret_access_key", "oss_security_token",
-            "access_key_id", "access_key_secret", "security_token"
+            // OSS credentials only reach these options because of this change, so they have to be
+            // recognized here too. The emitted spelling is the only one that occurs: the map read
+            // below is the merged one, where a vended alias has already been normalized onto it.
+            "oss_access_key_id", "oss_secret_access_key", "oss_security_token"
     };
 
     private transient LanceNamespace namespace;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceExternalCatalog.java
@@ -34,8 +34,6 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.lance.namespace.LanceNamespace;
 import org.lance.namespace.errors.NamespaceNotFoundException;
 import org.lance.namespace.errors.TableNotFoundException;
@@ -62,7 +60,6 @@ import java.util.Set;
 
 /** Read-only Lance Directory or REST Namespace catalog. */
 public class LanceExternalCatalog extends ExternalCatalog {
-    private static final Logger LOG = LogManager.getLogger(LanceExternalCatalog.class);
     public static final String LANCE_CATALOG_TYPE = AbstractLanceProperties.LANCE_CATALOG_TYPE;
     public static final String LANCE_FILESYSTEM = AbstractLanceProperties.LANCE_FILESYSTEM;
     public static final String LANCE_REST = AbstractLanceProperties.LANCE_REST;
@@ -147,10 +144,8 @@ public class LanceExternalCatalog extends ExternalCatalog {
                 closeNamespace(testNamespace);
             }
         } catch (Exception e) {
-            // The catalog is not initialized yet, so the namespace options this test just built are
-            // the only ones the sanitizer can see. The warehouse is deliberately not passed as the
-            // dataset URI: it came from this very DDL, and blanking it would hide the mistyped
-            // bucket the operator needs to see.
+            // No dataset URI: the warehouse came from this very DDL, and redacting it would hide
+            // the mistyped bucket the operator needs to see.
             String sanitizedMessage = sanitizedRootCauseMessage(e, null, storageOptions);
             throw new DdlException("Lance " + type + " catalog connectivity test failed: "
                     + sanitizedMessage, sanitizedCause(e, sanitizedMessage));
@@ -513,11 +508,6 @@ public class LanceExternalCatalog extends ExternalCatalog {
         }
     }
 
-    /**
-     * Every provider-facing failure has at least the namespace's own storage options behind it, so
-     * default to those rather than redacting only the REST secrets. Callers holding a resolved
-     * table pass its dataset URI and options to the overload below instead.
-     */
     private String sanitizedRootCauseMessage(Throwable throwable) {
         return sanitizedRootCauseMessage(throwable, null, namespaceStorageOptions);
     }
@@ -531,9 +521,8 @@ public class LanceExternalCatalog extends ExternalCatalog {
         List<String> sensitiveValues = new ArrayList<>();
         sensitiveValues.add(catalogProperty.getOrDefault(REST_BEARER_TOKEN, ""));
         sensitiveValues.add(catalogProperty.getOrDefault(REST_API_KEY, ""));
-        // Match on a trailing dotted segment as well as the bare key, so any namespace that scopes
-        // an option to one store still has its secret redacted. Over-redaction costs nothing here,
-        // while an exact-key lookup would print a secret it did not recognize.
+        // Suffix match as well as exact: defensive, so a namespace scoping an option to one store
+        // cannot print a secret this list would otherwise have recognized.
         nonNullStorageOptions.forEach((key, value) -> {
             if (key == null) {
                 return;
@@ -554,26 +543,20 @@ public class LanceExternalCatalog extends ExternalCatalog {
         return truncateUtf8(removeControlCharacters(message), MAX_PROVIDER_MESSAGE_BYTES);
     }
 
-    /**
-     * Always hand back a rebuilt cause. Returning the original once left every catalog without REST
-     * auth - a directory namespace on OSS, say - free to carry provider text holding its
-     * credentials, which the message beside it had just redacted.
-     */
     private Throwable safeCause(Throwable throwable) {
         return sanitizedCause(throwable, sanitizedRootCauseMessage(throwable));
     }
 
     private static Throwable sanitizedCause(Throwable throwable, String sanitizedMessage) {
-        // The rebuilt cause keeps the provider's credentials out of the user-visible error, but it
-        // also drops the original type, stack and suppressed exceptions. Keep them at debug level:
-        // the untouched text can hold those same credentials, so it must not reach the log by
-        // default, and an operator debugging a provider failure can turn it on deliberately.
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Lance provider failure, replaced by a redacted cause", throwable);
-        }
-        return throwable instanceof IllegalArgumentException
+        Throwable sanitized = throwable instanceof IllegalArgumentException
                 ? new IllegalArgumentException(sanitizedMessage)
                 : new RuntimeException(sanitizedMessage);
+        // The message comes from the root cause, so the stack must too - the wrapper's frames
+        // would point somewhere the message never describes. A stack holds only class, method,
+        // file and line, so unlike the message it cannot carry a credential.
+        Throwable rootCause = ExceptionUtils.getRootCause(throwable);
+        sanitized.setStackTrace((rootCause == null ? throwable : rootCause).getStackTrace());
+        return sanitized;
     }
 
     private static String removeControlCharacters(String value) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceMetadataLoader.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceMetadataLoader.java
@@ -54,7 +54,7 @@ public final class LanceMetadataLoader {
             throws Exception {
         try (BufferAllocator allocator = new RootAllocator(ALLOCATOR_LIMIT)) {
             return loadLatest(datasetUri,
-                    LanceStorageOptions.forUri(datasetUri, storageProperties), allocator);
+                    LanceStorageOptions.fromDorisStorageProperties(datasetUri, storageProperties), allocator);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
@@ -38,7 +38,12 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
     private static final String REGION = "oss_region";
     private static final String SECURITY_TOKEN = "oss_security_token";
     private static final String ADDRESSING_STYLE = "addressing_style";
+    private static final String SKIP_SIGNATURE = "skip_signature";
     private static final String ALLOW_ANONYMOUS = "allow_anonymous";
+    private static final String ROLE_ARN = "role_arn";
+    private static final String OIDC_TOKEN = "oidc_token";
+    private static final String OIDC_PROVIDER_ARN = "oidc_provider_arn";
+    private static final String OIDC_TOKEN_FILE = "oidc_token_file";
 
     /**
      * Lance exposes the {@code oss_*} names as its public storage-option vocabulary and normalizes
@@ -56,13 +61,18 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
             .put(REGION, REGION)
             .put("security_token", SECURITY_TOKEN)
             .put(SECURITY_TOKEN, SECURITY_TOKEN)
+            // OpenDAL 0.57 renamed this option to skip_signature, but lance-c 0.1.6 still uses
+            // OpenDAL 0.56. Emit the old spelling, which newer OpenDAL keeps as an alias.
+            .put(SKIP_SIGNATURE, ALLOW_ANONYMOUS)
+            .put(ALLOW_ANONYMOUS, ALLOW_ANONYMOUS)
             .build();
 
     private LanceOssStorageProvider() {
     }
 
     @Override
-    public Map<String, String> fromDorisProperties(List<StorageProperties> storageProperties) {
+    public Map<String, String> normalizeDorisStorageOptions(
+            List<StorageProperties> storageProperties) {
         Map<String, String> result = new HashMap<>();
         OSSProperties properties = selectOss(storageProperties);
         if (properties == null) {
@@ -70,7 +80,7 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
         }
         putIfNotEmpty(result, ENDPOINT, properties.getEndpoint());
         putIfNotEmpty(result, REGION, properties.getRegion());
-        putAuth(result, properties.getAccessKey(), properties.getSecretKey(),
+        putCredentials(result, properties.getAccessKey(), properties.getSecretKey(),
                 properties.getSessionToken());
 
         // Lance snapshots the host's OSS_*/AWS_*/ALIBABA_CLOUD_* environment into the same config
@@ -85,7 +95,8 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
     }
 
     @Override
-    public Map<String, String> normalizeVended(Map<String, String> vendedOptions) {
+    public Map<String, String> normalizeVendedStorageOptions(
+            Map<String, String> vendedOptions) {
         Map<String, String> result = new HashMap<>();
         if (vendedOptions == null) {
             return result;
@@ -107,12 +118,9 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
      * over the catalog's.
      *
      * <p>Authentication is one value, not a set of independent keys: a key pair, the token that
-     * belongs to that pair, and the flag saying there is no pair at all. The overlay that produced
+     * belongs to that pair, and an explicit choice to skip signing. The overlay that produced
      * {@code merged} is key by key, so on its own it can pair one side's access key with the
-     * other's secret, or leave a token attached to a pair it was never issued for. OpenDAL does not
-     * second-guess any of that - {@code OssCore::sign} returns the request unsigned whenever
-     * {@code allow_anonymous} is set, whatever credentials sit beside it, and it signs with
-     * whatever token it finds next to a pair.
+     * other's secret, or leave a token attached to a pair it was never issued for.
      *
      * <p>So the two sides are never mixed. A namespace that supplies any part of the authentication
      * has just described this table and supplies all of it; otherwise the catalog's stands
@@ -127,26 +135,25 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
         boolean vendedSuppliesAuth = normalizedVended.containsKey(ACCESS_KEY_ID)
                 || normalizedVended.containsKey(SECRET_ACCESS_KEY)
                 || normalizedVended.containsKey(SECURITY_TOKEN)
-                || normalizedVended.containsKey(ALLOW_ANONYMOUS);
+                || normalizedVended.containsKey(ALLOW_ANONYMOUS)
+                || normalizedVended.containsKey(ROLE_ARN)
+                || normalizedVended.containsKey(OIDC_TOKEN)
+                || normalizedVended.containsKey(OIDC_PROVIDER_ARN)
+                || normalizedVended.containsKey(OIDC_TOKEN_FILE);
         if (!vendedSuppliesAuth) {
             return;
         }
-        putAuth(merged, normalizedVended.get(ACCESS_KEY_ID),
+        putCredentials(merged, normalizedVended.get(ACCESS_KEY_ID),
                 normalizedVended.get(SECRET_ACCESS_KEY), normalizedVended.get(SECURITY_TOKEN));
     }
 
     /**
-     * Writes one authentication state into {@code options}, replacing whatever was there.
+     * Writes one credential tuple into {@code options}, replacing whatever was there.
      *
-     * <p>States the anonymous flag either way rather than only when true. Absence is not neutral:
-     * lance snapshots the host's {@code OSS_}/{@code AWS_} environment into the same config map
-     * before these options are applied, so an omitted key hands the decision to an exported
-     * {@code OSS_ALLOW_ANONYMOUS}.
-     *
-     * <p>Blank is not a credential, so a blank pair is anonymous rather than a signer built from
-     * empty strings, and a token is only carried when there is a pair for it to belong to.
+     * <p>Blank is not a credential, and a token is only carried when there is a pair for it to
+     * belong to. Whether the resulting request is signed is inferred from the complete merged map.
      */
-    private static void putAuth(Map<String, String> options, String keyId, String secret,
+    private static void putCredentials(Map<String, String> options, String keyId, String secret,
             String token) {
         options.remove(ACCESS_KEY_ID);
         options.remove(SECRET_ACCESS_KEY);
@@ -163,7 +170,31 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
             options.put(SECRET_ACCESS_KEY, secret);
             putIfNotEmpty(options, SECURITY_TOKEN, token);
         }
-        options.put(ALLOW_ANONYMOUS, String.valueOf(!hasKeyId));
+    }
+
+    @Override
+    public Map<String, String> inferStorageOptions(Map<String, String> effectiveOptions) {
+        Map<String, String> inferred = new HashMap<>();
+        boolean hasSigningConfiguration = hasSigningConfiguration(effectiveOptions);
+        String allowAnonymous = effectiveOptions.get(ALLOW_ANONYMOUS);
+        if (allowAnonymous != null) {
+            if (Boolean.parseBoolean(allowAnonymous) && hasSigningConfiguration) {
+                throw new IllegalArgumentException(
+                        "Conflicting OSS authentication: anonymous access is enabled but signing "
+                                + "credentials are also configured");
+            }
+            return inferred;
+        }
+        inferred.put(ALLOW_ANONYMOUS, String.valueOf(!hasSigningConfiguration));
+        return inferred;
+    }
+
+    private static boolean hasSigningConfiguration(Map<String, String> options) {
+        return StringUtils.isNotEmpty(options.get(ACCESS_KEY_ID))
+                || StringUtils.isNotEmpty(options.get(ROLE_ARN))
+                || StringUtils.isNotEmpty(options.get(OIDC_TOKEN))
+                || StringUtils.isNotEmpty(options.get(OIDC_PROVIDER_ARN))
+                || StringUtils.isNotEmpty(options.get(OIDC_TOKEN_FILE));
     }
 
     private static OSSProperties selectOss(List<StorageProperties> storageProperties) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource.lance;
+
+import org.apache.doris.datasource.property.storage.OSSProperties;
+import org.apache.doris.datasource.property.storage.StorageProperties;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Alibaba Cloud OSS storage, which Lance reaches through its OpenDAL OSS provider. */
+final class LanceOssStorageProvider implements LanceStorageProvider {
+
+    static final LanceOssStorageProvider INSTANCE = new LanceOssStorageProvider();
+
+    private static final String ENDPOINT = "oss_endpoint";
+    private static final String ACCESS_KEY_ID = "oss_access_key_id";
+    private static final String SECRET_ACCESS_KEY = "oss_secret_access_key";
+    private static final String REGION = "oss_region";
+    private static final String SECURITY_TOKEN = "oss_security_token";
+
+    /**
+     * Lance exposes the {@code oss_*} names as its public storage-option vocabulary and normalizes
+     * them to OpenDAL's field names before constructing the operator. Both spellings are accepted,
+     * so collapse only these known pairs before merging static and namespace-vended options.
+     */
+    private static final Map<String, String> PUBLIC_BY_ALIAS = ImmutableMap.<String, String>builder()
+            .put("endpoint", ENDPOINT)
+            .put(ENDPOINT, ENDPOINT)
+            .put("access_key_id", ACCESS_KEY_ID)
+            .put(ACCESS_KEY_ID, ACCESS_KEY_ID)
+            .put("access_key_secret", SECRET_ACCESS_KEY)
+            .put(SECRET_ACCESS_KEY, SECRET_ACCESS_KEY)
+            .put("region", REGION)
+            .put(REGION, REGION)
+            .put("security_token", SECURITY_TOKEN)
+            .put(SECURITY_TOKEN, SECURITY_TOKEN)
+            .build();
+
+    private LanceOssStorageProvider() {
+    }
+
+    @Override
+    public Map<String, String> fromDorisProperties(List<StorageProperties> storageProperties) {
+        Map<String, String> result = new HashMap<>();
+        OSSProperties properties = selectOss(storageProperties);
+        if (properties == null) {
+            return result;
+        }
+        putIfNotEmpty(result, ENDPOINT, properties.getEndpoint());
+        putIfNotEmpty(result, ACCESS_KEY_ID, properties.getAccessKey());
+        putIfNotEmpty(result, SECRET_ACCESS_KEY, properties.getSecretKey());
+        putIfNotEmpty(result, REGION, properties.getRegion());
+        putIfNotEmpty(result, SECURITY_TOKEN, properties.getSessionToken());
+        return result;
+    }
+
+    @Override
+    public Map<String, String> normalizeVended(Map<String, String> vendedOptions) {
+        Map<String, String> result = new HashMap<>();
+        if (vendedOptions == null) {
+            return result;
+        }
+        vendedOptions.forEach((key, value) -> {
+            String publicKey = PUBLIC_BY_ALIAS.getOrDefault(key, key);
+            String previous = result.put(publicKey, value);
+            if (previous != null && !previous.equals(value)) {
+                throw new IllegalArgumentException(
+                        "Lance namespace vended conflicting values for storage option '"
+                                + publicKey + "'");
+            }
+        });
+        return result;
+    }
+
+    private static OSSProperties selectOss(List<StorageProperties> storageProperties) {
+        if (storageProperties == null) {
+            return null;
+        }
+        for (StorageProperties candidate : storageProperties) {
+            if (candidate instanceof OSSProperties) {
+                return (OSSProperties) candidate;
+            }
+        }
+        return null;
+    }
+
+    private static void putIfNotEmpty(Map<String, String> target, String key, String value) {
+        if (value != null && !value.isEmpty()) {
+            target.put(key, value);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
@@ -21,6 +21,7 @@ import org.apache.doris.datasource.property.storage.OSSProperties;
 import org.apache.doris.datasource.property.storage.StorageProperties;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
 import java.util.List;
@@ -36,6 +37,8 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
     private static final String SECRET_ACCESS_KEY = "oss_secret_access_key";
     private static final String REGION = "oss_region";
     private static final String SECURITY_TOKEN = "oss_security_token";
+    private static final String ADDRESSING_STYLE = "addressing_style";
+    private static final String ALLOW_ANONYMOUS = "allow_anonymous";
 
     /**
      * Lance exposes the {@code oss_*} names as its public storage-option vocabulary and normalizes
@@ -70,6 +73,21 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
         putIfNotEmpty(result, SECRET_ACCESS_KEY, properties.getSecretKey());
         putIfNotEmpty(result, REGION, properties.getRegion());
         putIfNotEmpty(result, SECURITY_TOKEN, properties.getSessionToken());
+
+        // Doris reads a blank key pair as a request for anonymous access. Lance forwards options it
+        // does not recognize straight to OpenDAL, whose OSS service only skips request signing when
+        // allow_anonymous is set; without it the open fails in credential loading instead of
+        // issuing the unsigned request Doris asked for.
+        if (StringUtils.isBlank(properties.getAccessKey())
+                && StringUtils.isBlank(properties.getSecretKey())) {
+            result.put(ALLOW_ANONYMOUS, "true");
+        }
+
+        // OpenDAL's OSS service addresses buckets virtual-host style by default, which is also
+        // Doris's default, so only an explicit path-style request needs translating.
+        if (Boolean.parseBoolean(properties.getUsePathStyle())) {
+            result.put(ADDRESSING_STYLE, "path");
+        }
         return result;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
@@ -46,6 +46,17 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
     private static final String OIDC_TOKEN_FILE = "oidc_token_file";
 
     /**
+     * The options that together say who the caller is. They are replaced as a unit, so the removal
+     * below reads this list rather than naming each key again. {@code allow_anonymous} is
+     * deliberately absent: it states a conclusion about these rather than being one of them, and is
+     * inferred once everything else has settled.
+     */
+    private static final String[] AUTH_OPTIONS = {
+            ACCESS_KEY_ID, SECRET_ACCESS_KEY, SECURITY_TOKEN,
+            ROLE_ARN, OIDC_TOKEN, OIDC_PROVIDER_ARN, OIDC_TOKEN_FILE,
+    };
+
+    /**
      * Lance exposes the {@code oss_*} names as its public storage-option vocabulary and normalizes
      * them to OpenDAL's field names before constructing the operator. Both spellings are accepted,
      * so collapse only these known pairs before merging static and namespace-vended options.
@@ -118,30 +129,37 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
      * over the catalog's.
      *
      * <p>Authentication is one value, not a set of independent keys: a key pair, the token that
-     * belongs to that pair, and an explicit choice to skip signing. The overlay that produced
-     * {@code merged} is key by key, so on its own it can pair one side's access key with the
-     * other's secret, or leave a token attached to a pair it was never issued for.
+     * belongs to that pair, and any role or identity binding standing in for them. The overlay that
+     * produced {@code merged} is key by key, so on its own it can pair one side's access key with
+     * the other's secret, or leave a token attached to a pair it was never issued for.
      *
      * <p>So the two sides are never mixed. A namespace that supplies any part of the authentication
      * has just described this table and supplies all of it; otherwise the catalog's stands
-     * untouched. Every case the merge could previously get wrong - a half pair, a stale token, a
-     * vended blank, an explicit anonymous request - follows from that one rule.
-     *
-     * <p>This lives here rather than on {@link LanceStorageProvider} because OSS is the only
-     * provider whose options carry the coupling. The S3 adapter has a comparable overlay but
-     * predates this work, and a hook only one implementation honoured would read as an oversight.
+     * untouched. Every case the merge could get wrong - a half pair, a stale token, a vended blank,
+     * an explicit anonymous request - follows from that one rule.
      */
-    static void reconcileAuth(Map<String, String> merged, Map<String, String> normalizedVended) {
-        boolean vendedSuppliesAuth = normalizedVended.containsKey(ACCESS_KEY_ID)
-                || normalizedVended.containsKey(SECRET_ACCESS_KEY)
-                || normalizedVended.containsKey(SECURITY_TOKEN)
-                || normalizedVended.containsKey(ALLOW_ANONYMOUS)
-                || normalizedVended.containsKey(ROLE_ARN)
-                || normalizedVended.containsKey(OIDC_TOKEN)
-                || normalizedVended.containsKey(OIDC_PROVIDER_ARN)
-                || normalizedVended.containsKey(OIDC_TOKEN_FILE);
+    @Override
+    public void reconcileVendedStorageOptions(Map<String, String> merged,
+            Map<String, String> normalizedVended) {
+        // A vended anonymous flag counts as supplying authentication: saying "this table needs no
+        // credential" is a statement about the same group, and outranks one the catalog holds.
+        boolean vendedSuppliesAuth = normalizedVended.containsKey(ALLOW_ANONYMOUS);
+        for (String option : AUTH_OPTIONS) {
+            if (normalizedVended.containsKey(option)) {
+                vendedSuppliesAuth = true;
+                break;
+            }
+        }
         if (!vendedSuppliesAuth) {
             return;
+        }
+        // Whatever the namespace did not send belonged to the credential it is replacing. That
+        // includes a role or identity binding: inference below counts those as signing
+        // configuration, so leaving one behind would describe an identity that is no longer in use.
+        for (String option : AUTH_OPTIONS) {
+            if (!normalizedVended.containsKey(option)) {
+                merged.remove(option);
+            }
         }
         putCredentials(merged, normalizedVended.get(ACCESS_KEY_ID),
                 normalizedVended.get(SECRET_ACCESS_KEY), normalizedVended.get(SECURITY_TOKEN));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
@@ -77,16 +77,20 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
         // Doris reads a blank key pair as a request for anonymous access. Lance forwards options it
         // does not recognize straight to OpenDAL, whose OSS service only skips request signing when
         // allow_anonymous is set; without it the open fails in credential loading instead of
-        // issuing the unsigned request Doris asked for.
-        if (StringUtils.isBlank(properties.getAccessKey())
-                && StringUtils.isBlank(properties.getSecretKey())) {
+        // issuing the unsigned request Doris asked for. Decide from what was actually emitted above
+        // rather than re-testing the properties, so a credential this class considers present can
+        // never be paired with a claim that there is none.
+        if (!result.containsKey(ACCESS_KEY_ID) && !result.containsKey(SECRET_ACCESS_KEY)) {
             result.put(ALLOW_ANONYMOUS, "true");
         }
 
-        // OpenDAL's OSS service addresses buckets virtual-host style by default, which is also
-        // Doris's default, so only an explicit path-style request needs translating.
-        if (Boolean.parseBoolean(properties.getUsePathStyle())) {
-            result.put(ADDRESSING_STYLE, "path");
+        // Lance snapshots the host's OSS_*/AWS_*/ALIBABA_CLOUD_* environment into the same config
+        // map before storage options are applied, so state both addressing styles explicitly the
+        // way the S3 provider does. Leaving the default implicit would let an exported
+        // OSS_ADDRESSING_STYLE outrank an explicit oss.use_path_style=false.
+        String usePathStyle = properties.getUsePathStyle();
+        if (StringUtils.isNotEmpty(usePathStyle)) {
+            result.put(ADDRESSING_STYLE, Boolean.parseBoolean(usePathStyle) ? "path" : "virtual");
         }
         return result;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
@@ -69,20 +69,9 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
             return result;
         }
         putIfNotEmpty(result, ENDPOINT, properties.getEndpoint());
-        putIfNotEmpty(result, ACCESS_KEY_ID, properties.getAccessKey());
-        putIfNotEmpty(result, SECRET_ACCESS_KEY, properties.getSecretKey());
         putIfNotEmpty(result, REGION, properties.getRegion());
-        putIfNotEmpty(result, SECURITY_TOKEN, properties.getSessionToken());
-
-        // Doris reads a blank key pair as a request for anonymous access. Lance forwards options it
-        // does not recognize straight to OpenDAL, whose OSS service only skips request signing when
-        // allow_anonymous is set; without it the open fails in credential loading instead of
-        // issuing the unsigned request Doris asked for. Decide from what was actually emitted above
-        // rather than re-testing the properties, so a credential this class considers present can
-        // never be paired with a claim that there is none.
-        if (!result.containsKey(ACCESS_KEY_ID) && !result.containsKey(SECRET_ACCESS_KEY)) {
-            result.put(ALLOW_ANONYMOUS, "true");
-        }
+        putAuth(result, properties.getAccessKey(), properties.getSecretKey(),
+                properties.getSessionToken());
 
         // Lance snapshots the host's OSS_*/AWS_*/ALIBABA_CLOUD_* environment into the same config
         // map before storage options are applied, so state both addressing styles explicitly the
@@ -111,6 +100,70 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
             }
         });
         return result;
+    }
+
+    /**
+     * Chooses which side's OSS authentication to keep once a namespace's options have been laid
+     * over the catalog's.
+     *
+     * <p>Authentication is one value, not a set of independent keys: a key pair, the token that
+     * belongs to that pair, and the flag saying there is no pair at all. The overlay that produced
+     * {@code merged} is key by key, so on its own it can pair one side's access key with the
+     * other's secret, or leave a token attached to a pair it was never issued for. OpenDAL does not
+     * second-guess any of that - {@code OssCore::sign} returns the request unsigned whenever
+     * {@code allow_anonymous} is set, whatever credentials sit beside it, and it signs with
+     * whatever token it finds next to a pair.
+     *
+     * <p>So the two sides are never mixed. A namespace that supplies any part of the authentication
+     * has just described this table and supplies all of it; otherwise the catalog's stands
+     * untouched. Every case the merge could previously get wrong - a half pair, a stale token, a
+     * vended blank, an explicit anonymous request - follows from that one rule.
+     *
+     * <p>This lives here rather than on {@link LanceStorageProvider} because OSS is the only
+     * provider whose options carry the coupling. The S3 adapter has a comparable overlay but
+     * predates this work, and a hook only one implementation honoured would read as an oversight.
+     */
+    static void reconcileAuth(Map<String, String> merged, Map<String, String> normalizedVended) {
+        boolean vendedSuppliesAuth = normalizedVended.containsKey(ACCESS_KEY_ID)
+                || normalizedVended.containsKey(SECRET_ACCESS_KEY)
+                || normalizedVended.containsKey(SECURITY_TOKEN)
+                || normalizedVended.containsKey(ALLOW_ANONYMOUS);
+        if (!vendedSuppliesAuth) {
+            return;
+        }
+        putAuth(merged, normalizedVended.get(ACCESS_KEY_ID),
+                normalizedVended.get(SECRET_ACCESS_KEY), normalizedVended.get(SECURITY_TOKEN));
+    }
+
+    /**
+     * Writes one authentication state into {@code options}, replacing whatever was there.
+     *
+     * <p>States the anonymous flag either way rather than only when true. Absence is not neutral:
+     * lance snapshots the host's {@code OSS_}/{@code AWS_} environment into the same config map
+     * before these options are applied, so an omitted key hands the decision to an exported
+     * {@code OSS_ALLOW_ANONYMOUS}.
+     *
+     * <p>Blank is not a credential, so a blank pair is anonymous rather than a signer built from
+     * empty strings, and a token is only carried when there is a pair for it to belong to.
+     */
+    private static void putAuth(Map<String, String> options, String keyId, String secret,
+            String token) {
+        options.remove(ACCESS_KEY_ID);
+        options.remove(SECRET_ACCESS_KEY);
+        options.remove(SECURITY_TOKEN);
+
+        boolean hasKeyId = StringUtils.isNotEmpty(keyId);
+        boolean hasSecret = StringUtils.isNotEmpty(secret);
+        if (hasKeyId != hasSecret) {
+            throw new IllegalArgumentException("Incomplete OSS credential: '"
+                    + (hasKeyId ? SECRET_ACCESS_KEY : ACCESS_KEY_ID) + "' is missing");
+        }
+        if (hasKeyId) {
+            options.put(ACCESS_KEY_ID, keyId);
+            options.put(SECRET_ACCESS_KEY, secret);
+            putIfNotEmpty(options, SECURITY_TOKEN, token);
+        }
+        options.put(ALLOW_ANONYMOUS, String.valueOf(!hasKeyId));
     }
 
     private static OSSProperties selectOss(List<StorageProperties> storageProperties) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /** Alibaba Cloud OSS storage, which Lance reaches through its OpenDAL OSS provider. */
@@ -99,7 +100,12 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
             return result;
         }
         vendedOptions.forEach((key, value) -> {
-            String publicKey = PUBLIC_BY_ALIAS.getOrDefault(key, key);
+            // Look the alias up in lower case, the way the S3 adapter does. OpenDAL lower-cases
+            // every key before deserializing its config, so a vended ACCESS_KEY_ID reaches the
+            // store as a credential either way - but left unrecognized here it would not count as
+            // signing configuration, and the anonymous flag would be inferred as true beside it.
+            // An unrecognized key keeps its original spelling: only the store knows what it means.
+            String publicKey = PUBLIC_BY_ALIAS.getOrDefault(key.toLowerCase(Locale.ROOT), key);
             String previous = result.put(publicKey, value);
             if (previous != null && !previous.equals(value)) {
                 throw new IllegalArgumentException(
@@ -116,7 +122,13 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
         boolean hasSigningConfiguration = hasSigningConfiguration(effectiveOptions);
         String allowAnonymous = effectiveOptions.get(ALLOW_ANONYMOUS);
         if (allowAnonymous != null) {
-            if (Boolean.parseBoolean(allowAnonymous) && hasSigningConfiguration) {
+            Boolean anonymous = parseOpenDalBoolean(allowAnonymous);
+            if (anonymous == null) {
+                throw new IllegalArgumentException("Unrecognized value for OSS storage option '"
+                        + ALLOW_ANONYMOUS + "': '" + allowAnonymous
+                        + "'. Expected one of true, on, false, off");
+            }
+            if (anonymous && hasSigningConfiguration) {
                 throw new IllegalArgumentException(
                         "Conflicting OSS authentication: anonymous access is enabled but signing "
                                 + "credentials are also configured");
@@ -125,6 +137,28 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
         }
         inferred.put(ALLOW_ANONYMOUS, String.valueOf(!hasSigningConfiguration));
         return inferred;
+    }
+
+    /**
+     * Reads a flag the way the store will. OpenDAL deserializes its config with a boolean grammar
+     * of its own - {@code true|on} and {@code false|off}, anything else refused - so judging a
+     * vended value by Java's rules would let {@code on} through as "not anonymous" while the store
+     * reads it as anonymous and stops signing. Null for a value OpenDAL would reject, so it can be
+     * refused here rather than deep inside the operator build.
+     *
+     * <p>See {@code opendal-core/src/raw/serde_util.rs}, {@code Pair::deserialize_bool}.
+     */
+    private static Boolean parseOpenDalBoolean(String value) {
+        switch (value.toLowerCase(Locale.ROOT)) {
+            case "true":
+            case "on":
+                return Boolean.TRUE;
+            case "false":
+            case "off":
+                return Boolean.FALSE;
+            default:
+                return null;
+        }
     }
 
     private static boolean hasSigningConfiguration(Map<String, String> options) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceOssStorageProvider.java
@@ -40,21 +40,6 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
     private static final String ADDRESSING_STYLE = "addressing_style";
     private static final String SKIP_SIGNATURE = "skip_signature";
     private static final String ALLOW_ANONYMOUS = "allow_anonymous";
-    private static final String ROLE_ARN = "role_arn";
-    private static final String OIDC_TOKEN = "oidc_token";
-    private static final String OIDC_PROVIDER_ARN = "oidc_provider_arn";
-    private static final String OIDC_TOKEN_FILE = "oidc_token_file";
-
-    /**
-     * The options that together say who the caller is. They are replaced as a unit, so the removal
-     * below reads this list rather than naming each key again. {@code allow_anonymous} is
-     * deliberately absent: it states a conclusion about these rather than being one of them, and is
-     * inferred once everything else has settled.
-     */
-    private static final String[] AUTH_OPTIONS = {
-            ACCESS_KEY_ID, SECRET_ACCESS_KEY, SECURITY_TOKEN,
-            ROLE_ARN, OIDC_TOKEN, OIDC_PROVIDER_ARN, OIDC_TOKEN_FILE,
-    };
 
     /**
      * Lance exposes the {@code oss_*} names as its public storage-option vocabulary and normalizes
@@ -91,8 +76,9 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
         }
         putIfNotEmpty(result, ENDPOINT, properties.getEndpoint());
         putIfNotEmpty(result, REGION, properties.getRegion());
-        putCredentials(result, properties.getAccessKey(), properties.getSecretKey(),
-                properties.getSessionToken());
+        putIfNotEmpty(result, ACCESS_KEY_ID, properties.getAccessKey());
+        putIfNotEmpty(result, SECRET_ACCESS_KEY, properties.getSecretKey());
+        putIfNotEmpty(result, SECURITY_TOKEN, properties.getSessionToken());
 
         // Lance snapshots the host's OSS_*/AWS_*/ALIBABA_CLOUD_* environment into the same config
         // map before storage options are applied, so state both addressing styles explicitly the
@@ -124,72 +110,6 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
         return result;
     }
 
-    /**
-     * Chooses which side's OSS authentication to keep once a namespace's options have been laid
-     * over the catalog's.
-     *
-     * <p>Authentication is one value, not a set of independent keys: a key pair, the token that
-     * belongs to that pair, and any role or identity binding standing in for them. The overlay that
-     * produced {@code merged} is key by key, so on its own it can pair one side's access key with
-     * the other's secret, or leave a token attached to a pair it was never issued for.
-     *
-     * <p>So the two sides are never mixed. A namespace that supplies any part of the authentication
-     * has just described this table and supplies all of it; otherwise the catalog's stands
-     * untouched. Every case the merge could get wrong - a half pair, a stale token, a vended blank,
-     * an explicit anonymous request - follows from that one rule.
-     */
-    @Override
-    public void reconcileVendedStorageOptions(Map<String, String> merged,
-            Map<String, String> normalizedVended) {
-        // A vended anonymous flag counts as supplying authentication: saying "this table needs no
-        // credential" is a statement about the same group, and outranks one the catalog holds.
-        boolean vendedSuppliesAuth = normalizedVended.containsKey(ALLOW_ANONYMOUS);
-        for (String option : AUTH_OPTIONS) {
-            if (normalizedVended.containsKey(option)) {
-                vendedSuppliesAuth = true;
-                break;
-            }
-        }
-        if (!vendedSuppliesAuth) {
-            return;
-        }
-        // Whatever the namespace did not send belonged to the credential it is replacing. That
-        // includes a role or identity binding: inference below counts those as signing
-        // configuration, so leaving one behind would describe an identity that is no longer in use.
-        for (String option : AUTH_OPTIONS) {
-            if (!normalizedVended.containsKey(option)) {
-                merged.remove(option);
-            }
-        }
-        putCredentials(merged, normalizedVended.get(ACCESS_KEY_ID),
-                normalizedVended.get(SECRET_ACCESS_KEY), normalizedVended.get(SECURITY_TOKEN));
-    }
-
-    /**
-     * Writes one credential tuple into {@code options}, replacing whatever was there.
-     *
-     * <p>Blank is not a credential, and a token is only carried when there is a pair for it to
-     * belong to. Whether the resulting request is signed is inferred from the complete merged map.
-     */
-    private static void putCredentials(Map<String, String> options, String keyId, String secret,
-            String token) {
-        options.remove(ACCESS_KEY_ID);
-        options.remove(SECRET_ACCESS_KEY);
-        options.remove(SECURITY_TOKEN);
-
-        boolean hasKeyId = StringUtils.isNotEmpty(keyId);
-        boolean hasSecret = StringUtils.isNotEmpty(secret);
-        if (hasKeyId != hasSecret) {
-            throw new IllegalArgumentException("Incomplete OSS credential: '"
-                    + (hasKeyId ? SECRET_ACCESS_KEY : ACCESS_KEY_ID) + "' is missing");
-        }
-        if (hasKeyId) {
-            options.put(ACCESS_KEY_ID, keyId);
-            options.put(SECRET_ACCESS_KEY, secret);
-            putIfNotEmpty(options, SECURITY_TOKEN, token);
-        }
-    }
-
     @Override
     public Map<String, String> inferStorageOptions(Map<String, String> effectiveOptions) {
         Map<String, String> inferred = new HashMap<>();
@@ -208,11 +128,7 @@ final class LanceOssStorageProvider implements LanceStorageProvider {
     }
 
     private static boolean hasSigningConfiguration(Map<String, String> options) {
-        return StringUtils.isNotEmpty(options.get(ACCESS_KEY_ID))
-                || StringUtils.isNotEmpty(options.get(ROLE_ARN))
-                || StringUtils.isNotEmpty(options.get(OIDC_TOKEN))
-                || StringUtils.isNotEmpty(options.get(OIDC_PROVIDER_ARN))
-                || StringUtils.isNotEmpty(options.get(OIDC_TOKEN_FILE));
+        return StringUtils.isNotEmpty(options.get(ACCESS_KEY_ID));
     }
 
     private static OSSProperties selectOss(List<StorageProperties> storageProperties) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LancePassThroughStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LancePassThroughStorageProvider.java
@@ -59,6 +59,12 @@ final class LancePassThroughStorageProvider implements LanceStorageProvider {
     }
 
     @Override
+    public void reconcileVendedStorageOptions(Map<String, String> merged,
+            Map<String, String> normalizedVended) {
+        // No vocabulary of its own, so no way to tell which keys form a credential.
+    }
+
+    @Override
     public Map<String, String> inferStorageOptions(Map<String, String> effectiveOptions) {
         return Collections.emptyMap();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LancePassThroughStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LancePassThroughStorageProvider.java
@@ -33,8 +33,8 @@ import java.util.Map;
  * {@code endpoint} and takes {@code token} as a bearer token. Rewriting either onto the S3
  * spellings would leave the dataset unreachable, which is what this class exists to prevent.
  *
- * <p>{@link #fromDorisProperties} is empty for want of a translation, not for want of input: Doris
- * does model these - {@code COSProperties} carries an endpoint and
+ * <p>{@link #normalizeDorisStorageOptions} is empty for want of a translation, not for want of
+ * input: Doris does model these - {@code COSProperties} carries an endpoint and
  * credentials like any other. Writing that translation means committing to a vocabulary per
  * provider with no way to exercise it here, which is how the rewriting bug above got in, so it
  * waits for a backend that can be tested against.
@@ -47,12 +47,19 @@ final class LancePassThroughStorageProvider implements LanceStorageProvider {
     }
 
     @Override
-    public Map<String, String> fromDorisProperties(List<StorageProperties> storageProperties) {
+    public Map<String, String> normalizeDorisStorageOptions(
+            List<StorageProperties> storageProperties) {
         return Collections.emptyMap();
     }
 
     @Override
-    public Map<String, String> normalizeVended(Map<String, String> vendedOptions) {
+    public Map<String, String> normalizeVendedStorageOptions(
+            Map<String, String> vendedOptions) {
         return vendedOptions == null ? new HashMap<>() : new HashMap<>(vendedOptions);
+    }
+
+    @Override
+    public Map<String, String> inferStorageOptions(Map<String, String> effectiveOptions) {
+        return Collections.emptyMap();
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LancePassThroughStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LancePassThroughStorageProvider.java
@@ -25,17 +25,16 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Every provider Lance routes somewhere other than S3 - Azure, GCS, OSS, Tencent COS, local files,
+ * Every provider Lance routes somewhere other than S3 or OSS - Azure, GCS, Tencent COS, local files,
  * and anything Lance adds later.
  *
  * <p>Both halves are deliberately inert, so such a dataset is reachable only through what its
- * namespace vends. Those options are the namespace's to name: Lance's OSS provider reads
- * {@code access_key_id} and requires {@code endpoint}, object_store's Azure parser reads
- * {@code endpoint} and takes {@code token} as a bearer token. Rewriting any of that onto the S3
+ * namespace vends. Those options are the namespace's to name: object_store's Azure parser reads
+ * {@code endpoint} and takes {@code token} as a bearer token. Rewriting either onto the S3
  * spellings would leave the dataset unreachable, which is what this class exists to prevent.
  *
  * <p>{@link #fromDorisProperties} is empty for want of a translation, not for want of input: Doris
- * does model these - {@code OSSProperties} and {@code COSProperties} carry an endpoint and
+ * does model these - {@code COSProperties} carries an endpoint and
  * credentials like any other. Writing that translation means committing to a vocabulary per
  * provider with no way to exercise it here, which is how the rewriting bug above got in, so it
  * waits for a backend that can be tested against.

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LancePassThroughStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LancePassThroughStorageProvider.java
@@ -59,12 +59,6 @@ final class LancePassThroughStorageProvider implements LanceStorageProvider {
     }
 
     @Override
-    public void reconcileVendedStorageOptions(Map<String, String> merged,
-            Map<String, String> normalizedVended) {
-        // No vocabulary of its own, so no way to tell which keys form a credential.
-    }
-
-    @Override
     public Map<String, String> inferStorageOptions(Map<String, String> effectiveOptions) {
         return Collections.emptyMap();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceS3StorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceS3StorageProvider.java
@@ -182,6 +182,14 @@ final class LanceS3StorageProvider implements LanceStorageProvider {
     }
 
     @Override
+    public void reconcileVendedStorageOptions(Map<String, String> merged,
+            Map<String, String> normalizedVended) {
+        // S3 authentication has the same coupling as OSS - a vended pair should replace the
+        // catalog's whole, rather than half-merging with it - but that predates OSS support and is
+        // tracked with the rest of #66805, so this stays a no-op until it can be tested against.
+    }
+
+    @Override
     public Map<String, String> inferStorageOptions(Map<String, String> effectiveOptions) {
         Map<String, String> inferred = new HashMap<>();
         if (effectiveOptions.containsKey(ALLOW_HTTP)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceS3StorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceS3StorageProvider.java
@@ -108,7 +108,8 @@ final class LanceS3StorageProvider implements LanceStorageProvider {
     }
 
     @Override
-    public Map<String, String> fromDorisProperties(List<StorageProperties> storageProperties) {
+    public Map<String, String> normalizeDorisStorageOptions(
+            List<StorageProperties> storageProperties) {
         Map<String, String> result = new HashMap<>();
         AbstractS3CompatibleProperties properties = selectS3Compatible(storageProperties);
         if (properties == null) {
@@ -125,12 +126,6 @@ final class LanceS3StorageProvider implements LanceStorageProvider {
             result.put(VIRTUAL_HOSTED_STYLE, String.valueOf(!Boolean.parseBoolean(usePathStyle)));
         }
 
-        // Lance refuses a plain-HTTP endpoint unless this is set, and Doris configures one for
-        // MinIO. It describes the endpoint just mapped, so it is derived from the same properties.
-        String endpoint = properties.getEndpoint();
-        if (endpoint != null && endpoint.startsWith("http://")) {
-            result.put(ALLOW_HTTP, "true");
-        }
         return result;
     }
 
@@ -166,7 +161,8 @@ final class LanceS3StorageProvider implements LanceStorageProvider {
     }
 
     @Override
-    public Map<String, String> normalizeVended(Map<String, String> vendedOptions) {
+    public Map<String, String> normalizeVendedStorageOptions(
+            Map<String, String> vendedOptions) {
         Map<String, String> result = new HashMap<>();
         if (vendedOptions == null) {
             return result;
@@ -183,6 +179,20 @@ final class LanceS3StorageProvider implements LanceStorageProvider {
             }
         });
         return result;
+    }
+
+    @Override
+    public Map<String, String> inferStorageOptions(Map<String, String> effectiveOptions) {
+        Map<String, String> inferred = new HashMap<>();
+        if (effectiveOptions.containsKey(ALLOW_HTTP)) {
+            return inferred;
+        }
+        String endpoint = effectiveOptions.get(ENDPOINT);
+        if (endpoint != null && endpoint.startsWith("http://")) {
+            // object_store rejects a plain-HTTP endpoint unless this client option is enabled.
+            inferred.put(ALLOW_HTTP, "true");
+        }
+        return inferred;
     }
 
     private static void putIfNotEmpty(Map<String, String> target, String key, String value) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceS3StorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceS3StorageProvider.java
@@ -182,14 +182,6 @@ final class LanceS3StorageProvider implements LanceStorageProvider {
     }
 
     @Override
-    public void reconcileVendedStorageOptions(Map<String, String> merged,
-            Map<String, String> normalizedVended) {
-        // S3 authentication has the same coupling as OSS - a vended pair should replace the
-        // catalog's whole, rather than half-merging with it - but that predates OSS support and is
-        // tracked with the rest of #66805, so this stays a no-op until it can be tested against.
-    }
-
-    @Override
     public Map<String, String> inferStorageOptions(Map<String, String> effectiveOptions) {
         Map<String, String> inferred = new HashMap<>();
         if (effectiveOptions.containsKey(ALLOW_HTTP)) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageOptions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageOptions.java
@@ -46,12 +46,9 @@ public final class LanceStorageOptions {
      * <p>Used wherever no namespace is involved: the storage a namespace client reads itself, and
      * the {@code s3()} table-valued function.
      */
-    public static Map<String, String> forUri(String uri, List<StorageProperties> storageProperties) {
-        Map<String, String> result = new HashMap<>(
-                LanceStorageProvider.forDataset(uri).fromDorisProperties(storageProperties));
-        result.forEach((key, value) -> rejectUntransportable(key, value,
-                "Doris storage configuration"));
-        return result;
+    public static Map<String, String> fromDorisStorageProperties(
+            String uri, List<StorageProperties> storageProperties) {
+        return buildStorageOptions(uri, storageProperties, null);
     }
 
     /**
@@ -63,28 +60,39 @@ public final class LanceStorageOptions {
      * whichever its HashMap yields last - independently in the FE and in the BE.
      *
      * <p>{@code vendedOptions} may be null or empty; a namespace that describes a table without
-     * vending storage options is ordinary, and this then degenerates to {@link #forUri}.
+     * vending storage options is ordinary, and this then degenerates to
+     * {@link #fromDorisStorageProperties}.
      */
-    public static Map<String, String> forVendedTable(String datasetUri,
+    public static Map<String, String> fromDorisAndVendedStorageOptions(String datasetUri,
             List<StorageProperties> storageProperties, Map<String, String> vendedOptions) {
-        Map<String, String> result = forUri(datasetUri, storageProperties);
-        if (vendedOptions == null || vendedOptions.isEmpty()) {
-            return result;
-        }
-        vendedOptions.forEach(LanceStorageOptions::validateVendedOption);
-        // Safe to validate the vended half before normalizing: normalizeVended only ever renames a
-        // key to one of this class's own constants or passes it through unchanged, so it cannot
-        // introduce a NUL that the check above would have missed.
+        return buildStorageOptions(datasetUri, storageProperties, vendedOptions);
+    }
+
+    private static Map<String, String> buildStorageOptions(String datasetUri,
+            List<StorageProperties> storageProperties, Map<String, String> vendedOptions) {
         LanceStorageProvider provider = LanceStorageProvider.forDataset(datasetUri);
-        Map<String, String> normalizedVended = provider.normalizeVended(vendedOptions);
+        Map<String, String> result = new HashMap<>(
+                provider.normalizeDorisStorageOptions(storageProperties));
+        result.forEach((key, value) -> rejectUntransportable(key, value,
+                "Doris storage configuration"));
+        Map<String, String> normalizedVended = new HashMap<>();
+        if (vendedOptions != null && !vendedOptions.isEmpty()) {
+            vendedOptions.forEach(LanceStorageOptions::validateVendedOption);
+            // Safe to validate before normalizing: normalization only renames a key to a provider
+            // constant or passes it through, so it cannot introduce a NUL missed above.
+            normalizedVended = provider.normalizeVendedStorageOptions(vendedOptions);
+        }
         result.putAll(normalizedVended);
         // The overlay above is key by key, which can leave OSS's authentication options - a key
-        // pair, its token, and the flag saying there is no pair - disagreeing with one another.
+        // pair, its token, and the signing choice - disagreeing with one another.
         // Only OSS couples its options this way, so this is a direct call rather than a hook on
         // LanceStorageProvider that one implementation would honour and the others ignore.
         if (provider instanceof LanceOssStorageProvider) {
             LanceOssStorageProvider.reconcileAuth(result, normalizedVended);
         }
+        provider.inferStorageOptions(result).forEach(result::putIfAbsent);
+        result.forEach((key, value) -> rejectUntransportable(key, value,
+                "Lance storage configuration"));
         return result;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageOptions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageOptions.java
@@ -75,7 +75,16 @@ public final class LanceStorageOptions {
         // Safe to validate the vended half before normalizing: normalizeVended only ever renames a
         // key to one of this class's own constants or passes it through unchanged, so it cannot
         // introduce a NUL that the check above would have missed.
-        result.putAll(LanceStorageProvider.forDataset(datasetUri).normalizeVended(vendedOptions));
+        LanceStorageProvider provider = LanceStorageProvider.forDataset(datasetUri);
+        Map<String, String> normalizedVended = provider.normalizeVended(vendedOptions);
+        result.putAll(normalizedVended);
+        // The overlay above is key by key, which can leave OSS's authentication options - a key
+        // pair, its token, and the flag saying there is no pair - disagreeing with one another.
+        // Only OSS couples its options this way, so this is a direct call rather than a hook on
+        // LanceStorageProvider that one implementation would honour and the others ignore.
+        if (provider instanceof LanceOssStorageProvider) {
+            LanceOssStorageProvider.reconcileAuth(result, normalizedVended);
+        }
         return result;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageOptions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageOptions.java
@@ -83,13 +83,7 @@ public final class LanceStorageOptions {
             normalizedVended = provider.normalizeVendedStorageOptions(vendedOptions);
         }
         result.putAll(normalizedVended);
-        // The overlay above is key by key, which can leave OSS's authentication options - a key
-        // pair, its token, and the signing choice - disagreeing with one another.
-        // Only OSS couples its options this way, so this is a direct call rather than a hook on
-        // LanceStorageProvider that one implementation would honour and the others ignore.
-        if (provider instanceof LanceOssStorageProvider) {
-            LanceOssStorageProvider.reconcileAuth(result, normalizedVended);
-        }
+        provider.reconcileVendedStorageOptions(result, normalizedVended);
         provider.inferStorageOptions(result).forEach(result::putIfAbsent);
         result.forEach((key, value) -> rejectUntransportable(key, value,
                 "Lance storage configuration"));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageOptions.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageOptions.java
@@ -83,7 +83,6 @@ public final class LanceStorageOptions {
             normalizedVended = provider.normalizeVendedStorageOptions(vendedOptions);
         }
         result.putAll(normalizedVended);
-        provider.reconcileVendedStorageOptions(result, normalizedVended);
         provider.inferStorageOptions(result).forEach(result::putIfAbsent);
         result.forEach((key, value) -> rejectUntransportable(key, value,
                 "Lance storage configuration"));

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageProvider.java
@@ -68,6 +68,7 @@ public interface LanceStorageProvider {
      */
     Map<String, String> normalizeVended(Map<String, String> vendedOptions);
 
+
     /** The provider Lance will route this dataset to. */
     static LanceStorageProvider forDataset(String datasetUri) {
         String scheme = schemeOf(datasetUri);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageProvider.java
@@ -70,6 +70,21 @@ public interface LanceStorageProvider {
     Map<String, String> normalizeVendedStorageOptions(Map<String, String> vendedOptions);
 
     /**
+     * Settles options that only mean anything together, once the vended half has been laid over
+     * the catalog's.
+     *
+     * <p>That overlay is key by key, which is wrong for a group like a credential: a key pair, the
+     * token issued for that pair, and any role or identity binding standing in for them. Merged
+     * independently they can pair one side's access key with the other's secret, or leave a token
+     * attached to a pair it was never issued for, and the stores below second-guess neither.
+     *
+     * <p>Empty for a provider whose options carry no such coupling, or which has no vocabulary of
+     * its own to recognize one by.
+     */
+    void reconcileVendedStorageOptions(Map<String, String> merged,
+            Map<String, String> normalizedVended);
+
+    /**
      * Derives provider options from the fully normalized and merged option map.
      *
      * <p>The returned entries are defaults: an explicitly supplied option always wins. Inference

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageProvider.java
@@ -52,8 +52,8 @@ public interface LanceStorageProvider {
      * and flattens every configured storage into one namespace where two S3-compatible ones would
      * silently overwrite each other.
      *
-     * <p>Empty when the list holds nothing this provider can read, which is every provider but S3
-     * today - those datasets are reachable only through what a namespace vends.
+     * <p>Empty when the list holds nothing this provider can read. Providers without a Doris
+     * adapter are reachable only through what a namespace vends.
      */
     Map<String, String> fromDorisProperties(List<StorageProperties> storageProperties);
 
@@ -70,8 +70,14 @@ public interface LanceStorageProvider {
 
     /** The provider Lance will route this dataset to. */
     static LanceStorageProvider forDataset(String datasetUri) {
-        return S3_SCHEMES.contains(schemeOf(datasetUri))
-                ? LanceS3StorageProvider.INSTANCE : LancePassThroughStorageProvider.INSTANCE;
+        String scheme = schemeOf(datasetUri);
+        if (S3_SCHEMES.contains(scheme)) {
+            return LanceS3StorageProvider.INSTANCE;
+        }
+        if ("oss".equals(scheme)) {
+            return LanceOssStorageProvider.INSTANCE;
+        }
+        return LancePassThroughStorageProvider.INSTANCE;
     }
 
     static String schemeOf(String datasetUri) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageProvider.java
@@ -55,19 +55,27 @@ public interface LanceStorageProvider {
      * <p>Empty when the list holds nothing this provider can read. Providers without a Doris
      * adapter are reachable only through what a namespace vends.
      */
-    Map<String, String> fromDorisProperties(List<StorageProperties> storageProperties);
+    Map<String, String> normalizeDorisStorageOptions(List<StorageProperties> storageProperties);
 
     /**
-     * Rewrites the options a namespace vended onto the spelling {@link #fromDorisProperties}
-     * emits, so that the two cannot reach Lance as competing entries for one config key.
+     * Rewrites the options a namespace vended onto the spelling
+     * {@link #normalizeDorisStorageOptions} emits, so that the two cannot reach Lance as competing
+     * entries for one config key.
      *
      * <p>Only the options Doris itself emits are rewritten. Everything else is passed through
      * untouched: the Lance Namespace specification describes {@code storage_options} as
      * configuration "passed directly to Lance", so a client cannot assume a vocabulary beyond the
      * one it contributes to itself.
      */
-    Map<String, String> normalizeVended(Map<String, String> vendedOptions);
+    Map<String, String> normalizeVendedStorageOptions(Map<String, String> vendedOptions);
 
+    /**
+     * Derives provider options from the fully normalized and merged option map.
+     *
+     * <p>The returned entries are defaults: an explicitly supplied option always wins. Inference
+     * therefore runs only after catalog and namespace options have been reconciled.
+     */
+    Map<String, String> inferStorageOptions(Map<String, String> effectiveOptions);
 
     /** The provider Lance will route this dataset to. */
     static LanceStorageProvider forDataset(String datasetUri) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/lance/LanceStorageProvider.java
@@ -70,21 +70,6 @@ public interface LanceStorageProvider {
     Map<String, String> normalizeVendedStorageOptions(Map<String, String> vendedOptions);
 
     /**
-     * Settles options that only mean anything together, once the vended half has been laid over
-     * the catalog's.
-     *
-     * <p>That overlay is key by key, which is wrong for a group like a credential: a key pair, the
-     * token issued for that pair, and any role or identity binding standing in for them. Merged
-     * independently they can pair one side's access key with the other's secret, or leave a token
-     * attached to a pair it was never issued for, and the stores below second-guess neither.
-     *
-     * <p>Empty for a provider whose options carry no such coupling, or which has no vocabulary of
-     * its own to recognize one by.
-     */
-    void reconcileVendedStorageOptions(Map<String, String> merged,
-            Map<String, String> normalizedVended);
-
-    /**
      * Derives provider options from the fully normalized and merged option map.
      *
      * <p>The returned entries are defaults: an explicitly supplied option always wins. Inference

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/LanceFileSystemMetastoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/LanceFileSystemMetastoreProperties.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.datasource.property.metastore;
 
+import org.apache.doris.datasource.property.storage.OSSProperties;
 import org.apache.doris.foundation.property.ConnectorProperty;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -77,6 +78,7 @@ public class LanceFileSystemMetastoreProperties extends AbstractLanceProperties 
             throw new IllegalArgumentException(
                     "Missing required property 'warehouse' for Lance filesystem catalog");
         }
+        warehouse = normalizeWarehouse(warehouse);
         validateWarehouse(warehouse);
         for (String key : origProps.keySet()) {
             if (key.startsWith("lance.rest.")) {
@@ -106,5 +108,35 @@ public class LanceFileSystemMetastoreProperties extends AbstractLanceProperties 
             throw new IllegalArgumentException("Unsupported Lance filesystem warehouse scheme '" + scheme
                     + "'; supported schemes are local/file, s3, and oss");
         }
+        // An object-store root names its bucket in the authority. Lance reads that authority as the
+        // bucket and fails deep inside the store when it is absent, so reject the no-authority form
+        // here where the message can still name the property.
+        if (("s3".equals(scheme) || "oss".equals(scheme)) && StringUtils.isBlank(uri.getAuthority())) {
+            throw new IllegalArgumentException(
+                    "Lance " + scheme + " warehouse must name a bucket, as in " + scheme
+                            + "://bucket/path, but was: " + warehouse);
+        }
+    }
+
+    /**
+     * Doris accepts an OSS URL that spells out the endpoint in its authority and normalizes it to
+     * the bare bucket. Lance takes the authority as the bucket verbatim, so a warehouse left in the
+     * qualified form would address {@code bucket.oss-<region>.aliyuncs.com.<endpoint>}. Apply the
+     * same normalization Doris applies elsewhere before the root reaches the namespace.
+     */
+    private static String normalizeWarehouse(String warehouse) {
+        if (StringUtils.isBlank(warehouse)) {
+            return warehouse;
+        }
+        URI uri;
+        try {
+            uri = URI.create(warehouse);
+        } catch (IllegalArgumentException e) {
+            return warehouse;
+        }
+        if (uri.getScheme() == null || !"oss".equals(uri.getScheme().toLowerCase(Locale.ROOT))) {
+            return warehouse;
+        }
+        return OSSProperties.rewriteOssBucketIfNecessary(warehouse);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/LanceFileSystemMetastoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/LanceFileSystemMetastoreProperties.java
@@ -79,8 +79,11 @@ public class LanceFileSystemMetastoreProperties extends AbstractLanceProperties 
             throw new IllegalArgumentException(
                     "Missing required property 'warehouse' for Lance filesystem catalog");
         }
-        warehouse = normalizeWarehouse(warehouse);
+        rejectOssHdfs();
+        // Validate before normalizing: the rewrite collapses the authority at its first dot, which
+        // would strip the very marker that identifies an OSS-HDFS root.
         validateWarehouse(warehouse);
+        warehouse = normalizeWarehouse(warehouse);
         for (String key : origProps.keySet()) {
             if (key.startsWith("lance.rest.")) {
                 throw new IllegalArgumentException(
@@ -120,6 +123,28 @@ public class LanceFileSystemMetastoreProperties extends AbstractLanceProperties 
     }
 
     /**
+     * Doris routes an OSS-HDFS configuration to {@code OSSHdfsProperties}, which the Lance OSS
+     * provider cannot read - it accepts only {@code OSSProperties} - so the namespace would be
+     * handed no endpoint and no credentials and could not open at all.
+     *
+     * <p>Checks every property rather than only the warehouse: {@code OSSHdfsProperties.guessIsMe}
+     * selects on the endpoint, so {@code oss://bucket/path} with an {@code oss.endpoint} ending in
+     * the OSS-HDFS suffix routes there just the same, with a clean-looking warehouse.
+     */
+    private void rejectOssHdfs() {
+        for (Map.Entry<String, String> property : origProps.entrySet()) {
+            String value = property.getValue();
+            if (value != null && value.toLowerCase(Locale.ROOT).contains(OSS_HDFS_MARKER)) {
+                throw new IllegalArgumentException(
+                        "OSS-HDFS is not supported by the Lance catalog, but '"
+                                + property.getKey() + "' names it. Doris reads this form through "
+                                + "its HDFS-compatible properties, which carry no Lance OSS "
+                                + "storage options.");
+            }
+        }
+    }
+
+    /**
      * Doris accepts an OSS URL that spells out the endpoint in its authority and normalizes it to
      * the bare bucket. Lance takes the authority as the bucket verbatim, so a warehouse left in the
      * qualified form would address {@code bucket.oss-<region>.aliyuncs.com.<endpoint>}. Apply the
@@ -136,12 +161,6 @@ public class LanceFileSystemMetastoreProperties extends AbstractLanceProperties 
             return warehouse;
         }
         if (uri.getScheme() == null || !"oss".equals(uri.getScheme().toLowerCase(Locale.ROOT))) {
-            return warehouse;
-        }
-        // OSS-HDFS is the one oss:// form whose qualified authority is the required spelling -
-        // OSSHdfsProperties validates such a URL without ever rewriting it - so leave it alone.
-        String authority = uri.getAuthority();
-        if (authority != null && authority.toLowerCase(Locale.ROOT).contains(OSS_HDFS_MARKER)) {
             return warehouse;
         }
         return OSSProperties.rewriteOssBucketIfNecessary(warehouse);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/LanceFileSystemMetastoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/LanceFileSystemMetastoreProperties.java
@@ -37,7 +37,7 @@ public class LanceFileSystemMetastoreProperties extends AbstractLanceProperties 
     @ConnectorProperty(
             names = {WAREHOUSE},
             required = false,
-            description = "The local, file, or S3 warehouse containing Lance datasets."
+            description = "The local, file, S3, or OSS warehouse containing Lance datasets."
     )
     private String warehouse;
 
@@ -102,9 +102,9 @@ public class LanceFileSystemMetastoreProperties extends AbstractLanceProperties 
             return;
         }
         String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
-        if (!"file".equals(scheme) && !"s3".equals(scheme)) {
+        if (!"file".equals(scheme) && !"s3".equals(scheme) && !"oss".equals(scheme)) {
             throw new IllegalArgumentException("Unsupported Lance filesystem warehouse scheme '" + scheme
-                    + "'; first phase supports local/file and s3");
+                    + "'; supported schemes are local/file, s3, and oss");
         }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/LanceFileSystemMetastoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/LanceFileSystemMetastoreProperties.java
@@ -34,6 +34,7 @@ import java.util.Map;
 /** Properties for a Lance directory namespace backed by a filesystem warehouse. */
 public class LanceFileSystemMetastoreProperties extends AbstractLanceProperties {
     public static final String WAREHOUSE = "warehouse";
+    private static final String OSS_HDFS_MARKER = ".oss-dls.aliyuncs.com";
 
     @ConnectorProperty(
             names = {WAREHOUSE},
@@ -135,6 +136,12 @@ public class LanceFileSystemMetastoreProperties extends AbstractLanceProperties 
             return warehouse;
         }
         if (uri.getScheme() == null || !"oss".equals(uri.getScheme().toLowerCase(Locale.ROOT))) {
+            return warehouse;
+        }
+        // OSS-HDFS is the one oss:// form whose qualified authority is the required spelling -
+        // OSSHdfsProperties validates such a URL without ever rewriting it - so leave it alone.
+        String authority = uri.getAuthority();
+        if (authority != null && authority.toLowerCase(Locale.ROOT).contains(OSS_HDFS_MARKER)) {
             return warehouse;
         }
         return OSSProperties.rewriteOssBucketIfNecessary(warehouse);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/LanceFileSystemMetastoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/LanceFileSystemMetastoreProperties.java
@@ -17,7 +17,6 @@
 
 package org.apache.doris.datasource.property.metastore;
 
-import org.apache.doris.datasource.property.storage.OSSProperties;
 import org.apache.doris.foundation.property.ConnectorProperty;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -80,10 +79,7 @@ public class LanceFileSystemMetastoreProperties extends AbstractLanceProperties 
                     "Missing required property 'warehouse' for Lance filesystem catalog");
         }
         rejectOssHdfs();
-        // Validate before normalizing: the rewrite collapses the authority at its first dot, which
-        // would strip the very marker that identifies an OSS-HDFS root.
         validateWarehouse(warehouse);
-        warehouse = normalizeWarehouse(warehouse);
         for (String key : origProps.keySet()) {
             if (key.startsWith("lance.rest.")) {
                 throw new IllegalArgumentException(
@@ -144,25 +140,4 @@ public class LanceFileSystemMetastoreProperties extends AbstractLanceProperties 
         }
     }
 
-    /**
-     * Doris accepts an OSS URL that spells out the endpoint in its authority and normalizes it to
-     * the bare bucket. Lance takes the authority as the bucket verbatim, so a warehouse left in the
-     * qualified form would address {@code bucket.oss-<region>.aliyuncs.com.<endpoint>}. Apply the
-     * same normalization Doris applies elsewhere before the root reaches the namespace.
-     */
-    private static String normalizeWarehouse(String warehouse) {
-        if (StringUtils.isBlank(warehouse)) {
-            return warehouse;
-        }
-        URI uri;
-        try {
-            uri = URI.create(warehouse);
-        } catch (IllegalArgumentException e) {
-            return warehouse;
-        }
-        if (uri.getScheme() == null || !"oss".equals(uri.getScheme().toLowerCase(Locale.ROOT))) {
-            return warehouse;
-        }
-        return OSSProperties.rewriteOssBucketIfNecessary(warehouse);
-    }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/LanceFileSystemMetastoreProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/metastore/LanceFileSystemMetastoreProperties.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.datasource.property.metastore;
 
+import org.apache.doris.datasource.property.storage.OSSHdfsProperties;
 import org.apache.doris.foundation.property.ConnectorProperty;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -33,7 +34,6 @@ import java.util.Map;
 /** Properties for a Lance directory namespace backed by a filesystem warehouse. */
 public class LanceFileSystemMetastoreProperties extends AbstractLanceProperties {
     public static final String WAREHOUSE = "warehouse";
-    private static final String OSS_HDFS_MARKER = ".oss-dls.aliyuncs.com";
 
     @ConnectorProperty(
             names = {WAREHOUSE},
@@ -128,15 +128,11 @@ public class LanceFileSystemMetastoreProperties extends AbstractLanceProperties 
      * the OSS-HDFS suffix routes there just the same, with a clean-looking warehouse.
      */
     private void rejectOssHdfs() {
-        for (Map.Entry<String, String> property : origProps.entrySet()) {
-            String value = property.getValue();
-            if (value != null && value.toLowerCase(Locale.ROOT).contains(OSS_HDFS_MARKER)) {
-                throw new IllegalArgumentException(
-                        "OSS-HDFS is not supported by the Lance catalog, but '"
-                                + property.getKey() + "' names it. Doris reads this form through "
-                                + "its HDFS-compatible properties, which carry no Lance OSS "
-                                + "storage options.");
-            }
+        if (OSSHdfsProperties.guessIsMe(origProps)) {
+            throw new IllegalArgumentException(
+                    "OSS-HDFS is not supported by the Lance catalog. Doris reads this form through "
+                            + "its HDFS-compatible properties, which carry no Lance OSS storage "
+                            + "options.");
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
@@ -21,7 +21,6 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.foundation.property.ConnectorPropertiesUtils;
 import org.apache.doris.foundation.property.ConnectorProperty;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import lombok.Getter;
 import lombok.Setter;
@@ -344,13 +343,6 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
      *
      * @param uri the original URI string
      * @return the rewritten URI string, or the original URI if no rewrite is needed
-     */
-    @VisibleForTesting
-    /**
-     * Collapses the qualified {@code oss://bucket.oss-<region>.aliyuncs.com/path} form Doris
-     * accepts down to {@code oss://bucket/path}. Public so that callers outside this package
-     * which take an OSS URL before any {@link OSSProperties} instance exists - the Lance
-     * directory namespace root, for one - can apply the same contract.
      */
     public static String rewriteOssBucketIfNecessary(String uri) {
         if (uri == null || uri.isEmpty()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
@@ -346,7 +346,13 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
      * @return the rewritten URI string, or the original URI if no rewrite is needed
      */
     @VisibleForTesting
-    protected static String rewriteOssBucketIfNecessary(String uri) {
+    /**
+     * Collapses the qualified {@code oss://bucket.oss-<region>.aliyuncs.com/path} form Doris
+     * accepts down to {@code oss://bucket/path}. Public so that callers outside this package
+     * which take an OSS URL before any {@link OSSProperties} instance exists - the Lance
+     * directory namespace root, for one - can apply the same contract.
+     */
+    public static String rewriteOssBucketIfNecessary(String uri) {
         if (uri == null || uri.isEmpty()) {
             return uri;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/storage/OSSProperties.java
@@ -21,6 +21,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.foundation.property.ConnectorPropertiesUtils;
 import org.apache.doris.foundation.property.ConnectorProperty;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import lombok.Getter;
 import lombok.Setter;
@@ -344,7 +345,8 @@ public class OSSProperties extends AbstractS3CompatibleProperties {
      * @param uri the original URI string
      * @return the rewritten URI string, or the original URI if no rewrite is needed
      */
-    public static String rewriteOssBucketIfNecessary(String uri) {
+    @VisibleForTesting
+    protected static String rewriteOssBucketIfNecessary(String uri) {
         if (uri == null || uri.isEmpty()) {
             return uri;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/tvf/source/TVFScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/tvf/source/TVFScanNode.java
@@ -133,7 +133,7 @@ public class TVFScanNode extends FileQueryScanNode {
         if (tableValuedFunction.isLanceFormat()) {
             // lance-c opens the dataset itself and needs the options in Lance's own vocabulary.
             // Set at ScanNode level so credentials are not serialized once per fragment split.
-            Map<String, String> lanceStorageOptions = LanceStorageOptions.forUri(
+            Map<String, String> lanceStorageOptions = LanceStorageOptions.fromDorisStorageProperties(
                     tableValuedFunction.getFilePath(),
                     Collections.singletonList(tableValuedFunction.getStorageProperties()));
             if (!lanceStorageOptions.isEmpty()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/ExternalFileTableValuedFunction.java
@@ -539,7 +539,7 @@ public abstract class ExternalFileTableValuedFunction extends TableValuedFunctio
         fileScanRangeParams.setProperties(beProperties);
         if (fileFormatProperties.getFileFormatType() == TFileFormatType.FORMAT_LANCE) {
             // lance-c opens the dataset itself and needs the options in Lance's own vocabulary.
-            Map<String, String> lanceStorageOptions = LanceStorageOptions.forUri(
+            Map<String, String> lanceStorageOptions = LanceStorageOptions.fromDorisStorageProperties(
                     filePath, Collections.singletonList(storageProperties));
             if (!lanceStorageOptions.isEmpty()) {
                 fileScanRangeParams.setLanceScanParams(

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceFilesystemCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceFilesystemCatalogTest.java
@@ -146,6 +146,9 @@ public class LanceFilesystemCatalogTest {
         String accessKey = "sentinel-access-key";
         String secretKey = "sentinel-secret-key";
         String sessionToken = "sentinel-session-token";
+        String ossAccessKey = "sentinel-oss-access-key";
+        String ossSecretKey = "sentinel-oss-secret-key";
+        String ossSecurityToken = "sentinel-oss-security-token";
         String datasetUri = "s3://sentinel-user:sentinel-password@bucket/private/table.lance";
 
         Map<String, String> catalogProperties = new HashMap<>();
@@ -158,9 +161,14 @@ public class LanceFilesystemCatalogTest {
         runtimeStorageOptions.put("aws_access_key_id", accessKey);
         runtimeStorageOptions.put("aws_secret_access_key", secretKey);
         runtimeStorageOptions.put("aws_session_token", sessionToken);
+        runtimeStorageOptions.put("oss_access_key_id", ossAccessKey);
+        runtimeStorageOptions.put("oss_secret_access_key", ossSecretKey);
+        runtimeStorageOptions.put("oss_security_token", ossSecurityToken);
         String providerMessage = "provider failure\nuri=" + datasetUri
                 + " bearer=" + bearerToken + " api-key=" + apiKey
-                + " access=" + accessKey + " secret=" + secretKey + " session=" + sessionToken;
+                + " access=" + accessKey + " secret=" + secretKey + " session=" + sessionToken
+                + " oss-access=" + ossAccessKey + " oss-secret=" + ossSecretKey
+                + " oss-token=" + ossSecurityToken;
 
         RuntimeException providerFailure = new RuntimeException(providerMessage);
         RuntimeException exposed = catalog.indexMetadataLoadFailure(
@@ -169,7 +177,7 @@ public class LanceFilesystemCatalogTest {
         exposed.printStackTrace(new PrintWriter(stackTrace));
 
         for (String sentinel : Arrays.asList(bearerToken, apiKey, accessKey, secretKey,
-                sessionToken, datasetUri)) {
+                sessionToken, ossAccessKey, ossSecretKey, ossSecurityToken, datasetUri)) {
             Assert.assertFalse(exposed.getMessage().contains(sentinel));
             Assert.assertFalse(exposed.getCause().getMessage().contains(sentinel));
             Assert.assertFalse(stackTrace.toString().contains(sentinel));

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceFilesystemCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceFilesystemCatalogTest.java
@@ -410,30 +410,4 @@ public class LanceFilesystemCatalogTest {
             Assert.assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
         }
     }
-
-    /**
-     * Lance also accepts a storage option scoped to one base, so a secret can arrive spelled
-     * base_0.oss_secret_access_key. An exact-key lookup would walk straight past it.
-     */
-    @Test
-    public void testBaseScopedOssSecretsAreRedacted() {
-        String scopedSecret = "sentinel-base-scoped-secret";
-        String scopedToken = "sentinel-base-scoped-token";
-        LanceExternalCatalog catalog = new LanceExternalCatalog(
-                1, "lance_filesystem", null, new HashMap<>(), "");
-
-        Map<String, String> runtimeStorageOptions = new HashMap<>();
-        runtimeStorageOptions.put("base_0.oss_secret_access_key", scopedSecret);
-        runtimeStorageOptions.put("base_1.oss_security_token", scopedToken);
-
-        RuntimeException exposed = catalog.indexMetadataLoadFailure("db", "table",
-                new RuntimeException("provider failure secret=" + scopedSecret
-                        + " token=" + scopedToken),
-                "oss://bucket/table.lance", runtimeStorageOptions);
-
-        for (String sentinel : Arrays.asList(scopedSecret, scopedToken)) {
-            Assert.assertFalse(exposed.getMessage().contains(sentinel));
-            Assert.assertFalse(exposed.getCause().getMessage().contains(sentinel));
-        }
-    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceFilesystemCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceFilesystemCatalogTest.java
@@ -410,4 +410,30 @@ public class LanceFilesystemCatalogTest {
             Assert.assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
         }
     }
+
+    /**
+     * Lance also accepts a storage option scoped to one base, so a secret can arrive spelled
+     * base_0.oss_secret_access_key. An exact-key lookup would walk straight past it.
+     */
+    @Test
+    public void testBaseScopedOssSecretsAreRedacted() {
+        String scopedSecret = "sentinel-base-scoped-secret";
+        String scopedToken = "sentinel-base-scoped-token";
+        LanceExternalCatalog catalog = new LanceExternalCatalog(
+                1, "lance_filesystem", null, new HashMap<>(), "");
+
+        Map<String, String> runtimeStorageOptions = new HashMap<>();
+        runtimeStorageOptions.put("base_0.oss_secret_access_key", scopedSecret);
+        runtimeStorageOptions.put("base_1.oss_security_token", scopedToken);
+
+        RuntimeException exposed = catalog.indexMetadataLoadFailure("db", "table",
+                new RuntimeException("provider failure secret=" + scopedSecret
+                        + " token=" + scopedToken),
+                "oss://bucket/table.lance", runtimeStorageOptions);
+
+        for (String sentinel : Arrays.asList(scopedSecret, scopedToken)) {
+            Assert.assertFalse(exposed.getMessage().contains(sentinel));
+            Assert.assertFalse(exposed.getCause().getMessage().contains(sentinel));
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
@@ -131,7 +131,7 @@ public class LanceStorageOptionsTest {
         Assertions.assertEquals(
                 new TreeSet<>(Arrays.asList("oss_endpoint", "oss_access_key_id",
                         "oss_secret_access_key", "oss_region", "oss_security_token",
-                        "addressing_style")),
+                        "addressing_style", "allow_anonymous")),
                 new TreeSet<>(options.keySet()));
     }
 
@@ -179,7 +179,10 @@ public class LanceStorageOptionsTest {
 
     @Test
     public void testOssAliasesCollapseAndConflictsAreRejected() {
+        // Carries a whole credential: a lone secret is a one-sided pair, which reconciliation
+        // now rejects on its own account, and that is not what this case is about.
         Map<String, String> agreeing = new HashMap<>();
+        agreeing.put("access_key_id", "ak");
         agreeing.put("access_key_secret", "same");
         agreeing.put("oss_secret_access_key", "same");
         Assertions.assertEquals("same", LanceStorageOptions.forVendedTable(
@@ -457,7 +460,7 @@ public class LanceStorageOptionsTest {
     public void testOssCredentialedModeDoesNotClaimAnonymous() {
         Map<String, String> options = LanceStorageOptions.forUri(OSS_URI, createAll(ossProperties()));
 
-        Assertions.assertNull(options.get("allow_anonymous"));
+        Assertions.assertEquals("false", options.get("allow_anonymous"));
     }
 
     /**
@@ -502,5 +505,164 @@ public class LanceStorageOptionsTest {
         Assertions.assertNotEquals(
                 options.containsKey("oss_access_key_id"), options.containsKey("allow_anonymous"),
                 "a credential and a claim of anonymity must never both be emitted");
+    }
+
+    /**
+     * The case that makes this matter: an anonymous catalog whose namespace vends real credentials.
+     * OpenDAL's OssCore::sign returns the request unsigned whenever allow_anonymous is set, no
+     * matter what credentials sit beside it, so leaving the flag on would silently unsign every
+     * FE metadata read and BE scan that the vended credentials were supposed to authorize.
+     */
+    @Test
+    public void testVendedOssCredentialsClearStaticAnonymousMode() {
+        Map<String, String> properties = ossProperties();
+        properties.remove("oss.access_key");
+        properties.remove("oss.secret_key");
+        Assertions.assertEquals("true",
+                LanceStorageOptions.forUri(OSS_URI, createAll(properties)).get("allow_anonymous"),
+                "precondition: the static half alone is anonymous");
+
+        Map<String, String> vended = new HashMap<>();
+        vended.put("access_key_id", "vended-ak");
+        vended.put("access_key_secret", "vended-sk");
+
+        Map<String, String> merged = LanceStorageOptions.forVendedTable(
+                OSS_URI, createAll(properties), vended);
+
+        // Stated false rather than removed: an absent key would let an exported
+        // OSS_ALLOW_ANONYMOUS put the flag back, which is the bug this guards.
+        Assertions.assertEquals("false", merged.get("allow_anonymous"));
+        Assertions.assertEquals("vended-ak", merged.get("oss_access_key_id"));
+        Assertions.assertEquals("vended-sk", merged.get("oss_secret_access_key"));
+    }
+
+    /**
+     * A vended key pair replaces the catalog's. A token from the static half belonged to the pair
+     * that was just replaced, and signing the new pair with it fails; drop it with its pair.
+     */
+    @Test
+    public void testVendedOssKeyPairDropsTheStaticToken() {
+        Map<String, String> properties = ossProperties();
+        properties.put("oss.session_token", "static-token");
+        Map<String, String> vended = new HashMap<>();
+        vended.put("access_key_id", "vended-ak");
+        vended.put("access_key_secret", "vended-sk");
+
+        Map<String, String> merged = LanceStorageOptions.forVendedTable(
+                OSS_URI, createAll(properties), vended);
+
+        Assertions.assertNull(merged.get("oss_security_token"));
+        Assertions.assertEquals("vended-ak", merged.get("oss_access_key_id"));
+    }
+
+    /**
+     * A namespace that vends its own token keeps it - only a stale one is dropped. The token
+     * assertion alone would pass without reconciliation, since the overlay overwrites it anyway,
+     * so this also pins the flag that only reconciliation states.
+     */
+    @Test
+    public void testVendedOssTokenSurvivesWithItsOwnPair() {
+        Map<String, String> properties = ossProperties();
+        properties.put("oss.session_token", "static-token");
+        Map<String, String> vended = new HashMap<>();
+        vended.put("access_key_id", "vended-ak");
+        vended.put("access_key_secret", "vended-sk");
+        vended.put("security_token", "vended-token");
+
+        Map<String, String> merged = LanceStorageOptions.forVendedTable(
+                OSS_URI, createAll(properties), vended);
+
+        Assertions.assertEquals("vended-token", merged.get("oss_security_token"));
+        Assertions.assertEquals("false", merged.get("allow_anonymous"));
+    }
+
+    /**
+     * The half that was not vended belongs to the pair being replaced. Keeping it produces a
+     * mismatched tuple that OpenDAL signs with anyway, failing at scan time with
+     * SignatureDoesNotMatch; the catalog's own both-or-neither rule cannot catch it, because the
+     * merged map is not one-sided until the stale half is dropped.
+     */
+    @Test
+    public void testVendedOssHalfPairDoesNotMixWithTheStaticOne() {
+        Map<String, String> properties = ossProperties();
+        Map<String, String> vended = new HashMap<>();
+        vended.put("access_key_id", "vended-ak");
+
+        IllegalArgumentException thrown = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> LanceStorageOptions.forVendedTable(OSS_URI, createAll(properties), vended));
+        Assertions.assertTrue(thrown.getMessage().contains("Incomplete OSS credential"),
+                "unexpected message: " + thrown.getMessage());
+    }
+
+    /**
+     * A namespace asking for anonymous access has just described this table, which outranks a
+     * credential the catalog holds for something else. Signing with it would 403 on a bucket the
+     * catalog's account cannot read.
+     */
+    @Test
+    public void testVendedAnonymousModeOutranksStaticOssCredentials() {
+        Map<String, String> vended = new HashMap<>();
+        vended.put("allow_anonymous", "true");
+
+        Map<String, String> merged = LanceStorageOptions.forVendedTable(
+                OSS_URI, createAll(ossProperties()), vended);
+
+        Assertions.assertEquals("true", merged.get("allow_anonymous"));
+        Assertions.assertNull(merged.get("oss_access_key_id"));
+        Assertions.assertNull(merged.get("oss_secret_access_key"));
+    }
+
+    /**
+     * Blank is not a credential. OpenDAL would otherwise build a signer from empty strings and
+     * sign every request with them, while nothing says the access is anonymous.
+     */
+    @Test
+    public void testVendedEmptyOssCredentialsFallBackToAnonymous() {
+        Map<String, String> properties = ossProperties();
+        properties.put("oss.session_token", "static-token");
+        Map<String, String> vended = new HashMap<>();
+        vended.put("access_key_id", "");
+        vended.put("access_key_secret", "");
+
+        Map<String, String> merged = LanceStorageOptions.forVendedTable(
+                OSS_URI, createAll(properties), vended);
+
+        Assertions.assertEquals("true", merged.get("allow_anonymous"));
+        Assertions.assertNull(merged.get("oss_access_key_id"));
+        Assertions.assertNull(merged.get("oss_secret_access_key"));
+        Assertions.assertNull(merged.get("oss_security_token"));
+    }
+
+    /**
+     * Absence is not neutral: lance snapshots the host's OSS_/AWS_ environment into the same config
+     * map before these options are applied, so an exported OSS_ALLOW_ANONYMOUS decides this unless
+     * Doris states the answer.
+     */
+    @Test
+    public void testOssAnonymousModeIsStatedEitherWay() {
+        Assertions.assertEquals("false",
+                LanceStorageOptions.forUri(OSS_URI, createAll(ossProperties()))
+                        .get("allow_anonymous"));
+
+        Map<String, String> anonymous = ossProperties();
+        anonymous.remove("oss.access_key");
+        anonymous.remove("oss.secret_key");
+        Assertions.assertEquals("true",
+                LanceStorageOptions.forUri(OSS_URI, createAll(anonymous)).get("allow_anonymous"));
+    }
+
+    /** Half a credential cannot sign; fail where the catalog is defined rather than at scan time. */
+    @Test
+    public void testOneSidedVendedOssCredentialIsRejected() {
+        Map<String, String> vended = new HashMap<>();
+        vended.put("access_key_id", "vended-ak-only");
+
+        IllegalArgumentException thrown = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> LanceStorageOptions.forVendedTable(
+                        OSS_URI, Collections.emptyList(), vended));
+        Assertions.assertTrue(thrown.getMessage().contains("Incomplete OSS credential"),
+                "unexpected message: " + thrown.getMessage());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
@@ -431,4 +431,49 @@ public class LanceStorageOptionsTest {
         Assertions.assertTrue(
                 LanceOssStorageProvider.INSTANCE.normalizeVended(null).isEmpty());
     }
+
+    /**
+     * Doris reads a blank key pair as anonymous access. OpenDAL only skips signing when it is told
+     * to, so the flag has to be emitted rather than merely leaving the credentials out.
+     */
+    @Test
+    public void testOssAnonymousModeIsForwardedToOpenDal() {
+        Map<String, String> properties = ossProperties();
+        properties.remove("oss.access_key");
+        properties.remove("oss.secret_key");
+
+        Map<String, String> options = LanceStorageOptions.forUri(OSS_URI, createAll(properties));
+
+        Assertions.assertEquals("true", options.get("allow_anonymous"));
+        Assertions.assertNull(options.get("oss_access_key_id"));
+        Assertions.assertNull(options.get("oss_secret_access_key"));
+    }
+
+    @Test
+    public void testOssCredentialedModeDoesNotClaimAnonymous() {
+        Map<String, String> options = LanceStorageOptions.forUri(OSS_URI, createAll(ossProperties()));
+
+        Assertions.assertNull(options.get("allow_anonymous"));
+    }
+
+    /**
+     * OpenDAL's OSS service addresses buckets virtual-host style by default, so only an explicit
+     * path-style request is translated; the default must stay absent rather than say "virtual".
+     */
+    @Test
+    public void testOssPathStyleAddressingIsForwarded() {
+        Map<String, String> properties = ossProperties();
+        properties.put("oss.use_path_style", "true");
+
+        Map<String, String> options = LanceStorageOptions.forUri(OSS_URI, createAll(properties));
+
+        Assertions.assertEquals("path", options.get("addressing_style"));
+    }
+
+    @Test
+    public void testOssVirtualHostAddressingStaysImplicit() {
+        Map<String, String> options = LanceStorageOptions.forUri(OSS_URI, createAll(ossProperties()));
+
+        Assertions.assertNull(options.get("addressing_style"));
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
@@ -32,6 +32,7 @@ import java.util.TreeSet;
 public class LanceStorageOptionsTest {
 
     private static final String S3_URI = "s3://warehouse/table.lance";
+    private static final String OSS_URI = "oss://warehouse/table.lance";
 
     /**
      * Parsed by Doris exactly as a real catalog would, so these fixtures also have to satisfy its
@@ -58,6 +59,16 @@ public class LanceStorageOptionsTest {
 
     private static List<StorageProperties> minioCatalog() {
         return createAll(minioProperties());
+    }
+
+    private static Map<String, String> ossProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("fs.oss.support", "true");
+        properties.put("oss.endpoint", "https://oss-cn-hangzhou.aliyuncs.com");
+        properties.put("oss.region", "cn-hangzhou");
+        properties.put("oss.access_key", "oss-ak");
+        properties.put("oss.secret_key", "oss-sk");
+        return properties;
     }
 
     @Test
@@ -98,6 +109,95 @@ public class LanceStorageOptionsTest {
         // allow_http only makes sense for a plain-HTTP endpoint.
         Assertions.assertNull(options.get("allow_http"));
         Assertions.assertEquals("https://s3.amazonaws.com", options.get("aws_endpoint"));
+    }
+
+    @Test
+    public void testOssCatalogPropertiesMapToThePublicSpelling() {
+        Map<String, String> properties = ossProperties();
+        properties.put("oss.session_token", "oss-token");
+
+        Map<String, String> options = LanceStorageOptions.forUri(
+                OSS_URI, createAll(properties));
+
+        Assertions.assertEquals("https://oss-cn-hangzhou.aliyuncs.com",
+                options.get("oss_endpoint"));
+        Assertions.assertEquals("oss-ak", options.get("oss_access_key_id"));
+        Assertions.assertEquals("oss-sk", options.get("oss_secret_access_key"));
+        Assertions.assertEquals("cn-hangzhou", options.get("oss_region"));
+        Assertions.assertEquals("oss-token", options.get("oss_security_token"));
+        Assertions.assertEquals(
+                new TreeSet<>(Arrays.asList("oss_endpoint", "oss_access_key_id",
+                        "oss_secret_access_key", "oss_region", "oss_security_token")),
+                new TreeSet<>(options.keySet()));
+    }
+
+    @Test
+    public void testOssAnonymousAccessEmitsNoCredentials() {
+        Map<String, String> properties = ossProperties();
+        properties.remove("oss.access_key");
+        properties.remove("oss.secret_key");
+
+        Map<String, String> options = LanceStorageOptions.forUri(
+                OSS_URI, createAll(properties));
+
+        Assertions.assertEquals("https://oss-cn-hangzhou.aliyuncs.com",
+                options.get("oss_endpoint"));
+        Assertions.assertEquals("cn-hangzhou", options.get("oss_region"));
+        Assertions.assertNull(options.get("oss_access_key_id"));
+        Assertions.assertNull(options.get("oss_secret_access_key"));
+        Assertions.assertNull(options.get("oss_security_token"));
+    }
+
+    @Test
+    public void testVendedOssOptionsSupersedeTheCatalog() {
+        Map<String, String> properties = ossProperties();
+        properties.put("oss.session_token", "static-token");
+        Map<String, String> vended = new HashMap<>();
+        vended.put("endpoint", "https://oss-cn-shanghai.aliyuncs.com");
+        vended.put("access_key_id", "vended-ak");
+        vended.put("access_key_secret", "vended-sk");
+        vended.put("region", "cn-shanghai");
+        vended.put("security_token", "vended-token");
+
+        Map<String, String> merged = LanceStorageOptions.forVendedTable(
+                OSS_URI, createAll(properties), vended);
+
+        Assertions.assertEquals("https://oss-cn-shanghai.aliyuncs.com",
+                merged.get("oss_endpoint"));
+        Assertions.assertEquals("vended-ak", merged.get("oss_access_key_id"));
+        Assertions.assertEquals("vended-sk", merged.get("oss_secret_access_key"));
+        Assertions.assertEquals("cn-shanghai", merged.get("oss_region"));
+        Assertions.assertEquals("vended-token", merged.get("oss_security_token"));
+        for (String alias : vended.keySet()) {
+            Assertions.assertNull(merged.get(alias), alias + " must not survive beside its twin");
+        }
+    }
+
+    @Test
+    public void testOssAliasesCollapseAndConflictsAreRejected() {
+        Map<String, String> agreeing = new HashMap<>();
+        agreeing.put("access_key_secret", "same");
+        agreeing.put("oss_secret_access_key", "same");
+        Assertions.assertEquals("same", LanceStorageOptions.forVendedTable(
+                OSS_URI, Collections.emptyList(), agreeing).get("oss_secret_access_key"));
+
+        Map<String, String> conflicting = new HashMap<>();
+        conflicting.put("endpoint", "https://one.example.com");
+        conflicting.put("oss_endpoint", "https://another.example.com");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> LanceStorageOptions
+                .forVendedTable(OSS_URI, Collections.emptyList(), conflicting));
+    }
+
+    @Test
+    public void testUnknownVendedOssOptionsPassThrough() {
+        Map<String, String> vended = new HashMap<>();
+        vended.put("role_arn", "acs:ram::123456789:role/lance");
+        vended.put("allow_anonymous", "true");
+
+        Map<String, String> merged = LanceStorageOptions.forVendedTable(
+                OSS_URI, Collections.emptyList(), vended);
+
+        Assertions.assertEquals(vended, merged);
     }
 
     /**
@@ -172,9 +272,8 @@ public class LanceStorageOptionsTest {
 
     /**
      * The regression that motivated all of this: object_store's Azure parser reads
-     * {@code endpoint} but not {@code aws_endpoint}, and Lance's OSS provider requires
-     * {@code endpoint} and reads {@code access_key_id}. Rewriting those onto the S3 spellings
-     * leaves the dataset unreachable, so a non-S3 dataset must come through untouched.
+     * {@code endpoint} but not {@code aws_endpoint}. Rewriting it onto the S3 spelling leaves the
+     * dataset unreachable, so a provider with no Doris adapter must come through untouched.
      */
     @Test
     public void testNonS3DatasetsAreNeverRewritten() {
@@ -184,7 +283,7 @@ public class LanceStorageOptionsTest {
         vended.put("secret_access_key", "vended-sk");
 
         for (String uri : new String[] {"az://container/table.lance", "abfss://fs@acct/table",
-                "oss://bucket/table.lance", "gs://bucket/table.lance", "cos://bucket/table",
+                "gs://bucket/table.lance", "cos://bucket/table",
                 "file:///tmp/table.lance"}) {
             Map<String, String> merged =
                     LanceStorageOptions.forVendedTable(uri, minioCatalog(), vended);
@@ -207,7 +306,7 @@ public class LanceStorageOptionsTest {
         }
     }
 
-    /** Doris has no Lance vocabulary for a non-S3 provider yet, so it contributes none. */
+    /** A provider never receives another provider's static configuration. */
     @Test
     public void testCatalogPropertiesAreNotAppliedToANonS3Dataset() {
         Map<String, String> merged = LanceStorageOptions.forUri(

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
@@ -760,4 +760,33 @@ public class LanceStorageOptionsTest {
         Assertions.assertTrue(thrown.getMessage().contains("Incomplete OSS credential"),
                 "unexpected message: " + thrown.getMessage());
     }
+
+    /**
+     * A vended key pair replaces the whole credential, including a role or identity binding the
+     * catalog contributed. Inference counts those as signing configuration, so one left behind
+     * would describe an identity no longer in use.
+     *
+     * <p>Exercised through the provider rather than a catalog because Doris has no static property
+     * that emits a role today - this pins the contract before one exists.
+     */
+    @Test
+    public void testVendedOssKeyPairReplacesARoleBinding() {
+        Map<String, String> merged = new HashMap<>();
+        merged.put("role_arn", "acs:ram::1:role/stale");
+        merged.put("oidc_token_file", "/var/run/stale-token");
+        merged.put("oss_access_key_id", "static-ak");
+        merged.put("oss_secret_access_key", "static-sk");
+
+        Map<String, String> vended = new HashMap<>();
+        vended.put("oss_access_key_id", "vended-ak");
+        vended.put("oss_secret_access_key", "vended-sk");
+        merged.putAll(vended);
+
+        LanceStorageProvider.forDataset(OSS_URI).reconcileVendedStorageOptions(merged, vended);
+
+        Assertions.assertEquals("vended-ak", merged.get("oss_access_key_id"));
+        Assertions.assertEquals("vended-sk", merged.get("oss_secret_access_key"));
+        Assertions.assertNull(merged.get("role_arn"));
+        Assertions.assertNull(merged.get("oidc_token_file"));
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
@@ -77,7 +77,7 @@ public class LanceStorageOptionsTest {
         properties.put("s3.session_token", "token");
 
         Map<String, String> options =
-                LanceStorageOptions.forUri(S3_URI, createAll(properties));
+                LanceStorageOptions.fromDorisStorageProperties(S3_URI, createAll(properties));
         Assertions.assertEquals("ak", options.get("aws_access_key_id"));
         Assertions.assertEquals("sk", options.get("aws_secret_access_key"));
         Assertions.assertEquals("token", options.get("aws_session_token"));
@@ -102,7 +102,7 @@ public class LanceStorageOptionsTest {
         properties.put("s3.region", "us-east-1");
 
         Map<String, String> options =
-                LanceStorageOptions.forUri(S3_URI, createAll(properties));
+                LanceStorageOptions.fromDorisStorageProperties(S3_URI, createAll(properties));
         Assertions.assertNull(options.get("aws_access_key_id"));
         Assertions.assertNull(options.get("aws_secret_access_key"));
         Assertions.assertNull(options.get("aws_session_token"));
@@ -116,7 +116,7 @@ public class LanceStorageOptionsTest {
         Map<String, String> properties = ossProperties();
         properties.put("oss.session_token", "oss-token");
 
-        Map<String, String> options = LanceStorageOptions.forUri(
+        Map<String, String> options = LanceStorageOptions.fromDorisStorageProperties(
                 OSS_URI, createAll(properties));
 
         Assertions.assertEquals("https://oss-cn-hangzhou.aliyuncs.com",
@@ -133,6 +133,7 @@ public class LanceStorageOptionsTest {
                         "oss_secret_access_key", "oss_region", "oss_security_token",
                         "addressing_style", "allow_anonymous")),
                 new TreeSet<>(options.keySet()));
+        Assertions.assertEquals("false", options.get("allow_anonymous"));
     }
 
     @Test
@@ -141,7 +142,7 @@ public class LanceStorageOptionsTest {
         properties.remove("oss.access_key");
         properties.remove("oss.secret_key");
 
-        Map<String, String> options = LanceStorageOptions.forUri(
+        Map<String, String> options = LanceStorageOptions.fromDorisStorageProperties(
                 OSS_URI, createAll(properties));
 
         Assertions.assertEquals("https://oss-cn-hangzhou.aliyuncs.com",
@@ -163,7 +164,7 @@ public class LanceStorageOptionsTest {
         vended.put("region", "cn-shanghai");
         vended.put("security_token", "vended-token");
 
-        Map<String, String> merged = LanceStorageOptions.forVendedTable(
+        Map<String, String> merged = LanceStorageOptions.fromDorisAndVendedStorageOptions(
                 OSS_URI, createAll(properties), vended);
 
         Assertions.assertEquals("https://oss-cn-shanghai.aliyuncs.com",
@@ -185,26 +186,26 @@ public class LanceStorageOptionsTest {
         agreeing.put("access_key_id", "ak");
         agreeing.put("access_key_secret", "same");
         agreeing.put("oss_secret_access_key", "same");
-        Assertions.assertEquals("same", LanceStorageOptions.forVendedTable(
+        Assertions.assertEquals("same", LanceStorageOptions.fromDorisAndVendedStorageOptions(
                 OSS_URI, Collections.emptyList(), agreeing).get("oss_secret_access_key"));
 
         Map<String, String> conflicting = new HashMap<>();
         conflicting.put("endpoint", "https://one.example.com");
         conflicting.put("oss_endpoint", "https://another.example.com");
         Assertions.assertThrows(IllegalArgumentException.class, () -> LanceStorageOptions
-                .forVendedTable(OSS_URI, Collections.emptyList(), conflicting));
+                .fromDorisAndVendedStorageOptions(OSS_URI, Collections.emptyList(), conflicting));
     }
 
     @Test
     public void testUnknownVendedOssOptionsPassThrough() {
         Map<String, String> vended = new HashMap<>();
-        vended.put("role_arn", "acs:ram::123456789:role/lance");
-        vended.put("allow_anonymous", "true");
+        vended.put("unknown_provider_option", "value");
 
-        Map<String, String> merged = LanceStorageOptions.forVendedTable(
+        Map<String, String> merged = LanceStorageOptions.fromDorisAndVendedStorageOptions(
                 OSS_URI, Collections.emptyList(), vended);
 
-        Assertions.assertEquals(vended, merged);
+        Assertions.assertEquals("value", merged.get("unknown_provider_option"));
+        Assertions.assertEquals("true", merged.get("allow_anonymous"));
     }
 
     /**
@@ -223,7 +224,7 @@ public class LanceStorageOptionsTest {
         vended.put("virtual_hosted_style_request", "true");
 
         Map<String, String> merged =
-                LanceStorageOptions.forVendedTable(S3_URI, minioCatalog(), vended);
+                LanceStorageOptions.fromDorisAndVendedStorageOptions(S3_URI, minioCatalog(), vended);
 
         Assertions.assertEquals("vended-ak", merged.get("aws_access_key_id"));
         Assertions.assertEquals("vended-sk", merged.get("aws_secret_access_key"));
@@ -246,12 +247,43 @@ public class LanceStorageOptionsTest {
             vended.put(alias, "http://127.0.0.1:9000");
 
             Map<String, String> merged =
-                    LanceStorageOptions.forVendedTable(S3_URI, minioCatalog(), vended);
+                    LanceStorageOptions.fromDorisAndVendedStorageOptions(S3_URI, minioCatalog(), vended);
             long endpoints = merged.keySet().stream().filter(k -> k.contains("endpoint")).count();
             Assertions.assertEquals(1, endpoints, alias + " left a competing entry");
             Assertions.assertEquals("http://127.0.0.1:9000", merged.get("aws_endpoint"),
                     alias + " did not win");
         }
+    }
+
+    @Test
+    public void testS3AllowHttpIsInferredAfterVendedEndpointWins() {
+        Map<String, String> httpsEndpoint = Collections.singletonMap(
+                "endpoint", "https://s3.example.com");
+        Map<String, String> httpsOptions = LanceStorageOptions
+                .fromDorisAndVendedStorageOptions(S3_URI, minioCatalog(), httpsEndpoint);
+        Assertions.assertEquals("https://s3.example.com", httpsOptions.get("aws_endpoint"));
+        Assertions.assertNull(httpsOptions.get("allow_http"));
+
+        Map<String, String> explicitFalse = new HashMap<>();
+        explicitFalse.put("endpoint", "http://127.0.0.1:9000");
+        explicitFalse.put("allow_http", "false");
+        Map<String, String> explicitOptions = LanceStorageOptions
+                .fromDorisAndVendedStorageOptions(S3_URI, minioCatalog(), explicitFalse);
+        Assertions.assertEquals("false", explicitOptions.get("allow_http"));
+    }
+
+    @Test
+    public void testNormalizationDoesNotInferProviderOptions() {
+        Map<String, String> s3 = LanceS3StorageProvider.INSTANCE
+                .normalizeDorisStorageOptions(minioCatalog());
+        Assertions.assertEquals("http://minio:9000", s3.get("aws_endpoint"));
+        Assertions.assertFalse(s3.containsKey("allow_http"));
+
+        Map<String, String> oss = LanceOssStorageProvider.INSTANCE
+                .normalizeDorisStorageOptions(createAll(ossProperties()));
+        Assertions.assertEquals("oss-ak", oss.get("oss_access_key_id"));
+        Assertions.assertFalse(oss.containsKey("skip_signature"));
+        Assertions.assertFalse(oss.containsKey("allow_anonymous"));
     }
 
     /**
@@ -267,11 +299,11 @@ public class LanceStorageOptionsTest {
         Map<String, String> vended = new HashMap<>();
         vended.put("token", "vended-token");
 
-        Map<String, String> onS3 = LanceStorageOptions.forVendedTable(S3_URI, catalog, vended);
+        Map<String, String> onS3 = LanceStorageOptions.fromDorisAndVendedStorageOptions(S3_URI, catalog, vended);
         Assertions.assertEquals("vended-token", onS3.get("aws_session_token"));
         Assertions.assertNull(onS3.get("token"));
 
-        Map<String, String> onAzure = LanceStorageOptions.forVendedTable(
+        Map<String, String> onAzure = LanceStorageOptions.fromDorisAndVendedStorageOptions(
                 "az://container/table.lance", catalog, vended);
         Assertions.assertEquals("vended-token", onAzure.get("token"));
         Assertions.assertNull(onAzure.get("aws_session_token"));
@@ -293,7 +325,7 @@ public class LanceStorageOptionsTest {
                 "gs://bucket/table.lance", "cos://bucket/table",
                 "file:///tmp/table.lance"}) {
             Map<String, String> merged =
-                    LanceStorageOptions.forVendedTable(uri, minioCatalog(), vended);
+                    LanceStorageOptions.fromDorisAndVendedStorageOptions(uri, minioCatalog(), vended);
             Assertions.assertEquals(vended, merged,
                     uri + " must reach Lance exactly as the namespace wrote it");
         }
@@ -308,7 +340,7 @@ public class LanceStorageOptionsTest {
     public void testCatalogWithoutAnS3UrlGetsNoS3Options() {
         for (String uri : new String[] {"file:///warehouse/lance", "", null}) {
             Assertions.assertTrue(
-                    LanceStorageOptions.forUri(uri, minioCatalog()).isEmpty(),
+                    LanceStorageOptions.fromDorisStorageProperties(uri, minioCatalog()).isEmpty(),
                     "expected no options for " + uri);
         }
     }
@@ -316,9 +348,10 @@ public class LanceStorageOptionsTest {
     /** A provider never receives another provider's static configuration. */
     @Test
     public void testCatalogPropertiesAreNotAppliedToANonS3Dataset() {
-        Map<String, String> merged = LanceStorageOptions.forUri(
+        Map<String, String> merged = LanceStorageOptions.fromDorisStorageProperties(
                 "oss://bucket/table.lance", minioCatalog());
-        Assertions.assertTrue(merged.isEmpty(), "S3 credentials must not leak onto another provider");
+        Assertions.assertEquals(Collections.singletonMap("allow_anonymous", "true"), merged,
+                "S3 credentials must not leak onto another provider");
     }
 
     /**
@@ -331,7 +364,7 @@ public class LanceStorageOptionsTest {
         Assertions.assertTrue(catalog.size() > 1,
                 "expected Doris to add its default non-S3 entry ahead of the S3 one");
         Assertions.assertEquals("ak",
-                LanceStorageOptions.forUri(S3_URI, catalog).get("aws_access_key_id"));
+                LanceStorageOptions.fromDorisStorageProperties(S3_URI, catalog).get("aws_access_key_id"));
     }
 
     @Test
@@ -344,18 +377,18 @@ public class LanceStorageOptionsTest {
         vended.put("deliberately_empty", "");
 
         Map<String, String> merged =
-                LanceStorageOptions.forVendedTable(S3_URI, Collections.emptyList(), vended);
+                LanceStorageOptions.fromDorisAndVendedStorageOptions(S3_URI, Collections.emptyList(), vended);
         Assertions.assertEquals(vended, merged);
     }
 
     @Test
     public void testAbsentVendedOptionsLeaveCatalogOptionsIntact() {
         Map<String, String> catalogOptions =
-                LanceStorageOptions.forUri(S3_URI, minioCatalog());
+                LanceStorageOptions.fromDorisStorageProperties(S3_URI, minioCatalog());
         Assertions.assertEquals(catalogOptions,
-                LanceStorageOptions.forUri(S3_URI, minioCatalog()));
+                LanceStorageOptions.fromDorisStorageProperties(S3_URI, minioCatalog()));
         Assertions.assertEquals(catalogOptions,
-                LanceStorageOptions.forVendedTable(S3_URI, minioCatalog(), new HashMap<>()));
+                LanceStorageOptions.fromDorisAndVendedStorageOptions(S3_URI, minioCatalog(), new HashMap<>()));
     }
 
     /** A namespace contradicting itself is not something to resolve by coin toss. */
@@ -365,14 +398,14 @@ public class LanceStorageOptionsTest {
         vended.put("access_key_id", "one");
         vended.put("aws_access_key_id", "another");
         Assertions.assertThrows(IllegalArgumentException.class,
-                () -> LanceStorageOptions.forVendedTable(S3_URI, minioCatalog(), vended));
+                () -> LanceStorageOptions.fromDorisAndVendedStorageOptions(S3_URI, minioCatalog(), vended));
 
         // Agreeing on the value is not a conflict.
         Map<String, String> agreeing = new HashMap<>();
         agreeing.put("access_key_id", "same");
         agreeing.put("aws_access_key_id", "same");
         Assertions.assertEquals("same", LanceStorageOptions
-                .forVendedTable(S3_URI, minioCatalog(), agreeing).get("aws_access_key_id"));
+                .fromDorisAndVendedStorageOptions(S3_URI, minioCatalog(), agreeing).get("aws_access_key_id"));
     }
 
     /**
@@ -385,7 +418,7 @@ public class LanceStorageOptionsTest {
         properties.put("s3.access_key", "ak\0ignored");
 
         IllegalArgumentException thrown = Assertions.assertThrows(IllegalArgumentException.class,
-                () -> LanceStorageOptions.forUri(S3_URI, createAll(properties)));
+                () -> LanceStorageOptions.fromDorisStorageProperties(S3_URI, createAll(properties)));
         // The message has to say which side to fix - the catalog, not the namespace.
         Assertions.assertTrue(thrown.getMessage().contains("Doris storage configuration"),
                 "unexpected message: " + thrown.getMessage());
@@ -400,48 +433,49 @@ public class LanceStorageOptionsTest {
         Map<String, String> withNulKey = new HashMap<>();
         withNulKey.put("bucket\0ignored", "other-bucket");
         Assertions.assertThrows(IllegalArgumentException.class, () -> LanceStorageOptions
-                .forVendedTable(S3_URI, Collections.emptyList(), withNulKey));
+                .fromDorisAndVendedStorageOptions(S3_URI, Collections.emptyList(), withNulKey));
 
         Map<String, String> withNulValue = new HashMap<>();
         withNulValue.put("aws_region", "us-east-1\0ignored");
         Assertions.assertThrows(IllegalArgumentException.class, () -> LanceStorageOptions
-                .forVendedTable(S3_URI, Collections.emptyList(), withNulValue));
+                .fromDorisAndVendedStorageOptions(S3_URI, Collections.emptyList(), withNulValue));
 
         Map<String, String> withNullValue = new HashMap<>();
         withNullValue.put("aws_region", null);
         Assertions.assertThrows(IllegalArgumentException.class, () -> LanceStorageOptions
-                .forVendedTable(S3_URI, Collections.emptyList(), withNullValue));
+                .fromDorisAndVendedStorageOptions(S3_URI, Collections.emptyList(), withNullValue));
 
         Map<String, String> withNullKey = new HashMap<>();
         withNullKey.put(null, "value");
         Assertions.assertThrows(IllegalArgumentException.class, () -> LanceStorageOptions
-                .forVendedTable(S3_URI, Collections.emptyList(), withNullKey));
+                .fromDorisAndVendedStorageOptions(S3_URI, Collections.emptyList(), withNullKey));
     }
 
     /**
      * A catalog can be absent entirely - a Lance table reached purely through vended options has no
      * Doris storage properties behind it. The provider has to answer with no options rather than
-     * fail, so that {@link LanceStorageOptions#forVendedTable} still has a map to merge onto.
+     * fail, so that {@link LanceStorageOptions#fromDorisAndVendedStorageOptions} still has a map to merge onto.
      */
     @Test
-    public void testOssDatasetWithoutACatalogYieldsNoOptions() {
-        Assertions.assertTrue(LanceStorageOptions.forUri(OSS_URI, null).isEmpty());
+    public void testOssDatasetWithoutACatalogInfersAnonymousAccess() {
+        Assertions.assertEquals(Collections.singletonMap("allow_anonymous", "true"),
+                LanceStorageOptions.fromDorisStorageProperties(OSS_URI, null));
     }
 
     /**
-     * {@link LanceStorageOptions#forVendedTable} screens out a null vended map before it reaches a
+     * {@link LanceStorageOptions#fromDorisAndVendedStorageOptions} screens out a null vended map before it reaches a
      * provider, but the interface still admits one and the sibling providers all tolerate it. Pin
      * that down directly, since no public entry point can reach it.
      */
     @Test
     public void testOssNormalizeVendedToleratesNoVendedOptions() {
         Assertions.assertTrue(
-                LanceOssStorageProvider.INSTANCE.normalizeVended(null).isEmpty());
+                LanceOssStorageProvider.INSTANCE.normalizeVendedStorageOptions(null).isEmpty());
     }
 
     /**
      * Doris reads a blank key pair as anonymous access. OpenDAL only skips signing when it is told
-     * to, so the flag has to be emitted rather than merely leaving the credentials out.
+     * to, so the Lance-native flag has to be emitted rather than merely leaving credentials out.
      */
     @Test
     public void testOssAnonymousModeIsForwardedToOpenDal() {
@@ -449,7 +483,7 @@ public class LanceStorageOptionsTest {
         properties.remove("oss.access_key");
         properties.remove("oss.secret_key");
 
-        Map<String, String> options = LanceStorageOptions.forUri(OSS_URI, createAll(properties));
+        Map<String, String> options = LanceStorageOptions.fromDorisStorageProperties(OSS_URI, createAll(properties));
 
         Assertions.assertEquals("true", options.get("allow_anonymous"));
         Assertions.assertNull(options.get("oss_access_key_id"));
@@ -457,8 +491,9 @@ public class LanceStorageOptionsTest {
     }
 
     @Test
-    public void testOssCredentialedModeDoesNotClaimAnonymous() {
-        Map<String, String> options = LanceStorageOptions.forUri(OSS_URI, createAll(ossProperties()));
+    public void testOssCredentialedModeRequiresSigning() {
+        Map<String, String> options = LanceStorageOptions.fromDorisStorageProperties(
+                OSS_URI, createAll(ossProperties()));
 
         Assertions.assertEquals("false", options.get("allow_anonymous"));
     }
@@ -472,7 +507,7 @@ public class LanceStorageOptionsTest {
         Map<String, String> properties = ossProperties();
         properties.put("oss.use_path_style", "true");
 
-        Map<String, String> options = LanceStorageOptions.forUri(OSS_URI, createAll(properties));
+        Map<String, String> options = LanceStorageOptions.fromDorisStorageProperties(OSS_URI, createAll(properties));
 
         Assertions.assertEquals("path", options.get("addressing_style"));
     }
@@ -484,15 +519,16 @@ public class LanceStorageOptionsTest {
      */
     @Test
     public void testOssVirtualHostAddressingIsStatedExplicitly() {
-        Map<String, String> options = LanceStorageOptions.forUri(OSS_URI, createAll(ossProperties()));
+        Map<String, String> options = LanceStorageOptions.fromDorisStorageProperties(
+                OSS_URI, createAll(ossProperties()));
 
         Assertions.assertEquals("virtual", options.get("addressing_style"));
     }
 
     /**
      * Doris accepts a whitespace-only key pair as "both set", so the emitted credentials and the
-     * anonymous claim have to agree: whatever this provider treats as a usable credential must
-     * suppress allow_anonymous, or OpenDAL signs with the blank key and cannot fall back.
+     * signing choice have to agree: whatever this provider treats as a usable credential must
+     * suppress anonymous access, or OpenDAL sends the request unsigned.
      */
     @Test
     public void testWhitespaceOssCredentialsAreNotAlsoCalledAnonymous() {
@@ -500,18 +536,19 @@ public class LanceStorageOptionsTest {
         properties.put("oss.access_key", " ");
         properties.put("oss.secret_key", " ");
 
-        Map<String, String> options = LanceStorageOptions.forUri(OSS_URI, createAll(properties));
+        Map<String, String> options = LanceStorageOptions.fromDorisStorageProperties(OSS_URI, createAll(properties));
 
         Assertions.assertNotEquals(
-                options.containsKey("oss_access_key_id"), options.containsKey("allow_anonymous"),
-                "a credential and a claim of anonymity must never both be emitted");
+                options.containsKey("oss_access_key_id"),
+                Boolean.parseBoolean(options.get("allow_anonymous")),
+                "a credential and allow_anonymous=true must never both be emitted");
     }
 
     /**
      * The case that makes this matter: an anonymous catalog whose namespace vends real credentials.
-     * OpenDAL's OssCore::sign returns the request unsigned whenever allow_anonymous is set, no
-     * matter what credentials sit beside it, so leaving the flag on would silently unsign every
-     * FE metadata read and BE scan that the vended credentials were supposed to authorize.
+     * OpenDAL's OSS signer returns the request unsigned whenever anonymous access is enabled, no
+     * matter what credentials sit beside it. Leaving the flag on would silently unsign every FE
+     * metadata read and BE scan that the vended credentials were supposed to authorize.
      */
     @Test
     public void testVendedOssCredentialsClearStaticAnonymousMode() {
@@ -519,18 +556,17 @@ public class LanceStorageOptionsTest {
         properties.remove("oss.access_key");
         properties.remove("oss.secret_key");
         Assertions.assertEquals("true",
-                LanceStorageOptions.forUri(OSS_URI, createAll(properties)).get("allow_anonymous"),
+                LanceStorageOptions.fromDorisStorageProperties(OSS_URI, createAll(properties))
+                        .get("allow_anonymous"),
                 "precondition: the static half alone is anonymous");
 
         Map<String, String> vended = new HashMap<>();
         vended.put("access_key_id", "vended-ak");
         vended.put("access_key_secret", "vended-sk");
 
-        Map<String, String> merged = LanceStorageOptions.forVendedTable(
+        Map<String, String> merged = LanceStorageOptions.fromDorisAndVendedStorageOptions(
                 OSS_URI, createAll(properties), vended);
 
-        // Stated false rather than removed: an absent key would let an exported
-        // OSS_ALLOW_ANONYMOUS put the flag back, which is the bug this guards.
         Assertions.assertEquals("false", merged.get("allow_anonymous"));
         Assertions.assertEquals("vended-ak", merged.get("oss_access_key_id"));
         Assertions.assertEquals("vended-sk", merged.get("oss_secret_access_key"));
@@ -548,7 +584,7 @@ public class LanceStorageOptionsTest {
         vended.put("access_key_id", "vended-ak");
         vended.put("access_key_secret", "vended-sk");
 
-        Map<String, String> merged = LanceStorageOptions.forVendedTable(
+        Map<String, String> merged = LanceStorageOptions.fromDorisAndVendedStorageOptions(
                 OSS_URI, createAll(properties), vended);
 
         Assertions.assertNull(merged.get("oss_security_token"));
@@ -569,7 +605,7 @@ public class LanceStorageOptionsTest {
         vended.put("access_key_secret", "vended-sk");
         vended.put("security_token", "vended-token");
 
-        Map<String, String> merged = LanceStorageOptions.forVendedTable(
+        Map<String, String> merged = LanceStorageOptions.fromDorisAndVendedStorageOptions(
                 OSS_URI, createAll(properties), vended);
 
         Assertions.assertEquals("vended-token", merged.get("oss_security_token"));
@@ -590,7 +626,7 @@ public class LanceStorageOptionsTest {
 
         IllegalArgumentException thrown = Assertions.assertThrows(
                 IllegalArgumentException.class,
-                () -> LanceStorageOptions.forVendedTable(OSS_URI, createAll(properties), vended));
+                () -> LanceStorageOptions.fromDorisAndVendedStorageOptions(OSS_URI, createAll(properties), vended));
         Assertions.assertTrue(thrown.getMessage().contains("Incomplete OSS credential"),
                 "unexpected message: " + thrown.getMessage());
     }
@@ -605,12 +641,71 @@ public class LanceStorageOptionsTest {
         Map<String, String> vended = new HashMap<>();
         vended.put("allow_anonymous", "true");
 
-        Map<String, String> merged = LanceStorageOptions.forVendedTable(
+        Map<String, String> merged = LanceStorageOptions.fromDorisAndVendedStorageOptions(
                 OSS_URI, createAll(ossProperties()), vended);
 
         Assertions.assertEquals("true", merged.get("allow_anonymous"));
         Assertions.assertNull(merged.get("oss_access_key_id"));
         Assertions.assertNull(merged.get("oss_secret_access_key"));
+    }
+
+    @Test
+    public void testOssAnonymousAliasesCollapseAndConflict() {
+        Map<String, String> agreeing = new HashMap<>();
+        agreeing.put("allow_anonymous", "true");
+        agreeing.put("skip_signature", "true");
+        Assertions.assertEquals("true", LanceStorageOptions
+                .fromDorisAndVendedStorageOptions(OSS_URI, Collections.emptyList(), agreeing)
+                .get("allow_anonymous"));
+
+        Map<String, String> conflicting = new HashMap<>();
+        conflicting.put("allow_anonymous", "true");
+        conflicting.put("skip_signature", "false");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> LanceStorageOptions
+                .fromDorisAndVendedStorageOptions(
+                        OSS_URI, Collections.emptyList(), conflicting));
+    }
+
+    @Test
+    public void testOssRoleAndOidcRequireSigning() {
+        for (String option : new String[] {
+                "role_arn", "oidc_token", "oidc_provider_arn", "oidc_token_file"}) {
+            Map<String, String> vended = Collections.singletonMap(option, "signed-value");
+            Map<String, String> merged = LanceStorageOptions
+                    .fromDorisAndVendedStorageOptions(OSS_URI, createAll(ossProperties()), vended);
+            Assertions.assertEquals("signed-value", merged.get(option));
+            Assertions.assertEquals("false", merged.get("allow_anonymous"));
+            Assertions.assertNull(merged.get("oss_access_key_id"));
+            Assertions.assertNull(merged.get("oss_secret_access_key"));
+        }
+    }
+
+    @Test
+    public void testOssAnonymousConflictsWithSigningConfiguration() {
+        Map<String, String> vended = new HashMap<>();
+        vended.put("skip_signature", "true");
+        vended.put("role_arn", "acs:ram::123456789:role/lance");
+
+        IllegalArgumentException thrown = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> LanceStorageOptions.fromDorisAndVendedStorageOptions(
+                        OSS_URI, Collections.emptyList(), vended));
+        Assertions.assertTrue(thrown.getMessage().contains("Conflicting OSS authentication"),
+                "unexpected message: " + thrown.getMessage());
+    }
+
+    @Test
+    public void testOssExplicitSigningChoiceWinsAndInferenceIsIdempotent() {
+        Map<String, String> vended = Collections.singletonMap("skip_signature", "false");
+        Map<String, String> explicit = LanceStorageOptions.fromDorisAndVendedStorageOptions(
+                OSS_URI, Collections.emptyList(), vended);
+        Assertions.assertEquals("false", explicit.get("allow_anonymous"));
+        Assertions.assertFalse(explicit.containsKey("skip_signature"));
+
+        Map<String, String> inferred = LanceStorageOptions.fromDorisStorageProperties(
+                OSS_URI, createAll(ossProperties()));
+        Assertions.assertEquals(inferred, LanceStorageOptions.fromDorisAndVendedStorageOptions(
+                OSS_URI, Collections.emptyList(), inferred));
     }
 
     /**
@@ -625,7 +720,7 @@ public class LanceStorageOptionsTest {
         vended.put("access_key_id", "");
         vended.put("access_key_secret", "");
 
-        Map<String, String> merged = LanceStorageOptions.forVendedTable(
+        Map<String, String> merged = LanceStorageOptions.fromDorisAndVendedStorageOptions(
                 OSS_URI, createAll(properties), vended);
 
         Assertions.assertEquals("true", merged.get("allow_anonymous"));
@@ -635,21 +730,21 @@ public class LanceStorageOptionsTest {
     }
 
     /**
-     * Absence is not neutral: lance snapshots the host's OSS_/AWS_ environment into the same config
-     * map before these options are applied, so an exported OSS_ALLOW_ANONYMOUS decides this unless
-     * Doris states the answer.
+     * Absence is not neutral: Lance and OpenDAL may otherwise resolve authentication from their
+     * environment. Doris states whether the final normalized configuration should be signed.
      */
     @Test
     public void testOssAnonymousModeIsStatedEitherWay() {
         Assertions.assertEquals("false",
-                LanceStorageOptions.forUri(OSS_URI, createAll(ossProperties()))
+                LanceStorageOptions.fromDorisStorageProperties(OSS_URI, createAll(ossProperties()))
                         .get("allow_anonymous"));
 
         Map<String, String> anonymous = ossProperties();
         anonymous.remove("oss.access_key");
         anonymous.remove("oss.secret_key");
         Assertions.assertEquals("true",
-                LanceStorageOptions.forUri(OSS_URI, createAll(anonymous)).get("allow_anonymous"));
+                LanceStorageOptions.fromDorisStorageProperties(OSS_URI, createAll(anonymous))
+                        .get("allow_anonymous"));
     }
 
     /** Half a credential cannot sign; fail where the catalog is defined rather than at scan time. */
@@ -660,7 +755,7 @@ public class LanceStorageOptionsTest {
 
         IllegalArgumentException thrown = Assertions.assertThrows(
                 IllegalArgumentException.class,
-                () -> LanceStorageOptions.forVendedTable(
+                () -> LanceStorageOptions.fromDorisAndVendedStorageOptions(
                         OSS_URI, Collections.emptyList(), vended));
         Assertions.assertTrue(thrown.getMessage().contains("Incomplete OSS credential"),
                 "unexpected message: " + thrown.getMessage());

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
@@ -410,4 +410,25 @@ public class LanceStorageOptionsTest {
         Assertions.assertThrows(IllegalArgumentException.class, () -> LanceStorageOptions
                 .forVendedTable(S3_URI, Collections.emptyList(), withNullKey));
     }
+
+    /**
+     * A catalog can be absent entirely - a Lance table reached purely through vended options has no
+     * Doris storage properties behind it. The provider has to answer with no options rather than
+     * fail, so that {@link LanceStorageOptions#forVendedTable} still has a map to merge onto.
+     */
+    @Test
+    public void testOssDatasetWithoutACatalogYieldsNoOptions() {
+        Assertions.assertTrue(LanceStorageOptions.forUri(OSS_URI, null).isEmpty());
+    }
+
+    /**
+     * {@link LanceStorageOptions#forVendedTable} screens out a null vended map before it reaches a
+     * provider, but the interface still admits one and the sibling providers all tolerate it. Pin
+     * that down directly, since no public entry point can reach it.
+     */
+    @Test
+    public void testOssNormalizeVendedToleratesNoVendedOptions() {
+        Assertions.assertTrue(
+                LanceOssStorageProvider.INSTANCE.normalizeVended(null).isEmpty());
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
@@ -125,9 +125,13 @@ public class LanceStorageOptionsTest {
         Assertions.assertEquals("oss-sk", options.get("oss_secret_access_key"));
         Assertions.assertEquals("cn-hangzhou", options.get("oss_region"));
         Assertions.assertEquals("oss-token", options.get("oss_security_token"));
+        // Stated rather than implied, so the host environment cannot decide it; see
+        // testOssVirtualHostAddressingIsStatedExplicitly.
+        Assertions.assertEquals("virtual", options.get("addressing_style"));
         Assertions.assertEquals(
                 new TreeSet<>(Arrays.asList("oss_endpoint", "oss_access_key_id",
-                        "oss_secret_access_key", "oss_region", "oss_security_token")),
+                        "oss_secret_access_key", "oss_region", "oss_security_token",
+                        "addressing_style")),
                 new TreeSet<>(options.keySet()));
     }
 
@@ -470,10 +474,33 @@ public class LanceStorageOptionsTest {
         Assertions.assertEquals("path", options.get("addressing_style"));
     }
 
+    /**
+     * Lance snapshots the host's {@code OSS_} and {@code AWS_} environment variables into the same
+     * config map before storage options are applied, so the default has to be stated rather than
+     * left implicit - otherwise an exported OSS_ADDRESSING_STYLE would outrank the catalog.
+     */
     @Test
-    public void testOssVirtualHostAddressingStaysImplicit() {
+    public void testOssVirtualHostAddressingIsStatedExplicitly() {
         Map<String, String> options = LanceStorageOptions.forUri(OSS_URI, createAll(ossProperties()));
 
-        Assertions.assertNull(options.get("addressing_style"));
+        Assertions.assertEquals("virtual", options.get("addressing_style"));
+    }
+
+    /**
+     * Doris accepts a whitespace-only key pair as "both set", so the emitted credentials and the
+     * anonymous claim have to agree: whatever this provider treats as a usable credential must
+     * suppress allow_anonymous, or OpenDAL signs with the blank key and cannot fall back.
+     */
+    @Test
+    public void testWhitespaceOssCredentialsAreNotAlsoCalledAnonymous() {
+        Map<String, String> properties = ossProperties();
+        properties.put("oss.access_key", " ");
+        properties.put("oss.secret_key", " ");
+
+        Map<String, String> options = LanceStorageOptions.forUri(OSS_URI, createAll(properties));
+
+        Assertions.assertNotEquals(
+                options.containsKey("oss_access_key_id"), options.containsKey("allow_anonymous"),
+                "a credential and a claim of anonymity must never both be emitted");
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
@@ -499,8 +499,9 @@ public class LanceStorageOptionsTest {
     }
 
     /**
-     * OpenDAL's OSS service addresses buckets virtual-host style by default, so only an explicit
-     * path-style request is translated; the default must stay absent rather than say "virtual".
+     * Doris models path-style addressing as a property with a default, so both answers are stated
+     * rather than only the non-default one - see
+     * {@link #testOssVirtualHostAddressingIsStatedExplicitly} for why absence is not neutral here.
      */
     @Test
     public void testOssPathStyleAddressingIsForwarded() {
@@ -573,9 +574,9 @@ public class LanceStorageOptionsTest {
     }
 
     /**
-     * A namespace that vends its own token keeps it - only a stale one is dropped. The token
-     * assertion alone would pass without reconciliation, since the overlay overwrites it anyway,
-     * so this also pins the flag that only reconciliation states.
+     * A namespace vending a whole credential has all of it carried through, token included, and the
+     * signing flag inferred from it. Options merge key by key, so a namespace is expected to vend
+     * the credential it wants used in full - what the catalog holds is not combined with it.
      */
     @Test
     public void testVendedOssTokenSurvivesWithItsOwnPair() {
@@ -700,5 +701,64 @@ public class LanceStorageOptionsTest {
                         .get("allow_anonymous"));
     }
 
-    /** Half a credential cannot sign; fail where the catalog is defined rather than at scan time. */
+    /**
+     * OpenDAL lower-cases every config key before deserializing, so a credential vended in upper
+     * case still reaches the store. Left unrecognized here it would not count as signing
+     * configuration, and the anonymous flag would be inferred as true beside it - the store would
+     * then load the credential and skip signing anyway, sending every request unsigned.
+     */
+    @Test
+    public void testVendedOssOptionsAreRecognizedRegardlessOfCase() {
+        Map<String, String> vended = new HashMap<>();
+        vended.put("ACCESS_KEY_ID", "vended-ak");
+        vended.put("Access_Key_Secret", "vended-sk");
+
+        Map<String, String> merged = LanceStorageOptions.fromDorisAndVendedStorageOptions(
+                OSS_URI, Collections.emptyList(), vended);
+
+        Assertions.assertEquals("vended-ak", merged.get("oss_access_key_id"));
+        Assertions.assertEquals("vended-sk", merged.get("oss_secret_access_key"));
+        Assertions.assertEquals("false", merged.get("allow_anonymous"));
+    }
+
+    /**
+     * The signing flag is read with OpenDAL's boolean grammar, not Java's. Judging {@code on} by
+     * Boolean.parseBoolean would call it "not anonymous" and let it through beside a credential,
+     * while the store reads it as anonymous and stops signing.
+     */
+    @Test
+    public void testVendedOssAnonymousFlagUsesTheStoresBooleanGrammar() {
+        for (String spelling : new String[] {"true", "on", "ON"}) {
+            Map<String, String> vended = new HashMap<>();
+            vended.put("allow_anonymous", spelling);
+            IllegalArgumentException thrown = Assertions.assertThrows(
+                    IllegalArgumentException.class,
+                    () -> LanceStorageOptions.fromDorisAndVendedStorageOptions(
+                            OSS_URI, createAll(ossProperties()), vended),
+                    "'" + spelling + "' should conflict with configured credentials");
+            Assertions.assertTrue(thrown.getMessage().contains("Conflicting OSS authentication"),
+                    "unexpected message: " + thrown.getMessage());
+        }
+        // off/false are the store's own spellings for "sign", and agree with a credential
+        for (String spelling : new String[] {"false", "off"}) {
+            Map<String, String> vended = new HashMap<>();
+            vended.put("allow_anonymous", spelling);
+            Assertions.assertEquals(spelling, LanceStorageOptions.fromDorisAndVendedStorageOptions(
+                    OSS_URI, createAll(ossProperties()), vended).get("allow_anonymous"));
+        }
+    }
+
+    /** A value OpenDAL cannot parse is refused here, not several layers down in the operator build. */
+    @Test
+    public void testVendedOssAnonymousFlagRejectsAnUnparsableValue() {
+        Map<String, String> vended = new HashMap<>();
+        vended.put("allow_anonymous", "yes");
+
+        IllegalArgumentException thrown = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> LanceStorageOptions.fromDorisAndVendedStorageOptions(
+                        OSS_URI, Collections.emptyList(), vended));
+        Assertions.assertTrue(thrown.getMessage().contains("Unrecognized value"),
+                "unexpected message: " + thrown.getMessage());
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/lance/LanceStorageOptionsTest.java
@@ -573,25 +573,6 @@ public class LanceStorageOptionsTest {
     }
 
     /**
-     * A vended key pair replaces the catalog's. A token from the static half belonged to the pair
-     * that was just replaced, and signing the new pair with it fails; drop it with its pair.
-     */
-    @Test
-    public void testVendedOssKeyPairDropsTheStaticToken() {
-        Map<String, String> properties = ossProperties();
-        properties.put("oss.session_token", "static-token");
-        Map<String, String> vended = new HashMap<>();
-        vended.put("access_key_id", "vended-ak");
-        vended.put("access_key_secret", "vended-sk");
-
-        Map<String, String> merged = LanceStorageOptions.fromDorisAndVendedStorageOptions(
-                OSS_URI, createAll(properties), vended);
-
-        Assertions.assertNull(merged.get("oss_security_token"));
-        Assertions.assertEquals("vended-ak", merged.get("oss_access_key_id"));
-    }
-
-    /**
      * A namespace that vends its own token keeps it - only a stale one is dropped. The token
      * assertion alone would pass without reconciliation, since the overlay overwrites it anyway,
      * so this also pins the flag that only reconciliation states.
@@ -613,40 +594,24 @@ public class LanceStorageOptionsTest {
     }
 
     /**
-     * The half that was not vended belongs to the pair being replaced. Keeping it produces a
-     * mismatched tuple that OpenDAL signs with anyway, failing at scan time with
-     * SignatureDoesNotMatch; the catalog's own both-or-neither rule cannot catch it, because the
-     * merged map is not one-sided until the stale half is dropped.
-     */
-    @Test
-    public void testVendedOssHalfPairDoesNotMixWithTheStaticOne() {
-        Map<String, String> properties = ossProperties();
-        Map<String, String> vended = new HashMap<>();
-        vended.put("access_key_id", "vended-ak");
-
-        IllegalArgumentException thrown = Assertions.assertThrows(
-                IllegalArgumentException.class,
-                () -> LanceStorageOptions.fromDorisAndVendedStorageOptions(OSS_URI, createAll(properties), vended));
-        Assertions.assertTrue(thrown.getMessage().contains("Incomplete OSS credential"),
-                "unexpected message: " + thrown.getMessage());
-    }
-
-    /**
      * A namespace asking for anonymous access has just described this table, which outranks a
      * credential the catalog holds for something else. Signing with it would 403 on a bucket the
      * catalog's account cannot read.
      */
     @Test
-    public void testVendedAnonymousModeOutranksStaticOssCredentials() {
+    public void testVendedAnonymousModeConflictsWithStaticOssCredentials() {
         Map<String, String> vended = new HashMap<>();
         vended.put("allow_anonymous", "true");
 
-        Map<String, String> merged = LanceStorageOptions.fromDorisAndVendedStorageOptions(
-                OSS_URI, createAll(ossProperties()), vended);
-
-        Assertions.assertEquals("true", merged.get("allow_anonymous"));
-        Assertions.assertNull(merged.get("oss_access_key_id"));
-        Assertions.assertNull(merged.get("oss_secret_access_key"));
+        // The catalog's credentials are not cleared to make room for it: a namespace asking for
+        // anonymous access to a catalog that holds a credential is a contradiction, and saying so
+        // beats silently picking one of the two.
+        IllegalArgumentException thrown = Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> LanceStorageOptions.fromDorisAndVendedStorageOptions(
+                        OSS_URI, createAll(ossProperties()), vended));
+        Assertions.assertTrue(thrown.getMessage().contains("Conflicting OSS authentication"),
+                "unexpected message: " + thrown.getMessage());
     }
 
     @Test
@@ -667,24 +632,11 @@ public class LanceStorageOptionsTest {
     }
 
     @Test
-    public void testOssRoleAndOidcRequireSigning() {
-        for (String option : new String[] {
-                "role_arn", "oidc_token", "oidc_provider_arn", "oidc_token_file"}) {
-            Map<String, String> vended = Collections.singletonMap(option, "signed-value");
-            Map<String, String> merged = LanceStorageOptions
-                    .fromDorisAndVendedStorageOptions(OSS_URI, createAll(ossProperties()), vended);
-            Assertions.assertEquals("signed-value", merged.get(option));
-            Assertions.assertEquals("false", merged.get("allow_anonymous"));
-            Assertions.assertNull(merged.get("oss_access_key_id"));
-            Assertions.assertNull(merged.get("oss_secret_access_key"));
-        }
-    }
-
-    @Test
     public void testOssAnonymousConflictsWithSigningConfiguration() {
         Map<String, String> vended = new HashMap<>();
         vended.put("skip_signature", "true");
-        vended.put("role_arn", "acs:ram::123456789:role/lance");
+        vended.put("access_key_id", "ak");
+        vended.put("access_key_secret", "sk");
 
         IllegalArgumentException thrown = Assertions.assertThrows(
                 IllegalArgumentException.class,
@@ -723,10 +675,11 @@ public class LanceStorageOptionsTest {
         Map<String, String> merged = LanceStorageOptions.fromDorisAndVendedStorageOptions(
                 OSS_URI, createAll(properties), vended);
 
+        // The blanks themselves survive - the merge overlays key by key and does not judge values.
+        // What matters is that they are not mistaken for a credential: inference reads them as
+        // absent, so the request is marked anonymous rather than signed with empty strings.
         Assertions.assertEquals("true", merged.get("allow_anonymous"));
-        Assertions.assertNull(merged.get("oss_access_key_id"));
-        Assertions.assertNull(merged.get("oss_secret_access_key"));
-        Assertions.assertNull(merged.get("oss_security_token"));
+        Assertions.assertEquals("", merged.get("oss_access_key_id"));
     }
 
     /**
@@ -748,45 +701,4 @@ public class LanceStorageOptionsTest {
     }
 
     /** Half a credential cannot sign; fail where the catalog is defined rather than at scan time. */
-    @Test
-    public void testOneSidedVendedOssCredentialIsRejected() {
-        Map<String, String> vended = new HashMap<>();
-        vended.put("access_key_id", "vended-ak-only");
-
-        IllegalArgumentException thrown = Assertions.assertThrows(
-                IllegalArgumentException.class,
-                () -> LanceStorageOptions.fromDorisAndVendedStorageOptions(
-                        OSS_URI, Collections.emptyList(), vended));
-        Assertions.assertTrue(thrown.getMessage().contains("Incomplete OSS credential"),
-                "unexpected message: " + thrown.getMessage());
-    }
-
-    /**
-     * A vended key pair replaces the whole credential, including a role or identity binding the
-     * catalog contributed. Inference counts those as signing configuration, so one left behind
-     * would describe an identity no longer in use.
-     *
-     * <p>Exercised through the provider rather than a catalog because Doris has no static property
-     * that emits a role today - this pins the contract before one exists.
-     */
-    @Test
-    public void testVendedOssKeyPairReplacesARoleBinding() {
-        Map<String, String> merged = new HashMap<>();
-        merged.put("role_arn", "acs:ram::1:role/stale");
-        merged.put("oidc_token_file", "/var/run/stale-token");
-        merged.put("oss_access_key_id", "static-ak");
-        merged.put("oss_secret_access_key", "static-sk");
-
-        Map<String, String> vended = new HashMap<>();
-        vended.put("oss_access_key_id", "vended-ak");
-        vended.put("oss_secret_access_key", "vended-sk");
-        merged.putAll(vended);
-
-        LanceStorageProvider.forDataset(OSS_URI).reconcileVendedStorageOptions(merged, vended);
-
-        Assertions.assertEquals("vended-ak", merged.get("oss_access_key_id"));
-        Assertions.assertEquals("vended-sk", merged.get("oss_secret_access_key"));
-        Assertions.assertNull(merged.get("role_arn"));
-        Assertions.assertNull(merged.get("oidc_token_file"));
-    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/LancePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/LancePropertiesTest.java
@@ -43,6 +43,21 @@ public class LancePropertiesTest {
     }
 
     @Test
+    public void testOssFilesystemProperties() throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("type", "lance");
+        properties.put(LanceFileSystemMetastoreProperties.WAREHOUSE,
+                "oss://bucket/lance");
+
+        AbstractLanceProperties lanceProperties =
+                (AbstractLanceProperties) MetastoreProperties.create(properties);
+
+        Assertions.assertInstanceOf(LanceFileSystemMetastoreProperties.class, lanceProperties);
+        Assertions.assertEquals("oss://bucket/lance",
+                ((LanceFileSystemMetastoreProperties) lanceProperties).getWarehouse());
+    }
+
+    @Test
     public void testRestProperties() throws Exception {
         Map<String, String> properties = new HashMap<>();
         properties.put("type", "lance");

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/LancePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/LancePropertiesTest.java
@@ -110,20 +110,37 @@ public class LancePropertiesTest {
     }
 
     /**
-     * OSS-HDFS is the one oss:// form whose qualified authority is required rather than incidental,
-     * so the bucket rewrite must not touch it.
+     * Doris reads an OSS-HDFS URL through its HDFS-compatible properties, which the Lance OSS
+     * provider cannot consume, so such a catalog could never be handed an endpoint or credentials.
+     * Refuse it outright rather than accept a warehouse that cannot open.
      */
     @Test
-    public void testOssHdfsWarehouseKeepsItsQualifiedAuthority() throws Exception {
-        String warehouse = "oss://bkt.cn-hangzhou.oss-dls.aliyuncs.com/lance";
+    public void testOssHdfsWarehouseIsRejected() {
         Map<String, String> properties = new HashMap<>();
         properties.put("type", "lance");
-        properties.put(LanceFileSystemMetastoreProperties.WAREHOUSE, warehouse);
+        properties.put(LanceFileSystemMetastoreProperties.WAREHOUSE,
+                "oss://bkt.cn-hangzhou.oss-dls.aliyuncs.com/lance");
 
-        AbstractLanceProperties lanceProperties =
-                (AbstractLanceProperties) MetastoreProperties.create(properties);
+        IllegalArgumentException thrown = Assertions.assertThrows(
+                IllegalArgumentException.class, () -> MetastoreProperties.create(properties));
+        Assertions.assertTrue(thrown.getMessage().contains("OSS-HDFS is not supported"),
+                "unexpected message: " + thrown.getMessage());
+    }
 
-        Assertions.assertEquals(warehouse,
-                ((LanceFileSystemMetastoreProperties) lanceProperties).getWarehouse());
+    /**
+     * OSSHdfsProperties selects on the endpoint, so a clean-looking warehouse still routes there
+     * when the endpoint names OSS-HDFS. Checking only the warehouse authority would miss it.
+     */
+    @Test
+    public void testOssHdfsEndpointIsRejectedEvenWithAPlainWarehouse() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("type", "lance");
+        properties.put(LanceFileSystemMetastoreProperties.WAREHOUSE, "oss://bkt/lance");
+        properties.put("oss.endpoint", "cn-hangzhou.oss-dls.aliyuncs.com");
+
+        IllegalArgumentException thrown = Assertions.assertThrows(
+                IllegalArgumentException.class, () -> MetastoreProperties.create(properties));
+        Assertions.assertTrue(thrown.getMessage().contains("OSS-HDFS is not supported"),
+                "unexpected message: " + thrown.getMessage());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/LancePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/LancePropertiesTest.java
@@ -108,4 +108,22 @@ public class LancePropertiesTest {
                     "unexpected message: " + thrown.getMessage());
         }
     }
+
+    /**
+     * OSS-HDFS is the one oss:// form whose qualified authority is required rather than incidental,
+     * so the bucket rewrite must not touch it.
+     */
+    @Test
+    public void testOssHdfsWarehouseKeepsItsQualifiedAuthority() throws Exception {
+        String warehouse = "oss://bkt.cn-hangzhou.oss-dls.aliyuncs.com/lance";
+        Map<String, String> properties = new HashMap<>();
+        properties.put("type", "lance");
+        properties.put(LanceFileSystemMetastoreProperties.WAREHOUSE, warehouse);
+
+        AbstractLanceProperties lanceProperties =
+                (AbstractLanceProperties) MetastoreProperties.create(properties);
+
+        Assertions.assertEquals(warehouse,
+                ((LanceFileSystemMetastoreProperties) lanceProperties).getWarehouse());
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/LancePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/LancePropertiesTest.java
@@ -75,4 +75,37 @@ public class LancePropertiesTest {
         Assertions.assertEquals("http://localhost:8080", restProperties.getRestUri());
         Assertions.assertEquals("bearer", restProperties.getSecurityType());
     }
+
+    /**
+     * Doris accepts the qualified OSS form and reduces it to the bare bucket. Lance takes the
+     * authority as the bucket verbatim, so the warehouse has to be normalized before it becomes a
+     * namespace root - otherwise OpenDAL addresses bucket.oss-<region>.aliyuncs.com.<endpoint>.
+     */
+    @Test
+    public void testQualifiedOssWarehouseIsNormalizedToTheBucket() throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("type", "lance");
+        properties.put(LanceFileSystemMetastoreProperties.WAREHOUSE,
+                "oss://bucket.oss-cn-hangzhou.aliyuncs.com/lance");
+
+        AbstractLanceProperties lanceProperties =
+                (AbstractLanceProperties) MetastoreProperties.create(properties);
+
+        Assertions.assertEquals("oss://bucket/lance",
+                ((LanceFileSystemMetastoreProperties) lanceProperties).getWarehouse());
+    }
+
+    @Test
+    public void testObjectStoreWarehouseMustNameABucket() {
+        for (String warehouse : new String[] {"oss:/lance", "s3:/lance"}) {
+            Map<String, String> properties = new HashMap<>();
+            properties.put("type", "lance");
+            properties.put(LanceFileSystemMetastoreProperties.WAREHOUSE, warehouse);
+
+            IllegalArgumentException thrown = Assertions.assertThrows(
+                    IllegalArgumentException.class, () -> MetastoreProperties.create(properties));
+            Assertions.assertTrue(thrown.getMessage().contains("must name a bucket"),
+                    "unexpected message: " + thrown.getMessage());
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/LancePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/LancePropertiesTest.java
@@ -76,25 +76,6 @@ public class LancePropertiesTest {
         Assertions.assertEquals("bearer", restProperties.getSecurityType());
     }
 
-    /**
-     * Doris accepts the qualified OSS form and reduces it to the bare bucket. Lance takes the
-     * authority as the bucket verbatim, so the warehouse has to be normalized before it becomes a
-     * namespace root - otherwise OpenDAL addresses bucket.oss-<region>.aliyuncs.com.<endpoint>.
-     */
-    @Test
-    public void testQualifiedOssWarehouseIsNormalizedToTheBucket() throws Exception {
-        Map<String, String> properties = new HashMap<>();
-        properties.put("type", "lance");
-        properties.put(LanceFileSystemMetastoreProperties.WAREHOUSE,
-                "oss://bucket.oss-cn-hangzhou.aliyuncs.com/lance");
-
-        AbstractLanceProperties lanceProperties =
-                (AbstractLanceProperties) MetastoreProperties.create(properties);
-
-        Assertions.assertEquals("oss://bucket/lance",
-                ((LanceFileSystemMetastoreProperties) lanceProperties).getWarehouse());
-    }
-
     @Test
     public void testObjectStoreWarehouseMustNameABucket() {
         for (String warehouse : new String[] {"oss:/lance", "s3:/lance"}) {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/LancePropertiesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/property/metastore/LancePropertiesTest.java
@@ -91,24 +91,6 @@ public class LancePropertiesTest {
     }
 
     /**
-     * Doris reads an OSS-HDFS URL through its HDFS-compatible properties, which the Lance OSS
-     * provider cannot consume, so such a catalog could never be handed an endpoint or credentials.
-     * Refuse it outright rather than accept a warehouse that cannot open.
-     */
-    @Test
-    public void testOssHdfsWarehouseIsRejected() {
-        Map<String, String> properties = new HashMap<>();
-        properties.put("type", "lance");
-        properties.put(LanceFileSystemMetastoreProperties.WAREHOUSE,
-                "oss://bkt.cn-hangzhou.oss-dls.aliyuncs.com/lance");
-
-        IllegalArgumentException thrown = Assertions.assertThrows(
-                IllegalArgumentException.class, () -> MetastoreProperties.create(properties));
-        Assertions.assertTrue(thrown.getMessage().contains("OSS-HDFS is not supported"),
-                "unexpected message: " + thrown.getMessage());
-    }
-
-    /**
      * OSSHdfsProperties selects on the endpoint, so a clean-looking warehouse still routes there
      * when the endpoint names OSS-HDFS. Checking only the warehouse authority would miss it.
      */


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67131

Related PR: #66805

Problem Summary:

Lance catalogs already forward provider-native storage options, but Doris did not translate its typed OSS properties, and filesystem catalogs rejected `oss://` warehouses.

This change:

- maps Doris OSS properties to Lance's public OSS options, including anonymous access and addressing style;
- normalizes Namespace-vended aliases so the two spellings of one option cannot reach Lance as competing entries, rejecting conflicting values and passing unknown options through untouched;
- reads a vended option the way the store will: aliases are matched case-insensitively, since OpenDAL lower-cases every config key before deserializing, and the anonymous flag is parsed with OpenDAL's own boolean grammar (`true|on` / `false|off`) rather than Java's, so a vended `ACCESS_KEY_ID` or `allow_anonymous=on` cannot end up with a credential configured and every request sent unsigned;
- separates translation from inference, so options derived from another option - `allow_http` from the effective S3 endpoint, the OSS anonymous flag from the effective credential - are computed once from the final merged configuration rather than from the catalog's half alone;
- accepts `oss://` filesystem warehouses, requiring one that names a bucket, and refuses OSS-HDFS - recognized with the same predicate Doris routes on - since Doris reads that form through its HDFS-compatible properties, which carry no Lance OSS storage options; and
- redacts OSS credentials from every provider-facing failure.

It reuses the FE-to-BE storage-option transport introduced by #66805 and changes no Thrift or BE code.

### Release note

Support native Alibaba Cloud OSS storage options for Lance catalogs.

Two derived options now follow the final merged configuration instead of the catalog's half alone. For S3, `allow_http` is decided by the endpoint actually in effect, so a namespace that vends a plain-HTTP endpoint no longer fails to reach it, and one that vends an HTTPS endpoint no longer carries a stale permission. For OSS, a dataset the catalog holds no storage configuration for is now explicitly marked anonymous rather than leaving that key absent; a deployment that relied on an exported `OSS_ALLOW_ANONYMOUS` to decide it for such a catalog should configure the catalog instead.

### Check List (For Author)

- Test:
    - Unit Test: Official Doris build image `run-fe-ut.sh`; locally 94 tests across the Lance and storage-property suites.
    - Manual test: End-to-end scans against a real Alibaba Cloud OSS bucket on a native arm64 cluster. Every case returns `count(*) = 4, sum(amount) = 100` with matching full rows, type mapping (`bigint`/`text`/`int`) and predicate pushdown:
        - **dir namespace** (`lance.catalog.type=filesystem` → `LanceNamespace.connect("dir")`) over an `oss://` warehouse with Doris OSS properties;
        - **REST namespace** against a real **Apache Gravitino 1.3.0** `lance-rest` service with **no static OSS credentials on the Doris catalog at all** — Gravitino vends the bare OSS-native spellings `endpoint` / `access_key_id` / `access_key_secret` / `region`, which this PR normalizes before handing them to the BE, so the scan succeeding is what shows the vended path works;
        - a warehouse with no bucket (`oss:/path`) is rejected at `CREATE CATALOG`, and the qualified `oss://bucket.<endpoint>/path` form is passed to the engine as written rather than rewritten - the store then reports the host it actually tried, `bucket.<endpoint>.<endpoint>`;
        - **STS temporary credentials**: an `AssumeRole` triple scans, and the same temporary key pair *without* `oss.session_token` fails with OSS's own `InvalidAccessKeyId` / "The Security Token may be lost to specify that it is a STS Access Id" — the negative control that shows the token reaches the BE rather than the scan succeeding by another route;
        - **anonymous flag vs. vended credentials**: a catalog with `oss.endpoint`/`oss.region` but no key pair reads as anonymous on its own, and still scans once Gravitino vends a credential. This is the case the plain Gravitino test cannot reach, because a catalog with no `oss.*` at all never builds an OSSProperties and so never claims anonymity.

      Two more negative controls: a Gravitino catalog vending both `endpoint` and `oss_endpoint` with different values is rejected; a vended half key pair is rejected rather than silently paired with the catalog's other half.

      Query profiles confirm the scans ran on the BE, not the FE: splits assigned to the backend and `FILE_SCAN_OPERATOR(table_name=all_types)` reporting `RowsProduced: sum 4`. The BE is a stock arm64 build of the same `branch-4.1` base — this PR changes no BE code, and `gensrc/thrift` and `gensrc/proto` are byte-identical between the two trees.
    - Build: Full FE build and Checkstyle passed.
- Behavior changed: Yes. Lance catalogs can use `oss://` with Doris OSS properties and with OSS options vended by a Namespace.
- Does this need documentation: Yes — apache/doris-website#4094 adds an OSS section to the lance-catalog page, in both the English and zh-CN copies.

### Scope

Not included: role-based credential vending, STS credential refresh during a scan, a new Thrift envelope, or static support for other object-store providers.

Namespace-vended options overlay the catalog's key by key, so a namespace is expected to vend a complete credential rather than part of one. An earlier revision of this PR replaced the credential as a unit; it was removed as more machinery than the cases it guarded against warranted. Where a vended anonymous flag meets a configured credential the two are reported as a conflict rather than one side quietly winning.

`LanceS3StorageProvider` is left alone. Its comparable defects predate this work (#66805) and are better addressed for all providers at once than widened into an OSS change.

Anonymous OSS access itself is covered by unit tests only — how the flag is inferred is exercised end to end, but issuing a genuinely unsigned read needs an anonymously readable bucket, which I do not have. Its correctness rests on lance forwarding unrecognized options to OpenDAL plus OpenDAL's OSS config accepting the flag (`OssCore::sign` returns the request unsigned whenever it is set).




