### PR TITLE
[improvement](fe) Release cloud tablet scheduling indexes after balance (#66451)

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTabletRebalancer.java
@@ -517,14 +517,18 @@ public class CloudTabletRebalancer extends MasterDaemon {
             return;
         }
 
-        statRouteInfo();
-        migrateTabletsForSmoothUpgrade();
-        statRouteInfo();
+        try {
+            statRouteInfo();
+            migrateTabletsForSmoothUpgrade();
+            statRouteInfo();
 
-        indexBalanced = true;
-        tableBalanced = true;
+            indexBalanced = true;
+            tableBalanced = true;
 
-        performBalancing();
+            performBalancing();
+        } finally {
+            releaseSchedulingIndexes();
+        }
 
         checkDecommissionState(clusterToBes);
         inited = true;
@@ -638,6 +642,15 @@ public class CloudTabletRebalancer extends MasterDaemon {
                 globalBalance();
             }
         }
+    }
+
+    private void releaseSchedulingIndexes() {
+        // These indexes are no longer used after balancing. Replace their top-level maps instead of clearing
+        // every entry so the complete tablet membership graphs can become collectible without an O(N) traversal.
+        partitionToTablets = new ConcurrentHashMap<>();
+        futurePartitionToTablets = new ConcurrentHashMap<>();
+        beToTabletsInTable = new ConcurrentHashMap<>();
+        futureBeToTabletsInTable = new ConcurrentHashMap<>();
     }
 
     private boolean balanceAllPartitionsByPhase(ActiveSchedulePhase phase) {


### PR DESCRIPTION
pick from https://github.com/apache/doris/pull/66451

Release scheduling indexes after each balancing round and on migration failures.

(cherry picked from commit b0d6429032dacd9b6fa23e5643ea591c14bae87c)

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

