### PR TITLE
[optimize](nereids) allow multi keys for skew join

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SkewJoin.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/SkewJoin.java
@@ -70,7 +70,9 @@ public class SkewJoin extends OneRewriteRuleFactory {
         LogicalJoin<Plan, Plan> join = ctx.root;
         Expression skewExpr = null;
         List<Expression> hotValues = new ArrayList<>();
-        if (join.getHashJoinConjuncts().size() != 1) {
+        boolean allowMultiKey =
+                ConnectContext.get().getSessionVariable().isEnableSkewJoinMultiKey();
+        if (!allowMultiKey && join.getHashJoinConjuncts().size() != 1) {
             return null;
         }
         AbstractPlan left = (AbstractPlan) join.left();
@@ -82,35 +84,37 @@ public class SkewJoin extends OneRewriteRuleFactory {
             right.accept(derive, new DeriveContext());
         }
 
-        EqualPredicate equal = (EqualPredicate) join.getHashJoinConjuncts().get(0);
-        if (join.left().getOutputSet().contains(equal.right())) {
-            equal = equal.commute();
-        }
-
-        if (join.getJoinType().isInnerJoin() || join.getJoinType().isLeftOuterJoin()) {
-            Expression leftEqHand = equal.child(0);
-            if (left.getStats().findColumnStatistics(leftEqHand) != null) {
-                ColumnStatistic leftColStats = left.getStats().findColumnStatistics(leftEqHand);
-                Map<Literal, Float> filtered = StatisticsUtil.getHotValuesWithOriginalThreshold(
-                        leftColStats.getHotValues(), leftColStats.ndv);
-                if (filtered != null) {
-                    skewExpr = leftEqHand;
-                    hotValues.addAll(filtered.keySet());
-                }
+        for (Expression conjunct : join.getHashJoinConjuncts()) {
+            EqualPredicate equal = (EqualPredicate) conjunct;
+            if (join.left().getOutputSet().contains(equal.right())) {
+                equal = equal.commute();
             }
-        } else if (join.getJoinType().isRightOuterJoin()) {
-            Expression rightEqHand = equal.child(1);
-            if (right.getStats().findColumnStatistics(rightEqHand) != null) {
-                ColumnStatistic rightColStats = right.getStats().findColumnStatistics(rightEqHand);
-                Map<Literal, Float> filtered = StatisticsUtil.getHotValuesWithOriginalThreshold(
-                        rightColStats.getHotValues(), rightColStats.ndv);
-                if (filtered != null) {
-                    skewExpr = rightEqHand;
-                    hotValues.addAll(filtered.keySet());
+            Map<Literal, Float> filtered = null;
+            Expression sideExpr = null;
+            if (join.getJoinType().isInnerJoin() || join.getJoinType().isLeftOuterJoin()) {
+                Expression leftEqHand = equal.child(0);
+                if (left.getStats().findColumnStatistics(leftEqHand) != null) {
+                    ColumnStatistic leftColStats = left.getStats().findColumnStatistics(leftEqHand);
+                    filtered = StatisticsUtil.getHotValuesWithOriginalThreshold(
+                            leftColStats.getHotValues(), leftColStats.ndv);
+                    sideExpr = leftEqHand;
                 }
+            } else if (join.getJoinType().isRightOuterJoin()) {
+                Expression rightEqHand = equal.child(1);
+                if (right.getStats().findColumnStatistics(rightEqHand) != null) {
+                    ColumnStatistic rightColStats = right.getStats().findColumnStatistics(rightEqHand);
+                    filtered = StatisticsUtil.getHotValuesWithOriginalThreshold(
+                            rightColStats.getHotValues(), rightColStats.ndv);
+                    sideExpr = rightEqHand;
+                }
+            } else {
+                return null;
             }
-        } else {
-            return null;
+            if (filtered != null && !filtered.isEmpty()) {
+                skewExpr = sideExpr;
+                hotValues.addAll(filtered.keySet());
+                break;
+            }
         }
         if (skewExpr == null || hotValues.isEmpty()) {
             return null;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -326,6 +326,9 @@ public class SessionVariable implements Serializable, Writable {
     // turn off all automatic join reorder algorithms
     public static final String DISABLE_JOIN_REORDER = "disable_join_reorder";
 
+    // Allow SkewJoin auto-salt to trigger on joins with more than one hash key.
+    public static final String ENABLE_SKEW_JOIN_MULTI_KEY = "enable_skew_join_multi_key";
+
     public static final String MAX_JOIN_NUMBER_OF_REORDER = "max_join_number_of_reorder";
 
     public static final String ENABLE_NEREIDS_DML = "enable_nereids_dml";
@@ -1948,6 +1951,9 @@ public class SessionVariable implements Serializable, Writable {
 
     @VarAttrDef.VarAttr(name = DISABLE_JOIN_REORDER)
     private boolean disableJoinReorder = false;
+
+    @VariableMgr.VarAttr(name = ENABLE_SKEW_JOIN_MULTI_KEY, needForward = true)
+    private boolean enableSkewJoinMultiKey = false;
 
     @VarAttrDef.VarAttr(name = MAX_JOIN_NUMBER_OF_REORDER)
     private int maxJoinNumberOfReorder = 63;
@@ -5015,6 +5021,14 @@ public class SessionVariable implements Serializable, Writable {
 
     public boolean isDisableJoinReorder() {
         return disableJoinReorder;
+    }
+
+    public boolean isEnableSkewJoinMultiKey() {
+        return enableSkewJoinMultiKey;
+    }
+
+    public void setEnableSkewJoinMultiKey(boolean enable) {
+        this.enableSkewJoinMultiKey = enable;
     }
 
     public boolean isEnableBushyTree() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1952,7 +1952,7 @@ public class SessionVariable implements Serializable, Writable {
     @VarAttrDef.VarAttr(name = DISABLE_JOIN_REORDER)
     private boolean disableJoinReorder = false;
 
-    @VariableMgr.VarAttr(name = ENABLE_SKEW_JOIN_MULTI_KEY, needForward = true)
+    @VarAttrDef.VarAttr(name = ENABLE_SKEW_JOIN_MULTI_KEY, needForward = true)
     private boolean enableSkewJoinMultiKey = true;
 
     @VarAttrDef.VarAttr(name = MAX_JOIN_NUMBER_OF_REORDER)

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -1953,7 +1953,7 @@ public class SessionVariable implements Serializable, Writable {
     private boolean disableJoinReorder = false;
 
     @VariableMgr.VarAttr(name = ENABLE_SKEW_JOIN_MULTI_KEY, needForward = true)
-    private boolean enableSkewJoinMultiKey = false;
+    private boolean enableSkewJoinMultiKey = true;
 
     @VarAttrDef.VarAttr(name = MAX_JOIN_NUMBER_OF_REORDER)
     private int maxJoinNumberOfReorder = 63;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

I noticed that salt join has support multi keys but skew join don't support
This commit allow multi keys for skew join.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

