### PR TITLE
[feature](cloud) Add TLS hooks for outbound clients

### DIFF
--- a/cloud/src/client/client_connection_provider.h
+++ b/cloud/src/client/client_connection_provider.h
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <foundationdb/fdb_c.h>
+
+#include <functional>
+#include <string_view>
+
+namespace brpc {
+struct ChannelOptions;
+}
+
+namespace doris::cloud::client {
+
+using FdbNetworkOptionSetter = std::function<bool(FDBNetworkOption option, std::string_view value)>;
+
+// Applies build-specific FoundationDB options before fdb_setup_network().
+// The caller must abort network setup when this function returns false.
+bool configure_fdb_network_options(const FdbNetworkOptionSetter& set_option);
+
+// Applies build-specific options before initializing an internal peer meta-service channel.
+// The caller must not initialize the channel when this function returns false.
+bool configure_meta_service_channel_options(brpc::ChannelOptions* options);
+
+} // namespace doris::cloud::client

--- a/cloud/src/client/oss/client_connection_provider.cpp
+++ b/cloud/src/client/oss/client_connection_provider.cpp
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "client/client_connection_provider.h"
+
+namespace doris::cloud::client {
+
+bool configure_fdb_network_options(const FdbNetworkOptionSetter& set_option) {
+    (void)set_option;
+    return true;
+}
+
+bool configure_meta_service_channel_options(brpc::ChannelOptions* options) {
+    (void)options;
+    return true;
+}
+
+} // namespace doris::cloud::client

--- a/cloud/src/common/CMakeLists.txt
+++ b/cloud/src/common/CMakeLists.txt
@@ -31,10 +31,12 @@ set(COMMON_FILES
     metric.cpp
     kms.cpp
     network_util.cpp
+    ../client/oss/client_connection_provider.cpp
     ../server/oss/cloud_server_starter_factory.cpp
 )
 
 if (ENABLE_TLS)
+    list(REMOVE_ITEM COMMON_FILES ../client/oss/client_connection_provider.cpp)
     list(REMOVE_ITEM COMMON_FILES ../server/oss/cloud_server_starter_factory.cpp)
     file(GLOB_RECURSE EXTRA_SOURCES CONFIGURE_DEPENDS
             "${CMAKE_CURRENT_SOURCE_DIR}/../${TLS_MODULE_DIR}/*.cpp")

--- a/cloud/src/common/config.h
+++ b/cloud/src/common/config.h
@@ -64,6 +64,8 @@ CONF_String(tls_private_key_password, "");
 CONF_String(tls_verify_mode, "verify_peer");
 CONF_String(tls_ca_certificate_path, "");
 CONF_Int32(tls_cert_refresh_interval_seconds, "3600");
+// FoundationDB peer certificate constraints, for example Check.Valid=1.
+CONF_String(tls_fdb_verify_peers, "Check.Valid=1");
 CONF_String(tls_excluded_protocols, "");
 CONF_String(tls_peer_cert_required_san_dns, "");
 

--- a/cloud/src/meta-service/meta_service_resource.cpp
+++ b/cloud/src/meta-service/meta_service_resource.cpp
@@ -31,6 +31,7 @@
 #include <tuple>
 #include <unordered_set>
 
+#include "client/client_connection_provider.h"
 #include "common/bvars.h"
 #include "common/config.h"
 #include "common/encryption_util.h"
