### PR TITLE
[fix](parquet) Fix bloom filter cross-column reuse in AND/OR predicate group

### DIFF
--- a/be/src/format/parquet/parquet_predicate.h
+++ b/be/src/format/parquet/parquet_predicate.h
@@ -163,6 +163,12 @@ public:
         const FieldSchema* col_schema;
         const cctz::time_zone* ctz;
         std::unique_ptr<ParquetBlockSplitBloomFilter> bloom_filter;
+        // Parquet physical column id that the currently held bloom_filter belongs to.
+        // A single ColumnStat is reused across the child predicates of an AND/OR group, which may
+        // reference different columns; without tracking ownership the bloom_filter of the first
+        // column would be wrongly reused to test the second column's value (false negative -> the
+        // whole row group is skipped). -1 means no bloom_filter is currently held.
+        int bloom_filter_col_id = -1;
         std::function<bool(ParquetPredicate::ColumnStat*, const int)>* get_stat_func = nullptr;
         std::function<bool(ParquetPredicate::ColumnStat*, const int)>* get_bloom_filter_func =
                 nullptr;

--- a/be/src/format/parquet/vparquet_reader.cpp
+++ b/be/src/format/parquet/vparquet_reader.cpp
@@ -1561,11 +1561,25 @@ Status ParquetReader::_process_column_stat_filter(
                         return false;
                     }
 
+                    // The same ColumnStat is reused across the child predicates of an AND/OR
+                    // group, which may reference different columns. If it still holds the bloom
+                    // filter of a previous (different) column, stash it back into the per-column
+                    // cache and clear it, so the guard below reads THIS column's bloom filter
+                    // instead of wrongly reusing another column's (which would falsely miss and
+                    // skip the whole row group).
+                    if (stat->bloom_filter && stat->bloom_filter_col_id != parquet_col_id) {
+                        bloom_filter_cache[stat->bloom_filter_col_id] =
+                                std::move(stat->bloom_filter);
+                        stat->bloom_filter.reset();
+                        stat->bloom_filter_col_id = -1;
+                    }
+
                     // Check cache first
                     auto cache_iter = bloom_filter_cache.find(parquet_col_id);
                     if (cache_iter != bloom_filter_cache.end()) {
                         // Bloom filter already loaded for this column, reuse it
                         stat->bloom_filter = std::move(cache_iter->second);
+                        stat->bloom_filter_col_id = parquet_col_id;
                         bloom_filter_cache.erase(cache_iter);
                         return stat->bloom_filter != nullptr;
                     }
@@ -1579,8 +1593,10 @@ Status ParquetReader::_process_column_stat_filter(
                                          << col_schema->name << " in file " << _scan_range.path
                                          << ", status: " << st.to_string();
                             stat->bloom_filter.reset();
+                            stat->bloom_filter_col_id = -1;
                             return false;
                         }
+                        stat->bloom_filter_col_id = parquet_col_id;
                     }
                     return stat->bloom_filter != nullptr;
                 };
@@ -1605,22 +1621,13 @@ Status ParquetReader::_process_column_stat_filter(
             return Status::OK();
         }
 
-        // After evaluating, if the bloom filter was used, cache it for subsequent predicates
-        if (stat.bloom_filter) {
-            // Find the column id for caching
-            for (auto* slot : _tuple_descriptor->slots()) {
-                if (_table_info_node_ptr->children_column_exists(slot->col_name())) {
-                    const auto& file_col_name =
-                            _table_info_node_ptr->children_file_column_name(slot->col_name());
-                    const FieldSchema* col_schema =
-                            _file_metadata->schema().get_column(file_col_name);
-                    int parquet_col_id = col_schema->physical_column_index;
-                    if (stat.col_schema == col_schema) {
-                        bloom_filter_cache[parquet_col_id] = std::move(stat.bloom_filter);
-                        break;
-                    }
-                }
-            }
+        // After evaluating, if a bloom filter is still held, cache it for subsequent predicates.
+        // Use bloom_filter_col_id (the column the bloom actually belongs to) as the key: col_schema
+        // is overwritten by every child's get_stat_func and may not match the column that owns the
+        // currently held bloom filter, so keying by col_schema could stash it under the wrong column
+        // and reintroduce the cross-column reuse bug.
+        if (stat.bloom_filter && stat.bloom_filter_col_id >= 0) {
+            bloom_filter_cache[stat.bloom_filter_col_id] = std::move(stat.bloom_filter);
         }
     }
 

--- a/be/test/format/parquet/parquet_expr_test.cpp
+++ b/be/test/format/parquet/parquet_expr_test.cpp
@@ -1969,6 +1969,84 @@ TEST_F(ParquetExprTest, test_bloom_filter_accepts_value) {
     EXPECT_EQ(1, loader_calls);
 }
 
