### PR TITLE
[fix](be) Avoid abort on absent schema tree columns

### DIFF
--- a/be/src/format/table/table_schema_change_helper.h
+++ b/be/src/format/table/table_schema_change_helper.h
@@ -77,11 +77,10 @@ public:
             return nullptr;
         }
 
-        // Presence-only check (does NOT DCHECK). Distinct from children_column_exists, which asserts
-        // the key exists and then reports the file-side exists flag. Callers use this to reject a
-        // projected column that is absent from the table-side schema tree (an FE/BE schema-contract
-        // mismatch) BEFORE calling children_column_exists, turning a would-be process abort into a
-        // graceful per-query error.
+        // Presence-only check. Distinct from children_column_exists, which reports the file-side
+        // exists flag and also returns false for an unregistered key. Callers use this to distinguish
+        // a projected column absent from the table-side schema tree (an FE/BE schema-contract mismatch)
+        // from a registered column that is absent from the data file.
         virtual bool has_children_column(std::string table_column_name) const {
             throw std::logic_error(
                     "has_children_column should not be called on base TableInfoNode");
@@ -188,8 +187,8 @@ public:
         }
 
         bool children_column_exists(std::string table_column_name) const override {
-            DCHECK(children.contains(table_column_name));
-            return children.at(table_column_name).exists;
+            auto child = children.find(table_column_name);
+            return child != children.end() && child->second.exists;
         }
 
         const schema::external::TField* get_missing_column_field(

--- a/be/test/format/table/table_schema_change_helper_test.cpp
+++ b/be/test/format/table/table_schema_change_helper_test.cpp
@@ -117,6 +117,17 @@ TEST(PartitionColumnFillerTest, FillNullableIntPartitionValue) {
     }
 }
 
+TEST(MockTableSchemaChangeHelper, UnknownStructChildDoesNotExist) {
+    TableSchemaChangeHelper::StructNode root;
+    root.add_children("file_column", "file_column",
+                      std::make_shared<TableSchemaChangeHelper::ScalarNode>());
+    root.add_not_exist_children("missing_file_column");
+
+    EXPECT_TRUE(root.children_column_exists("file_column"));
+    EXPECT_FALSE(root.children_column_exists("missing_file_column"));
+    EXPECT_FALSE(root.children_column_exists("partition_column"));
+}
+
 TEST(MockTableSchemaChangeHelper, OrcNameNoSchemaChange) {
     std::vector<DataTypePtr> data_types;
     std::vector<std::string> column_names;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #66835

Problem Summary:

Table-format predicate probes can reference a column that is not registered in the schema tree. `StructNode::children_column_exists()` assumed every probe had an entry, so an absent key triggered a DCHECK in debug builds or `std::out_of_range` in release builds and terminated the BE process.

This change treats an unregistered child as unavailable for file-level processing while preserving `has_children_column()` for callers that need to distinguish an FE/BE schema-contract mismatch from a file-missing column. The unit test covers present, known-missing, and unregistered children.

### Release note

Prevent a BE abort when table-format processing probes a column absent from the schema tree.

### Check List (For Author)

- Test:
  - No local BE build or unit test was run per the requested validation boundary.
  - `build-support/clang-format.sh` passed with clang-format 16.
  - `build-support/check-format.sh` passed with clang-format 16.
  - `build-support/check-build-hygiene.sh` passed.
  - `git diff --check` passed.
- Behavior changed: Yes. An unregistered schema-tree child now reports unavailable instead of terminating the BE process.
- Does this need documentation: No