### PR TITLE
[fix](storage) Reject prepare txn on shutdown tablet (#66448)

### DIFF
--- a/be/src/olap/tablet.cpp
+++ b/be/src/olap/tablet.cpp
@@ -2939,8 +2939,7 @@ Status Tablet::prepare_txn(TPartitionId partition_id, TTransactionId transaction
     }
 
     std::lock_guard<std::mutex> push_lock(get_push_lock());
-    return _engine.txn_manager()->prepare_txn(partition_id, transaction_id, tablet_id(),
-                                              tablet_uid(), load_id, ingest);
+    return _engine.txn_manager()->prepare_txn(partition_id, *this, transaction_id, load_id, ingest);
 }
 
 #include "common/compile_check_end.h"


### PR DESCRIPTION
pick from https://github.com/apache/doris/pull/66448

Call the Tablet-aware transaction preparation overload while migration and push locks are held, restoring the shutdown-tablet guard and preventing stale tablet transaction entries.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