@@ -5209,6 +5210,10 @@ void notify_refresh_instance(std::shared_ptr<TxnKv> txn_kv, const std::string& i
 
     brpc::ChannelOptions options;
     options.connection_type = brpc::ConnectionType::CONNECTION_TYPE_SHORT;
+    if (!client::configure_meta_service_channel_options(&options)) {
+        LOG(WARNING) << "failed to configure internal meta-service channel";
+        return;
+    }
 
     static std::unordered_map<std::string, std::shared_ptr<MetaService_Stub>> stubs;
     static std::mutex mtx;

--- a/cloud/src/meta-store/txn_kv.cpp
+++ b/cloud/src/meta-store/txn_kv.cpp
@@ -33,6 +33,7 @@
 #include <variant>
 #include <vector>
 
+#include "client/client_connection_provider.h"
 #include "common/bvars.h"
 #include "common/config.h"
 #include "common/defer.h"
@@ -408,6 +409,19 @@ int Network::init() {
             return 1;
         }
         LOG(INFO) << "set fdb external client directory: " << config::fdb_external_client_directory;
+    }
+
+    if (!client::configure_fdb_network_options([&](FDBNetworkOption option,
+                                                   std::string_view value) {
+            err = fdb_network_set_option(option, reinterpret_cast<const uint8_t*>(value.data()),
+                                         value.size());
+            if (err != 0) {
+                LOG(WARNING) << "failed to set FDB network option=" << static_cast<int>(option)
+                             << ", err=" << fdb_get_error(err);
+            }
+            return err == 0;
+        })) {
+        return 1;
     }
 
     if (config::enable_fdb_locality_load_balance) {

--- a/cloud/test/CMakeLists.txt
+++ b/cloud/test/CMakeLists.txt
@@ -104,6 +104,8 @@ add_executable(util_test util_test.cpp)
 
 add_executable(network_util_test network_util_test.cpp)
 
+add_executable(client_connection_provider_test client_connection_provider_test.cpp)
+
 add_executable(cloud_server_starter_factory_test cloud_server_starter_factory_test.cpp)
 
 set(TLS_UT_TARGETS)
@@ -185,6 +187,8 @@ target_link_libraries(stopwatch_test ${TEST_LINK_LIBS})
 target_link_libraries(util_test ${TEST_LINK_LIBS})
 
 target_link_libraries(network_util_test ${TEST_LINK_LIBS})
+
+target_link_libraries(client_connection_provider_test ${TEST_LINK_LIBS})
 
 target_link_libraries(cloud_server_starter_factory_test ${TEST_LINK_LIBS})
 

--- a/cloud/test/client_connection_provider_test.cpp
+++ b/cloud/test/client_connection_provider_test.cpp
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "client/client_connection_provider.h"
+
+#include <brpc/channel.h>
+#include <gtest/gtest.h>
+
+namespace doris::cloud::client {
+
+TEST(ClientConnectionProviderTest, OssProvidersKeepPlaintextDefaults) {
+    int fdb_option_calls = 0;
+    EXPECT_TRUE(configure_fdb_network_options([&](FDBNetworkOption, std::string_view) {
+        ++fdb_option_calls;
+        return true;
+    }));
+    EXPECT_EQ(fdb_option_calls, 0);
+
+    brpc::ChannelOptions options;
+    EXPECT_TRUE(configure_meta_service_channel_options(&options));
+    EXPECT_FALSE(options.has_ssl_options());
+}
+
+} // namespace doris::cloud::client


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

Cloud feature modules can replace the inbound BRPC server starter, but public Cloud code has no extension points for configuring either:

- FoundationDB network options before the one-time `fdb_setup_network()` call.
- Peer Meta-Service BRPC channel options before `Channel::Init()`.

This leaves optional TLS modules unable to protect these outbound connections without introducing feature-specific dependencies into public Cloud code.

This PR adds a public client-provider contract, an OSS plaintext implementation, and build-time implementation replacement alongside the existing Cloud server-starter module split. It invokes the FDB provider before network setup and the peer Meta-Service provider before channel initialization. Provider failures abort the corresponding setup instead of silently falling back to plaintext. It also exposes the FDB peer-certificate constraint setting needed by a TLS implementation.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - `./run-cloud-ut.sh --run --filter=client_connection_provider_test:ClientConnectionProviderTest.* -j80`
        - Cloud ASAN unit-test targets compiled successfully; the focused test passed 1/1.
        - Clang Format 16 and format check passed.
        - Clang-Tidy 20.1.8 passed for changed lines with the Cloud ASAN compilation database.
        - `git diff --check` passed.
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No. The OSS provider preserves plaintext defaults; optional feature modules can replace the provider implementation.
    - [ ] Yes.

- Does this need documentation?
    - [x] No. The change is a source-level extension point and does not expose TLS in the OSS build.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label