### PR TITLE
[fix](fe) Preserve SQL-rendering fields in Expr Gson serialization

### DIFF
--- a/fe/fe-catalog/src/main/java/org/apache/doris/analysis/AGENTS.md
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/analysis/AGENTS.md
@@ -1,0 +1,26 @@
+# Legacy Expr persistence — Review Guide
+
+Legacy `Expr` objects are persisted by metadata consumers such as Routine Load images and
+`ALTER ROUTINE LOAD` journals. Doris Gson serializes only fields annotated with
+`@SerializedName`, so an unclassified field can be silently lost during FE recovery.
+
+## Expr changes
+
+- [ ] Any field that changes `ExprToSqlVisitor` output has a stable `@SerializedName` key.
+- [ ] Existing serialized keys are not renamed, removed, or reused for a different meaning.
+- [ ] Analysis caches and execution-only fields remain unpersisted only when they can be rebuilt
+  after the restored expression is converted to SQL and analyzed again.
+- [ ] Every unpersisted instance field is listed with that rationale in
+  `ExprGsonSerializationTest.NON_DURABLE_EXPR_FIELDS`; do not add fields to the list merely to
+  make the test pass.
+- [ ] New concrete `Expr` subtypes are registered in both Gson factories and have a non-default
+  sample in `ExprGsonSerializationTest`.
+- [ ] Samples set every SQL-relevant option to a non-default value so semantic loss is observable.
+
+## Required tests
+
+- [ ] `ExprGsonSerializationTest` preserves the concrete subtype and `ExprToSqlVisitor` output
+  with and without table names across Gson round-trip.
+- [ ] Metadata consumers that introduce a new Expr carrier add an image and journal replay test.
+- [ ] Routine Load expression changes cover column mappings, preceding filters, where filters, and
+  delete conditions as applicable.

