### PR TITLE
[opt](column) Avoid redundant nullable column scans

### DIFF
--- a/be/src/core/data_type_serde/data_type_nullable_serde.cpp
+++ b/be/src/core/data_type_serde/data_type_nullable_serde.cpp
@@ -493,7 +493,7 @@ Status DataTypeNullableSerDe::write_column_to_mysql_binary(const IColumn& column
                                                            const FormatOptions& options) const {
     const auto& col = assert_cast<const ColumnNullable&>(column);
     const auto col_index = index_check_const(row_idx, col_const);
-    if (col.has_null() && col.is_null_at(col_index)) {
+    if (col.is_null_at(col_index)) {
         if (UNLIKELY(0 != result.push_null())) {
             return Status::InternalError("pack mysql buffer failed.");
         }

--- a/be/src/storage/segment/variant/v2/variant_path_builder.cpp
+++ b/be/src/storage/segment/variant/v2/variant_path_builder.cpp
@@ -962,16 +962,23 @@ struct VariantPathBuilder::Impl {
         // Inferred widening is only a storage representation choice. If CAST loses a valid value
         // at any array depth, preserve the whole path as JSONB instead. Forced typed-path
         // conversion intentionally retains its existing cast-null filtering below.
+        bool promoted_has_null = false;
+        bool promoted_null_state_known = false;
         if (!filter_cast_nulls && target->get_primitive_type() != TYPE_JSONB &&
             cast_introduced_null(*column, *promoted)) {
             target = jsonb_type();
             RETURN_IF_ERROR(
                     variant_util::cast_column({column->get_ptr(), nullable_type, path.get_path()},
                                               make_nullable(target), &promoted));
-            DORIS_CHECK(!assert_cast<const ColumnNullable&>(*promoted).has_null());
+            promoted_has_null = assert_cast<const ColumnNullable&>(*promoted).has_null();
+            promoted_null_state_known = true;
+            DORIS_CHECK(!promoted_has_null);
         }
         const auto& nullable = assert_cast<const ColumnNullable&>(*promoted);
-        if (nullable.has_null()) {
+        if (!promoted_null_state_known) {
+            promoted_has_null = nullable.has_null();
+        }
+        if (promoted_has_null) {
             DORIS_CHECK(filter_cast_nulls);
             DORIS_CHECK_EQ(promoted->size(), rowids.size());
             IColumn::Filter non_null_filter(promoted->size(), 1);

--- a/be/test/core/data_type_serde/data_type_serde_string_test.cpp
+++ b/be/test/core/data_type_serde/data_type_serde_string_test.cpp
@@ -357,4 +357,53 @@ TEST_F(DataTypeStringSerDeTest, FixedSizeBinaryReadColumnFromArrowWithNonZeroSta
     EXPECT_EQ(column->get_data_at(2).to_string(), "dddd");
 }
 
+TEST_F(DataTypeStringSerDeTest, NullableMysqlBinaryUsesRowNullMap) {
+    auto nested = ColumnString::create();
+    nested->insert_data("one", 3);
+    nested->insert_data("two", 3);
+    nested->insert_data("three", 5);
+    auto null_map = ColumnUInt8::create();
+    null_map->get_data() = {0, 1, 0};
+    auto column = ColumnNullable::create(std::move(nested), std::move(null_map));
+    DataTypeNullableSerDe serde(serde_str);
+    DataTypeSerDe::FormatOptions options;
+
+    for (size_t row = 0; row < column->size(); ++row) {
+        MysqlRowBinaryBuffer buffer;
+        buffer.start_binary_row(1);
+        ASSERT_TRUE(serde.write_column_to_mysql_binary(*column, buffer, row, false, options).ok());
+        if (row == 1) {
+            EXPECT_EQ(static_cast<unsigned char>(buffer.buf()[1]), 4);
+        } else {
+            EXPECT_EQ(static_cast<unsigned char>(buffer.buf()[1]), 0);
+            EXPECT_EQ(static_cast<unsigned char>(buffer.buf()[2]), row == 0 ? 3 : 5);
+        }
+    }
+
+    auto const_nested = ColumnString::create();
+    const_nested->insert_data("constant", 8);
+    auto const_null_map = ColumnUInt8::create();
+    const_null_map->get_data().push_back(1);
+    auto const_null = ColumnNullable::create(std::move(const_nested), std::move(const_null_map));
+    MysqlRowBinaryBuffer const_null_buffer;
+    const_null_buffer.start_binary_row(1);
+    ASSERT_TRUE(serde.write_column_to_mysql_binary(*const_null, const_null_buffer, 3, true, options)
+                        .ok());
+    EXPECT_EQ(static_cast<unsigned char>(const_null_buffer.buf()[1]), 4);
+
+    auto const_value_nested = ColumnString::create();
+    const_value_nested->insert_data("constant", 8);
+    auto const_value_null_map = ColumnUInt8::create();
+    const_value_null_map->get_data().push_back(0);
+    auto const_value =
+            ColumnNullable::create(std::move(const_value_nested), std::move(const_value_null_map));
+    MysqlRowBinaryBuffer const_value_buffer;
+    const_value_buffer.start_binary_row(1);
+    ASSERT_TRUE(
+            serde.write_column_to_mysql_binary(*const_value, const_value_buffer, 3, true, options)
+                    .ok());
+    EXPECT_EQ(static_cast<unsigned char>(const_value_buffer.buf()[1]), 0);
+    EXPECT_EQ(static_cast<unsigned char>(const_value_buffer.buf()[2]), 8);
+}
+
 } // namespace doris


### PR DESCRIPTION
Variant path promotion could scan the same promoted nullable column twice during JSONB fallback. 

MySQL binary serialization also scanned the complete nullable column for every output row before checking that row's null flag. This change reuses the Variant null state and performs a direct per-row null-map lookup for MySQL binary output, preserving existing serialization and fallback behavior.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

