### PR TITLE
[fix](be) Restore default iterator for schema-missing columns

### DIFF
--- a/be/src/storage/segment/segment.cpp
+++ b/be/src/storage/segment/segment.cpp
@@ -793,6 +793,13 @@ DataTypePtr Segment::get_data_type_of(const TabletColumn& read_column, const Dat
         return DataTypeFactory::instance().create_data_type(read_column);
     }
 
+    // A historical rowset schema can omit a variant root that is still present in the segment
+    // footer. Preserve the schema-change fallback instead of trying to infer a path type from a
+    // reader that the rowset schema does not admit.
+    if (!_tablet_schema->has_column_unique_id(unique_id)) {
+        return DataTypeFactory::instance().create_data_type(read_column);
+    }
+
     std::shared_ptr<ColumnReader> v_reader;
     OlapReaderStatistics tmp_stats;
     auto* stats = read_options.stats == nullptr ? &tmp_stats : read_options.stats;
@@ -917,6 +924,13 @@ Status Segment::new_column_iterator(const TabletColumn& tablet_column,
         }
     }
 
+    // The rowset schema may omit a column that is still present in an old segment footer.
+    // Keep read-time constant columns on their existing path.
+    if (!_tablet_schema->has_column_unique_id(unique_id) && !const_value.has_value()) {
+        RETURN_IF_ERROR(new_default_iterator(tablet_column, iter));
+        return Status::OK();
+    }
+
     // init iterator by unique id
     std::shared_ptr<ColumnReader> reader;
     RETURN_IF_ERROR(get_column_reader(unique_id, &reader, opt->stats, &opt->io_ctx,
@@ -975,7 +989,7 @@ Status Segment::get_column_reader(int32_t col_uid, std::shared_ptr<ColumnReader>
     RETURN_IF_ERROR(_create_column_meta_once(stats, source_io_ctx));
     SCOPED_RAW_TIMER(&stats->segment_create_column_readers_timer_ns);
     // The column is not in this segment, return nullptr
-    if (!_tablet_schema->has_column_unique_id(col_uid)) {
+    if (!_tablet_schema->has_column_unique_id(col_uid) && !const_value.has_value()) {
         *column_reader = nullptr;
         return Status::Error<ErrorCode::NOT_FOUND, false>("column not found in segment, col_uid={}",
                                                           col_uid);
@@ -1001,7 +1015,7 @@ Status Segment::get_column_reader(const TabletColumn& col,
     SCOPED_RAW_TIMER(&stats->segment_create_column_readers_timer_ns);
     int col_uid = col.unique_id() >= 0 ? col.unique_id() : col.parent_unique_id();
     // The column is not in this segment, return nullptr
-    if (!_tablet_schema->has_column_unique_id(col_uid)) {
+    if (!_tablet_schema->has_column_unique_id(col_uid) && !const_value.has_value()) {
         *column_reader = nullptr;
         return Status::Error<ErrorCode::NOT_FOUND, false>("column not found in segment, col_uid={}",
                                                           col_uid);

--- a/be/test/storage/segment/segment_iterator_expr_zonemap_test.cpp
+++ b/be/test/storage/segment/segment_iterator_expr_zonemap_test.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "core/assert_cast.h"
+#include "core/block/block.h"
 #include "core/column/column_vector.h"
 #include "core/data_type/data_type_number.h"
 #include "core/field.h"
@@ -38,6 +39,7 @@
 #include "storage/predicate/block_column_predicate.h"
 #include "storage/predicate/comparison_predicate.h"
 #include "storage/row_cursor.h"
+#include "storage/segment/column_reader.h"
 #include "storage/segment/row_ranges.h"
 #include "storage/segment/segment.h"
 #include "storage/segment/segment_iterator.h"
@@ -118,6 +120,16 @@ std::shared_ptr<AndBlockColumnPredicate> make_commit_tso_gt_predicate(int32_t co
     auto predicates = AndBlockColumnPredicate::create_shared();
     std::shared_ptr<ColumnPredicate> pred(
             new ComparisonPredicateBase<TYPE_BIGINT, PredicateType::GT>(
+                    column_id, COMMIT_TSO_COL, Field::create_field<TYPE_BIGINT>(value)));
+    predicates->add_column_predicate(SingleColumnBlockPredicate::create_unique(pred));
+    return predicates;
+}
+
+std::shared_ptr<AndBlockColumnPredicate> make_commit_tso_lt_predicate(int32_t column_id,
+                                                                      int64_t value) {
+    auto predicates = AndBlockColumnPredicate::create_shared();
+    std::shared_ptr<ColumnPredicate> pred(
+            new ComparisonPredicateBase<TYPE_BIGINT, PredicateType::LT>(
                     column_id, COMMIT_TSO_COL, Field::create_field<TYPE_BIGINT>(value)));
     predicates->add_column_predicate(SingleColumnBlockPredicate::create_unique(pred));
     return predicates;
@@ -218,6 +230,46 @@ protected:
                            segment);
         ASSERT_TRUE(st.ok()) << st;
         ASSERT_EQ(kCommitTsoRows, (*segment)->num_rows());
+    }
+
+    void build_segment_with_rowset_schema(const TabletSchemaSPtr& writer_schema,
+                                          const TabletSchemaSPtr& rowset_schema,
+                                          std::shared_ptr<Segment>* segment) {
+        const auto path = std::string(kTestDir) + "/schema_evolution_segment.dat";
+        auto fs = io::global_local_filesystem();
+        io::FileWriterPtr file_writer;
+        auto st = fs->create_file(path, &file_writer);
+        ASSERT_TRUE(st.ok()) << st;
+
+        SegmentWriterOptions opts;
+        opts.num_rows_per_block = 1024;
+        TestSegmentWriter writer(file_writer.get(), 0, writer_schema, nullptr, nullptr, opts,
+                                 nullptr);
+        st = writer.init();
+        ASSERT_TRUE(st.ok()) << st;
+
+        RowCursor row;
+        std::vector<Field> fields(writer_schema->num_columns(), Field(PrimitiveType::TYPE_NULL));
+        st = row.init_scan_key(writer_schema, std::move(fields));
+        ASSERT_TRUE(st.ok()) << st;
+        row.mutable_field(0) = int_field(1);
+        row.mutable_field(1) = writer_schema->column(1).type() == FieldType::OLAP_FIELD_TYPE_BIGINT
+                                       ? Field::create_field<TYPE_BIGINT>(0)
+                                       : int_field(42);
+        st = writer.append_row(row);
+        ASSERT_TRUE(st.ok()) << st;
+
+        uint64_t file_size = 0;
+        uint64_t index_size = 0;
+        st = writer.finalize(&file_size, &index_size);
+        ASSERT_TRUE(st.ok()) << st;
+        st = file_writer->close();
+        ASSERT_TRUE(st.ok()) << st;
+
+        st = Segment::open(fs, path, 100, 0, kRowsetId, rowset_schema, io::FileReaderOptions {},
+                           segment);
+        ASSERT_TRUE(st.ok()) << st;
+        ASSERT_EQ(1, (*segment)->num_rows());
     }
 
     void prepare_expr_context(const VExprContextSPtr& expr_ctx) {
@@ -338,6 +390,117 @@ TEST_F(SegmentIteratorExprZonemapTest, NewColumnIteratorReadsCommitTsoFromReadOp
     for (size_t i = 0; i < dst->size(); ++i) {
         EXPECT_EQ(kCommitTso, col->get_element(i));
     }
+}
+
+TEST_F(SegmentIteratorExprZonemapTest,
+       NewColumnIteratorUsesDefaultForFooterColumnMissingFromRowsetSchema) {
+    auto writer_schema = std::make_shared<TabletSchema>();
+    writer_schema->append_column(*create_int_key(0, false));
+    writer_schema->append_column(
+            *create_int_value(1, FieldAggregationMethod::OLAP_FIELD_AGGREGATION_NONE, true, "7"));
+    writer_schema->set_storage_page_size(4096);
+
+    auto rowset_schema = std::make_shared<TabletSchema>();
+    rowset_schema->append_column(*create_int_key(0, false));
+    rowset_schema->set_storage_page_size(4096);
+
+    std::shared_ptr<Segment> segment;
+    ASSERT_NO_FATAL_FAILURE(
+            build_segment_with_rowset_schema(writer_schema, rowset_schema, &segment));
+
+    StorageReadOptions read_options;
+    read_options.stats = &_stats;
+    read_options.tablet_schema = writer_schema;
+
+    ColumnIteratorUPtr iter;
+    auto st = segment->new_column_iterator(writer_schema->column(1), &iter, &read_options);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_NE(nullptr, iter);
+    EXPECT_NE(nullptr, dynamic_cast<DefaultValueColumnIterator*>(iter.get()));
+
+    MutableColumnPtr dst = ColumnVector<TYPE_INT>::create();
+    size_t rows = 1;
+    bool has_null = true;
+    ASSERT_TRUE(iter->next_batch(&rows, dst, &has_null).ok());
+    ASSERT_FALSE(has_null);
+    ASSERT_EQ(1, dst->size());
+    EXPECT_EQ(7, assert_cast<const ColumnInt32&>(*dst).get_element(0));
+}
+
+TEST_F(SegmentIteratorExprZonemapTest,
+       NewIteratorUsesDefaultForFooterColumnMissingFromRowsetSchema) {
+    auto writer_schema = std::make_shared<TabletSchema>();
+    writer_schema->append_column(*create_int_key(0, false));
+    writer_schema->append_column(
+            *create_int_value(1, FieldAggregationMethod::OLAP_FIELD_AGGREGATION_NONE, true, "7"));
+    writer_schema->set_storage_page_size(4096);
+
+    auto rowset_schema = std::make_shared<TabletSchema>();
+    rowset_schema->append_column(*create_int_key(0, false));
+    rowset_schema->set_storage_page_size(4096);
+
+    std::shared_ptr<Segment> segment;
+    ASSERT_NO_FATAL_FAILURE(
+            build_segment_with_rowset_schema(writer_schema, rowset_schema, &segment));
+
+    StorageReadOptions read_options;
+    read_options.stats = &_stats;
+    read_options.tablet_schema = writer_schema;
+    read_options.io_ctx.reader_type = ReaderType::READER_QUERY;
+
+    auto read_schema = make_read_schema(writer_schema);
+    std::unique_ptr<RowwiseIterator> row_iter;
+    auto st = segment->new_iterator(read_schema, read_options, &row_iter);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_NE(nullptr, row_iter);
+
+    Block block = read_schema->create_read_block();
+    st = row_iter->next_batch(&block);
+    ASSERT_TRUE(st.ok()) << st;
+    EXPECT_EQ(1, block.rows());
+}
+
+TEST_F(SegmentIteratorExprZonemapTest,
+       NewColumnIteratorUsesCommitTsoForFooterColumnMissingFromRowsetSchema) {
+    constexpr int64_t kCommitTso = 466872251335573505L;
+    auto writer_schema = make_commit_tso_tablet_schema();
+
+    auto rowset_schema = std::make_shared<TabletSchema>();
+    rowset_schema->append_column(*create_int_key(0, false));
+    rowset_schema->set_storage_page_size(4096);
+
+    std::shared_ptr<Segment> segment;
+    ASSERT_NO_FATAL_FAILURE(
+            build_segment_with_rowset_schema(writer_schema, rowset_schema, &segment));
+
+    StorageReadOptions read_options;
+    read_options.stats = &_stats;
+    read_options.tablet_schema = writer_schema;
+    read_options.version = Version(7, 7);
+    read_options.commit_tso = TsoRange(kCommitTso, kCommitTso);
+    read_options.io_ctx.reader_type = ReaderType::READER_QUERY;
+
+    auto read_schema = make_read_schema(writer_schema);
+    read_options.col_id_to_predicates.emplace(1, make_commit_tso_lt_predicate(1, kCommitTso));
+    std::unique_ptr<RowwiseIterator> row_iter;
+    auto st = segment->new_iterator(read_schema, read_options, &row_iter);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_NE(nullptr, row_iter);
+    EXPECT_TRUE(row_iter->empty());
+
+    ColumnIteratorUPtr column_iter;
+    st = segment->new_column_iterator(writer_schema->column(1), &column_iter, &read_options);
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_NE(nullptr, column_iter);
+    EXPECT_NE(nullptr, dynamic_cast<ConstantColumnIterator*>(column_iter.get()));
+
+    MutableColumnPtr dst = ColumnVector<TYPE_BIGINT>::create();
+    size_t rows = 1;
+    bool has_null = true;
+    ASSERT_TRUE(column_iter->next_batch(&rows, dst, &has_null).ok());
+    ASSERT_FALSE(has_null);
+    ASSERT_EQ(1, dst->size());
+    EXPECT_EQ(kCommitTso, assert_cast<const ColumnInt64&>(*dst).get_element(0));
 }
 
 TEST_F(SegmentIteratorExprZonemapTest, NewIteratorPrunesCommitTsoByReadOptionValue) {


### PR DESCRIPTION
## What problem does this PR solve?

A historical segment footer can retain a column UID that is absent from the rowset schema. In the partial column-reader path introduced by #53511, the footer metadata makes reader lookup proceed, but the rowset schema rejects the UID and `Segment::new_column_iterator` returns `column reader is nullptr`. The previous reader path treated the same schema-evolution column as a default-value column.

This failure mode was observed in a Cloud deployment with a historical rowset/schema mismatch. The affected case involved a hidden delete-sign column that was present in the segment footer but absent from the rowset schema.

The exact upstream producer of that malformed schema is not established. This PR therefore fixes the proven reader compatibility boundary: restore the default-value iterator when a footer column is absent from the rowset schema, and avoid variant path type inference through a reader that the rowset schema does not admit.

## Test

- Local physical natural chain on SelectDB cloud 4.1.8 -> 4.1.8.2: real rename/delete/write/full compaction and scans passed; it did not independently generate the malformed schema, so this is not claimed as a natural red reproduction.
- Deterministic BE regression fixture for a physical segment footer/rowset-schema mismatch:
  - parent revision: red with `NOT_FOUND`/`column reader is nullptr`;
  - this PR: green for the default iterator, full iterator, and commit-Tso paths.
- `build-support/clang-format.sh` and `git diff --check` passed.

## Release note

Restore query compatibility for historical segments whose footer contains columns omitted from the rowset schema.

## Checklist

- Test: BE unit test and physical Cloud validation
- Behavior changed: Yes (restores schema-evolution default fallback)
- Documentation: No