--- a/fe/fe-catalog/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/analysis/FunctionCallExpr.java
@@ -43,6 +43,7 @@ public class FunctionCallExpr extends Expr {
 
     private FunctionParams aggFnParams;
 
+    @SerializedName("obe")
     private List<OrderByElement> orderByElements = Lists.newArrayList();
 
     // check analytic function

--- a/fe/fe-catalog/src/main/java/org/apache/doris/analysis/MatchPredicate.java
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/analysis/MatchPredicate.java
@@ -72,6 +72,7 @@ public class MatchPredicate extends Predicate {
     private String invertedIndexParserStopwords = "";
     private String invertedIndexAnalyzerName = "";
     // Fields for SQL generation
+    @SerializedName("ea")
     private String explicitAnalyzer = "";
 
     private MatchPredicate() {

--- a/fe/fe-catalog/src/main/java/org/apache/doris/analysis/OrderByElement.java
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/analysis/OrderByElement.java
@@ -21,6 +21,7 @@
 package org.apache.doris.analysis;
 
 import com.google.common.collect.Lists;
+import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
 
@@ -28,11 +29,14 @@ import java.util.List;
  * Combination of expr and ASC/DESC, and nulls ordering.
  */
 public class OrderByElement {
+    @SerializedName("e")
     private Expr expr;
+    @SerializedName("ia")
     private final boolean isAsc;
 
     // Represents the NULLs ordering specified: true when "NULLS FIRST", false when
     // "NULLS LAST", and null if not specified.
+    @SerializedName("nfp")
     private final Boolean nullsFirstParam;
 
     public OrderByElement(Expr expr, boolean isAsc, Boolean nullsFirstParam) {

--- a/fe/fe-catalog/src/main/java/org/apache/doris/analysis/PlaceHolderExpr.java
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/analysis/PlaceHolderExpr.java
@@ -22,12 +22,15 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.Type;
 
 import com.google.common.base.Preconditions;
+import com.google.gson.annotations.SerializedName;
 
 import java.nio.ByteBuffer;
 
 // PlaceHolderExpr is a reference class point to real LiteralExpr
 public class PlaceHolderExpr extends LiteralExpr {
+    @SerializedName("le")
     private LiteralExpr lExpr;
+    @SerializedName("mtc")
     int mysqlTypeCode = -1;
 
     public PlaceHolderExpr() {

--- a/fe/fe-catalog/src/main/java/org/apache/doris/analysis/SearchPredicate.java
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/analysis/SearchPredicate.java
@@ -21,6 +21,8 @@ import org.apache.doris.analysis.SearchDslParser.QsPlan;
 import org.apache.doris.catalog.Index;
 import org.apache.doris.catalog.Type;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -29,6 +31,7 @@ import java.util.List;
  * for BE VSearchExpr processing. This is only used during FE->BE translation.
  */
 public class SearchPredicate extends Predicate {
+    @SerializedName("dsl")
     private final String dslString;
     private final QsPlan qsPlan;
     private final List<Index> fieldIndexes;

--- a/fe/fe-catalog/src/main/java/org/apache/doris/analysis/SlotRef.java
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/analysis/SlotRef.java
@@ -38,7 +38,9 @@ public class SlotRef extends Expr {
     @SerializedName("col")
     private String col;
     // Used in toSql
+    @SerializedName("l")
     private String label;
+    @SerializedName("scp")
     private List<String> subColPath;
 
     // results of analysis

--- a/fe/fe-catalog/src/main/java/org/apache/doris/analysis/TimeV2Literal.java
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/analysis/TimeV2Literal.java
@@ -20,14 +20,21 @@ package org.apache.doris.analysis;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.catalog.Type;
 
+import com.google.gson.annotations.SerializedName;
+
 public class TimeV2Literal extends LiteralExpr {
     public static final TimeV2Literal MIN_VALUE = new TimeV2Literal(838, 59, 59, 999999, 6, true);
     public static final TimeV2Literal MAX_VALUE = new TimeV2Literal(838, 59, 59, 999999, 6, false);
 
+    @SerializedName("h")
     protected int hour;
+    @SerializedName("m")
     protected int minute;
+    @SerializedName("s")
     protected int second;
+    @SerializedName("us")
     protected int microsecond;
+    @SerializedName("neg")
     protected boolean negative;
 
     /**

--- a/fe/fe-catalog/src/main/java/org/apache/doris/analysis/VariableExpr.java
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/analysis/VariableExpr.java
@@ -17,13 +17,17 @@
 
 package org.apache.doris.analysis;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.math.BigDecimal;
 import java.util.Objects;
 
 // Variable expr: including the system variable and user define variable.
 // Converted to StringLiteral in analyze, if this variable is not exist, throw AnalysisException.
 public class VariableExpr extends Expr {
+    @SerializedName("n")
     private String name;
+    @SerializedName("st")
     private SetType setType;
     private boolean isNull;
     private boolean boolValue;

--- a/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprGsonSerializationTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/analysis/ExprGsonSerializationTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.ArrayType;
 import org.apache.doris.catalog.Function.NullableMode;
 import org.apache.doris.catalog.FunctionName;
 import org.apache.doris.catalog.MapType;
+import org.apache.doris.catalog.MysqlColType;
 import org.apache.doris.catalog.ScalarFunction;
 import org.apache.doris.catalog.StructType;
 import org.apache.doris.catalog.Type;
@@ -29,6 +30,7 @@ import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.persist.gson.GsonUtilsCatalog;
 import org.apache.doris.persist.gson.RuntimeTypeAdapterFactory;
 
+import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -51,6 +53,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -59,6 +62,38 @@ import java.util.stream.Stream;
 public class ExprGsonSerializationTest {
     private static final Pattern CLASS_DECLARATION_PATTERN = Pattern.compile(
             "public\\s+(abstract\\s+)?(?:final\\s+)?class\\s+(\\w+)\\s+extends\\s+(\\w+)\\b");
+    // These fields are analysis caches or execution-only state. They can be rebuilt after the
+    // restored expression is converted to SQL and analyzed again. Keeping this list explicit
+    // makes every newly added unannotated Expr field fail the persistence contract test.
+    private static final Set<String> NON_DURABLE_EXPR_FIELDS = new TreeSet<>(Arrays.asList(
+            "BinaryPredicate.slotIsLeft",
+            "Expr.fn",
+            "Expr.isConstant",
+            "Expr.nullable",
+            "FunctionCallExpr.aggFnParams",
+            "FunctionCallExpr.isMergeAggFn",
+            "FunctionCallExpr.originChildSize",
+            "InformationFunction.intValue",
+            "InformationFunction.strValue",
+            "JsonLiteral.beConverted",
+            "JsonLiteral.parser",
+            "MatchPredicate.invertedIndexAnalyzerName",
+            "MatchPredicate.invertedIndexCharFilter",
+            "MatchPredicate.invertedIndexParser",
+            "MatchPredicate.invertedIndexParserLowercase",
+            "MatchPredicate.invertedIndexParserMode",
+            "MatchPredicate.invertedIndexParserStopwords",
+            "SearchPredicate.fieldIndexes",
+            "SearchPredicate.qsPlan",
+            "SlotRef.desc",
+            "TryCastExpr.originCastNullable",
+            "VariableExpr.boolValue",
+            "VariableExpr.decimalValue",
+            "VariableExpr.floatValue",
+            "VariableExpr.intValue",
+            "VariableExpr.isNull",
+            "VariableExpr.literalExpr",
+            "VariableExpr.strValue"));
 
     private static class ExprHolder {
         @SerializedName("expr")
@@ -94,7 +129,34 @@ public class ExprGsonSerializationTest {
     }
 
     @Test
-    public void testExprHolderRoundTrip() {
+    public void testExprSqlRoundTripForAllConcreteRegisteredSubtypes() throws Exception {
+        Map<Class<? extends Expr>, Expr> samples = createExprSamples();
+        Assertions.assertAll(
+                () -> assertExprSqlRoundTrip(samples, GsonUtils.GSON, "GsonUtils.GSON"),
+                () -> assertExprSqlRoundTrip(samples, GsonUtilsCatalog.GSON, "GsonUtilsCatalog.GSON"));
+    }
+
+    @Test
+    public void testExprFieldsAreExplicitlyClassifiedForPersistence() throws Exception {
+        Set<String> unclassifiedFields = new TreeSet<>();
+        for (Class<? extends Expr> exprClass : createExprSamples().keySet()) {
+            for (Class<?> current = exprClass; Expr.class.isAssignableFrom(current);
+                    current = current.getSuperclass()) {
+                for (Field field : current.getDeclaredFields()) {
+                    int modifiers = field.getModifiers();
+                    if (!field.isSynthetic() && !Modifier.isStatic(modifiers) && !Modifier.isTransient(modifiers)
+                            && field.getAnnotation(SerializedName.class) == null) {
+                        unclassifiedFields.add(current.getSimpleName() + "." + field.getName());
+                    }
+                }
+            }
+        }
+        Assertions.assertEquals(NON_DURABLE_EXPR_FIELDS, unclassifiedFields,
+                "New Expr fields must use @SerializedName or be explicitly classified as non-durable");
+    }
+
+    @Test
+    public void testExprHolderRoundTrip() throws Exception {
         ExprHolder holder = new ExprHolder(
                 createArithmeticExpr(),
                 Arrays.asList(createSearchPredicate(), createVirtualSlotRef(), createLambdaFunctionExpr()));
@@ -110,11 +172,65 @@ public class ExprGsonSerializationTest {
         Assertions.assertEquals(json, GsonUtilsCatalog.GSON.toJson(restored));
     }
 
+    @Test
+    public void testFunctionOrderByElementRoundTrip() {
+        FunctionCallExpr original = createFunctionCallExpr();
+        Assertions.assertAll(
+                () -> assertFunctionOrderByElementRoundTrip(original, GsonUtils.GSON, "GsonUtils.GSON"),
+                () -> assertFunctionOrderByElementRoundTrip(
+                        original, GsonUtilsCatalog.GSON, "GsonUtilsCatalog.GSON"));
+    }
+
+    @Test
+    public void testPlaceHolderMysqlTypeRoundTrip() {
+        PlaceHolderExpr original = new PlaceHolderExpr(new StringLiteral("placeholder"));
+        original.mysqlTypeCode = MysqlColType.MYSQL_TYPE_LONG.getCode() | MysqlColType.UNSIGNED_MASK;
+        Assertions.assertAll(
+                () -> assertPlaceHolderMysqlTypeRoundTrip(original, GsonUtils.GSON, "GsonUtils.GSON"),
+                () -> assertPlaceHolderMysqlTypeRoundTrip(
+                        original, GsonUtilsCatalog.GSON, "GsonUtilsCatalog.GSON"));
+    }
+
     private void assertExprRoundTrip(Class<? extends Expr> expectedClass, Expr expr) {
         String json = GsonUtilsCatalog.GSON.toJson(expr, Expr.class);
         Expr restored = GsonUtilsCatalog.GSON.fromJson(json, Expr.class);
         Assertions.assertEquals(expectedClass, restored.getClass());
         Assertions.assertEquals(json, GsonUtilsCatalog.GSON.toJson(restored, Expr.class));
+    }
+
+    private void assertExprSqlRoundTrip(Map<Class<? extends Expr>, Expr> samples, Gson gson, String gsonName) {
+        Assertions.assertAll(samples.entrySet().stream().flatMap(entry -> Stream.of(
+                () -> assertExprSqlRoundTrip(entry.getValue(), gson, gsonName, ToSqlParams.WITHOUT_TABLE),
+                () -> assertExprSqlRoundTrip(entry.getValue(), gson, gsonName, ToSqlParams.WITH_TABLE))));
+    }
+
+    private void assertExprSqlRoundTrip(Expr original, Gson gson, String gsonName, ToSqlParams params) {
+        String expectedSql = original.accept(ExprToSqlVisitor.INSTANCE, params);
+        String json = gson.toJson(original, Expr.class);
+        Expr restored = gson.fromJson(json, Expr.class);
+        String actualSql = restored.accept(ExprToSqlVisitor.INSTANCE, params);
+        Assertions.assertEquals(expectedSql, actualSql,
+                gsonName + " changed SQL for " + original.getClass().getSimpleName());
+    }
+
+    private void assertFunctionOrderByElementRoundTrip(FunctionCallExpr original, Gson gson, String gsonName) {
+        String json = gson.toJson(original, Expr.class);
+        FunctionCallExpr restored = (FunctionCallExpr) gson.fromJson(json, Expr.class);
+        Assertions.assertEquals(1, restored.getOrderByElements().size(), gsonName);
+        OrderByElement expected = original.getOrderByElements().get(0);
+        OrderByElement actual = restored.getOrderByElements().get(0);
+        Assertions.assertEquals(
+                expected.getExpr().accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE),
+                actual.getExpr().accept(ExprToSqlVisitor.INSTANCE, ToSqlParams.WITH_TABLE), gsonName);
+        Assertions.assertEquals(expected.getIsAsc(), actual.getIsAsc(), gsonName);
+        Assertions.assertEquals(expected.getNullsFirstParam(), actual.getNullsFirstParam(), gsonName);
+    }
+
+    private void assertPlaceHolderMysqlTypeRoundTrip(PlaceHolderExpr original, Gson gson, String gsonName) {
+        String json = gson.toJson(original, Expr.class);
+        PlaceHolderExpr restored = (PlaceHolderExpr) gson.fromJson(json, Expr.class);
+        Assertions.assertEquals(original.mysqlTypeCode, restored.mysqlTypeCode, gsonName);
+        Assertions.assertTrue(restored.isUnsigned(), gsonName);
     }
 
     private Map<Class<? extends Expr>, Expr> createExprSamples() throws Exception {
@@ -146,7 +262,7 @@ public class ExprGsonSerializationTest {
         samples.put(StringLiteral.class, new StringLiteral("expr-gson"));
         samples.put(StructLiteral.class, new StructLiteral(new StructType(),
                 new IntLiteral(7L), new StringLiteral("field")));
-        samples.put(TimeV2Literal.class, new TimeV2Literal(12, 34, 56, 123456, 6, false));
+        samples.put(TimeV2Literal.class, new TimeV2Literal(12, 34, 56, 123456, 6, true));
         samples.put(VarBinaryLiteral.class, new VarBinaryLiteral("bin".getBytes(StandardCharsets.UTF_8)));
         samples.put(BetweenPredicate.class, createBetweenPredicate());
         samples.put(BinaryPredicate.class, createBinaryPredicate());
@@ -164,8 +280,12 @@ public class ExprGsonSerializationTest {
     }
 
     private FunctionCallExpr createFunctionCallExpr() {
-        return new FunctionCallExpr("ifnull",
-                Arrays.asList(NullLiteral.create(Type.VARCHAR), new StringLiteral("fallback")), true);
+        IntLiteral orderKey = new IntLiteral(7L);
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr("group_concat",
+                Arrays.asList(new StringLiteral("value"), orderKey), true);
+        functionCallExpr.setOrderByElements(
+                Collections.singletonList(new OrderByElement(orderKey, true, Boolean.TRUE)));
+        return functionCallExpr;
     }
 
     private LambdaFunctionCallExpr createLambdaFunctionCallExpr() {
@@ -224,7 +344,7 @@ public class ExprGsonSerializationTest {
 
     private MatchPredicate createMatchPredicate() {
         return new MatchPredicate(MatchPredicate.Operator.MATCH_ANY,
-                new SlotRef(Type.VARCHAR, false), new StringLiteral("hello"),
+                createNamedSlotRef("content"), new StringLiteral("hello"),
                 Type.BOOLEAN, NullableMode.DEPEND_ON_ARGUMENT, null, false, "english");
     }
 
@@ -268,13 +388,14 @@ public class ExprGsonSerializationTest {
                 Type.BIGINT, NullableMode.ALWAYS_NOT_NULLABLE, false);
     }
 
-    private SlotRef createSlotRef() {
+    private SlotRef createSlotRef() throws Exception {
         SlotRef slotRef = createNamedSlotRef("col1");
         slotRef.setType(Type.BIGINT);
+        setDeclaredField(SlotRef.class, slotRef, "subColPath", Arrays.asList("nested", "leaf"));
         return slotRef;
     }
 
-    private VirtualSlotRef createVirtualSlotRef() {
+    private VirtualSlotRef createVirtualSlotRef() throws Exception {
         String json = GsonUtilsCatalog.GSON.toJson(createSlotRef(), Expr.class)
                 .replace("\"clazz\":\"SlotRef\"", "\"clazz\":\"VirtualSlotRef\"");
         return (VirtualSlotRef) GsonUtilsCatalog.GSON.fromJson(json, Expr.class);
@@ -288,7 +409,7 @@ public class ExprGsonSerializationTest {
     }
 
     private VariableExpr createVariableExpr() {
-        VariableExpr variableExpr = new VariableExpr("sql_mode");
+        VariableExpr variableExpr = new VariableExpr("sql_mode", SetType.GLOBAL);
         variableExpr.setStringValue("STRICT_TRANS_TABLES");
         variableExpr.setType(Type.VARCHAR);
         return variableExpr;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #62900

Problem Summary:

Doris metadata Gson instances use an exclusion strategy that omits fields without `@SerializedName`.

`ExprGsonSerializationTest` previously verified the restored concrete subtype and JSON idempotence. Those assertions can still pass after a field has already been omitted from the first serialized JSON, so they do not prove that an expression keeps the same canonical SQL.

This PR adds stable serialized names for state used by SQL reconstruction in:

- `FunctionCallExpr` and its nested `OrderByElement`
- `MatchPredicate`
- `PlaceHolderExpr`
- `SearchPredicate`
- `SlotRef`
- `TimeV2Literal`
- `VariableExpr`

It also strengthens the shared Expr serialization contract:

- the source Expr hierarchy, both Gson subtype registries, and the sample corpus must cover the same concrete subtypes;
- every direct Expr instance field must be serialized or explicitly classified as derived, non-durable state;
- every concrete sample must preserve `ExprToSqlVisitor` output with and without table names through both `GsonUtils.GSON` and `GsonUtilsCatalog.GSON`;
- non-default nested function `ORDER BY` state and placeholder MySQL protocol state are checked directly.

A colocated `AGENTS.md` records these persistence and test requirements as a review checklist for future Expr and metadata-consumer changes.

The durable contract is concrete subtype plus canonical SQL reconstruction. Analyzer, planner, translation, and execution caches remain intentionally non-durable and are rebuilt by later analysis. The newly added JSON fields are additive; metadata written before this change cannot recover values that were never serialized.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - `./run-fe-ut.sh --run org.apache.doris.analysis.ExprGsonSerializationTest`
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No. User-facing SQL syntax and interfaces are unchanged; newly written Expr JSON preserves the covered SQL-rendering state.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
