### PR TITLE
[fix](be) Reject empty Iceberg equality delete field IDs

### DIFF
--- a/be/src/format/table/iceberg_reader_mixin.h
+++ b/be/src/format/table/iceberg_reader_mixin.h
@@ -840,8 +840,9 @@ Status IcebergReaderMixin<BaseReader>::_merge_equality_delete_rows(
 template <typename BaseReader>
 Status IcebergReaderMixin<BaseReader>::_read_equality_delete_file(
         const TIcebergDeleteFileDesc& delete_file) {
-    if (!delete_file.__isset.field_ids) [[unlikely]] {
-        return Status::InternalError("missing delete field ids when reading equality delete file");
+    // Equality deletes require at least one key; a zero-column block would make every row equal.
+    if (!delete_file.__isset.field_ids || delete_file.field_ids.empty()) [[unlikely]] {
+        return Status::InternalError("Iceberg equality delete file is missing field ids");
     }
     TFileRangeDesc delete_desc;
     delete_desc.__set_fs_name(this->get_scan_range().fs_name);

--- a/be/test/format/table/iceberg/iceberg_reader_test.cpp
+++ b/be/test/format/table/iceberg/iceberg_reader_test.cpp
@@ -1718,6 +1718,39 @@ TEST_F(IcebergReaderTest, v1_position_delete_read_error_releases_cache_entry) {
     EXPECT_NE(status.to_string().find(delete_file.path), std::string::npos);
 }
 
+TEST_F(IcebergReaderTest, v1_rejects_equality_delete_file_with_empty_field_ids) {
+    RuntimeState runtime_state = RuntimeState(TQueryOptions(), TQueryGlobals());
+    TFileScanRangeParams scan_params;
+    scan_params.__set_file_type(TFileType::FILE_LOCAL);
+    scan_params.__set_format_type(TFileFormatType::FORMAT_PARQUET);
+
+    TFileRangeDesc scan_range;
+    scan_range.__set_fs_name("");
+    scan_range.__set_path("data.parquet");
+    scan_range.__set_start_offset(0);
+    scan_range.__set_size(0);
+
+    RuntimeProfile profile("test_profile");
+    cctz::time_zone ctz;
+    TimezoneUtils::find_cctz_time_zone(TimezoneUtils::default_time_zone, ctz);
+    io::IOContext io_ctx;
+    ShardedKVCache kv_cache(8);
+
+    IcebergParquetReader iceberg_reader(&kv_cache, &profile, scan_params, scan_range, 1024, &ctz,
+                                        &io_ctx, &runtime_state, cache.get());
+
+    TIcebergDeleteFileDesc delete_file;
+    delete_file.__set_content(IcebergReaderMixin<ParquetReader>::EQUALITY_DELETE);
+    delete_file.__set_path("empty-equality-delete.parquet");
+    delete_file.__set_field_ids({});
+
+    const auto status = iceberg_reader._equality_delete_base({delete_file});
+
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("Iceberg equality delete file is missing field ids"),
+              std::string::npos);
+}
+
 TEST_F(IcebergReaderTest, v1_rejects_missing_required_field_without_initial_default) {
     schema::external::TField field;
     field.__set_name("required_added");


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

The File Scanner V1 Iceberg reader accepted equality delete metadata with an empty field ID list. That allowed malformed metadata to reach a zero-column equality comparison, where every row could compare equal.

This change rejects missing or empty equality delete field IDs at the reader entry point, matching the File Scanner V2 invariant. It also adds a BE unit test that verifies rejection happens before delete-file I/O.

### Release note

Reject malformed Iceberg equality delete files with no field IDs.

### Check List (For Author)

- Test
    - [x] Unit Test
        - `IcebergReaderTest.v1_rejects_equality_delete_file_with_empty_field_ids`
        - `IcebergReaderTest.*` (42 tests passed)

- Behavior changed:
    - [x] Yes. Malformed equality delete metadata with no field IDs is rejected.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label