### PR TITLE
[feature](lance) Add thrift definitions for Lance index entries inspection

### DIFF
--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -955,6 +955,7 @@ struct TMetadataTableRequestParams {
   // Reserved for downstream field `current_roles` to keep thrift field ids
   // wire-compatible across maintained branches. Do not reuse this id.
   15: optional set<string> reserved_field_15
+  16: optional PlanNodes.TLanceIndexMetadataParams lance_index_metadata_params
 }
 
 struct TSchemaTableRequestParams {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -796,6 +796,13 @@ struct TPartitionBoundary {
   6: optional bool range_end_inclusive = false
 }
 
+// Identifies a Lance table for read-only physical index entry inspection.
+struct TLanceIndexMetadataParams {
+  1: optional string catalog
+  2: optional string database
+  3: optional string table
+}
+
 struct TMetaScanRange {
   1: optional Types.TMetadataType metadata_type
   2: optional TIcebergMetadataParams iceberg_params // deprecated
@@ -816,6 +823,7 @@ struct TMetaScanRange {
   15: optional string serialized_table;
   16: optional list<string> serialized_splits;
   17: optional TParquetMetadataParams parquet_params;
+  18: optional TLanceIndexMetadataParams lance_index_params;
 }
 
 // Specification of an individual data range which is held in its entirety

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -767,6 +767,9 @@ enum TMetadataType {
   PAIMON = 12,
   PARQUET = 13,
   STREAMS = 14,
+  // Also assigned on branch-4.1 for Lance physical index entries inspection.
+  // Keep the value aligned across maintained branches. Do not renumber.
+  LANCE_INDEX_ENTRIES = 15,
 }
 
 // deprecated


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #66497

Related PR: #66671 (branch-4.1)

Problem Summary:

PR #66671 on `branch-4.1` adds the read-only `lance_index_entries` table-valued function — delivery slice 2 of the Lance index lifecycle design (#66497) — and wires it through the BE meta-scanner (`TMetaScanRange`) and the FE master schema-table service (`TFetchSchemaTableDataRequest`). That feature requires four thrift additions:

- `TMetadataType.LANCE_INDEX_ENTRIES` (Types.thrift)
- `TLanceIndexMetadataParams {catalog, database, table}` (PlanNodes.thrift)
- `TMetaScanRange.lance_index_params`, field 18 (PlanNodes.thrift)
- `TMetadataTableRequestParams.lance_index_metadata_params`, field 16 (FrontendService.thrift)

Thrift field ids and enum values are a wire contract shared by all maintained branches: once branch-4.1 clusters run with these assignments, master must never assign the same ids to anything else, and mixed-version clusters during rolling upgrades must interpret them identically (same precedent as the `reserved_field_15` reservation in `TMetadataTableRequestParams`). This PR lands the same definitions on master so the ids stay reserved and aligned, as requested in the #66671 review.

Notes on the assignments:

- `TMetadataType = 14` is already `STREAMS` on master, so `LANCE_INDEX_ENTRIES` takes **15** here. #66671 is being aligned to 15 as well before it merges, so both branches agree on the value; 14 remains STREAMS-only.
- Field 18 (`TMetaScanRange`) and field 16 (`TMetadataTableRequestParams`) match the branch-4.1 assignments exactly; both are unused on master today.
- This is an IDL-only change: no FE/BE code on master references these definitions yet, so there is no behavior change on master. The full feature code lands on master with the later lifecycle slices tracked in #66497.

### Release note

None - thrift IDL compatibility definitions only; no behavior change.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit test
    - [x] Manual test (please describe)
        - IDL validated with `thrift -r --gen java` (0.16.0) against the full include graph; generated `TMetadataType` carries `LANCE_INDEX_ENTRIES(15)` and `TLanceIndexMetadataParams` compiles.
        - No runtime behavior on master, so no new regression/UT coverage applies; the feature-side tests live in #66671.
    - [ ] No need to test

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- for branch-4.1 the definitions arrive via #66671, which this PR mirrors -->
