### PR TITLE
[feature](be) Add incremental coverage HTTP APIs

### DIFF
--- a/be/src/service/CMakeLists.txt
+++ b/be/src/service/CMakeLists.txt
@@ -34,6 +34,10 @@ endif()
 
 add_library(Service STATIC ${SRC_FILES})
 
+if (ENABLE_CLANG_COVERAGE AND ENABLE_CLANG_COVERAGE STREQUAL ON AND COMPILER_CLANG)
+    target_compile_definitions(Service PRIVATE LLVM_PROFILE)
+endif ()
+
 pch_reuse(Service)
 
 # Unity build scoped to the http glue: ~60 small handlers re-parsing the same
@@ -60,7 +64,7 @@ if (${MAKE_TEST} STREQUAL "OFF" AND ${BUILD_BENCHMARK} STREQUAL "OFF")
     )
 
     if (ENABLE_CLANG_COVERAGE AND ENABLE_CLANG_COVERAGE STREQUAL ON AND COMPILER_CLANG)
-        target_compile_definitions(doris_be PRIVATE -DLLVM_PROFILE)
+        target_compile_definitions(doris_be PRIVATE LLVM_PROFILE)
     endif ()
     pch_reuse(doris_be)
 

--- a/be/src/service/http/action/coverage_action.cpp
+++ b/be/src/service/http/action/coverage_action.cpp
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "service/http/action/coverage_action.h"
+
+#ifdef LLVM_PROFILE
+
+#include "common/status.h"
+#include "service/http/action/action_constants.h"
+#include "service/http/http_channel.h"
+#include "service/http/http_headers.h"
+#include "service/http/http_request.h"
+#include "service/http/http_status.h"
+
+extern "C" {
+void __llvm_profile_reset_counters();
+int __llvm_profile_write_file();
+}
+
+namespace doris {
+namespace {
+
+void send_status(HttpRequest* req, HttpStatus http_status, const Status& status) {
+    req->add_output_header(HttpHeaders::CONTENT_TYPE, HEADER_JSON.c_str());
+    HttpChannel::send_reply(req, http_status, status.to_json());
+}
+
+} // namespace
+
+void CoverageResetAction::handle(HttpRequest* req) {
+    __llvm_profile_reset_counters();
+    send_status(req, HttpStatus::OK, Status::OK());
+}
+
+void CoverageDumpAction::handle(HttpRequest* req) {
+    int result = __llvm_profile_write_file();
+    if (result != 0) {
+        auto status = Status::InternalError("Failed to write LLVM profile, error code: {}", result);
+        LOG(ERROR) << status;
+        send_status(req, HttpStatus::INTERNAL_SERVER_ERROR, status);
+        return;
+    }
+    send_status(req, HttpStatus::OK, Status::OK());
+}
+
+} // namespace doris
+
+#endif

--- a/be/src/service/http/action/coverage_action.h
+++ b/be/src/service/http/action/coverage_action.h
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#ifdef LLVM_PROFILE
+
+#include "service/http/http_handler_with_auth.h"
+
+namespace doris {
+
+class ExecEnv;
+class HttpRequest;
+
+class CoverageResetAction final : public HttpHandlerWithAuth {
+public:
+    explicit CoverageResetAction(ExecEnv* exec_env)
+            : HttpHandlerWithAuth(exec_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN) {}
+
+    void handle(HttpRequest* req) override;
+};
+
+class CoverageDumpAction final : public HttpHandlerWithAuth {
+public:
+    explicit CoverageDumpAction(ExecEnv* exec_env)
+            : HttpHandlerWithAuth(exec_env, TPrivilegeHier::GLOBAL, TPrivilegeType::ADMIN) {}
+
+    void handle(HttpRequest* req) override;
+};
+
+} // namespace doris
+
+#endif

--- a/be/src/service/http_service.cpp
+++ b/be/src/service/http_service.cpp
@@ -46,6 +46,9 @@
 #include "service/http/action/compaction_profile_action.h"
 #include "service/http/action/compaction_score_action.h"
 #include "service/http/action/config_action.h"
+#ifdef LLVM_PROFILE
+#include "service/http/action/coverage_action.h"
+#endif
 #include "service/http/action/debug_point_action.h"
 #include "service/http/action/delete_bitmap_action.h"
 #include "service/http/action/dictionary_status_action.h"
@@ -285,6 +288,15 @@ Status HttpService::start() {
     // shrink memory for starting co-exist process during upgrade
     ShrinkMemAction* shrink_mem_action = _pool.add(new ShrinkMemAction(_env));
     _ev_http_server->register_handler(HttpMethod::GET, "/api/shrink_mem", shrink_mem_action);
+
+#ifdef LLVM_PROFILE
+    auto* coverage_reset_action = _pool.add(new CoverageResetAction(_env));
+    _ev_http_server->register_handler(HttpMethod::POST, "/api/coverage/reset",
+                                      coverage_reset_action);
+
+    auto* coverage_dump_action = _pool.add(new CoverageDumpAction(_env));
+    _ev_http_server->register_handler(HttpMethod::POST, "/api/coverage/dump", coverage_dump_action);
+#endif
 
 #ifndef BE_TEST
     auto& engine = _env->storage_engine();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Coverage-enabled BE processes only flushed LLVM profiles during graceful shutdown, so test harnesses could not isolate and export coverage without restarting the process. Add Clang-coverage-only ADMIN endpoints to reset counters and synchronously dump the configured LLVM_PROFILE_FILE while keeping GCC and normal builds free of LLVM runtime references.

### Release note

Add test-only POST /api/coverage/reset and /api/coverage/dump endpoints to Clang coverage BE builds.

### Check List (For Author)

- Test: Manual test
    - build-support/check-build-hygiene.sh
    - Clang coverage action syntax check with LLVM_PROFILE enabled
    - GCC coverage action syntax check with LLVM_PROFILE disabled
- Behavior changed: Yes, Clang coverage BE builds expose two ADMIN coverage-control endpoints
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

