### PR TITLE
[improvement](fe) Reuse boxed IDs in cloud tablet indexes (#66389)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
@@ -356,7 +356,7 @@ public class CloudTabletRebalancer extends MasterDaemon {
     }
 
     private class InfightTask {
-        public long pickedTabletId;
+        public Long pickedTabletId;
         public long srcBe;
         public long destBe;
         public long startTimestamp;
@@ -392,12 +392,12 @@ public class CloudTabletRebalancer extends MasterDaemon {
     }
 
     private static class WarmupTabletTask {
-        private final long pickedTabletId;
+        private final Long pickedTabletId;
         private final long srcBe;
         private final long destBe;
         private final String clusterId;
 
-        WarmupTabletTask(long pickedTabletId, long srcBe, long destBe, String clusterId) {
+        WarmupTabletTask(Long pickedTabletId, long srcBe, long destBe, String clusterId) {
             this.pickedTabletId = pickedTabletId;
             this.srcBe = srcBe;
             this.destBe = destBe;

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
@@ -1740,7 +1740,7 @@ public class CloudTabletRebalancer extends MasterDaemon {
         }
     }
 
-    private void updateBeToTablets(long tabletId, long srcBe, long destBe,
+    private void updateBeToTablets(Long tabletId, Long srcBe, Long destBe,
                                    ConcurrentHashMap<Long, Set<Long>> globalBeToTablets,
                                    ConcurrentHashMap<Long, ConcurrentHashMap<Long, Set<Long>>> beToTabletsInTable,
                                    ConcurrentHashMap<Long, ConcurrentHashMap<Long, ConcurrentHashMap<Long,
@@ -1750,9 +1750,9 @@ public class CloudTabletRebalancer extends MasterDaemon {
             LOG.warn("tablet {} meta not found in inverted index, skip updateBeToTablets", tabletId);
             return;
         }
-        long tableId = tabletMeta.getTableId();
-        long partId = tabletMeta.getPartitionId();
-        long indexId = tabletMeta.getIndexId();
+        Long tableId = tabletMeta.getTableId();
+        Long partId = tabletMeta.getPartitionId();
+        Long indexId = tabletMeta.getIndexId();
 
         Set<Long> globalSrcTablets = globalBeToTablets.get(srcBe);
         if (globalSrcTablets == null || !globalSrcTablets.remove(tabletId)) {
@@ -2045,8 +2045,8 @@ public class CloudTabletRebalancer extends MasterDaemon {
                 break; // no need balance
             }
 
-            long srcBe = pairInfo.srcBe;
-            long destBe = pairInfo.destBe;
+            Long srcBe = pairInfo.srcBe;
+            Long destBe = pairInfo.destBe;
 
             Long pickedTabletId = pickTabletPreferCold(srcBe, beToTablets.get(srcBe),
                     this.activeTabletIds, pickedTabletIds);
@@ -2187,7 +2187,7 @@ public class CloudTabletRebalancer extends MasterDaemon {
         return chosen;
     }
 
-    private boolean preheatAndUpdateTablet(long pickedTabletId, long srcBe, long destBe, String clusterId,
+    private boolean preheatAndUpdateTablet(Long pickedTabletId, Long srcBe, Long destBe, String clusterId,
                                      BalanceType balanceType, Map<Long, Set<Long>> beToTablets) {
         Backend srcBackend = cloudSystemInfoService.getBackend(srcBe);
         Backend destBackend = cloudSystemInfoService.getBackend(destBe);
@@ -2213,7 +2213,7 @@ public class CloudTabletRebalancer extends MasterDaemon {
         return true;
     }
 
-    private boolean transferTablet(long pickedTabletId, long srcBe, long destBe, String clusterId,
+    private boolean transferTablet(Long pickedTabletId, Long srcBe, Long destBe, String clusterId,
                             BalanceType balanceType, List<UpdateCloudReplicaInfo> infos) {
         LOG.debug("transfer {} from {} to {}, cluster {}, type {}",
                 pickedTabletId, srcBe, destBe, clusterId, balanceType);

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudTabletRebalancerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudTabletRebalancerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.AbstractMap;
@@ -92,6 +93,36 @@ public class CloudTabletRebalancerTest {
         Method m = CloudTabletRebalancer.class.getDeclaredMethod(method, types);
         m.setAccessible(true);
         return (T) m.invoke(obj, args);
+    }
+
+    @Test
+    public void testInfightTaskPreservesSelectedBoxedTabletId() throws Exception {
+        TestRebalancer rebalancer = new TestRebalancer();
+        Long tabletId = Long.valueOf(50_001L);
+        Class<?> taskClass = Class.forName(CloudTabletRebalancer.class.getName() + "$InfightTask");
+        Constructor<?> constructor = taskClass.getDeclaredConstructor(CloudTabletRebalancer.class);
+        constructor.setAccessible(true);
+        Object task = constructor.newInstance(rebalancer);
+        Field tabletIdField = taskClass.getDeclaredField("pickedTabletId");
+        tabletIdField.setAccessible(true);
+
+        tabletIdField.set(task, tabletId);
+
+        Assertions.assertSame(tabletId, tabletIdField.get(task));
+    }
+
+    @Test
+    public void testWarmupTaskPreservesSelectedBoxedTabletId() throws Exception {
+        Long tabletId = Long.valueOf(50_001L);
+        Class<?> taskClass = Class.forName(CloudTabletRebalancer.class.getName() + "$WarmupTabletTask");
+        Constructor<?> constructor = taskClass.getDeclaredConstructors()[0];
+        constructor.setAccessible(true);
+
+        Object task = constructor.newInstance(tabletId, 1L, 2L, "cluster-a");
+        Field tabletIdField = taskClass.getDeclaredField("pickedTabletId");
+        tabletIdField.setAccessible(true);
+
+        Assertions.assertSame(tabletId, tabletIdField.get(task));
     }
 
     @Test


### PR DESCRIPTION
pick from https://github.com/apache/doris/pull/66389

Reuse boxed backend, table, partition, index, and tablet IDs in cloud tablet indexes.

(cherry picked from commit 53d6fa3de6698509d862eba9ac1d3ebc671aae85)

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

