### PR TITLE
[fix](fe) Preserve light schema job timestamps during replay

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/AlterJobV2.java
@@ -210,6 +210,14 @@ public abstract class AlterJobV2 implements Writable {
         return jobState.isFinalState();
     }
 
+    public long getCreateTimeMs() {
+        return createTimeMs;
+    }
+
+    public void setCreateTimeMs(long createTimeMs) {
+        this.createTimeMs = createTimeMs;
+    }
+
     public long getFinishedTimeMs() {
         return finishedTimeMs;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/SchemaChangeHandler.java
@@ -2677,13 +2677,13 @@ public class SchemaChangeHandler extends AlterHandler {
                 long jobId = Env.getCurrentEnv().getNextId();
                 //for schema change add/drop value column optimize, direct modify table meta.
                 modifyTableLightSchemaChange(rawSql, db, olapTable, indexSchemaMap, newIndexes,
-                        null, isDropIndex, jobId, false, propertyMap);
+                        null, isDropIndex, jobId, false, propertyMap, null, null);
             } else if (Config.enable_light_index_change && lightIndexChange) {
                 Index.checkConflict(newIndexes, olapTable.getCopiedBfColumns());
                 long jobId = Env.getCurrentEnv().getNextId();
                 // For light index changes, directly modify table metadata first.
                 modifyTableLightSchemaChange(rawSql, db, olapTable, indexSchemaMap, newIndexes,
-                        alterIndexes, isDropIndex, jobId, false, propertyMap);
+                        alterIndexes, isDropIndex, jobId, false, propertyMap, null, null);
             } else if (buildIndexChange) {
                 if (alterIndexes.isEmpty()) {
                     throw new DdlException("Altered index is empty. please check your alter stmt.");
@@ -3478,7 +3478,8 @@ public class SchemaChangeHandler extends AlterHandler {
     public void modifyTableLightSchemaChange(String rawSql, Database db, OlapTable olapTable,
                                              Map<Long, LinkedList<Column>> indexSchemaMap, List<Index> indexes,
                                              List<Index> alterIndexes, boolean isDropIndex,
-                                             long jobId, boolean isReplay, Map<String, String> propertyMap)
+                                             long jobId, boolean isReplay, Map<String, String> propertyMap,
+                                             Long createTimeMs, Long finishedTimeMs)
             throws DdlException, AnalysisException {
 
         if (LOG.isDebugEnabled()) {
@@ -3509,6 +3510,9 @@ public class SchemaChangeHandler extends AlterHandler {
         SchemaChangeJobV2 schemaChangeJob = AlterJobV2Factory.createSchemaChangeJobV2(
                 rawSql, jobId, db.getId(), olapTable.getId(),
                 olapTable.getName(), 1000);
+        if (createTimeMs != null) {
+            schemaChangeJob.setCreateTimeMs(createTimeMs);
+        }
 
         for (Map.Entry<Long, List<Column>> entry : changedIndexIdToSchema.entrySet()) {
             long originIndexId = entry.getKey();
@@ -3531,33 +3535,18 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         schemaChangeJob.stateWait("FE.LIGHT_SCHEMA_CHANGE");
+        long jobFinishedTimeMs = finishedTimeMs != null ? finishedTimeMs : System.currentTimeMillis();
 
         if (alterIndexes != null) {
             if (!isReplay) {
                 TableAddOrDropInvertedIndicesInfo info = new TableAddOrDropInvertedIndicesInfo(rawSql, db.getId(),
-                        olapTable.getId(), indexSchemaMap, indexes, alterIndexes, isDropIndex, jobId);
+                        olapTable.getId(), indexSchemaMap, indexes, alterIndexes, isDropIndex, jobId,
+                        schemaChangeJob.getCreateTimeMs(), jobFinishedTimeMs);
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("logModifyTableAddOrDropInvertedIndices info:{}", info);
                 }
                 if (!FeConstants.runningUnitTest) {
                     Env.getCurrentEnv().getEditLog().logModifyTableAddOrDropInvertedIndices(info);
-                    // Drop table column stats after light schema change finished.
-                    Env.getCurrentEnv().getAnalysisManager().removeTableStats(olapTable.getId());
-                    Env.getCurrentEnv().getAnalysisManager().dropStats(olapTable, null);
-                }
-
-                if (isDropIndex) {
-                    // send drop rpc to be
-                    Map<Long, Set<String>> invertedIndexOnPartitions = new HashMap<>();
-                    for (Index index : alterIndexes) {
-                        invertedIndexOnPartitions.put(index.getIndexId(), olapTable.getPartitionNames());
-                    }
-                    try {
-                        buildOrDeleteTableInvertedIndices(db, olapTable, indexSchemaMap,
-                                alterIndexes, invertedIndexOnPartitions, true);
-                    } catch (Exception e) {
-                        throw new DdlException(e.getMessage());
-                    }
                 }
             }
 
@@ -3568,20 +3557,24 @@ public class SchemaChangeHandler extends AlterHandler {
                 Map<String, Long> indexNameToId = new HashMap<>(olapTable.getIndexNameToId());
                 TableAddOrDropColumnsInfo info = new TableAddOrDropColumnsInfo(
                         rawSql, db.getId(), olapTable.getId(), olapTable.getBaseIndexId(),
-                        indexSchemaMap, oldIndexSchemaMap, indexNameToId, indexes, jobId);
+                        indexSchemaMap, oldIndexSchemaMap, indexNameToId, indexes, jobId,
+                        schemaChangeJob.getCreateTimeMs(), jobFinishedTimeMs);
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("logModifyTableAddOrDropColumns info:{}", info);
                 }
                 if (!FeConstants.runningUnitTest) {
                     Env.getCurrentEnv().getEditLog().logModifyTableAddOrDropColumns(info);
-                    // Drop table column stats after light schema change finished.
-                    Env.getCurrentEnv().getAnalysisManager().removeTableStats(olapTable.getId());
-                    Env.getCurrentEnv().getAnalysisManager().dropStats(olapTable, null);
                 }
             }
             LOG.info("finished modify table's add or drop or modify columns. table: {}, job: {}, is replay: {}",
                     olapTable.getName(), jobId, isReplay);
         }
+        // The metadata edit log is the commit point for light schema change. Register the compatibility job
+        // before post-commit work so the live state remains consistent with replay if that work fails.
+        schemaChangeJob.setJobState(AlterJobV2.JobState.FINISHED);
+        schemaChangeJob.setFinishedTimeMs(jobFinishedTimeMs);
+        this.addAlterJobV2(schemaChangeJob);
+
         // for bloom filter, rebuild bloom filter info by table schema in replay
         if (isReplay) {
             Set<String> bfCols = olapTable.getCopiedBfColumns();
@@ -3602,11 +3595,25 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         }
 
-        // add job after edit log
-        // set Job state then add job
-        schemaChangeJob.setJobState(AlterJobV2.JobState.FINISHED);
-        schemaChangeJob.setFinishedTimeMs(System.currentTimeMillis());
-        this.addAlterJobV2(schemaChangeJob);
+        if (!isReplay && !FeConstants.runningUnitTest) {
+            // Drop table column stats after light schema change finished.
+            Env.getCurrentEnv().getAnalysisManager().removeTableStats(olapTable.getId());
+            Env.getCurrentEnv().getAnalysisManager().dropStats(olapTable, null);
+        }
+
+        if (alterIndexes != null && !isReplay && isDropIndex) {
+            // send drop rpc to be
+            Map<Long, Set<String>> invertedIndexOnPartitions = new HashMap<>();
+            for (Index index : alterIndexes) {
+                invertedIndexOnPartitions.put(index.getIndexId(), olapTable.getPartitionNames());
+            }
+            try {
+                buildOrDeleteTableInvertedIndices(db, olapTable, indexSchemaMap,
+                        alterIndexes, invertedIndexOnPartitions, true);
+            } catch (Exception e) {
+                throw new DdlException(e.getMessage());
+            }
+        }
     }
 
     public void replayModifyTableLightSchemaChange(TableAddOrDropColumnsInfo info)
@@ -3626,7 +3633,7 @@ public class SchemaChangeHandler extends AlterHandler {
         olapTable.writeLock();
         try {
             modifyTableLightSchemaChange("", db, olapTable, indexSchemaMap, indexes, null, false, jobId,
-                    true, new HashMap<>());
+                    true, new HashMap<>(), info.getCreateTimeMs(), info.getFinishedTimeMs());
         } catch (DdlException e) {
             // should not happen
             LOG.warn("failed to replay modify table add or drop or modify columns", e);
@@ -3771,7 +3778,8 @@ public class SchemaChangeHandler extends AlterHandler {
         olapTable.writeLock();
         try {
             modifyTableLightSchemaChange("", db, olapTable, indexSchemaMap, newIndexes,
-                                             alterIndexes, isDropIndex, jobId, true, new HashMap<>());
+                                             alterIndexes, isDropIndex, jobId, true, new HashMap<>(),
+                                             info.getCreateTimeMs(), info.getFinishedTimeMs());
         } catch (UserException e) {
             // should not happen
             LOG.warn("failed to replay modify table add or drop indexes", e);

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/TableAddOrDropColumnsInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/TableAddOrDropColumnsInfo.java
@@ -52,6 +52,10 @@ public class TableAddOrDropColumnsInfo implements Writable {
     private List<Index> indexes;
     @SerializedName(value = "jobId")
     private long jobId;
+    @SerializedName(value = "createTimeMs")
+    private Long createTimeMs;
+    @SerializedName(value = "finishedTimeMs")
+    private Long finishedTimeMs;
     @SerializedName(value = "rawSql")
     private String rawSql;
 
@@ -59,7 +63,7 @@ public class TableAddOrDropColumnsInfo implements Writable {
             Map<Long, LinkedList<Column>> indexSchemaMap,
             Map<Long, List<Column>> oldIndexSchemaMap,
             Map<String, Long> indexNameToId,
-            List<Index> indexes, long jobId) {
+            List<Index> indexes, long jobId, Long createTimeMs, Long finishedTimeMs) {
         this.rawSql = rawSql;
         this.dbId = dbId;
         this.tableId = tableId;
@@ -69,6 +73,8 @@ public class TableAddOrDropColumnsInfo implements Writable {
         this.indexNameToId = indexNameToId;
         this.indexes = indexes;
         this.jobId = jobId;
+        this.createTimeMs = createTimeMs;
+        this.finishedTimeMs = finishedTimeMs;
     }
 
     public long getDbId() {
@@ -89,6 +95,14 @@ public class TableAddOrDropColumnsInfo implements Writable {
 
     public long getJobId() {
         return jobId;
+    }
+
+    public Long getCreateTimeMs() {
+        return createTimeMs;
+    }
+
+    public Long getFinishedTimeMs() {
+        return finishedTimeMs;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/TableAddOrDropInvertedIndicesInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/TableAddOrDropInvertedIndicesInfo.java
@@ -50,13 +50,17 @@ public class TableAddOrDropInvertedIndicesInfo implements Writable {
     private boolean isDropInvertedIndex;
     @SerializedName(value = "jobId")
     private long jobId;
+    @SerializedName(value = "createTimeMs")
+    private Long createTimeMs;
+    @SerializedName(value = "finishedTimeMs")
+    private Long finishedTimeMs;
     @SerializedName(value = "rawSql")
     private String rawSql;
 
     public TableAddOrDropInvertedIndicesInfo(String rawSql, long dbId, long tableId,
             Map<Long, LinkedList<Column>> indexSchemaMap, List<Index> indexes,
             List<Index> alterInvertedIndexes, boolean isDropInvertedIndex,
-            long jobId) {
+            long jobId, Long createTimeMs, Long finishedTimeMs) {
         this.rawSql = rawSql;
         this.dbId = dbId;
         this.tableId = tableId;
@@ -65,6 +69,8 @@ public class TableAddOrDropInvertedIndicesInfo implements Writable {
         this.alterInvertedIndexes = alterInvertedIndexes;
         this.isDropInvertedIndex = isDropInvertedIndex;
         this.jobId = jobId;
+        this.createTimeMs = createTimeMs;
+        this.finishedTimeMs = finishedTimeMs;
     }
 
     public long getDbId() {
@@ -93,6 +99,14 @@ public class TableAddOrDropInvertedIndicesInfo implements Writable {
 
     public long getJobId() {
         return jobId;
+    }
+
+    public Long getCreateTimeMs() {
+        return createTimeMs;
+    }
+
+    public Long getFinishedTimeMs() {
+        return finishedTimeMs;
     }
 
     public String toJson() {

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/LightSchemaChangeReplayTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/LightSchemaChangeReplayTest.java
@@ -1,0 +1,415 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.alter;
+
+import org.apache.doris.catalog.AggregateType;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.Index;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.catalog.info.IndexType;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.TimeUtils;
+import org.apache.doris.persist.EditLog;
+import org.apache.doris.persist.TableAddOrDropColumnsInfo;
+import org.apache.doris.persist.TableAddOrDropInvertedIndicesInfo;
+import org.apache.doris.persist.gson.GsonUtils;
+import org.apache.doris.utframe.TestWithFeService;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class LightSchemaChangeReplayTest extends TestWithFeService {
+    private static final String DB_NAME = "light_schema_change_replay";
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase(DB_NAME);
+    }
+
+    @Test
+    public void testReplayAddDropAndModifyColumnsPreservesJobTimestamps() throws Exception {
+        Database db = Env.getCurrentInternalCatalog().getDbOrMetaException(DB_NAME);
+        OlapTable table = createLightSchemaChangeTable("column_replay");
+        SchemaChangeHandler handler = Env.getCurrentEnv().getSchemaChangeHandler();
+
+        LinkedList<Column> originalSchema = copyBaseSchema(table);
+        LinkedList<Column> addedSchema = new LinkedList<>(originalSchema);
+        Column addedColumn = new Column("v2", ScalarType.createType(PrimitiveType.INT),
+                false, AggregateType.NONE, "0", "");
+        addedColumn.setUniqueId(table.getBaseIndexMeta().getMaxColUniqueId() + 1);
+        addedSchema.add(addedColumn);
+
+        long addJobId = Env.getCurrentEnv().getNextId();
+        TableAddOrDropColumnsInfo addInfo = executeAndCaptureColumnsInfo(
+                handler, db, table, addedSchema, addJobId);
+        long addCreateTimeMs = addInfo.getCreateTimeMs();
+        long addFinishedTimeMs = addInfo.getFinishedTimeMs();
+        assertJobAndShowAlterTimestamps(handler, db, addJobId, addCreateTimeMs, addFinishedTimeMs);
+        handler.getAlterJobsV2().remove(addJobId);
+        handler.runnableSchemaChangeJobV2.remove(addJobId);
+        Map<Long, LinkedList<Column>> originalSchemaMap = Maps.newHashMap();
+        originalSchemaMap.put(table.getBaseIndexId(), originalSchema);
+        table.writeLock();
+        try {
+            handler.updateBaseIndexSchema(table, originalSchemaMap, table.getIndexes());
+        } finally {
+            table.writeUnlock();
+        }
+        Assertions.assertNull(table.getColumn("v2"));
+
+        addInfo = roundTrip(addInfo);
+        handler.replayModifyTableLightSchemaChange(addInfo);
+
+        Assertions.assertNotNull(table.getColumn("v2"));
+        assertJobAndShowAlterTimestamps(handler, db, addJobId, addCreateTimeMs, addFinishedTimeMs);
+
+        LinkedList<Column> droppedSchema = copyBaseSchema(table);
+        droppedSchema.removeIf(column -> column.getName().equals("v2"));
+        long dropJobId = Env.getCurrentEnv().getNextId();
+        long dropCreateTimeMs = System.currentTimeMillis() - 2000;
+        long dropFinishedTimeMs = System.currentTimeMillis() - 1000;
+        TableAddOrDropColumnsInfo dropInfo = roundTrip(createColumnsInfo(
+                db, table, droppedSchema, dropJobId, dropCreateTimeMs, dropFinishedTimeMs));
+        handler.replayModifyTableLightSchemaChange(dropInfo);
+
+        Assertions.assertNull(table.getColumn("v2"));
+        assertJobAndShowAlterTimestamps(handler, db, dropJobId, dropCreateTimeMs, dropFinishedTimeMs);
+
+        LinkedList<Column> modifiedSchema = copyBaseSchema(table);
+        Column modifiedColumn = modifiedSchema.stream()
+                .filter(column -> column.getName().equals("v1"))
+                .findFirst()
+                .orElseThrow();
+        modifiedColumn.setType(ScalarType.createVarchar(40));
+        long modifyJobId = Env.getCurrentEnv().getNextId();
+        long modifyCreateTimeMs = System.currentTimeMillis() - 500;
+        long modifyFinishedTimeMs = System.currentTimeMillis();
+        TableAddOrDropColumnsInfo modifyInfo = roundTrip(createColumnsInfo(
+                db, table, modifiedSchema, modifyJobId, modifyCreateTimeMs, modifyFinishedTimeMs));
+        handler.replayModifyTableLightSchemaChange(modifyInfo);
+
+        Assertions.assertEquals(ScalarType.createVarchar(40), table.getColumn("v1").getType());
+        assertJobAndShowAlterTimestamps(
+                handler, db, modifyJobId, modifyCreateTimeMs, modifyFinishedTimeMs);
+    }
+
+    @Test
+    public void testReplayAddAndDropInvertedIndexPreservesJobTimestamps() throws Exception {
+        Database db = Env.getCurrentInternalCatalog().getDbOrMetaException(DB_NAME);
+        OlapTable table = createLightSchemaChangeTable("inverted_index_replay");
+        SchemaChangeHandler handler = Env.getCurrentEnv().getSchemaChangeHandler();
+
+        Index invertedIndex = new Index(Env.getCurrentEnv().getNextId(), "idx_v1",
+                Lists.newArrayList("v1"), IndexType.INVERTED, null, "");
+        List<Index> addedIndexes = Lists.newArrayList(table.getIndexes());
+        addedIndexes.add(invertedIndex);
+        long addJobId = Env.getCurrentEnv().getNextId();
+        long baseTimeMs = System.currentTimeMillis() - 5000;
+        long addCreateTimeMs = baseTimeMs;
+        long addFinishedTimeMs = baseTimeMs + 1000;
+        TableAddOrDropInvertedIndicesInfo persistedAddInfo = new TableAddOrDropInvertedIndicesInfo(
+                "", db.getId(), table.getId(), createIndexSchemaMap(table), addedIndexes,
+                Lists.newArrayList(invertedIndex), false, addJobId, addCreateTimeMs, addFinishedTimeMs);
+        TableAddOrDropInvertedIndicesInfo addInfo = roundTrip(persistedAddInfo);
+        handler.replayModifyTableAddOrDropInvertedIndices(addInfo);
+
+        Index replayedIndex = table.getIndexes().stream()
+                .filter(index -> index.getIndexName().equals("idx_v1"))
+                .findFirst()
+                .orElseThrow();
+        assertJobAndShowAlterTimestamps(handler, db, addJobId, addCreateTimeMs, addFinishedTimeMs);
+
+        List<Index> droppedIndexes = table.getIndexes().stream()
+                .filter(index -> !index.getIndexName().equals("idx_v1"))
+                .collect(Collectors.toList());
+        long dropJobId = Env.getCurrentEnv().getNextId();
+        long dropCreateTimeMs = baseTimeMs + 2000;
+        long dropFinishedTimeMs = baseTimeMs + 3000;
+        TableAddOrDropInvertedIndicesInfo dropInfo = roundTrip(new TableAddOrDropInvertedIndicesInfo(
+                "", db.getId(), table.getId(), createIndexSchemaMap(table), droppedIndexes,
+                Lists.newArrayList(replayedIndex), true, dropJobId, dropCreateTimeMs, dropFinishedTimeMs));
+        handler.replayModifyTableAddOrDropInvertedIndices(dropInfo);
+
+        Assertions.assertTrue(table.getIndexes().stream()
+                .noneMatch(index -> index.getIndexName().equals("idx_v1")));
+        assertJobAndShowAlterTimestamps(handler, db, dropJobId, dropCreateTimeMs, dropFinishedTimeMs);
+    }
+
+    @Test
+    public void testDropInvertedIndexPostCommitFailureKeepsReplayTimestamps() throws Exception {
+        Database db = Env.getCurrentInternalCatalog().getDbOrMetaException(DB_NAME);
+        OlapTable table = createLightSchemaChangeTable("inverted_index_post_commit_failure");
+        SchemaChangeHandler handler = Env.getCurrentEnv().getSchemaChangeHandler();
+        SchemaChangeHandler failingHandler = Mockito.spy(handler);
+
+        Index invertedIndex = new Index(Env.getCurrentEnv().getNextId(), "idx_v1",
+                Lists.newArrayList("v1"), IndexType.INVERTED, null, "");
+        List<Index> indexesWithInvertedIndex = Lists.newArrayList(table.getIndexes());
+        indexesWithInvertedIndex.add(invertedIndex);
+        updateIndexes(handler, table, indexesWithInvertedIndex);
+
+        Mockito.doThrow(new UserException("injected physical index cleanup failure"))
+                .when(failingHandler)
+                .buildOrDeleteTableInvertedIndices(Mockito.eq(db), Mockito.eq(table), Mockito.anyMap(),
+                        Mockito.anyList(), Mockito.anyMap(), Mockito.eq(true));
+
+        EditLog originalEditLog = Env.getCurrentEnv().getEditLog();
+        EditLog capturedEditLog = Mockito.mock(EditLog.class);
+        ArgumentCaptor<TableAddOrDropInvertedIndicesInfo> infoCaptor =
+                ArgumentCaptor.forClass(TableAddOrDropInvertedIndicesInfo.class);
+        Mockito.doNothing().when(capturedEditLog)
+                .logModifyTableAddOrDropInvertedIndices(infoCaptor.capture());
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        Env.getCurrentEnv().setEditLog(capturedEditLog);
+        FeConstants.runningUnitTest = false;
+        long jobId = Env.getCurrentEnv().getNextId();
+        List<Index> droppedIndexes = table.getIndexes().stream()
+                .filter(index -> !index.getIndexName().equals("idx_v1"))
+                .collect(Collectors.toList());
+        try {
+            table.writeLock();
+            try {
+                DdlException exception = Assertions.assertThrows(DdlException.class,
+                        () -> failingHandler.modifyTableLightSchemaChange("", db, table,
+                                createIndexSchemaMap(table), droppedIndexes, Lists.newArrayList(invertedIndex),
+                                true, jobId, false, Maps.newHashMap(), null, null));
+                Assertions.assertTrue(exception.getMessage().contains("injected physical index cleanup failure"));
+            } finally {
+                table.writeUnlock();
+            }
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
+            Env.getCurrentEnv().setEditLog(originalEditLog);
+        }
+
+        TableAddOrDropInvertedIndicesInfo committedInfo = infoCaptor.getValue();
+        long createTimeMs = committedInfo.getCreateTimeMs();
+        long finishedTimeMs = committedInfo.getFinishedTimeMs();
+        assertJobAndShowAlterTimestamps(failingHandler, db, jobId, createTimeMs, finishedTimeMs);
+
+        handler.getAlterJobsV2().remove(jobId);
+        handler.runnableSchemaChangeJobV2.remove(jobId);
+        updateIndexes(handler, table, indexesWithInvertedIndex);
+        Assertions.assertTrue(table.getIndexes().stream()
+                .anyMatch(index -> index.getIndexName().equals("idx_v1")));
+
+        handler.replayModifyTableAddOrDropInvertedIndices(roundTrip(committedInfo));
+
+        Assertions.assertTrue(table.getIndexes().stream()
+                .noneMatch(index -> index.getIndexName().equals("idx_v1")));
+        assertJobAndShowAlterTimestamps(handler, db, jobId, createTimeMs, finishedTimeMs);
+    }
+
+    @Test
+    public void testReplayLegacyJournalUsesReplayTimestamps() throws Exception {
+        Database db = Env.getCurrentInternalCatalog().getDbOrMetaException(DB_NAME);
+        OlapTable table = createLightSchemaChangeTable("legacy_replay");
+        LinkedList<Column> addedSchema = copyBaseSchema(table);
+        Column addedColumn = new Column("v2", ScalarType.createType(PrimitiveType.INT),
+                false, AggregateType.NONE, "0", "");
+        addedColumn.setUniqueId(table.getBaseIndexMeta().getMaxColUniqueId() + 1);
+        addedSchema.add(addedColumn);
+
+        long jobId = Env.getCurrentEnv().getNextId();
+        TableAddOrDropColumnsInfo currentInfo = createColumnsInfo(
+                db, table, addedSchema, jobId, 1700000021000L, 1700000022000L);
+        JsonObject legacyJson = GsonUtils.GSON.toJsonTree(currentInfo).getAsJsonObject();
+        legacyJson.remove("createTimeMs");
+        legacyJson.remove("finishedTimeMs");
+        TableAddOrDropColumnsInfo legacyInfo = GsonUtils.GSON.fromJson(
+                legacyJson, TableAddOrDropColumnsInfo.class);
+        Assertions.assertNull(legacyInfo.getCreateTimeMs());
+        Assertions.assertNull(legacyInfo.getFinishedTimeMs());
+
+        long beforeReplayMs = System.currentTimeMillis();
+        SchemaChangeHandler handler = Env.getCurrentEnv().getSchemaChangeHandler();
+        handler.replayModifyTableLightSchemaChange(legacyInfo);
+        long afterReplayMs = System.currentTimeMillis();
+
+        AlterJobV2 replayedJob = handler.getAlterJobsV2().get(jobId);
+        Assertions.assertNotNull(replayedJob);
+        Assertions.assertTrue(replayedJob.getCreateTimeMs() >= beforeReplayMs);
+        Assertions.assertTrue(replayedJob.getCreateTimeMs() <= afterReplayMs);
+        Assertions.assertTrue(replayedJob.getFinishedTimeMs() >= beforeReplayMs);
+        Assertions.assertTrue(replayedJob.getFinishedTimeMs() <= afterReplayMs);
+        assertJobAndShowAlterTimestamps(handler, db, jobId,
+                replayedJob.getCreateTimeMs(), replayedJob.getFinishedTimeMs());
+
+        OlapTable invertedIndexTable = createLightSchemaChangeTable("legacy_inverted_index_replay");
+        Index invertedIndex = new Index(Env.getCurrentEnv().getNextId(), "idx_v1",
+                Lists.newArrayList("v1"), IndexType.INVERTED, null, "");
+        List<Index> indexes = Lists.newArrayList(invertedIndexTable.getIndexes());
+        indexes.add(invertedIndex);
+        long invertedIndexJobId = Env.getCurrentEnv().getNextId();
+        TableAddOrDropInvertedIndicesInfo currentIndexInfo = new TableAddOrDropInvertedIndicesInfo(
+                "", db.getId(), invertedIndexTable.getId(), createIndexSchemaMap(invertedIndexTable), indexes,
+                Lists.newArrayList(invertedIndex), false, invertedIndexJobId, 1700000023000L, 1700000024000L);
+        JsonObject legacyIndexJson = GsonUtils.GSON.toJsonTree(currentIndexInfo).getAsJsonObject();
+        legacyIndexJson.remove("createTimeMs");
+        legacyIndexJson.remove("finishedTimeMs");
+        TableAddOrDropInvertedIndicesInfo legacyIndexInfo = GsonUtils.GSON.fromJson(
+                legacyIndexJson, TableAddOrDropInvertedIndicesInfo.class);
+        Assertions.assertNull(legacyIndexInfo.getCreateTimeMs());
+        Assertions.assertNull(legacyIndexInfo.getFinishedTimeMs());
+
+        long beforeIndexReplayMs = System.currentTimeMillis();
+        handler.replayModifyTableAddOrDropInvertedIndices(legacyIndexInfo);
+        long afterIndexReplayMs = System.currentTimeMillis();
+
+        AlterJobV2 replayedIndexJob = handler.getAlterJobsV2().get(invertedIndexJobId);
+        Assertions.assertNotNull(replayedIndexJob);
+        Assertions.assertTrue(replayedIndexJob.getCreateTimeMs() >= beforeIndexReplayMs);
+        Assertions.assertTrue(replayedIndexJob.getCreateTimeMs() <= afterIndexReplayMs);
+        Assertions.assertTrue(replayedIndexJob.getFinishedTimeMs() >= beforeIndexReplayMs);
+        Assertions.assertTrue(replayedIndexJob.getFinishedTimeMs() <= afterIndexReplayMs);
+        assertJobAndShowAlterTimestamps(handler, db, invertedIndexJobId,
+                replayedIndexJob.getCreateTimeMs(), replayedIndexJob.getFinishedTimeMs());
+    }
+
+    private OlapTable createLightSchemaChangeTable(String tableName) throws Exception {
+        createTable("CREATE TABLE " + DB_NAME + "." + tableName + " (\n"
+                + "k1 INT NOT NULL,\n"
+                + "v1 VARCHAR(20)\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(k1)\n"
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1\n"
+                + "PROPERTIES ('replication_num' = '1', 'light_schema_change' = 'true')");
+        Database db = Env.getCurrentInternalCatalog().getDbOrMetaException(DB_NAME);
+        return (OlapTable) db.getTableOrMetaException(tableName, Table.TableType.OLAP);
+    }
+
+    private TableAddOrDropColumnsInfo createColumnsInfo(Database db, OlapTable table,
+            LinkedList<Column> schema, long jobId, Long createTimeMs, Long finishedTimeMs) {
+        Map<Long, LinkedList<Column>> indexSchemaMap = Maps.newHashMap();
+        indexSchemaMap.put(table.getBaseIndexId(), schema);
+        return new TableAddOrDropColumnsInfo("", db.getId(), table.getId(), table.getBaseIndexId(),
+                indexSchemaMap, table.getCopiedIndexIdToSchema(true, true),
+                Maps.newHashMap(table.getIndexNameToId()), table.getIndexes(), jobId,
+                createTimeMs, finishedTimeMs);
+    }
+
+    private TableAddOrDropColumnsInfo executeAndCaptureColumnsInfo(SchemaChangeHandler handler,
+            Database db, OlapTable table, LinkedList<Column> schema, long jobId) throws Exception {
+        EditLog originalEditLog = Env.getCurrentEnv().getEditLog();
+        EditLog capturedEditLog = Mockito.mock(EditLog.class);
+        ArgumentCaptor<TableAddOrDropColumnsInfo> infoCaptor =
+                ArgumentCaptor.forClass(TableAddOrDropColumnsInfo.class);
+        Mockito.doNothing().when(capturedEditLog).logModifyTableAddOrDropColumns(infoCaptor.capture());
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        Env.getCurrentEnv().setEditLog(capturedEditLog);
+        FeConstants.runningUnitTest = false;
+        Map<Long, LinkedList<Column>> indexSchemaMap = Maps.newHashMap();
+        indexSchemaMap.put(table.getBaseIndexId(), schema);
+        try {
+            table.writeLock();
+            try {
+                handler.modifyTableLightSchemaChange("", db, table, indexSchemaMap, table.getIndexes(),
+                        null, false, jobId, false, Maps.newHashMap(), null, null);
+            } finally {
+                table.writeUnlock();
+            }
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
+            Env.getCurrentEnv().setEditLog(originalEditLog);
+        }
+        TableAddOrDropColumnsInfo info = infoCaptor.getValue();
+        Assertions.assertNotNull(info.getCreateTimeMs());
+        Assertions.assertNotNull(info.getFinishedTimeMs());
+        return info;
+    }
+
+    private Map<Long, LinkedList<Column>> createIndexSchemaMap(OlapTable table) {
+        Map<Long, LinkedList<Column>> indexSchemaMap = Maps.newHashMap();
+        indexSchemaMap.put(table.getBaseIndexId(), copyBaseSchema(table));
+        return indexSchemaMap;
+    }
+
+    private void updateIndexes(SchemaChangeHandler handler, OlapTable table, List<Index> indexes)
+            throws IOException {
+        table.writeLock();
+        try {
+            handler.updateBaseIndexSchema(table, createIndexSchemaMap(table), indexes);
+        } finally {
+            table.writeUnlock();
+        }
+    }
+
+    private LinkedList<Column> copyBaseSchema(OlapTable table) {
+        return table.getBaseSchema(true).stream()
+                .map(Column::new)
+                .collect(Collectors.toCollection(LinkedList::new));
+    }
+
+    private void assertJobAndShowAlterTimestamps(SchemaChangeHandler handler, Database db,
+            long jobId, long createTimeMs, long finishedTimeMs) {
+        AlterJobV2 job = handler.getAlterJobsV2().get(jobId);
+        Assertions.assertNotNull(job);
+        Assertions.assertEquals(createTimeMs, job.getCreateTimeMs());
+        Assertions.assertEquals(finishedTimeMs, job.getFinishedTimeMs());
+
+        List<Comparable> showAlterRow = handler.getAlterJobInfosByDb(db).stream()
+                .filter(row -> ((Number) row.get(0)).longValue() == jobId)
+                .findFirst()
+                .orElseThrow();
+        Assertions.assertEquals(TimeUtils.longToTimeStringWithms(createTimeMs), showAlterRow.get(2));
+        Assertions.assertEquals(TimeUtils.longToTimeStringWithms(finishedTimeMs), showAlterRow.get(3));
+    }
+
+    private TableAddOrDropColumnsInfo roundTrip(TableAddOrDropColumnsInfo info) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bytes)) {
+            info.write(out);
+        }
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return TableAddOrDropColumnsInfo.read(in);
+        }
+    }
+
+    private TableAddOrDropInvertedIndicesInfo roundTrip(TableAddOrDropInvertedIndicesInfo info)
+            throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bytes)) {
+            info.write(out);
+        }
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return TableAddOrDropInvertedIndicesInfo.read(in);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/SchemaChangeHandlerTest.java
@@ -359,7 +359,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         try {
             table.setBloomFilterInfo(Sets.newHashSet("K1"), table.getBfFpp());
             schemaChangeHandler.modifyTableLightSchemaChange("", db, table, indexSchemaMap, table.getIndexes(),
-                    null, false, replayJobId, true, Maps.newHashMap());
+                    null, false, replayJobId, true, Maps.newHashMap(), null, null);
 
             Assertions.assertNotNull(table.getColumn("v2"));
             Assertions.assertEquals(Sets.newHashSet("k1"), table.getCopiedBfColumns());

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/TableAddOrDropColumnsInfoTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/TableAddOrDropColumnsInfoTest.java
@@ -55,6 +55,8 @@ public class TableAddOrDropColumnsInfoTest {
         long dbId = 12345678;
         long tableId = 87654321;
         long jobId = 23456781;
+        long createTimeMs = 1234L;
+        long finishedTimeMs = 5678L;
         LinkedList<Column> fullSchema = new LinkedList<>();
         fullSchema.add(new Column("testCol1", ScalarType.createType(PrimitiveType.INT)));
         fullSchema.add(new Column("testCol2", ScalarType.createType(PrimitiveType.VARCHAR)));
@@ -75,7 +77,8 @@ public class TableAddOrDropColumnsInfoTest {
 
         TableAddOrDropColumnsInfo tableAddOrDropColumnsInfo1 = new TableAddOrDropColumnsInfo(
                 "", dbId, tableId, tableId,
-                indexSchemaMap, oldIndexSchemaMap, indexNameToId, indexes, jobId);
+                indexSchemaMap, oldIndexSchemaMap, indexNameToId, indexes, jobId,
+                createTimeMs, finishedTimeMs);
 
         String c1Json = GsonUtils.GSON.toJson(tableAddOrDropColumnsInfo1);
         Text.writeString(out, c1Json);
@@ -93,6 +96,10 @@ public class TableAddOrDropColumnsInfoTest {
         Assert.assertEquals(tableAddOrDropColumnsInfo1.getTableId(), tableAddOrDropColumnsInfo2.getTableId());
         Assert.assertEquals(tableAddOrDropColumnsInfo1.getIndexSchemaMap(),
                 tableAddOrDropColumnsInfo2.getIndexSchemaMap());
+        Assert.assertEquals(tableAddOrDropColumnsInfo1.getCreateTimeMs(),
+                tableAddOrDropColumnsInfo2.getCreateTimeMs());
+        Assert.assertEquals(tableAddOrDropColumnsInfo1.getFinishedTimeMs(),
+                tableAddOrDropColumnsInfo2.getFinishedTimeMs());
 
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #62861

Problem Summary: Light schema changes create a finished compatibility job after directly updating table metadata. Their column and inverted-index journal records did not persist the job's creation and finish times, so replay rebuilt the job with the replay timestamp. This changed SHOW ALTER history and delayed expiration after every restart. Persist both timestamps at the metadata journal commit point and restore them during replay. Register the live compatibility job immediately after that commit so later inverted-index cleanup failures remain consistent with replay, while treating missing fields from older journals as replay-time defaults.

### Release note

Preserve light schema change job creation and finish timestamps across FE replay.

### Check List (For Author)

- Test: Unit Test
    - `./run-fe-ut.sh --run 'org.apache.doris.alter.LightSchemaChangeReplayTest,org.apache.doris.persist.TableAddOrDropColumnsInfoTest,org.apache.doris.alter.SchemaChangeHandlerTest#testModifyTableLightSchemaChangeReplayNormalizesBfColumns'` (6 tests, 0 failures/errors/skips; FE reactor BUILD SUCCESS)
    - Checkstyle 9.3 on all changed Java files
- Behavior changed: Yes. Replayed light schema change jobs retain their original creation and finish timestamps.
- Does this need documentation: No
