### PR TITLE
[fix](thirdparty) Keep accepting the pre-#67158 Paimon prebuilt fingerprint

### DIFF
--- a/thirdparty/arrow-paimon-vars.sh
+++ b/thirdparty/arrow-paimon-vars.sh
@@ -71,6 +71,11 @@ ARROW_LEGACY_BUILD_FINGERPRINTS=(
     9d03645dd1cded5184a8126f5c7f4a6eb9b92b53
 )
 PAIMON_LEGACY_BUILD_FINGERPRINTS=(
+    # semantic marker stamped by the prebuilt currently shipped in the compile
+    # image, published from master before apache/doris#67158; that change only
+    # reorders the Paimon codec dependencies and does not alter installed
+    # artifacts, so this prebuilt remains compatible with the new inputs
+    cb82e41ba46f534e611cdd52e66b53c227d49bf8
     # published 2026-08-19, master after apache/doris#66842
     2bbf52e719bdbc8aaa428caab200ac13848f92e5
     # published 2026-08-05, master after apache/doris#66221


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #67158

Problem Summary:

#67158 rotated `PAIMON_LEGACY_COMPATIBLE_SEMANTIC_FINGERPRINT` to the new semantic fingerprint `9887cf1ec…`, but did not keep the *previous* semantic marker `cb82e41ba46f534e611cdd52e66b53c227d49bf8` accepted. The prebuilt currently shipped in the compile image (`apache/doris:build-env-ldb-toolchain-latest`, digest `sha256:5d474521b72d…`) is stamped with exactly that old semantic marker, and it is in no accept list. As a result, every CI build that merges current master and validates the prebuilt (COMPILE and performance pipelines) aborts before compiling:

```
Paimon build fingerprint does not match selected inputs
Arrow/Paimon thirdparty libraries need to be rebuilt ...
Cannot rebuild thirdparty libraries: /var/local/thirdparty/build-thirdparty.sh is missing.
```

Evidence that the installed marker is `cb82e41ba…` (elimination): the identical image digest passed the same pipeline one day before #67158 merged (pre-#67158 checkout: expected == `cb82e41ba` == installed marker) and fails after it (installed ∉ {`9887cf1ec`, `2bbf52e7…`, `dbb6ca6e…`}). Example failing TeamCity builds: COMPILE 1034233 and 1034257, performance 1034228 and 1034249.

Fix: since #67158 only reorders Paimon codec dependencies and does not change the installed artifacts, list the previous semantic marker in `PAIMON_LEGACY_BUILD_FINGERPRINTS` so the in-circulation prebuilt stays accepted.

### Release note

None

### Check List (For Author)

- Test
    - [x] Manual test (add detailed scripts or steps below)
        - Gate check with the repo's own functions: `arrow_paimon_fingerprint_matches cb82e41ba… $(paimon_build_fingerprint) …` is rejected on master and accepted with this change; a bogus marker is still rejected in both cases.
        - `bash thirdparty/test/arrow-paimon-lifecycle-test.sh` → PASS.
    - [x] Previous test can cover this change. (`thirdparty/test/arrow-paimon-lifecycle-test.sh`)

- Behavior changed:
    - [x] No. (Restores the pre-#67158 acceptance of the same, artifact-identical prebuilt; no behavior change beyond unblocking CI.)

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label