### PR TITLE
[fix](pipeline) Unify fragment cancellation and close lifecycle

### DIFF
--- a/be/src/exec/pipeline/pipeline_fragment_context.cpp
+++ b/be/src/exec/pipeline/pipeline_fragment_context.cpp
@@ -209,13 +209,32 @@ bool PipelineFragmentContext::notify_close() {
 // Method like exchange sink buffer will call query ctx cancel. If we add lock here
 // There maybe dead lock.
 void PipelineFragmentContext::cancel(const Status reason) {
+    if (notify_close()) {
+        return;
+    }
+    auto expected = LifecycleState::CREATED;
+    if (!_lifecycle_state.compare_exchange_strong(expected, LifecycleState::CANCELLING,
+                                                  std::memory_order_acq_rel,
+                                                  std::memory_order_acquire)) {
+        return;
+    }
+
+    if (auto error_url = get_load_error_url(); !error_url.empty()) {
+        _query_ctx->set_load_error_url(error_url);
+    }
+
+    if (auto first_error_msg = get_first_error_msg(); !first_error_msg.empty()) {
+        _query_ctx->set_first_error_msg(first_error_msg);
+    }
+
+    // Publish the query error before potentially expensive fragment diagnostics. Other tasks can
+    // continue closing after they observe CANCELLING, so reports must see the failed query status.
+    _query_ctx->cancel(reason, _fragment_id);
+
     LOG_INFO("PipelineFragmentContext::cancel")
             .tag("query_id", print_id(_query_id))
             .tag("fragment_id", _fragment_id)
             .tag("reason", reason.to_string());
-    if (notify_close()) {
-        return;
-    }
     // Timeout is a special error code, we need print current stack to debug timeout issue.
     if (reason.is<ErrorCode::TIMEOUT>()) {
         auto dbg_str = fmt::format("PipelineFragmentContext is cancelled due to timeout:\n{}",
@@ -233,15 +252,6 @@ void PipelineFragmentContext::cancel(const Status reason) {
         print_profile("cancel pipeline, reason: " + reason.to_string());
     }
 
-    if (auto error_url = get_load_error_url(); !error_url.empty()) {
-        _query_ctx->set_load_error_url(error_url);
-    }
-
-    if (auto first_error_msg = get_first_error_msg(); !first_error_msg.empty()) {
-        _query_ctx->set_first_error_msg(first_error_msg);
-    }
-
-    _query_ctx->cancel(reason, _fragment_id);
     if (!reason.is<ErrorCode::LIMIT_REACH>() && !reason.is<ErrorCode::FINISHED>()) {
         for (auto& id : _fragment_instance_ids) {
             LOG(WARNING) << "PipelineFragmentContext cancel instance: " << print_id(id);
@@ -2232,6 +2242,19 @@ void PipelineFragmentContext::print_profile(const std::string& extra_info) {
         LOG_LONG_STRING(INFO, profile_str);
     }
 }
+
+bool PipelineFragmentContext::_try_start_close() {
+    auto state = _lifecycle_state.load(std::memory_order_acquire);
+    while (state == LifecycleState::CREATED || state == LifecycleState::CANCELLING) {
+        if (_lifecycle_state.compare_exchange_weak(state, LifecycleState::CLOSING,
+                                                   std::memory_order_acq_rel,
+                                                   std::memory_order_acquire)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // If all pipeline tasks binded to the fragment instance are finished, then we could
 // close the fragment instance.
 // Returns true if the caller should call remove_pipeline_context() **after** releasing
@@ -2241,10 +2264,11 @@ void PipelineFragmentContext::print_profile(const std::string& extra_info) {
 // dump_pipeline_tasks(), which acquires _pipeline_map first and then _task_mutex
 // (via debug_string()).
 bool PipelineFragmentContext::_close_fragment_instance() {
-    if (_is_fragment_instance_closed) {
+    if (!_try_start_close()) {
         return false;
     }
-    Defer defer_op {[&]() { _is_fragment_instance_closed = true; }};
+    Defer defer_op {
+            [&]() { _lifecycle_state.store(LifecycleState::CLOSED, std::memory_order_release); }};
     _fragment_level_profile->total_time_counter()->update(_fragment_watcher.elapsed_time());
     if (!_need_notify_close) {
         auto st = send_report(true);

--- a/be/src/exec/pipeline/pipeline_fragment_context.h
+++ b/be/src/exec/pipeline/pipeline_fragment_context.h
@@ -152,6 +152,14 @@ public:
     }
 
 private:
+    // Fragment termination lifecycle (monotonic, with no backward transitions):
+    //
+    //     CREATED -------- normal close --------> CLOSING -------- close done --------> CLOSED
+    //        |                                      ^
+    //        +-------- cancel --------> CANCELLING --+
+    //
+    // The CREATED -> CANCELLING transition elects the sole cancellation owner. A transition
+    // from CREATED or CANCELLING to CLOSING elects the sole close owner.
     enum class LifecycleState : uint8_t {
         CREATED,
         CANCELLING,

--- a/be/src/exec/pipeline/pipeline_fragment_context.h
+++ b/be/src/exec/pipeline/pipeline_fragment_context.h
@@ -152,6 +152,13 @@ public:
     }
 
 private:
+    enum class LifecycleState : uint8_t {
+        CREATED,
+        CANCELLING,
+        CLOSING,
+        CLOSED,
+    };
+
     void _coordinator_callback(const ReportStatusRequest& req);
     void _append_external_file_commit_data(const ReportStatusRequest& req,
                                            TReportExecStatusParams* params) const;
@@ -207,6 +214,7 @@ private:
     Status _build_pipeline_tasks_for_instance(
             int instance_idx,
             const std::vector<std::shared_ptr<RuntimeProfile>>& pipeline_id_to_profile);
+    bool _try_start_close();
     // Close the fragment instance and return true if the caller should call
     // remove_pipeline_context() **after** releasing _task_mutex. This avoids
     // holding _task_mutex while acquiring _pipeline_map's shard lock, which
@@ -222,6 +230,8 @@ private:
 
     std::atomic_bool _prepared = false;
     bool _submitted = false;
+    // Cancellation is a terminal path that drains into close. Prepare and submit are orthogonal.
+    std::atomic<LifecycleState> _lifecycle_state {LifecycleState::CREATED};
 
     Pipelines _pipelines;
     PipelineId _next_pipeline_id = 0;
@@ -250,7 +260,6 @@ private:
     RuntimeProfile::Counter* _build_tasks_timer = nullptr;
 
     std::function<void(RuntimeState*, Status*)> _call_back;
-    std::atomic_bool _is_fragment_instance_closed = false;
 
     // 0 indicates reporting is in progress or not required
     std::atomic_bool _disable_period_report = true;

--- a/be/test/exec/pipeline/pipeline_task_test.cpp
+++ b/be/test/exec/pipeline/pipeline_task_test.cpp
@@ -165,6 +165,28 @@ private:
     std::promise<std::string>* _close_status;
 };
 
+class FragmentCancelLogSink final : public google::LogSink {
+public:
+    void send(google::LogSeverity /*severity*/, const char* /*full_filename*/,
+              const char* /*base_filename*/, int /*line*/, const google::LogMessageTime& /*time*/,
+              const char* message, std::size_t message_len) override {
+        std::string log(message, message_len);
+        if (log.find("PipelineFragmentContext::cancel") != std::string::npos) {
+            cancel_count.fetch_add(1, std::memory_order_relaxed);
+        }
+        if (log.find("PipelineFragmentContext is cancelled due to timeout") != std::string::npos) {
+            timeout_dump_count.fetch_add(1, std::memory_order_relaxed);
+        }
+        if (log.find("PipelineFragmentContext cancel instance") != std::string::npos) {
+            instance_cancel_count.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
+    std::atomic<int> cancel_count {0};
+    std::atomic<int> timeout_dump_count {0};
+    std::atomic<int> instance_cancel_count {0};
+};
+
 TEST_F(PipelineTaskTest, TEST_CONSTRUCTOR) {
     auto num_instances = 1;
     auto pip_id = 0;
@@ -816,6 +838,90 @@ TEST_F(PipelineTaskTest, TEST_SCHEDULER_CATCH_STD_EXCEPTION) {
               std::string::npos)
             << close_status_string;
     EXPECT_TRUE(_context->is_canceled());
+}
+
+TEST_F(PipelineTaskTest, TEST_FRAGMENT_CANCEL_AND_CLOSE_LIFECYCLE) {
+    _context->_runtime_state = std::move(_runtime_state);
+    _context->_fragment_level_profile = std::make_unique<RuntimeProfile>("Fragment");
+    _context->_total_tasks = 1;
+    TUniqueId fragment_instance_id;
+    fragment_instance_id.__set_hi(1);
+    fragment_instance_id.__set_lo(1);
+    _context->_fragment_instance_ids.push_back(fragment_instance_id);
+
+    auto* exec_env = ExecEnv::GetInstance();
+    bool need_clear_new_load_stream_mgr = exec_env->new_load_stream_mgr() == nullptr;
+    if (need_clear_new_load_stream_mgr) {
+        exec_env->set_new_load_stream_mgr(NewLoadStreamMgr::create_unique());
+    }
+    Defer clear_new_load_stream_mgr {[&]() {
+        if (need_clear_new_load_stream_mgr) {
+            exec_env->clear_new_load_stream_mgr();
+        }
+    }};
+
+    FragmentCancelLogSink log_sink;
+    google::AddLogSink(&log_sink);
+    Defer remove_log_sink {[&]() { google::RemoveLogSink(&log_sink); }};
+
+    Status timeout = Status::TimedOut("test timeout");
+    std::atomic<bool> start {false};
+    auto cancel = [&]() {
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        _context->cancel(timeout);
+    };
+    std::thread first(cancel);
+    std::thread second(cancel);
+    std::thread third(cancel);
+    start.store(true, std::memory_order_release);
+    first.join();
+    second.join();
+    third.join();
+    _context->cancel(Status::InternalError("later cancellation"));
+
+    EXPECT_EQ(log_sink.cancel_count.load(std::memory_order_relaxed), 1);
+    EXPECT_EQ(log_sink.timeout_dump_count.load(std::memory_order_relaxed), 1);
+    EXPECT_EQ(log_sink.instance_cancel_count.load(std::memory_order_relaxed), 1);
+    EXPECT_EQ(_context->_lifecycle_state.load(std::memory_order_acquire),
+              PipelineFragmentContext::LifecycleState::CANCELLING);
+
+    _context->_closed_tasks = 1;
+    _context->_need_notify_close = true;
+    {
+        std::lock_guard<std::mutex> lock(_context->_task_mutex);
+        EXPECT_FALSE(_context->_close_fragment_instance());
+        EXPECT_FALSE(_context->_close_fragment_instance());
+    }
+    EXPECT_EQ(_context->_lifecycle_state.load(std::memory_order_acquire),
+              PipelineFragmentContext::LifecycleState::CLOSED);
+
+    _context->_need_notify_close = false;
+    _context->cancel(Status::InternalError("cancel after close"));
+    EXPECT_EQ(log_sink.cancel_count.load(std::memory_order_relaxed), 1);
+}
+
+TEST_F(PipelineTaskTest, TEST_FRAGMENT_NORMAL_CLOSE_LIFECYCLE) {
+    _context->_runtime_state = std::move(_runtime_state);
+    _context->_fragment_level_profile = std::make_unique<RuntimeProfile>("Fragment");
+    _context->_need_notify_close = true;
+
+    EXPECT_EQ(_context->_lifecycle_state.load(std::memory_order_acquire),
+              PipelineFragmentContext::LifecycleState::CREATED);
+    {
+        std::lock_guard<std::mutex> lock(_context->_task_mutex);
+        EXPECT_FALSE(_context->_close_fragment_instance());
+        EXPECT_FALSE(_context->_close_fragment_instance());
+    }
+    EXPECT_EQ(_context->_lifecycle_state.load(std::memory_order_acquire),
+              PipelineFragmentContext::LifecycleState::CLOSED);
+
+    _context->_need_notify_close = false;
+    _context->cancel(Status::TimedOut("cancel after successful close"));
+    EXPECT_FALSE(_context->is_canceled());
+    EXPECT_EQ(_context->_lifecycle_state.load(std::memory_order_acquire),
+              PipelineFragmentContext::LifecycleState::CLOSED);
 }
 
 TEST_F(PipelineTaskTest, TEST_FINALIZED_TASK_REJECTS_HYBRID_SUBMIT) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #67236

Problem Summary:

When a query times out, every pending pipeline task can close with the same error and call `PipelineFragmentContext::cancel()` before the fragment task count is drained. Each call previously repeated fragment cancellation logs, the full timeout task dump, stream-pipe cancellation, and dependency wakeups, causing severe log amplification.

This PR replaces the separate cancellation/closed flags with one atomic terminal lifecycle inside `PipelineFragmentContext`:

- `CREATED -> CANCELLING` elects the only cancellation winner.
- `CREATED/CANCELLING -> CLOSING -> CLOSED` makes final close one-shot and handles the cancel/last-task-close race.
- `notify_close()` remains before cancellation arbitration so recursive CTE fragments retain their external close-notification semantics.
- The winning cancellation publishes the `QueryContext` error before expensive diagnostics, so closing tasks observe the failed query status.

No per-fragment cancellation reason is stored because no runtime reader requires it; the query-wide first error remains owned by `QueryContext::AtomicStatus`.

### Release note

None

### Check List (For Author)

- Test: Unit Test
    - `GLIBC_COMPATIBILITY=OFF ./run-be-ut.sh -j 48 --run --filter=PipelineTaskTest.TEST_FRAGMENT_*LIFECYCLE`
    - `PATH=/mnt/disk6/common/ldb_toolchain_toucan/bin:$PATH build-support/check-format.sh`
    - `build-support/check-build-hygiene.sh`
    - `CLANG_TIDY_BINARY=/mnt/disk6/common/ldb_toolchain_028/bin/clang-tidy build-support/run-clang-tidy.sh --base apache/master --build-dir be/ut_build_ASAN`
- Behavior changed: Yes; repeated fragment cancellation diagnostics and side effects now run once, and cancellation after close is ignored.
- Does this need documentation: No