### PR TITLE
[fix](brpc) Disable SSL BIO buffering on branch-3.1

### DIFF
--- a/thirdparty/patches/brpc-1.4.0-disable-ssl-bio-buffer.patch
+++ b/thirdparty/patches/brpc-1.4.0-disable-ssl-bio-buffer.patch
@@ -1,0 +1,19 @@
+diff --git a/src/brpc/socket.cpp b/src/brpc/socket.cpp
+index e3878c19..d0dd4f4d 100644
+--- a/src/brpc/socket.cpp
++++ b/src/brpc/socket.cpp
+@@ -1889,7 +1889,13 @@ int Socket::SSLHandshake(int fd, bool server_mode) {
+         int rc = SSL_do_handshake(_ssl_session);
+         if (rc == 1) {
+             _ssl_state = SSL_CONNECTED;
+-            AddBIOBuffer(_ssl_session, fd, FLAGS_ssl_bio_buffer_size);
++            // Do not add BIO_f_buffer on SSL connections.
++            //
++            // brpc-1.4.0 flushes this buffered BIO after SSL_write(), but a
++            // non-fatal EAGAIN from BIO_flush() is not propagated as
++            // SSL_ERROR_WANT_WRITE. Large TLS responses may then be considered
++            // written while encrypted bytes are still buffered and never retried.
++            // Let OpenSSL's socket BIO surface WANT_WRITE to KeepWrite instead.
+             return 0;
+         }
+ 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: apache/doris#64962

Doris branch-3.1 still uses BRPC 1.4.0 with an additional buffered BIO layer after the TLS handshake. Under socket backpressure, `SSL_write()` can consume plaintext while the later BIO flush returns EAGAIN; BRPC 1.4.0 does not propagate that condition to its existing WANT_WRITE retry path, so large TLS responses can be truncated or time out.

This is the branch-3.1 backport of the patch already merged on master. It disables the extra SSL BIO buffer so WANT_WRITE is handled by the existing socket retry mechanism.

### Release note

Fix possible BRPC TLS response timeouts under socket backpressure.

### Check List (For Author)

- Test: Applied the complete branch-3.1 BRPC patch stack to the BRPC 1.4.0 source tree.
- Test: Built both `brpc-static` and `brpc-shared` successfully.
- Behavior changed: Yes. TLS connections no longer use BRPC's extra buffered BIO layer.
- Does this need documentation: No.
