### PR TITLE
[fix](balance) do not pick tablets whose data size is zero for BE balance (#66499)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/BeLoadRebalancer.java
@@ -123,6 +123,10 @@ public class BeLoadRebalancer extends Rebalancer {
                 .collect(Collectors.toList());
 
         boolean hasCandidateTablet = false;
+        // Only for logging. This counts scanned tablets, not balance attempts, so it is summarized
+        // once per round here instead of going into TabletSchedulerStat: when every replica size is
+        // still unreported, every tablet of every high load backend hits it on every round.
+        int zeroSizeTabletNum = 0;
 
         // choose tablets from high load backends.
         // BackendLoadStatistic is sorted by load score in ascend order,
@@ -225,6 +229,18 @@ public class BeLoadRebalancer extends Rebalancer {
                         continue;
                     }
 
+                    // A tablet with no data relocates nothing, so moving it can not improve the disk usage
+                    // difference that triggered this balance. It only shifts the replica count term of the
+                    // load score, which destroys the round-robin distribution a newly created table got
+                    // from createTablets(). Zero also means the size has not been reported yet: replica
+                    // data size is not persisted in the image (see LocalTablet), so it remains zero after
+                    // an FE restart until the next tablet stat update, and balancing on an unknown size is
+                    // guesswork. This is the same rule as DiskRebalancer.completeSchedCtx().
+                    if (replicaDataSize <= 0) {
+                        zeroSizeTabletNum++;
+                        continue;
+                    }
+
                     hasCandidateTablet = true;
 
                     // for urgent disk, pick tablets order by size,
@@ -273,11 +289,16 @@ public class BeLoadRebalancer extends Rebalancer {
         } // end for high backends
 
         if (!alternativeTablets.isEmpty()) {
-            LOG.info("select alternative tablets, medium: {}, is urgent: {}, num: {}, detail: {}",
-                    medium, isUrgent, alternativeTablets.size(), alternativeTabletInfos);
+            LOG.info("select alternative tablets, medium: {}, is urgent: {}, num: {},"
+                            + " skip {} tablets whose size is zero, detail: {}",
+                    medium, isUrgent, alternativeTablets.size(), zeroSizeTabletNum, alternativeTabletInfos);
         } else if (isUrgent && !hasCandidateTablet) {
-            LOG.info("urgent balance cann't found candidate tablets. medium: {}, tag: {}",
-                    medium, clusterStat.getTag());
+            LOG.info("urgent balance cann't found candidate tablets. medium: {}, tag: {},"
+                            + " skip {} tablets whose size is zero",
+                    medium, clusterStat.getTag(), zeroSizeTabletNum);
+        } else if (zeroSizeTabletNum > 0) {
+            LOG.info("no alternative tablet, {} tablets are skipped because their size is zero."
+                            + " medium: {}, tag: {}", zeroSizeTabletNum, medium, clusterStat.getTag());
         }
         return alternativeTablets;
     }
@@ -332,6 +353,16 @@ public class BeLoadRebalancer extends Rebalancer {
         if (replicaHighBEs.isEmpty()) {
             throw new SchedException(Status.UNRECOVERABLE, SubCode.DIAGNOSE_IGNORE,
                     "no replica on high load backend" + isUrgentInfo);
+        }
+
+        // Recheck because selection and scheduling can be far apart. Zero also means the size has not been
+        // reported yet: replica data size is not persisted in the image (see LocalTablet), so it remains zero
+        // after an FE restart until the next tablet stat update. Balancing on an unknown size is guesswork.
+        // This is the same rule as DiskRebalancer.completeSchedCtx().
+        if (tabletCtx.getTabletSize() <= 0) {
+            schedulerStat.counterBalanceRejectByZeroDataSize.incrementAndGet();
+            throw new SchedException(Status.UNRECOVERABLE, SubCode.DIAGNOSE_IGNORE,
+                    "size of src replica is zero");
         }
 
         // select a replica as source

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/Rebalancer.java
@@ -64,6 +64,9 @@ public abstract class Rebalancer {
     protected Map<Long, PathSlot> backendsWorkingSlots;
     protected TabletInvertedIndex invertedIndex;
     protected SystemInfoService infoService;
+    // Owned by TabletScheduler, which injects itself via setSchedulerStat() after construction.
+    // Defaults to a standalone instance so that unit tests can build a Rebalancer on its own.
+    protected TabletSchedulerStat schedulerStat = new TabletSchedulerStat();
     // be id -> end time of prio
     protected Map<Long, Long> prioBackends = Maps.newConcurrentMap();
 
@@ -161,6 +164,10 @@ public abstract class Rebalancer {
 
     public void updateLoadStatistic(Map<Tag, LoadStatisticForTag> statisticMap) {
         this.statisticMap = statisticMap;
+    }
+
+    public void setSchedulerStat(TabletSchedulerStat schedulerStat) {
+        this.schedulerStat = schedulerStat;
     }
 
     public void updateAlterTableIds(Set<Long> alterTableIds) {

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletScheduler.java
@@ -165,6 +165,8 @@ public class TabletScheduler extends MasterDaemon {
         }
         // if rebalancer can not get new task, then use diskRebalancer to get task
         this.diskRebalancer = new DiskRebalancer(infoService, invertedIndex, backendsWorkingSlots);
+        this.rebalancer.setSchedulerStat(stat);
+        this.diskRebalancer.setSchedulerStat(stat);
     }
 
     // for fe ut

--- a/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedulerStat.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/clone/TabletSchedulerStat.java
@@ -111,6 +111,8 @@ public class TabletSchedulerStat {
     public AtomicLong counterReplicaMissingForTagErr = new AtomicLong(0L);
     @StatField("num of balance scheduled")
     public AtomicLong counterBalanceSchedule = new AtomicLong(0L);
+    @StatField("num of BE balance rejected for zero data size")
+    public AtomicLong counterBalanceRejectByZeroDataSize = new AtomicLong(0L);
     @StatField("num of colocate replica mismatch")
     public AtomicLong counterReplicaColocateMismatch = new AtomicLong(0L);
     @StatField("num of colocate replica redundant")


### PR DESCRIPTION
pick from https://github.com/apache/doris/pull/66499

Skip zero-size tablets during BE balance selection and scheduling so empty or unreported replicas are not migrated solely to adjust replica counts.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

