### PR TITLE
[fix](dml) Enforce partition guard for delete

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommand.java
@@ -302,6 +302,14 @@ public class DeleteFromCommand extends Command implements ForwardWithSync, Expla
         if (olapTable.getPartitionInfo().getType().equals(PartitionType.UNPARTITIONED)) {
             return Lists.newArrayList(olapTable.getPartitions());
         }
+        if (olapTable.getKeysType() != KeysType.UNIQUE_KEYS
+                && partitionNames.isEmpty()
+                && !scan.hasPartitionPredicate()
+                && !ConnectContext.get().getSessionVariable().isDeleteWithoutPartition()) {
+            throw new AnalysisException("This is a range or list partitioned table."
+                    + " You should specify partition in delete stmt,"
+                    + " or set delete_without_partition to true");
+        }
         List<Slot> partitionSlots = Lists.newArrayList();
         for (Column c : olapTable.getPartitionColumns()) {
             Slot partitionSlot = null;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommandTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/DeleteFromCommandTest.java
@@ -17,14 +17,24 @@
 
 package org.apache.doris.nereids.trees.plans.commands;
 
+import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Partition;
+import org.apache.doris.catalog.PartitionInfo;
+import org.apache.doris.catalog.PartitionType;
 import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalFilter;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapScan;
+import org.apache.doris.qe.ConnectContext;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.List;
 
 public class DeleteFromCommandTest {
 
@@ -68,6 +78,57 @@ public class DeleteFromCommandTest {
         Assertions.assertSame(initialException, mergedException.getSuppressed()[0]);
     }
 
+    @Test
+    public void testUnpartitionedDeleteDoesNotRequireSessionOverride() throws Exception {
+        DeleteFromCommand command = new DeleteFromCommand(Collections.emptyList(), null,
+                false, Collections.emptyList(), null);
+        OlapTable table = Mockito.mock(OlapTable.class);
+        PartitionInfo partitionInfo = Mockito.mock(PartitionInfo.class);
+        Partition partition = Mockito.mock(Partition.class);
+        Mockito.when(table.getPartitionInfo()).thenReturn(partitionInfo);
+        Mockito.when(partitionInfo.getType()).thenReturn(PartitionType.UNPARTITIONED);
+        Mockito.when(table.getPartitions()).thenReturn(Collections.singletonList(partition));
+
+        List<Partition> selectedPartitions = invokeGetSelectedPartitions(command, table,
+                null, null, Collections.emptyList());
+
+        Assertions.assertEquals(Collections.singletonList(partition), selectedPartitions);
+    }
+
+    @Test
+    public void testRejectPartitionedDeleteWithoutEffectivePartition() throws Exception {
+        ConnectContext previousContext = ConnectContext.get();
+        ConnectContext connectContext = new ConnectContext();
+        connectContext.getSessionVariable().deleteWithoutPartition = false;
+        connectContext.setThreadLocalInfo();
+        try {
+            DeleteFromCommand command = new DeleteFromCommand(Collections.emptyList(), null,
+                    false, Collections.emptyList(), null);
+            OlapTable table = Mockito.mock(OlapTable.class);
+            PartitionInfo partitionInfo = Mockito.mock(PartitionInfo.class);
+            PhysicalOlapScan scan = Mockito.mock(PhysicalOlapScan.class);
+            Mockito.when(table.getPartitionInfo()).thenReturn(partitionInfo);
+            Mockito.when(partitionInfo.getType()).thenReturn(PartitionType.RANGE);
+            Mockito.when(table.getKeysType()).thenReturn(KeysType.DUP_KEYS);
+            Mockito.when(scan.hasPartitionPredicate()).thenReturn(false);
+
+            InvocationTargetException exception = Assertions.assertThrows(InvocationTargetException.class,
+                    () -> invokeGetSelectedPartitions(command, table, null, scan, Collections.emptyList()));
+
+            Assertions.assertTrue(exception.getCause() instanceof AnalysisException);
+            Assertions.assertEquals("This is a range or list partitioned table."
+                            + " You should specify partition in delete stmt,"
+                            + " or set delete_without_partition to true",
+                    exception.getCause().getMessage());
+        } finally {
+            if (previousContext == null) {
+                ConnectContext.remove();
+            } else {
+                previousContext.setThreadLocalInfo();
+            }
+        }
+    }
+
     // Use reflection to validate the helper without exposing it only for tests.
     private AnalysisException invokeBuildDeleteFallbackException(DeleteFromCommand command,
             Exception initialException, Exception fallbackException)
@@ -76,5 +137,14 @@ public class DeleteFromCommandTest {
                 Exception.class, Exception.class);
         method.setAccessible(true);
         return (AnalysisException) method.invoke(command, initialException, fallbackException);
+    }
+
+    private List<Partition> invokeGetSelectedPartitions(DeleteFromCommand command,
+            OlapTable table, PhysicalFilter<?> filter, PhysicalOlapScan scan,
+            List<String> partitionNames) throws Exception {
+        Method method = DeleteFromCommand.class.getDeclaredMethod("getSelectedPartitions",
+                OlapTable.class, PhysicalFilter.class, PhysicalOlapScan.class, List.class);
+        method.setAccessible(true);
+        return (List<Partition>) method.invoke(command, table, filter, scan, partitionNames);
     }
 }

