### PR TITLE
[fix](load) correct quorum participants for incremental streams (#66016)

### DIFF
--- a/be/src/vec/sink/load_stream_stub.h
+++ b/be/src/vec/sink/load_stream_stub.h
@@ -217,6 +217,8 @@ public:
 
     bool is_open() const { return _is_open.load(); }
 
+    bool is_closing() const { return _is_closing.load(); }
+
     bool is_incremental() const { return _is_incremental; }
 
     friend std::ostream& operator<<(std::ostream& ostr, const LoadStreamStub& stub);

--- a/be/src/vec/sink/writer/vtablet_writer_v2.cpp
+++ b/be/src/vec/sink/writer/vtablet_writer_v2.cpp
@@ -718,9 +718,23 @@ Status VTabletWriterV2::close(Status exec_status) {
         // close_wait on all non-incremental streams, even if this is not the last sink.
         // because some per-instance data structures are now shared among all sinks
         // due to sharing delta writers and load stream stubs.
-        // Do not need to wait after quorum success,
-        // for first-stage close_wait only ensure incremental streams load has been completed,
-        // unified waiting in the second-stage close_wait.
+        //
+        // This stage is also a cross-source fence for a source that has incremental streams:
+        // it must not close those streams before every other source has entered the close
+        // phase and can no longer open new incremental streams.
+        //
+        // A stream contributes to quorum only after CLOSE_LOAD has been sent
+        // (LoadStreamStub::is_closing) and the sender has observed both EOS and StreamClose.
+        // When this source has incremental streams, its non-incremental CLOSE_LOAD carries
+        // num_incremental_streams > 0, so the destination defers StreamClose until CLOSE_LOAD
+        // has arrived from all sources (LoadStream::_dispatch). Therefore, any non-incremental
+        // stream counted towards quorum is a valid lifecycle fence for this source.
+        //
+        // A source without incremental streams does not require this fence because it has no
+        // incremental streams to close.
+        //
+        // The remaining streams do not need to be waited for in this stage; they are included
+        // in the second-stage close_wait.
         RETURN_IF_ERROR(_close_wait(_non_incremental_streams(), false));
 
         // send CLOSE_LOAD on all incremental streams if this is the last sink.
@@ -890,7 +904,9 @@ bool VTabletWriterV2::_quorum_success(
     for (const auto& [dst_id, streams] : streams_for_node) {
         bool finished = true;
         for (const auto& stream : streams->streams()) {
-            if (unfinished_streams.contains(stream) || !stream->check_cancel().ok()) {
+            // Incremental streams do not participate in the first close stage.
+            if (!stream->is_closing() || unfinished_streams.contains(stream) ||
+                !stream->check_cancel().ok()) {
                 finished = false;
                 break;
             }


### PR DESCRIPTION
pick from https://github.com/apache/doris/pull/66016

Exclude streams that have not entered the current close stage from V2 quorum accounting. Incremental streams now require CLOSE_LOAD participation before contributing to quorum success, preserving the two-stage close fence and preventing premature tablet commits.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

