### PR TITLE
[feature](coordinator) Add backend selection extension framework (#65173)

### DIFF
--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -153,6 +153,17 @@ public class Config extends ConfigBase {
             description = {"是否检查 table 锁泄漏", "Whether to check table lock leaky"})
     public static boolean check_table_lock_leaky = false;
 
+    @ConfField(mutable = false, description = "The Resource Group that the current FE node belongs to. It can be "
+            + "overridden by the `--local_resource_group` command line option or the "
+            + "`DORIS_LOCAL_RESOURCE_GROUP` environment variable. An empty string means unset.")
+    public static String local_resource_group = "";
+
+    @ConfField(mutable = false,
+            description = "Whether to enable replica filtering based on location resource tags. If disabled, "
+                    + "invalid compute groups are still rejected, but replicas are no longer filtered by the "
+                    + "user's location resource tag.")
+    public static boolean enable_resource_tag_location_check = true;
+
     @ConfField(mutable = true, masterOnly = false,
             description = {"PreparedStatement stmtId 起始位置，仅用于测试",
                     "PreparedStatement stmtId starting position, used for testing onl"})
@@ -1092,6 +1103,11 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true, masterOnly = true)
     public static long tablet_schedule_high_priority_second = 30 * 60;
+
+    @ConfField(mutable = true, masterOnly = true,
+            description = "Whether optional backend selection policies may participate in repair clone source "
+                    + "selection. The default policy is a no-op and does not change repair behavior.")
+    public static boolean enable_repair_source_backend_selection = true;
 
     /**
      * publish version queue's size in be, report it to fe,

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/EnvFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/EnvFactory.java
@@ -179,7 +179,7 @@ public class EnvFactory {
                 statementContext = new StatementContext(connectContext, new OriginStatement("", 0));
             }
             DistributePlanner distributePlanner = new DistributePlanner(
-                    statementContext, fragments, false, true);
+                    statementContext, fragments, false, true, true);
             FragmentIdMapping<DistributedPlan> distributedPlans = distributePlanner.plan();
 
             return new NereidsCoordinator(

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -292,6 +292,11 @@ public class Tablet extends MetaObject {
     // for query
     public List<Replica> getQueryableReplicas(long visibleVersion, Map<Long, Set<Long>> backendAlivePathHashs,
             boolean allowMissingVersion) {
+        return getQueryableReplicas(visibleVersion, backendAlivePathHashs, allowMissingVersion, true);
+    }
+
+    public List<Replica> getQueryableReplicas(long visibleVersion, Map<Long, Set<Long>> backendAlivePathHashs,
+            boolean allowMissingVersion, boolean skipCompactionSlowerReplica) {
         int replicaNum = replicas.size();
         List<Replica> allQueryableReplica = Lists.newArrayListWithCapacity(replicaNum);
         List<Replica> auxiliaryReplica = Lists.newArrayListWithCapacity(replicaNum);
@@ -354,7 +359,8 @@ public class Tablet extends MetaObject {
             allQueryableReplica = userDropReplica;
         }
 
-        if (Config.skip_compaction_slower_replica && allQueryableReplica.size() > 1) {
+        if (skipCompactionSlowerReplica
+                && Config.skip_compaction_slower_replica && allQueryableReplica.size() > 1) {
             long minVersionCount = Long.MAX_VALUE;
             for (Replica replica : allQueryableReplica) {
                 long visibleVersionCount = replica.getVisibleVersionCount();

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedCtx.java
@@ -35,10 +35,13 @@ import org.apache.doris.clone.TabletScheduler.PathSlot;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.persist.ReplicaPersistInfo;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.resource.Tag;
+import org.apache.doris.resource.spi.BackendSelectionProvider;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.task.AgentTaskQueue;
@@ -57,6 +60,7 @@ import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -189,6 +193,9 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
     private ReplicaAllocation replicaAlloc;
     // tag is only set for BALANCE task, used to identify which workload group this Balance job is in
     private Tag tag;
+
+    private BackendSelectionProvider.RepairSourceSelectionResult repairSourceSelectionResult =
+            BackendSelectionProvider.RepairSourceSelectionResult.DISABLED;
 
     private SubCode schedFailedCode;
 
@@ -438,6 +445,10 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         return copyTimeMs;
     }
 
+    public BackendSelectionProvider.RepairSourceSelectionResult getRepairSourceSelectionResult() {
+        return repairSourceSelectionResult;
+    }
+
     public long getSrcBackendId() {
         if (srcReplica != null) {
             return srcReplica.getBackendIdWithoutException();
@@ -645,7 +656,12 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         // choose a replica which slot is available from candidates.
         // sort replica by version count asc and isUserDrop, so that we prefer to choose replicas with fewer versions
         Collections.sort(candidates, CLONE_SRC_COMPARATOR);
-        for (Replica srcReplica : candidates) {
+
+        boolean selectionEnabled = isRepairSourceSelectionEnabled(destBackendId);
+        List<Replica> orderedCandidates = selectionEnabled
+                ? orderRepairSourceCandidates(candidates, destBackendId)
+                : candidates;
+        for (Replica srcReplica : orderedCandidates) {
             long replicaBeId = srcReplica.getBackendIdWithoutException();
             PathSlot slot = backendsWorkingSlots.get(replicaBeId);
             if (slot == null) {
@@ -665,10 +681,30 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                 continue;
             }
             setSrc(srcReplica);
+            repairSourceSelectionResult = selectionEnabled
+                    ? BackendSelectionManager.classifyRepairSource(replicaBeId, destBackendId,
+                            tablet.getReplicas(), candidates)
+                    : BackendSelectionProvider.RepairSourceSelectionResult.DISABLED;
             return;
         }
         throw new SchedException(Status.SCHEDULE_FAILED, SubCode.WAITING_SLOT,
                 "waiting for source replica's slot");
+    }
+
+    static List<Replica> orderRepairSourceCandidates(List<Replica> candidates, long destBackendId)
+            throws SchedException {
+        try {
+            return new ArrayList<>(BackendSelectionManager.orderRepairSourceCandidates(
+                    candidates, destBackendId));
+        } catch (UserException e) {
+            throw new SchedException(Status.UNRECOVERABLE, e.getMessage());
+        }
+    }
+
+    static boolean isRepairSourceSelectionEnabled(long destBackendId) {
+        return Config.enable_repair_source_backend_selection
+                && BackendSelectionManager.isRepairSourceSelectionEnabled()
+                && destBackendId != -1;
     }
 
     /*

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -47,8 +47,10 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.MasterDaemon;
+import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.persist.ReplicaPersistInfo;
 import org.apache.doris.resource.Tag;
+import org.apache.doris.resource.spi.BackendSelectionProvider.RepairSourceSelectionResult;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.task.AgentBatchTask;
@@ -1916,6 +1918,8 @@ public class TabletScheduler extends MasterDaemon {
      * This should only be called when the tablet is down with state FINISHED.
      */
     private void gatherStatistics(TabletSchedCtx tabletCtx) {
+        gatherCloneAzBytes(tabletCtx);
+
         if (tabletCtx.getCopySize() > 0 && tabletCtx.getCopyTimeMs() > 0) {
             if (tabletCtx.getSrcBackendId() != -1 && tabletCtx.getSrcPathHash() != -1) {
                 PathSlot pathSlot = backendsWorkingSlots.get(tabletCtx.getSrcBackendId());
@@ -1942,6 +1946,39 @@ public class TabletScheduler extends MasterDaemon {
         // need to find a better way to determine the slot number.
 
         lastSlotAdjustTime = System.currentTimeMillis();
+    }
+
+    private void gatherCloneAzBytes(TabletSchedCtx tabletCtx) {
+        long bytes = tabletCtx.getCopySize();
+        if (bytes <= 0) {
+            return;
+        }
+        Backend src = infoService.getBackend(tabletCtx.getSrcBackendId());
+        Backend dest = infoService.getBackend(tabletCtx.getDestBackendId());
+        if (src == null || dest == null) {
+            return;
+        }
+        if (src.getLocationTag().equals(dest.getLocationTag())) {
+            if (MetricRepo.COUNTER_CLONE_BYTES_LOCAL_AZ != null) {
+                MetricRepo.COUNTER_CLONE_BYTES_LOCAL_AZ.increase(bytes);
+            }
+            return;
+        }
+
+        if (MetricRepo.COUNTER_CLONE_BYTES_CROSS_AZ != null) {
+            MetricRepo.COUNTER_CLONE_BYTES_CROSS_AZ.increase(bytes);
+        }
+        RepairSourceSelectionResult result = tabletCtx.getRepairSourceSelectionResult();
+        if (result == RepairSourceSelectionResult.FALLBACK_SLOT_FULL) {
+            if (MetricRepo.COUNTER_CLONE_CROSS_AZ_SLOT_FULL != null) {
+                MetricRepo.COUNTER_CLONE_CROSS_AZ_SLOT_FULL.increase(bytes);
+            }
+        } else if (result == RepairSourceSelectionResult.FALLBACK_NO_PREFERRED
+                || result == RepairSourceSelectionResult.FALLBACK_PREFERRED_UNAVAILABLE) {
+            if (MetricRepo.COUNTER_CLONE_CROSS_AZ_NO_LOCAL != null) {
+                MetricRepo.COUNTER_CLONE_CROSS_AZ_NO_LOCAL.increase(bytes);
+            }
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -77,6 +77,8 @@ public class SummaryProfile {
     public static final String DISTRIBUTED_PLAN = "Distributed Plan";
     public static final String SYSTEM_MESSAGE = "System Message";
     public static final String EXECUTED_BY_FRONTEND = "Executed By Frontend";
+    public static final String QUERY_BACKEND_SELECTION = "Query Backend Selection";
+    public static final String LOAD_BACKEND_SELECTION = "Load Backend Selection";
     // Execution Summary
     public static final String EXECUTION_SUMMARY_PROFILE_NAME = "Execution Summary";
     public static final String INIT_SCAN_NODE_TIME = "Init Scan Node Time";
@@ -205,6 +207,8 @@ public class SummaryProfile {
             TRANSACTION_COMMIT_TIME,
             SYSTEM_MESSAGE,
             EXECUTED_BY_FRONTEND,
+            QUERY_BACKEND_SELECTION,
+            LOAD_BACKEND_SELECTION,
             SPLITS_ASSIGNMENT_WEIGHT
     );
 
@@ -794,6 +798,16 @@ public class SummaryProfile {
 
         public SummaryBuilder workloadGroup(String workloadGroup) {
             map.put(WORKLOAD_GROUP, workloadGroup);
+            return this;
+        }
+
+        public SummaryBuilder queryBackendSelection(String selection) {
+            map.put(QUERY_BACKEND_SELECTION, selection);
+            return this;
+        }
+
+        public SummaryBuilder loadBackendSelection(String selection) {
+            map.put(LOAD_BACKEND_SELECTION, selection);
             return this;
         }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/FederationBackendPolicy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/FederationBackendPolicy.java
@@ -208,6 +208,13 @@ public class FederationBackendPolicy {
         return selectedBackend;
     }
 
+    /** Replace only the round-robin order; candidate membership and backend metadata remain unchanged. */
+    public void replaceBackendOrder(List<Backend> orderedBackends) {
+        backends.clear();
+        backends.addAll(orderedBackends);
+        nextBe = 0;
+    }
+
     @VisibleForTesting
     public void setEnableSplitsRedistribution(boolean enableSplitsRedistribution) {
         this.enableSplitsRedistribution = enableSplitsRedistribution;
@@ -500,4 +507,3 @@ public class FederationBackendPolicy {
         }
     }
 }
-

--- a/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/httpv2/rest/LoadAction.java
@@ -38,6 +38,7 @@ import org.apache.doris.mysql.privilege.PrivPredicate;
 import org.apache.doris.planner.GroupCommitPlanner;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.resource.computegroup.ComputeGroup;
 import org.apache.doris.service.ExecuteEnv;
 import org.apache.doris.system.Backend;
@@ -62,6 +63,7 @@ import org.springframework.web.servlet.view.RedirectView;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Optional;
@@ -428,8 +430,7 @@ public class LoadAction extends RestBaseController {
         policy = new BeSelectionPolicy.Builder().setEnableRoundRobin(true).needLoadAvailable().build();
         policy.nextRoundRobinIndex = getLastSelectedBackendIndexAndUpdate();
         List<Long> backendIds;
-        int number = groupCommit ? -1 : 1;
-        backendIds = Env.getCurrentSystemInfo().selectBackendIdsByPolicy(policy, number, computeGroup.getBackendList());
+        backendIds = Env.getCurrentSystemInfo().selectBackendIdsByPolicy(policy, -1, computeGroup.getBackendList());
         if (backendIds.isEmpty()) {
             throw new LoadException(
                     SystemInfoService.NO_BACKEND_LOAD_AVAILABLE_MSG + ", policy: " + policy + ", compute group is "
@@ -440,12 +441,24 @@ public class LoadAction extends RestBaseController {
             backend = preSelectedBackend != null ? preSelectedBackend
                     : selectBackendForGroupCommit("", request, tableId);
         } else {
-            backend = Env.getCurrentSystemInfo().getBackend(backendIds.get(0));
+            backend = chooseRedirectBackendWithSelection(ctx, backendIds);
         }
         if (backend == null) {
             throw new LoadException(SystemInfoService.NO_BACKEND_LOAD_AVAILABLE_MSG + ", policy: " + policy);
         }
         return selectEndpointByRedirectPolicy(request, backend);
+    }
+
+    private Backend chooseRedirectBackendWithSelection(ConnectContext context, List<Long> backendIds)
+            throws LoadException {
+        List<Backend> candidates = new ArrayList<>();
+        for (Long backendId : backendIds) {
+            Backend candidate = Env.getCurrentSystemInfo().getBackend(backendId);
+            if (candidate != null) {
+                candidates.add(candidate);
+            }
+        }
+        return BackendSelectionManager.chooseLoadBackend(context, candidates);
     }
 
     private TNetworkAddress selectCloudRedirectBackend(String clusterName, HttpServletRequest req, boolean groupCommit,
@@ -752,26 +765,50 @@ public class LoadAction extends RestBaseController {
 
     private Backend selectBackendForGroupCommit(String clusterName, HttpServletRequest req, long tableId)
             throws LoadException {
+        ConnectContext currentCtx = ConnectContext.get();
         ConnectContext ctx = new ConnectContext();
         ctx.setEnv(Env.getCurrentEnv());
-        ctx.setThreadLocalInfo();
         ctx.setRemoteIP(req.getRemoteAddr());
         // We set this variable to fulfill required field 'user' in
         // TMasterOpRequest(FrontendService.thrift)
         ctx.setCurrentUserIdentity(UserIdentity.ADMIN);
-        ctx.setThreadLocalInfo();
+        inheritLoadSelectionContext(currentCtx, ctx);
         if (Config.isCloudMode()) {
             ctx.setCloudCluster(clusterName);
         }
 
         Backend backend = null;
         try {
+            ctx.setThreadLocalInfo();
             backend = Env.getCurrentEnv().getGroupCommitManager()
                     .selectBackendForGroupCommit(tableId, ctx);
         } catch (DdlException e) {
             throw new LoadException(e.getMessage(), e);
+        } finally {
+            if (currentCtx != null) {
+                currentCtx.setThreadLocalInfo();
+            } else {
+                ConnectContext.remove();
+            }
         }
         return backend;
+    }
+
+    private static void inheritLoadSelectionContext(ConnectContext source, ConnectContext target) {
+        if (source == null) {
+            return;
+        }
+        UserIdentity sourceIdentity = source.getCurrentUserIdentity();
+        if (sourceIdentity != null) {
+            target.setCurrentUserIdentity(sourceIdentity);
+        }
+        target.getSessionVariable().enableLoadBackendSelection =
+                source.getSessionVariable().isEnableLoadBackendSelection();
+        target.getSessionVariable().preferredBackendSelectionKey =
+                source.getSessionVariable().getPreferredBackendSelectionKey();
+        target.getSessionVariable().backendSelectionMode =
+                source.getSessionVariable().getBackendSelectionMode();
+        target.setConnectingFeLocalResourceGroup(source.getConnectingFeLocalResourceGroup());
     }
 
     /*
@@ -827,7 +864,7 @@ public class LoadAction extends RestBaseController {
      * Problem:
      * Group commit requires that requests for the same table be sent to the same BE node
      * to achieve better batching efficiency. However, in cloud mode with Load Balancer (LB),
-     * the LB randomly selects a BE node for forwarding, which breaks the group commit strategy
+     * the LB selects a BE node by default for forwarding, which breaks the group commit strategy
      * and reduces batching effectiveness.
      *
      * Solution:

--- a/fe/fe-core/src/main/java/org/apache/doris/load/GroupCommitManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/GroupCommitManager.java
@@ -28,12 +28,15 @@ import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.ErrorReport;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.LoadException;
+import org.apache.doris.common.UserException;
 import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.SlidingWindowCounter;
 import org.apache.doris.proto.InternalService.PGetWalQueueSizeRequest;
 import org.apache.doris.proto.InternalService.PGetWalQueueSizeResponse;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.MasterOpExecutor;
+import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.rpc.BackendServiceProxy;
 import org.apache.doris.system.Backend;
 import org.apache.doris.thrift.TNetworkAddress;
@@ -223,13 +226,16 @@ public class GroupCommitManager {
                 }
                 return be;
             } catch (Exception e) {
-                throw new LoadException(e.getMessage());
+                String message = e.getMessage() != null ? e.getMessage() : e.toString();
+                throw new LoadException(message, e);
             }
         } else {
             try {
                 // Master FE will select BE by itself.
+                BackendSelection.SelectionHint selectionHint =
+                        Config.isCloudMode() ? null : getGroupCommitLoadSelectionHint(context);
                 return Env.getCurrentSystemInfo()
-                        .getBackend(selectBackendForGroupCommitInternal(tableId, clusterName));
+                        .getBackend(selectBackendForGroupCommitInternal(tableId, clusterName, selectionHint));
             } catch (Exception e) {
                 LOG.warn("get backend failed, tableId: {}, exception", tableId, e);
                 throw new LoadException(e.getMessage());
@@ -237,7 +243,18 @@ public class GroupCommitManager {
         }
     }
 
+    @Nullable
+    static BackendSelection.SelectionHint getGroupCommitLoadSelectionHint(ConnectContext context) {
+        return BackendSelectionManager.resolveLoadSelectionHint(context);
+    }
+
     public long selectBackendForGroupCommitInternal(long tableId, String cluster)
+            throws LoadException, DdlException {
+        return selectBackendForGroupCommitInternal(tableId, cluster, null);
+    }
+
+    public long selectBackendForGroupCommitInternal(long tableId, String cluster,
+            @Nullable BackendSelection.SelectionHint selectionHint)
             throws LoadException, DdlException {
         // Understanding Group Commit and Backend Selection Logic
         //
@@ -270,7 +287,7 @@ public class GroupCommitManager {
         // This approach ensures that group commits can effectively batch data together
         // while managing the load on each BE efficiently.
         return Config.isCloudMode() ? selectBackendForCloudGroupCommitInternal(tableId, cluster)
-                : selectBackendForLocalGroupCommitInternal(tableId);
+                : selectBackendForLocalGroupCommitInternal(tableId, selectionHint);
     }
 
     private long selectBackendForCloudGroupCommitInternal(long tableId, String cluster)
@@ -283,7 +300,8 @@ public class GroupCommitManager {
             ErrorReport.reportDdlException(ErrorCode.ERR_NO_CLUSTER_ERROR);
         }
 
-        Long cachedBackendId = getCachedBackend(cluster, tableId);
+        String cacheKey = buildCloudGroupCommitCacheKey(cluster, tableId);
+        Long cachedBackendId = getCachedCloudBackend(cacheKey, cluster, tableId);
         if (cachedBackendId != null) {
             return cachedBackendId;
         }
@@ -295,7 +313,7 @@ public class GroupCommitManager {
             throw new LoadException("No alive backend");
         }
         // If the cached backend is not active or decommissioned, select a random new backend.
-        Long randomBackendId = getRandomBackend(cluster, tableId, backends);
+        Long randomBackendId = getRandomCloudBackend(cacheKey, cluster, tableId, backends);
         if (randomBackendId != null) {
             return randomBackendId;
         }
@@ -307,12 +325,16 @@ public class GroupCommitManager {
         throw new LoadException("No suitable backend for cloud cluster=" + cluster + ", backends = " + backendsInfo);
     }
 
-    private long selectBackendForLocalGroupCommitInternal(long tableId) throws LoadException {
+    private long selectBackendForLocalGroupCommitInternal(long tableId,
+            @Nullable BackendSelection.SelectionHint selectionHint) throws LoadException {
         if (LOG.isDebugEnabled()) {
             LOG.debug("group commit select be info, tableToBeMap {}, tablePressureMap {}", tableToBeMap.toString(),
                     tableToPressureMap.toString());
         }
-        Long cachedBackendId = getCachedBackend(null, tableId);
+        boolean hasLoadSelectionPreference = BackendSelectionManager.hasLoadSelectionPreference(selectionHint);
+        String cacheKey = buildLocalGroupCommitCacheKey(tableId, selectionHint, hasLoadSelectionPreference);
+        Long cachedBackendId = BackendSelectionManager.isRequiredSelection(selectionHint)
+                ? null : getCachedBackend(cacheKey, null, tableId);
         if (cachedBackendId != null) {
             return cachedBackendId;
         }
@@ -330,7 +352,8 @@ public class GroupCommitManager {
         }
 
         // If the cached backend is not active or decommissioned, select a random new backend.
-        Long randomBackendId = getRandomBackend(null, tableId, backends);
+        Long randomBackendId = getRandomLocalBackend(cacheKey, tableId, backends, selectionHint,
+                hasLoadSelectionPreference);
         if (randomBackendId != null) {
             return randomBackendId;
         }
@@ -343,9 +366,14 @@ public class GroupCommitManager {
     }
 
     @Nullable
-    private Long getCachedBackend(String cluster, long tableId) {
+    private Long getCachedCloudBackend(String cacheKey, String cluster, long tableId) {
+        return getCachedBackend(cacheKey, cluster, tableId);
+    }
+
+    @Nullable
+    private Long getCachedBackend(String cacheKey, @Nullable String cloudCluster, long tableId) {
         OlapTable table = (OlapTable) Env.getCurrentEnv().getInternalCatalog().getTableByTableId(tableId);
-        if (tableToBeMap.containsKey(encode(cluster, tableId))) {
+        if (tableToBeMap.containsKey(cacheKey)) {
             if (tableToPressureMap.get(tableId) == null) {
                 return null;
             } else if (tableToPressureMap.get(tableId).get() < table.getGroupCommitDataBytes()) {
@@ -353,24 +381,24 @@ public class GroupCommitManager {
                 // Maybe one thread removes the tableId from the tableToBeMap.
                 // Another thread gets the same tableId but can not find this tableId.
                 // So another thread needs to get the random backend.
-                Long backendId = tableToBeMap.get(encode(cluster, tableId));
+                Long backendId = tableToBeMap.get(cacheKey);
                 if (backendId == null) {
                     return null;
                 }
                 Backend backend = Env.getCurrentSystemInfo().getBackend(backendId);
-                if (isBackendAvailable(backend, cluster)) {
+                if (isBackendAvailable(backend, cloudCluster)) {
                     return backend.getId();
                 } else {
-                    tableToBeMap.remove(encode(cluster, tableId));
+                    tableToBeMap.remove(cacheKey);
                 }
             } else {
-                tableToBeMap.remove(encode(cluster, tableId));
+                tableToBeMap.remove(cacheKey);
             }
         }
         return null;
     }
 
-    private boolean isBackendAvailable(Backend backend, String cluster) {
+    private boolean isBackendAvailable(Backend backend, @Nullable String cloudCluster) {
         if (backend == null || !backend.isAlive() || backend.isDecommissioned() || backend.isDecommissioning()
                 || !backend.isLoadAvailable()) {
             return false;
@@ -378,16 +406,40 @@ public class GroupCommitManager {
         if (!Config.isCloudMode()) {
             return true;
         }
-        return cluster == null || cluster.equals(backend.getCloudClusterName());
+        return cloudCluster == null || cloudCluster.equals(backend.getCloudClusterName());
     }
 
     @Nullable
-    private Long getRandomBackend(String cluster, long tableId, List<Backend> backends) {
+    private Long getRandomCloudBackend(String cacheKey, String cluster, long tableId, List<Backend> backends)
+            throws LoadException {
         OlapTable table = (OlapTable) Env.getCurrentEnv().getInternalCatalog().getTableByTableId(tableId);
         Collections.shuffle(backends);
-        for (Backend backend : backends) {
-            if (isBackendAvailable(backend, cluster)) {
-                tableToBeMap.put(encode(cluster, tableId), backend.getId());
+        return selectAvailableBackend(cacheKey, cluster, tableId, table, backends);
+    }
+
+    @Nullable
+    private Long getRandomLocalBackend(String cacheKey, long tableId, List<Backend> backends,
+            @Nullable BackendSelection.SelectionHint selectionHint, boolean hasLoadSelectionPreference)
+            throws LoadException {
+        OlapTable table = (OlapTable) Env.getCurrentEnv().getInternalCatalog().getTableByTableId(tableId);
+        Collections.shuffle(backends);
+        List<Backend> orderedBackends;
+        try {
+            orderedBackends = hasLoadSelectionPreference
+                    ? BackendSelectionManager.orderLoadCandidates(selectionHint, backends)
+                    : backends;
+        } catch (UserException e) {
+            throw new LoadException(e.getMessage());
+        }
+        return selectAvailableBackend(cacheKey, null, tableId, table, orderedBackends);
+    }
+
+    @Nullable
+    private Long selectAvailableBackend(String cacheKey, @Nullable String cloudCluster, long tableId, OlapTable table,
+            List<Backend> orderedBackends) {
+        for (Backend backend : orderedBackends) {
+            if (isBackendAvailable(backend, cloudCluster)) {
+                tableToBeMap.put(cacheKey, backend.getId());
                 tableToPressureMap.put(tableId,
                         new SlidingWindowCounter(table.getGroupCommitIntervalMs() / 1000 + 1));
                 return backend.getId();
@@ -396,12 +448,18 @@ public class GroupCommitManager {
         return null;
     }
 
-    private String encode(String cluster, long tableId) {
-        if (cluster == null) {
-            return String.valueOf(tableId);
-        } else {
-            return cluster + tableId;
+    private String buildCloudGroupCommitCacheKey(String cluster, long tableId) {
+        return cluster + tableId;
+    }
+
+    private String buildLocalGroupCommitCacheKey(long tableId,
+            @Nullable BackendSelection.SelectionHint selectionHint, boolean hasLoadSelectionPreference) {
+        String cacheKey = String.valueOf(tableId);
+        if (!hasLoadSelectionPreference) {
+            return cacheKey;
         }
+        return cacheKey + "#" + selectionHint.getPreferredKey()
+                + "#" + selectionHint.getMode();
     }
 
     public void updateLoadData(long tableId, long receiveData) {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -53,6 +53,7 @@ import org.apache.doris.load.FailMsg;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.OriginStatement;
 import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.resource.computegroup.ComputeGroup;
 import org.apache.doris.service.ExecuteEnv;
 import org.apache.doris.service.FrontendOptions;
@@ -91,6 +92,9 @@ public class BrokerLoadJob extends BulkLoadJob {
     protected Profile jobProfile;
     // If set to true, the profile of load job with be pushed to ProfileManager
     protected boolean enableProfile = false;
+
+    // Runtime-only selection result recorded by a loading task's coordinator.
+    private transient volatile String loadBackendSelectionSummary;
 
     private boolean enableMemTableOnSinkNode = false;
     private int batchSize = 0;
@@ -297,6 +301,7 @@ public class BrokerLoadJob extends BulkLoadJob {
         }
 
         context.setComputeGroup(computeGroup);
+        BackendSelectionManager.restoreLoadSelection(context, getLoadBackendSelectionHint());
     }
 
     protected LoadLoadingTask createTask(Database db, OlapTable table, List<BrokerFileGroup> brokerFileGroups,
@@ -309,6 +314,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                 getLoadParallelism(), getSendBatchParallelism(),
                 getMaxFilterRatio() <= 0, enableProfile ? jobProfile : null, isSingleTabletLoadPerSink(),
                 getPriority(), isEnableMemtableOnSinkNode, batchSize);
+        task.setLoadBackendSelectionHint(getLoadBackendSelectionHint());
 
         UUID uuid = UUID.randomUUID();
         TUniqueId loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
@@ -317,6 +323,10 @@ public class BrokerLoadJob extends BulkLoadJob {
 
         task.init(loadId, attachment.getFileStatusByTable(aggKey),
                 attachment.getFileNumByTable(aggKey), getUserInfo());
+        ConnectContext context = ConnectContext.get();
+        if (context != null) {
+            recordLoadBackendSelectionSummary(context.getBackendSelectionProfile().getLoadSummary());
+        }
         task.settWorkloadGroups(tWorkloadGroups);
         return task;
     }
@@ -495,6 +505,17 @@ public class BrokerLoadJob extends BulkLoadJob {
 
     protected void afterCommit() throws DdlException {}
 
+    void recordLoadBackendSelectionSummary(String summary) {
+        if (StringUtils.isEmpty(summary) || loadBackendSelectionSummary != null) {
+            return;
+        }
+        synchronized (this) {
+            if (loadBackendSelectionSummary == null) {
+                loadBackendSelectionSummary = summary;
+            }
+        }
+    }
+
     protected LoadJobFinalOperation getLoadJobFinalOperation() {
         return new LoadJobFinalOperation(id, loadingStatus, progress, loadStartTimestamp, finishTimestamp, state,
                 failMsg);
@@ -521,6 +542,9 @@ public class BrokerLoadJob extends BulkLoadJob {
         builder.defaultCatalog(InternalCatalog.INTERNAL_CATALOG_NAME);
         builder.defaultDb(getDefaultDb());
         builder.sqlStatement(getOriginStmt().originStmt);
+        if (loadBackendSelectionSummary != null) {
+            builder.loadBackendSelection(loadBackendSelectionSummary);
+        }
         return builder.build();
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
@@ -46,6 +46,8 @@ import org.apache.doris.qe.OriginStatement;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.SqlModeHelper;
 import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.transaction.TabletCommitInfo;
 import org.apache.doris.transaction.TransactionState;
 
@@ -90,6 +92,9 @@ public abstract class BulkLoadJob extends LoadJob implements GsonPostProcessable
     // we persist these sessionVariables due to the session is not available when replaying the job.
     @SerializedName(value = "svs")
     protected Map<String, String> sessionVariables = Maps.newHashMap();
+
+    @SerializedName(value = "lbsc")
+    private BackendSelection.SelectionHint loadBackendSelectionHint;
 
     public BulkLoadJob(EtlJobType jobType) {
         super(jobType);
@@ -138,6 +143,7 @@ public abstract class BulkLoadJob extends LoadJob implements GsonPostProcessable
             }
             bulkLoadJob.setComment(command.getComment());
             bulkLoadJob.setJobProperties(command.getProperties());
+            bulkLoadJob.setLoadBackendSelectionHint(BackendSelectionManager.captureLoadSelection(ctx));
             bulkLoadJob.checkAndSetDataSourceInfoByNereids(db, command.getDataDescriptions(), ctx);
             // In the construction method, there may not be table information yet
             bulkLoadJob.rebuildAuthorizationInfo();
@@ -145,6 +151,14 @@ public abstract class BulkLoadJob extends LoadJob implements GsonPostProcessable
         } catch (MetaNotFoundException e) {
             throw new DdlException(e.getMessage());
         }
+    }
+
+    public void setLoadBackendSelectionHint(BackendSelection.SelectionHint hint) {
+        loadBackendSelectionHint = hint;
+    }
+
+    public BackendSelection.SelectionHint getLoadBackendSelectionHint() {
+        return loadBackendSelectionHint;
     }
 
     public void checkAndSetDataSourceInfoByNereids(Database db, List<NereidsDataDescription> dataDescriptions,

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadLoadingTask.java
@@ -35,8 +35,11 @@ import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.load.FailMsg;
 import org.apache.doris.nereids.load.NereidsBrokerFileGroup;
 import org.apache.doris.nereids.load.NereidsLoadingTaskPlanner;
+import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.Coordinator;
 import org.apache.doris.qe.QeProcessorImpl;
+import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.thrift.TBrokerFileStatus;
 import org.apache.doris.thrift.TPartialUpdateNewRowPolicy;
 import org.apache.doris.thrift.TPipelineWorkloadGroup;
@@ -89,6 +92,7 @@ public class LoadLoadingTask extends LoadTask {
     private long beginTime;
 
     private List<TPipelineWorkloadGroup> tWorkloadGroups = null;
+    private BackendSelection.SelectionHint loadBackendSelectionHint;
 
     protected UserIdentity userInfo;
 
@@ -135,7 +139,12 @@ public class LoadLoadingTask extends LoadTask {
         planner = new NereidsLoadingTaskPlanner(callback.getCallbackId(), txnId, db.getId(), table, brokerDesc,
                 brokerFileGroups, strictMode, isPartialUpdate, partialUpdateNewKeyPolicy, timezone, timeoutS,
                 loadParallelism, sendBatchParallelism, userInfo, singleTabletLoadPerSink, enableMemTableOnSinkNode);
+        planner.setLoadBackendSelectionHint(loadBackendSelectionHint);
         planner.plan(loadId, fileStatusList, fileNum);
+    }
+
+    public void setLoadBackendSelectionHint(BackendSelection.SelectionHint hint) {
+        loadBackendSelectionHint = hint;
     }
 
     public TUniqueId getLoadId() {
@@ -157,6 +166,16 @@ public class LoadLoadingTask extends LoadTask {
     }
 
     protected void executeOnce() throws Exception {
+        // The task may execute on a different worker after the submitting session has been
+        // cleared or reused. Restore the job-owned hint immediately before Coordinator resolves
+        // load backends, otherwise it can fall back to the current global/session variables.
+        ConnectContext executionContext = ConnectContext.get();
+        if (executionContext == null) {
+            executionContext = new ConnectContext();
+            executionContext.setThreadLocalInfo();
+            executionContext.setEnv(Env.getCurrentEnv());
+        }
+        BackendSelectionManager.restoreLoadSelection(executionContext, loadBackendSelectionHint);
         final boolean enableProfile = this.jobProfile != null;
         // New one query id,
         Coordinator curCoordinator =  EnvFactory.getInstance().createCoordinator(callback.getCallbackId(),

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/MysqlLoadManager.java
@@ -44,6 +44,7 @@ import org.apache.doris.nereids.trees.plans.commands.load.MysqlLoadCommand;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.VariableMgr;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.BeSelectionPolicy;
 import org.apache.doris.system.SystemInfoService;
@@ -189,7 +190,7 @@ public class MysqlLoadManager {
         try (final CloseableHttpClient httpclient = HttpUtils.getHttpClient()) {
             for (String file : filePaths) {
                 InputStreamEntity entity = getInputStreamEntity(context, clientLocal, file, loadId);
-                HttpPut request = generateRequestForMySqlLoadV2(entity, dataDesc, database, table, token);
+                HttpPut request = generateRequestForMySqlLoadV2(context, entity, dataDesc, database, table, token);
                 loadContext.setRequest(request);
                 try (final CloseableHttpResponse response = httpclient.execute(request)) {
                     String body = EntityUtils.toString(response.getEntity());
@@ -256,7 +257,7 @@ public class MysqlLoadManager {
         try (final CloseableHttpClient httpclient = HttpClients.createDefault()) {
             for (String file : filePaths) {
                 InputStreamEntity entity = getInputStreamEntity(context, clientLocal, file, loadId);
-                HttpPut request = generateRequestForMySqlLoad(entity, dataDesc, database, table, token);
+                HttpPut request = generateRequestForMySqlLoad(context, entity, dataDesc, database, table, token);
                 loadContext.setRequest(request);
                 try (final CloseableHttpResponse response = httpclient.execute(request)) {
                     String body = EntityUtils.toString(response.getEntity());
@@ -452,19 +453,19 @@ public class MysqlLoadManager {
         });
     }
 
-    private HttpPut generateRequestForMySqlLoad(
+    private HttpPut generateRequestForMySqlLoad(ConnectContext context,
             InputStreamEntity entity,
             NereidsDataDescription desc,
             String database,
             String table,
             String token) throws LoadException {
-        final HttpPut httpPut = new HttpPut(selectBackendForMySqlLoad(database, table));
+        final HttpPut httpPut = new HttpPut(selectBackendForMySqlLoad(context, database, table));
 
         httpPut.addHeader("Expect", "100-continue");
         httpPut.addHeader("Content-Type", "text/plain");
         httpPut.addHeader("token", token);
 
-        UserIdentity uid = ConnectContext.get().getCurrentUserIdentity();
+        UserIdentity uid = context.getCurrentUserIdentity();
         if (uid == null || StringUtils.isEmpty(uid.getQualifiedUser())) {
             throw new LoadException("user is null");
         }
@@ -544,7 +545,7 @@ public class MysqlLoadManager {
         if (Config.isCloudMode()) {
             String clusterName = "";
             try {
-                clusterName = ConnectContext.get().getCloudCluster();
+                clusterName = context.getCloudCluster();
             } catch (Exception e) {
                 LOG.warn("failed to get compute group: " + e.getMessage());
                 throw new LoadException("failed to get compute group: " + e.getMessage());
@@ -559,19 +560,19 @@ public class MysqlLoadManager {
         return httpPut;
     }
 
-    private HttpPut generateRequestForMySqlLoadV2(
+    private HttpPut generateRequestForMySqlLoadV2(ConnectContext context,
             InputStreamEntity entity,
             MysqlDataDescription desc,
             String database,
             String table,
             String token) throws LoadException {
-        final HttpPut httpPut = new HttpPut(selectBackendForMySqlLoad(database, table));
+        final HttpPut httpPut = new HttpPut(selectBackendForMySqlLoad(context, database, table));
 
         httpPut.addHeader("Expect", "100-continue");
         httpPut.addHeader("Content-Type", "text/plain");
         httpPut.addHeader("token", token);
 
-        UserIdentity uid = ConnectContext.get().getCurrentUserIdentity();
+        UserIdentity uid = context.getCurrentUserIdentity();
         if (uid == null || StringUtils.isEmpty(uid.getQualifiedUser())) {
             throw new LoadException("user is null");
         }
@@ -651,7 +652,7 @@ public class MysqlLoadManager {
         if (Config.isCloudMode()) {
             String clusterName = "";
             try {
-                clusterName = ConnectContext.get().getCloudCluster();
+                clusterName = context.getCloudCluster();
             } catch (Exception e) {
                 LOG.warn("failed to get compute group: " + e.getMessage());
                 throw new LoadException("failed to get compute group: " + e.getMessage());
@@ -666,24 +667,37 @@ public class MysqlLoadManager {
         return httpPut;
     }
 
-    private String selectBackendForMySqlLoad(String database, String table) throws LoadException {
+    private String selectBackendForMySqlLoad(ConnectContext context, String database, String table)
+            throws LoadException {
         Backend backend = null;
         if (Config.isCloudMode()) {
             String clusterName = "";
             try {
-                clusterName = ConnectContext.get().getCloudCluster();
+                clusterName = context.getCloudCluster();
             } catch (Exception e) {
                 LOG.warn("failed to get cloud cluster: " + e.getMessage());
                 throw new LoadException("failed to get cloud cluster: " + e);
             }
             backend = StreamLoadHandler.selectBackend(clusterName);
+            if (backend == null) {
+                throw new LoadException(SystemInfoService.NO_BACKEND_LOAD_AVAILABLE_MSG
+                        + ", cluster: " + clusterName);
+            }
         } else {
             BeSelectionPolicy policy = new BeSelectionPolicy.Builder().needLoadAvailable().build();
-            List<Long> backendIds = Env.getCurrentSystemInfo().selectBackendIdsByPolicy(policy, 1);
+            // The backend selection policy may reorder all eligible candidates.
+            List<Long> backendIds = Env.getCurrentSystemInfo().selectBackendIdsByPolicy(policy, -1);
             if (backendIds.isEmpty()) {
                 throw new LoadException(SystemInfoService.NO_BACKEND_LOAD_AVAILABLE_MSG + ", policy: " + policy);
             }
-            backend = Env.getCurrentSystemInfo().getBackend(backendIds.get(0));
+            List<Backend> candidates = new ArrayList<>();
+            for (Long backendId : backendIds) {
+                Backend candidate = Env.getCurrentSystemInfo().getBackend(backendId);
+                if (candidate != null) {
+                    candidates.add(candidate);
+                }
+            }
+            backend = BackendSelectionManager.chooseLoadBackend(context, candidates);
             if (backend == null) {
                 throw new LoadException(SystemInfoService.NO_BACKEND_LOAD_AVAILABLE_MSG + ", policy: " + policy);
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/metric/MetricRepo.java
@@ -112,6 +112,10 @@ public final class MetricRepo {
     public static LongCounterMetric COUNTER_QUERY_TABLE;
     public static LongCounterMetric COUNTER_QUERY_OLAP_TABLE;
     public static LongCounterMetric COUNTER_QUERY_HIVE_TABLE;
+    public static LongCounterMetric COUNTER_CLONE_BYTES_LOCAL_AZ;
+    public static LongCounterMetric COUNTER_CLONE_BYTES_CROSS_AZ;
+    public static LongCounterMetric COUNTER_CLONE_CROSS_AZ_SLOT_FULL;
+    public static LongCounterMetric COUNTER_CLONE_CROSS_AZ_NO_LOCAL;
 
     public static LongCounterMetric HTTP_COUNTER_COPY_INFO_UPLOAD_REQUEST;
     public static LongCounterMetric HTTP_COUNTER_COPY_INFO_UPLOAD_ERR;
@@ -529,6 +533,18 @@ public final class MetricRepo {
         COUNTER_QUERY_HIVE_TABLE = new LongCounterMetric("query_hive_table", MetricUnit.REQUESTS,
                 "total query from hive table");
         DORIS_METRIC_REGISTER.addMetrics(COUNTER_QUERY_HIVE_TABLE);
+        COUNTER_CLONE_BYTES_LOCAL_AZ = new LongCounterMetric("clone_bytes_local_az", MetricUnit.BYTES,
+                "total clone bytes within the same tag.location");
+        DORIS_METRIC_REGISTER.addMetrics(COUNTER_CLONE_BYTES_LOCAL_AZ);
+        COUNTER_CLONE_BYTES_CROSS_AZ = new LongCounterMetric("clone_bytes_cross_az", MetricUnit.BYTES,
+                "total clone bytes across different tag.location");
+        DORIS_METRIC_REGISTER.addMetrics(COUNTER_CLONE_BYTES_CROSS_AZ);
+        COUNTER_CLONE_CROSS_AZ_SLOT_FULL = new LongCounterMetric("clone_cross_az_slot_full", MetricUnit.BYTES,
+                "total cross-AZ clone bytes caused by local source slot exhaustion");
+        DORIS_METRIC_REGISTER.addMetrics(COUNTER_CLONE_CROSS_AZ_SLOT_FULL);
+        COUNTER_CLONE_CROSS_AZ_NO_LOCAL = new LongCounterMetric("clone_cross_az_no_local", MetricUnit.BYTES,
+                "total cross-AZ clone bytes caused by no local healthy source");
+        DORIS_METRIC_REGISTER.addMetrics(COUNTER_CLONE_CROSS_AZ_NO_LOCAL);
         USER_COUNTER_QUERY_ALL = new AutoMappedMetric<>(name -> {
             LongCounterMetric userCountQueryAll = new LongCounterMetric("query_total", MetricUnit.REQUESTS,
                     "total query for single user");

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -70,6 +70,7 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSqlCache;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalDictionarySink;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapTableSink;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalRelation;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalSqlCache;
@@ -715,7 +716,9 @@ public class NereidsPlanner extends Planner {
             }
         }
 
-        distributedPlans = new DistributePlanner(statementContext, fragments, notNeedBackend, false).plan();
+        boolean useLoadBackendSelection = physicalPlan.anyMatch(PhysicalOlapTableSink.class::isInstance);
+        distributedPlans = new DistributePlanner(
+                statementContext, fragments, notNeedBackend, false, useLoadBackendSelection).plan();
         if (statementContext.getConnectContext().getExecutor() != null) {
             statementContext.getConnectContext().getExecutor().getSummaryProfile()
                     .setNereidsDistributeTime(TimeUtils.getStartTimeMs());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadingTaskPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsLoadingTaskPlanner.java
@@ -39,6 +39,8 @@ import org.apache.doris.planner.PlanNodeId;
 import org.apache.doris.planner.ScanContext;
 import org.apache.doris.planner.ScanNode;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.thrift.TBrokerFileStatus;
 import org.apache.doris.thrift.TPartialUpdateNewRowPolicy;
 import org.apache.doris.thrift.TUniqueId;
@@ -78,6 +80,7 @@ public class NereidsLoadingTaskPlanner {
     private final boolean enableMemtableOnSinkNode;
     private UserIdentity userInfo;
     private final DescriptorTable descTable = new DescriptorTable();
+    private BackendSelection.SelectionHint loadBackendSelectionHint;
 
     // Output params
     private List<PlanFragment> fragments = Lists.newArrayList();
@@ -117,6 +120,13 @@ public class NereidsLoadingTaskPlanner {
      */
     public void plan(TUniqueId loadId, List<List<TBrokerFileStatus>> fileStatusesList, int filesAdded)
             throws UserException {
+        // Broker loads are planned asynchronously and may execute after the submitting session
+        // has changed. Re-assert the job-owned hint immediately before planning every sink and
+        // scan, so no current/global session value can replace the persisted decision.
+        ConnectContext planningContext = ConnectContext.get();
+        if (planningContext != null) {
+            BackendSelectionManager.restoreLoadSelection(planningContext, loadBackendSelectionHint);
+        }
         if (isPartialUpdate && !table.getEnableUniqueKeyMergeOnWrite()) {
             throw new UserException("Only unique key merge on write support partial update");
         }
@@ -211,6 +221,10 @@ public class NereidsLoadingTaskPlanner {
             fragment.finalize(null);
         }
         Collections.reverse(fragments);
+    }
+
+    public void setLoadBackendSelectionHint(BackendSelection.SelectionHint hint) {
+        loadBackendSelectionHint = hint;
     }
 
     public DescriptorTable getDescTable() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/distribute/DistributePlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/distribute/DistributePlanner.java
@@ -73,13 +73,16 @@ public class DistributePlanner {
     private final FragmentIdMapping<PlanFragment> idToFragments;
     private final boolean notNeedBackend;
     private final boolean isLoadJob;
+    private final boolean useLoadBackendSelection;
 
     public DistributePlanner(StatementContext statementContext,
-            List<PlanFragment> fragments, boolean notNeedBackend, boolean isLoadJob) {
+            List<PlanFragment> fragments, boolean notNeedBackend, boolean isLoadJob,
+            boolean useLoadBackendSelection) {
         this.statementContext = Objects.requireNonNull(statementContext, "statementContext can not be null");
         this.idToFragments = FragmentIdMapping.buildFragmentMapping(fragments);
         this.notNeedBackend = notNeedBackend;
         this.isLoadJob = isLoadJob;
+        this.useLoadBackendSelection = useLoadBackendSelection;
     }
 
     /** plan */
@@ -87,9 +90,11 @@ public class DistributePlanner {
         updateProfileIfPresent(profile -> profile.setQueryPlanFinishTime(TimeUtils.getStartTimeMs()));
         try {
             BackendDistributedPlanWorkerManager workerManager = new BackendDistributedPlanWorkerManager(
-                            statementContext.getConnectContext(), notNeedBackend, isLoadJob);
+                            statementContext.getConnectContext(), notNeedBackend, isLoadJob,
+                            useLoadBackendSelection);
             addExternalBackends(workerManager);
-            LoadBalanceScanWorkerSelector workerSelector = new LoadBalanceScanWorkerSelector(workerManager);
+            LoadBalanceScanWorkerSelector workerSelector = new LoadBalanceScanWorkerSelector(
+                    workerManager, statementContext.getConnectContext(), useLoadBackendSelection);
             FragmentIdMapping<UnassignedJob> fragmentJobs
                     = UnassignedJobBuilder.buildJobs(workerSelector, statementContext, idToFragments);
             // assign BE and dop, to instance

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/distribute/worker/BackendDistributedPlanWorkerManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/distribute/worker/BackendDistributedPlanWorkerManager.java
@@ -26,6 +26,8 @@ import org.apache.doris.common.Reference;
 import org.apache.doris.common.UserException;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.SimpleScheduler;
+import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.resource.computegroup.ComputeGroup;
 import org.apache.doris.resource.computegroup.ComputeGroupMgr;
 import org.apache.doris.system.Backend;
@@ -39,6 +41,7 @@ import com.google.common.collect.Maps;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -57,12 +60,23 @@ public class BackendDistributedPlanWorkerManager implements DistributedPlanWorke
     private final Map<Long, Supplier<ImmutableMap<Long, Backend>>> allClusterBackends = Maps.newHashMap();
 
     private final Map<Long, ImmutableMap<Long, Backend>> currentClusterBackends;
+    private final ConnectContext selectionContext;
+    private final boolean useLoadBackendSelection;
 
     /**
      * Constructor
      */
     public BackendDistributedPlanWorkerManager(
             ConnectContext context, boolean notNeedBackend, boolean isLoadJob) throws UserException {
+        this(context, notNeedBackend, isLoadJob, isLoadJob);
+    }
+
+    /** Constructor with an independent load backend selection flag. */
+    public BackendDistributedPlanWorkerManager(
+            ConnectContext context, boolean notNeedBackend, boolean isLoadJob,
+            boolean useLoadBackendSelection) throws UserException {
+        this.selectionContext = context;
+        this.useLoadBackendSelection = useLoadBackendSelection;
         this.currentClusterBackends = Maps.newHashMap();
         ImmutableMap<Long, Backend> internalBackends = checkAndInitClusterBackends(context, notNeedBackend, isLoadJob);
         this.currentClusterBackends.put(Env.getCurrentInternalCatalog().getId(), internalBackends);
@@ -152,6 +166,10 @@ public class BackendDistributedPlanWorkerManager implements DistributedPlanWorke
         try {
             Reference<Long> selectedBackendId = new Reference<>();
             ImmutableMap<Long, Backend> backends = this.currentClusterBackends.get(catalogId);
+            Backend selectedBackend = chooseLoadBackend(backends.values());
+            if (selectedBackend != null) {
+                return new BackendWorker(catalogId, selectedBackend);
+            }
             SimpleScheduler.getHost(backends, selectedBackendId);
             Backend selctedBackend = backends.get(selectedBackendId.getRef());
             return new BackendWorker(catalogId, selctedBackend);
@@ -165,8 +183,44 @@ public class BackendDistributedPlanWorkerManager implements DistributedPlanWorke
 
     @Override
     public long randomAvailableWorker(Map<TNetworkAddress, Long> addressToBackendID) {
+        if (useLoadBackendSelection) {
+            List<Backend> candidates = Lists.newArrayList();
+            for (Long backendId : addressToBackendID.values()) {
+                for (Supplier<ImmutableMap<Long, Backend>> backends : allClusterBackends.values()) {
+                    Backend backend = backends.get().get(backendId);
+                    if (backend != null) {
+                        candidates.add(backend);
+                        break;
+                    }
+                }
+            }
+            Backend selectedBackend = chooseLoadBackend(candidates);
+            if (selectedBackend != null) {
+                return selectedBackend.getId();
+            }
+        }
         TNetworkAddress backend = SimpleScheduler.getHostByCurrentBackend(addressToBackendID);
         return addressToBackendID.get(backend);
+    }
+
+    private Backend chooseLoadBackend(Iterable<Backend> candidates) {
+        if (!useLoadBackendSelection) {
+            return null;
+        }
+        List<Backend> candidateList = Lists.newArrayList(candidates);
+        Collections.shuffle(candidateList);
+        Backend selectedBackend;
+        try {
+            selectedBackend = BackendSelectionManager.chooseFirstPreferredLoadBackend(
+                    selectionContext, candidateList, SimpleScheduler::isAvailable);
+        } catch (UserException e) {
+            throw new NereidsException(e, false);
+        }
+        if (selectedBackend != null) {
+            BackendSelection.SelectionHint hint = BackendSelectionManager.resolveLoadSelectionHint(selectionContext);
+            selectionContext.getBackendSelectionProfile().recordLoadCoordinator(hint, selectedBackend);
+        }
+        return selectedBackend;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/distribute/worker/LoadBalanceScanWorkerSelector.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/distribute/worker/LoadBalanceScanWorkerSelector.java
@@ -17,7 +17,9 @@
 
 package org.apache.doris.nereids.trees.plans.distribute.worker;
 
+import org.apache.doris.common.Config;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.UserException;
 import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.plans.distribute.worker.job.BucketScanSource;
 import org.apache.doris.nereids.trees.plans.distribute.worker.job.DefaultScanSource;
@@ -30,6 +32,9 @@ import org.apache.doris.planner.OlapScanNode;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.ScanNode;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.BackendSelectionManager;
+import org.apache.doris.system.Backend;
 import org.apache.doris.thrift.TExplainLevel;
 import org.apache.doris.thrift.TExternalScanRange;
 import org.apache.doris.thrift.TFileRangeDesc;
@@ -56,10 +61,15 @@ import java.util.function.BiFunction;
 /** LoadBalanceScanWorkerSelector */
 public class LoadBalanceScanWorkerSelector implements ScanWorkerSelector {
     private final DistributedPlanWorkerManager workerManager;
+    private final ConnectContext context;
+    private final boolean useLoadBackendSelection;
     private final Map<DistributedPlanWorker, WorkerWorkload> workloads = Maps.newLinkedHashMap();
 
-    public LoadBalanceScanWorkerSelector(DistributedPlanWorkerManager workerManager) {
+    public LoadBalanceScanWorkerSelector(DistributedPlanWorkerManager workerManager,
+            ConnectContext context, boolean useLoadBackendSelection) {
         this.workerManager = workerManager;
+        this.context = context;
+        this.useLoadBackendSelection = useLoadBackendSelection;
     }
 
     @Override
@@ -101,6 +111,7 @@ public class LoadBalanceScanWorkerSelector implements ScanWorkerSelector {
 
             WorkerScanRanges assigned = selectScanReplicaAndMinWorkloadWorker(
                     onePartitionOneScanRangeLocation, bytes, orderedScanRangeLocations, scanNode.getCatalogId());
+            recordQuerySelection(scanNode, assigned.worker.id());
             UninstancedScanSource scanRanges = workerScanRanges.computeIfAbsent(
                     assigned.worker,
                     w -> new UninstancedScanSource(
@@ -243,6 +254,12 @@ public class LoadBalanceScanWorkerSelector implements ScanWorkerSelector {
     private WorkerScanRanges selectScanReplicaAndMinWorkloadWorker(
             TScanRangeLocations tabletLocation, long tabletBytes, boolean orderedScanRangeLocations, long catalogId) {
         List<TScanRangeLocation> replicaLocations = tabletLocation.getLocations();
+        if (orderedScanRangeLocations) {
+            replicaLocations = Lists.newArrayList(replicaLocations);
+            Collections.sort(replicaLocations);
+        }
+        replicaLocations = orderLoadReplicas(replicaLocations, catalogId);
+
         if (replicaLocations.size() == 1) {
             TScanRangeLocation replicaLocation = replicaLocations.get(0);
             DistributedPlanWorker worker = workerManager.getWorker(catalogId, replicaLocation.getBackendId());
@@ -254,18 +271,36 @@ public class LoadBalanceScanWorkerSelector implements ScanWorkerSelector {
             return new WorkerScanRanges(worker, scanRanges);
         }
 
-        if (orderedScanRangeLocations) {
-            replicaLocations = Lists.newArrayList(replicaLocations);
-            Collections.sort(replicaLocations);
+        BackendSelection.CandidateSelection<TScanRangeLocation> selection =
+                partitionPreferredReplicas(replicaLocations, catalogId);
+        if (selection != null && !selection.getPreferredCandidates().isEmpty()) {
+            WorkerScanRanges selected = selectMinWorkloadWorkerInTier(
+                    tabletLocation, tabletBytes, selection.getPreferredCandidates(), catalogId);
+            if (selected != null) {
+                return selected;
+            }
+            selected = selectMinWorkloadWorkerInTier(
+                    tabletLocation, tabletBytes, selection.getFallbackCandidates(), catalogId);
+            if (selected != null) {
+                return selected;
+            }
+        } else {
+            WorkerScanRanges selected = selectMinWorkloadWorkerInTier(
+                    tabletLocation, tabletBytes, replicaLocations, catalogId);
+            if (selected != null) {
+                return selected;
+            }
         }
+        throw new AnalysisException("No available workers");
+    }
 
-        int replicaNum = replicaLocations.size();
+    private WorkerScanRanges selectMinWorkloadWorkerInTier(TScanRangeLocations tabletLocation, long tabletBytes,
+            List<TScanRangeLocation> replicaLocations, long catalogId) {
         WorkerWorkload minWorkload = new WorkerWorkload(Integer.MAX_VALUE, Long.MAX_VALUE);
         DistributedPlanWorker minWorkLoadWorker = null;
         TScanRangeLocation selectedReplicaLocation = null;
 
-        for (int i = 0; i < replicaNum; i++) {
-            TScanRangeLocation replicaLocation = replicaLocations.get(i);
+        for (TScanRangeLocation replicaLocation : replicaLocations) {
             DistributedPlanWorker worker = workerManager.getWorker(catalogId, replicaLocation.getBackendId());
             if (!worker.available()) {
                 continue;
@@ -279,15 +314,82 @@ public class LoadBalanceScanWorkerSelector implements ScanWorkerSelector {
             }
         }
         if (minWorkLoadWorker == null) {
-            throw new AnalysisException("No available workers");
-        } else {
-            minWorkload.recordOneScanTask(tabletBytes);
-            ScanRanges scanRanges = new ScanRanges();
-            TScanRangeParams scanReplicaParams =
-                    ScanWorkerSelector.buildScanReplicaParams(tabletLocation, selectedReplicaLocation);
-            scanRanges.addScanRange(scanReplicaParams, tabletBytes);
-            return new WorkerScanRanges(minWorkLoadWorker, scanRanges);
+            return null;
         }
+        minWorkload.recordOneScanTask(tabletBytes);
+        ScanRanges scanRanges = new ScanRanges();
+        TScanRangeParams scanReplicaParams =
+                ScanWorkerSelector.buildScanReplicaParams(tabletLocation, selectedReplicaLocation);
+        scanRanges.addScanRange(scanReplicaParams, tabletBytes);
+        return new WorkerScanRanges(minWorkLoadWorker, scanRanges);
+    }
+
+    private BackendSelection.CandidateSelection<TScanRangeLocation> partitionPreferredReplicas(
+            List<TScanRangeLocation> replicaLocations, long catalogId) {
+        try {
+            if (useLoadBackendSelection) {
+                BackendSelection.SelectionHint hint = BackendSelectionManager.resolveLoadSelectionHint(context);
+                List<Backend> candidates = Lists.newArrayListWithCapacity(replicaLocations.size());
+                for (TScanRangeLocation location : replicaLocations) {
+                    candidates.add(((BackendWorker) workerManager.getWorker(catalogId, location.getBackendId()))
+                            .getBackend());
+                }
+                BackendSelection.CandidateSelection<Backend> selection =
+                        BackendSelectionManager.partitionPreferredLoadCandidates(hint, candidates);
+                if (selection == null) {
+                    return null;
+                }
+                Map<Long, TScanRangeLocation> locationsByBackendId = Maps.newHashMap();
+                for (TScanRangeLocation location : replicaLocations) {
+                    locationsByBackendId.put(location.getBackendId(), location);
+                }
+                return new BackendSelection.CandidateSelection<>(
+                        toLocations(selection.getPreferredCandidates(), locationsByBackendId),
+                        toLocations(selection.getFallbackCandidates(), locationsByBackendId));
+            }
+            if (context == null) {
+                return null;
+            }
+            BackendSelection.SelectionHint hint = context.getQueryBackendSelectionDecision();
+            return BackendSelectionManager.partitionPreferredQueryCandidates(
+                    hint, replicaLocations, location -> ((BackendWorker) workerManager.getWorker(
+                            catalogId, location.getBackendId())).getBackend().getLocationTag());
+        } catch (UserException e) {
+            throw new AnalysisException(e.getMessage(), e);
+        }
+    }
+
+    private List<TScanRangeLocation> toLocations(List<Backend> backends,
+            Map<Long, TScanRangeLocation> locationsByBackendId) {
+        List<TScanRangeLocation> locations = Lists.newArrayListWithCapacity(backends.size());
+        for (Backend backend : backends) {
+            locations.add(locationsByBackendId.get(backend.getId()));
+        }
+        return locations;
+    }
+
+    List<TScanRangeLocation> orderLoadReplicas(List<TScanRangeLocation> locations, long catalogId) {
+        if (!useLoadBackendSelection || Config.isCloudMode()
+                || !BackendSelectionManager.hasLoadSelectionPreference(context)) {
+            return locations;
+        }
+        Map<Long, TScanRangeLocation> locationByBackendId = Maps.newHashMap();
+        List<Backend> candidates = Lists.newArrayList();
+        for (TScanRangeLocation location : locations) {
+            BackendWorker worker = (BackendWorker) workerManager.getWorker(catalogId, location.getBackendId());
+            Backend backend = worker.getBackend();
+            candidates.add(backend);
+            locationByBackendId.put(backend.getId(), location);
+        }
+        List<TScanRangeLocation> orderedLocations = Lists.newArrayList();
+        try {
+            for (Backend backend : BackendSelectionManager.orderLoadCandidates(context, candidates)) {
+                orderedLocations.add(locationByBackendId.get(backend.getId()));
+            }
+        } catch (UserException e) {
+            throw new AnalysisException(e.getMessage(), e);
+        }
+        return orderedLocations;
     }
 
     private List<Pair<TScanRangeParams, Long>> filterReplicaByWorkerInBucket(
@@ -305,6 +407,7 @@ public class LoadBalanceScanWorkerSelector implements ScanWorkerSelector {
                                 onePartitionOneTabletLocation, replicaLocation);
                         Long replicaSize = ((OlapScanNode) scanNode).getTabletSingleReplicaSize(tabletId);
                         selectedReplicasInOneBucket.add(Pair.of(scanReplicaParams, replicaSize));
+                        recordQuerySelection(scanNode, replicaLocation.getBackendId());
                         foundTabletInThisWorker = true;
                         break;
                     }
@@ -324,6 +427,21 @@ public class LoadBalanceScanWorkerSelector implements ScanWorkerSelector {
             }
         }
         return selectedReplicasInOneBucket;
+    }
+
+    private void recordQuerySelection(ScanNode scanNode, long backendId) {
+        if (!(scanNode instanceof OlapScanNode) || context == null) {
+            return;
+        }
+        DistributedPlanWorker worker = workerManager.getWorker(scanNode.getCatalogId(), backendId);
+        if (!(worker instanceof BackendWorker)) {
+            return;
+        }
+        Backend backend = ((BackendWorker) worker).getBackend();
+        BackendSelection.SelectionHint hint = context.getQueryBackendSelectionDecision();
+        BackendSelection.QuerySelectionResult result = BackendSelectionManager.classifyQuerySelection(
+                hint, Collections.singletonList(backend), Backend::getLocationTag);
+        context.getBackendSelectionProfile().recordQuerySelection(hint, result);
     }
 
     private Map<Integer, Long> computeEachBucketScanBytes(

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/FileLoadScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/FileLoadScanNode.java
@@ -27,13 +27,18 @@ import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.nereids.load.NereidsFileGroupInfo;
 import org.apache.doris.nereids.load.NereidsLoadPlanInfoCollector;
 import org.apache.doris.nereids.load.NereidsParamCreateContext;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.statistics.StatisticalType;
+import org.apache.doris.system.Backend;
 import org.apache.doris.system.BeSelectionPolicy;
 import org.apache.doris.thrift.TBrokerFileStatus;
 import org.apache.doris.thrift.TFileScanRangeParams;
 import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Map;
@@ -80,6 +85,7 @@ public class FileLoadScanNode extends FileScanNode {
                 .build();
         FederationBackendPolicy localBackendPolicy = new FederationBackendPolicy();
         localBackendPolicy.init(policy);
+        applyLoadBackendSelection(ConnectContext.get(), localBackendPolicy);
         for (int i = 0; i < contexts.size(); ++i) {
             NereidsParamCreateContext context = contexts.get(i);
             NereidsFileGroupInfo fileGroupInfo = fileGroupInfos.get(i);
@@ -99,6 +105,19 @@ public class FileLoadScanNode extends FileScanNode {
             for (TBrokerFileStatus fileStatus : fileGroupInfo.getFileStatuses()) {
                 this.totalFileSize += fileStatus.getSize();
             }
+        }
+    }
+
+    static void applyLoadBackendSelection(ConnectContext context, FederationBackendPolicy backendPolicy)
+            throws UserException {
+        List<Backend> orderedBackends = BackendSelectionManager.orderLoadCandidates(
+                context, ImmutableList.copyOf(backendPolicy.getBackends()));
+        backendPolicy.replaceBackendOrder(orderedBackends);
+        BackendSelection.SelectionHint hint = BackendSelectionManager.resolveLoadSelectionHint(context);
+        if (context != null
+                && BackendSelectionManager.hasLoadSelectionPreference(hint)
+                && !orderedBackends.isEmpty()) {
+            context.getBackendSelectionProfile().recordLoadCoordinator(hint, orderedBackends.get(0));
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -62,6 +62,9 @@ import org.apache.doris.nereids.trees.plans.ScoreRangeInfo;
 import org.apache.doris.planner.normalize.Normalizer;
 import org.apache.doris.planner.normalize.PartitionRangePredicateNormalizer;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.BackendSelectionManager;
+import org.apache.doris.resource.Tag;
 import org.apache.doris.resource.computegroup.ComputeGroup;
 import org.apache.doris.statistics.StatisticalType;
 import org.apache.doris.system.Backend;
@@ -105,6 +108,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 // Full scan of an Olap table.
@@ -211,6 +215,11 @@ public class OlapScanNode extends ScanNode {
     private final PartitionPruneV2ForShortCircuitPlan cachedPartitionPruner =
                         new PartitionPruneV2ForShortCircuitPlan();
 
+    private BackendSelection.SelectionHint selectionHint;
+    private boolean scanBackendOrderBySelection = false;
+    private long querySelectionPreferredHitTablets;
+    private long querySelectionFallbackTablets;
+
     private boolean isTopnLazyMaterialize = false;
     private List<Column> topnLazyMaterializeOutputColumns = new ArrayList<>();
 
@@ -242,8 +251,12 @@ public class OlapScanNode extends ScanNode {
         return isPreAggregation;
     }
 
-    public HashSet<Long> getScanBackendIds() {
+    public Set<Long> getScanBackendIds() {
         return scanBackendIds;
+    }
+
+    public boolean isScanBackendOrderBySelection() {
+        return scanBackendOrderBySelection;
     }
 
     public void setSampleTabletIds(List<Long> sampleTablets) {
@@ -505,6 +518,13 @@ public class OlapScanNode extends ScanNode {
         boolean isInvalidComputeGroup = ComputeGroup.INVALID_COMPUTE_GROUP.equals(computeGroup);
         boolean isNotCloudComputeGroup = computeGroup != null && !Config.isCloudMode();
 
+        if (context != null && !Config.isCloudMode() && selectionHint == null) {
+            selectionHint = context.getQueryBackendSelectionDecision();
+        }
+        if (context != null && !Config.isCloudMode() && (skipMissingVersion || useFixReplica >= 0)) {
+            validateRequiredQuerySelection(skipMissingVersion, useFixReplica, selectionHint);
+        }
+
         ImmutableMap<Long, Backend> allBackends = olapTable.getAllBackendsByAllCluster();
         long partitionVisibleVersion = visibleVersion;
         String partitionVisibleVersionStr = fastToString(visibleVersion);
@@ -543,8 +563,9 @@ public class OlapScanNode extends ScanNode {
             //
             // ATTN: visibleVersion is not used in cloud mode, see CloudReplica.checkVersionCatchup
             // for details.
-            List<Replica> replicas = tablet.getQueryableReplicas(
-                    visibleVersion, backendAlivePathHashs, skipMissingVersion);
+            List<Replica> replicas = BackendSelectionManager.isRequiredSelection(selectionHint)
+                    ? tablet.getQueryableReplicas(visibleVersion, backendAlivePathHashs, skipMissingVersion, false)
+                    : tablet.getQueryableReplicas(visibleVersion, backendAlivePathHashs, skipMissingVersion);
             locations.setLocations(new ArrayList<>(replicas.size()));
             paloRange.setHosts(new ArrayList<>(replicas.size()));
             if (replicas.isEmpty()) {
@@ -563,12 +584,26 @@ public class OlapScanNode extends ScanNode {
                 throw new UserException(sb.toString());
             }
 
+            boolean querySelectionEvaluated = false;
             if (useFixReplica <= -1) {
                 if (skipMissingVersion) {
-                    // sort by replica's last success version, higher success version in the front.
-                    replicas.sort(Replica.LAST_SUCCESS_VERSION_COMPARATOR);
-                } else if (replicas.size() > 1) {
-                    Collections.shuffle(replicas);
+                    List<Replica> orderedReplicas = orderReplicasForQuerySelection(
+                            true, replicas, selectionHint,
+                            replica -> getReplicaLocationTag(replica, allBackends));
+                    querySelectionEvaluated = !Config.isCloudMode();
+                    if (orderedReplicas != replicas) {
+                        replicas = new ArrayList<>(orderedReplicas);
+                        scanBackendOrderBySelection = true;
+                    }
+                } else {
+                    List<Replica> orderedReplicas = orderReplicasForQuerySelection(
+                            false, replicas, selectionHint,
+                            replica -> getReplicaLocationTag(replica, allBackends));
+                    querySelectionEvaluated = shouldApplyQuerySelection(false);
+                    if (orderedReplicas != replicas) {
+                        replicas = new ArrayList<>(orderedReplicas);
+                        scanBackendOrderBySelection = true;
+                    }
                 }
             } else {
                 if (LOG.isDebugEnabled()) {
@@ -616,17 +651,16 @@ public class OlapScanNode extends ScanNode {
                 // third time we choose BE C, after this time all replica is cached
                 // but it means we will do 3 S3 IO to get the data which will bring 3 slow query
                 if (-1L != coolDownReplicaId) {
-                    final Optional<Replica> replicaOptional = replicas.stream()
+                    Optional<Replica> replicaOptional = replicas.stream()
                             .filter(r -> r.getId() == coolDownReplicaId).findAny();
-                    replicaOptional.ifPresent(
-                            r -> {
-                                Backend backend = allBackends.get(r.getBackendIdWithoutException());
-                                if (backend != null && backend.isAlive()) {
-                                    replicas.clear();
-                                    replicas.add(r);
-                                }
-                            }
-                    );
+                    if (replicaOptional.isPresent()) {
+                        Replica replica = replicaOptional.get();
+                        Backend backend = allBackends.get(replica.getBackendIdWithoutException());
+                        if (backend != null && backend.isAlive()) {
+                            replicas.clear();
+                            replicas.add(replica);
+                        }
+                    }
                 }
             }
 
@@ -672,7 +706,8 @@ public class OlapScanNode extends ScanNode {
                     continue;
                 }
                 String beTagName = backend.getLocationTag().value;
-                if (isInvalidComputeGroup || (isNotCloudComputeGroup && !computeGroup.containsBackend(beTagName))) {
+                if (shouldFilterReplicaByResourceTag(isInvalidComputeGroup, isNotCloudComputeGroup,
+                        computeGroup, beTagName)) {
                     String err = String.format(
                             "Replica on backend %d with tag %s," + " which is not in user's resource tag: %s",
                             backend.getId(), beTagName, computeGroup.toString());
@@ -717,6 +752,11 @@ public class OlapScanNode extends ScanNode {
                 throw new UserException("tablet " + tabletId + " has no queryable replicas. err: "
                         + Joiner.on(", ").join(errs));
             }
+            if (querySelectionEvaluated) {
+                recordQuerySelectionResult(selectionHint, BackendSelectionManager.classifyQuerySelection(
+                        selectionHint, locations.getLocations(),
+                        location -> allBackends.get(location.getBackendId()).getLocationTag()));
+            }
             TScanRange scanRange = new TScanRange();
             scanRange.setPaloScanRange(paloRange);
             locations.setScanRange(scanRange);
@@ -740,6 +780,12 @@ public class OlapScanNode extends ScanNode {
             version /= 10;
         }
         return new String(chars, index + 1, 23 - index);
+    }
+
+    private Tag getReplicaLocationTag(Replica replica, ImmutableMap<Long, Backend> allBackends) {
+        long backendId = replica.getBackendIdWithoutException();
+        Backend backend = allBackends.get(backendId);
+        return backend == null ? null : backend.getLocationTag();
     }
 
     private boolean isEnableCooldownReplicaAffinity(ConnectContext connectContext) {
@@ -781,6 +827,8 @@ public class OlapScanNode extends ScanNode {
     @Override
     protected void createScanRangeLocations() throws UserException {
         scanRangeLocations = Lists.newArrayList();
+        querySelectionPreferredHitTablets = 0;
+        querySelectionFallbackTablets = 0;
         if (selectedPartitionIds.isEmpty()) {
             return;
         }
@@ -997,6 +1045,8 @@ public class OlapScanNode extends ScanNode {
         computeColumnsFilter(olapTable.getBaseSchemaKeyColumns(), olapTable.getPartitionInfo());
         computePartitionInfo();
         scanBackendIds.clear();
+        selectionHint = null;
+        scanBackendOrderBySelection = false;
         scanTabletIds.clear();
         bucketSeq2locations.clear();
         scanReplicaIds.clear();
@@ -1007,6 +1057,85 @@ public class OlapScanNode extends ScanNode {
             throw new UserException(e.getMessage());
         }
         return scanRangeLocations;
+    }
+
+    @VisibleForTesting
+    static boolean shouldFilterReplicaByResourceTag(boolean isInvalidComputeGroup, boolean isNotCloudComputeGroup,
+            ComputeGroup computeGroup, String beTagName) {
+        return isInvalidComputeGroup
+                || (Config.enable_resource_tag_location_check
+                        && isNotCloudComputeGroup && !computeGroup.containsBackend(beTagName));
+    }
+
+    @VisibleForTesting
+    static boolean shouldApplyQuerySelection(boolean skipMissingVersion) {
+        return !Config.isCloudMode() && !skipMissingVersion;
+    }
+
+    @VisibleForTesting
+    static List<Replica> orderReplicasForQuerySelection(boolean skipMissingVersion, List<Replica> replicas,
+            BackendSelection.SelectionHint hint, Function<Replica, Tag> tagOf)
+            throws UserException {
+        if (skipMissingVersion) {
+            // Sort by replica's last success version, higher success version in the front.
+            replicas.sort(Replica.LAST_SUCCESS_VERSION_COMPARATOR);
+            if (!Config.isCloudMode()) {
+                return BackendSelectionManager.orderQueryCandidatesWithinTies(
+                        hint, replicas, Replica.LAST_SUCCESS_VERSION_COMPARATOR, tagOf);
+            }
+            return replicas;
+        }
+        if (replicas.size() > 1) {
+            Collections.shuffle(replicas);
+        }
+        if (shouldApplyQuerySelection(false)) {
+            return BackendSelectionManager.orderQueryCandidates(hint, replicas, tagOf);
+        }
+        return replicas;
+    }
+
+    @VisibleForTesting
+    static void validateRequiredQuerySelection(boolean skipMissingVersion, int useFixReplica,
+            BackendSelection.SelectionHint hint) throws UserException {
+        if (!BackendSelectionManager.isRequiredSelection(hint)) {
+            return;
+        }
+        if (skipMissingVersion) {
+            throw new UserException("Required backend selection is incompatible with skip_missing_version");
+        }
+        if (useFixReplica >= 0) {
+            throw new UserException("Required backend selection is incompatible with use_fix_replica");
+        }
+    }
+
+    @VisibleForTesting
+    void recordQuerySelectionResult(BackendSelection.SelectionHint hint,
+            BackendSelection.QuerySelectionResult result) {
+        switch (result) {
+            case PREFERRED_HIT:
+                selectionHint = hint;
+                querySelectionPreferredHitTablets++;
+                break;
+            case FALLBACK_PREFERRED_UNAVAILABLE:
+                selectionHint = hint;
+                querySelectionFallbackTablets++;
+                break;
+            case DISABLED:
+                break;
+            default:
+                throw new IllegalStateException("Unknown query selection result: " + result);
+        }
+    }
+
+    @VisibleForTesting
+    String getQuerySelectionExplain(String prefix) {
+        if (querySelectionPreferredHitTablets == 0 && querySelectionFallbackTablets == 0) {
+            return "";
+        }
+        return prefix + "QUERY BACKEND SELECTION: preferred=" + selectionHint.getPreferredKey()
+                + ", mode=" + selectionHint.getMode()
+                + ", preferred_available_tablets=" + querySelectionPreferredHitTablets
+                + ", fallback_preferred_unavailable_tablets=" + querySelectionFallbackTablets + "\n";
     }
 
     @Override
@@ -1038,6 +1167,7 @@ public class OlapScanNode extends ScanNode {
             output.append(", PREAGGREGATION: OFF. Reason: ").append(reasonOfPreAggregation);
         }
         output.append("\n");
+        output.append(getQuerySelectionExplain(prefix));
 
         if (sortColumn != null) {
             output.append(prefix).append("SORT COLUMN: ").append(sortColumn).append("\n");

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -58,6 +58,8 @@ import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.DebugPointUtil.DebugPoint;
 import org.apache.doris.nereids.trees.plans.commands.insert.OlapInsertCommandContext;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.system.Backend;
 import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TColumn;
@@ -363,6 +365,7 @@ public class OlapTableSink extends DataSink {
         }
         strBuilder.append(prefix + "  TUPLE ID: " + tupleDescriptor.getId() + "\n");
         strBuilder.append(prefix + "  " + DataPartition.RANDOM.getExplainString(explainLevel));
+        appendSinkSelectionExplain(strBuilder, prefix);
         boolean isPartialUpdate = uniqueKeyUpdateMode != TUniqueKeyUpdateMode.UPSERT;
         strBuilder.append(prefix + "  IS_PARTIAL_UPDATE: " + isPartialUpdate);
         if (isPartialUpdate) {
@@ -375,6 +378,17 @@ public class OlapTableSink extends DataSink {
             strBuilder.append("\n" + prefix + "  PARTIAL_UPDATE_NEW_KEY_BEHAVIOR: " + partialUpdateNewKeyPolicy);
         }
         return strBuilder.toString();
+    }
+
+    private void appendSinkSelectionExplain(StringBuilder strBuilder, String prefix) {
+        BackendSelection.SelectionHint decision =
+                BackendSelectionManager.resolveLoadSelectionHint(ConnectContext.get());
+        if (decision == null) {
+            return;
+        }
+        strBuilder.append(prefix).append("  sink backend selection: preferred=").append(decision.getPreferredKey())
+                .append(", mode=").append(decision.getMode())
+                .append(", source=").append(decision.getReason()).append("\n");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/ScanNode.java
@@ -72,6 +72,7 @@ import org.apache.logging.log4j.Logger;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -111,9 +112,9 @@ public abstract class ScanNode extends PlanNode implements SplitGenerator {
     protected List<Column> columns;
 
     // Save the id of backends which this scan node will be executed on.
-    // This is also important for local shuffle logic.
+    // Iteration order is part of the semantics for point-query and selection-sensitive consumers.
     // Now only OlapScanNode and FileQueryScanNode implement this.
-    protected HashSet<Long> scanBackendIds = new HashSet<>();
+    protected Set<Long> scanBackendIds = new LinkedHashSet<>();
     // Immutable scan context used for evolving scan-related metadata.
     protected final ScanContext scanContext;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/AuditLogHelper.java
@@ -46,6 +46,7 @@ import org.apache.doris.plugin.AuditEvent;
 import org.apache.doris.plugin.AuditEvent.AuditEventBuilder;
 import org.apache.doris.plugin.AuditEvent.EventType;
 import org.apache.doris.qe.QueryState.MysqlStateType;
+import org.apache.doris.resource.BackendSelection;
 import org.apache.doris.resource.workloadgroup.QueueToken;
 import org.apache.doris.service.FrontendOptions;
 
@@ -194,7 +195,15 @@ public class AuditLogHelper {
         } catch (ComputeGroupException e) {
             LOG.warn("Failed to get cloud cluster", e);
         }
-        String cluster = Config.isCloudMode() ? cloudCluster : "";
+        // Load statements resolve their own hint at the scheduling sites and record it on the
+        // context; prefer it over the scan-side query decision so load audits are accurate.
+        BackendSelection.SelectionHint selectionHint = ctx.getLoadBackendSelectionDecisionForAudit();
+        if (selectionHint == null) {
+            selectionHint = ctx.getQueryBackendSelectionDecisionForAudit();
+        }
+        // In cloud mode, compute_group keeps its existing cloud compute group meaning. In integrated
+        // mode, resource groups provide compute affinity, so reuse compute_group for the preferred group.
+        String cluster = Config.isCloudMode() ? cloudCluster : selectionHint.getPreferredKey();
         String stmtType = getStmtType(parsedStmt);
 
         AuditEventBuilder auditEventBuilder = ctx.getAuditEventBuilder();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -66,6 +66,9 @@ import org.apache.doris.nereids.util.MoreFieldsThread;
 import org.apache.doris.plsql.Exec;
 import org.apache.doris.plsql.executor.PlSqlOperation;
 import org.apache.doris.plugin.AuditEvent.AuditEventBuilder;
+import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.BackendSelectionManager;
+import org.apache.doris.resource.BackendSelectionProfile;
 import org.apache.doris.resource.Tag;
 import org.apache.doris.resource.computegroup.ComputeGroup;
 import org.apache.doris.resource.computegroup.ComputeGroupMgr;
@@ -231,6 +234,7 @@ public class ConnectContext {
 
     // The FE ip current connected
     private String currentConnectedFEIp = "";
+    private transient String connectingFeLocalResourceGroup = "";
 
     private InsertResult insertResult;
 
@@ -246,6 +250,13 @@ public class ConnectContext {
 
     private String workloadGroupName = "";
     private boolean isGroupCommit;
+    private BackendSelection.SelectionHint queryBackendSelectionDecision;
+    private BackendSelection.SelectionHint loadBackendSelectionDecision;
+    // A replayed async load owns this hint independently of the statement lifecycle. The
+    // statement-level decision is reset by setStartTime(), but the persisted load intent must
+    // remain available while the load planner is being rebuilt.
+    private BackendSelection.SelectionHint loadBackendSelectionHint;
+    private final BackendSelectionProfile backendSelectionProfile = new BackendSelectionProfile();
 
     private TResultSinkType resultSinkType = TResultSinkType.MYSQL_PROTOCOL;
 
@@ -772,6 +783,51 @@ public class ConnectContext {
     public void setStartTime() {
         startTime = System.currentTimeMillis();
         returnRows = 0;
+        queryBackendSelectionDecision = null;
+        loadBackendSelectionDecision = null;
+        backendSelectionProfile.reset();
+    }
+
+    public BackendSelection.SelectionHint getQueryBackendSelectionDecision() {
+        if (queryBackendSelectionDecision == null) {
+            queryBackendSelectionDecision = BackendSelectionManager.getQuerySelectionHint(this);
+        }
+        return queryBackendSelectionDecision;
+    }
+
+    // Audit runs for every statement type, so it must not create a query selection hint.
+    public BackendSelection.SelectionHint getQueryBackendSelectionDecisionForAudit() {
+        return queryBackendSelectionDecision == null
+                ? BackendSelection.SelectionHint.noSelection()
+                : queryBackendSelectionDecision;
+    }
+
+    // Load hints are resolved at several scheduling sites (sink, coordinator, group commit);
+    // each records the statement-level hint here so the audit reflects the load decision
+    // instead of the scan-side query decision.
+    public void recordLoadBackendSelectionDecision(BackendSelection.SelectionHint hint) {
+        loadBackendSelectionDecision = hint;
+    }
+
+    public void recordLoadBackendSelectionHint(BackendSelection.SelectionHint hint) {
+        loadBackendSelectionHint = hint;
+    }
+
+    public BackendSelection.SelectionHint getLoadBackendSelectionHint() {
+        return loadBackendSelectionHint;
+    }
+
+    public BackendSelection.SelectionHint getLoadBackendSelectionDecision() {
+        return loadBackendSelectionDecision;
+    }
+
+    public BackendSelection.SelectionHint getLoadBackendSelectionDecisionForAudit() {
+        return loadBackendSelectionDecision != null
+                ? loadBackendSelectionDecision : loadBackendSelectionHint;
+    }
+
+    public BackendSelectionProfile getBackendSelectionProfile() {
+        return backendSelectionProfile;
     }
 
     public void updateReturnRows(int returnRows) {
@@ -932,6 +988,8 @@ public class ConnectContext {
     public void clear() {
         executor = null;
         statementContext = null;
+        loadBackendSelectionDecision = null;
+        loadBackendSelectionHint = null;
     }
 
     public PlSqlOperation getPlSqlOperation() {
@@ -1269,6 +1327,14 @@ public class ConnectContext {
 
     public String getCurrentConnectedFEIp() {
         return currentConnectedFEIp;
+    }
+
+    public void setConnectingFeLocalResourceGroup(String connectingFeLocalResourceGroup) {
+        this.connectingFeLocalResourceGroup = Strings.nullToEmpty(connectingFeLocalResourceGroup);
+    }
+
+    public String getConnectingFeLocalResourceGroup() {
+        return connectingFeLocalResourceGroup;
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -58,6 +58,7 @@ import org.apache.doris.planner.IntersectNode;
 import org.apache.doris.planner.MultiCastDataSink;
 import org.apache.doris.planner.MultiCastPlanFragment;
 import org.apache.doris.planner.OlapScanNode;
+import org.apache.doris.planner.OlapTableSink;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.PlanFragmentId;
 import org.apache.doris.planner.PlanNode;
@@ -79,6 +80,8 @@ import org.apache.doris.proto.Types;
 import org.apache.doris.proto.Types.PUniqueId;
 import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.qe.QueryStatisticsItem.FragmentInstanceInfo;
+import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.resource.workloadgroup.QueryQueue;
 import org.apache.doris.resource.workloadgroup.QueueToken;
 import org.apache.doris.resource.workloadgroup.WorkloadGroup;
@@ -129,6 +132,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -1814,9 +1818,9 @@ public class Coordinator implements CoordInterface {
                     // can be executed on any BE. addressToBackendID can be empty when this is a constant
                     // select stmt like:
                     //      SELECT  @@session.auto_increment_increment AS auto_increment_increment;
-                    execHostport = SimpleScheduler.getHostByCurrentBackend(addressToBackendID);
+                    execHostport = chooseHostByCurrentBackendSelection(addressToBackendID);
                 } else {
-                    execHostport = SimpleScheduler.getHost(this.idToBackend, backendIdRef);
+                    execHostport = chooseHostWithSelection(this.idToBackend, backendIdRef);
                 }
                 if (execHostport == null) {
                     LOG.warn("DataPartition UNPARTITIONED, no scanNode Backend available");
@@ -2000,9 +2004,9 @@ public class Coordinator implements CoordInterface {
                     // of the query can be executed on any BE. addressToBackendID can be empty when this is a constant
                     // select stmt like:
                     //      SELECT  @@session.auto_increment_increment AS auto_increment_increment;
-                    execHostport = SimpleScheduler.getHostByCurrentBackend(addressToBackendID);
+                    execHostport = chooseHostByCurrentBackendSelection(addressToBackendID);
                 } else {
-                    execHostport = SimpleScheduler.getHost(this.idToBackend, backendIdRef);
+                    execHostport = chooseHostWithSelection(this.idToBackend, backendIdRef);
                 }
                 if (execHostport == null) {
                     throw new UserException(SystemInfoService.NO_SCAN_NODE_BACKEND_AVAILABLE_MSG);
@@ -2015,6 +2019,7 @@ public class Coordinator implements CoordInterface {
                 params.instanceExecParams.add(instanceParam);
             }
         }
+        recordLoadSinkCoordinator();
     }
 
     private int findMaxParallelFragmentIndex(PlanFragment fragment) {
@@ -2046,6 +2051,102 @@ public class Coordinator implements CoordInterface {
                 groupCommitBackend.getBePort());
         addressToBackendID.put(execHostport, groupCommitBackend.getId());
         return execHostport;
+    }
+
+    private boolean isLoadSelectionCoordinator() {
+        return queryOptions != null && queryOptions.getQueryType() == TQueryType.LOAD
+                && BackendSelectionManager.isLoadSelectionEnabled(context);
+    }
+
+    private BackendSelection.SelectionHint resolveLoadSelectionHint() {
+        return BackendSelectionManager.resolveLoadSelectionHint(context);
+    }
+
+    private TNetworkAddress chooseHostWithSelection(ImmutableMap<Long, Backend> backends, Reference<Long> backendIdRef)
+            throws UserException {
+        if (!isLoadSelectionCoordinator()) {
+            return SimpleScheduler.getHost(backends, backendIdRef);
+        }
+        BackendSelection.SelectionHint decision = resolveLoadSelectionHint();
+        if (!BackendSelectionManager.hasLoadSelectionPreference(decision)) {
+            return SimpleScheduler.getHost(backends, backendIdRef);
+        }
+        List<Backend> orderedBackends = BackendSelectionManager.orderLoadCandidates(
+                decision, ImmutableList.copyOf(backends.values()));
+        TNetworkAddress address = firstAvailableLoadBackend(orderedBackends, backendIdRef);
+        if (address == null) {
+            BackendSelectionManager.ensureRequiredSelectionSatisfied(decision, false);
+            address = SimpleScheduler.getHost(backends, backendIdRef);
+        }
+        recordLoadCoordinator(decision, backendIdRef.getRef());
+        return address;
+    }
+
+    private TNetworkAddress chooseHostByCurrentBackendSelection(Map<TNetworkAddress, Long> addressToBackendID)
+            throws UserException {
+        if (!isLoadSelectionCoordinator()) {
+            return SimpleScheduler.getHostByCurrentBackend(addressToBackendID);
+        }
+        ImmutableList.Builder<Backend> candidateBuilder = ImmutableList.builder();
+        for (Long backendId : addressToBackendID.values()) {
+            Backend backend = idToBackend.get(backendId);
+            if (backend != null) {
+                candidateBuilder.add(backend);
+            }
+        }
+        BackendSelection.SelectionHint decision = resolveLoadSelectionHint();
+        if (!BackendSelectionManager.hasLoadSelectionPreference(decision)) {
+            return SimpleScheduler.getHostByCurrentBackend(addressToBackendID);
+        }
+        Reference<Long> backendIdRef = new Reference<>();
+        List<Backend> orderedBackends = BackendSelectionManager.orderLoadCandidates(decision, candidateBuilder.build());
+        TNetworkAddress address = firstAvailableLoadBackend(orderedBackends, backendIdRef);
+        if (address == null) {
+            BackendSelectionManager.ensureRequiredSelectionSatisfied(decision, false);
+            address = SimpleScheduler.getHostByCurrentBackend(addressToBackendID);
+            backendIdRef.setRef(addressToBackendID.get(address));
+        }
+        recordLoadCoordinator(decision, backendIdRef.getRef());
+        return address;
+    }
+
+    private void recordLoadCoordinator(BackendSelection.SelectionHint decision, Long backendId) {
+        if (context == null || backendId == null) {
+            return;
+        }
+        context.getBackendSelectionProfile().recordLoadCoordinator(decision, idToBackend.get(backendId));
+    }
+
+    private void recordLoadSinkCoordinator() {
+        if (!isLoadSelectionCoordinator()) {
+            return;
+        }
+        BackendSelection.SelectionHint decision = resolveLoadSelectionHint();
+        if (!BackendSelectionManager.hasLoadSelectionPreference(decision)) {
+            return;
+        }
+        for (PlanFragment fragment : fragments) {
+            if (!(fragment.getSink() instanceof OlapTableSink)) {
+                continue;
+            }
+            FragmentExecParams params = fragmentExecParamsMap.get(fragment.getFragmentId());
+            if (params == null || params.instanceExecParams.isEmpty()) {
+                continue;
+            }
+            Long backendId = addressToBackendID.get(params.instanceExecParams.get(0).host);
+            recordLoadCoordinator(decision, backendId);
+            return;
+        }
+    }
+
+    private TNetworkAddress firstAvailableLoadBackend(List<Backend> orderedBackends, Reference<Long> backendIdRef) {
+        for (Backend backend : orderedBackends) {
+            if (SimpleScheduler.isAvailable(backend)) {
+                backendIdRef.setRef(backend.getId());
+                return new TNetworkAddress(backend.getHost(), backend.getBePort());
+            }
+        }
+        return null;
     }
 
     // Traverse the expected runtimeFilterID in each fragment, and establish the corresponding relationship
@@ -2223,10 +2324,12 @@ public class Coordinator implements CoordInterface {
             // A fragment may contain both colocate join and bucket shuffle join
             // on need both compute scanRange to init basic data for query coordinator
             if (fragmentContainsColocateJoin) {
+                // Query selection already orders OlapScanNode replica locations before bucket assignment.
                 computeScanRangeAssignmentByColocate((OlapScanNode) scanNode, assignedBytesPerHost,
                         replicaNumPerHost, isEnableOrderedLocations);
             }
             if (fragmentContainsBucketShuffleJoin) {
+                // Keep bucket co-location intact; use the replica order produced by OlapScanNode as the hint.
                 bucketShuffleJoinController.computeScanRangeAssignmentByBucket((OlapScanNode) scanNode,
                         idToBackend, addressToBackendID, replicaNumPerHost);
             }
@@ -2315,34 +2418,110 @@ public class Coordinator implements CoordInterface {
                                                          Map<TNetworkAddress, Long> replicaNumPerHost,
                                                          Reference<Long> backendIdRef,
                                                          boolean isEnableOrderedLocations) throws UserException {
+        return selectBackendsByRoundRobin(seqLocation, assignedBytesPerHost, replicaNumPerHost, backendIdRef,
+                isEnableOrderedLocations, false);
+    }
+
+    private TScanRangeLocation selectBackendsByRoundRobin(TScanRangeLocations seqLocation,
+                                                         Map<TNetworkAddress, Long> assignedBytesPerHost,
+                                                         Map<TNetworkAddress, Long> replicaNumPerHost,
+                                                         Reference<Long> backendIdRef,
+                                                         boolean isEnableOrderedLocations,
+                                                         boolean enableBackendSelection) throws UserException {
         List<TScanRangeLocation> locations = seqLocation.getLocations();
         if (isEnableOrderedLocations) {
             Collections.sort(locations);
         }
+        locations = applyBackendSelection(locations, enableBackendSelection);
+        TScanRangeLocation selectedLocation;
         if (!Config.enable_local_replica_selection) {
-            return selectBackendsByRoundRobin(locations, assignedBytesPerHost, replicaNumPerHost,
+            selectedLocation = selectBackendsByRoundRobin(locations, assignedBytesPerHost, replicaNumPerHost,
                     backendIdRef);
-        }
+        } else {
+            List<TScanRangeLocation> localLocations = new ArrayList<>();
+            List<TScanRangeLocation> nonlocalLocations = new ArrayList<>();
+            long localBeId = Env.getCurrentSystemInfo().getBackendIdByHost(FrontendOptions.getLocalHostAddress());
+            for (final TScanRangeLocation location : locations) {
+                if (location.backend_id == localBeId) {
+                    localLocations.add(location);
+                } else {
+                    nonlocalLocations.add(location);
+                }
+            }
 
-        List<TScanRangeLocation> localLocations = new ArrayList<>();
-        List<TScanRangeLocation> nonlocalLocations = new ArrayList<>();
-        long localBeId = Env.getCurrentSystemInfo().getBackendIdByHost(FrontendOptions.getLocalHostAddress());
-        for (final TScanRangeLocation location : locations) {
-            if (location.backend_id == localBeId) {
-                localLocations.add(location);
-            } else {
-                nonlocalLocations.add(location);
+            try {
+                selectedLocation = selectBackendsByRoundRobin(
+                        localLocations, assignedBytesPerHost, replicaNumPerHost, backendIdRef);
+            } catch (UserException ue) {
+                if (!Config.enable_local_replica_selection_fallback) {
+                    throw ue;
+                }
+                selectedLocation = selectBackendsByRoundRobin(
+                        nonlocalLocations, assignedBytesPerHost, replicaNumPerHost, backendIdRef);
             }
         }
+        recordQueryBackendSelection(enableBackendSelection, selectedLocation);
+        return selectedLocation;
+    }
 
-        try {
-            return selectBackendsByRoundRobin(localLocations, assignedBytesPerHost, replicaNumPerHost, backendIdRef);
-        } catch (UserException ue) {
-            if (!Config.enable_local_replica_selection_fallback) {
-                throw ue;
-            }
-            return selectBackendsByRoundRobin(nonlocalLocations, assignedBytesPerHost, replicaNumPerHost, backendIdRef);
+    private List<TScanRangeLocation> applyBackendSelection(List<TScanRangeLocation> locations,
+            boolean enableBackendSelection) throws UserException {
+        if (!enableBackendSelection || Config.isCloudMode()) {
+            return locations;
         }
+        BackendSelection.SelectionHint decision = getQueryBackendSelectionDecision();
+        BackendSelection.CandidateSelection<TScanRangeLocation> preferredSelection =
+                BackendSelectionManager.partitionPreferredQueryCandidates(decision, locations,
+                        location -> {
+                            Backend backend = idToBackend.get(location.backend_id);
+                            return backend == null ? null : backend.getLocationTag();
+                        });
+        if (preferredSelection != null) {
+            List<TScanRangeLocation> preferredCandidates = preferredSelection.getPreferredCandidates();
+            if (preferredCandidates.isEmpty()) {
+                return preferredSelection.getFallbackCandidates();
+            }
+            if (decision.getMode() == BackendSelection.Mode.PREFER
+                    && !hasAvailableQueryBackend(preferredCandidates)
+                    && !preferredSelection.getFallbackCandidates().isEmpty()) {
+                return preferredSelection.getFallbackCandidates();
+            }
+            return preferredCandidates;
+        }
+        return BackendSelectionManager.orderQueryCandidates(decision, locations,
+                location -> {
+                    Backend backend = idToBackend.get(location.backend_id);
+                    return backend == null ? null : backend.getLocationTag();
+                });
+    }
+
+    private boolean hasAvailableQueryBackend(List<TScanRangeLocation> locations) {
+        for (TScanRangeLocation location : locations) {
+            if (SimpleScheduler.isAvailable(idToBackend.get(location.backend_id))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private BackendSelection.SelectionHint getQueryBackendSelectionDecision() {
+        if (context != null) {
+            return context.getQueryBackendSelectionDecision();
+        }
+        return BackendSelection.SelectionHint.noSelection();
+    }
+
+    private void recordQueryBackendSelection(boolean enableBackendSelection, TScanRangeLocation selectedLocation) {
+        if (!enableBackendSelection || context == null || selectedLocation == null) {
+            return;
+        }
+        BackendSelection.SelectionHint decision = getQueryBackendSelectionDecision();
+        BackendSelection.QuerySelectionResult result = BackendSelectionManager.classifyQuerySelection(
+                decision, Collections.singletonList(selectedLocation), location -> {
+                    Backend backend = idToBackend.get(location.getBackendId());
+                    return backend == null ? null : backend.getLocationTag();
+                });
+        context.getBackendSelectionProfile().recordQuerySelection(decision, result);
     }
 
     public TScanRangeLocation selectBackendsByRoundRobin(List<TScanRangeLocation> sortedLocations,
@@ -2387,7 +2566,8 @@ public class Coordinator implements CoordInterface {
         for (TScanRangeLocations scanRangeLocations : locations) {
             Reference<Long> backendIdRef = new Reference<Long>();
             TScanRangeLocation minLocation = selectBackendsByRoundRobin(scanRangeLocations,
-                    assignedBytesPerHost, replicaNumPerHost, backendIdRef, isEnableOrderedLocations);
+                    assignedBytesPerHost, replicaNumPerHost, backendIdRef, isEnableOrderedLocations,
+                    scanNode instanceof OlapScanNode);
             Backend backend = this.idToBackend.get(backendIdRef.getRef());
             TNetworkAddress execHostPort = new TNetworkAddress(backend.getHost(), backend.getBePort());
             this.addressToBackendID.put(execHostPort, backendIdRef.getRef());
@@ -3521,4 +3701,3 @@ public class Coordinator implements CoordInterface {
         this.queryOptions.setEnableProfile(isSafe && queryOptions.isEnableProfile());
     }
 }
-

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/FEOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/FEOpExecutor.java
@@ -164,6 +164,7 @@ public class FEOpExecutor {
         // node ident
         params.setClientNodeHost(Env.getCurrentEnv().getSelfNode().getHost());
         params.setClientNodePort(Env.getCurrentEnv().getSelfNode().getPort());
+        params.setConnectingFeLocalResourceGroup(Config.local_resource_group);
         params.setSql(originStmt.originStmt);
         params.setStmtIdx(originStmt.idx);
         params.setUser(ctx.getQualifiedUser());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -20,8 +20,12 @@ package org.apache.doris.qe;
 import org.apache.doris.analysis.RedirectStatus;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.LoadException;
+import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.thrift.TGroupCommitInfo;
 import org.apache.doris.thrift.TMasterOpRequest;
+import org.apache.doris.thrift.TMasterOpResult;
 import org.apache.doris.thrift.TNetworkAddress;
 
 import org.apache.logging.log4j.LogManager;
@@ -77,8 +81,20 @@ public class MasterOpExecutor extends FEOpExecutor {
 
     public long getGroupCommitLoadBeId(long tableId, String cluster) throws Exception {
         result = forward(buildGetGroupCommitLoadBeIdParmas(tableId, cluster));
-        waitOnReplaying();
+        if (result.isSetStatusCode() && result.getStatusCode() != 0) {
+            throw new LoadException(getForwardResultErrorMessage(result));
+        }
+        if (result.isSetErrMessage()) {
+            throw new LoadException(result.getErrMessage());
+        }
         return result.groupCommitLoadBeId;
+    }
+
+    private static String getForwardResultErrorMessage(TMasterOpResult result) {
+        if (result.isSetErrMessage() && result.getErrMessage() != null && !result.getErrMessage().isEmpty()) {
+            return result.getErrMessage();
+        }
+        return "failed to select backend for group commit, status code: " + result.getStatusCode();
     }
 
     public void updateLoadData(long tableId, long receiveData) throws Exception {
@@ -104,7 +120,18 @@ public class MasterOpExecutor extends FEOpExecutor {
         groupCommitParams.setGetGroupCommitLoadBeId(true);
         groupCommitParams.setGroupCommitLoadTableId(tableId);
         groupCommitParams.setCluster(cluster);
+        groupCommitParams.setSupportsSelectionErrorResult(true);
+        setGroupCommitLoadSelectionHint(groupCommitParams, ctx);
         return getMasterOpRequestForGroupCommit(groupCommitParams);
+    }
+
+    static void setGroupCommitLoadSelectionHint(TGroupCommitInfo groupCommitParams, ConnectContext context) {
+        BackendSelection.SelectionHint decision = BackendSelectionManager.resolveLoadSelectionHint(context);
+        if (decision == null) {
+            return;
+        }
+        groupCommitParams.setLoadSelectionPreferredKey(decision.getPreferredKey());
+        groupCommitParams.setLoadSelectionMode(decision.getMode().name());
     }
 
     private TMasterOpRequest buildUpdateLoadDataParams(long tableId, long receiveData) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
@@ -35,6 +35,7 @@ import org.apache.doris.nereids.trees.plans.distribute.worker.DistributedPlanWor
 import org.apache.doris.nereids.trees.plans.distribute.worker.job.AssignedJob;
 import org.apache.doris.nereids.util.Utils;
 import org.apache.doris.planner.DataSink;
+import org.apache.doris.planner.OlapTableSink;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.ResultFileSink;
 import org.apache.doris.planner.ResultSink;
@@ -49,6 +50,8 @@ import org.apache.doris.qe.runtime.PipelineExecutionTaskBuilder;
 import org.apache.doris.qe.runtime.QueryProcessor;
 import org.apache.doris.qe.runtime.SingleFragmentPipelineTask;
 import org.apache.doris.qe.runtime.ThriftPlansBuilder;
+import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.resource.workloadgroup.QueryQueue;
 import org.apache.doris.resource.workloadgroup.QueueToken;
 import org.apache.doris.resource.workloadgroup.WorkloadGroup;
@@ -456,8 +459,29 @@ public class NereidsCoordinator extends Coordinator {
 
     protected void processTopSink(
             CoordinatorContext coordinatorContext, PipelineDistributedPlan topPlan) throws AnalysisException {
+        recordLoadSinkCoordinator(coordinatorContext, topPlan);
         setForArrowFlight(coordinatorContext, topPlan);
         setForBroker(coordinatorContext, topPlan);
+    }
+
+    private void recordLoadSinkCoordinator(
+            CoordinatorContext coordinatorContext, PipelineDistributedPlan topPlan) {
+        ConnectContext connectContext = coordinatorContext.connectContext;
+        if (!(coordinatorContext.dataSink instanceof OlapTableSink)
+                || coordinatorContext.queryOptions.getQueryType() != TQueryType.LOAD
+                || !BackendSelectionManager.isLoadSelectionEnabled(connectContext)
+                || topPlan.getInstanceJobs().isEmpty()) {
+            return;
+        }
+        BackendSelection.SelectionHint hint = BackendSelectionManager.resolveLoadSelectionHint(connectContext);
+        if (!BackendSelectionManager.hasLoadSelectionPreference(hint)) {
+            return;
+        }
+        DistributedPlanWorker worker = topPlan.getInstanceJobs().get(0).getAssignedWorker();
+        if (worker instanceof BackendWorker) {
+            connectContext.getBackendSelectionProfile().recordLoadCoordinator(
+                    hint, ((BackendWorker) worker).getBackend());
+        }
     }
 
     private void setForArrowFlight(CoordinatorContext coordinatorContext, PipelineDistributedPlan topPlan) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/PointQueryExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/PointQueryExecutor.java
@@ -130,11 +130,16 @@ public class PointQueryExecutor implements CoordInterface {
                 candidateBackends.add(backend);
             }
         }
-        // Random read replicas
-        Collections.shuffle(this.candidateBackends);
+        if (shouldShuffleCandidateBackends(scanNode)) {
+            Collections.shuffle(candidateBackends);
+        }
         if (LOG.isDebugEnabled()) {
             LOG.debug("set scan locations, backend ids {}, tablet id {}", candidateBackends, tabletID);
         }
+    }
+
+    static boolean shouldShuffleCandidateBackends(OlapScanNode scanNode) {
+        return !scanNode.isScanBackendOrderBySelection();
     }
 
     // execute query without analyze & plan

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -24,6 +24,8 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.cloud.qe.ComputeGroupException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.common.FeNameFormat;
+import org.apache.doris.common.FeNameFormat;
 import org.apache.doris.common.VariableAnnotation;
 import org.apache.doris.common.io.Text;
 import org.apache.doris.common.io.Writable;
@@ -38,6 +40,7 @@ import org.apache.doris.nereids.rules.RuleType;
 import org.apache.doris.nereids.rules.expression.ExpressionRuleType;
 import org.apache.doris.planner.GroupCommitBlockSink;
 import org.apache.doris.qe.VariableMgr.VarAttr;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.thrift.TGroupCommitMode;
 import org.apache.doris.thrift.TPartialUpdateNewRowPolicy;
 import org.apache.doris.thrift.TQueryOptions;
@@ -109,6 +112,9 @@ public class SessionVariable implements Serializable, Writable {
     public static final String SQL_MODE = "sql_mode";
     public static final String WORKLOAD_VARIABLE = "workload_group";
     public static final String RESOURCE_VARIABLE = "resource_group";
+    public static final String PREFERRED_BACKEND_SELECTION_KEY = "preferred_backend_selection_key";
+    public static final String BACKEND_SELECTION_MODE = "backend_selection_mode";
+    public static final String ENABLE_LOAD_BACKEND_SELECTION = "enable_load_backend_selection";
     public static final String AUTO_COMMIT = "autocommit";
     public static final String TX_ISOLATION = "tx_isolation";
     public static final String TX_READ_ONLY = "tx_read_only";
@@ -1129,6 +1135,26 @@ public class SessionVariable implements Serializable, Writable {
 
     @VariableMgr.VarAttr(name = RESOURCE_VARIABLE)
     public String resourceGroup = "";
+
+    @VariableMgr.VarAttr(name = PREFERRED_BACKEND_SELECTION_KEY, needForward = true,
+            checker = "checkPreferredBackendSelectionKey",
+            description = "The preferred backend selection key for the current session. The default empty string "
+                    + "means no selection preference is provided.")
+    public String preferredBackendSelectionKey = "";
+
+    @VariableMgr.VarAttr(name = BACKEND_SELECTION_MODE, needForward = true,
+            checker = "checkBackendSelectionMode",
+            setter = "setBackendSelectionMode",
+            options = {"prefer", "require", "default"},
+            description = "Backend selection mode for optional policies. The default policy is a no-op and does "
+                    + "not change replica or backend selection behavior. `require` is available only when the "
+                    + "extension declares support. Supported values are `prefer`, `require`, and `default`.")
+    public String backendSelectionMode = "prefer";
+
+    @VariableMgr.VarAttr(name = ENABLE_LOAD_BACKEND_SELECTION, needForward = true,
+            description = "Whether optional backend selection policies may participate in load scheduling. "
+                    + "The default policy is a no-op and does not change load behavior.")
+    public boolean enableLoadBackendSelection = false;
 
     // this is used to make mysql client happy
     // autocommit is actually a boolean value, but @@autocommit is type of BIGINT.
@@ -3954,8 +3980,61 @@ public class SessionVariable implements Serializable, Writable {
         return resourceGroup;
     }
 
+    public String getPreferredBackendSelectionKey() {
+        return preferredBackendSelectionKey;
+    }
+
+    public String getBackendSelectionMode() {
+        return backendSelectionMode;
+    }
+
+    public boolean isEnableLoadBackendSelection() {
+        return enableLoadBackendSelection;
+    }
+
     public void setResourceGroup(String resourceGroup) {
         this.resourceGroup = resourceGroup;
+    }
+
+    public void checkPreferredBackendSelectionKey(String preferredBackendSelectionKey) {
+        if (Strings.isNullOrEmpty(preferredBackendSelectionKey)) {
+            return;
+        }
+        try {
+            FeNameFormat.checkCommonName(PREFERRED_BACKEND_SELECTION_KEY, preferredBackendSelectionKey);
+        } catch (Exception e) {
+            LOG.warn("preferred_backend_selection_key value is invalid, the invalid value is {}",
+                    preferredBackendSelectionKey, e);
+            throw new UnsupportedOperationException(
+                    "preferred_backend_selection_key value is invalid, the invalid value is "
+                            + preferredBackendSelectionKey);
+        }
+    }
+
+    public void checkBackendSelectionMode(String backendSelectionMode) {
+        String normalized = Strings.nullToEmpty(backendSelectionMode).toLowerCase(Locale.ROOT);
+        if (!"prefer".equals(normalized)
+                && !"require".equals(normalized)
+                && !"default".equals(normalized)) {
+            LOG.warn("backend_selection_mode value is invalid, the invalid value is {}",
+                    backendSelectionMode);
+            throw new UnsupportedOperationException(
+                    "backend_selection_mode value is invalid, the invalid value is "
+                            + backendSelectionMode
+                            + ", supported values are prefer, require and default");
+        }
+        if ("require".equals(normalized) && Config.isCloudMode()) {
+            throw new UnsupportedOperationException(
+                    "Required backend selection is not supported in cloud mode");
+        }
+        if ("require".equals(normalized) && !BackendSelectionManager.supportsRequiredSelection()) {
+            throw new UnsupportedOperationException(
+                    "Backend selection provider does not support required backend selection");
+        }
+    }
+
+    public void setBackendSelectionMode(String backendSelectionMode) {
+        this.backendSelectionMode = Strings.nullToEmpty(backendSelectionMode).toLowerCase(Locale.ROOT);
     }
 
     public boolean isDisableFileCache() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -335,6 +335,14 @@ public class StmtExecutor {
         builder.defaultCatalog(context.getCurrentCatalog().getName());
         builder.defaultDb(context.getDatabase());
         builder.workloadGroup(context.getWorkloadGroupName());
+        String queryBackendSelection = context.getBackendSelectionProfile().getQuerySummary();
+        if (queryBackendSelection != null) {
+            builder.queryBackendSelection(queryBackendSelection);
+        }
+        String loadBackendSelection = context.getBackendSelectionProfile().getLoadSummary();
+        if (loadBackendSelection != null) {
+            builder.loadBackendSelection(loadBackendSelection);
+        }
         builder.sqlStatement(originStmt == null ? "" : originStmt.originStmt);
         builder.isCached(isCached ? "Yes" : "No");
 

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/BackendSelection.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/BackendSelection.java
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.resource;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public final class BackendSelection {
+    public enum Mode {
+        PREFER,
+        REQUIRE,
+        DEFAULT
+    }
+
+    /** Outcome of query backend selection for one scan candidate set. */
+    public enum QuerySelectionResult {
+        DISABLED,
+        PREFERRED_HIT,
+        FALLBACK_PREFERRED_UNAVAILABLE
+    }
+
+    /** Provider partition used by the kernel to enforce required backend selection. */
+    public static final class CandidateSelection<T> {
+        private final List<T> preferredCandidates;
+        private final List<T> fallbackCandidates;
+
+        public CandidateSelection(List<T> preferredCandidates, List<T> fallbackCandidates) {
+            this.preferredCandidates = preferredCandidates;
+            this.fallbackCandidates = fallbackCandidates;
+        }
+
+        public List<T> getPreferredCandidates() {
+            return preferredCandidates;
+        }
+
+        public List<T> getFallbackCandidates() {
+            return fallbackCandidates;
+        }
+    }
+
+    public static final class SelectionHint {
+        @SerializedName("k")
+        private final String preferredKey;
+        @SerializedName("m")
+        private final Mode mode;
+        @SerializedName("r")
+        private final String reason;
+
+        public SelectionHint(String preferredKey, Mode mode, String reason) {
+            this.preferredKey = preferredKey == null ? "" : preferredKey;
+            this.mode = mode == null ? Mode.DEFAULT : mode;
+            this.reason = reason == null ? "" : reason;
+        }
+
+        public static SelectionHint noSelection() {
+            return new SelectionHint("", Mode.DEFAULT, "no_preferred");
+        }
+
+        public String getPreferredKey() {
+            return preferredKey == null ? "" : preferredKey;
+        }
+
+        public Mode getMode() {
+            return mode == null ? Mode.DEFAULT : mode;
+        }
+
+        public String getReason() {
+            return reason == null ? "" : reason;
+        }
+    }
+
+    private BackendSelection() {
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/BackendSelectionManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/BackendSelectionManager.java
@@ -1,0 +1,440 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.resource;
+
+import org.apache.doris.catalog.Replica;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.LoadException;
+import org.apache.doris.common.UserException;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.resource.spi.BackendSelectionProvider;
+import org.apache.doris.system.Backend;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.ServiceLoader;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/** Kernel facade and provider lifecycle manager for optional backend selection. */
+public final class BackendSelectionManager {
+    private static final Logger LOG = LogManager.getLogger(BackendSelectionManager.class);
+
+    private static final BackendSelectionProvider DEFAULT_PROVIDER = new BackendSelectionProvider() {
+    };
+
+    private static volatile BackendSelectionProvider provider;
+
+    private static BackendSelectionProvider provider() {
+        BackendSelectionProvider current = provider;
+        if (current == null) {
+            synchronized (BackendSelectionManager.class) {
+                current = provider;
+                if (current == null) {
+                    current = loadProvider(BackendSelectionManager.class.getClassLoader());
+                    provider = current;
+                }
+            }
+        }
+        return current;
+    }
+
+    @VisibleForTesting
+    static BackendSelectionProvider loadProvider(ClassLoader classLoader) {
+        ServiceLoader<BackendSelectionProvider> loader =
+                ServiceLoader.load(BackendSelectionProvider.class, classLoader);
+        Iterator<BackendSelectionProvider> it = loader.iterator();
+        if (it.hasNext()) {
+            BackendSelectionProvider loadedProvider = it.next();
+            if (it.hasNext()) {
+                BackendSelectionProvider duplicateProvider = it.next();
+                throw new IllegalStateException("Multiple BackendSelectionProvider implementations found: "
+                        + loadedProvider.getClass().getName() + ", "
+                        + duplicateProvider.getClass().getName());
+            }
+            LOG.info("Loaded BackendSelectionProvider implementation: {}",
+                    loadedProvider.getClass().getName());
+            return loadedProvider;
+        }
+        LOG.info("No BackendSelectionProvider implementation found, using no-op backend selection provider");
+        return DEFAULT_PROVIDER;
+    }
+
+    @VisibleForTesting
+    public static synchronized void setProviderForTest(BackendSelectionProvider testProvider) {
+        provider = Objects.requireNonNull(testProvider, "testProvider must not be null");
+    }
+
+    @VisibleForTesting
+    public static synchronized void resetProviderForTest() {
+        provider = null;
+    }
+
+    public static boolean supportsRequiredSelection() {
+        return provider().supportsRequiredSelection();
+    }
+
+    public static BackendSelection.SelectionHint getQuerySelectionHint(ConnectContext context) {
+        return provider().getQuerySelectionHint(context);
+    }
+
+    public static BackendSelection.SelectionHint getForwardedLoadSelectionHint(String preferredKey, String mode) {
+        return provider().getForwardedLoadSelectionHint(preferredKey, mode);
+    }
+
+    public static boolean isRepairSourceSelectionEnabled() {
+        return provider().isRepairSourceSelectionEnabled();
+    }
+
+    public static BackendSelectionProvider.RepairSourceSelectionResult classifyRepairSource(
+            long chosenSrcBackendId, long destBackendId, List<Replica> allReplicas, List<Replica> healthyCandidates) {
+        return provider().classifyRepairSource(
+                chosenSrcBackendId, destBackendId, allReplicas, healthyCandidates);
+    }
+
+    public static boolean isLoadSelectionEnabled(ConnectContext context) {
+        if (Config.isCloudMode() || context == null) {
+            return false;
+        }
+        return context.getLoadBackendSelectionDecision() != null
+                || context.getLoadBackendSelectionHint() != null
+                || provider().isLoadSelectionEnabled(context);
+    }
+
+    public static BackendSelection.SelectionHint resolveLoadSelectionHint(ConnectContext context) {
+        if (Config.isCloudMode() || context == null) {
+            return null;
+        }
+        BackendSelection.SelectionHint recorded = context.getLoadBackendSelectionDecision();
+        if (recorded != null) {
+            return recorded;
+        }
+        BackendSelection.SelectionHint persisted = context.getLoadBackendSelectionHint();
+        if (persisted != null) {
+            context.recordLoadBackendSelectionDecision(persisted);
+            return persisted;
+        }
+        BackendSelectionProvider policy = provider();
+        if (!policy.isLoadSelectionEnabled(context)) {
+            return null;
+        }
+        BackendSelection.SelectionHint hint = policy.getLoadSelectionHint(context);
+        context.recordLoadBackendSelectionDecision(hint);
+        return hint;
+    }
+
+    /** Capture the resolved load selection intent before an asynchronous load loses its session context. */
+    public static BackendSelection.SelectionHint captureLoadSelection(ConnectContext context) {
+        return resolveLoadSelectionHint(context);
+    }
+
+    /** Restore a previously captured load selection intent into the execution context. */
+    public static void restoreLoadSelection(ConnectContext context, BackendSelection.SelectionHint hint) {
+        context.recordLoadBackendSelectionHint(hint);
+        context.recordLoadBackendSelectionDecision(hint);
+    }
+
+    public static boolean hasLoadSelectionPreference(ConnectContext context) {
+        if (Config.isCloudMode()) {
+            return false;
+        }
+        return hasLoadSelectionPreference(resolveLoadSelectionHint(context));
+    }
+
+    public static boolean hasLoadSelectionPreference(BackendSelection.SelectionHint hint) {
+        return !Config.isCloudMode() && hint != null
+                && (isRequiredSelection(hint)
+                        || provider().hasLoadSelectionPreference(hint));
+    }
+
+    /** Apply an optional load policy while preserving the caller's candidate and availability semantics. */
+    public static List<Backend> orderLoadCandidates(ConnectContext context, List<Backend> candidates)
+            throws UserException {
+        if (Config.isCloudMode()) {
+            return candidates;
+        }
+        BackendSelection.SelectionHint hint = resolveLoadSelectionHint(context);
+        BackendSelectionProvider policy = provider();
+        if (isRequiredSelection(hint)) {
+            return requiredLoadCandidates(policy, hint, candidates);
+        }
+        if (hint == null || !policy.hasLoadSelectionPreference(hint)) {
+            return candidates;
+        }
+        List<Backend> orderedCandidates = policy.orderLoadCandidates(hint, candidates);
+        validateOrderedCandidates("orderLoadCandidates", candidates, orderedCandidates);
+        return orderedCandidates;
+    }
+
+    public static List<Backend> orderLoadCandidates(BackendSelection.SelectionHint hint, List<Backend> candidates)
+            throws UserException {
+        BackendSelectionProvider policy = provider();
+        if (isRequiredSelection(hint)) {
+            return requiredLoadCandidates(policy, hint, candidates);
+        }
+        if (hint == null || !policy.hasLoadSelectionPreference(hint)) {
+            return candidates;
+        }
+        List<Backend> orderedCandidates = policy.orderLoadCandidates(hint, candidates);
+        validateOrderedCandidates("orderLoadCandidates", candidates, orderedCandidates);
+        return orderedCandidates;
+    }
+
+    /** Apply preferred load selection as availability-aware candidate tiers. */
+    public static BackendSelection.CandidateSelection<Backend> partitionPreferredLoadCandidates(
+            BackendSelection.SelectionHint hint, List<Backend> candidates) throws UserException {
+        BackendSelectionProvider policy = provider();
+        if (hint == null || hint.getMode() != BackendSelection.Mode.PREFER
+                || !policy.hasLoadSelectionPreference(hint)) {
+            return null;
+        }
+        BackendSelection.CandidateSelection<Backend> selection =
+                policy.partitionPreferredLoadCandidates(hint, candidates);
+        if (selection == null || selection.getPreferredCandidates() == null
+                || selection.getFallbackCandidates() == null) {
+            return null;
+        }
+        validateCandidatePartition("partitionPreferredLoadCandidates", candidates, selection);
+        return selection;
+    }
+
+    /** Apply query ordering while requiring the provider to preserve the exact candidate instances. */
+    public static <T> List<T> orderQueryCandidates(BackendSelection.SelectionHint hint, List<T> candidates,
+            Function<T, Tag> locationKey) throws UserException {
+        BackendSelectionProvider policy = provider();
+        if (isRequiredSelection(hint)) {
+            BackendSelection.CandidateSelection<T> selection =
+                    policy.partitionRequiredQueryCandidates(hint, candidates, locationKey);
+            return requiredCandidates("partitionRequiredQueryCandidates", hint, candidates, selection);
+        }
+        if (!policy.hasQuerySelectionPreference(hint)) {
+            return candidates;
+        }
+        List<T> orderedCandidates = policy.orderQueryCandidates(hint, candidates, locationKey);
+        validateOrderedCandidates("orderQueryCandidates", candidates, orderedCandidates);
+        return orderedCandidates;
+    }
+
+    /** Apply strict preferred query selection when the provider supports candidate partitioning. */
+    public static <T> BackendSelection.CandidateSelection<T> partitionPreferredQueryCandidates(
+            BackendSelection.SelectionHint hint, List<T> candidates, Function<T, Tag> locationKey)
+            throws UserException {
+        BackendSelectionProvider policy = provider();
+        if (hint == null || hint.getMode() != BackendSelection.Mode.PREFER
+                || !policy.hasQuerySelectionPreference(hint)) {
+            return null;
+        }
+        BackendSelection.CandidateSelection<T> selection =
+                policy.partitionPreferredQueryCandidates(hint, candidates, locationKey);
+        if (selection == null || selection.getPreferredCandidates() == null
+                || selection.getFallbackCandidates() == null) {
+            return null;
+        }
+        validateCandidatePartition("partitionPreferredQueryCandidates", candidates, selection);
+        return selection;
+    }
+
+    /**
+     * Apply query selection independently within each contiguous tie group while preserving group order.
+     * The input candidates must already be sorted by {@code tieComparator}, and candidates with the same
+     * priority must be contiguous. The provider must preserve every candidate instance in each group.
+     * Required selection is applied globally because it is a hard filter.
+     */
+    public static <T> List<T> orderQueryCandidatesWithinTies(BackendSelection.SelectionHint hint,
+            List<T> candidates, Comparator<T> tieComparator, Function<T, Tag> tagOf) throws UserException {
+        BackendSelectionProvider policy = provider();
+        if (isRequiredSelection(hint)) {
+            BackendSelection.CandidateSelection<T> selection =
+                    policy.partitionRequiredQueryCandidates(hint, candidates, tagOf);
+            return requiredCandidates("partitionRequiredQueryCandidates", hint, candidates, selection);
+        }
+        if (!policy.hasQuerySelectionPreference(hint) || candidates.size() < 2) {
+            return candidates;
+        }
+
+        List<T> result = new ArrayList<>(candidates.size());
+        boolean changed = false;
+        int start = 0;
+        while (start < candidates.size()) {
+            int end = start + 1;
+            while (end < candidates.size()
+                    && tieComparator.compare(candidates.get(start), candidates.get(end)) == 0) {
+                end++;
+            }
+
+            List<T> originalGroup = new ArrayList<>(candidates.subList(start, end));
+            List<T> providerInput = new ArrayList<>(originalGroup);
+            List<T> ordered = policy.orderQueryCandidates(hint, providerInput, tagOf);
+            validateOrderedCandidates("orderQueryCandidatesWithinTies", originalGroup, ordered);
+            for (int i = 0; i < originalGroup.size(); i++) {
+                if (ordered.get(i) != originalGroup.get(i)) {
+                    changed = true;
+                    break;
+                }
+            }
+            result.addAll(ordered);
+            start = end;
+        }
+        return changed ? result : candidates;
+    }
+
+    /** Classify the query selection outcome after the kernel has applied its candidate filters. */
+    public static <T> BackendSelection.QuerySelectionResult classifyQuerySelection(
+            BackendSelection.SelectionHint hint, List<T> candidates, Function<T, Tag> locationKey) {
+        if (isRequiredSelection(hint)) {
+            return BackendSelection.QuerySelectionResult.PREFERRED_HIT;
+        }
+        BackendSelectionProvider policy = provider();
+        if (hint == null || !policy.hasQuerySelectionPreference(hint)) {
+            return BackendSelection.QuerySelectionResult.DISABLED;
+        }
+        return policy.classifyQuerySelection(hint, candidates, locationKey);
+    }
+
+    /** Apply repair-source ordering while requiring the provider to preserve the exact replicas. */
+    public static List<Replica> orderRepairSourceCandidates(List<Replica> candidates, long destBackendId)
+            throws UserException {
+        List<Replica> orderedCandidates = provider()
+                .orderRepairSourceCandidates(candidates, destBackendId);
+        validateOrderedCandidates("orderRepairSourceCandidates", candidates, orderedCandidates);
+        return orderedCandidates;
+    }
+
+    public static Backend chooseLoadBackend(ConnectContext context, List<Backend> candidates)
+            throws LoadException {
+        if (context == null) {
+            return chooseFirstAvailable(candidates, Backend::isLoadAvailable);
+        }
+        List<Backend> orderedCandidates;
+        try {
+            orderedCandidates = orderLoadCandidates(context, candidates);
+        } catch (UserException e) {
+            throw new LoadException(e.getMessage(), e);
+        }
+        return chooseFirstAvailable(orderedCandidates, Backend::isLoadAvailable);
+    }
+
+    public static Backend chooseFirstPreferredLoadBackend(ConnectContext context, List<Backend> candidates,
+            Predicate<Backend> available) throws UserException {
+        if (!hasLoadSelectionPreference(context)) {
+            return null;
+        }
+        BackendSelection.SelectionHint hint = resolveLoadSelectionHint(context);
+        Backend selected = chooseFirstAvailable(orderLoadCandidates(hint, candidates), available);
+        ensureRequiredSelectionSatisfied(hint, selected != null);
+        return selected;
+    }
+
+    public static boolean isRequiredSelection(BackendSelection.SelectionHint hint) {
+        return hint != null && hint.getMode() == BackendSelection.Mode.REQUIRE;
+    }
+
+    public static void ensureRequiredSelectionSatisfied(BackendSelection.SelectionHint hint, boolean satisfied)
+            throws UserException {
+        if (isRequiredSelection(hint) && !satisfied) {
+            throw new UserException("No available candidate satisfies required backend selection key '"
+                    + hint.getPreferredKey() + "'");
+        }
+    }
+
+    private static Backend chooseFirstAvailable(List<Backend> candidates, Predicate<Backend> available) {
+        for (Backend backend : candidates) {
+            if (available.test(backend)) {
+                return backend;
+            }
+        }
+        return null;
+    }
+
+    private static List<Backend> requiredLoadCandidates(BackendSelectionProvider policy,
+            BackendSelection.SelectionHint hint, List<Backend> candidates) throws UserException {
+        BackendSelection.CandidateSelection<Backend> selection =
+                policy.partitionRequiredLoadCandidates(hint, candidates);
+        return requiredCandidates("partitionRequiredLoadCandidates", hint, candidates, selection);
+    }
+
+    private static <T> List<T> requiredCandidates(String method, BackendSelection.SelectionHint hint,
+            List<T> candidates, BackendSelection.CandidateSelection<T> selection) throws UserException {
+        if (selection == null || selection.getPreferredCandidates() == null
+                || selection.getFallbackCandidates() == null) {
+            throw invalidCandidatePartition(method);
+        }
+        List<T> partitionedCandidates = new ArrayList<>(selection.getPreferredCandidates().size()
+                + selection.getFallbackCandidates().size());
+        partitionedCandidates.addAll(selection.getPreferredCandidates());
+        partitionedCandidates.addAll(selection.getFallbackCandidates());
+        validateOrderedCandidates(method, candidates, partitionedCandidates);
+        if (selection.getPreferredCandidates().isEmpty()) {
+            throw new UserException("No candidate satisfies required backend selection key '"
+                    + hint.getPreferredKey() + "'");
+        }
+        return new ArrayList<>(selection.getPreferredCandidates());
+    }
+
+    private static <T> void validateCandidatePartition(String method, List<T> candidates,
+            BackendSelection.CandidateSelection<T> selection) throws UserException {
+        List<T> partitionedCandidates = new ArrayList<>(selection.getPreferredCandidates().size()
+                + selection.getFallbackCandidates().size());
+        partitionedCandidates.addAll(selection.getPreferredCandidates());
+        partitionedCandidates.addAll(selection.getFallbackCandidates());
+        validateOrderedCandidates(method, candidates, partitionedCandidates);
+    }
+
+    private static <T> void validateOrderedCandidates(String method, List<T> candidates, List<T> orderedCandidates)
+            throws UserException {
+        if (orderedCandidates == null || orderedCandidates.size() != candidates.size()) {
+            throw invalidCandidateOrder(method);
+        }
+        Map<T, Integer> remainingCandidates = new IdentityHashMap<>();
+        for (T candidate : candidates) {
+            remainingCandidates.merge(candidate, 1, Integer::sum);
+        }
+        for (T candidate : orderedCandidates) {
+            Integer remaining = remainingCandidates.get(candidate);
+            if (remaining == null || remaining == 0) {
+                throw invalidCandidateOrder(method);
+            }
+            remainingCandidates.put(candidate, remaining - 1);
+        }
+    }
+
+    private static UserException invalidCandidateOrder(String method) {
+        if (method.startsWith("partitionRequired")) {
+            return invalidCandidatePartition(method);
+        }
+        return new UserException("BackendSelectionProvider." + method
+                + " must preserve all candidates using the original instances");
+    }
+
+    private static UserException invalidCandidatePartition(String method) {
+        return new UserException("BackendSelectionProvider." + method
+                + " must partition all candidates exactly once using the original instances");
+    }
+
+    private BackendSelectionManager() {
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/BackendSelectionProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/BackendSelectionProfile.java
@@ -1,0 +1,87 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.resource;
+
+import org.apache.doris.system.Backend;
+
+/** Statement-level backend selection results displayed in the query profile. */
+public final class BackendSelectionProfile {
+    private BackendSelection.SelectionHint queryHint;
+    private long selectedPreferredScanRanges;
+    private long selectedNonPreferredScanRanges;
+    private BackendSelection.SelectionHint loadHint;
+    private Long coordinatorBackendId;
+    private String coordinatorGroup;
+
+    public synchronized void recordQuerySelection(BackendSelection.SelectionHint hint,
+            BackendSelection.QuerySelectionResult result) {
+        switch (result) {
+            case PREFERRED_HIT:
+                queryHint = hint;
+                selectedPreferredScanRanges++;
+                break;
+            case FALLBACK_PREFERRED_UNAVAILABLE:
+                queryHint = hint;
+                selectedNonPreferredScanRanges++;
+                break;
+            case DISABLED:
+                break;
+            default:
+                throw new IllegalStateException("Unknown query selection result: " + result);
+        }
+    }
+
+    public synchronized void recordLoadCoordinator(BackendSelection.SelectionHint hint, Backend backend) {
+        if (hint == null || backend == null || coordinatorBackendId != null) {
+            return;
+        }
+        loadHint = hint;
+        coordinatorBackendId = backend.getId();
+        Tag locationTag = backend.getLocationTag();
+        coordinatorGroup = locationTag == null ? "N/A" : locationTag.value;
+    }
+
+    public synchronized String getQuerySummary() {
+        if (queryHint == null) {
+            return null;
+        }
+        return "preferred=" + queryHint.getPreferredKey()
+                + ", mode=" + queryHint.getMode()
+                + ", selected_preferred_scan_ranges=" + selectedPreferredScanRanges
+                + ", selected_non_preferred_scan_ranges=" + selectedNonPreferredScanRanges;
+    }
+
+    public synchronized String getLoadSummary() {
+        if (loadHint == null || coordinatorBackendId == null) {
+            return null;
+        }
+        return "preferred=" + loadHint.getPreferredKey()
+                + ", mode=" + loadHint.getMode()
+                + ", coordinator_backend=" + coordinatorBackendId
+                + ", coordinator_group=" + coordinatorGroup;
+    }
+
+    public synchronized void reset() {
+        queryHint = null;
+        selectedPreferredScanRanges = 0;
+        selectedNonPreferredScanRanges = 0;
+        loadHint = null;
+        coordinatorBackendId = null;
+        coordinatorGroup = null;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/resource/spi/BackendSelectionProvider.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/resource/spi/BackendSelectionProvider.java
@@ -1,0 +1,161 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.resource.spi;
+
+import org.apache.doris.catalog.Replica;
+import org.apache.doris.common.UserException;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.Tag;
+import org.apache.doris.system.Backend;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * SPI for optional backend selection hints.
+ * <p>
+ * Implementations are discovered through {@link java.util.ServiceLoader}. Default methods preserve
+ * the existing backend selection behavior. Candidate-ordering methods must not mutate their input list:
+ * implementations that change the order must return a new list, while implementations that keep the order
+ * may return the input list unchanged.
+ */
+public interface BackendSelectionProvider {
+
+    /** Observability classification of how a repair clone source was selected. */
+    enum RepairSourceSelectionResult {
+        DISABLED,
+        PREFERRED_HIT,
+        FALLBACK_NO_PREFERRED,
+        FALLBACK_PREFERRED_UNAVAILABLE,
+        FALLBACK_SLOT_FULL
+    }
+
+    /** Whether repair-clone source selection is active. */
+    default boolean isRepairSourceSelectionEnabled() {
+        return false;
+    }
+
+    /**
+     * Reorder healthy clone-source candidates while preserving the caller's existing ordering inside
+     * each implementation-defined tier. Implementations must not drop candidates.
+     */
+    default List<Replica> orderRepairSourceCandidates(List<Replica> healthyCandidates, long destBackendId) {
+        return healthyCandidates;
+    }
+
+    /**
+     * Classify which implementation-defined tier the finally chosen source fell into, for observability.
+     */
+    default RepairSourceSelectionResult classifyRepairSource(long chosenSrcBackendId, long destBackendId,
+            List<Replica> allReplicas, List<Replica> healthyCandidates) {
+        return RepairSourceSelectionResult.DISABLED;
+    }
+
+    default BackendSelection.SelectionHint getQuerySelectionHint(ConnectContext context) {
+        return BackendSelection.SelectionHint.noSelection();
+    }
+
+    default boolean hasQuerySelectionPreference(BackendSelection.SelectionHint hint) {
+        return false;
+    }
+
+    /**
+     * Classify query selection after the kernel has applied availability and access filters.
+     * Implementations must not mutate the candidates and must return a non-null result.
+     */
+    default <T> BackendSelection.QuerySelectionResult classifyQuerySelection(
+            BackendSelection.SelectionHint hint, List<T> candidates, Function<T, Tag> beTagOf) {
+        return BackendSelection.QuerySelectionResult.DISABLED;
+    }
+
+    /**
+     * Partition query candidates for preferred selection. When preferred candidates are available, the query
+     * scheduler must only use them; otherwise it may use the fallback candidates. Implementations must preserve
+     * every input candidate exactly once using the original instances. A null result means that the provider only
+     * supports the legacy ordering hint.
+     */
+    default <T> BackendSelection.CandidateSelection<T> partitionPreferredQueryCandidates(
+            BackendSelection.SelectionHint hint, List<T> candidates, Function<T, Tag> beTagOf) throws UserException {
+        return null;
+    }
+
+    /** Whether this provider implements required query and load candidate partitioning. */
+    default boolean supportsRequiredSelection() {
+        return false;
+    }
+
+    /**
+     * Partition query candidates for {@link BackendSelection.Mode#REQUIRE}. The two lists must contain every
+     * input candidate exactly once using the original instances. The kernel schedules only preferred candidates.
+     */
+    default <T> BackendSelection.CandidateSelection<T> partitionRequiredQueryCandidates(
+            BackendSelection.SelectionHint hint, List<T> candidates, Function<T, Tag> beTagOf) throws UserException {
+        throw new UserException("BackendSelectionProvider does not support required backend selection");
+    }
+
+    /**
+     * Optionally reorder query scan candidates before the existing scheduler chooses a backend. This
+     * is only a placement hint: callers may still apply their normal load-balancing policy after this
+     * method. Implementations must not drop candidates.
+     */
+    default <T> List<T> orderQueryCandidates(BackendSelection.SelectionHint hint, List<T> candidates,
+            Function<T, Tag> beTagOf) throws UserException {
+        return candidates;
+    }
+
+    default boolean isLoadSelectionEnabled(ConnectContext context) {
+        return false;
+    }
+
+    /**
+     * Reorder load candidates without changing the candidate set. Implementations must return every input
+     * candidate exactly once and must not add candidates.
+     */
+    default List<Backend> orderLoadCandidates(BackendSelection.SelectionHint hint,
+            List<Backend> candidates) throws UserException {
+        return candidates;
+    }
+
+    /** Partition load candidates for preferred selection without changing OSS behavior. */
+    default BackendSelection.CandidateSelection<Backend> partitionPreferredLoadCandidates(
+            BackendSelection.SelectionHint hint, List<Backend> candidates) throws UserException {
+        return null;
+    }
+
+    /**
+     * Partition load candidates for {@link BackendSelection.Mode#REQUIRE}. The two lists must contain every
+     * input candidate exactly once using the original instances. The kernel schedules only preferred candidates.
+     */
+    default BackendSelection.CandidateSelection<Backend> partitionRequiredLoadCandidates(
+            BackendSelection.SelectionHint hint, List<Backend> candidates) throws UserException {
+        throw new UserException("BackendSelectionProvider does not support required backend selection");
+    }
+
+    default boolean hasLoadSelectionPreference(BackendSelection.SelectionHint hint) {
+        return false;
+    }
+
+    default BackendSelection.SelectionHint getLoadSelectionHint(ConnectContext context) {
+        return null;
+    }
+
+    default BackendSelection.SelectionHint getForwardedLoadSelectionHint(String preferredKey, String mode) {
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -129,6 +129,8 @@ import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.qe.VariableMgr;
+import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.service.arrowflight.FlightSqlConnectProcessor;
 import org.apache.doris.statistics.AnalysisManager;
 import org.apache.doris.statistics.ColStatsData;
@@ -1114,8 +1116,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
     @Override
     public TMasterOpResult forward(TMasterOpRequest params) throws TException {
-        Frontend fe = Env.getCurrentEnv().checkFeExist(params.getClientNodeHost(), params.getClientNodePort());
-        if (fe == null) {
+        Frontend requester = Env.getCurrentEnv().checkFeExist(params.getClientNodeHost(), params.getClientNodePort());
+        if (requester == null) {
             LOG.warn("reject request from invalid host. client: {}", params.getClientNodeHost());
             throw new TException("request from invalid host was rejected.");
         }
@@ -1131,9 +1133,16 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             final TMasterOpResult result = new TMasterOpResult();
             try {
                 result.setGroupCommitLoadBeId(Env.getCurrentEnv().getGroupCommitManager()
-                        .selectBackendForGroupCommitInternal(info.groupCommitLoadTableId, info.cluster));
+                        .selectBackendForGroupCommitInternal(info.groupCommitLoadTableId, info.cluster,
+                                forwardedGroupCommitLoadSelectionHint(info)));
             } catch (LoadException | DdlException e) {
-                throw new TException(e.getMessage());
+                LOG.warn("failed to select backend for forwarded group commit load, tableId={}, cluster={}",
+                        info.groupCommitLoadTableId, info.cluster, e);
+                if (!info.isSetSupportsSelectionErrorResult() || !info.isSupportsSelectionErrorResult()) {
+                    throw new TException(e.getMessage() == null ? e.toString() : e.getMessage());
+                }
+                result.setStatusCode(1);
+                result.setErrMessage(e.getMessage() == null ? e.toString() : e.getMessage());
             }
             // just make the protocol happy
             result.setPacket("".getBytes());
@@ -1173,6 +1182,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         // Set current connected FE to the client address, so that we can know where
         // this request come from.
         context.setCurrentConnectedFEIp(params.getClientNodeHost());
+        context.setConnectingFeLocalResourceGroup(params.isSetConnectingFeLocalResourceGroup()
+                ? params.getConnectingFeLocalResourceGroup() : Config.local_resource_group);
         if (Config.isCloudMode() && !Strings.isNullOrEmpty(params.getCloudCluster())) {
             context.setCloudCluster(params.getCloudCluster());
         }
@@ -1199,6 +1210,14 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         ConnectContext.remove();
         clearCallback.run();
         return result;
+    }
+
+    static BackendSelection.SelectionHint forwardedGroupCommitLoadSelectionHint(TGroupCommitInfo info) {
+        if (!info.isSetLoadSelectionPreferredKey() || !info.isSetLoadSelectionMode()) {
+            return null;
+        }
+        return BackendSelectionManager.getForwardedLoadSelectionHint(
+                info.getLoadSelectionPreferredKey(), info.getLoadSelectionMode());
     }
 
     private List<String> getTableNames(String dbName, List<Long> tableIds) throws UserException {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -367,6 +367,11 @@ struct TGroupCommitInfo{
     5: optional bool updateLoadData
     6: optional i64 tableId 
     7: optional i64 receiveData
+    8: optional string loadSelectionPreferredKey
+    9: optional string loadSelectionMode
+    // set by followers that understand selection errors carried in TMasterOpResult
+    // statusCode/errMessage; masters must keep throwing for callers without it
+    10: optional bool supportsSelectionErrorResult
 }
 
 struct TMasterOpRequest {
@@ -411,6 +416,7 @@ struct TMasterOpRequest {
     // thrift field ids wire-compatible across maintained branches. Do not reuse these ids.
     34: optional set<string> reserved_field_34
     35: optional bool reserved_field_35
+    36: optional string connectingFeLocalResourceGroup
 
     // selectdb cloud
     1000: optional string cloud_cluster


### PR DESCRIPTION
pick from https://github.com/apache/doris/pull/65173

This PR introduces a public backend selection extension framework for query, load, and replica-repair scheduling paths. The public interfaces are aligned with the downstream implementation so that downstream extensions can be maintained without carrying kernel API differences. Apache Doris does not provide or register an affinity BackendSelectionProvider. The default community provider is strictly no-op, preserving existing query scheduling, load candidate ordering, placement, and replica-repair source selection behavior. This PR does not introduce resource-group affinity implementation, enterprise provider, enterprise configuration, or other enterprise-only behavior.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