--- a/regression-test/suites/delete_p0/test_basic_delete_job.groovy
+++ b/regression-test/suites/delete_p0/test_basic_delete_job.groovy
@@ -37,6 +37,7 @@ suite("test_basic_delete_job") {
     """
     sql """insert into ${unpartitionTable} values (1, "a"), (2, "b"), (3, "c")"""
     qt_unpartition1 """select * from ${unpartitionTable} order by id"""
+    sql """set delete_without_partition = false"""
     sql """delete from ${unpartitionTable} where id < 0"""
     qt_unpartition2 """select * from ${unpartitionTable} order by id"""
     sql """delete from ${unpartitionTable} where id = 1"""
@@ -70,6 +71,11 @@ suite("test_basic_delete_job") {
     qt_one_range4 """select * from ${oneRangeColumnTable} order by id"""
     sql """delete from ${oneRangeColumnTable} partition(p0) where id < 22"""
     qt_one_range5 """select * from ${oneRangeColumnTable} order by id"""
+    test {
+        sql """delete from ${oneRangeColumnTable} where name = "d" """
+        exception "This is a range or list partitioned table. You should specify partition in delete stmt, or set delete_without_partition to true"
+    }
+    sql """set delete_without_partition = true"""
     sql """delete from ${oneRangeColumnTable} where name = "d" """
     qt_one_range6 """select * from ${oneRangeColumnTable} order by id"""
     sql """delete from ${oneRangeColumnTable} partition(p2) where name = "g" """
@@ -117,6 +123,7 @@ suite("test_basic_delete_job") {
     qt_two_range9 """select * from ${twoRangeColumnTable} order by id1, id2"""
 
     // Test one list partition column
+    sql """set delete_without_partition = false"""
     sql """DROP TABLE IF EXISTS ${oneListColumnTable} """
     sql """CREATE TABLE ${oneListColumnTable} (
           `id` int NOT NULL,
@@ -142,6 +149,11 @@ suite("test_basic_delete_job") {
     qt_one_list4 """select * from ${oneListColumnTable} order by id"""
     sql """delete from ${oneListColumnTable} partition(p0) where id < 22"""
     qt_one_list5 """select * from ${oneListColumnTable} order by id"""
+    test {
+        sql """delete from ${oneListColumnTable} where name = "d" """
+        exception "This is a range or list partitioned table. You should specify partition in delete stmt, or set delete_without_partition to true"
+    }
+    sql """set delete_without_partition = true"""
     sql """delete from ${oneListColumnTable} where name = "d" """
     qt_one_list6 """select * from ${oneListColumnTable} order by id"""
     sql """delete from ${oneListColumnTable} partition(p2) where name = "g" """
@@ -187,4 +199,5 @@ suite("test_basic_delete_job") {
     qt_two_list8 """select * from ${twoListColumnTable} order by id1, id2"""
     sql """delete from ${twoListColumnTable} where id2 > 300"""
     qt_two_list9 """select * from ${twoListColumnTable} order by id1, id2"""
+    sql """set delete_without_partition = false"""
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #62944

Problem Summary: Nereids predicate DELETE bypassed delete_without_partition for non-Unique range and list tables after partition pruning moved into the planner. A predicate that did not restrict the target partitions could therefore delete across every partition while the safety switch was false, even though unpartitioned tables must remain allowed. Use the physical scan effective partition-pruning signal to reject only non-Unique partitioned deletes that neither specify nor restrict partitions, while preserving Unique and DELETE USING behavior.

### Release note

Nereids DELETE now honors delete_without_partition for non-Unique range and list tables when no effective partition target is specified.

### Check List (For Author)

- Test: Unit Test and regression test case
    - ./run-fe-ut.sh --run org.apache.doris.nereids.trees.plans.commands.DeleteFromCommandTest
    - ./run-fe-ut.sh --run org.apache.doris.nereids.rules.rewrite.PartitionPrunerTest
    - Added delete_p0/test_basic_delete_job coverage; not run locally because this worktree has no FE/BE cluster output
- Behavior changed: Yes. Unsafe full-partition predicate deletes now require delete_without_partition=true on non-Unique range/list tables; unpartitioned and Unique table behavior is unchanged.
- Does this need documentation: No. The change restores the documented safety-switch behavior.

Co-authored-by: Siyang Tang <tangsiyang@selectdb.com>
