### PR TITLE
[fix](job) Prevent stale cloud broker load retries

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/load/CloudBrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/load/CloudBrokerLoadJob.java
@@ -277,6 +277,14 @@ public class CloudBrokerLoadJob extends BrokerLoadJob {
 
         try {
             writeLock();
+            // The transaction callback or another terminal path may finish the job while tasks drain.
+            if (state != JobState.RETRY) {
+                LOG.info(new LogBuilder(LogKey.LOAD_JOB, id)
+                        .add("state", state)
+                        .add("msg", "skip retry because the load job is no longer retrying")
+                        .build());
+                return;
+            }
             this.state = JobState.PENDING;
             this.idToTasks.clear();
             this.failMsg = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/LoadJob.java
@@ -430,6 +430,11 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback
                     id, this.state, jobState);
             return false;
         }
+        // RETRY closes the current attempt. The next attempt must enter PENDING before LOADING.
+        if (this.state == JobState.RETRY && jobState == JobState.LOADING) {
+            LOG.info("the load job {} is retrying, should not update state to {}", id, jobState);
+            return false;
+        }
         switch (jobState) {
             case UNKNOWN:
                 executeUnknown();

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/load/CloudBrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/load/CloudBrokerLoadJobTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.load.BrokerFileGroupAggInfo;
 import org.apache.doris.load.FailMsg;
 import org.apache.doris.load.loadv2.JobState;
+import org.apache.doris.load.loadv2.LoadTask;
 import org.apache.doris.transaction.GlobalTransactionMgrIface;
 import org.apache.doris.transaction.TxnStateCallbackFactory;
 
@@ -31,6 +32,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+
+import java.util.Map;
 
 public class CloudBrokerLoadJobTest {
 
@@ -85,5 +88,37 @@ public class CloudBrokerLoadJobTest {
 
         Assert.assertEquals(0L, job.getTransactionId());
         Assert.assertEquals(JobState.RETRY, job.getState());
+    }
+
+    @Test
+    public void testStaleRetryDoesNotReviveFinishedJob() throws Exception {
+        GlobalTransactionMgrIface transactionMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+        TxnStateCallbackFactory callbackFactory = Mockito.mock(TxnStateCallbackFactory.class);
+        CloudBrokerLoadJob job = new CloudBrokerLoadJob();
+        LoadTask failedTask = Mockito.mock(LoadTask.class);
+        LoadTask otherTask = Mockito.mock(LoadTask.class);
+        Deencapsulation.setField(job, "id", 1003L);
+        Deencapsulation.setField(job, "dbId", 2003L);
+        Deencapsulation.setField(job, "label", "cloud_broker_load_finished_during_retry");
+        Deencapsulation.setField(job, "transactionId", 3003L);
+        Deencapsulation.setField(job, "cloudClusterId", "cluster_id");
+        Map<Long, LoadTask> idToTasks = Deencapsulation.getField(job, "idToTasks");
+        idToTasks.put(4003L, failedTask);
+        idToTasks.put(4004L, otherTask);
+        Mockito.when(otherTask.isDone()).thenAnswer(invocation -> {
+            Deencapsulation.setField(job, "state", JobState.FINISHED);
+            return true;
+        });
+
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class)) {
+            envMockedStatic.when(Env::getCurrentGlobalTransactionMgr).thenReturn(transactionMgr);
+            Mockito.when(transactionMgr.getCallbackFactory()).thenReturn(callbackFactory);
+
+            job.onTaskFailed(4003L, new FailMsg(FailMsg.CancelType.ETL_RUN_FAIL, "rpc failed"));
+        }
+
+        Assert.assertEquals(JobState.FINISHED, job.getState());
+        Mockito.verify(callbackFactory).removeCallback(1003L);
+        Mockito.verify(callbackFactory, Mockito.never()).addCallback(job);
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/LoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/LoadJobTest.java
@@ -156,6 +156,15 @@ public class LoadJobTest {
     }
 
     @Test
+    public void testRetryStateCannotReturnToLoading() {
+        LoadJob loadJob = new BrokerLoadJob();
+        Deencapsulation.setField(loadJob, "state", JobState.RETRY);
+
+        Assert.assertFalse(loadJob.updateState(JobState.LOADING));
+        Assert.assertEquals(JobState.RETRY, loadJob.getState());
+    }
+
+    @Test
     public void testUpdateStateToFinished() {
         try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class)) {
             Env env = Mockito.mock(Env.class);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #66987

Problem Summary:

In cloud mode, a Broker Load attempt can have many loading tasks queued in the FE executor. After the first task failure moves the job to RETRY, a queued task can currently move it back to LOADING. This allows several concurrent failures to enter the job-level retry path and wait on the shared idToTasks map.

An older retry handler can consequently follow tasks from a newer attempt. If that newer attempt finishes successfully, the stale handler can overwrite FINISHED with PENDING, schedule another pending task, and reuse the already VISIBLE transaction. New rowsets are then rejected by Meta Service because the transaction is no longer PREPARED.

This change closes the current attempt once the job enters RETRY and verifies that the job is still RETRY before scheduling the next PENDING attempt. It does not change transaction protocols, Meta Service behavior, or the non-cloud retry implementation.

### Release note

Fix Cloud Broker Load jobs being retried after a later attempt already finished.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test (focused coverage added; not executed locally per request)
    - [ ] Manual test
    - [ ] No need to test or manual test

- Behavior changed:
    - [ ] No.
    - [x] Yes. Loading tasks from a closed attempt can no longer reopen a retrying job, and stale retry handlers cannot revive a completed job.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label