### PR TITLE
[fix](exec) Retain sliding window rows during eviction

### DIFF
--- a/be/src/exec/operator/analytic_sink_operator.cpp
+++ b/be/src/exec/operator/analytic_sink_operator.cpp
@@ -64,9 +64,10 @@ Status AnalyticSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& inf
     } else {
         if (!p._has_window_start) {
             _executor.get_next_impl = &AnalyticSinkLocalState::_get_next_for_unbounded_rows;
+            _rows_window_type = RowsWindowType::UNBOUNDED_START;
         } else {
             _executor.get_next_impl = &AnalyticSinkLocalState::_get_next_for_sliding_rows;
-            _is_sliding_rows = true;
+            _rows_window_type = RowsWindowType::SLIDING;
         }
         _streaming_mode = true;
         _support_incremental_calculate = (p._has_window_start && p._has_window_end);
@@ -845,10 +846,14 @@ void AnalyticSinkLocalState::_remove_unused_rows() {
         if (idx < 0 || _input_block_first_row_positions[idx] <= unused_rows_pos) {
             return;
         }
-        if (_is_sliding_rows) {
-            // A sliding aggregate may still need frame_start - 1 to remove the outgoing row.
-            const int64_t earliest_required_row = std::max(
-                    _partition_by_pose.start, _current_row_position + _rows_start_offset - 1);
+        if (_rows_window_type != RowsWindowType::NONE) {
+            // Sliding frames need the outgoing row; unbounded-start frames need the next unread row.
+            const int64_t earliest_required_row =
+                    _rows_window_type == RowsWindowType::SLIDING
+                            ? std::max(_partition_by_pose.start,
+                                       _current_row_position + _rows_start_offset - 1)
+                            : std::max(_partition_by_pose.start,
+                                       _current_row_position + _rows_end_offset);
             if (_have_removed_rows + earliest_required_row < unused_rows_pos) {
                 return;
             }

--- a/be/src/exec/operator/analytic_sink_operator.cpp
+++ b/be/src/exec/operator/analytic_sink_operator.cpp
@@ -66,6 +66,7 @@ Status AnalyticSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& inf
             _executor.get_next_impl = &AnalyticSinkLocalState::_get_next_for_unbounded_rows;
         } else {
             _executor.get_next_impl = &AnalyticSinkLocalState::_get_next_for_sliding_rows;
+            _is_sliding_rows = true;
         }
         _streaming_mode = true;
         _support_incremental_calculate = (p._has_window_start && p._has_window_end);
@@ -843,6 +844,14 @@ void AnalyticSinkLocalState::_remove_unused_rows() {
         auto idx = _output_block_index - 1;
         if (idx < 0 || _input_block_first_row_positions[idx] <= unused_rows_pos) {
             return;
+        }
+        if (_is_sliding_rows) {
+            // A sliding aggregate may still need frame_start - 1 to remove the outgoing row.
+            const int64_t earliest_required_row = std::max(
+                    _partition_by_pose.start, _current_row_position + _rows_start_offset - 1);
+            if (_have_removed_rows + earliest_required_row < unused_rows_pos) {
+                return;
+            }
         }
     } else {
         if (_have_removed_rows + _partition_by_pose.start <= unused_rows_pos) {

--- a/be/src/exec/operator/analytic_sink_operator.h
+++ b/be/src/exec/operator/analytic_sink_operator.h
@@ -20,6 +20,8 @@
 
 #include <stdint.h>
 
+#include <algorithm>
+
 #include "exec/operator/operator.h"
 #include "exec/pipeline/dependency.h"
 
@@ -31,8 +33,8 @@ struct BoundaryPose {
     int64_t end = 0;
     bool is_ended = false;
     void remove_unused_rows(int64_t cnt) {
-        start -= cnt;
-        end -= cnt;
+        start = std::max<int64_t>(0, start - cnt);
+        end = std::max<int64_t>(0, end - cnt);
     }
 };
 
@@ -144,6 +146,7 @@ private:
     std::vector<uint8_t> _use_null_result;
     std::vector<uint8_t> _could_use_previous_result;
     bool _streaming_mode = false;
+    bool _is_sliding_rows = false;
     bool _support_incremental_calculate = true;
     bool _need_more_data = false;
     int64_t _current_row_position = 0;

--- a/be/src/exec/operator/analytic_sink_operator.h
+++ b/be/src/exec/operator/analytic_sink_operator.h
@@ -74,6 +74,8 @@ public:
     Status close(RuntimeState* state, Status exec_status) override;
 
 private:
+    enum class RowsWindowType { NONE, UNBOUNDED_START, SLIDING };
+
     friend class AnalyticSinkOperatorX;
     Status _execute_impl(RuntimeState* state);
     // over(partition by k1 order by k2 range|rows unbounded preceding and unbounded following)
@@ -146,7 +148,7 @@ private:
     std::vector<uint8_t> _use_null_result;
     std::vector<uint8_t> _could_use_previous_result;
     bool _streaming_mode = false;
-    bool _is_sliding_rows = false;
+    RowsWindowType _rows_window_type = RowsWindowType::NONE;
     bool _support_incremental_calculate = true;
     bool _need_more_data = false;
     int64_t _current_row_position = 0;

--- a/be/test/exec/operator/analytic_sink_operator_test.cpp
+++ b/be/test/exec/operator/analytic_sink_operator_test.cpp
@@ -86,6 +86,15 @@ private:
 
 } // namespace
 
+TEST(BoundaryPoseTest, RemoveUnusedRowsKeepsPhysicalCoordinatesNonNegative) {
+    BoundaryPose pose {.start = 1, .end = 5};
+
+    pose.remove_unused_rows(2);
+
+    EXPECT_EQ(pose.start, 0);
+    EXPECT_EQ(pose.end, 3);
+}
+
 struct AnalyticSinkOperatorTest : public ::testing::Test {
     void Initialize(int batch_size) {
         sink = std::make_unique<AnalyticSinkOperatorX>(&pool);
@@ -444,7 +453,7 @@ TEST_F(AnalyticSinkOperatorTest, AggFunction3) {
     std::cout << "######### AggFunction with row_number test end #########" << std::endl;
 }
 
-TEST_F(AnalyticSinkOperatorTest, AggFunction4) {
+TEST_F(AnalyticSinkOperatorTest, SlidingRowsSumRetainsOutgoingRowDuringEviction) {
     int batch_size = 2;
     Initialize(batch_size);
     create_operator(true, 1, "sum", {std::make_shared<DataTypeInt64>()},
@@ -456,14 +465,14 @@ TEST_F(AnalyticSinkOperatorTest, AggFunction4) {
     temp_window.type = TAnalyticWindowType::ROWS;
     TAnalyticWindowBoundary window_start;
     window_start.type = TAnalyticWindowBoundaryType::PRECEDING;
-    window_start.__set_rows_offset_value(1);
+    window_start.__set_rows_offset_value(4);
     temp_window.__set_window_start(window_start);
     TAnalyticWindowBoundary window_end;
     window_end.type = TAnalyticWindowBoundaryType::CURRENT_ROW;
     temp_window.__set_window_end(window_end);
     create_window_type(true, true, temp_window);
     create_local_state();
-    // test with row_number agg function and has window: _get_next_for_unbounded_rows
+    // The frame is wider than one buffered block, so eviction must retain its outgoing row.
 
     auto sink_data = [&](int row_count, bool eos) {
         std::vector<int64_t> data_vals;
@@ -507,7 +516,7 @@ TEST_F(AnalyticSinkOperatorTest, AggFunction4) {
     {
         int row_count = 0;
         std::vector<int64_t> data_vals {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-        std::vector<int64_t> expect_vals {0, 1, 3, 5, 7, 9, 11, 13, 15, 17}; //sum
+        std::vector<int64_t> expect_vals {0, 1, 3, 6, 10, 15, 20, 25, 30, 35}; //sum
         for (int i = 0; i < 5; i++) {
             compare_block_result(row_count, data_vals, expect_vals);
             row_count += batch_size;
@@ -519,7 +528,7 @@ TEST_F(AnalyticSinkOperatorTest, AggFunction4) {
         EXPECT_EQ(block2.rows(), 0);
         EXPECT_TRUE(eos2);
     }
-    std::cout << "######### AggFunction with row_number test end #########" << std::endl;
+    std::cout << "######### sliding rows sum eviction test end #########" << std::endl;
 }
 
 TEST_F(AnalyticSinkOperatorTest, AggFunction5) {

--- a/be/test/exec/operator/analytic_sink_operator_test.cpp
+++ b/be/test/exec/operator/analytic_sink_operator_test.cpp
@@ -453,6 +453,47 @@ TEST_F(AnalyticSinkOperatorTest, AggFunction3) {
     std::cout << "######### AggFunction with row_number test end #########" << std::endl;
 }
 
+TEST_F(AnalyticSinkOperatorTest, UnboundedRowsRetainsNextUnreadRowDuringEviction) {
+    constexpr int batch_size = 2;
+    Initialize(batch_size);
+    create_operator(true, 1, "sum", {std::make_shared<DataTypeInt64>()},
+                    std::make_shared<DataTypeInt64>());
+    sink->_agg_expr_ctxs.resize(1);
+    sink->_agg_expr_ctxs[0] =
+            MockSlotRef::create_mock_contexts(0, std::make_shared<DataTypeInt64>());
+    TAnalyticWindow window;
+    window.type = TAnalyticWindowType::ROWS;
+    TAnalyticWindowBoundary window_end;
+    window_end.type = TAnalyticWindowBoundaryType::PRECEDING;
+    window_end.__set_rows_offset_value(5);
+    window.__set_window_end(window_end);
+    create_window_type(false, true, window);
+    create_local_state();
+
+    for (int row = 1; row <= 8; row += batch_size) {
+        Block block = ColumnHelper::create_block<DataTypeInt64>({row, row + 1});
+        auto status = sink->sink(state.get(), &block, row + batch_size > 8);
+        EXPECT_TRUE(status.ok()) << status.msg();
+    }
+
+    const std::vector<int64_t> expected_sums {0, 0, 0, 0, 0, 1, 3, 6};
+    for (int row = 1; row <= 8; row += batch_size) {
+        Block block = ColumnHelper::create_block<DataTypeInt64>({});
+        bool eos = false;
+        auto status = source->get_block(state.get(), &block, &eos);
+        EXPECT_TRUE(status.ok()) << status.msg();
+        EXPECT_TRUE(ColumnHelper::block_equal(
+                block, ColumnHelper::create_block<DataTypeInt64>(
+                               {row, row + 1}, {expected_sums[row - 1], expected_sums[row]})));
+    }
+
+    Block block = ColumnHelper::create_block<DataTypeInt64>({});
+    bool eos = false;
+    auto status = source->get_block(state.get(), &block, &eos);
+    EXPECT_TRUE(status.ok()) << status.msg();
+    EXPECT_TRUE(eos);
+}
+
 TEST_F(AnalyticSinkOperatorTest, SlidingRowsSumRetainsOutgoingRowDuringEviction) {
     int batch_size = 2;
     Initialize(batch_size);


### PR DESCRIPTION

Problem Summary: Streaming `ROWS` window aggregates retain state across frame evaluations. The eviction path previously considered only whether buffered blocks had been emitted, so it could erase either the outgoing row needed by a bounded sliding frame or the next unread row needed by an `UNBOUNDED PRECEDING ... N PRECEDING` frame. After rebasing, negative partition and outgoing positions could allow a nullable aggregate to access its null map out of bounds. Evicting either kind of required row could also produce incorrect aggregate results.

Root cause: `_remove_unused_rows()` did not account for the earliest row required by the next ROWS frame evaluation, and `BoundaryPose::remove_unused_rows()` allowed retained-column coordinates to become negative.

This change defers block-aligned eviction when the candidate prefix contains either `frame_start - 1`, the outgoing row required by a bounded sliding update, or the next unread row required by an `UNBOUNDED PRECEDING ... N PRECEDING` frame. It also rebases partition and order boundaries to nonnegative physical-column coordinates. The BE unit coverage exercises both ROWS executors across eviction boundaries and verifies boundary rebasing.

Observed ASAN failure before this change (`output/be/log/be.out`):

```text
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 1
    #0 doris::AggregateFunctionNullUnaryInlineV2<...>::execute_function_with_incremental(...)
       be/src/exprs/aggregate/aggregate_function_null_v2.h:595
    #1 doris::AggFnEvaluator::execute_function_with_incremental(...)
       be/src/exprs/vectorized_agg_fn.cpp:334
    #2 doris::AnalyticSinkLocalState::_execute_for_function<true>(...)
       be/src/exec/operator/analytic_sink_operator.cpp:385
    #3 doris::AnalyticSinkLocalState::_get_next_for_sliding_rows(...)
       be/src/exec/operator/analytic_sink_operator.cpp:203
    #4 doris::AnalyticSinkLocalState::_execute_impl(...)
       be/src/exec/operator/analytic_sink_operator.cpp:358
    #5 doris::AnalyticSinkOperatorX::sink_impl(...)
       be/src/exec/operator/analytic_sink_operator.cpp:757
SUMMARY: AddressSanitizer: heap-buffer-overflow in
doris::AggregateFunctionNullUnaryInlineV2<...>::execute_function_with_incremental(...)
```


### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