+// A single ColumnStat is shared across the child predicates of an AND group. Before the fix, once
+// the first EQ child loaded column A's bloom filter, the second EQ child on column B found
+// stat->bloom_filter non-empty, skipped loading B's own bloom, and tested B's value against A's
+// bloom -> almost always a false miss -> the whole row group was wrongly filtered out (data loss).
+// The fix tracks ownership via ColumnStat::bloom_filter_col_id and reloads when the held bloom
+// belongs to a different column. This test injects a get_bloom_filter_func that faithfully mirrors
+// that ownership-aware guard, drives an AND of two EQ predicates on two different columns sharing
+// one ColumnStat, and asserts each column is tested against ITS OWN bloom (group not filtered, and
+// the loader ran once per distinct column). Under the old guard the second column would reuse the
+// first column's bloom and the group would be filtered (evaluate_and == false).
+TEST_F(ParquetExprTest, test_bloom_filter_not_reused_across_columns) {
+    const int col_a = 2; // int64_col
+    const int col_b = 0; // int32_partial_null_col (nulls overridden via has_null=false below)
+    const int64_t value_a = 10000000001;
+    const int32_t value_b = 12345;
+
+    const FieldSchema* schema_a = doris_file_metadata->schema().get_column(col_a);
+    const FieldSchema* schema_b = doris_file_metadata->schema().get_column(col_b);
+
+    // Return false from get_stat_func so the EQ predicate skips the min/max stage entirely and
+    // falls straight through to the bloom filter check for both columns. This keeps the test
+    // focused on the bloom cross-column reuse path and independent of min/max encoding details.
+    std::function<bool(ParquetPredicate::ColumnStat*, int)> get_stat_func =
+            [&](ParquetPredicate::ColumnStat* current_stat, int cid) {
+                current_stat->col_schema = (cid == col_a) ? schema_a : schema_b;
+                return false;
+            };
+
+    int loads_a = 0;
+    int loads_b = 0;
+    // Mirrors the production ownership-aware guard: if the held bloom belongs to a different
+    // column, stash it and clear before loading this column's own bloom.
+    std::function<bool(ParquetPredicate::ColumnStat*, int)> get_bloom_filter_func =
+            [&](ParquetPredicate::ColumnStat* current_stat, int cid) {
+                if (current_stat->bloom_filter && current_stat->bloom_filter_col_id != cid) {
+                    current_stat->bloom_filter.reset();
+                    current_stat->bloom_filter_col_id = -1;
+                }
+                if (!current_stat->bloom_filter) {
+                    current_stat->bloom_filter = std::make_unique<ParquetBlockSplitBloomFilter>();
+                    auto* bf = static_cast<ParquetBlockSplitBloomFilter*>(
+                            current_stat->bloom_filter.get());
+                    Status st = bf->init(256, segment_v2::HashStrategyPB::XX_HASH_64);
+                    EXPECT_TRUE(st.ok());
+                    if (cid == col_a) {
+                        loads_a++;
+                        bf->add_bytes(reinterpret_cast<const char*>(&value_a), sizeof(value_a));
+                    } else {
+                        loads_b++;
+                        bf->add_bytes(reinterpret_cast<const char*>(&value_b), sizeof(value_b));
+                    }
+                    current_stat->bloom_filter_col_id = cid;
+                }
+                return current_stat->bloom_filter != nullptr;
+            };
+
+    // Build the AND group: col_a = value_a AND col_b = value_b, both present in their own bloom.
+    std::unique_ptr<MutilColumnBlockPredicate> pred = AndBlockColumnPredicate::create_unique();
+    pred->add_column_predicate(SingleColumnBlockPredicate::create_unique(
+            ComparisonPredicateBase<TYPE_BIGINT, PredicateType::EQ>::create_shared(
+                    col_a, "", Field::create_field<TYPE_BIGINT>(value_a))));
+    pred->add_column_predicate(SingleColumnBlockPredicate::create_unique(
+            ComparisonPredicateBase<TYPE_INT, PredicateType::EQ>::create_shared(
+                    col_b, "", Field::create_field<TYPE_INT>(value_b))));
+
+    ParquetPredicate::ColumnStat stat;
+    stat.ctz = &ctz;
+    stat.get_stat_func = &get_stat_func;
+    stat.get_bloom_filter_func = &get_bloom_filter_func;
+
+    // Both columns match their own bloom -> the AND must NOT filter the group out.
+    // With the old (buggy) guard, col_b would reuse col_a's bloom, miss, and this would be false.
+    EXPECT_TRUE(pred->evaluate_and(&stat));
+    // Each distinct column loaded its own bloom exactly once (no cross-column reuse).
+    EXPECT_EQ(1, loads_a);
+    EXPECT_EQ(1, loads_b);
+}
+
 TEST_F(ParquetExprTest, test_bloom_filter_skipped_when_min_max_evicts_rowgroup) {
     const int col_idx = 2;
     const int64_t predicate_value = 10000000001;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

A single `ColumnStat` is shared across the child predicates of an AND/OR group, which may reference different columns. After the first child loaded column A's bloom filter into `stat.bloom_filter`, the next child on column B saw it non-empty, skipped loading B's own bloom, and tested B's value against A's bloom -> almost always a false miss -> the whole row group was wrongly filtered out, silently dropping matching rows.

The write-back path made it worse: it keyed the per-column cache by `stat.col_schema`, which is overwritten by every child's `get_stat_func` and may no longer match the column that actually owns the held bloom filter, so the bloom could be stashed under the wrong column id.

The fix tracks the owning physical column id via `ColumnStat::bloom_filter_col_id`. Before checking the cache, if the held bloom belongs to a different column, it is stashed back and cleared so this column loads its own bloom. The write-back cache is keyed by `bloom_filter_col_id` instead of `col_schema`.

### Release note

Fix Parquet bloom filter being reused across different columns within an AND/OR predicate group, which could wrongly skip row groups and drop matching rows.

### Check List (For Author)

- Test
    - [x] Unit Test
- Behavior changed:
    - [x] Yes. Queries that previously dropped matching rows due to the cross-column bloom filter reuse now return correct results.
- Does this need documentation?
    - [x] No.