### PR TITLE
[fix](be) Check timezone resolver results

### DIFF
--- a/be/src/exec/common/arrow_column_to_doris_column.cpp
+++ b/be/src/exec/common/arrow_column_to_doris_column.cpp
@@ -92,7 +92,9 @@ Status arrow_column_to_doris_column(const arrow::Array* arrow_column, size_t arr
                                     ColumnPtr& doris_column, const DataTypePtr& type,
                                     size_t num_elements, const std::string& timezone) {
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(timezone, ctz);
+    if (!TimezoneUtils::find_cctz_time_zone(timezone, ctz)) {
+        return Status::InvalidArgument("Invalid timezone: {}", timezone);
+    }
     return arrow_column_to_doris_column(arrow_column, arrow_batch_cur_idx, doris_column, type,
                                         num_elements, ctz);
 }

--- a/be/src/exprs/aggregate/aggregate_function_python_udaf.cpp
+++ b/be/src/exprs/aggregate/aggregate_function_python_udaf.cpp
@@ -63,7 +63,7 @@ Status AggregatePythonUDAFData::add(int64_t place_id, const IColumn** columns,
     RETURN_IF_ERROR(
             get_arrow_schema_from_block(input_block, &schema, TimezoneUtils::default_time_zone));
     cctz::time_zone timezone_obj;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, timezone_obj);
+    DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, timezone_obj));
 
     std::shared_ptr<arrow::RecordBatch> batch;
     // Zero-copy: convert only the specified range
@@ -108,7 +108,7 @@ Status AggregatePythonUDAFData::add_batch(AggregateDataPtr* places, size_t place
     RETURN_IF_ERROR(
             get_arrow_schema_from_block(input_block, &schema, TimezoneUtils::default_time_zone));
     cctz::time_zone timezone_obj;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, timezone_obj);
+    DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, timezone_obj));
 
     std::shared_ptr<arrow::RecordBatch> batch;
     // Zero-copy: convert only the [start, end) range
@@ -175,7 +175,7 @@ Status AggregatePythonUDAFData::get(IColumn& to, const DataTypePtr& result_type,
     Block result_block;
     DataTypes types = {result_type};
     cctz::time_zone timezone_obj;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, timezone_obj);
+    DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, timezone_obj));
     RETURN_IF_ERROR(convert_from_arrow_batch(result, types, &result_block, timezone_obj));
 
     // Insert the result value into output column

--- a/be/src/exprs/table_function/python_udtf_function.cpp
+++ b/be/src/exprs/table_function/python_udtf_function.cpp
@@ -23,6 +23,7 @@
 #include <arrow/type_fwd.h>
 #include <glog/logging.h>
 
+#include "common/logging.h"
 #include "core/assert_cast.h"
 #include "core/block/block.h"
 #include "core/block/column_numbers.h"
@@ -50,7 +51,8 @@ namespace doris {
 
 PythonUDTFFunction::PythonUDTFFunction(const TFunction& t_fn) : TableFunction(), _t_fn(t_fn) {
     _fn_name = _t_fn.name.function_name;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _timezone_obj);
+    DORIS_CHECK(
+            TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _timezone_obj));
 
     // Like Java UDTF, FE passes the element type T, and we wrap it into array<T> here
     // This makes the behavior consistent with Java UDTF

--- a/be/src/format/arrow/arrow_stream_reader.cpp
+++ b/be/src/format/arrow/arrow_stream_reader.cpp
@@ -49,7 +49,7 @@ ArrowStreamReader::ArrowStreamReader(RuntimeState* state, RuntimeProfile* profil
           _file_slot_descs(file_slot_descs),
           _io_ctx(io_ctx),
           _file_reader(nullptr) {
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _ctzz);
+    DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _ctzz));
 }
 
 ArrowStreamReader::~ArrowStreamReader() = default;

--- a/be/src/format/orc/vorc_reader.cpp
+++ b/be/src/format/orc/vorc_reader.cpp
@@ -51,6 +51,7 @@
 #include "common/config.h"
 #include "common/consts.h"
 #include "common/exception.h"
+#include "common/logging.h"
 #include "core/block/block.h"
 #include "core/block/column_with_type_and_name.h"
 #include "core/column/column.h"
