### PR TITLE
[fix](fe) Redirect forward-to-master statements to the real master after failover

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/FEOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/FEOpExecutor.java
@@ -161,6 +161,41 @@ public class FEOpExecutor {
         }
     }
 
+    /**
+     * Whether this executor should redirect to the real master when the target FE
+     * rejects the request with NOT_MASTER. Only master-directed executors enable this;
+     * generic FE-to-FE calls (config propagation, cross-FE query kill) target a
+     * specific FE on purpose and must NOT be redirected.
+     */
+    protected boolean supportNotMasterRedirect() {
+        return false;
+    }
+
+    /**
+     * Send the request to the given address, ignoring NOT_MASTER semantics. Used for
+     * the single redirect retry against a re-discovered master.
+     */
+    protected TMasterOpResult forwardTo(TMasterOpRequest params, TNetworkAddress target) throws Exception {
+        FrontendService.Client client;
+        try {
+            client = ClientPool.frontendPool.borrowObject(target, thriftTimeoutMs);
+        } catch (Exception e) {
+            throw new Exception("Failed to get client for " + target + ".", e);
+        }
+        boolean isReturnToPool = false;
+        try {
+            TMasterOpResult result = client.forward(params);
+            isReturnToPool = true;
+            return result;
+        } finally {
+            if (isReturnToPool) {
+                ClientPool.frontendPool.returnObject(target, client);
+            } else {
+                ClientPool.frontendPool.invalidateObject(target, client);
+            }
+        }
+    }
+
     protected TMasterOpRequest buildStmtForwardParams() throws AnalysisException {
         TMasterOpRequest params = new TMasterOpRequest();
         // node ident

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MasterOpExecutor.java
@@ -19,13 +19,20 @@ package org.apache.doris.qe;
 
 import org.apache.doris.analysis.RedirectStatus;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.ha.FrontendNodeType;
+import org.apache.doris.system.Frontend;
 import org.apache.doris.thrift.TGroupCommitInfo;
 import org.apache.doris.thrift.TMasterOpRequest;
+import org.apache.doris.thrift.TMasterOpResult;
 import org.apache.doris.thrift.TNetworkAddress;
 
+import com.google.common.base.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.net.InetSocketAddress;
 
 /**
  * MasterOpExecutor is used to send request to Master FE.
@@ -54,8 +61,22 @@ public class MasterOpExecutor extends FEOpExecutor {
     }
 
     @Override
+    public boolean supportNotMasterRedirect() {
+        return true;
+    }
+
+    @Override
     public void execute() throws Exception {
-        super.execute();
+        TMasterOpRequest params = buildStmtForwardParams();
+        result = forward(params);
+        if (isNotMasterResult(result)) {
+            // The FE we forwarded to is not the master any more (our masterInfo is stale,
+            // typically after a master failover while journal replay is lagging).
+            // The statement was NOT executed there, so it is safe to re-discover the real
+            // master and retry once, even for non-idempotent statements.
+            result = redirectAndRetry(params);
+        }
+        processForwardResult(result);
         waitOnReplaying();
     }
 
@@ -65,7 +86,174 @@ public class MasterOpExecutor extends FEOpExecutor {
         waitOnReplaying();
     }
 
+    private void processForwardResult(TMasterOpResult result) throws Exception {
+        if (ctx.isTxnModel()) {
+            if (result.isSetTxnLoadInfo()) {
+                ctx.getTxnEntry().setTxnLoadInfoInObserver(result.getTxnLoadInfo());
+            } else {
+                ctx.setTxnEntry(null);
+                LOG.info("set txn entry to null");
+            }
+        }
+        if (result.isSetAffectedRows()) {
+            ctx.updateReturnRows((int) result.getAffectedRows());
+        }
+    }
+
+    private boolean isNotMasterResult(TMasterOpResult result) {
+        return isNotMasterResultForTest(result);
+    }
+
+    static boolean isNotMasterResultForTest(TMasterOpResult result) {
+        return result != null && result.isSetNotMaster() && result.isNotMaster();
+    }
+
+    private TNetworkAddress validateHint(TNetworkAddress hint) {
+        return validateHintForTest(hint);
+    }
+
+    /**
+     * Handle a NOT_MASTER rejection: validate the hint carried by the rejecting FE,
+     * or discover the current master on our own, then retry the request once against it.
+     *
+     * The hint is best-effort and must not be trusted blindly: a degraded old master
+     * may still keep masterInfo = itself, so a hint pointing back to the failed target
+     * (or to this node) is rejected and we fall back to our own discovery.
+     */
+    private TMasterOpResult redirectAndRetry(TMasterOpRequest params) throws Exception {
+        TNetworkAddress newMaster = validateHint(result.getMasterAddress());
+        if (newMaster == null) {
+            newMaster = discoverMasterByLeader();
+        }
+        if (newMaster == null) {
+            newMaster = discoverMasterByProbe();
+        }
+        if (newMaster == null) {
+            LOG.warn("forward target {} is not master and no new master could be discovered", feAddr);
+            throw new MasterRedirectException(
+                    "forward to master FE " + feAddr + " failed: target is not master any more"
+                            + " and no new master could be discovered. You may need to check FE's status");
+        }
+        LOG.warn("forward target {} is not master any more, retry against the new master {}",
+                feAddr, newMaster);
+        TMasterOpResult retryResult = forwardTo(params, newMaster);
+        if (isNotMasterResult(retryResult)) {
+            // single retry only: never loop on redirects
+            throw new MasterRedirectException(
+                    "forward to master FE " + newMaster + " also rejected as not-master");
+        }
+        feAddr = newMaster;
+        return retryResult;
+    }
+
+    /**
+     * Thrown when a forward target rejects the request as NOT_MASTER and no usable
+     * new master can be discovered (or the retry target also rejects it).
+     */
+    public static class MasterRedirectException extends RuntimeException {
+        public MasterRedirectException(String msg) {
+            super(msg);
+        }
+    }
+
+    /**
+     * A usable hint must be non-empty, and must not point back to the failed target or to
+     * this node (both are possible for a degraded old master whose masterInfo = itself).
+     */
+    TNetworkAddress validateHintForTest(TNetworkAddress hint) {
+        if (hint == null || Strings.isNullOrEmpty(hint.hostname) || hint.port <= 0) {
+            return null;
+        }
+        if (hint.hostname.equals(feAddr.getHostname()) && hint.port == feAddr.getPort()) {
+            return null;
+        }
+        String selfHost = Env.getCurrentEnv().getSelfNode().getHost();
+        if (hint.hostname.equals(selfHost) && hint.port == Config.rpc_port) {
+            return null;
+        }
+        return hint;
+    }
+
+    /**
+     * Discover the current master by asking the bdbje group directly (independent of
+     * journal replay), then map the leader's (host, editLogPort) to its rpc port via the
+     * local frontend list. May fail when the bdbje channel itself is partitioned.
+     */
+    private TNetworkAddress discoverMasterByLeader() {
+        try {
+            InetSocketAddress leader = ctx.getEnv().getHaProtocol().getLeader();
+            if (leader == null) {
+                return null;
+            }
+            for (Frontend fe : ctx.getEnv().getFrontends(null)) {
+                if (fe.getRole() == FrontendNodeType.FOLLOWER
+                        && fe.getHost().equals(leader.getHostString())
+                        && fe.getEditLogPort() == leader.getPort()) {
+                    return new TNetworkAddress(fe.getHost(), fe.getRpcPort());
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("failed to discover master by bdbje leader: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Last-resort discovery, tolerant of a partitioned bdbje channel: probe the thrift
+     * endpoints of alive followers (excluding the failed target and this node) with a
+     * lightweight isMasterProbe request, bounded to at most a few probes.
+     */
+    private TNetworkAddress discoverMasterByProbe() {
+        int probed = 0;
+        final int maxProbes = 2;
+        String selfHost = Env.getCurrentEnv().getSelfNode().getHost();
+        for (Frontend fe : ctx.getEnv().getFrontends(FrontendNodeType.FOLLOWER)) {
+            if (probed >= maxProbes) {
+                break;
+            }
+            if (!fe.isAlive()) {
+                continue;
+            }
+            TNetworkAddress candidate = new TNetworkAddress(fe.getHost(), fe.getRpcPort());
+            if (candidate.hostname.equals(feAddr.getHostname()) && candidate.port == feAddr.getPort()) {
+                continue;
+            }
+            if (fe.getHost().equals(selfHost)) {
+                continue;
+            }
+            probed++;
+            try {
+                TMasterOpResult probeResult = forwardTo(buildMasterProbeParams(), candidate);
+                if (probeResult.isSetNotMaster() && !probeResult.isNotMaster()) {
+                    return candidate;
+                }
+            } catch (Exception e) {
+                LOG.warn("master probe to {} failed: {}", candidate, e.getMessage());
+            }
+        }
+        return null;
+    }
+
+    private TMasterOpRequest buildMasterProbeParams() {
+        TMasterOpRequest params = new TMasterOpRequest();
+        params.setClientNodeHost(Env.getCurrentEnv().getSelfNode().getHost());
+        params.setClientNodePort(Env.getCurrentEnv().getSelfNode().getPort());
+        params.setIsMasterProbe(true);
+        params.setDb(ctx.getDatabase());
+        params.setUser(ctx.getQualifiedUser());
+        // just make the protocol happy
+        params.setSql("");
+        return params;
+    }
+
     private void waitOnReplaying() throws DdlException {
+        if (isNotMasterResult(result)) {
+            // A NOT_MASTER rejection carries no valid journal-sync target; waiting on it
+            // (typically journal id 0 or a stale id from the rejecting FE) would hang the
+            // client for the whole journal-wait timeout. Surface the error immediately.
+            LOG.info("forward result is a NOT_MASTER rejection, skip journal replay wait");
+            return;
+        }
         LOG.info("forwarding to master get result max journal id: {}", result.maxJournalId);
         ctx.getEnv().getJournalObservable().waitOn(result.maxJournalId, journalWaitTimeoutMs);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -66,6 +66,7 @@ import org.apache.doris.common.ClientPool;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.DuplicatedRequestException;
+import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.InternalErrorCode;
 import org.apache.doris.common.LabelAlreadyUsedException;
@@ -1154,6 +1155,15 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     @Override
     public TMasterOpResult forward(TMasterOpRequest params) throws TException {
         validateForwardRequester(params);
+        // If this node is not the master any more (e.g. after a master failover while the
+        // sender's journal replay is still lagging), reject the forwarded statement before
+        // executing it. Otherwise the statement would run deep into StmtExecutor and fail
+        // with "Master FE is not ready", which the sender cannot recover from.
+        if (!params.isSetIsMasterProbe() || !params.isIsMasterProbe()) {
+            if (!Env.getCurrentEnv().isMaster()) {
+                return buildNotMasterResult();
+            }
+        }
         TMasterOpResult shortcut = handleForwardShortcut(params);
         if (shortcut != null) {
             return shortcut;
@@ -1170,6 +1180,35 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
     }
 
+    /**
+     * Build a NOT_MASTER rejection for a forwarded statement. The statement is NOT executed,
+     * so the sender may safely retry it (even non-idempotent statements) against the real
+     * master discovered via the hint below or by its own discovery.
+     */
+    private TMasterOpResult buildNotMasterResult() {
+        TMasterOpResult result = new TMasterOpResult();
+        // No journal-sync target for a rejection; the sender must skip its journal wait.
+        result.setMaxJournalId(0L);
+        result.setPacket(new byte[0]);
+        result.setNotMaster(true);
+        result.setStatus(QueryState.MysqlStateType.ERR.name());
+        result.setStatusCode(ErrorCode.ERR_UNKNOWN_ERROR.getCode());
+        result.setErrMessage(NOT_MASTER_REJECT_MSG.replace("{}", Env.getCurrentEnv().getSelfNode().getHost()));
+        // Hint the sender with the master this node knows about, if any. This is best-effort:
+        // the hint may be stale or even point to this node itself, so the sender must
+        // validate it (not equal to the failed target / itself) before use.
+        if (Env.getCurrentEnv().isReady() && !Strings.isNullOrEmpty(Env.getCurrentEnv().getMasterHost())) {
+            result.setMasterAddress(new TNetworkAddress(Env.getCurrentEnv().getMasterHost(),
+                    Env.getCurrentEnv().getMasterRpcPort()));
+        }
+        LOG.warn("reject forwarded statement because current node is not master. known master: {}",
+                result.getMasterAddress());
+        return result;
+    }
+
+    private static final String NOT_MASTER_REJECT_MSG =
+            "Current FE({}) is not the master any more, please retry against the current master.";
+
     private void validateForwardRequester(TMasterOpRequest params) throws TException {
         Frontend fe = Env.getCurrentEnv().checkFeExist(params.getClientNodeHost(), params.getClientNodePort());
         if (fe != null) {
@@ -1180,6 +1219,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     }
 
     private TMasterOpResult handleForwardShortcut(TMasterOpRequest params) throws TException {
+        if (params.isSetIsMasterProbe() && params.isIsMasterProbe()) {
+            return handleMasterProbe();
+        }
         if (params.isSyncJournalOnly()) {
             return createForwardResultWithJournalSync();
         }
@@ -1201,6 +1243,29 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         TMasterOpResult result = new TMasterOpResult();
         result.setMaxJournalId(Env.getCurrentEnv().getMaxJournalId());
         result.setPacket("".getBytes());
+        return result;
+    }
+
+    /**
+     * Lightweight probe: answer whether this node is the master, without executing anything.
+     * Used by a sender re-discovering the real master after a NOT_MASTER rejection.
+     */
+    private TMasterOpResult handleMasterProbe() {
+        TMasterOpResult result = new TMasterOpResult();
+        result.setMaxJournalId(0L);
+        result.setPacket(new byte[0]);
+        if (Env.getCurrentEnv().isMaster()) {
+            result.setNotMaster(false);
+            // confirm self as master: hint points to this node
+            result.setMasterAddress(new TNetworkAddress(Env.getCurrentEnv().getSelfNode().getHost(),
+                    Config.rpc_port));
+        } else {
+            result.setNotMaster(true);
+            if (Env.getCurrentEnv().isReady() && !Strings.isNullOrEmpty(Env.getCurrentEnv().getMasterHost())) {
+                result.setMasterAddress(new TNetworkAddress(Env.getCurrentEnv().getMasterHost(),
+                        Env.getCurrentEnv().getMasterRpcPort()));
+            }
+        }
         return result;
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/MasterOpExecutorNotMasterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/MasterOpExecutorNotMasterTest.java
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe;
+
+import org.apache.doris.analysis.RedirectStatus;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.Config;
+import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.system.SystemInfoService;
+import org.apache.doris.thrift.TMasterOpResult;
+import org.apache.doris.thrift.TNetworkAddress;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class MasterOpExecutorNotMasterTest {
+
+    // The static Env mock must stay open for the whole test method, because
+    // validateHintForTest() reads Env.getCurrentEnv() outside the constructor.
+    private static MasterOpExecutor newExecutor(String masterHost, int masterPort, MockedStatic<Env> mockedEnv) {
+        Env env = Mockito.mock(Env.class);
+        Mockito.when(env.getSelfNode()).thenReturn(new SystemInfoService.HostInfo("127.0.0.1", 9010));
+        Mockito.when(env.getMasterHost()).thenReturn(masterHost);
+        Mockito.when(env.getMasterRpcPort()).thenReturn(masterPort);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Mockito.when(catalog.getName()).thenReturn("internal");
+        Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+        mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+        ConnectContext ctx = new ConnectContext();
+        ctx.setEnv(env);
+        ctx.setSessionVariable(VariableMgr.newSessionVariable());
+        ctx.getSessionVariable().setQueryTimeoutS(10);
+        return new MasterOpExecutor(null, ctx, RedirectStatus.FORWARD_WITH_SYNC, true);
+    }
+
+    // A hint equal to the failed target must be rejected (a degraded old master whose
+    // masterInfo = itself would otherwise create a retry loop).
+    @Test
+    public void testHintPointingToFailedTargetRejected() {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            MasterOpExecutor executor = newExecutor("10.0.0.1", 9020, mockedEnv);
+            Assert.assertNull(executor.validateHintForTest(new TNetworkAddress("10.0.0.1", 9020)));
+        }
+    }
+
+    // A hint pointing to this node must be rejected as well.
+    @Test
+    public void testHintPointingToSelfRejected() {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            MasterOpExecutor executor = newExecutor("10.0.0.1", 9020, mockedEnv);
+            Assert.assertNull(executor.validateHintForTest(new TNetworkAddress("127.0.0.1", Config.rpc_port)));
+        }
+    }
+
+    // A valid hint pointing elsewhere is accepted.
+    @Test
+    public void testValidHintAccepted() {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            MasterOpExecutor executor = newExecutor("10.0.0.1", 9020, mockedEnv);
+            TNetworkAddress hint = new TNetworkAddress("10.0.0.2", 9020);
+            Assert.assertEquals(hint, executor.validateHintForTest(hint));
+        }
+    }
+
+    // Empty/invalid hints are rejected.
+    @Test
+    public void testInvalidHintRejected() {
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            MasterOpExecutor executor = newExecutor("10.0.0.1", 9020, mockedEnv);
+            Assert.assertNull(executor.validateHintForTest(null));
+            Assert.assertNull(executor.validateHintForTest(new TNetworkAddress("", 9020)));
+            Assert.assertNull(executor.validateHintForTest(new TNetworkAddress("10.0.0.2", 0)));
+        }
+    }
+
+    // NOT_MASTER detection.
+    @Test
+    public void testIsNotMasterResult() {
+        Assert.assertFalse(MasterOpExecutor.isNotMasterResultForTest(null));
+        TMasterOpResult normal = new TMasterOpResult();
+        Assert.assertFalse(MasterOpExecutor.isNotMasterResultForTest(normal));
+        TMasterOpResult notMaster = new TMasterOpResult();
+        notMaster.setNotMaster(true);
+        Assert.assertTrue(MasterOpExecutor.isNotMasterResultForTest(notMaster));
+    }
+}

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -430,6 +430,11 @@ struct TMasterOpRequest {
     1005: optional string delegated_credential_token
     1006: optional i64 delegated_credential_expires_at_millis
     1007: optional string delegated_credential_session_id
+
+    // if set to true, this request is a lightweight probe asking whether the receiving
+    // FE is the master. Used by a sender to re-discover the real master after a
+    // NOT_MASTER rejection. No statement is executed.
+    36: optional bool isMasterProbe
 }
 
 struct TColumnDefinition {
@@ -461,6 +466,13 @@ struct TMasterOpResult {
     9: optional TTxnLoadInfo txnLoadInfo;
     10: optional i64 groupCommitLoadBeId;
     11: optional i64 affectedRows;
+    // Set when the receiving FE is not the master, so the sender can refresh its stale
+    // masterInfo and retry against the real master instead of failing with
+    // "Master FE is not ready".
+    12: optional bool notMaster;
+    // The master address known by the rejecting FE (may be stale or even point to the
+    // rejecting FE itself; the sender must validate it before use).
+    13: optional Types.TNetworkAddress masterAddress;
 }
 
 // Certificate-based authentication info forwarded from BE to FE


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67297

Problem Summary:

After a master FE failover (the old master lost leadership, e.g. due to OOM/GC pause, but the process stayed alive and kept serving its MySQL/thrift ports), a non-master FE (observer/follower) with a lagging journal replay keeps forwarding statements to the **old master** because:

1. The forward target comes from `Env.masterInfo`, which is only refreshed by replaying the `OP_MASTER_INFO_CHANGE` journal (or by loading an image at startup). There is no active master re-discovery on the forward path.
2. The forwarded thrift call succeeds at the transport level on the degraded old master, which runs the statement deep into `StmtExecutor` and throws "The statement has been forwarded to master FE(...) and failed to execute because Master FE is not ready" — an error the sender cannot recover from.
3. For `FORWARD_WITH_SYNC` statements, the old master's error response still carries a `maxJournalId`, so the sender blocks in `JournalObservable.waitOn()` (up to `query_timeout * 1.2`, default ~18 min) before surfacing anything.

The issue above contains a deterministic 4-FE docker reproduction with iptables-based fault injection, which this PR fixes.

**Fix:**

- **Receiver side** (`FrontendServiceImpl.forward()`): reject a forwarded statement up front with a structured `NOT_MASTER` result (`notMaster` + best-effort `masterAddress` hint) when the receiving FE is not the master. The statement is **not executed**, which makes a sender-side retry safe even for non-idempotent statements. A lightweight `isMasterProbe` shortcut is added for master discovery.
- **Sender side** (`MasterOpExecutor`): on `NOT_MASTER`, validate the hint (rejecting hints that point back to the failed target or to itself — a degraded old master may keep `masterInfo = itself`), then fall back to a bdbje leader lookup (`getHaProtocol().getLeader()`, independent of journal replay), then to probing alive followers via `isMasterProbe`, and retry the statement **once** against the discovered master.
- **Journal wait**: a `NOT_MASTER` result skips `JournalObservable.waitOn()` so rejections surface to the client immediately instead of hanging for the journal-wait timeout. Successful results keep the existing wait semantics (read-your-writes unchanged).
- **Scoping**: redirect is enabled only for `MasterOpExecutor` (`supportNotMasterRedirect()`); generic `FEOpExecutor` calls (all-FE config propagation, cross-FE query kill) that intentionally target a specific non-master FE keep their semantics. Transport-failure retry semantics are unchanged — only an explicit pre-execution `NOT_MASTER` rejection is retried, never an ambiguous timeout.

**Compatibility**: the new thrift fields are all `optional`, so mixed old/new deployments behave as before (an old sender ignores the new fields; a new sender falling back to the old error path is no worse than the status quo). `maxJournalId` of the rejection is `0`, whose journal wait is a no-op even for old senders.

### Release note

Fix an availability issue where, after a master FE failover, non-master FEs kept forwarding statements to the old degraded master for up to `meta_delay_toleration_second` (default 300s), failing with "The statement has been forwarded to master FE(...) and failed to execute because Master FE is not ready", and `FORWARD_WITH_SYNC` statements hung in journal-sync wait for up to 18 minutes. Forwarded statements are now rejected up front by a non-master receiver and retried once against the re-discovered master.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason? -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->
        A non-master FE that receives a forwarded statement now rejects it immediately with a structured `NOT_MASTER` result instead of executing it deep into `StmtExecutor`; `MasterOpExecutor` then retries once against the re-discovered master. `FORWARD_WITH_SYNC` statements no longer hang on the journal wait when the forward target is not the master. Generic `FEOpExecutor` behavior (config propagation, query kill, transport-failure retry) is unchanged.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

#### Unit tests

`MasterOpExecutorNotMasterTest` (5 cases, all passing):
- hint pointing to the failed target is rejected (prevents retry loop against a degraded old master whose `masterInfo = itself`)
- hint pointing to this node is rejected
- a valid hint pointing elsewhere is accepted
- empty/invalid hints are rejected
- `NOT_MASTER` result detection

#### Manual test (deterministic reproduction from the issue)

4-FE docker cluster (fe1=initial master, fe2/fe3=followers, fe4=observer), fault injection via host-side `nsenter`+iptables:
1. freeze the observer's journal replay toward fe2/fe3 (block bdbje 9010) — its `masterInfo` stays = fe1
2. `docker kill` fe1 (old master "OOM" death); fe3 elected new master
3. restart fe1 and isolate its bdbje — alive-but-degraded old master (thrift 9020 still serving)
4. execute statements via the observer (port 19033)

Before this PR (official `apache/doris:fe-3.0.8` image), same injection:

```
$ mysql -h 127.0.0.1 -P 19033 -u root -e 'ADMIN SET FRONTEND CONFIG ("label_keep_max_second" = "259200")'
ERROR 1105 (HY000) at line 1: errCode = 2, detailMessage = The statement has been forwarded to master FE(172.20.80.2) and failed to execute because Master FE is not ready. You may need to check FE's status

$ mysql -h 127.0.0.1 -P 19033 -u root -e 'CREATE USER x IDENTIFIED BY 'p''
(hangs in JournalObservable.waitOn() for up to 18 min)
```

After this PR (patched build, same injection):

```
$ mysql -h 127.0.0.1 -P 19033 -u root -e 'ADMIN SET FRONTEND CONFIG ("label_keep_max_second" = "259200")'   -> OK (x3)
$ mysql -h 127.0.0.1 -P 19033 -u root -e 'CREATE USER verify_1 IDENTIFIED BY 'p''                            -> OK
```

Observer log shows the redirect working as designed:

```
[fe4] forward to master FE TNetworkAddress(hostname:172.20.80.2, port:9020)
[fe4] forward target 172.20.80.2:9020 is not master any more, retry against the new master TNetworkAddress(hostname:172.20.80.4, port:9020)
[fe3] finished to create user: 'verify_1'@'%'   <- statement actually executed on the real master
[fe2] replay add user verify_1                   <- journal sync to other nodes unaffected
```
