### PR TITLE
[fix](fe) Reject MOW key additions with sync MVs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -1375,6 +1375,15 @@ public class SchemaChangeHandler extends AlterHandler {
                 } else {
                     newColumn.setAggregationType(AggregateType.REPLACE, true);
                 }
+            } else if (olapTable.getEnableUniqueKeyMergeOnWrite()) {
+                Optional<String> syncMvName = getSyncMvName(olapTable);
+                if (syncMvName.isPresent()) {
+                    throw new DdlException(String.format(
+                            "Can not add key column to merge-on-write table when table has sync materialized view[%s]. "
+                                    + "Please drop the sync materialized view first, then alter the table "
+                                    + "and recreate it.",
+                            syncMvName.get()));
+                }
             }
         } else {
             if (newColumn.getAggregationType() != null && newColumn.isKey()) {
@@ -1552,6 +1561,16 @@ public class SchemaChangeHandler extends AlterHandler {
             checkAndAddColumn(modIndexSchema, newColumn, columnPos, newColNameSet, false, rollUpNewColumnUniqueId);
         }
         return lightSchemaChange;
+    }
+
+    private Optional<String> getSyncMvName(OlapTable olapTable) {
+        for (Map.Entry<Long, MaterializedIndexMeta> entry : olapTable.getVisibleIndexIdToMeta().entrySet()) {
+            if (entry.getKey() == olapTable.getBaseIndexId()) {
+                continue;
+            }
+            return Optional.of(Preconditions.checkNotNull(olapTable.getIndexNameById(entry.getKey())));
+        }
+        return Optional.empty();
     }
 
     /*

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
@@ -899,6 +899,79 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
     }
 
     @Test
+    public void testUniqAddKeyColumnWithSyncMv() throws Exception {
+        dropTable("test.sc_uniq_sync_mv", false);
+        createTable("CREATE TABLE test.sc_uniq_sync_mv (\n"
+                + "user_id LARGEINT NOT NULL,\n"
+                + "username VARCHAR(50) NOT NULL,\n"
+                + "city VARCHAR(20),\n"
+                + "age SMALLINT\n"
+                + ")\n"
+                + "UNIQUE KEY(user_id, username)\n"
+                + "DISTRIBUTED BY HASH(user_id) BUCKETS 1\n"
+                + "PROPERTIES ('replication_num' = '1', 'light_schema_change' = 'true',\n"
+                + "'enable_unique_key_merge_on_write' = 'true');");
+        createMv("CREATE MATERIALIZED VIEW sync_mv_key_guard AS "
+                + "SELECT username AS mv_username, user_id AS mv_user_id, city AS mv_city "
+                + "FROM test.sc_uniq_sync_mv");
+
+        expectException("ALTER TABLE test.sc_uniq_sync_mv ADD COLUMN rejected_key INT KEY DEFAULT '0'",
+                "Can not add key column to merge-on-write table when table has sync materialized "
+                        + "view[sync_mv_key_guard]");
+
+        Database db = Env.getCurrentInternalCatalog().getDbOrMetaException("test");
+        OlapTable tbl = (OlapTable) db.getTableOrMetaException("sc_uniq_sync_mv", Table.TableType.OLAP);
+        tbl.readLock();
+        try {
+            Assertions.assertNull(tbl.getColumn("rejected_key"));
+        } finally {
+            tbl.readUnlock();
+        }
+
+        alterTable("ALTER TABLE test.sc_uniq_sync_mv ADD COLUMN allowed_value INT DEFAULT '0'", connectContext);
+        tbl.readLock();
+        try {
+            Assertions.assertNotNull(tbl.getColumn("allowed_value"));
+            Assertions.assertFalse(tbl.getColumn("allowed_value").isKey());
+        } finally {
+            tbl.readUnlock();
+        }
+
+        executeNereidsSql("DROP MATERIALIZED VIEW sync_mv_key_guard ON test.sc_uniq_sync_mv");
+        alterTable("ALTER TABLE test.sc_uniq_sync_mv ADD COLUMN allowed_key INT KEY DEFAULT '0'", connectContext);
+        waitAlterJobDone(Env.getCurrentEnv().getSchemaChangeHandler().getAlterJobsV2());
+        tbl.readLock();
+        try {
+            Assertions.assertNotNull(tbl.getColumn("allowed_key"));
+            Assertions.assertTrue(tbl.getColumn("allowed_key").isKey());
+        } finally {
+            tbl.readUnlock();
+        }
+    }
+
+    @Test
+    public void testUniqAddKeyColumnWithRollup() throws Exception {
+        dropTable("test.sc_uniq_sync_rollup", false);
+        createTable("CREATE TABLE test.sc_uniq_sync_rollup (\n"
+                + "user_id LARGEINT NOT NULL,\n"
+                + "username VARCHAR(50) NOT NULL,\n"
+                + "city VARCHAR(20),\n"
+                + "age SMALLINT\n"
+                + ")\n"
+                + "UNIQUE KEY(user_id, username)\n"
+                + "DISTRIBUTED BY HASH(user_id) BUCKETS 1\n"
+                + "PROPERTIES ('replication_num' = '1', 'light_schema_change' = 'true',\n"
+                + "'enable_unique_key_merge_on_write' = 'true');");
+        alterTable("ALTER TABLE test.sc_uniq_sync_rollup ADD ROLLUP rollup_key_guard(username, user_id)",
+                connectContext);
+        waitAlterJobDone(Env.getCurrentEnv().getMaterializedViewHandler().getAlterJobsV2());
+
+        expectException("ALTER TABLE test.sc_uniq_sync_rollup ADD COLUMN rejected_key INT KEY DEFAULT '0'",
+                "Can not add key column to merge-on-write table when table has sync materialized "
+                        + "view[rollup_key_guard]");
+    }
+
+    @Test
     public void testDupAddOrDropColumn() throws Exception {
 
         LOG.info("dbName: {}", Env.getCurrentInternalCatalog().getDbNames());


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #62875

Problem Summary: Adding a key column to a merge-on-write unique table updates every visible materialized index schema without updating its synchronous materialized view definition. Queries rewritten to that index can then decode stored rows with the wrong schema and return incorrect values.

Reject this unsupported schema change while a visible synchronous materialized view or rollup exists. Users can drop the materialized index, add the key column, and recreate it. Value-column additions remain unchanged.

### Release note

Reject adding key columns to merge-on-write unique tables while synchronous materialized views or rollups exist.

### Check List (For Author)

- Test: Unit Test
    - ./run-fe-ut.sh --run org.apache.doris.alter.SchemaChangeHandlerTest#testUniqAddKeyColumnWithSyncMv+testUniqAddKeyColumnWithRollup (2 tests passed)
- Behavior changed: Yes (unsafe key-column additions are rejected until synchronous materialized views or rollups are dropped)
- Does this need documentation: No

Co-authored-by: Siyang Tang <tangsiyang@selectdb.com>