@@ -237,7 +238,7 @@ OrcReader::OrcReader(RuntimeProfile* profile, RuntimeState* state,
           _enable_filter_by_min_max(
                   state == nullptr ? true : state->query_options().enable_orc_filter_by_min_max),
           _dict_cols_has_converted(false) {
-    TimezoneUtils::find_cctz_time_zone(normalized_orc_timezone_name(ctz), _time_zone);
+    DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(normalized_orc_timezone_name(ctz), _time_zone));
     _meta_cache = meta_cache;
     _init_profile();
     _init_system_properties();
@@ -263,7 +264,7 @@ OrcReader::OrcReader(RuntimeProfile* profile, RuntimeState* state,
           _enable_filter_by_min_max(
                   state == nullptr ? true : state->query_options().enable_orc_filter_by_min_max),
           _dict_cols_has_converted(false) {
-    TimezoneUtils::find_cctz_time_zone(normalized_orc_timezone_name(ctz), _time_zone);
+    DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(normalized_orc_timezone_name(ctz), _time_zone));
     _meta_cache = meta_cache;
     _init_profile();
     _init_system_properties();
@@ -297,7 +298,7 @@ OrcReader::OrcReader(const TFileScanRangeParams& params, const TFileRangeDesc& r
           _enable_lazy_mat(enable_lazy_mat),
           _enable_filter_by_min_max(true),
           _dict_cols_has_converted(false) {
-    TimezoneUtils::find_cctz_time_zone(normalized_orc_timezone_name(ctz), _time_zone);
+    DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(normalized_orc_timezone_name(ctz), _time_zone));
     _meta_cache = meta_cache;
     _init_system_properties();
     _init_file_description();
@@ -318,7 +319,7 @@ OrcReader::OrcReader(const TFileScanRangeParams& params, const TFileRangeDesc& r
           _enable_lazy_mat(enable_lazy_mat),
           _enable_filter_by_min_max(true),
           _dict_cols_has_converted(false) {
-    TimezoneUtils::find_cctz_time_zone(normalized_orc_timezone_name(ctz), _time_zone);
+    DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(normalized_orc_timezone_name(ctz), _time_zone));
     _meta_cache = meta_cache;
     _init_system_properties();
     _init_file_description();

--- a/be/src/format/table/es/es_scroll_parser.cpp
+++ b/be/src/format/table/es/es_scroll_parser.cpp
@@ -206,16 +206,13 @@ Status get_date_value_int(const rapidjson::Value& col, PrimitiveType type, bool 
             RE2 time_zone_pattern(R"([+-]\d{2}:?\d{2}|Z)");
             bool ok = false;
             std::string fmt;
-            re2::StringPiece value;
-            if (time_zone_pattern.Match(str_date, 0, str_date.size(), RE2::UNANCHORED, &value, 1)) {
+            if (time_zone_pattern.Match(str_date, 0, str_date.size(), RE2::UNANCHORED,
+                                        nullptr, 0)) {
                 // with time_zone info
                 // YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DDTHH:MM:SS+08:00
                 // or 2022-08-08T12:10:10.000Z or YYYY-MM-DDTHH:MM:SS-08:00
                 fmt = "%Y-%m-%dT%H:%M:%E*S%Ez";
-                cctz::time_zone ctz;
-                // find time_zone by time_zone suffix string
-                TimezoneUtils::find_cctz_time_zone(value.as_string(), ctz);
-                ok = cctz::parse(fmt, str_date, ctz, &tp);
+                ok = cctz::parse(fmt, str_date, cctz::utc_time_zone(), &tp);
             } else {
                 // without time_zone info
                 // 2022-08-08T12:10:10.000

--- a/be/src/format/table/paimon_cpp_reader.cpp
+++ b/be/src/format/table/paimon_cpp_reader.cpp
@@ -26,6 +26,7 @@
 #include "arrow/c/bridge.h"
 #include "arrow/record_batch.h"
 #include "arrow/result.h"
+#include "common/logging.h"
 #include "core/block/block.h"
 #include "core/block/column_with_type_and_name.h"
 #include "format/table/paimon_doris_file_system.h"
@@ -54,7 +55,7 @@ PaimonCppReader::PaimonCppReader(const std::vector<SlotDescriptor*>& file_slot_d
           _profile(profile),
           _range(range),
           _range_params(range_params) {
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _ctzz);
+    DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _ctzz));
     if (range.__isset.table_format_params &&
         range.table_format_params.__isset.table_level_row_count) {
         _remaining_table_level_row_count = range.table_format_params.table_level_row_count;

--- a/be/src/format/table/paimon_predicate_converter.cpp
+++ b/be/src/format/table/paimon_predicate_converter.cpp
@@ -21,6 +21,7 @@
 #include <cctype>
 #include <utility>
 
+#include "common/logging.h"
 #include "core/column/column_const.h"
 #include "core/column/column_nullable.h"
 #include "core/data_type/data_type.h"
@@ -59,7 +60,7 @@ PaimonPredicateConverter::PaimonPredicateConverter(
     }
 
     if (!TimezoneUtils::find_cctz_time_zone("GMT", _gmt_tz)) {
-        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _gmt_tz);
+        DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _gmt_tz));
     }
 }
 

--- a/be/src/format/table/remote_doris_reader.cpp
+++ b/be/src/format/table/remote_doris_reader.cpp
@@ -28,6 +28,7 @@
 #include "arrow/memory_pool.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
+#include "common/logging.h"
 #include "common/status.h"
 #include "core/block/block.h"
 #include "core/block/column_with_type_and_name.h"
@@ -49,7 +50,7 @@ RemoteDorisReader::RemoteDorisReader(const std::vector<SlotDescriptor*>& file_sl
                                      RuntimeState* state, RuntimeProfile* profile,
                                      const TFileRangeDesc& range)
         : _range(range), _file_slot_descs(file_slot_descs) {
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _ctzz);
+    DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _ctzz));
 }
 
 Status RemoteDorisReader::init_reader() {

--- a/be/src/format_v2/orc/orc_reader.cpp
+++ b/be/src/format_v2/orc/orc_reader.cpp
@@ -907,7 +907,7 @@ Status OrcReader::init(RuntimeState* state) {
     SCOPED_TIMER(_orc_profile.total_time);
     RETURN_IF_ERROR(format::FileReader::init(state));
     _state = std::make_unique<OrcReaderScanState>();
-    TimezoneUtils::find_cctz_time_zone(_state->timezone, _state->timezone_obj);
+    DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(_state->timezone, _state->timezone_obj));
     if (state != nullptr) {
         _state->enable_lazy_materialization = state->query_options().enable_orc_lazy_mat;
         _state->enable_filter_by_min_max = state->query_options().enable_orc_filter_by_min_max;

--- a/be/src/format_v2/table/adbc_reader.cpp
+++ b/be/src/format_v2/table/adbc_reader.cpp
@@ -33,6 +33,7 @@
 
 #include "common/cast_set.h"
 #include "common/check.h"
+#include "common/logging.h"
 #include "core/assert_cast.h"
 #include "core/block/block.h"
 #include "core/data_type/data_type.h"
@@ -580,7 +581,7 @@ AdbcFileReader::AdbcFileReader(std::shared_ptr<io::FileSystemProperties>& system
           _range(range),
           _file_slot_descs(file_slot_descs),
           _stream_factory(std::move(stream_factory)) {
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _ctz);
+    DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _ctz));
 }
 
 AdbcFileReader::~AdbcFileReader() {

--- a/be/src/format_v2/table/remote_doris_reader.cpp
+++ b/be/src/format_v2/table/remote_doris_reader.cpp
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "common/cast_set.h"
+#include "common/logging.h"
 #include "core/assert_cast.h"
 #include "core/block/block.h"
 #include "core/data_type/data_type.h"
@@ -330,7 +331,7 @@ RemoteDorisFileReader::RemoteDorisFileReader(
           _range(range),
           _file_slot_descs(file_slot_descs),
           _stream_factory(std::move(stream_factory)) {
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _ctz);
+    DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, _ctz));
 }
 
 RemoteDorisFileReader::~RemoteDorisFileReader() {

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -164,7 +164,7 @@ RuntimeState::RuntimeState(const TPlanFragmentExecParams& fragment_exec_params,
           _query_ctx(ctx) {
     Status status =
             init(fragment_exec_params.fragment_instance_id, query_options, query_globals, exec_env);
-    DCHECK(status.ok());
+    DORIS_CHECK(status.ok()) << status;
     _query_mem_tracker = query_mem_tracker;
     DCHECK(_query_mem_tracker != nullptr);
 }
@@ -187,8 +187,8 @@ RuntimeState::RuntimeState(const TUniqueId& instance_id, const TUniqueId& query_
           _num_bytes_load_total(0),
           _num_finished_scan_range(0),
           _query_ctx(ctx) {
-    [[maybe_unused]] auto status = init(instance_id, query_options, query_globals, exec_env);
-    DCHECK(status.ok());
+    Status status = init(instance_id, query_options, query_globals, exec_env);
+    DORIS_CHECK(status.ok()) << status;
     _query_mem_tracker = ctx->query_mem_tracker();
 }
 
@@ -212,7 +212,7 @@ RuntimeState::RuntimeState(const TUniqueId& query_id, int32_t fragment_id,
           _query_ctx(ctx) {
     // TODO: do we really need instance id?
     Status status = init(TUniqueId(), query_options, query_globals, exec_env);
-    DCHECK(status.ok());
+    DORIS_CHECK(status.ok()) << status;
     _query_mem_tracker = ctx->query_mem_tracker();
 }
 
@@ -235,7 +235,7 @@ RuntimeState::RuntimeState(const TUniqueId& query_id, int32_t fragment_id,
           _num_bytes_load_total(0),
           _num_finished_scan_range(0) {
     Status status = init(TUniqueId(), query_options, query_globals, exec_env);
-    DCHECK(status.ok());
+    DORIS_CHECK(status.ok()) << status;
     _query_mem_tracker = query_mem_tracker;
     DCHECK(_query_mem_tracker != nullptr);
 }
@@ -249,7 +249,7 @@ RuntimeState::RuntimeState(const TQueryOptions& query_options, const TQueryGloba
     Status status = init(TUniqueId(), query_options, query_globals, nullptr);
     _exec_env = ExecEnv::GetInstance();
     init_mem_trackers("<unnamed>");
-    DCHECK(status.ok());
+    DORIS_CHECK(status.ok()) << status;
 }
 
 RuntimeState::RuntimeState()
@@ -263,7 +263,7 @@ RuntimeState::RuntimeState()
     _timezone = TimezoneUtils::default_time_zone;
     _timestamp_ms = 0;
     _nano_seconds = 0;
-    TimezoneUtils::find_cctz_time_zone(_timezone, _timezone_obj);
+    DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(_timezone, _timezone_obj));
     _exec_env = ExecEnv::GetInstance();
     init_mem_trackers("<unnamed>");
 }
@@ -316,7 +316,9 @@ Status RuntimeState::init(const TUniqueId& fragment_instance_id, const TQueryOpt
         _timestamp_ms = 0;
         _nano_seconds = 0;
     }
-    TimezoneUtils::find_cctz_time_zone(_timezone, _timezone_obj);
+    if (!TimezoneUtils::find_cctz_time_zone(_timezone, _timezone_obj)) {
+        return Status::InvalidArgument("Invalid timezone: {}", _timezone);
+    }
 
     if (query_globals.__isset.load_zero_tolerance) {
         _load_zero_tolerance = query_globals.load_zero_tolerance;

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -38,6 +38,7 @@
 #include "agent/be_exec_version_manager.h"
 #include "cctz/time_zone.h"
 #include "common/be_mock_util.h"
+#include "common/check.h"
 #include "common/compiler_util.h" // IWYU pragma: keep
 #include "common/config.h"
 #include "common/factory_creator.h"
@@ -227,7 +228,7 @@ public:
     const cctz::time_zone& timezone_obj() const { return _timezone_obj; }
     void set_timezone(const std::string& timezone) {
         _timezone = timezone;
-        TimezoneUtils::find_cctz_time_zone(_timezone, _timezone_obj);
+        DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(_timezone, _timezone_obj));
     }
     const std::string& lc_time_names() const { return _lc_time_names; }
     const TUniqueId& query_id() const { return _query_id; }

--- a/be/src/service/arrow_flight/arrow_flight_batch_reader.cpp
+++ b/be/src/service/arrow_flight/arrow_flight_batch_reader.cpp
@@ -262,8 +262,13 @@ arrow::Status ArrowFlightBatchRemoteReader::_fetch_data() {
 
         std::call_once(_timezone_once_flag, [this, callback] {
             DCHECK(callback->response_->has_timezone());
-            TimezoneUtils::find_cctz_time_zone(callback->response_->timezone(), _timezone_obj);
+            _timezone_valid = TimezoneUtils::find_cctz_time_zone(callback->response_->timezone(),
+                                                                 _timezone_obj);
         });
+        if (!_timezone_valid) {
+            return _return_invalid_status(
+                    fmt::format("Invalid timezone: {}", callback->response_->timezone()));
+        }
 
         {
             SCOPED_ATOMIC_TIMER(&_deserialize_block_timer);

--- a/be/src/service/arrow_flight/arrow_flight_batch_reader.h
+++ b/be/src/service/arrow_flight/arrow_flight_batch_reader.h
@@ -100,6 +100,7 @@ private:
 
     std::shared_ptr<PBackendService_Stub> _brpc_stub = nullptr;
     std::once_flag _timezone_once_flag;
+    bool _timezone_valid = false;
     std::shared_ptr<Block> _block;
 };
 

--- a/be/src/util/timezone_utils.h
+++ b/be/src/util/timezone_utils.h
@@ -34,7 +34,8 @@ class TimezoneUtils {
 public:
     static void load_timezones_to_cache();
 
-    static bool find_cctz_time_zone(const std::string& timezone, cctz::time_zone& ctz);
+    [[nodiscard]] static bool find_cctz_time_zone(const std::string& timezone,
+                                                  cctz::time_zone& ctz);
 
     static bool try_get_fixed_offset_seconds(const cctz::time_zone& timezone,
                                              int32_t* offset_seconds);

--- a/be/test/core/data_type/data_type_struct_test.cpp
+++ b/be/test/core/data_type/data_type_struct_test.cpp
@@ -452,7 +452,7 @@ TEST_F(DataTypeStructTest, writeColumnToOrc) {
     TimezoneUtils::load_timezones_to_cache();
     DataTypeSerDe::FormatOptions format_options;
     cctz::time_zone tz;
-    TimezoneUtils::find_cctz_time_zone("UTC", tz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("UTC", tz));
     format_options.timezone = &tz;
 
     Status status = serde->write_column_to_orc("UTC", *struct_column, nullptr, &structBatch, 0, 1,

--- a/be/test/core/data_type_serde/data_type_jsonb_serde_test.cpp
+++ b/be/test/core/data_type_serde/data_type_jsonb_serde_test.cpp
@@ -217,7 +217,7 @@ TEST_F(DataTypeJsonbSerDeTest, serdes) {
             TimezoneUtils::load_timezones_to_cache();
             DataTypeSerDe::FormatOptions format_options;
             cctz::time_zone tz;
-            TimezoneUtils::find_cctz_time_zone("UTC", tz);
+            ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("UTC", tz));
             format_options.timezone = &tz;
             auto orc_batch =
                     std::make_unique<orc::StringVectorBatch>(row_count, *orc::getDefaultPool());

--- a/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_arrow_test.cpp
@@ -74,6 +74,7 @@
 #include "core/data_type/data_type_timestamptz.h"
 #include "core/data_type/define_primitive_type.h"
 #include "core/field.h"
+#include "common/check.h"
 #include "core/types.h"
 #include "core/value/hll.h"
 #include "core/value/vdatetime_value.h"
@@ -289,7 +290,7 @@ std::shared_ptr<Block> create_test_block(std::vector<PrimitiveType> cols, int ro
             DateV2Value<DateTimeV2ValueType> value;
             std::string date_literal = "2022-01-01 11:11:11.111";
             cctz::time_zone ctz;
-            TimezoneUtils::find_cctz_time_zone("UTC", ctz);
+            DORIS_CHECK(TimezoneUtils::find_cctz_time_zone("UTC", ctz));
             {
                 CastParameters p;
                 EXPECT_TRUE(CastToDatetimeV2::from_string_strict_mode<DatelikeParseMode::STRICT>(

--- a/be/test/core/data_type_serde/data_type_serde_timestamptz_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_timestamptz_test.cpp
@@ -67,7 +67,7 @@ public:
         std::cout << "loading test dataset" << std::endl;
         TimezoneUtils::load_timezones_to_cache();
         cctz::time_zone tz;
-        TimezoneUtils::find_cctz_time_zone("+08:00", tz);
+        ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("+08:00", tz));
         auto test_func = [&](const MutableColumnPtr& column, const auto& serde,
                              const std::string& data_file_name) {
             MutableColumns columns;
@@ -90,7 +90,7 @@ TEST_F(DataTypeTimeStampTzSerDeTest, serdes) {
     char field_delim = ';';
     option.field_delim = std::string(1, field_delim);
     cctz::time_zone tz;
-    TimezoneUtils::find_cctz_time_zone("+08:00", tz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("+08:00", tz));
     option.timezone = &tz;
     auto test_func = [&](const auto& serde, const auto& source_column) {
         using SerdeType = decltype(serde);

--- a/be/test/core/data_type_serde/data_type_serde_varbinary_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_varbinary_test.cpp
@@ -255,7 +255,7 @@ TEST_F(DataTypeVarbinarySerDeTest, OrcWriteSupported) {
     TimezoneUtils::load_timezones_to_cache();
     DataTypeSerDe::FormatOptions format_options;
     cctz::time_zone tz;
-    TimezoneUtils::find_cctz_time_zone("UTC", tz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("UTC", tz));
     format_options.timezone = &tz;
     auto batch = std::make_unique<orc::StringVectorBatch>(1, *orc::getDefaultPool());
     auto st = serde.write_column_to_orc("UTC", *col, nullptr, batch.get(), 0, 0, arena,
@@ -368,7 +368,7 @@ TEST_F(DataTypeVarbinarySerDeTest, OrcWriteStartEndNullMapIgnoredAndEmptyRange) 
     TimezoneUtils::load_timezones_to_cache();
     DataTypeSerDe::FormatOptions format_options;
     cctz::time_zone tz;
-    TimezoneUtils::find_cctz_time_zone("UTC", tz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("UTC", tz));
     format_options.timezone = &tz;
 
     // Provide a null_map but implementation ignores it; ensure data still written.

--- a/be/test/exprs/vexpr_test.cpp
+++ b/be/test/exprs/vexpr_test.cpp
@@ -568,7 +568,7 @@ TEST(TEST_VEXPR, LITERALTEST) {
         int scale = 6;
         std::string tz_str = "+08:00";
         cctz::time_zone tz;
-        TimezoneUtils::find_cctz_time_zone(tz_str, tz);
+        ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(tz_str, tz));
         DateV2Value<DateTimeV2ValueType> datetime_v2;
         datetime_v2.unchecked_set_time(year, month, day, hour, minute, second, microsecond);
         TimestampTzValue tz_value;

--- a/be/test/format/parquet/parquet_expr_test.cpp
+++ b/be/test/format/parquet/parquet_expr_test.cpp
@@ -49,6 +49,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/check.h"
 #include "common/config.h"
 #include "common/object_pool.h"
 #include "common/status.h"
@@ -419,7 +420,7 @@ public:
         auto local_fs = io::global_local_filesystem();
         io::FileReaderSPtr local_file_reader;
         static_cast<void>(local_fs->open_file(file_path, &local_file_reader));
-        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+        ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
         //        auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
         std::vector<std::string> column_names;
         std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -474,7 +475,7 @@ public:
         static_cast<void>(local_fs->open_file(file_path, &local_file_reader));
 
         cctz::time_zone local_ctz;
-        TimezoneUtils::find_cctz_time_zone(timezone_name, local_ctz);
+        DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(timezone_name, local_ctz));
 
         std::vector<std::string> column_names;
         std::unordered_map<std::string, uint32_t> col_name_to_block_idx;

--- a/be/test/format/parquet/parquet_read_lines.cpp
+++ b/be/test/format/parquet/parquet_read_lines.cpp
@@ -122,7 +122,7 @@ static void read_parquet_lines(std::vector<std::string> numeric_types,
                                 &reader));
 
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
     std::vector<std::string> column_names;
     std::unordered_map<std::string, uint32_t> col_name_to_block_idx;

--- a/be/test/format/parquet/parquet_reader_test.cpp
+++ b/be/test/format/parquet/parquet_reader_test.cpp
@@ -95,7 +95,7 @@ public:
         EXPECT_TRUE(st.ok()) << st;
 
         cctz::time_zone ctz;
-        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+        ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
         auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
         std::vector<std::string> column_names;
         std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -197,7 +197,7 @@ public:
         EXPECT_TRUE(st.ok()) << st;
 
         cctz::time_zone ctz;
-        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+        ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
         auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
         std::vector<std::string> column_names;
         std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -370,7 +370,7 @@ TEST_F(ParquetReaderTest, normal) {
             "./be/test/exec/test_data/parquet_scanner/type-decoder.parquet", &reader));
 
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
     std::vector<std::string> column_names;
     std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -435,7 +435,7 @@ TEST_F(ParquetReaderTest, uuid_varbinary) {
     EXPECT_TRUE(st.ok()) << st;
 
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
     std::vector<std::string> column_names;
     std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -509,7 +509,7 @@ TEST_F(ParquetReaderTest, varbinary_varbinary) {
     EXPECT_TRUE(st.ok()) << st;
 
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
     std::vector<std::string> column_names;
     std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -583,7 +583,7 @@ TEST_F(ParquetReaderTest, varbinary_string) {
     EXPECT_TRUE(st.ok()) << st;
 
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
     std::vector<std::string> column_names;
     std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -659,7 +659,7 @@ TEST_F(ParquetReaderTest, varbinary_string2) {
     EXPECT_TRUE(st.ok()) << st;
 
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
     std::vector<std::string> column_names;
     std::unordered_map<std::string, uint32_t> col_name_to_block_idx;
@@ -991,7 +991,7 @@ TEST_F(ParquetReaderTest, only_partition_column) {
     EXPECT_TRUE(st.ok()) << st;
 
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     auto tuple_desc = desc_tbl->get_tuple_descriptor(0);
     std::vector<std::string> column_names;
     std::unordered_map<std::string, uint32_t> col_name_to_block_idx;

--- a/be/test/format/parquet/parquet_thrift_test.cpp
+++ b/be/test/format/parquet/parquet_thrift_test.cpp
@@ -184,7 +184,10 @@ static Status get_column_values(io::FileReaderSPtr file_reader, tparquet::Column
     size_t chunk_size = chunk_meta.total_compressed_size;
 
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    if (!TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz)) {
+        return Status::InvalidArgument("Invalid default timezone: {}",
+                                       TimezoneUtils::default_time_zone);
+    }
     auto _converter = parquet::PhysicalToLogicalConverter::get_converter(
             field_schema, field_schema->data_type, data_type, &ctz, false);
     if (!_converter->support()) {

--- a/be/test/format/table/hive/hive_reader_create_column_ids_test.cpp
+++ b/be/test/format/table/hive/hive_reader_create_column_ids_test.cpp
@@ -28,6 +28,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "common/check.h"
 #include "common/object_pool.h"
 #include "core/block/block.h"
 #include "core/block/column_with_type_and_name.h"
@@ -163,8 +164,8 @@ protected:
         cache = std::make_unique<doris::FileMetaCache>(1024);
 
         // Setup timezone
-        doris::TimezoneUtils::find_cctz_time_zone(doris::TimezoneUtils::default_time_zone,
-                                                  timezone_obj);
+        ASSERT_TRUE(doris::TimezoneUtils::find_cctz_time_zone(
+                doris::TimezoneUtils::default_time_zone, timezone_obj));
     }
 
     void TearDown() override { cache.reset(); }
@@ -659,7 +660,7 @@ protected:
         RuntimeProfile profile("test_profile");
 
         cctz::time_zone ctz;
-        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+        DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
 
         auto hive_reader =
                 std::make_unique<HiveParquetReader>(&profile, scan_params, scan_range, 1024, &ctz,
@@ -699,7 +700,7 @@ protected:
         RuntimeProfile profile("test_profile");
 
         cctz::time_zone ctz;
-        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+        DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
 
         auto hive_reader =
                 std::make_unique<HiveOrcReader>(&profile, &runtime_state, scan_params, scan_range,

--- a/be/test/format/table/hive/hive_reader_test.cpp
+++ b/be/test/format/table/hive/hive_reader_test.cpp
@@ -63,8 +63,8 @@ protected:
         cache = std::make_unique<doris::FileMetaCache>(1024);
 
         // Setup timezone
-        doris::TimezoneUtils::find_cctz_time_zone(doris::TimezoneUtils::default_time_zone,
-                                                  timezone_obj);
+        ASSERT_TRUE(doris::TimezoneUtils::find_cctz_time_zone(
+                doris::TimezoneUtils::default_time_zone, timezone_obj));
     }
 
     void TearDown() override { cache.reset(); }
@@ -530,7 +530,7 @@ TEST_F(HiveReaderTest, read_hive_parquet_file) {
 
     // Create HiveParquetReader (directly inherits ParquetReader)
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     auto hive_reader =
             std::make_unique<HiveParquetReader>(&profile, scan_params, scan_range, 1024, &ctz,
                                                 nullptr, &runtime_state, nullptr, cache.get());

--- a/be/test/format/table/iceberg/iceberg_reader_create_column_ids_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_reader_create_column_ids_test.cpp
@@ -28,6 +28,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "common/check.h"
 #include "common/consts.h"
 #include "common/object_pool.h"
 #include "core/block/block.h"
@@ -163,8 +164,8 @@ protected:
         cache = std::make_unique<doris::FileMetaCache>(1024);
 
         // Setup timezone
-        doris::TimezoneUtils::find_cctz_time_zone(doris::TimezoneUtils::default_time_zone,
-                                                  timezone_obj);
+        ASSERT_TRUE(doris::TimezoneUtils::find_cctz_time_zone(
+                doris::TimezoneUtils::default_time_zone, timezone_obj));
     }
 
     void TearDown() override { cache.reset(); }
@@ -689,7 +690,7 @@ protected:
 
         // Create IcebergParquetReader (IS-A ParquetReader via CRTP mixin)
         cctz::time_zone ctz;
-        TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+        DORIS_CHECK(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
 
         auto iceberg_reader = std::make_unique<IcebergParquetReader>(
                 nullptr /* kv_cache */, &profile, scan_params, scan_range, 1024, &ctz,

--- a/be/test/format/table/iceberg/iceberg_reader_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_reader_test.cpp
@@ -946,8 +946,8 @@ protected:
         cache = std::make_unique<doris::FileMetaCache>(1024);
 
         // Setup timezone
-        doris::TimezoneUtils::find_cctz_time_zone(doris::TimezoneUtils::default_time_zone,
-                                                  timezone_obj);
+        ASSERT_TRUE(doris::TimezoneUtils::find_cctz_time_zone(
+                doris::TimezoneUtils::default_time_zone, timezone_obj));
     }
 
     void TearDown() override { cache.reset(); }
@@ -1581,7 +1581,7 @@ TEST_F(IcebergReaderTest, read_iceberg_parquet_file) {
 
     // Create IcebergParquetReader (IS-A ParquetReader via CRTP mixin)
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
 
     auto iceberg_reader = std::make_unique<IcebergParquetReader>(
             nullptr /* kv_cache */, &profile, scan_params, scan_range, 1024, &ctz,
@@ -1666,7 +1666,7 @@ TEST_F(IcebergReaderTest, v1_deletion_vector_read_error_releases_cache_entry) {
 
     RuntimeProfile profile("test_profile");
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
 
@@ -1700,7 +1700,7 @@ TEST_F(IcebergReaderTest, v1_position_delete_read_error_releases_cache_entry) {
 
     RuntimeProfile profile("test_profile");
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
 
@@ -2046,7 +2046,7 @@ TEST_F(IcebergReaderTest, v2_parquet_materializes_nested_initial_default_without
     RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
     runtime_state.set_timezone("UTC");
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone("UTC", ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("UTC", ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
     IcebergParquetReader reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz, &io_ctx,
@@ -2201,7 +2201,7 @@ TEST_F(IcebergReaderTest, v1_materializes_missing_equality_delete_initial_defaul
     RuntimeProfile profile("test_profile");
     RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
     IcebergParquetReader reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz, &io_ctx,
@@ -2270,7 +2270,7 @@ TEST_F(IcebergReaderTest, v1_top_level_missing_binary_prefers_iceberg_initial_de
     RuntimeProfile profile("test_profile");
     RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
     IcebergParquetReader reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz, &io_ctx,
@@ -2321,7 +2321,7 @@ TEST_F(IcebergReaderTest, v1_legacy_plan_keeps_missing_binary_null) {
     RuntimeProfile profile("test_profile");
     RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
     IcebergParquetReader reader(&kv_cache, &profile, old_fe_scan_params, scan_range, 1024, &ctz,
@@ -2357,7 +2357,7 @@ TEST_F(IcebergReaderTest, v1_multi_equality_delete_hashes_materialized_missing_d
     RuntimeProfile profile("test_profile");
     RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
     IcebergParquetReader reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz, &io_ctx,
@@ -2418,7 +2418,7 @@ TEST_F(IcebergReaderTest, v2_recovers_dropped_equality_key_default_from_historic
     RuntimeProfile profile("test_profile");
     RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
     IcebergParquetReader reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz, &io_ctx,
@@ -2465,7 +2465,7 @@ TEST_F(IcebergReaderTest, v1_missing_equality_key_returns_error_for_pruned_descr
     RuntimeProfile profile("test_profile");
     RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
     IcebergParquetReader reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz, &io_ctx,
@@ -2623,7 +2623,7 @@ TEST_F(IcebergReaderTest, v1_parquet_reads_idless_wrapper_with_authoritative_emp
     RuntimeProfile profile("test_profile");
     RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone("UTC", ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("UTC", ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
     IcebergParquetReader reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz, &io_ctx,
@@ -2719,7 +2719,7 @@ TEST_F(IcebergReaderTest, v1_parquet_keeps_file_id_mode_inside_nested_struct) {
     RuntimeProfile profile("test_profile");
     RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone("UTC", ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("UTC", ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
     IcebergParquetReader reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz, &io_ctx,
@@ -3338,7 +3338,7 @@ TEST_F(IcebergReaderTest, v2_parquet_keeps_dropped_equality_id_when_name_is_reus
     RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
     runtime_state.set_timezone("UTC");
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone("UTC", ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("UTC", ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
     IcebergParquetReader reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz, &io_ctx,
@@ -3440,7 +3440,7 @@ TEST_F(IcebergReaderTest, v2_parquet_separates_hidden_reused_equality_names) {
     RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
     runtime_state.set_timezone("UTC");
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone("UTC", ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("UTC", ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
     IcebergParquetReader reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz, &io_ctx,
@@ -3534,7 +3534,7 @@ TEST_F(IcebergReaderTest, v1_parquet_mixed_ids_prefer_existing_equality_field_id
     RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
     runtime_state.set_timezone("UTC");
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone("UTC", ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("UTC", ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
     IcebergParquetReader reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz, &io_ctx,
@@ -3662,7 +3662,7 @@ TEST_F(IcebergReaderTest, v1_parquet_uses_descendant_id_for_hidden_nested_equali
     RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
     runtime_state.set_timezone("UTC");
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone("UTC", ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("UTC", ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
     IcebergParquetReader reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz, &io_ctx,
@@ -3758,7 +3758,7 @@ TEST_F(IcebergReaderTest, v2_parquet_idless_equality_key_uses_delete_file_name) 
     RuntimeState runtime_state {TQueryOptions(), TQueryGlobals()};
     runtime_state.set_timezone("UTC");
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone("UTC", ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("UTC", ctz));
     io::IOContext io_ctx;
     ShardedKVCache kv_cache(8);
     IcebergParquetReader reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz, &io_ctx,

--- a/be/test/format/table/paimon_cpp_reader_test.cpp
+++ b/be/test/format/table/paimon_cpp_reader_test.cpp
@@ -313,7 +313,7 @@ TEST(PaimonDeletionVectorTest, V1ParquetReaderReadErrorReleasesCacheEntry) {
     const auto range = make_paimon_range_with_deletion_file(
             "./be/test/exec/test_data/missing_paimon_v1_delete_vector.bin");
     cctz::time_zone ctz;
-    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz));
     io::IOContext io_ctx;
     FileMetaCache meta_cache(1024);
     ShardedKVCache kv_cache(8);

--- a/be/test/testutil/run_all_tests.cpp
+++ b/be/test/testutil/run_all_tests.cpp
@@ -41,6 +41,7 @@
 #include "util/disk_info.h"
 #include "util/mem_info.h"
 #include "util/threadpool.h"
+#include "util/timezone_utils.h"
 
 int main(int argc, char** argv) {
     SCOPED_INIT_THREAD_CONTEXT();
@@ -92,6 +93,7 @@ int main(int argc, char** argv) {
     doris::DiskInfo::init();
     doris::MemInfo::init();
     doris::BackendOptions::init();
+    doris::TimezoneUtils::load_timezones_to_cache();
 
     auto service = std::make_unique<doris::HttpService>(doris::ExecEnv::GetInstance(), 0, 1);
     auto status = service->start();


### PR DESCRIPTION
Some BE callers ignored the boolean result of `TimezoneUtils::find_cctz_time_zone()`, allowing execution to continue with an unresolved timezone object.

This change marks the resolver as `[[nodiscard]]` and handles every previously unchecked result. Invalid external timezone values now return an error, while failures for internal constant timezones are treated as invariants. `RuntimeState::set_timezone()` also preserves its previous state when resolution fails.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

