### PR TITLE
[improvement](cloud) Disable rowset delete bitmap range removal

### DIFF
--- a/be/src/cloud/cloud_cumulative_compaction.cpp
+++ b/be/src/cloud/cloud_cumulative_compaction.cpp
@@ -462,7 +462,8 @@ Status CloudCumulativeCompaction::modify_rowsets() {
         }
     }
     // agg delete bitmap for pre rowsets
-    if (config::enable_agg_and_remove_pre_rowsets_delete_bitmap &&
+    if (config::delete_bitmap_store_write_version != 2 &&
+        config::enable_agg_and_remove_pre_rowsets_delete_bitmap &&
         _tablet->keys_type() == KeysType::UNIQUE_KEYS &&
         _tablet->enable_unique_key_merge_on_write() && _input_rowsets.size() != 1) {
         OlapStopWatch watch;
@@ -478,17 +479,23 @@ Status CloudCumulativeCompaction::modify_rowsets() {
         std::sort(pre_rowsets.begin(), pre_rowsets.end(), Rowset::comparator);
         auto pre_rowsets_delete_bitmap = std::make_shared<DeleteBitmap>(_tablet->tablet_id());
         std::map<std::string, int64_t> pre_rowset_to_versions;
+        std::unique_ptr<CloudTablet::PreRowsetDeleteBitmapStats> pre_rowset_delete_bitmap_stats;
+        if (config::enable_remove_pre_rowsets_delete_bitmap_by_keys) {
+            pre_rowset_delete_bitmap_stats =
+                    std::make_unique<CloudTablet::PreRowsetDeleteBitmapStats>();
+        }
         cloud_tablet()->agg_delete_bitmap_for_compaction(
                 _output_rowset->start_version(), _output_rowset->end_version(), pre_rowsets,
-                pre_rowsets_delete_bitmap, pre_rowset_to_versions);
+                pre_rowsets_delete_bitmap, pre_rowset_to_versions,
+                pre_rowset_delete_bitmap_stats.get());
         // update delete bitmap to ms
         DBUG_EXECUTE_IF(
                 "CumulativeCompaction.modify_rowsets.cloud_update_delete_bitmap_without_lock.block",
                 DBUG_BLOCK);
         auto status = _engine.meta_mgr().cloud_update_delete_bitmap_without_lock(
                 *cloud_tablet(), pre_rowsets_delete_bitmap.get(), pre_rowset_to_versions,
-                cloud_tablet()->table_id(), _output_rowset->start_version(),
-                _output_rowset->end_version());
+                pre_rowset_delete_bitmap_stats.get(), cloud_tablet()->table_id(),
+                _output_rowset->start_version(), _output_rowset->end_version());
         if (!status.ok()) {
             LOG(WARNING) << "failed to agg pre rowsets delete bitmap to ms. tablet_id="
                          << _tablet->tablet_id() << ", pre rowset num=" << pre_rowsets.size()

--- a/be/src/cloud/cloud_meta_mgr.cpp
+++ b/be/src/cloud/cloud_meta_mgr.cpp
@@ -2206,8 +2206,10 @@ Status CloudMetaMgr::update_delete_bitmap(const CloudTablet& tablet, int64_t loc
 
 Status CloudMetaMgr::cloud_update_delete_bitmap_without_lock(
         const CloudTablet& tablet, DeleteBitmap* delete_bitmap,
-        std::map<std::string, int64_t>& rowset_to_versions, int64_t table_id,
-        int64_t pre_rowset_agg_start_version, int64_t pre_rowset_agg_end_version) {
+        std::map<std::string, int64_t>& rowset_to_versions,
+        const CloudTablet::PreRowsetDeleteBitmapStats* pre_rowset_delete_bitmap_stats,
+        int64_t table_id, int64_t pre_rowset_agg_start_version,
+        int64_t pre_rowset_agg_end_version) {
     if (config::delete_bitmap_store_write_version == 2) {
         VLOG_DEBUG << "no need to agg delete bitmap v1 in ms because use v2";
         return Status::OK();
@@ -2223,6 +2225,10 @@ Status CloudMetaMgr::cloud_update_delete_bitmap_without_lock(
     // use a fake lock id to resolve compatibility issues
     req.set_lock_id(-3);
     req.set_without_lock(true);
+    req.set_enable_remove_agg_pre_rowsets_delete_bitmap_by_keys(
+            config::enable_remove_agg_pre_rowsets_delete_bitmap_by_keys);
+    req.set_enable_remove_pre_rowsets_delete_bitmap_by_keys(pre_rowset_delete_bitmap_stats !=
+                                                            nullptr);
     for (auto& [key, bitmap] : delete_bitmap->delete_bitmap) {
         req.add_rowset_ids(std::get<0>(key).to_string());
         req.add_segment_ids(std::get<1>(key));
@@ -2246,6 +2252,23 @@ Status CloudMetaMgr::cloud_update_delete_bitmap_without_lock(
         req.set_pre_rowset_agg_start_version(pre_rowset_agg_start_version);
         req.set_pre_rowset_agg_end_version(pre_rowset_agg_end_version);
     }
+    if (pre_rowset_delete_bitmap_stats != nullptr) {
+        for (const auto& [rowset_id, delete_bitmap_stats] : *pre_rowset_delete_bitmap_stats) {
+            if (delete_bitmap_stats.empty()) {
+                continue;
+            }
+            auto* rowset_stats_pb = req.add_pre_rowset_delete_bitmap_stats();
+            rowset_stats_pb->set_rowset_id(rowset_id);
+            for (const auto& [segment_id, version, delete_bitmap_size] : delete_bitmap_stats) {
+                auto* delete_bitmap_stat_pb = rowset_stats_pb->add_delete_bitmap_stats();
+                delete_bitmap_stat_pb->set_segment_id(segment_id);
+                delete_bitmap_stat_pb->set_version(version);
+                delete_bitmap_stat_pb->set_delete_bitmap_size(delete_bitmap_size);
+            }
+        }
+    }
+    TEST_SYNC_POINT_RETURN_WITH_VALUE(
+            "CloudMetaMgr::cloud_update_delete_bitmap_without_lock.before_rpc", Status::OK(), &req);
     return retry_rpc(MetaServiceRPC::UPDATE_DELETE_BITMAP, req, &res,
                      &MetaService_Stub::update_delete_bitmap,
                      {

--- a/be/src/cloud/cloud_meta_mgr.h
+++ b/be/src/cloud/cloud_meta_mgr.h
@@ -158,8 +158,10 @@ public:
 
     Status cloud_update_delete_bitmap_without_lock(
             const CloudTablet& tablet, DeleteBitmap* delete_bitmap,
-            std::map<std::string, int64_t>& rowset_to_versions, int64_t table_id,
-            int64_t pre_rowset_agg_start_version = 0, int64_t pre_rowset_agg_end_version = 0);
+            std::map<std::string, int64_t>& rowset_to_versions,
+            const CloudTablet::PreRowsetDeleteBitmapStats* pre_rowset_delete_bitmap_stats,
+            int64_t table_id, int64_t pre_rowset_agg_start_version = 0,
+            int64_t pre_rowset_agg_end_version = 0);
 
     Status get_delete_bitmap_update_lock(const CloudTablet& tablet, int64_t lock_id,
                                          int64_t initiator);

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -1484,12 +1484,34 @@ Status CloudTablet::calc_delete_bitmap_for_compaction(
 
 void CloudTablet::agg_delete_bitmap_for_compaction(
         int64_t start_version, int64_t end_version, const std::vector<RowsetSharedPtr>& pre_rowsets,
-        DeleteBitmapPtr& new_delete_bitmap,
-        std::map<std::string, int64_t>& pre_rowset_to_versions) {
-    for (auto& rowset : pre_rowsets) {
+        DeleteBitmapPtr& new_delete_bitmap, std::map<std::string, int64_t>& pre_rowset_to_versions,
+        PreRowsetDeleteBitmapStats* pre_rowset_delete_bitmap_stats) {
+    auto& delete_bitmap = tablet_meta()->delete_bitmap();
+    for (const auto& rowset : pre_rowsets) {
+        if (pre_rowset_delete_bitmap_stats != nullptr) {
+            auto& rowset_delete_bitmap_stats =
+                    (*pre_rowset_delete_bitmap_stats)[rowset->rowset_id().to_string()];
+            std::shared_lock lock(delete_bitmap.lock);
+            const auto bitmap_start_version = static_cast<DeleteBitmap::Version>(start_version);
+            const auto bitmap_end_version = static_cast<DeleteBitmap::Version>(end_version);
+            for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
+                DeleteBitmap::BitmapKey segment_start {rowset->rowset_id(), seg_id,
+                                                       bitmap_start_version};
+                for (auto it = delete_bitmap.delete_bitmap.lower_bound(segment_start);
+                     it != delete_bitmap.delete_bitmap.end(); ++it) {
+                    const auto& [key, bitmap] = *it;
+                    if (std::get<0>(key) != rowset->rowset_id() || std::get<1>(key) != seg_id ||
+                        std::get<2>(key) >= bitmap_end_version) {
+                        break;
+                    }
+                    rowset_delete_bitmap_stats.emplace_back(seg_id, std::get<2>(key),
+                                                            bitmap.getSizeInBytes());
+                }
+            }
+        }
         for (uint32_t seg_id = 0; seg_id < rowset->num_segments(); ++seg_id) {
-            auto d = tablet_meta()->delete_bitmap().get_agg_without_cache(
-                    {rowset->rowset_id(), seg_id, end_version}, start_version);
+            auto d = delete_bitmap.get_agg_without_cache({rowset->rowset_id(), seg_id, end_version},
+                                                         start_version);
             if (d->isEmpty()) {
                 continue;
             }

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <memory>
+#include <tuple>
 
 #include "storage/partial_update_info.h"
 #include "storage/rowset/rowset.h"
@@ -76,6 +77,11 @@ struct RecycledRowsets {
 
 class CloudTablet final : public BaseTablet {
 public:
+    // rowset id -> [(segment id, version, serialized delete bitmap size)]
+    using PreRowsetDeleteBitmapStats = std::map<
+            std::string,
+            std::vector<std::tuple<DeleteBitmap::SegmentId, DeleteBitmap::Version, size_t>>>;
+
     CloudTablet(CloudStorageEngine& engine, TabletMetaSharedPtr tablet_meta);
 
     ~CloudTablet() override;
@@ -357,10 +363,11 @@ public:
     // check that if the delete bitmap in delete bitmap cache has the same cardinality with the expected_delete_bitmap's
     Status check_delete_bitmap_cache(int64_t txn_id, DeleteBitmap* expected_delete_bitmap) override;
 
-    void agg_delete_bitmap_for_compaction(int64_t start_version, int64_t end_version,
-                                          const std::vector<RowsetSharedPtr>& pre_rowsets,
-                                          DeleteBitmapPtr& new_delete_bitmap,
-                                          std::map<std::string, int64_t>& pre_rowset_to_versions);
+    void agg_delete_bitmap_for_compaction(
+            int64_t start_version, int64_t end_version,
+            const std::vector<RowsetSharedPtr>& pre_rowsets, DeleteBitmapPtr& new_delete_bitmap,
+            std::map<std::string, int64_t>& pre_rowset_to_versions,
+            PreRowsetDeleteBitmapStats* pre_rowset_delete_bitmap_stats);
 
     bool need_remove_unused_rowsets();
 

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1506,6 +1506,12 @@ DEFINE_mBool(enable_mow_get_agg_by_cache, "true");
 DEFINE_mBool(enable_mow_get_agg_correctness_check_core, "false");
 DEFINE_mBool(enable_agg_and_remove_pre_rowsets_delete_bitmap, "true");
 DEFINE_mBool(enable_check_agg_and_remove_pre_rowsets_delete_bitmap, "false");
+// Remove pre-rowset delete bitmaps in [end_version, end_version] before writing aggregated delete
+// bitmaps. True: point delete; false: range delete.
+DEFINE_mBool(enable_remove_agg_pre_rowsets_delete_bitmap_by_keys, "true");
+// Remove pre-rowset delete bitmaps in [start_version, end_version). True: point delete; false:
+// range delete.
+DEFINE_mBool(enable_remove_pre_rowsets_delete_bitmap_by_keys, "true");
 
 // The secure path with user files, used in the `local` table function.
 DEFINE_String(user_files_secure_path, "${DORIS_HOME}");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1588,6 +1588,8 @@ DECLARE_mBool(enable_mow_get_agg_by_cache);
 DECLARE_mBool(enable_mow_get_agg_correctness_check_core);
 DECLARE_mBool(enable_agg_and_remove_pre_rowsets_delete_bitmap);
 DECLARE_mBool(enable_check_agg_and_remove_pre_rowsets_delete_bitmap);
+DECLARE_mBool(enable_remove_agg_pre_rowsets_delete_bitmap_by_keys);
+DECLARE_mBool(enable_remove_pre_rowsets_delete_bitmap_by_keys);
 
 // The secure path with user files, used in the `local` table function.
 DECLARE_String(user_files_secure_path);

--- a/be/test/cloud/cloud_meta_mgr_test.cpp
+++ b/be/test/cloud/cloud_meta_mgr_test.cpp
@@ -29,12 +29,14 @@
 
 #include "cloud/cloud_storage_engine.h"
 #include "cloud/cloud_tablet.h"
+#include "cloud/config.h"
 #include "cpp/sync_point.h"
 #include "load/stream_load/stream_load_context.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_meta.h"
 #include "storage/tablet/tablet_meta.h"
+#include "util/defer_op.h"
 #include "util/uid_util.h"
 
 namespace doris {
@@ -95,6 +97,87 @@ TEST_F(CloudMetaMgrTest, response_status_returns_undefined_without_any_code) {
 
     status.set_code(MetaServiceCode::OK);
     EXPECT_EQ(get_response_code(status), MetaServiceCode::OK);
+}
+
+TEST_F(CloudMetaMgrTest, PreRowsetDeleteBitmapStatsRequestEncoding) {
+    CloudStorageEngine engine(EngineOptions {});
+    CloudMetaMgr meta_mgr;
+    TabletMetaSharedPtr tablet_meta(
+            new TabletMeta(1001, 2, 15673, 15674, 4, 5, TTabletSchema(), 6, {{7, 8}},
+                           UniqueId(9, 10), TTabletType::TABLET_TYPE_DISK, TCompressionType::LZ4F));
+    auto tablet = std::make_shared<CloudTablet>(engine, std::make_shared<TabletMeta>(*tablet_meta));
+    DeleteBitmap delete_bitmap(tablet->tablet_id());
+    std::map<std::string, int64_t> rowset_to_versions;
+
+    int32_t old_write_version = config::delete_bitmap_store_write_version;
+    bool old_remove_agg_by_keys = config::enable_remove_agg_pre_rowsets_delete_bitmap_by_keys;
+    config::delete_bitmap_store_write_version = 1;
+    auto* sp = SyncPoint::get_instance();
+    sp->clear_all_call_backs();
+    sp->enable_processing();
+    Defer cleanup {[&] {
+        config::delete_bitmap_store_write_version = old_write_version;
+        config::enable_remove_agg_pre_rowsets_delete_bitmap_by_keys = old_remove_agg_by_keys;
+        sp->disable_processing();
+        sp->clear_all_call_backs();
+    }};
+
+    auto capture_request = [&](const CloudTablet::PreRowsetDeleteBitmapStats* stats) {
+        bool called = false;
+        UpdateDeleteBitmapRequest captured_req;
+        SyncPoint::CallbackGuard guard;
+        sp->set_call_back(
+                "CloudMetaMgr::cloud_update_delete_bitmap_without_lock.before_rpc",
+                [&](auto&& args) {
+                    auto* req = try_any_cast<UpdateDeleteBitmapRequest*>(args[0]);
+                    captured_req.CopyFrom(*req);
+                    called = true;
+                    auto* ret = try_any_cast<std::pair<Status, bool>*>(args.back());
+                    ret->first = Status::OK();
+                    ret->second = true;
+                },
+                &guard);
+        auto status = meta_mgr.cloud_update_delete_bitmap_without_lock(
+                *tablet, &delete_bitmap, rowset_to_versions, stats, tablet->table_id(), 1, 2);
+        EXPECT_TRUE(status.ok()) << status;
+        EXPECT_TRUE(called);
+        return captured_req;
+    };
+
+    config::enable_remove_agg_pre_rowsets_delete_bitmap_by_keys = false;
+    auto config_disabled_req = capture_request(nullptr);
+    EXPECT_FALSE(config_disabled_req.enable_remove_agg_pre_rowsets_delete_bitmap_by_keys());
+    EXPECT_FALSE(config_disabled_req.enable_remove_pre_rowsets_delete_bitmap_by_keys());
+    EXPECT_EQ(config_disabled_req.pre_rowset_delete_bitmap_stats_size(), 0);
+
+    CloudTablet::PreRowsetDeleteBitmapStats empty_stats;
+    empty_stats.emplace(
+            "rowset_without_delete_bitmap",
+            std::vector<std::tuple<DeleteBitmap::SegmentId, DeleteBitmap::Version, size_t>> {});
+    empty_stats.emplace(
+            "second_rowset_without_delete_bitmap",
+            std::vector<std::tuple<DeleteBitmap::SegmentId, DeleteBitmap::Version, size_t>> {});
+    config::enable_remove_agg_pre_rowsets_delete_bitmap_by_keys = true;
+    auto config_enabled_req = capture_request(&empty_stats);
+    EXPECT_TRUE(config_enabled_req.enable_remove_agg_pre_rowsets_delete_bitmap_by_keys());
+    EXPECT_TRUE(config_enabled_req.enable_remove_pre_rowsets_delete_bitmap_by_keys());
+    EXPECT_EQ(config_enabled_req.pre_rowset_delete_bitmap_stats_size(), 0);
+
+    using DeleteBitmapStat = std::tuple<DeleteBitmap::SegmentId, DeleteBitmap::Version, size_t>;
+    CloudTablet::PreRowsetDeleteBitmapStats populated_stats;
+    populated_stats.emplace("rowset_with_delete_bitmap",
+                            std::vector<DeleteBitmapStat> {{3, 7, 1024}, {8, 9, 2048}});
+    auto populated_stats_req = capture_request(&populated_stats);
+    ASSERT_EQ(populated_stats_req.pre_rowset_delete_bitmap_stats_size(), 1);
+    const auto& rowset_stats = populated_stats_req.pre_rowset_delete_bitmap_stats(0);
+    EXPECT_EQ(rowset_stats.rowset_id(), "rowset_with_delete_bitmap");
+    ASSERT_EQ(rowset_stats.delete_bitmap_stats_size(), 2);
+    EXPECT_EQ(rowset_stats.delete_bitmap_stats(0).segment_id(), 3);
+    EXPECT_EQ(rowset_stats.delete_bitmap_stats(0).version(), 7);
+    EXPECT_EQ(rowset_stats.delete_bitmap_stats(0).delete_bitmap_size(), 1024);
+    EXPECT_EQ(rowset_stats.delete_bitmap_stats(1).segment_id(), 8);
+    EXPECT_EQ(rowset_stats.delete_bitmap_stats(1).version(), 9);
+    EXPECT_EQ(rowset_stats.delete_bitmap_stats(1).delete_bitmap_size(), 2048);
 }
 
 static AbortTxnRequest get_abort_txn_request(CloudMetaMgr* meta_mgr, const StreamLoadContext& ctx) {

--- a/be/test/cloud/cloud_tablet_test.cpp
+++ b/be/test/cloud/cloud_tablet_test.cpp
@@ -74,6 +74,79 @@ protected:
     CloudStorageEngine _engine;
 };
 
+class CloudTabletDeleteBitmapTest : public CloudTabletWarmUpStateTest {};
+
+TEST_F(CloudTabletDeleteBitmapTest, AggDeleteBitmapForCompactionReturnsPreRowsetStats) {
+    auto rowset1 = create_rowset(Version(1, 1), 2);
+    auto rowset2 = create_rowset(Version(2, 2));
+    auto rowset_without_delete_bitmap = create_rowset(Version(3, 3));
+    ASSERT_NE(rowset1, nullptr);
+    ASSERT_NE(rowset2, nullptr);
+    ASSERT_NE(rowset_without_delete_bitmap, nullptr);
+
+    roaring::Roaring before_range;
+    before_range.add(1);
+    roaring::Roaring at_start;
+    at_start.add(2);
+    at_start.add(3);
+    roaring::Roaring within_range;
+    within_range.add(4);
+    roaring::Roaring at_end;
+    at_end.add(5);
+    roaring::Roaring second_segment;
+    second_segment.add(6);
+    second_segment.add(7);
+    second_segment.add(8);
+    roaring::Roaring second_rowset;
+    second_rowset.add(9);
+
+    auto& delete_bitmap = _tablet->tablet_meta()->delete_bitmap();
+    delete_bitmap.set({rowset1->rowset_id(), 0, 4}, before_range);
+    delete_bitmap.set({rowset1->rowset_id(), 0, 5}, at_start);
+    delete_bitmap.set({rowset1->rowset_id(), 0, 6}, within_range);
+    delete_bitmap.set({rowset1->rowset_id(), 0, 7}, at_end);
+    delete_bitmap.set({rowset1->rowset_id(), 1, 6}, second_segment);
+    delete_bitmap.set({rowset2->rowset_id(), 0, 5}, second_rowset);
+
+    auto aggregated_delete_bitmap = std::make_shared<DeleteBitmap>(_tablet->tablet_id());
+    std::map<std::string, int64_t> pre_rowset_to_versions;
+    CloudTablet::PreRowsetDeleteBitmapStats pre_rowset_delete_bitmap_stats;
+    _tablet->agg_delete_bitmap_for_compaction(
+            5, 7, {rowset1, rowset2, rowset_without_delete_bitmap}, aggregated_delete_bitmap,
+            pre_rowset_to_versions, &pre_rowset_delete_bitmap_stats);
+
+    using DeleteBitmapStat = std::tuple<DeleteBitmap::SegmentId, DeleteBitmap::Version, size_t>;
+    EXPECT_EQ(pre_rowset_delete_bitmap_stats.at(rowset1->rowset_id().to_string()),
+              (std::vector<DeleteBitmapStat> {
+                      {0, 5, at_start.getSizeInBytes()},
+                      {0, 6, within_range.getSizeInBytes()},
+                      {1, 6, second_segment.getSizeInBytes()},
+              }));
+    EXPECT_EQ(pre_rowset_delete_bitmap_stats.at(rowset2->rowset_id().to_string()),
+              (std::vector<DeleteBitmapStat> {{0, 5, second_rowset.getSizeInBytes()}}));
+    EXPECT_TRUE(
+            pre_rowset_delete_bitmap_stats.at(rowset_without_delete_bitmap->rowset_id().to_string())
+                    .empty());
+
+    roaring::Roaring aggregated;
+    ASSERT_EQ(aggregated_delete_bitmap->get({rowset1->rowset_id(), 0, 7}, &aggregated), 0);
+    EXPECT_EQ(aggregated.cardinality(), 4);
+    ASSERT_EQ(aggregated_delete_bitmap->get({rowset1->rowset_id(), 1, 7}, &aggregated), 0);
+    EXPECT_EQ(aggregated.cardinality(), 3);
+    ASSERT_EQ(aggregated_delete_bitmap->get({rowset2->rowset_id(), 0, 7}, &aggregated), 0);
+    EXPECT_EQ(aggregated.cardinality(), 1);
+    EXPECT_EQ(pre_rowset_to_versions.at(rowset1->rowset_id().to_string()), 1);
+    EXPECT_EQ(pre_rowset_to_versions.at(rowset2->rowset_id().to_string()), 2);
+
+    auto aggregated_without_stats = std::make_shared<DeleteBitmap>(_tablet->tablet_id());
+    std::map<std::string, int64_t> rowset_versions_without_stats;
+    _tablet->agg_delete_bitmap_for_compaction(
+            5, 7, {rowset1, rowset2, rowset_without_delete_bitmap}, aggregated_without_stats,
+            rowset_versions_without_stats, nullptr);
+    EXPECT_EQ(aggregated_without_stats->delete_bitmap, aggregated_delete_bitmap->delete_bitmap);
+    EXPECT_EQ(rowset_versions_without_stats, pre_rowset_to_versions);
+}
+
 // Test get_rowset_warmup_state for non-existent rowset
 TEST_F(CloudTabletWarmUpStateTest, TestGetRowsetWarmupStateNonExistent) {
     auto rowset = create_rowset(Version(1, 1));

--- a/cloud/src/meta-service/meta_service.cpp
+++ b/cloud/src/meta-service/meta_service.cpp
@@ -3803,6 +3803,112 @@ struct UpdateDeleteBitmapTxnStats {
     size_t total_txn_count = 0;
 };
 
+static bool check_delete_bitmap_point_delete(MetaServiceCode& code, std::string& msg,
+                                             std::unique_ptr<Transaction>& txn,
+                                             const std::string& key,
+                                             const UpdateDeleteBitmapRequest* request,
+                                             size_t request_index, bool& point_delete,
+                                             bool& delete_bitmap_exists,
+                                             std::optional<uint16_t>& max_blob_sequence) {
+    point_delete = request->enable_remove_agg_pre_rowsets_delete_bitmap_by_keys() &&
+                   request->lock_id() == COMPACTION_WITHOUT_LOCK_DELETE_BITMAP_LOCK_ID;
+    if (!point_delete) {
+        return true;
+    }
+    std::string end_key {key};
+    encode_int64(INT64_MAX, &end_key);
+    RangeGetOptions opts;
+    opts.batch_limit = 1;
+    opts.reverse = true;
+    std::unique_ptr<RangeGetIterator> it;
+    auto err = txn->get(key, end_key, &it, opts);
+    if (err != TxnErrorCode::TXN_OK) {
+        code = cast_as<ErrCategory::READ>(err);
+        msg = fmt::format(
+                "failed to get the last delete bitmap blob key, err={}, tablet_id={}, key={}", err,
+                request->tablet_id(), hex(key));
+        return false;
+    }
+
+    delete_bitmap_exists = it->has_next();
+    max_blob_sequence.reset();
+    if (!delete_bitmap_exists) {
+        return true;
+    }
+    auto max_key = it->next().first;
+    if (max_key.size() < key.size()) [[unlikely]] {
+        code = MetaServiceCode::UNDEFINED_ERR;
+        msg = fmt::format(
+                "delete bitmap range scan returned a shorter key, tablet_id={}, key={}, "
+                "max_key={}",
+                request->tablet_id(), hex(key), hex(max_key));
+        LOG(WARNING) << msg;
+        return false;
+    }
+    if (max_key.size() == key.size()) {
+        if (max_key != key) [[unlikely]] {
+            code = MetaServiceCode::UNDEFINED_ERR;
+            msg = fmt::format(
+                    "delete bitmap range scan returned an unexpected key, tablet_id={}, key={}, "
+                    "max_key={}",
+                    request->tablet_id(), hex(key), hex(max_key));
+            LOG(WARNING) << msg;
+            return false;
+        }
+        return true;
+    }
+    uint8_t blob_version = 0;
+    uint16_t sequence = 0;
+    std::vector<std::tuple<std::variant<int64_t, std::string>, int, int>> out;
+    if (!decode_blob_key(max_key, nullptr, &blob_version, &sequence, &out)) [[unlikely]] {
+        code = MetaServiceCode::UNDEFINED_ERR;
+        msg = fmt::format("failed to decode delete bitmap blob key, tablet_id={}, key={}",
+                          request->tablet_id(), hex(max_key));
+        LOG(WARNING) << msg;
+        return false;
+    }
+
+    constexpr size_t delete_bitmap_key_field_count = 7;
+    if (out.size() != delete_bitmap_key_field_count) [[unlikely]] {
+        code = MetaServiceCode::UNDEFINED_ERR;
+        msg = fmt::format(
+                "invalid delete bitmap blob origin key field count, tablet_id={}, key={}, "
+                "field_count={}",
+                request->tablet_id(), hex(max_key), out.size());
+        LOG(WARNING) << msg;
+        return false;
+    }
+
+    const auto* rowset_id = std::get_if<std::string>(&std::get<0>(out[4]));
+    const auto* version = std::get_if<int64_t>(&std::get<0>(out[5]));
+    const auto* segment_id = std::get_if<int64_t>(&std::get<0>(out[6]));
+    if (rowset_id == nullptr || version == nullptr || segment_id == nullptr) [[unlikely]] {
+        code = MetaServiceCode::UNDEFINED_ERR;
+        msg = fmt::format("invalid delete bitmap blob origin key fields, tablet_id={}, key={}",
+                          request->tablet_id(), hex(max_key));
+        LOG(WARNING) << msg;
+        return false;
+    }
+
+    if (*rowset_id != request->rowset_ids(request_index) ||
+        *version != request->versions(request_index) ||
+        *segment_id != request->segment_ids(request_index)) [[unlikely]] {
+        code = MetaServiceCode::UNDEFINED_ERR;
+        msg = fmt::format(
+                "unexpected delete bitmap blob origin key, tablet_id={}, key={}, rowset_id={}, "
+                "version={}, segment_id={}, expected_rowset_id={}, "
+                "expected_version={}, expected_segment_id={}",
+                request->tablet_id(), hex(max_key), *rowset_id, *version, *segment_id,
+                request->rowset_ids(request_index), request->versions(request_index),
+                request->segment_ids(request_index));
+        LOG(WARNING) << msg;
+        return false;
+    }
+
+    max_blob_sequence = sequence;
+    return true;
+}
+
 void _write_delete_bitmap_kvs(MetaServiceCode& code, std::string& msg, std::stringstream& ss,
                               std::shared_ptr<TxnKv> txn_kv, std::unique_ptr<Transaction>& txn,
                               std::string& use_version, std::set<std::string>& non_exist_rowset_ids,
@@ -3938,12 +4044,37 @@ void _write_delete_bitmap_kvs(MetaServiceCode& code, std::string& msg, std::stri
     }
     // remove first
     if (request->lock_id() == COMPACTION_WITHOUT_LOCK_DELETE_BITMAP_LOCK_ID) {
-        auto& start_key = key;
-        std::string end_key {start_key};
-        encode_int64(INT64_MAX, &end_key);
-        txn->remove(start_key, end_key);
-        LOG(INFO) << "xxx remove delete_bitmap_key=" << hex(start_key) << " tablet_id=" << tablet_id
-                  << " lock_id=" << request->lock_id() << " initiator=" << request->initiator();
+        bool point_delete = false;
+        bool delete_bitmap_exists = false;
+        std::optional<uint16_t> max_blob_sequence;
+        if (!check_delete_bitmap_point_delete(code, msg, txn, key, request, i, point_delete,
+                                              delete_bitmap_exists, max_blob_sequence)) {
+            return;
+        }
+        if (point_delete) {
+            if (delete_bitmap_exists) {
+                if (max_blob_sequence.has_value()) {
+                    for (size_t sequence = 0; sequence <= *max_blob_sequence; ++sequence) {
+                        txn->remove(encode_blob_key(key, 0, sequence));
+                    }
+                } else {
+                    // Compatibility with delete bitmaps written directly by the legacy txn->put.
+                    txn->remove(key);
+                }
+                LOG(INFO) << "xxx point remove delete_bitmap_key=" << hex(key)
+                          << " tablet_id=" << tablet_id << " lock_id=" << request->lock_id()
+                          << " initiator=" << request->initiator()
+                          << " delete_key_count=" << (max_blob_sequence.value_or(0) + 1);
+            }
+        } else {
+            auto& start_key = key;
+            std::string end_key {start_key};
+            encode_int64(INT64_MAX, &end_key);
+            txn->remove(start_key, end_key);
+            LOG(INFO) << "xxx range remove delete_bitmap_key=" << hex(start_key)
+                      << " tablet_id=" << tablet_id << " lock_id=" << request->lock_id()
+                      << " initiator=" << request->initiator();
+        }
     }
     // splitting large values (>90*1000) into multiple KVs
     cloud::blob_put(txn.get(), key, val, 0);
@@ -3954,6 +4085,136 @@ void _write_delete_bitmap_kvs(MetaServiceCode& code, std::string& msg, std::stri
     VLOG_DEBUG << "xxx update delete bitmap put delete_bitmap_key=" << hex(key)
                << " lock_id=" << request->lock_id() << " initiator=" << request->initiator()
                << " key_size: " << key.size() << " value_size: " << val.size();
+}
+
+static bool commit_pre_rowset_delete_bitmap_removal(
+        MetaServiceCode& code, std::string& msg, std::stringstream& ss,
+        const std::shared_ptr<TxnKv>& txn_kv, std::unique_ptr<Transaction>& txn, KVStats& stats,
+        UpdateDeleteBitmapTxnStats& txn_stats, int64_t tablet_id, const std::string& rowset_id) {
+    auto txn_size = txn->approximate_bytes();
+    LOG(INFO) << "commit delete bitmap point deletes before transaction size exceeds limit, "
+                 "tablet_id="
+              << tablet_id << ", rowset=" << rowset_id << ", txn_size=" << txn_size;
+    auto err = txn->commit();
+    TEST_SYNC_POINT_CALLBACK("update_delete_bitmap:remove_pre_rowsets:commit", txn_size);
+    txn_stats.total_txn_put_keys += txn->num_put_keys();
+    txn_stats.total_txn_put_bytes += txn->put_bytes();
+    txn_stats.total_txn_size += txn_size;
+    txn_stats.total_txn_count++;
+    if (err != TxnErrorCode::TXN_OK) {
+        code = cast_as<ErrCategory::COMMIT>(err);
+        ss << "failed to remove pre rowsets delete bitmap, err=" << err
+           << " tablet_id=" << tablet_id << " rowset_id=" << rowset_id << " txn_size=" << txn_size;
+        msg = ss.str();
+        g_bvar_update_delete_bitmap_fail_counter << 1;
+        return false;
+    }
+    stats.get_bytes += txn->get_bytes();
+    stats.put_bytes += txn->put_bytes();
+    stats.del_bytes += txn->delete_bytes();
+    stats.get_counter += txn->num_get_keys();
+    stats.put_counter += txn->num_put_keys();
+    stats.del_counter += txn->num_del_keys();
+    txn_stats.current_key_count = 0;
+    txn_stats.current_value_count = 0;
+    err = txn_kv->create_txn(&txn);
+    if (err != TxnErrorCode::TXN_OK) {
+        code = cast_as<ErrCategory::CREATE>(err);
+        msg = "failed to init txn when removing pre rowsets delete bitmap";
+        return false;
+    }
+    return true;
+}
+
+static bool remove_pre_rowset_delete_bitmap(
+        MetaServiceCode& code, std::string& msg, std::stringstream& ss,
+        const std::shared_ptr<TxnKv>& txn_kv, std::unique_ptr<Transaction>& txn, KVStats& stats,
+        const UpdateDeleteBitmapRequest* request, const std::string& instance_id,
+        const std::set<std::string>& non_exist_rowset_ids, UpdateDeleteBitmapTxnStats& txn_stats) {
+    if (!request->has_pre_rowset_agg_start_version() ||
+        !request->has_pre_rowset_agg_end_version() ||
+        request->pre_rowset_agg_start_version() >= request->pre_rowset_agg_end_version()) {
+        return true;
+    }
+
+    auto tablet_id = request->tablet_id();
+    if (!request->enable_remove_pre_rowsets_delete_bitmap_by_keys()) {
+        std::string pre_rowset_id;
+        for (size_t i = 0; i < request->rowset_ids_size(); ++i) {
+            if (request->rowset_ids(i) == pre_rowset_id) {
+                continue;
+            }
+            if (non_exist_rowset_ids.contains(request->rowset_ids(i))) {
+                LOG(INFO) << "skip remove pre rowsets delete bitmap, rowset_id="
+                          << request->rowset_ids(i) << " tablet_id=" << tablet_id
+                          << " because the rowset does not exist";
+                continue;
+            }
+            pre_rowset_id = request->rowset_ids(i);
+            auto delete_bitmap_start =
+                    meta_delete_bitmap_key({instance_id, tablet_id, request->rowset_ids(i),
+                                            request->pre_rowset_agg_start_version(), 0});
+            auto delete_bitmap_end =
+                    meta_delete_bitmap_key({instance_id, tablet_id, request->rowset_ids(i),
+                                            request->pre_rowset_agg_end_version(), 0});
+            txn->remove(delete_bitmap_start, delete_bitmap_end);
+            LOG(INFO) << "remove pre rowsets delete bitmap by range, tablet_id=" << tablet_id
+                      << ", rowset=" << request->rowset_ids(i)
+                      << ", start_version=" << request->pre_rowset_agg_start_version()
+                      << ", end_version=" << request->pre_rowset_agg_end_version()
+                      << ", start_key=" << hex(delete_bitmap_start)
+                      << ", end_key=" << hex(delete_bitmap_end);
+        }
+        return true;
+    }
+
+    for (const auto& rowset_stats : request->pre_rowset_delete_bitmap_stats()) {
+        if (non_exist_rowset_ids.contains(rowset_stats.rowset_id())) {
+            LOG(INFO) << "skip remove pre rowsets delete bitmap, rowset_id="
+                      << rowset_stats.rowset_id() << " tablet_id=" << tablet_id
+                      << " because the rowset does not exist";
+            continue;
+        }
+        uint64_t delete_key_count = 0;
+        for (const auto& delete_bitmap_stat : rowset_stats.delete_bitmap_stats()) {
+            DCHECK(delete_bitmap_stat.version() >= request->pre_rowset_agg_start_version() &&
+                   delete_bitmap_stat.version() < request->pre_rowset_agg_end_version());
+            auto delete_bitmap_key = meta_delete_bitmap_key(
+                    {instance_id, tablet_id, rowset_stats.rowset_id(), delete_bitmap_stat.version(),
+                     delete_bitmap_stat.segment_id()});
+            auto remove_key = [&](std::string_view key) {
+                auto txn_size = txn->approximate_bytes();
+                if (txn_size > 0 &&
+                    txn_size + key.size() * 3 > static_cast<size_t>(config::max_txn_commit_byte) &&
+                    !commit_pre_rowset_delete_bitmap_removal(code, msg, ss, txn_kv, txn, stats,
+                                                             txn_stats, tablet_id,
+                                                             rowset_stats.rowset_id())) {
+                    return false;
+                }
+                txn->remove(key);
+                delete_key_count++;
+                return true;
+            };
+            if (!remove_key(delete_bitmap_key)) {
+                return false;
+            }
+            auto split_key_count =
+                    delete_bitmap_stat.delete_bitmap_size() / DEFAULT_BLOB_SPLIT_SIZE +
+                    (delete_bitmap_stat.delete_bitmap_size() % DEFAULT_BLOB_SPLIT_SIZE != 0);
+            for (size_t i = 0; i < split_key_count; ++i) {
+                if (!remove_key(encode_blob_key(delete_bitmap_key, 0, i))) {
+                    return false;
+                }
+            }
+        }
+        if (delete_key_count > 0) {
+            LOG(INFO) << "remove pre rowsets delete bitmap by keys, tablet_id=" << tablet_id
+                      << ", rowset=" << rowset_stats.rowset_id()
+                      << ", delete_bitmap_count=" << rowset_stats.delete_bitmap_stats_size()
+                      << ", delete_key_count=" << delete_key_count;
+        }
+    }
+    return true;
 }
 
 void MetaServiceImpl::update_delete_bitmap(google::protobuf::RpcController* controller,
@@ -4177,35 +4438,9 @@ void MetaServiceImpl::update_delete_bitmap(google::protobuf::RpcController* cont
         if (code != MetaServiceCode::OK) return;
     }
 
-    // remove pre rowset delete bitmap
-    if (request->has_pre_rowset_agg_start_version() && request->has_pre_rowset_agg_end_version() &&
-        request->pre_rowset_agg_start_version() < request->pre_rowset_agg_end_version()) {
-        std::string pre_rowset_id = "";
-        for (size_t i = 0; i < request->rowset_ids_size(); ++i) {
-            if (request->rowset_ids(i) == pre_rowset_id) {
-                continue;
-            }
-            if (non_exist_rowset_ids.contains(request->rowset_ids(i))) {
-                LOG(INFO) << "skip remove pre rowsets delete bitmap, rowset_id="
-                          << request->rowset_ids(i) << " tablet_id=" << tablet_id
-                          << " because the rowset does not exist";
-                continue;
-            }
-            pre_rowset_id = request->rowset_ids(i);
-            auto delete_bitmap_start =
-                    meta_delete_bitmap_key({instance_id, tablet_id, request->rowset_ids(i),
-                                            request->pre_rowset_agg_start_version(), 0});
-            auto delete_bitmap_end =
-                    meta_delete_bitmap_key({instance_id, tablet_id, request->rowset_ids(i),
-                                            request->pre_rowset_agg_end_version(), 0});
-            txn->remove(delete_bitmap_start, delete_bitmap_end);
-            LOG(INFO) << "remove pre rowsets delete bitmap, tablet_id=" << tablet_id
-                      << ", rowset=" << request->rowset_ids(i)
-                      << ", start_version=" << request->pre_rowset_agg_start_version()
-                      << ", end_version=" << request->pre_rowset_agg_end_version()
-                      << ", start_key=" << hex(delete_bitmap_start)
-                      << ", end_key=" << hex(delete_bitmap_end);
-        }
+    if (!remove_pre_rowset_delete_bitmap(code, msg, ss, txn_kv_, txn, stats, request, instance_id,
+                                         non_exist_rowset_ids, txn_stats)) {
+        return;
     }
     err = txn->commit();
     txn_stats.total_txn_put_keys += txn->num_put_keys();
@@ -4342,6 +4577,9 @@ void MetaServiceImpl::get_delete_bitmap(google::protobuf::RpcController* control
             std::unique_ptr<RangeGetIterator> it;
             int64_t last_ver = -1;
             int64_t last_seg_id = -1;
+            std::string last_delete_bitmap_first_blob_key;
+            uint16_t next_blob_sequence = 0;
+            bool skip_last_delete_bitmap = false;
             int64_t round = 0;
             while (it == nullptr /* may be not init */ || it->more()) {
                 if (test) {
@@ -4362,6 +4600,31 @@ void MetaServiceImpl::get_delete_bitmap(google::protobuf::RpcController* control
                         ss << "failed to init txn, retry=" << retry << ", internal round=" << round;
                         msg = ss.str();
                         return;
+                    }
+                    if (!skip_last_delete_bitmap && !last_delete_bitmap_first_blob_key.empty()) {
+                        std::string first_blob_value;
+                        err = txn->get(last_delete_bitmap_first_blob_key, &first_blob_value);
+                        if (err == TxnErrorCode::TXN_KEY_NOT_FOUND) {
+                            delete_bitmap_byte -=
+                                    response->segment_delete_bitmaps(
+                                                    response->segment_delete_bitmaps_size() - 1)
+                                            .size();
+                            delete_bitmap_num--;
+                            response->mutable_rowset_ids()->RemoveLast();
+                            response->mutable_segment_ids()->RemoveLast();
+                            response->mutable_versions()->RemoveLast();
+                            response->mutable_segment_delete_bitmaps()->RemoveLast();
+                            skip_last_delete_bitmap = true;
+                            LOG(WARNING)
+                                    << "skip incomplete delete bitmap whose first blob key "
+                                       "disappeared after transaction retry"
+                                    << ", tablet_id=" << tablet_id
+                                    << ", rowset_id=" << rowset_ids[i] << ", version=" << last_ver
+                                    << ", segment_id=" << last_seg_id;
+                        } else if (err != TxnErrorCode::TXN_OK) {
+                            retry++;
+                            continue;
+                        }
                     }
                     if (test) {
                         err = txn->get(start_key, end_key, &it, false, 2);
@@ -4388,7 +4651,15 @@ void MetaServiceImpl::get_delete_bitmap(google::protobuf::RpcController* control
                     auto k1 = k;
                     k1.remove_prefix(1);
                     std::vector<std::tuple<std::variant<int64_t, std::string>, int, int>> out;
-                    decode_key(&k1, &out);
+                    auto decode_ret = decode_key(&k1, &out);
+                    if (decode_ret != 0 || (out.size() != 7 && out.size() != 8)) {
+                        code = MetaServiceCode::KV_TXN_GET_ERR;
+                        ss << "invalid delete bitmap key: " << hex(k)
+                           << ", decode_ret=" << decode_ret << ", field_count=" << out.size();
+                        msg = ss.str();
+                        g_bvar_get_delete_bitmap_fail_counter << 1;
+                        return;
+                    }
                     // 0x01 "meta" ${instance_id}  "delete_bitmap" ${tablet_id}
                     // ${rowset_id0} ${version1} ${segment_id0} -> DeleteBitmapPB
                     auto ver = std::get<int64_t>(std::get<0>(out[5]));
@@ -4397,15 +4668,58 @@ void MetaServiceImpl::get_delete_bitmap(google::protobuf::RpcController* control
                     // FIXME: Don't expose the implementation details of splitting large value.
                     // merge splitted large values (>90*1000)
                     if (ver != last_ver || seg_id != last_seg_id) {
+                        auto sequence =
+                                out.size() == 8
+                                        ? static_cast<uint16_t>(
+                                                  std::get<int64_t>(std::get<0>(out[7])) & 0xffff)
+                                        : uint16_t {0};
+                        last_ver = ver;
+                        last_seg_id = seg_id;
+                        last_delete_bitmap_first_blob_key.clear();
+                        next_blob_sequence = static_cast<uint16_t>(sequence + 1);
+                        // Key-based pre-rowset cleanup may leave an obsolete tail if its size estimate is
+                        // too small. The bitmap is already aggregated, so the tail can be skipped and will
+                        // be recycled with its rowset.
+                        skip_last_delete_bitmap = sequence != 0;
+                        if (skip_last_delete_bitmap) {
+                            LOG(WARNING)
+                                    << "skip incomplete delete bitmap whose first blob "
+                                       "sequence is not zero"
+                                    << ", tablet_id=" << tablet_id
+                                    << ", rowset_id=" << rowset_ids[i] << ", version=" << ver
+                                    << ", segment_id=" << seg_id << ", first_sequence=" << sequence;
+                            continue;
+                        }
+                        if (out.size() == 8) {
+                            last_delete_bitmap_first_blob_key.assign(k.data(), k.size());
+                        }
                         response->add_rowset_ids(rowset_ids[i]);
                         response->add_segment_ids(seg_id);
                         response->add_versions(ver);
                         response->add_segment_delete_bitmaps(std::string(v));
-                        last_ver = ver;
-                        last_seg_id = seg_id;
                         delete_bitmap_num++;
                         delete_bitmap_byte += v.length();
                     } else {
+                        if (skip_last_delete_bitmap) {
+                            continue;
+                        }
+                        auto sequence =
+                                out.size() == 8
+                                        ? static_cast<uint16_t>(
+                                                  std::get<int64_t>(std::get<0>(out[7])) & 0xffff)
+                                        : uint16_t {0};
+                        if (out.size() != 8 || sequence != next_blob_sequence) {
+                            code = MetaServiceCode::KV_TXN_GET_ERR;
+                            ss << "non-contiguous delete bitmap blob sequence, tablet_id="
+                               << tablet_id << ", rowset_id=" << rowset_ids[i]
+                               << ", version=" << ver << ", segment_id=" << seg_id
+                               << ", expected_sequence=" << next_blob_sequence
+                               << ", actual_sequence=" << sequence;
+                            msg = ss.str();
+                            g_bvar_get_delete_bitmap_fail_counter << 1;
+                            return;
+                        }
+                        next_blob_sequence++;
                         TEST_SYNC_POINT_CALLBACK("get_delete_bitmap_code", &code);
                         if (code != MetaServiceCode::OK) {
                             ss << "test get get_delete_bitmap fail, code="

--- a/cloud/src/meta-service/meta_service_job.cpp
+++ b/cloud/src/meta-service/meta_service_job.cpp
@@ -1273,7 +1273,10 @@ void process_compaction_job(MetaServiceCode& code, std::string& msg, std::string
                     meta_delete_bitmap_key({instance_id, tablet_id, rs.rowset_id_v2(), 0, 0});
             auto delete_bitmap_end = meta_delete_bitmap_key(
                     {instance_id, tablet_id, rs.rowset_id_v2(), INT64_MAX, INT64_MAX});
-            txn->remove(delete_bitmap_start, delete_bitmap_end);
+            INSTANCE_LOG(INFO) << "skip removing delete bitmap range, tablet_id=" << tablet_id
+                               << " rowset_id=" << rs.rowset_id_v2() << " range=["
+                               << hex(delete_bitmap_start) << "," << hex(delete_bitmap_end) << ")";
+            // txn->remove(delete_bitmap_start, delete_bitmap_end);
         }
 
         auto recycle_key = recycle_rowset_key({instance_id, tablet_id, rs.rowset_id_v2()});

--- a/cloud/src/meta-store/blob_message.cpp
+++ b/cloud/src/meta-store/blob_message.cpp
@@ -21,11 +21,13 @@
 #include <butil/iobuf_inl.h>
 #include <google/protobuf/message.h>
 
+#include <algorithm>
 #include <cstdint>
 
 #include "common/logging.h"
 #include "common/util.h"
 #include "meta-store/codec.h"
+#include "meta-store/keys.h"
 #include "meta-store/txn_kv.h"
 
 namespace doris::cloud {
@@ -38,6 +40,15 @@ static std::vector<std::string_view> split_string(const std::string_view& str, i
     }
 
     return substrings;
+}
+
+std::string encode_blob_key(std::string_view origin_key, uint8_t version, size_t sequence) {
+    std::string split_key(origin_key);
+    int64_t suffix = version;
+    suffix <<= 56;
+    suffix += sequence;
+    encode_int64(suffix, &split_key);
+    return split_key;
 }
 
 bool ValueBuf::to_pb(google::protobuf::Message* pb) const {
@@ -150,13 +161,10 @@ void blob_put(Transaction* txn, std::string_view key, const google::protobuf::Me
 
 void blob_put(Transaction* txn, std::string_view key, std::string_view value, uint8_t ver,
               size_t split_size) {
+    split_size = std::max(split_size, MIN_BLOB_SPLIT_SIZE);
     auto split_vec = split_string(value, split_size);
-    int64_t suffix_base = ver;
-    suffix_base <<= 56;
     for (size_t i = 0; i < split_vec.size(); ++i) {
-        std::string k(key);
-        encode_int64(suffix_base + i, &k);
-        txn->put(k, split_vec[i]);
+        txn->put(encode_blob_key(key, ver, i), split_vec[i]);
     }
 }
 
@@ -240,31 +248,47 @@ void BlobIterator::load_current_blob() {
     }
 }
 
-bool BlobIterator::extract_origin_key(std::string_view raw_key, std::string* output,
-                                      uint8_t* version, uint16_t* sequence) {
-    // The suffix is 8 bytes: |version(1)|dummy(5)|sequence(2)|
+bool decode_blob_key(
+        std::string_view raw_key, std::string* origin_key, uint8_t* version, uint16_t* sequence,
+        std::vector<std::tuple<std::variant<int64_t, std::string>, int, int>>* fields) {
     if (raw_key.size() < 9) {
-        LOG_WARNING("failed to extract origin key").tag("key", hex(raw_key));
-        error_code_ = TxnErrorCode::TXN_INVALID_DATA;
         return false;
     }
 
     const size_t origin_key_size = raw_key.size() - 9;
-    std::string_view origin_key = raw_key.substr(0, origin_key_size);
+    std::string_view decoded_origin_key = raw_key.substr(0, origin_key_size);
     raw_key.remove_prefix(origin_key_size);
     int64_t suffix = 0;
     if (decode_int64(&raw_key, &suffix) != 0) {
-        LOG_WARNING("failed to decode int64")
-                .tag("key", hex(raw_key))
-                .tag("origin_key", hex(origin_key));
-        error_code_ = TxnErrorCode::TXN_INVALID_DATA;
         return false;
+    }
+
+    if (fields != nullptr) {
+        if (decoded_origin_key.size() <= 1) {
+            return false;
+        }
+        auto encoded_origin_key = decoded_origin_key;
+        encoded_origin_key.remove_prefix(1);
+        if (decode_key(&encoded_origin_key, fields) != 0) {
+            return false;
+        }
     }
 
     *version = (suffix >> 56) & 0xff;
     *sequence = suffix & 0xffff;
-    *output = std::string(origin_key);
+    if (origin_key != nullptr) {
+        *origin_key = std::string(decoded_origin_key);
+    }
+    return true;
+}
 
+bool BlobIterator::extract_origin_key(std::string_view raw_key, std::string* output,
+                                      uint8_t* version, uint16_t* sequence) {
+    if (!decode_blob_key(raw_key, output, version, sequence)) {
+        LOG_WARNING("failed to extract origin key").tag("key", hex(raw_key));
+        error_code_ = TxnErrorCode::TXN_INVALID_DATA;
+        return false;
+    }
     return true;
 }
 
@@ -296,17 +320,14 @@ namespace versioned {
 
 void blob_put(Transaction* txn, std::string_view key, std::string_view value, uint8_t ver,
               size_t split_size) {
+    split_size = std::max(split_size, MIN_BLOB_SPLIT_SIZE);
     std::string encoded_key(key);
     uint32_t offset = encode_versionstamp(Versionstamp::min(), &encoded_key);
     encode_versionstamp_end(&encoded_key);
 
     auto split_vec = split_string(value, split_size);
-    int64_t suffix_base = ver;
-    suffix_base <<= 56;
     for (size_t i = 0; i < split_vec.size(); ++i) {
-        std::string k(encoded_key);
-        encode_int64(suffix_base + i, &k);
-        txn->atomic_set_ver_key(k, offset, split_vec[i]);
+        txn->atomic_set_ver_key(encode_blob_key(encoded_key, ver, i), offset, split_vec[i]);
     }
 }
 

--- a/cloud/src/meta-store/blob_message.h
+++ b/cloud/src/meta-store/blob_message.h
@@ -17,8 +17,12 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <string_view>
+#include <tuple>
+#include <variant>
+#include <vector>
 
 #include "meta-store/txn_kv.h"
 #include "meta-store/txn_kv_error.h"
@@ -39,6 +43,8 @@ namespace doris::cloud {
  *    |Bytes 0      |Bytes 1-5    |Bytes 6-7    |
  *    |-------------|-------------|-------------|
  *    |version      |dummy        |sequence     |
+ * version is uint8_t restricted to 0-127; sequence is uint16_t (0-65535).
+ * Reserved dummy bytes can extend sequence if needed.
  */
 struct ValueBuf {
     // TODO(plat1ko): Support decompression
@@ -59,8 +65,34 @@ struct ValueBuf {
     std::vector<std::string> keys() const;
 
     std::vector<std::unique_ptr<RangeGetIterator>> iters;
-    int8_t ver {-1};
+    int16_t ver {-1};
 };
+
+inline constexpr size_t DEFAULT_BLOB_SPLIT_SIZE = 90 * 1000;
+// A 10 MB FDB transaction produces at most 500 KVs with 20 KB splits, within uint16_t.
+inline constexpr size_t MIN_BLOB_SPLIT_SIZE = 20 * 1000;
+
+/**
+ * Encode a split KV key.
+ * @param origin_key logical key
+ * @param version value encoding version; valid range is [0, 127]
+ * @param sequence zero-based split KV index; valid range is [0, 65535]
+ * @return encoded split KV key
+ */
+std::string encode_blob_key(std::string_view origin_key, uint8_t version, size_t sequence);
+
+/**
+ * Decode a split KV key.
+ * @param raw_key encoded split KV key
+ * @param origin_key optional logical key output
+ * @param version value encoding version output, must not be nullptr
+ * @param sequence zero-based split KV index output, must not be nullptr
+ * @param fields optional decoded origin-key fields; non-null enables validation
+ * @return true on success
+ */
+bool decode_blob_key(
+        std::string_view raw_key, std::string* origin_key, uint8_t* version, uint16_t* sequence,
+        std::vector<std::tuple<std::variant<int64_t, std::string>, int, int>>* fields = nullptr);
 
 /**
  * Get a key, return key's value, value length may be bigger than 100k
@@ -78,22 +110,22 @@ TxnErrorCode blob_get(Transaction* txn, std::string_view key, ValueBuf* val, boo
  * @param txn fdb txn handler
  * @param key encode key
  * @param pb value to save
- * @param ver value version
- * @param split_size how many byte sized fragments are the value split into
+ * @param ver value version; valid range is [0, 127]
+ * @param split_size fragment size, clamped to MIN_BLOB_SPLIT_SIZE
  */
 void blob_put(Transaction* txn, std::string_view key, const google::protobuf::Message& pb,
-              uint8_t ver, size_t split_size = 90 * 1000);
+              uint8_t ver, size_t split_size = DEFAULT_BLOB_SPLIT_SIZE);
 
 /**
  * Put a KV, it's value may be bigger than 100k
  * @param txn fdb txn handler
  * @param key encode key
  * @param value value to save
- * @param ver value version
- * @param split_size how many byte sized fragments are the value split into
+ * @param ver value version; valid range is [0, 127]
+ * @param split_size fragment size, clamped to MIN_BLOB_SPLIT_SIZE
  */
 void blob_put(Transaction* txn, std::string_view key, std::string_view value, uint8_t ver,
-              size_t split_size = 90 * 1000);
+              size_t split_size = DEFAULT_BLOB_SPLIT_SIZE);
 
 // Iterator for blob key-value pairs.
 //
@@ -189,19 +221,20 @@ namespace versioned {
 
 // Put a blob message with a auto generated versionstamp.
 void blob_put(Transaction* txn, std::string_view key, const google::protobuf::Message& pb,
-              uint8_t ver = 0, size_t split_size = 90 * 1000);
+              uint8_t ver = 0, size_t split_size = DEFAULT_BLOB_SPLIT_SIZE);
 
 // Put a blob message with a auto generated versionstamp.
 void blob_put(Transaction* txn, std::string_view key, std::string_view value, uint8_t ver = 0,
-              size_t split_size = 90 * 1000);
+              size_t split_size = DEFAULT_BLOB_SPLIT_SIZE);
 
 // Put a blob message with a specified versionstamp.
 void blob_put(Transaction* txn, std::string_view key, Versionstamp v,
-              const google::protobuf::Message& pb, uint8_t ver = 0, size_t split_size = 90 * 1000);
+              const google::protobuf::Message& pb, uint8_t ver = 0,
+              size_t split_size = DEFAULT_BLOB_SPLIT_SIZE);
 
 // Put a blob message with a specified versionstamp.
 void blob_put(Transaction* txn, std::string_view key, Versionstamp v, std::string_view value,
-              uint8_t ver = 0, size_t split_size = 90 * 1000);
+              uint8_t ver = 0, size_t split_size = DEFAULT_BLOB_SPLIT_SIZE);
 
 } // namespace versioned
 

--- a/cloud/test/blob_message_test.cpp
+++ b/cloud/test/blob_message_test.cpp
@@ -25,6 +25,8 @@
 #include <memory>
 #include <string>
 
+#include "meta-store/codec.h"
+#include "meta-store/keys.h"
 #include "meta-store/mem_txn_kv.h"
 #include "meta-store/txn_kv.h"
 #include "meta-store/txn_kv_error.h"
@@ -62,6 +64,102 @@ static std::string dump_range(TxnKv* txn_kv, std::string_view begin = "",
     }
     EXPECT_TRUE(iter->is_valid()); // The iterator should still be valid after the next call.
     return buffer;
+}
+
+TEST(BlobMessageTest, BlobKeyCodec) {
+    const std::vector<std::tuple<std::string, uint8_t, uint16_t>> test_cases {
+            {"test_blob_key", 0, 0},
+            {std::string("\0binary\xff", 8), 127, std::numeric_limits<uint16_t>::max()},
+    };
+    for (const auto& [expected_origin_key, expected_version, expected_sequence] : test_cases) {
+        std::string origin_key;
+        uint8_t version = 0;
+        uint16_t sequence = 0;
+        auto raw_key = encode_blob_key(expected_origin_key, expected_version, expected_sequence);
+        ASSERT_TRUE(decode_blob_key(raw_key, &origin_key, &version, &sequence));
+        EXPECT_EQ(origin_key, expected_origin_key);
+        EXPECT_EQ(version, expected_version);
+        EXPECT_EQ(sequence, expected_sequence);
+        EXPECT_TRUE(decode_blob_key(raw_key, nullptr, &version, &sequence));
+    }
+
+    EXPECT_EQ(encode_blob_key("key", 0x56, 0x1234),
+              std::string("key\x12\x56\0\0\0\0\0\x12\x34", 12));
+}
+
+TEST(BlobMessageTest, BlobKeySequenceDoesNotWrap) {
+    const size_t sequence = static_cast<size_t>(std::numeric_limits<uint16_t>::max()) + 1;
+    EXPECT_NE(encode_blob_key("key", 0, 0), encode_blob_key("key", 0, sequence));
+}
+
+TEST(BlobMessageTest, ValueBufVersionAboveInt8Max) {
+    auto txn_kv = std::make_shared<MemTxnKv>();
+    ASSERT_EQ(txn_kv->init(), 0);
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+
+    std::string key = "version_above_int8_max";
+    std::string raw_key = key;
+    encode_int64(-(int64_t {1} << 56), &raw_key); // version 255, sequence 0
+    txn->put(raw_key, "value");
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+    ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+    ValueBuf value;
+    ASSERT_EQ(blob_get(txn.get(), key, &value), TxnErrorCode::TXN_OK);
+    EXPECT_EQ(value.ver, std::numeric_limits<uint8_t>::max());
+    EXPECT_EQ(value.value(), "value");
+}
+
+TEST(BlobMessageTest, ClampSmallSplitSize) {
+    auto txn_kv = std::make_shared<MemTxnKv>();
+    ASSERT_EQ(txn_kv->init(), 0);
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+
+    std::string value(MIN_BLOB_SPLIT_SIZE + 1, 'a');
+    blob_put(txn.get(), "key", value, 0, 1);
+    EXPECT_EQ(txn->num_put_keys(), 2);
+    versioned::blob_put(txn.get(), "versioned_key", value, 0, 1);
+    EXPECT_EQ(txn->num_put_keys(), 4);
+}
+
+TEST(BlobMessageTest, DecodeBlobKeyFields) {
+    auto encoded_origin_key = meta_delete_bitmap_key({"instance_id", 1, "rowset_id", 2, 3});
+    std::string origin_key;
+    uint8_t version = 0;
+    uint16_t sequence = 0;
+    std::vector<std::tuple<std::variant<int64_t, std::string>, int, int>> fields;
+    ASSERT_TRUE(decode_blob_key(encode_blob_key(encoded_origin_key, 2, 123), &origin_key, &version,
+                                &sequence, &fields));
+    EXPECT_EQ(origin_key, encoded_origin_key);
+    EXPECT_EQ(version, 2);
+    EXPECT_EQ(sequence, 123);
+    ASSERT_EQ(fields.size(), 7);
+    EXPECT_EQ(std::get<std::string>(std::get<0>(fields[0])), "meta");
+    EXPECT_EQ(std::get<std::string>(std::get<0>(fields[1])), "instance_id");
+    EXPECT_EQ(std::get<std::string>(std::get<0>(fields[2])), "delete_bitmap");
+    EXPECT_EQ(std::get<int64_t>(std::get<0>(fields[3])), 1);
+    EXPECT_EQ(std::get<std::string>(std::get<0>(fields[4])), "rowset_id");
+    EXPECT_EQ(std::get<int64_t>(std::get<0>(fields[5])), 2);
+    EXPECT_EQ(std::get<int64_t>(std::get<0>(fields[6])), 3);
+}
+
+TEST(BlobMessageTest, RejectInvalidBlobKey) {
+    std::string origin_key;
+    uint8_t version = 0;
+    uint16_t sequence = 0;
+    EXPECT_FALSE(decode_blob_key("invalid", &origin_key, &version, &sequence));
+
+    std::string invalid_suffix = "origin";
+    invalid_suffix.append(9, '\0');
+    EXPECT_FALSE(decode_blob_key(invalid_suffix, &origin_key, &version, &sequence));
+
+    std::vector<std::tuple<std::variant<int64_t, std::string>, int, int>> fields;
+    EXPECT_FALSE(
+            decode_blob_key(encode_blob_key("", 2, 123), nullptr, &version, &sequence, &fields));
+    EXPECT_FALSE(decode_blob_key(encode_blob_key("invalid", 2, 123), nullptr, &version, &sequence,
+                                 &fields));
 }
 
 // Test blob_put and blob_get with small message (single KV)
@@ -257,6 +355,32 @@ TEST(BlobMessageTest, GetRangeWithTxnKv) {
         ASSERT_FALSE(iter2->valid());
         ASSERT_EQ(iter2->error_code(), TxnErrorCode::TXN_OK);
     }
+}
+
+TEST(BlobMessageTest, BlobIteratorRejectsMalformedChunks) {
+    auto expect_invalid = [](std::string_view origin_key,
+                             const std::vector<std::string>& raw_keys) {
+        auto txn_kv = std::make_shared<MemTxnKv>();
+        ASSERT_EQ(txn_kv->init(), 0);
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+        for (const auto& raw_key : raw_keys) {
+            txn->put(raw_key, "value");
+        }
+        ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+        auto iter = blob_get_range(txn_kv, origin_key, std::string(origin_key) + "\xff");
+        EXPECT_FALSE(iter->valid());
+        EXPECT_EQ(iter->error_code(), TxnErrorCode::TXN_INVALID_DATA);
+    };
+
+    expect_invalid("sequence_gap",
+                   {encode_blob_key("sequence_gap", 0, 0), encode_blob_key("sequence_gap", 0, 2)});
+    expect_invalid("version_mismatch", {encode_blob_key("version_mismatch", 1, 0),
+                                        encode_blob_key("version_mismatch", 2, 1)});
+    std::string invalid_suffix = "invalid_suffix";
+    invalid_suffix.append(9, '\0');
+    expect_invalid("invalid_suffix", {invalid_suffix});
 }
 
 // Test blob_get_range with empty range

--- a/cloud/test/meta_service_test.cpp
+++ b/cloud/test/meta_service_test.cpp
@@ -40,6 +40,7 @@
 #include "cpp/sync_point.h"
 #include "meta-service/meta_service_helper.h"
 #include "meta-store/blob_message.h"
+#include "meta-store/codec.h"
 #include "meta-store/document_message.h"
 #include "meta-store/keys.h"
 #include "meta-store/mem_txn_kv.h"
@@ -6846,6 +6847,93 @@ TEST(MetaServiceTest, UpdateDeleteBitmap) {
     testUpdateDeleteBitmap(1);
 }
 
+TEST(MetaServiceTest, UpdateDeleteBitmapPointDelete) {
+    auto meta_service = get_meta_service();
+    auto txn_kv = std::dynamic_pointer_cast<MemTxnKv>(meta_service->txn_kv());
+    ASSERT_NE(txn_kv, nullptr);
+    extern std::string get_instance_id(const std::shared_ptr<ResourceManager>& rc_mgr,
+                                       const std::string& cloud_unique_id);
+    auto instance_id = get_instance_id(meta_service->resource_mgr(), "test_cloud_unique_id");
+    auto old_max_txn_commit_byte = config::max_txn_commit_byte;
+    auto sp = SyncPoint::get_instance();
+    DORIS_CLOUD_DEFER {
+        config::max_txn_commit_byte = old_max_txn_commit_byte;
+        sp->clear_all_call_backs();
+        sp->disable_processing();
+    };
+    int split_commit_count = 0;
+    sp->set_call_back("update_delete_bitmap:commit:err", [&](auto&&) { split_commit_count++; });
+    sp->enable_processing();
+
+    constexpr int64_t tablet_id = 3330;
+    auto replace_delete_bitmap = [&](const std::string& rowset_id, const std::string& value,
+                                     MetaServiceCode expected_code = MetaServiceCode::OK) {
+        brpc::Controller cntl;
+        UpdateDeleteBitmapRequest req;
+        UpdateDeleteBitmapResponse res;
+        req.set_cloud_unique_id("test_cloud_unique_id");
+        req.set_table_id(1120);
+        req.set_partition_id(1230);
+        req.set_without_lock(true);
+        req.set_enable_remove_agg_pre_rowsets_delete_bitmap_by_keys(true);
+        req.set_lock_id(-3);
+        req.set_initiator(tablet_id);
+        req.set_tablet_id(tablet_id);
+        req.add_rowset_ids(rowset_id);
+        req.add_segment_ids(0);
+        req.add_versions(2);
+        req.add_segment_delete_bitmaps(value);
+        meta_service->update_delete_bitmap(
+                reinterpret_cast<google::protobuf::RpcController*>(&cntl), &req, &res, nullptr);
+        ASSERT_EQ(res.status().code(), expected_code);
+    };
+    auto put_old_delete_bitmap = [&](const std::string& key, size_t blob_count) {
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+        std::string old_value(DEFAULT_BLOB_SPLIT_SIZE * (blob_count - 1) + 1, 'a');
+        blob_put(txn.get(), key, old_value, 0);
+        ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+    };
+    auto check_delete_bitmap = [&](const std::string& key, const std::string& expected) {
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+        ValueBuf value;
+        ASSERT_EQ(blob_get(txn.get(), key, &value), TxnErrorCode::TXN_OK);
+        EXPECT_EQ(value.value(), expected);
+    };
+
+    const std::string point_rowset_id = "point_delete_rowset";
+    auto point_key = meta_delete_bitmap_key({instance_id, tablet_id, point_rowset_id, 2, 0});
+    put_old_delete_bitmap(point_key, 4);
+    auto delete_count = txn_kv->del_count_;
+    replace_delete_bitmap(point_rowset_id, "point_replacement");
+    EXPECT_EQ(txn_kv->del_count_ - delete_count, 4);
+    EXPECT_EQ(split_commit_count, 0);
+    check_delete_bitmap(point_key, "point_replacement");
+
+    const std::string large_rowset_id = "large_point_delete_rowset";
+    auto large_key = meta_delete_bitmap_key({instance_id, tablet_id, large_rowset_id, 2, 0});
+    put_old_delete_bitmap(large_key, 11);
+    config::max_txn_commit_byte = 1500;
+    delete_count = txn_kv->del_count_;
+    replace_delete_bitmap(large_rowset_id, "large_point_replacement");
+    EXPECT_EQ(txn_kv->del_count_ - delete_count, 11);
+    EXPECT_EQ(split_commit_count, 0);
+    check_delete_bitmap(large_key, "large_point_replacement");
+
+    const std::string invalid_rowset_id = "invalid_point_delete_rowset";
+    auto invalid_key = meta_delete_bitmap_key({instance_id, tablet_id, invalid_rowset_id, 2, 0});
+    auto invalid_origin_key = invalid_key;
+    encode_int64(0, &invalid_origin_key);
+    {
+        std::unique_ptr<Transaction> txn;
+        ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
+        txn->put(encode_blob_key(invalid_origin_key, 0, 0), "invalid");
+        ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+    }
+    replace_delete_bitmap(invalid_rowset_id, "replacement", MetaServiceCode::UNDEFINED_ERR);
+}
+
 TEST(MetaServiceTest, UpdateDeleteBitmapWithException) {
     auto meta_service = get_meta_service();
     brpc::Controller cntl;
@@ -6928,9 +7016,25 @@ TEST(MetaServiceTest, UpdateDeleteBitmapWithException) {
     }
 }
 
+static void put_delete_bitmap_test_rowset(MetaServiceProxy* meta_service,
+                                          const std::string& instance_id, int64_t tablet_id,
+                                          int64_t version, const std::string& rowset_id) {
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+    std::string rowset_key = meta_rowset_key({instance_id, tablet_id, version});
+    doris::RowsetMetaCloudPB rowset_meta;
+    rowset_meta.set_rowset_id(0);
+    rowset_meta.set_rowset_id_v2(rowset_id);
+    std::string rowset_value;
+    ASSERT_TRUE(rowset_meta.SerializeToString(&rowset_value));
+    txn->put(rowset_key, rowset_value);
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+}
+
 void update_delete_bitmap_with_remove_pre(MetaServiceProxy* meta_service, int64_t table_id,
                                           int64_t tablet_id, bool inject = false,
-                                          bool rowset_non_exist = false) {
+                                          bool rowset_non_exist = false,
+                                          bool use_delete_bitmap_stats = true) {
     // create rowset, if `rowset_non_exist` enabled, only r4 exists
     {
         std::unique_ptr<Transaction> txn;
@@ -7043,6 +7147,8 @@ void update_delete_bitmap_with_remove_pre(MetaServiceProxy* meta_service, int64_
     update_delete_bitmap_req.set_initiator(tablet_id);
     update_delete_bitmap_req.set_pre_rowset_agg_start_version(4);
     update_delete_bitmap_req.set_pre_rowset_agg_end_version(6);
+    update_delete_bitmap_req.set_enable_remove_pre_rowsets_delete_bitmap_by_keys(
+            use_delete_bitmap_stats);
     std::vector<std::tuple<std::string, int64_t, int64_t, int64_t>>
             new_rowset_segment_version_vector = {/* r2-0 */ {"r2", 0, 6, 2},
                                                  /* r3-0 */ {"r3", 0, 6, 3},
@@ -7057,6 +7163,21 @@ void update_delete_bitmap_with_remove_pre(MetaServiceProxy* meta_service, int64_
         update_delete_bitmap_req.add_versions(version);
         update_delete_bitmap_req.add_segment_delete_bitmaps(new_large_value);
         update_delete_bitmap_req.add_pre_rowset_versions(rowset_version);
+    }
+    if (use_delete_bitmap_stats) {
+        for (const auto& rowset : rowset_vector) {
+            auto* rowset_stats = update_delete_bitmap_req.add_pre_rowset_delete_bitmap_stats();
+            rowset_stats->set_rowset_id(rowset);
+            for (const auto& [delete_bitmap_rowset, segment, version] :
+                 rowset_segment_version_vector) {
+                if (delete_bitmap_rowset == rowset && version >= 4 && version < 6) {
+                    auto* delete_bitmap_stat = rowset_stats->add_delete_bitmap_stats();
+                    delete_bitmap_stat->set_segment_id(segment);
+                    delete_bitmap_stat->set_version(version);
+                    delete_bitmap_stat->set_delete_bitmap_size(large_value.size());
+                }
+            }
+        }
     }
     meta_service->update_delete_bitmap(reinterpret_cast<google::protobuf::RpcController*>(&cntl),
                                        &update_delete_bitmap_req, &update_delete_bitmap_res,
@@ -7128,11 +7249,18 @@ TEST(MetaServiceTest, UpdateDeleteBitmapWithRemovePreDeleteBitmap) {
         SyncPoint::get_instance()->clear_all_call_backs();
     };
 
-    update_delete_bitmap_with_remove_pre(meta_service.get(), 200, 202);
+    update_delete_bitmap_with_remove_pre(meta_service.get(), 200, 202, false, false, false);
 
     int64_t max_txn_commit_byte = config::max_txn_commit_byte;
     config::max_txn_commit_byte = 1000;
+    int remove_pre_rowsets_commit_count = 0;
+    sp->set_call_back("update_delete_bitmap:remove_pre_rowsets:commit",
+                      [&](auto&&) { remove_pre_rowsets_commit_count++; });
+    sp->enable_processing();
     update_delete_bitmap_with_remove_pre(meta_service.get(), 300, 302);
+    EXPECT_GT(remove_pre_rowsets_commit_count, 0);
+    sp->clear_all_call_backs();
+    sp->disable_processing();
 
     sp->set_call_back("update_delete_bitmap:commit:err", [&](auto&& args) {
         auto initiator = try_any_cast<int64_t>(args[0]);
@@ -7149,6 +7277,287 @@ TEST(MetaServiceTest, UpdateDeleteBitmapWithRemovePreDeleteBitmap) {
     config::max_txn_commit_byte = max_txn_commit_byte;
 
     update_delete_bitmap_with_remove_pre(meta_service.get(), 500, 502, false, true);
+}
+
+TEST(MetaServiceTest, EmptyPreRowsetStatsUsesKeyRemoval) {
+    auto meta_service = get_meta_service();
+    extern std::string get_instance_id(const std::shared_ptr<ResourceManager>& rc_mgr,
+                                       const std::string& cloud_unique_id);
+    auto instance_id = get_instance_id(meta_service->resource_mgr(), "test_cloud_unique_id");
+    constexpr int64_t tablet_id = 622;
+    const std::string rowset_id = "empty_pre_rowset_stats";
+    put_delete_bitmap_test_rowset(meta_service.get(), instance_id, tablet_id, 1, rowset_id);
+
+    auto old_delete_bitmap_key = meta_delete_bitmap_key({instance_id, tablet_id, rowset_id, 1, 0});
+    const std::string old_delete_bitmap = "old_delete_bitmap";
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+    blob_put(txn.get(), old_delete_bitmap_key, old_delete_bitmap, 0);
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+    brpc::Controller cntl;
+    UpdateDeleteBitmapRequest req;
+    UpdateDeleteBitmapResponse res;
+    req.set_cloud_unique_id("test_cloud_unique_id");
+    req.set_table_id(620);
+    req.set_partition_id(621);
+    req.set_tablet_id(tablet_id);
+    req.set_lock_id(-3);
+    req.set_without_lock(true);
+    req.set_initiator(tablet_id);
+    req.set_pre_rowset_agg_start_version(1);
+    req.set_pre_rowset_agg_end_version(2);
+    req.add_rowset_ids(rowset_id);
+    req.add_segment_ids(0);
+    req.add_versions(2);
+    req.add_segment_delete_bitmaps("aggregated_delete_bitmap");
+    req.add_pre_rowset_versions(1);
+    req.set_enable_remove_pre_rowsets_delete_bitmap_by_keys(true);
+    meta_service->update_delete_bitmap(reinterpret_cast<google::protobuf::RpcController*>(&cntl),
+                                       &req, &res, nullptr);
+
+    ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+    ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+    ValueBuf val;
+    ASSERT_EQ(blob_get(txn.get(), old_delete_bitmap_key, &val), TxnErrorCode::TXN_OK);
+    EXPECT_EQ(val.value(), old_delete_bitmap);
+}
+
+TEST(MetaServiceTest, UnderestimatedPreRowsetDeleteBitmapSizeLeavesSkippedTail) {
+    auto meta_service = get_meta_service();
+    extern std::string get_instance_id(const std::shared_ptr<ResourceManager>& rc_mgr,
+                                       const std::string& cloud_unique_id);
+    auto instance_id = get_instance_id(meta_service->resource_mgr(), "test_cloud_unique_id");
+    constexpr int64_t tablet_id = 632;
+    const std::string rowset_id = "underestimated_delete_bitmap";
+    put_delete_bitmap_test_rowset(meta_service.get(), instance_id, tablet_id, 1, rowset_id);
+
+    auto old_delete_bitmap_key = meta_delete_bitmap_key({instance_id, tablet_id, rowset_id, 1, 0});
+    const std::string old_delete_bitmap(DEFAULT_BLOB_SPLIT_SIZE * 3 + 1, 'a');
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+    blob_put(txn.get(), old_delete_bitmap_key, old_delete_bitmap, 0);
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+    const std::string aggregated_delete_bitmap = "aggregated_delete_bitmap";
+    brpc::Controller update_cntl;
+    UpdateDeleteBitmapRequest update_req;
+    UpdateDeleteBitmapResponse update_res;
+    update_req.set_cloud_unique_id("test_cloud_unique_id");
+    update_req.set_table_id(630);
+    update_req.set_partition_id(631);
+    update_req.set_tablet_id(tablet_id);
+    update_req.set_lock_id(-3);
+    update_req.set_without_lock(true);
+    update_req.set_initiator(tablet_id);
+    update_req.set_pre_rowset_agg_start_version(1);
+    update_req.set_pre_rowset_agg_end_version(2);
+    update_req.add_rowset_ids(rowset_id);
+    update_req.add_segment_ids(0);
+    update_req.add_versions(2);
+    update_req.add_segment_delete_bitmaps(aggregated_delete_bitmap);
+    update_req.add_pre_rowset_versions(1);
+    update_req.set_enable_remove_pre_rowsets_delete_bitmap_by_keys(true);
+    auto* rowset_stats = update_req.add_pre_rowset_delete_bitmap_stats();
+    rowset_stats->set_rowset_id(rowset_id);
+    auto* delete_bitmap_stat = rowset_stats->add_delete_bitmap_stats();
+    delete_bitmap_stat->set_segment_id(0);
+    delete_bitmap_stat->set_version(1);
+    delete_bitmap_stat->set_delete_bitmap_size(DEFAULT_BLOB_SPLIT_SIZE);
+    meta_service->update_delete_bitmap(
+            reinterpret_cast<google::protobuf::RpcController*>(&update_cntl), &update_req,
+            &update_res, nullptr);
+    ASSERT_EQ(update_res.status().code(), MetaServiceCode::OK);
+
+    ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+    std::string value;
+    EXPECT_EQ(txn->get(encode_blob_key(old_delete_bitmap_key, 0, 0), &value),
+              TxnErrorCode::TXN_KEY_NOT_FOUND);
+    EXPECT_EQ(txn->get(encode_blob_key(old_delete_bitmap_key, 0, 1), &value), TxnErrorCode::TXN_OK);
+
+    brpc::Controller get_cntl;
+    GetDeleteBitmapRequest get_req;
+    GetDeleteBitmapResponse get_res;
+    get_req.set_cloud_unique_id("test_cloud_unique_id");
+    get_req.set_tablet_id(tablet_id);
+    get_req.add_rowset_ids(rowset_id);
+    get_req.add_begin_versions(0);
+    get_req.add_end_versions(3);
+    meta_service->get_delete_bitmap(reinterpret_cast<google::protobuf::RpcController*>(&get_cntl),
+                                    &get_req, &get_res, nullptr);
+
+    ASSERT_EQ(get_res.status().code(), MetaServiceCode::OK);
+    ASSERT_EQ(get_res.rowset_ids_size(), 1);
+    ASSERT_EQ(get_res.segment_ids_size(), 1);
+    ASSERT_EQ(get_res.versions_size(), 1);
+    ASSERT_EQ(get_res.segment_delete_bitmaps_size(), 1);
+    EXPECT_EQ(get_res.rowset_ids(0), rowset_id);
+    EXPECT_EQ(get_res.segment_ids(0), 0);
+    EXPECT_EQ(get_res.versions(0), 2);
+    EXPECT_EQ(get_res.segment_delete_bitmaps(0), aggregated_delete_bitmap);
+}
+
+static void test_get_delete_bitmap_during_point_cleanup(size_t delete_bitmap_size) {
+    auto meta_service = get_meta_service();
+    auto sp = SyncPoint::get_instance();
+    DORIS_CLOUD_DEFER {
+        sp->clear_all_call_backs();
+        sp->disable_processing();
+    };
+
+    extern std::string get_instance_id(const std::shared_ptr<ResourceManager>& rc_mgr,
+                                       const std::string& cloud_unique_id);
+    auto instance_id = get_instance_id(meta_service->resource_mgr(), "test_cloud_unique_id");
+    constexpr int64_t table_id = 640;
+    constexpr int64_t partition_id = 641;
+    constexpr int64_t tablet_id = 642;
+    const std::string rowset_id = "point_cleanup_during_paginated_read";
+    put_delete_bitmap_test_rowset(meta_service.get(), instance_id, tablet_id, 1, rowset_id);
+
+    auto old_delete_bitmap_key = meta_delete_bitmap_key({instance_id, tablet_id, rowset_id, 1, 0});
+    std::string old_delete_bitmap(DEFAULT_BLOB_SPLIT_SIZE, 'a');
+    old_delete_bitmap.append(DEFAULT_BLOB_SPLIT_SIZE, 'b');
+    old_delete_bitmap.append(DEFAULT_BLOB_SPLIT_SIZE, 'c');
+    old_delete_bitmap.push_back('d');
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+    blob_put(txn.get(), old_delete_bitmap_key, old_delete_bitmap, 0);
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+    const std::string aggregated_delete_bitmap = "aggregated_delete_bitmap";
+    UpdateDeleteBitmapRequest update_req;
+    update_req.set_cloud_unique_id("test_cloud_unique_id");
+    update_req.set_table_id(table_id);
+    update_req.set_partition_id(partition_id);
+    update_req.set_tablet_id(tablet_id);
+    update_req.set_lock_id(-3);
+    update_req.set_without_lock(true);
+    update_req.set_initiator(tablet_id);
+    update_req.set_pre_rowset_agg_start_version(1);
+    update_req.set_pre_rowset_agg_end_version(2);
+    update_req.add_rowset_ids(rowset_id);
+    update_req.add_segment_ids(0);
+    update_req.add_versions(2);
+    update_req.add_segment_delete_bitmaps(aggregated_delete_bitmap);
+    update_req.add_pre_rowset_versions(1);
+    update_req.set_enable_remove_pre_rowsets_delete_bitmap_by_keys(true);
+    auto* rowset_stats = update_req.add_pre_rowset_delete_bitmap_stats();
+    rowset_stats->set_rowset_id(rowset_id);
+    auto* delete_bitmap_stat = rowset_stats->add_delete_bitmap_stats();
+    delete_bitmap_stat->set_segment_id(0);
+    delete_bitmap_stat->set_version(1);
+    delete_bitmap_stat->set_delete_bitmap_size(delete_bitmap_size);
+
+    bool cleanup_done = false;
+    sp->set_call_back("get_delete_bitmap_test",
+                      [&](auto&& args) { *try_any_cast<bool*>(args[0]) = true; });
+    sp->set_call_back("get_delete_bitmap_err", [&](auto&& args) {
+        auto round = *try_any_cast<int64_t*>(args[0]);
+        if (round != 1 || cleanup_done) {
+            return;
+        }
+        cleanup_done = true;
+        brpc::Controller update_cntl;
+        UpdateDeleteBitmapResponse update_res;
+        meta_service->update_delete_bitmap(
+                reinterpret_cast<google::protobuf::RpcController*>(&update_cntl), &update_req,
+                &update_res, nullptr);
+        ASSERT_EQ(update_res.status().code(), MetaServiceCode::OK);
+        *try_any_cast<TxnErrorCode*>(args[1]) = TxnErrorCode::TXN_TOO_OLD;
+    });
+    sp->enable_processing();
+
+    brpc::Controller get_cntl;
+    GetDeleteBitmapRequest get_req;
+    GetDeleteBitmapResponse get_res;
+    get_req.set_cloud_unique_id("test_cloud_unique_id");
+    get_req.set_tablet_id(tablet_id);
+    get_req.add_rowset_ids(rowset_id);
+    get_req.add_begin_versions(0);
+    get_req.add_end_versions(3);
+    meta_service->get_delete_bitmap(reinterpret_cast<google::protobuf::RpcController*>(&get_cntl),
+                                    &get_req, &get_res, nullptr);
+
+    ASSERT_TRUE(cleanup_done);
+    ASSERT_EQ(get_res.status().code(), MetaServiceCode::OK);
+    ASSERT_EQ(get_res.rowset_ids_size(), 1);
+    ASSERT_EQ(get_res.segment_ids_size(), 1);
+    ASSERT_EQ(get_res.versions_size(), 1);
+    ASSERT_EQ(get_res.segment_delete_bitmaps_size(), 1);
+    EXPECT_EQ(get_res.rowset_ids(0), rowset_id);
+    EXPECT_EQ(get_res.segment_ids(0), 0);
+    EXPECT_EQ(get_res.versions(0), 2);
+    EXPECT_EQ(get_res.segment_delete_bitmaps(0), aggregated_delete_bitmap);
+}
+
+TEST(MetaServiceTest, GetDeleteBitmapSkipsPointCleanupTailAfterTxnTooOld) {
+    test_get_delete_bitmap_during_point_cleanup(DEFAULT_BLOB_SPLIT_SIZE * 3);
+}
+
+TEST(MetaServiceTest, GetDeleteBitmapDropsPartialValueAfterAllBlobKeysAreRemoved) {
+    test_get_delete_bitmap_during_point_cleanup(DEFAULT_BLOB_SPLIT_SIZE * 3 + 1);
+}
+
+TEST(MetaServiceTest, RemovePreDeleteBitmapBatchesEachBlobKey) {
+    auto meta_service = get_meta_service();
+    auto sp = SyncPoint::get_instance();
+    int64_t old_max_txn_commit_byte = config::max_txn_commit_byte;
+    DORIS_CLOUD_DEFER {
+        config::max_txn_commit_byte = old_max_txn_commit_byte;
+        sp->clear_all_call_backs();
+        sp->disable_processing();
+    };
+
+    constexpr size_t max_txn_commit_byte = 300;
+    config::max_txn_commit_byte = max_txn_commit_byte;
+    std::vector<size_t> committed_txn_sizes;
+    sp->set_call_back("update_delete_bitmap:remove_pre_rowsets:commit", [&](auto&& args) {
+        committed_txn_sizes.push_back(try_any_cast<size_t>(args[0]));
+    });
+    sp->enable_processing();
+
+    extern std::string get_instance_id(const std::shared_ptr<ResourceManager>& rc_mgr,
+                                       const std::string& cloud_unique_id);
+    auto instance_id = get_instance_id(meta_service->resource_mgr(), "test_cloud_unique_id");
+    constexpr int64_t tablet_id = 612;
+    const std::string rowset_id = "batch_blob_keys_rowset";
+    const std::string value(DEFAULT_BLOB_SPLIT_SIZE * 20, 'a');
+    auto delete_bitmap_key = meta_delete_bitmap_key({instance_id, tablet_id, rowset_id, 1, 0});
+    std::unique_ptr<Transaction> txn;
+    ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+    blob_put(txn.get(), delete_bitmap_key, value, 0);
+    ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
+
+    brpc::Controller cntl;
+    UpdateDeleteBitmapRequest req;
+    UpdateDeleteBitmapResponse res;
+    req.set_cloud_unique_id("test_cloud_unique_id");
+    req.set_table_id(610);
+    req.set_partition_id(611);
+    req.set_tablet_id(tablet_id);
+    req.set_lock_id(-3);
+    req.set_without_lock(true);
+    req.set_initiator(tablet_id);
+    req.set_pre_rowset_agg_start_version(1);
+    req.set_pre_rowset_agg_end_version(2);
+    req.set_enable_remove_pre_rowsets_delete_bitmap_by_keys(true);
+    auto* rowset_stats = req.add_pre_rowset_delete_bitmap_stats();
+    rowset_stats->set_rowset_id(rowset_id);
+    auto* delete_bitmap_stat = rowset_stats->add_delete_bitmap_stats();
+    delete_bitmap_stat->set_segment_id(0);
+    delete_bitmap_stat->set_version(1);
+    delete_bitmap_stat->set_delete_bitmap_size(value.size());
+    meta_service->update_delete_bitmap(reinterpret_cast<google::protobuf::RpcController*>(&cntl),
+                                       &req, &res, nullptr);
+
+    ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
+    ASSERT_FALSE(committed_txn_sizes.empty());
+    for (auto txn_size : committed_txn_sizes) {
+        EXPECT_LE(txn_size, max_txn_commit_byte);
+    }
+    ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+    ValueBuf val;
+    EXPECT_EQ(blob_get(txn.get(), delete_bitmap_key, &val), TxnErrorCode::TXN_KEY_NOT_FOUND);
 }
 
 TEST(MetaServiceTest, GetDeleteBitmapWithIdx) {

--- a/cloud/test/recycler_test.cpp
+++ b/cloud/test/recycler_test.cpp
@@ -820,8 +820,8 @@ static void create_delete_bitmaps(Transaction* txn, int64_t tablet_id, std::stri
                 std::string val {"test_data"};
                 txn->put(key, val);
             } else {
-                std::string val(1000, 'A');
-                cloud::blob_put(txn, key, val, 0, 300);
+                std::string val(MIN_BLOB_SPLIT_SIZE + 1, 'A');
+                cloud::blob_put(txn, key, val, 0, MIN_BLOB_SPLIT_SIZE);
             }
         }
     }
@@ -5017,8 +5017,9 @@ TEST(CheckerTest, delete_bitmap_inverted_check_normal) {
                 // delete bitmaps may be spilitted into mulitiple KVs if too large
                 auto delete_bitmap_key =
                         meta_delete_bitmap_key({instance_id, tablet_id, rowset_id, ver, 0});
-                std::string delete_bitmap_val(1000, 'A');
-                cloud::blob_put(txn.get(), delete_bitmap_key, delete_bitmap_val, 0, 300);
+                std::string delete_bitmap_val(MIN_BLOB_SPLIT_SIZE + 1, 'A');
+                cloud::blob_put(txn.get(), delete_bitmap_key, delete_bitmap_val, 0,
+                                MIN_BLOB_SPLIT_SIZE);
             }
         }
         if (is_last_tablet) {
@@ -5250,8 +5251,9 @@ TEST(CheckerTest, delete_bitmap_inverted_check_abnormal) {
                 // delete bitmaps may be spilitted into mulitiple KVs if too large
                 auto delete_bitmap_key =
                         meta_delete_bitmap_key({instance_id, tablet_id, rowset_id, ver, 0});
-                std::string delete_bitmap_val(1000, 'A');
-                cloud::blob_put(txn.get(), delete_bitmap_key, delete_bitmap_val, 0, 300);
+                std::string delete_bitmap_val(MIN_BLOB_SPLIT_SIZE + 1, 'A');
+                cloud::blob_put(txn.get(), delete_bitmap_key, delete_bitmap_val, 0,
+                                MIN_BLOB_SPLIT_SIZE);
             }
         }
     }

--- a/cloud/test/schema_kv_test.cpp
+++ b/cloud/test/schema_kv_test.cpp
@@ -963,9 +963,16 @@ TEST(AlterSchemaKVTest, BlobRemoveBeforeOverwriteTest) {
 
     // Compute the schema KV key.
     auto schema_key = meta_schema_key({instance_id, index_id, schema_version});
+    auto put_three_blob_chunks = [&](Transaction* txn, std::string_view value) {
+        const size_t split_size = value.size() / 3 + 1;
+        for (size_t offset = 0, sequence = 0; offset < value.size();
+             offset += split_size, ++sequence) {
+            txn->put(encode_blob_key(schema_key, config::meta_schema_value_version, sequence),
+                     value.substr(offset, split_size));
+        }
+    };
 
-    // Overwrite the schema KV with a small split_size to create 3 blob chunks.
-    // The normal schema (~120 bytes) with split_size=50 yields 3 chunks.
+    // Overwrite the schema KV with 3 blob chunks.
     {
         std::unique_ptr<Transaction> txn;
         ASSERT_EQ(meta_service->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
@@ -973,13 +980,10 @@ TEST(AlterSchemaKVTest, BlobRemoveBeforeOverwriteTest) {
         ValueBuf old_val;
         ASSERT_EQ(cloud::blob_get(txn.get(), schema_key, &old_val), TxnErrorCode::TXN_OK);
         old_val.remove(txn.get());
-        // Write with small split_size to create 3 chunks
         doris::TabletSchemaCloudPB schema;
         ASSERT_TRUE(old_val.to_pb(&schema));
         std::string serialized = schema.SerializeAsString();
-        size_t split_size = (serialized.size() / 3) + 1; // ensures exactly 3 chunks
-        cloud::blob_put(txn.get(), schema_key, schema, config::meta_schema_value_version,
-                        split_size);
+        put_three_blob_chunks(txn.get(), serialized);
         ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
     }
 
@@ -1020,9 +1024,7 @@ TEST(AlterSchemaKVTest, BlobRemoveBeforeOverwriteTest) {
         ASSERT_TRUE(old_val.to_pb(&schema));
         schema.set_disable_auto_compaction(false);
         std::string serialized = schema.SerializeAsString();
-        size_t split_size = (serialized.size() / 3) + 1;
-        cloud::blob_put(txn.get(), schema_key, schema, config::meta_schema_value_version,
-                        split_size);
+        put_three_blob_chunks(txn.get(), serialized);
         ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
     }
     {

--- a/cloud/test/txn_kv_test.cpp
+++ b/cloud/test/txn_kv_test.cpp
@@ -417,7 +417,7 @@ TEST(TxnKvTest, PutLargeValueTest) {
     auto key = meta_schema_key({instance_id, 10005, 1});
     std::unique_ptr<Transaction> txn;
     ASSERT_EQ(txn_kv->create_txn(&txn), TxnErrorCode::TXN_OK);
-    doris::cloud::blob_put(txn.get(), key, schema, 1, 100);
+    doris::cloud::blob_put(txn.get(), key, schema, 1, doris::cloud::MIN_BLOB_SPLIT_SIZE);
     ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
 
     // Check get
@@ -439,7 +439,7 @@ TEST(TxnKvTest, PutLargeValueTest) {
     // Check multi range get
     sp->set_call_back("memkv::Transaction::get", [](auto&& args) {
         auto* limit = doris::try_any_cast<int*>(args[0]);
-        *limit = 100;
+        *limit = 1;
     });
     err = doris::cloud::blob_get(txn.get(), key, &val_buf);
     ASSERT_EQ(err, TxnErrorCode::TXN_OK);

--- a/gensrc/proto/cloud.proto
+++ b/gensrc/proto/cloud.proto
@@ -2004,6 +2004,17 @@ message DeleteBitmapStoragePB {
     optional PackedSliceLocationPB packed_slice_location = 3;
 }
 
+message PreRowsetDeleteBitmapStatsPB {
+    message DeleteBitmapStatPB {
+        optional uint32 segment_id = 1;
+        optional int64 version = 2;
+        optional uint64 delete_bitmap_size = 3;
+    }
+
+    optional string rowset_id = 1;
+    repeated DeleteBitmapStatPB delete_bitmap_stats = 2;
+}
+
 message UpdateDeleteBitmapRequest {
     optional string cloud_unique_id = 1; // For auth
     optional int64 table_id = 2;
@@ -2029,6 +2040,14 @@ message UpdateDeleteBitmapRequest {
     optional int64 pre_rowset_agg_end_version = 17;
     // when update delete_bitmap of pre rowsets, check the rowset exists
     repeated int64 pre_rowset_versions = 18;
+    // remove pre-rowset delete bitmaps in [end_version, end_version] before writing aggregated
+    // delete bitmaps; true: point delete; false or unset: range delete
+    optional bool enable_remove_agg_pre_rowsets_delete_bitmap_by_keys = 19;
+    // remove pre-rowset delete bitmaps in [start_version, end_version):
+    // true: point delete; false or unset: range delete
+    optional bool enable_remove_pre_rowsets_delete_bitmap_by_keys = 20;
+    // stats of pre-rowset delete bitmaps in [start_version, end_version) used for point delete
+    repeated PreRowsetDeleteBitmapStatsPB pre_rowset_delete_bitmap_stats = 21;
     // 50-51: used for storage v2
     repeated string delta_rowset_ids = 50;
     repeated DeleteBitmapStoragePB delete_bitmap_storages = 51;


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #66598

This PR is based on #66598. Compaction input rowset recycling still issues a delete-bitmap range clear, which can add FoundationDB clear-range pressure.

### What is changed?

- Temporarily disable the delete-bitmap range removal when recycling compaction input rowsets.
- Log the skipped half-open range with both boundaries encoded by hex(), together with tablet and rowset context.

### Test

- sh run-cloud-ut.sh --run --fdb fdb_cluster0:cluster0@10.26.20.4:4500 --filter meta_service_test:MetaServiceJobTest.CompactionJobTest
- Result: 1 test passed.