### PR TITLE
[fix](outfile) Make distributed OUTFILE cleanup atomic

### DIFF
--- a/be/src/agent/be_exec_version_manager.cpp
+++ b/be/src/agent/be_exec_version_manager.cpp
@@ -131,8 +131,10 @@ void BeExecVersionManager::check_function_compatibility(int current_be_exec_vers
 // 13: start from master
 //   a. support strict ownership hash routing for external table sink writers.
 //   b. support Paimon default fixed-bucket routing in the external sink exchange.
+// 14: start from master
+//   a. support atomic commit or rollback for distributed OUTFILE writers.
 
-const int BeExecVersionManager::max_be_exec_version = 13;
+const int BeExecVersionManager::max_be_exec_version = 14;
 const int BeExecVersionManager::min_be_exec_version = 0;
 std::map<std::string, std::set<int>> BeExecVersionManager::_function_change_map {};
 std::set<std::string> BeExecVersionManager::_function_restrict_map;

--- a/be/src/agent/be_exec_version_manager.h
+++ b/be/src/agent/be_exec_version_manager.h
@@ -29,6 +29,7 @@ constexpr inline int USE_NEW_FIXED_OBJECT_SERIALIZATION_VERSION = 10;
 constexpr inline int SUPPORT_ICEBERG_MERGE_CARDINALITY_VERSION = 11;
 constexpr inline int SUPPORT_ICEBERG_VARIANT_VERSION = 12;
 constexpr inline int SUPPORT_EXTERNAL_TABLE_SINK_HASH_VERSION = 13;
+constexpr inline int SUPPORT_ATOMIC_OUTFILE_VERSION = 14;
 
 class BeExecVersionManager {
 public:

--- a/be/src/exec/operator/result_sink_operator.h
+++ b/be/src/exec/operator/result_sink_operator.h
@@ -64,6 +64,7 @@ struct ResultFileOptions {
     //Bring BOM when exporting to CSV format
     bool with_bom = false;
     int64_t orc_writer_version = 0;
+    bool enable_atomic_outfile = false;
 
     ResultFileOptions(const TResultFileSinkOptions& t_opt) {
         file_path = t_opt.file_path;
@@ -123,6 +124,9 @@ struct ResultFileOptions {
         }
         if (t_opt.__isset.compression_type) {
             compression_type = t_opt.compression_type;
+        }
+        if (t_opt.__isset.enable_atomic_outfile) {
+            enable_atomic_outfile = t_opt.enable_atomic_outfile;
         }
     }
 };

--- a/be/src/exec/sink/writer/vfile_result_writer.cpp
+++ b/be/src/exec/sink/writer/vfile_result_writer.cpp
@@ -123,13 +123,18 @@ Status VFileResultWriter::_create_next_file_writer() {
 
 Status VFileResultWriter::_create_file_writer(const std::string& file_name) {
     auto file_type = DORIS_TRY(FileFactory::convert_storage_type(_storage_type));
-    _file_writer_impl = DORIS_TRY(FileFactory::create_file_writer(
-            file_type, _state->exec_env(), _file_opts->broker_addresses,
-            _file_opts->broker_properties, file_name,
-            {
-                    .write_file_cache = false,
-                    .sync_file_data = false,
-            }));
+    if (_file_system == nullptr) {
+        io::FSPropertiesRef properties(file_type);
+        properties.broker_addresses = &_file_opts->broker_addresses;
+        properties.properties = &_file_opts->broker_properties;
+        io::FileDescription file_description;
+        file_description.path = file_name;
+        _file_system = DORIS_TRY(FileFactory::create_fs(properties, file_description));
+    }
+    const io::FileWriterOptions options {.write_file_cache = false, .sync_file_data = false};
+    RETURN_IF_ERROR(_file_system->create_file(file_name, &_file_writer_impl, &options));
+    // Exact ownership is recorded at creation so rollback never scans or removes another query's files.
+    _created_file_paths.emplace_back(file_name);
     switch (_file_opts->file_format) {
     case TFileFormatType::FORMAT_CSV_PLAIN:
         _vfile_writer.reset(new VCSVTransformer(
@@ -487,7 +492,43 @@ Status VFileResultWriter::close(Status exec_status) {
         }
         st = _close_file_writer(true);
     }
+    if (!st.ok()) {
+        _cleanup_created_files();
+    } else {
+        _register_created_files_cleanup();
+    }
     return st;
+}
+
+void VFileResultWriter::_cleanup_created_files() {
+    _vfile_writer.reset();
+    if (_file_writer_impl != nullptr) {
+        if (_created_file_paths.empty()) {
+            _created_file_paths.emplace_back(_file_writer_impl->path());
+        }
+        WARN_IF_ERROR(_file_writer_impl->abort(), "failed to abort outfile writer");
+        _file_writer_impl.reset();
+    }
+    if (_file_system == nullptr && _storage_type == TStorageBackendType::LOCAL) {
+        _file_system = io::global_local_filesystem();
+    }
+    if (_file_system != nullptr && !_created_file_paths.empty()) {
+        WARN_IF_ERROR(_file_system->batch_delete(_created_file_paths),
+                      "failed to remove files from aborted outfile");
+    }
+    _created_file_paths.clear();
+}
+
+void VFileResultWriter::_register_created_files_cleanup() {
+    if (_sinker == nullptr || _file_system == nullptr || _created_file_paths.empty()) {
+        return;
+    }
+    auto file_system = _file_system;
+    auto paths = std::move(_created_file_paths);
+    _sinker->add_outfile_cleanup([file_system = std::move(file_system), paths = std::move(paths)] {
+        WARN_IF_ERROR(file_system->batch_delete(paths),
+                      "failed to remove files from aborted outfile query");
+    });
 }
 
 } // namespace doris

--- a/be/src/exec/sink/writer/vfile_result_writer.cpp
+++ b/be/src/exec/sink/writer/vfile_result_writer.cpp
@@ -69,10 +69,12 @@ static double nons_to_second = 1000000000.00;
 
 namespace {
 
-using OwnedOutfile = std::pair<std::shared_ptr<io::FileSystem>, io::Path>;
+using OutfileFileSystemId = int32_t;
+using OwnedOutfile = std::pair<OutfileFileSystemId, io::Path>;
 
 struct OutfileCleanupState {
     std::shared_ptr<io::FileWriter> writer;
+    std::unordered_map<OutfileFileSystemId, std::shared_ptr<io::FileSystem>> file_systems;
     std::vector<OwnedOutfile> files;
 
     Status cleanup() {
@@ -87,13 +89,18 @@ struct OutfileCleanupState {
         }
 
         std::vector<OwnedOutfile> failed_files;
-        for (auto& [file_system, path] : files) {
-            Status status = file_system->delete_file(path);
+        for (auto& [file_system_id, path] : files) {
+            auto file_system = file_systems.find(file_system_id);
+            Status status = file_system == file_systems.end()
+                                    ? Status::InternalError(
+                                              "missing filesystem for OUTFILE cleanup path {}",
+                                              path.string())
+                                    : file_system->second->delete_file(path);
             if (!status.ok() && !status.is<ErrorCode::NOT_FOUND>()) {
                 if (first_failure.ok()) {
                     first_failure = status;
                 }
-                failed_files.emplace_back(file_system, path);
+                failed_files.emplace_back(file_system_id, path);
             }
         }
         files = std::move(failed_files);
@@ -170,15 +177,29 @@ Status VFileResultWriter::_create_next_file_writer() {
 
 Status VFileResultWriter::_create_file_writer(const std::string& file_name) {
     auto file_type = DORIS_TRY(FileFactory::convert_storage_type(_storage_type));
-    io::FSPropertiesRef properties(file_type);
-    properties.broker_addresses = &_file_opts->broker_addresses;
-    properties.properties = &_file_opts->broker_properties;
-    io::FileDescription file_description;
-    file_description.path = file_name;
-    _file_system = DORIS_TRY(FileFactory::create_fs(properties, file_description));
+    int32_t file_system_id = 0;
+    if (_storage_type == TStorageBackendType::BROKER) {
+        file_system_id = get_broker_index(_file_opts->broker_addresses, file_name);
+        if (file_system_id < 0) {
+            return Status::InternalError("empty broker_addresses");
+        }
+    }
+    auto file_system = _created_file_systems.find(file_system_id);
+    if (file_system == _created_file_systems.end()) {
+        io::FSPropertiesRef properties(file_type);
+        properties.broker_addresses = &_file_opts->broker_addresses;
+        properties.properties = &_file_opts->broker_properties;
+        io::FileDescription file_description;
+        file_description.path = file_name;
+        auto new_file_system = DORIS_TRY(FileFactory::create_fs(properties, file_description));
+        file_system =
+                _created_file_systems.emplace(file_system_id, std::move(new_file_system)).first;
+    }
+    _file_system = file_system->second;
     // Create/open can publish a path before returning an error, so claim deterministic ownership
-    // first. A separate filesystem preserves Broker's existing per-path endpoint selection.
-    _created_files.emplace_back(_file_system, file_name);
+    // first. Reuse one owned filesystem per storage identity or selected Broker endpoint so the
+    // deferred manifest grows only by paths, not initialized client wrappers.
+    _record_created_file(file_system_id, _file_system, file_name);
     // Local OUTFILE historically synced successful closes; preserve that durability while remote
     // writers keep the existing no-sync option to avoid redundant flushes.
     const io::FileWriterOptions options {
@@ -566,10 +587,11 @@ Status VFileResultWriter::_cleanup_created_files() {
                 file_system = io::global_local_filesystem();
             }
             if (file_system != nullptr) {
-                _created_files.emplace_back(std::move(file_system), cleanup_state->writer->path());
+                _record_created_file(0, std::move(file_system), cleanup_state->writer->path());
             }
         }
     }
+    cleanup_state->file_systems = std::move(_created_file_systems);
     cleanup_state->files = std::move(_created_files);
     Status status = run_cleanup_with_retries(cleanup_state);
     if (!status.ok() && _file_opts != nullptr && _file_opts->enable_atomic_outfile &&
@@ -586,15 +608,24 @@ Status VFileResultWriter::_cleanup_created_files() {
 Status VFileResultWriter::_register_created_files_cleanup() {
     if (_file_opts == nullptr || !_file_opts->enable_atomic_outfile) {
         _created_files.clear();
+        _created_file_systems.clear();
         return Status::OK();
     }
     if (_sinker == nullptr || _created_files.empty()) {
         return Status::InternalError("atomic OUTFILE has no result buffer cleanup owner");
     }
     auto cleanup_state = std::make_shared<OutfileCleanupState>();
+    cleanup_state->file_systems = std::move(_created_file_systems);
     cleanup_state->files = std::move(_created_files);
     return _sinker->add_outfile_cleanup(
             [cleanup_state] { return run_cleanup_with_retries(cleanup_state); });
+}
+
+void VFileResultWriter::_record_created_file(int32_t file_system_id,
+                                             std::shared_ptr<io::FileSystem> file_system,
+                                             const io::Path& path) {
+    _created_file_systems.try_emplace(file_system_id, std::move(file_system));
+    _created_files.emplace_back(file_system_id, path);
 }
 
 } // namespace doris

--- a/be/src/exec/sink/writer/vfile_result_writer.cpp
+++ b/be/src/exec/sink/writer/vfile_result_writer.cpp
@@ -67,6 +67,53 @@ namespace doris {
 
 static double nons_to_second = 1000000000.00;
 
+namespace {
+
+using OwnedOutfile = std::pair<std::shared_ptr<io::FileSystem>, io::Path>;
+
+struct OutfileCleanupState {
+    std::shared_ptr<io::FileWriter> writer;
+    std::vector<OwnedOutfile> files;
+
+    Status cleanup() {
+        Status first_failure = Status::OK();
+        if (writer != nullptr) {
+            Status status = writer->abort();
+            if (status.ok()) {
+                writer.reset();
+            } else {
+                first_failure = status;
+            }
+        }
+
+        std::vector<OwnedOutfile> failed_files;
+        for (auto& [file_system, path] : files) {
+            Status status = file_system->delete_file(path);
+            if (!status.ok() && !status.is<ErrorCode::NOT_FOUND>()) {
+                if (first_failure.ok()) {
+                    first_failure = status;
+                }
+                failed_files.emplace_back(file_system, path);
+            }
+        }
+        files = std::move(failed_files);
+        return first_failure;
+    }
+};
+
+Status run_cleanup_with_retries(const std::shared_ptr<OutfileCleanupState>& state) {
+    Status status;
+    for (int attempt = 0; attempt < 3; ++attempt) {
+        status = state->cleanup();
+        if (status.ok()) {
+            return status;
+        }
+    }
+    return status;
+}
+
+} // namespace
+
 VFileResultWriter::VFileResultWriter(const TDataSink& t_sink, const VExprContextSPtrs& output_exprs,
                                      std::shared_ptr<Dependency> dep,
                                      std::shared_ptr<Dependency> fin_dep)
@@ -123,18 +170,17 @@ Status VFileResultWriter::_create_next_file_writer() {
 
 Status VFileResultWriter::_create_file_writer(const std::string& file_name) {
     auto file_type = DORIS_TRY(FileFactory::convert_storage_type(_storage_type));
-    if (_file_system == nullptr) {
-        io::FSPropertiesRef properties(file_type);
-        properties.broker_addresses = &_file_opts->broker_addresses;
-        properties.properties = &_file_opts->broker_properties;
-        io::FileDescription file_description;
-        file_description.path = file_name;
-        _file_system = DORIS_TRY(FileFactory::create_fs(properties, file_description));
-    }
+    io::FSPropertiesRef properties(file_type);
+    properties.broker_addresses = &_file_opts->broker_addresses;
+    properties.properties = &_file_opts->broker_properties;
+    io::FileDescription file_description;
+    file_description.path = file_name;
+    _file_system = DORIS_TRY(FileFactory::create_fs(properties, file_description));
+    // Create/open can publish a path before returning an error, so claim deterministic ownership
+    // first. A separate filesystem preserves Broker's existing per-path endpoint selection.
+    _created_files.emplace_back(_file_system, file_name);
     const io::FileWriterOptions options {.write_file_cache = false, .sync_file_data = false};
     RETURN_IF_ERROR(_file_system->create_file(file_name, &_file_writer_impl, &options));
-    // Exact ownership is recorded at creation so rollback never scans or removes another query's files.
-    _created_file_paths.emplace_back(file_name);
     switch (_file_opts->file_format) {
     case TFileFormatType::FORMAT_CSV_PLAIN:
         _vfile_writer.reset(new VCSVTransformer(
@@ -493,42 +539,58 @@ Status VFileResultWriter::close(Status exec_status) {
         st = _close_file_writer(true);
     }
     if (!st.ok()) {
-        _cleanup_created_files();
+        WARN_IF_ERROR(_cleanup_created_files(), "failed to remove files from aborted OUTFILE");
     } else {
-        _register_created_files_cleanup();
+        RETURN_IF_ERROR(_register_created_files_cleanup());
     }
     return st;
 }
 
-void VFileResultWriter::_cleanup_created_files() {
-    _vfile_writer.reset();
+Status VFileResultWriter::_cleanup_created_files() {
+    if (_vfile_writer != nullptr) {
+        // Format writers must detach without closing the raw writer: Parquet/ORC destructors
+        // otherwise turn a cancelled multipart upload into a published object.
+        WARN_IF_ERROR(_vfile_writer->abort(), "failed to abort outfile format writer");
+        _vfile_writer.reset();
+    }
+    auto cleanup_state = std::make_shared<OutfileCleanupState>();
     if (_file_writer_impl != nullptr) {
-        if (_created_file_paths.empty()) {
-            _created_file_paths.emplace_back(_file_writer_impl->path());
+        cleanup_state->writer = std::shared_ptr<io::FileWriter>(std::move(_file_writer_impl));
+        if (_created_files.empty()) {
+            auto file_system = _file_system;
+            if (file_system == nullptr && _storage_type == TStorageBackendType::LOCAL) {
+                file_system = io::global_local_filesystem();
+            }
+            if (file_system != nullptr) {
+                _created_files.emplace_back(std::move(file_system), cleanup_state->writer->path());
+            }
         }
-        WARN_IF_ERROR(_file_writer_impl->abort(), "failed to abort outfile writer");
-        _file_writer_impl.reset();
     }
-    if (_file_system == nullptr && _storage_type == TStorageBackendType::LOCAL) {
-        _file_system = io::global_local_filesystem();
+    cleanup_state->files = std::move(_created_files);
+    Status status = run_cleanup_with_retries(cleanup_state);
+    if (!status.ok() && _file_opts != nullptr && _file_opts->enable_atomic_outfile &&
+        _sinker != nullptr) {
+        Status register_status = _sinker->add_outfile_cleanup(
+                [cleanup_state] { return run_cleanup_with_retries(cleanup_state); });
+        if (!register_status.ok()) {
+            status = register_status;
+        }
     }
-    if (_file_system != nullptr && !_created_file_paths.empty()) {
-        WARN_IF_ERROR(_file_system->batch_delete(_created_file_paths),
-                      "failed to remove files from aborted outfile");
-    }
-    _created_file_paths.clear();
+    return status;
 }
 
-void VFileResultWriter::_register_created_files_cleanup() {
-    if (_sinker == nullptr || _file_system == nullptr || _created_file_paths.empty()) {
-        return;
+Status VFileResultWriter::_register_created_files_cleanup() {
+    if (_file_opts == nullptr || !_file_opts->enable_atomic_outfile) {
+        _created_files.clear();
+        return Status::OK();
     }
-    auto file_system = _file_system;
-    auto paths = std::move(_created_file_paths);
-    _sinker->add_outfile_cleanup([file_system = std::move(file_system), paths = std::move(paths)] {
-        WARN_IF_ERROR(file_system->batch_delete(paths),
-                      "failed to remove files from aborted outfile query");
-    });
+    if (_sinker == nullptr || _created_files.empty()) {
+        return Status::InternalError("atomic OUTFILE has no result buffer cleanup owner");
+    }
+    auto cleanup_state = std::make_shared<OutfileCleanupState>();
+    cleanup_state->files = std::move(_created_files);
+    return _sinker->add_outfile_cleanup(
+            [cleanup_state] { return run_cleanup_with_retries(cleanup_state); });
 }
 
 } // namespace doris

--- a/be/src/exec/sink/writer/vfile_result_writer.cpp
+++ b/be/src/exec/sink/writer/vfile_result_writer.cpp
@@ -179,7 +179,11 @@ Status VFileResultWriter::_create_file_writer(const std::string& file_name) {
     // Create/open can publish a path before returning an error, so claim deterministic ownership
     // first. A separate filesystem preserves Broker's existing per-path endpoint selection.
     _created_files.emplace_back(_file_system, file_name);
-    const io::FileWriterOptions options {.write_file_cache = false, .sync_file_data = false};
+    // Local OUTFILE historically synced successful closes; preserve that durability while remote
+    // writers keep the existing no-sync option to avoid redundant flushes.
+    const io::FileWriterOptions options {
+            .write_file_cache = false,
+            .sync_file_data = _storage_type == TStorageBackendType::LOCAL};
     RETURN_IF_ERROR(_file_system->create_file(file_name, &_file_writer_impl, &options));
     switch (_file_opts->file_format) {
     case TFileFormatType::FORMAT_CSV_PLAIN:

--- a/be/src/exec/sink/writer/vfile_result_writer.h
+++ b/be/src/exec/sink/writer/vfile_result_writer.h
@@ -26,6 +26,7 @@
 #include <iosfwd>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "common/status.h"
@@ -104,6 +105,9 @@ private:
     Status _delete_dir();
     Status _cleanup_created_files();
     Status _register_created_files_cleanup();
+    void _record_created_file(int32_t file_system_id,
+                              std::shared_ptr<doris::io::FileSystem> file_system,
+                              const doris::io::Path& path);
     double _get_write_speed(int64_t write_bytes, int64_t write_time);
     std::string _compression_type_to_name();
 
@@ -117,7 +121,8 @@ private:
     // If the result file format is Parquet, this _file_writer is owned by _parquet_writer.
     std::unique_ptr<doris::io::FileWriter> _file_writer_impl;
     std::shared_ptr<doris::io::FileSystem> _file_system;
-    std::vector<std::pair<std::shared_ptr<doris::io::FileSystem>, doris::io::Path>> _created_files;
+    std::unordered_map<int32_t, std::shared_ptr<doris::io::FileSystem>> _created_file_systems;
+    std::vector<std::pair<int32_t, doris::io::Path>> _created_files;
     // Used to buffer the export data of plain text
     // TODO(cmy): I simply use a stringstrteam to buffer the data, to avoid calling
     // file writer's write() for every single row.

--- a/be/src/exec/sink/writer/vfile_result_writer.h
+++ b/be/src/exec/sink/writer/vfile_result_writer.h
@@ -80,6 +80,7 @@ public:
 private:
     FRIEND_TEST(VFileResultWriterTest, FailedCloseRemovesClosedOutputFile);
     FRIEND_TEST(VFileResultWriterTest, FailedCloseRemovesOnlyOwnedOutputFiles);
+    FRIEND_TEST(VFileResultWriterTest, LocalOutfilePreservesSynchronousClose);
 
     Status _write_file(const Block& block);
 

--- a/be/src/exec/sink/writer/vfile_result_writer.h
+++ b/be/src/exec/sink/writer/vfile_result_writer.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <gen_cpp/Types_types.h>
+#include <gtest/gtest_prod.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -77,6 +78,9 @@ public:
     }
 
 private:
+    FRIEND_TEST(VFileResultWriterTest, FailedCloseRemovesClosedOutputFile);
+    FRIEND_TEST(VFileResultWriterTest, FailedCloseRemovesOnlyOwnedOutputFiles);
+
     Status _write_file(const Block& block);
 
     void _init_profile(RuntimeProfile*);
@@ -97,6 +101,8 @@ private:
     Status _fill_result_block();
     // delete the dir of file_path
     Status _delete_dir();
+    void _cleanup_created_files();
+    void _register_created_files_cleanup();
     double _get_write_speed(int64_t write_bytes, int64_t write_time);
     std::string _compression_type_to_name();
 
@@ -109,6 +115,8 @@ private:
     // If the result file format is plain text, like CSV, this _file_writer is owned by this FileResultWriter.
     // If the result file format is Parquet, this _file_writer is owned by _parquet_writer.
     std::unique_ptr<doris::io::FileWriter> _file_writer_impl;
+    std::shared_ptr<doris::io::FileSystem> _file_system;
+    std::vector<doris::io::Path> _created_file_paths;
     // Used to buffer the export data of plain text
     // TODO(cmy): I simply use a stringstrteam to buffer the data, to avoid calling
     // file writer's write() for every single row.

--- a/be/src/exec/sink/writer/vfile_result_writer.h
+++ b/be/src/exec/sink/writer/vfile_result_writer.h
@@ -101,8 +101,8 @@ private:
     Status _fill_result_block();
     // delete the dir of file_path
     Status _delete_dir();
-    void _cleanup_created_files();
-    void _register_created_files_cleanup();
+    Status _cleanup_created_files();
+    Status _register_created_files_cleanup();
     double _get_write_speed(int64_t write_bytes, int64_t write_time);
     std::string _compression_type_to_name();
 
@@ -116,7 +116,7 @@ private:
     // If the result file format is Parquet, this _file_writer is owned by _parquet_writer.
     std::unique_ptr<doris::io::FileWriter> _file_writer_impl;
     std::shared_ptr<doris::io::FileSystem> _file_system;
-    std::vector<doris::io::Path> _created_file_paths;
+    std::vector<std::pair<std::shared_ptr<doris::io::FileSystem>, doris::io::Path>> _created_files;
     // Used to buffer the export data of plain text
     // TODO(cmy): I simply use a stringstrteam to buffer the data, to avoid calling
     // file writer's write() for every single row.

--- a/be/src/format/transformer/vfile_format_transformer.h
+++ b/be/src/format/transformer/vfile_format_transformer.h
@@ -50,6 +50,7 @@ public:
     virtual Status open() = 0;
     virtual Status write(const Block& block) = 0;
     virtual Status close() = 0;
+    virtual Status abort() { return Status::OK(); }
     virtual int64_t written_len() = 0;
 
 protected:

--- a/be/src/format/transformer/vorc_transformer.cpp
+++ b/be/src/format/transformer/vorc_transformer.cpp
@@ -414,6 +414,16 @@ Status VOrcTransformer::close() {
     return Status::OK();
 }
 
+Status VOrcTransformer::abort() {
+    if (_output_stream != nullptr) {
+        // ORC's writer destructor may flush buffered stripes, which must not finalize cancellation.
+        _output_stream->abort();
+    }
+    _writer.reset();
+    _output_stream.reset();
+    return Status::OK();
+}
+
 Status VOrcTransformer::collect_file_statistics_after_close(TIcebergColumnStats* stats) {
     if (stats == nullptr || _iceberg_schema == nullptr || _fs == nullptr) {
         return Status::OK();

--- a/be/src/format/transformer/vorc_transformer.h
+++ b/be/src/format/transformer/vorc_transformer.h
@@ -67,6 +67,8 @@ public:
 
     void close() override;
 
+    void abort() { _is_closed = true; }
+
     void set_written_len(int64_t written_len);
 
 private:
@@ -95,6 +97,8 @@ public:
 
     Status close() override;
 
+    Status abort() override;
+
     int64_t written_len() override;
 
     Status collect_file_statistics_after_close(TIcebergColumnStats* stats);
@@ -118,7 +122,7 @@ private:
     std::shared_ptr<io::FileSystem> _fs = nullptr;
     doris::io::FileWriter* _file_writer = nullptr;
     std::vector<std::string> _column_names;
-    std::unique_ptr<orc::OutputStream> _output_stream;
+    std::unique_ptr<VOrcOutputStream> _output_stream;
     std::unique_ptr<orc::WriterOptions> _write_options;
     std::string _schema_str;
     std::unique_ptr<orc::Type> _schema;

--- a/be/src/format/transformer/vparquet_transformer.cpp
+++ b/be/src/format/transformer/vparquet_transformer.cpp
@@ -325,6 +325,16 @@ Status VParquetTransformer::close() {
     return Status::OK();
 }
 
+Status VParquetTransformer::abort() {
+    if (_outstream != nullptr) {
+        // Parquet's writer destructor may emit a footer, so detach the stream before destroying it.
+        std::ignore = _outstream->Abort();
+    }
+    _writer.reset();
+    _outstream.reset();
+    return Status::OK();
+}
+
 Status VParquetTransformer::collect_file_statistics_after_close(TIcebergColumnStats* stats) {
     std::shared_ptr<::parquet::FileMetaData> file_metadata = _writer->metadata();
     if (file_metadata == nullptr) {

--- a/be/src/format/transformer/vparquet_transformer.h
+++ b/be/src/format/transformer/vparquet_transformer.h
@@ -54,6 +54,10 @@ public:
     // return the current write position of the stream
     arrow::Result<int64_t> Tell() const override;
     arrow::Status Close() override;
+    arrow::Status Abort() override {
+        _is_closed = true;
+        return arrow::Status::OK();
+    }
 
     bool closed() const override { return _is_closed; }
 
@@ -107,6 +111,8 @@ public:
     Status write(const Block& block) override;
 
     Status close() override;
+
+    Status abort() override;
 
     int64_t written_len() override;
 

--- a/be/src/io/file_factory.h
+++ b/be/src/io/file_factory.h
@@ -25,6 +25,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "common/factory_creator.h"
 #include "common/status.h"
@@ -86,6 +87,8 @@ struct FileDescription {
 class ExecEnv;
 class RuntimeProfile;
 class RuntimeState;
+
+int32_t get_broker_index(const std::vector<TNetworkAddress>& brokers, const std::string& path);
 
 class FileFactory {
     ENABLE_FACTORY_CREATOR(FileFactory);

--- a/be/src/io/fs/broker_file_system.h
+++ b/be/src/io/fs/broker_file_system.h
@@ -72,8 +72,10 @@ private:
 
     std::string error_msg(const std::string& err) const;
 
-    const TNetworkAddress& _broker_addr;
-    const std::map<std::string, std::string>& _broker_prop;
+    // File-system instances can outlive their caller during deferred cleanup, so broker routing
+    // and credentials must remain owned by the instance instead of aliasing operator state.
+    const TNetworkAddress _broker_addr;
+    const std::map<std::string, std::string> _broker_prop;
 
     std::shared_ptr<BrokerServiceConnection> _connection;
 };

--- a/be/src/io/fs/file_writer.h
+++ b/be/src/io/fs/file_writer.h
@@ -73,6 +73,10 @@ public:
     // If there is no data appended, an empty file will be persisted.
     virtual Status close(bool non_block = false) = 0;
 
+    // Abort releases writer resources without making partially written data part of a successful
+    // operation. Callers that own the path must still remove any already published object.
+    virtual Status abort() { return state() == State::CLOSED ? Status::OK() : close(); }
+
     // Non-blocking probe for a previous close(true).
     // OK means close finished successfully. NeedSendAgain means close is still running.
     // Other errors mean close finished with error or the writer does not support this API.

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -538,10 +538,12 @@ Status S3FileWriter::_complete() {
         return {resp.status.code, std::move(resp.status.msg)};
     }
 
+    // CompleteMultipartUpload publishes the object and consumes the upload ID. A later HEAD
+    // failure must be cleaned up as an object, not retried as an already-finished multipart upload.
+    _multipart_upload_completed = true;
     RETURN_IF_ERROR(check_after_upload(client.get(), resp, _obj_storage_path_opts, _bytes_appended,
                                        "complete_multipart"));
 
-    _multipart_upload_completed = true;
     s3_file_created_total << 1;
     return Status::OK();
 }

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -203,7 +203,13 @@ Status S3FileWriter::abort() {
         return Status::InternalError<false>("invalid obj storage client");
     }
     auto response = client->abort_multipart_upload(_obj_storage_path_opts, _upload_id);
-    return {response.status.code, std::move(response.status.msg)};
+    Status status {response.status.code, std::move(response.status.msg)};
+    if (status.ok()) {
+        // Keep the upload ID intact on failure so the cleanup owner can retry the same multipart
+        // upload instead of leaking hidden parts.
+        _upload_id.clear();
+    }
+    return status;
 }
 
 void S3FileWriter::_record_close_latency() {

--- a/be/src/io/fs/s3_file_writer.cpp
+++ b/be/src/io/fs/s3_file_writer.cpp
@@ -185,6 +185,27 @@ Status S3FileWriter::close(bool non_block) {
     return _st;
 }
 
+Status S3FileWriter::abort() {
+    if (_async_close_pack != nullptr) {
+        std::ignore = _async_close_pack->future.get();
+        _async_close_pack = nullptr;
+    } else {
+        _wait_until_finish(fmt::format("wait s3 file {} uploads before abort",
+                                       _obj_storage_path_opts.path.native()));
+    }
+    _pending_buf.reset();
+    _state = State::CLOSED;
+    if (_upload_id.empty() || _multipart_upload_completed) {
+        return Status::OK();
+    }
+    const auto& client = _obj_client->get();
+    if (client == nullptr) {
+        return Status::InternalError<false>("invalid obj storage client");
+    }
+    auto response = client->abort_multipart_upload(_obj_storage_path_opts, _upload_id);
+    return {response.status.code, std::move(response.status.msg)};
+}
+
 void S3FileWriter::_record_close_latency() {
     if (_close_latency_recorded || !_first_append_timestamp.has_value()) {
         return;
@@ -514,6 +535,7 @@ Status S3FileWriter::_complete() {
     RETURN_IF_ERROR(check_after_upload(client.get(), resp, _obj_storage_path_opts, _bytes_appended,
                                        "complete_multipart"));
 
+    _multipart_upload_completed = true;
     s3_file_created_total << 1;
     return Status::OK();
 }

--- a/be/src/io/fs/s3_file_writer.h
+++ b/be/src/io/fs/s3_file_writer.h
@@ -67,6 +67,7 @@ public:
     std::string upload_id() const { return _upload_id; }
 
     Status close(bool non_block = false) override;
+    Status abort() override;
     Status try_finish_close() override;
 
 private:
@@ -114,6 +115,7 @@ private:
     std::shared_ptr<ObjClientHolder> _obj_client;
     std::optional<std::chrono::steady_clock::time_point> _first_append_timestamp;
     bool _close_latency_recorded = false;
+    bool _multipart_upload_completed = false;
 };
 
 } // namespace io

--- a/be/src/runtime/result_block_buffer.cpp
+++ b/be/src/runtime/result_block_buffer.cpp
@@ -162,6 +162,12 @@ Status ResultBlockBuffer<ResultCtxType>::add_outfile_cleanup(OutfileCleanup clea
 template <typename ResultCtxType>
 Status ResultBlockBuffer<ResultCtxType>::finish_outfile(OutfileOperation operation) {
     SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
+    std::unique_lock<std::mutex> drain_guard(_outfile_cleanup_drain_lock, std::defer_lock);
+    if (operation == OutfileOperation::ABORT) {
+        // An empty callback vector is only terminal after the active drain returns; serializing
+        // drains preserves failed cleanup ownership for a concurrent timeout or shutdown retry.
+        drain_guard.lock();
+    }
     std::vector<OutfileCleanup> cleanups;
     {
         std::lock_guard<std::mutex> l(_lock);

--- a/be/src/runtime/result_block_buffer.cpp
+++ b/be/src/runtime/result_block_buffer.cpp
@@ -24,6 +24,7 @@
 #include <google/protobuf/stubs/callback.h>
 // IWYU pragma: no_include <bits/chrono.h>
 #include <chrono> // IWYU pragma: keep
+#include <iterator>
 #include <limits>
 #include <ostream>
 #include <string>
@@ -103,78 +104,136 @@ Status ResultBlockBuffer<ResultCtxType>::close(const TUniqueId& id, Status exec_
 }
 
 template <typename ResultCtxType>
-void ResultBlockBuffer<ResultCtxType>::cancel(const Status& reason) {
-    release_outfile_cleanup();
-    std::unique_lock<std::mutex> l(_lock);
+void ResultBlockBuffer<ResultCtxType>::cancel(const Status& reason, bool release_outfile) {
     SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
-    if (_status.ok()) {
-        _status = reason;
+    {
+        std::unique_lock<std::mutex> l(_lock);
+        if (_status.ok()) {
+            _status = reason;
+        }
+        _arrow_data_arrival.notify_all();
+        for (auto& ctx : _waiting_rpc) {
+            ctx->on_failure(reason);
+        }
+        _waiting_rpc.clear();
+        _update_dependency();
+        _result_batch_queue.clear();
     }
-    _arrow_data_arrival.notify_all();
-    for (auto& ctx : _waiting_rpc) {
-        ctx->on_failure(reason);
+    if (release_outfile) {
+        // Release query result memory before rollback performs potentially slow remote I/O.
+        release_outfile_cleanup();
     }
-    _waiting_rpc.clear();
-    _update_dependency();
-    _result_batch_queue.clear();
 }
 
 template <typename ResultCtxType>
-void ResultBlockBuffer<ResultCtxType>::add_outfile_cleanup(std::function<void()> cleanup) {
+Status ResultBlockBuffer<ResultCtxType>::add_outfile_cleanup(OutfileCleanup cleanup) {
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
     bool run_cleanup = false;
+    bool discard_cleanup = false;
     {
         std::lock_guard<std::mutex> l(_lock);
         if (_outfile_state == OutfileState::ABORTED) {
             run_cleanup = true;
+        } else if (_outfile_state == OutfileState::COMMITTED) {
+            discard_cleanup = true;
         } else {
             _outfile_cleanups.emplace_back(std::move(cleanup));
         }
     }
-    if (run_cleanup) {
-        cleanup();
+    if (discard_cleanup) {
+        cleanup = nullptr;
+        return Status::OK();
     }
+    if (run_cleanup) {
+        Status status = cleanup();
+        if (!status.ok()) {
+            std::lock_guard<std::mutex> l(_lock);
+            _outfile_cleanups.emplace_back(std::move(cleanup));
+        }
+        return status;
+    }
+    return Status::OK();
 }
 
 template <typename ResultCtxType>
-void ResultBlockBuffer<ResultCtxType>::finish_outfile(bool success) {
-    std::vector<std::function<void()>> cleanups;
+Status ResultBlockBuffer<ResultCtxType>::finish_outfile(OutfileOperation operation) {
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
+    std::vector<OutfileCleanup> cleanups;
     {
         std::lock_guard<std::mutex> l(_lock);
-        if (success) {
-            if (_outfile_state == OutfileState::PENDING) {
-                _outfile_state = OutfileState::COMMITTED;
+        if (operation == OutfileOperation::PREPARE) {
+            if (_outfile_state == OutfileState::ABORTED) {
+                return Status::Cancelled("outfile result buffer was already aborted");
             }
-            return;
+            if (_outfile_state == OutfileState::PENDING) {
+                _outfile_state = OutfileState::PREPARED;
+            }
+            return Status::OK();
         }
-        if (_outfile_state == OutfileState::ABORTED) {
-            return;
+        if (operation == OutfileOperation::COMMIT) {
+            if (_outfile_state == OutfileState::COMMITTED) {
+                return Status::OK();
+            }
+            if (_outfile_state != OutfileState::PREPARED) {
+                return Status::InternalError("outfile result buffer is not prepared");
+            }
+            // Keep rollback ownership after this provisional acknowledgement so an explicit ABORT
+            // can compensate a COMMIT that reached only a subset of receivers.
+            _outfile_state = OutfileState::COMMITTED;
+            return Status::OK();
         }
-        _outfile_state = OutfileState::ABORTED;
-        cleanups.swap(_outfile_cleanups);
+        if (operation == OutfileOperation::ABORT) {
+            if (_outfile_state == OutfileState::ABORTED && _outfile_cleanups.empty()) {
+                return Status::OK();
+            }
+            // A global COMMIT can fail after reaching only some receivers. Keep every local
+            // ownership record compensatable until FE observes all acknowledgements.
+            _outfile_state = OutfileState::ABORTED;
+            cleanups.swap(_outfile_cleanups);
+        } else {
+            return Status::InternalError("unknown outfile operation");
+        }
     }
+    Status first_failure = Status::OK();
+    std::vector<OutfileCleanup> failed_cleanups;
     for (auto& cleanup : cleanups) {
-        cleanup();
+        Status status = cleanup();
+        if (!status.ok()) {
+            if (first_failure.ok()) {
+                first_failure = status;
+            }
+            failed_cleanups.emplace_back(std::move(cleanup));
+        }
     }
+    if (!failed_cleanups.empty()) {
+        std::lock_guard<std::mutex> l(_lock);
+        _outfile_cleanups.insert(_outfile_cleanups.end(),
+                                 std::make_move_iterator(failed_cleanups.begin()),
+                                 std::make_move_iterator(failed_cleanups.end()));
+    }
+    return first_failure;
 }
 
 template <typename ResultCtxType>
 void ResultBlockBuffer<ResultCtxType>::release_outfile_cleanup() {
-    std::vector<std::function<void()>> cleanups;
+    SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
     {
         std::lock_guard<std::mutex> l(_lock);
         if (_outfile_state == OutfileState::COMMITTED) {
             _outfile_cleanups.clear();
             return;
         }
-        if (_outfile_state == OutfileState::ABORTED && _outfile_cleanups.empty()) {
+    }
+    Status status;
+    for (int attempt = 0; attempt < 3; ++attempt) {
+        status = finish_outfile(OutfileOperation::ABORT);
+        if (status.ok()) {
             return;
         }
-        _outfile_state = OutfileState::ABORTED;
-        cleanups.swap(_outfile_cleanups);
     }
-    for (auto& cleanup : cleanups) {
-        cleanup();
-    }
+    LOG(WARNING) << "Failed to clean up aborted OUTFILE after retries: " << status;
+    std::lock_guard<std::mutex> l(_lock);
+    _outfile_cleanups.clear();
 }
 
 template <typename ResultCtxType>

--- a/be/src/runtime/result_block_buffer.cpp
+++ b/be/src/runtime/result_block_buffer.cpp
@@ -145,11 +145,15 @@ Status ResultBlockBuffer<ResultCtxType>::add_outfile_cleanup(OutfileCleanup clea
         return Status::OK();
     }
     if (run_cleanup) {
-        Status status = cleanup();
-        if (!status.ok()) {
-            std::lock_guard<std::mutex> l(_lock);
-            _outfile_cleanups.emplace_back(std::move(cleanup));
+        Status status;
+        for (int attempt = 0; attempt < 3; ++attempt) {
+            status = cleanup();
+            if (status.ok()) {
+                return status;
+            }
         }
+        // Cancellation removed this buffer from the manager, so bounded inline retries are the
+        // last live-query owner for a cleanup registered after that point.
         return status;
     }
     return Status::OK();

--- a/be/src/runtime/result_block_buffer.cpp
+++ b/be/src/runtime/result_block_buffer.cpp
@@ -104,6 +104,7 @@ Status ResultBlockBuffer<ResultCtxType>::close(const TUniqueId& id, Status exec_
 
 template <typename ResultCtxType>
 void ResultBlockBuffer<ResultCtxType>::cancel(const Status& reason) {
+    release_outfile_cleanup();
     std::unique_lock<std::mutex> l(_lock);
     SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(_mem_tracker);
     if (_status.ok()) {
@@ -116,6 +117,64 @@ void ResultBlockBuffer<ResultCtxType>::cancel(const Status& reason) {
     _waiting_rpc.clear();
     _update_dependency();
     _result_batch_queue.clear();
+}
+
+template <typename ResultCtxType>
+void ResultBlockBuffer<ResultCtxType>::add_outfile_cleanup(std::function<void()> cleanup) {
+    bool run_cleanup = false;
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        if (_outfile_state == OutfileState::ABORTED) {
+            run_cleanup = true;
+        } else {
+            _outfile_cleanups.emplace_back(std::move(cleanup));
+        }
+    }
+    if (run_cleanup) {
+        cleanup();
+    }
+}
+
+template <typename ResultCtxType>
+void ResultBlockBuffer<ResultCtxType>::finish_outfile(bool success) {
+    std::vector<std::function<void()>> cleanups;
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        if (success) {
+            if (_outfile_state == OutfileState::PENDING) {
+                _outfile_state = OutfileState::COMMITTED;
+            }
+            return;
+        }
+        if (_outfile_state == OutfileState::ABORTED) {
+            return;
+        }
+        _outfile_state = OutfileState::ABORTED;
+        cleanups.swap(_outfile_cleanups);
+    }
+    for (auto& cleanup : cleanups) {
+        cleanup();
+    }
+}
+
+template <typename ResultCtxType>
+void ResultBlockBuffer<ResultCtxType>::release_outfile_cleanup() {
+    std::vector<std::function<void()>> cleanups;
+    {
+        std::lock_guard<std::mutex> l(_lock);
+        if (_outfile_state == OutfileState::COMMITTED) {
+            _outfile_cleanups.clear();
+            return;
+        }
+        if (_outfile_state == OutfileState::ABORTED && _outfile_cleanups.empty()) {
+            return;
+        }
+        _outfile_state = OutfileState::ABORTED;
+        cleanups.swap(_outfile_cleanups);
+    }
+    for (auto& cleanup : cleanups) {
+        cleanup();
+    }
 }
 
 template <typename ResultCtxType>

--- a/be/src/runtime/result_block_buffer.h
+++ b/be/src/runtime/result_block_buffer.h
@@ -147,6 +147,7 @@ protected:
 
     enum class OutfileState : uint8_t { PENDING, PREPARED, COMMITTED, ABORTED };
     OutfileState _outfile_state = OutfileState::PENDING;
+    std::mutex _outfile_cleanup_drain_lock;
     std::vector<OutfileCleanup> _outfile_cleanups;
 };
 

--- a/be/src/runtime/result_block_buffer.h
+++ b/be/src/runtime/result_block_buffer.h
@@ -45,6 +45,9 @@ class Controller;
 
 namespace doris {
 
+enum class OutfileOperation : uint8_t { PREPARE, COMMIT, ABORT };
+using OutfileCleanup = std::function<Status()>;
+
 class Dependency;
 
 class GetArrowResultBatchCtx;
@@ -65,7 +68,7 @@ public:
     // when scheduling cancel_at_time() for the deferred cleanup.
     virtual Status close(const TUniqueId& id, Status exec_status, int64_t num_rows,
                          bool& is_fully_closed) = 0;
-    virtual void cancel(const Status& reason) = 0;
+    virtual void cancel(const Status& reason, bool release_outfile = true) = 0;
 
     // The id under which this buffer was registered in ResultBufferMgr.
     // In parallel result-sink mode this equals query_id; in non-parallel mode
@@ -75,8 +78,8 @@ public:
     [[nodiscard]] virtual std::shared_ptr<MemTrackerLimiter> mem_tracker() = 0;
     virtual void set_dependency(const TUniqueId& id,
                                 std::shared_ptr<Dependency> result_sink_dependency) = 0;
-    virtual void add_outfile_cleanup(std::function<void()> cleanup) = 0;
-    virtual void finish_outfile(bool success) = 0;
+    virtual Status add_outfile_cleanup(OutfileCleanup cleanup) = 0;
+    virtual Status finish_outfile(OutfileOperation operation) = 0;
     virtual void release_outfile_cleanup() = 0;
 };
 
@@ -92,14 +95,14 @@ public:
     Status get_batch(std::shared_ptr<ResultCtxType> ctx);
     Status close(const TUniqueId& id, Status exec_status, int64_t num_rows,
                  bool& is_fully_closed) override;
-    void cancel(const Status& reason) override;
+    void cancel(const Status& reason, bool release_outfile = true) override;
 
     [[nodiscard]] const TUniqueId& buffer_id() const override { return _fragment_id; }
     [[nodiscard]] std::shared_ptr<MemTrackerLimiter> mem_tracker() override { return _mem_tracker; }
     void set_dependency(const TUniqueId& id,
                         std::shared_ptr<Dependency> result_sink_dependency) override;
-    void add_outfile_cleanup(std::function<void()> cleanup) override;
-    void finish_outfile(bool success) override;
+    Status add_outfile_cleanup(OutfileCleanup cleanup) override;
+    Status finish_outfile(OutfileOperation operation) override;
     void release_outfile_cleanup() override;
 
 protected:
@@ -142,9 +145,9 @@ protected:
     const segment_v2::CompressionTypePB _fragment_transmission_compression_type;
     const int _buffer_limit;
 
-    enum class OutfileState : uint8_t { PENDING, COMMITTED, ABORTED };
+    enum class OutfileState : uint8_t { PENDING, PREPARED, COMMITTED, ABORTED };
     OutfileState _outfile_state = OutfileState::PENDING;
-    std::vector<std::function<void()>> _outfile_cleanups;
+    std::vector<OutfileCleanup> _outfile_cleanups;
 };
 
 } // namespace doris

--- a/be/src/runtime/result_block_buffer.h
+++ b/be/src/runtime/result_block_buffer.h
@@ -26,6 +26,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <deque>
+#include <functional>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -74,6 +75,9 @@ public:
     [[nodiscard]] virtual std::shared_ptr<MemTrackerLimiter> mem_tracker() = 0;
     virtual void set_dependency(const TUniqueId& id,
                                 std::shared_ptr<Dependency> result_sink_dependency) = 0;
+    virtual void add_outfile_cleanup(std::function<void()> cleanup) = 0;
+    virtual void finish_outfile(bool success) = 0;
+    virtual void release_outfile_cleanup() = 0;
 };
 
 // This is used to serialize a result block by normal queries / arrow flight queries / point queries.
@@ -94,6 +98,9 @@ public:
     [[nodiscard]] std::shared_ptr<MemTrackerLimiter> mem_tracker() override { return _mem_tracker; }
     void set_dependency(const TUniqueId& id,
                         std::shared_ptr<Dependency> result_sink_dependency) override;
+    void add_outfile_cleanup(std::function<void()> cleanup) override;
+    void finish_outfile(bool success) override;
+    void release_outfile_cleanup() override;
 
 protected:
     friend class GetArrowResultBatchCtx;
@@ -134,6 +141,10 @@ protected:
     const int _be_exec_version;
     const segment_v2::CompressionTypePB _fragment_transmission_compression_type;
     const int _buffer_limit;
+
+    enum class OutfileState : uint8_t { PENDING, COMMITTED, ABORTED };
+    OutfileState _outfile_state = OutfileState::PENDING;
+    std::vector<std::function<void()>> _outfile_cleanups;
 };
 
 } // namespace doris

--- a/be/src/runtime/result_buffer_mgr.cpp
+++ b/be/src/runtime/result_buffer_mgr.cpp
@@ -63,7 +63,9 @@ void ResultBufferMgr::stop() {
     }
     std::vector<TUniqueId> remaining_ids;
     {
-        std::shared_lock<std::shared_mutex> rlock(_buffer_map_lock);
+        std::unique_lock<std::shared_mutex> wlock(_buffer_map_lock);
+        // Closing the registration gate under the map lock keeps the shutdown snapshot complete.
+        _stopping = true;
         remaining_ids.reserve(_buffer_map.size());
         for (const auto& item : _buffer_map) {
             remaining_ids.emplace_back(item.first);
@@ -89,6 +91,9 @@ Status ResultBufferMgr::create_sender(const TUniqueId& unique_id, int buffer_siz
                                       std::shared_ptr<arrow::Schema> schema) {
     {
         std::shared_lock<std::shared_mutex> rlock(_buffer_map_lock);
+        if (_stopping) {
+            return Status::Cancelled("ResultBufferMgr is stopping");
+        }
         auto iter = _buffer_map.find(unique_id);
 
         if (_buffer_map.end() != iter) {
@@ -108,6 +113,9 @@ Status ResultBufferMgr::create_sender(const TUniqueId& unique_id, int buffer_siz
 
     {
         std::unique_lock<std::shared_mutex> wlock(_buffer_map_lock);
+        if (_stopping) {
+            return Status::Cancelled("ResultBufferMgr is stopping");
+        }
         _buffer_map.insert(std::make_pair(unique_id, control_block));
         // ResultBlockBufferBase should destroy after max_timeout
         // for exceed max_timeout FE will return timeout to client

--- a/be/src/runtime/result_buffer_mgr.cpp
+++ b/be/src/runtime/result_buffer_mgr.cpp
@@ -24,10 +24,11 @@
 #include <cstdint>
 
 // IWYU pragma: no_include <bits/chrono.h>
-#include <atomic>
 #include <chrono> // IWYU pragma: keep
+#include <condition_variable>
 #include <memory>
 #include <ostream>
+#include <unordered_set>
 #include <utility>
 
 #include "arrow/type_fwd.h"
@@ -44,9 +45,45 @@
 
 namespace doris {
 
+class PendingOutfileCleanup {
+public:
+    explicit PendingOutfileCleanup(std::shared_ptr<ResultBlockBufferBase> buffer)
+            : _buffer(std::move(buffer)) {}
+
+    void mark_ready() {
+        std::lock_guard lock(_lock);
+        _ready = true;
+        _ready_condition.notify_all();
+    }
+
+    void run() {
+        std::unique_lock lock(_lock);
+        _ready_condition.wait(lock, [this] { return _ready; });
+        if (_buffer == nullptr) {
+            return;
+        }
+        _buffer->release_outfile_cleanup();
+        _buffer.reset();
+    }
+
+private:
+    std::mutex _lock;
+    std::condition_variable _ready_condition;
+    bool _ready = false;
+    std::shared_ptr<ResultBlockBufferBase> _buffer;
+};
+
+class PendingOutfileCleanupRegistry {
+public:
+    std::mutex lock;
+    std::unordered_set<std::shared_ptr<PendingOutfileCleanup>> cleanups;
+};
+
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(result_buffer_block_count, MetricUnit::NOUNIT);
 
-ResultBufferMgr::ResultBufferMgr() : _stop_background_threads_latch(1) {
+ResultBufferMgr::ResultBufferMgr()
+        : _stop_background_threads_latch(1),
+          _pending_outfile_cleanup_registry(std::make_shared<PendingOutfileCleanupRegistry>()) {
     // Each ResultBlockBufferBase has a limited queue size of 1024, it's not needed to count the
     // actual size of all ResultBlockBufferBase.
     REGISTER_HOOK_METRIC(result_buffer_block_count, [this]() {
@@ -75,6 +112,20 @@ void ResultBufferMgr::stop() {
         // Shutdown must retain cleanup ownership until rollback finishes; the lazy-release pool may
         // already be stopping and cannot provide that guarantee.
         cancel(id, Status::Cancelled("ResultBufferMgr is stopping"));
+    }
+
+    std::vector<std::shared_ptr<PendingOutfileCleanup>> pending_cleanups;
+    {
+        std::lock_guard lock(_pending_outfile_cleanup_registry->lock);
+        pending_cleanups.assign(_pending_outfile_cleanup_registry->cleanups.begin(),
+                                _pending_outfile_cleanup_registry->cleanups.end());
+    }
+    for (const auto& cleanup : pending_cleanups) {
+        cleanup->run();
+    }
+    {
+        std::lock_guard lock(_pending_outfile_cleanup_registry->lock);
+        _pending_outfile_cleanup_registry->cleanups.clear();
     }
 }
 
@@ -155,6 +206,7 @@ Status ResultBufferMgr::find_buffer(const TUniqueId& finst_id,
 
 bool ResultBufferMgr::cancel(const TUniqueId& unique_id, const Status& reason, bool cleanup_async) {
     std::shared_ptr<ResultBlockBufferBase> buffer;
+    std::shared_ptr<PendingOutfileCleanup> pending_cleanup;
     {
         std::unique_lock<std::shared_mutex> wlock(_buffer_map_lock);
         auto iter = _buffer_map.find(unique_id);
@@ -162,13 +214,29 @@ bool ResultBufferMgr::cancel(const TUniqueId& unique_id, const Status& reason, b
             return false;
         }
         buffer = std::move(iter->second);
+        cleanup_async = cleanup_async && !_stopping;
+        if (cleanup_async) {
+            // Register ownership before removing the buffer so shutdown cannot miss a cleanup
+            // that has not reached the lazy-release worker yet.
+            pending_cleanup = std::make_shared<PendingOutfileCleanup>(buffer);
+            std::lock_guard cleanup_lock(_pending_outfile_cleanup_registry->lock);
+            _pending_outfile_cleanup_registry->cleanups.emplace(pending_cleanup);
+        }
         _buffer_map.erase(iter);
     }
     buffer->cancel(reason, false);
-    auto cleanup_started = std::make_shared<std::atomic<bool>>(false);
-    auto cleanup = [buffer = std::move(buffer), cleanup_started] {
-        if (!cleanup_started->exchange(true)) {
-            buffer->release_outfile_cleanup();
+    if (!cleanup_async) {
+        buffer->release_outfile_cleanup();
+        return true;
+    }
+
+    pending_cleanup->mark_ready();
+    std::weak_ptr<PendingOutfileCleanupRegistry> weak_registry = _pending_outfile_cleanup_registry;
+    auto cleanup = [pending_cleanup, weak_registry] {
+        pending_cleanup->run();
+        if (auto registry = weak_registry.lock()) {
+            std::lock_guard lock(registry->lock);
+            registry->cleanups.erase(pending_cleanup);
         }
     };
     ThreadPool* pool = ExecEnv::GetInstance()->lazy_release_obj_pool();

--- a/be/src/runtime/result_buffer_mgr.cpp
+++ b/be/src/runtime/result_buffer_mgr.cpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 
 // IWYU pragma: no_include <bits/chrono.h>
+#include <atomic>
 #include <chrono> // IWYU pragma: keep
 #include <memory>
 #include <ostream>
@@ -35,8 +36,10 @@
 #include "common/status.h"
 #include "exec/sink/writer/varrow_flight_result_writer.h"
 #include "exec/sink/writer/vmysql_result_writer.h"
+#include "runtime/exec_env.h"
 #include "runtime/result_block_buffer.h"
 #include "util/thread.h"
+#include "util/threadpool.h"
 #include "util/uid_util.h"
 
 namespace doris {
@@ -57,6 +60,19 @@ void ResultBufferMgr::stop() {
     _stop_background_threads_latch.count_down();
     if (_clean_thread) {
         _clean_thread->join();
+    }
+    std::vector<TUniqueId> remaining_ids;
+    {
+        std::shared_lock<std::shared_mutex> rlock(_buffer_map_lock);
+        remaining_ids.reserve(_buffer_map.size());
+        for (const auto& item : _buffer_map) {
+            remaining_ids.emplace_back(item.first);
+        }
+    }
+    for (const auto& id : remaining_ids) {
+        // Shutdown must retain cleanup ownership until rollback finishes; the lazy-release pool may
+        // already be stopping and cannot provide that guarantee.
+        cancel(id, Status::Cancelled("ResultBufferMgr is stopping"));
     }
 }
 
@@ -129,7 +145,7 @@ Status ResultBufferMgr::find_buffer(const TUniqueId& finst_id,
                              : Status::OK();
 }
 
-bool ResultBufferMgr::cancel(const TUniqueId& unique_id, const Status& reason) {
+bool ResultBufferMgr::cancel(const TUniqueId& unique_id, const Status& reason, bool cleanup_async) {
     std::shared_ptr<ResultBlockBufferBase> buffer;
     {
         std::unique_lock<std::shared_mutex> wlock(_buffer_map_lock);
@@ -140,18 +156,33 @@ bool ResultBufferMgr::cancel(const TUniqueId& unique_id, const Status& reason) {
         buffer = std::move(iter->second);
         _buffer_map.erase(iter);
     }
-    // Outfile rollback can perform remote I/O, so it must not hold the manager-wide map lock.
-    buffer->cancel(reason);
+    buffer->cancel(reason, false);
+    auto cleanup_started = std::make_shared<std::atomic<bool>>(false);
+    auto cleanup = [buffer = std::move(buffer), cleanup_started] {
+        if (!cleanup_started->exchange(true)) {
+            buffer->release_outfile_cleanup();
+        }
+    };
+    ThreadPool* pool = ExecEnv::GetInstance()->lazy_release_obj_pool();
+    if (cleanup_async && pool != nullptr) {
+        Status submit_status = pool->submit_func(cleanup);
+        if (!submit_status.ok()) {
+            // submit_func may retain a runnable while returning an error; the guard keeps fallback
+            // cleanup single-shot and ensures ownership is not silently discarded.
+            cleanup();
+        }
+    } else {
+        cleanup();
+    }
     return true;
 }
 
-bool ResultBufferMgr::finish_outfile(const TUniqueId& unique_id, bool success) {
+Status ResultBufferMgr::finish_outfile(const TUniqueId& unique_id, OutfileOperation operation) {
     auto buffer = _find_control_block<ResultBlockBufferBase>(unique_id);
     if (buffer == nullptr) {
-        return false;
+        return Status::NotFound("outfile result buffer no longer exists");
     }
-    buffer->finish_outfile(success);
-    return true;
+    return buffer->finish_outfile(operation);
 }
 
 void ResultBufferMgr::cancel_at_time(time_t cancel_time, const TUniqueId& unique_id) {
@@ -189,8 +220,10 @@ void ResultBufferMgr::cancel_thread() {
 
         // cancel query
         for (const auto& id : query_to_cancel) {
-            cancel(id, Status::Cancelled("Clean up expired ResultBlockBuffer, queryId: {}",
-                                         print_id(id)));
+            cancel(id,
+                   Status::Cancelled("Clean up expired ResultBlockBuffer, queryId: {}",
+                                     print_id(id)),
+                   true);
         }
     } while (!_stop_background_threads_latch.wait_for(std::chrono::seconds(1)));
 

--- a/be/src/runtime/result_buffer_mgr.cpp
+++ b/be/src/runtime/result_buffer_mgr.cpp
@@ -130,15 +130,28 @@ Status ResultBufferMgr::find_buffer(const TUniqueId& finst_id,
 }
 
 bool ResultBufferMgr::cancel(const TUniqueId& unique_id, const Status& reason) {
-    std::unique_lock<std::shared_mutex> wlock(_buffer_map_lock);
-    auto iter = _buffer_map.find(unique_id);
-
-    auto exist = _buffer_map.end() != iter;
-    if (exist) {
-        iter->second->cancel(reason);
+    std::shared_ptr<ResultBlockBufferBase> buffer;
+    {
+        std::unique_lock<std::shared_mutex> wlock(_buffer_map_lock);
+        auto iter = _buffer_map.find(unique_id);
+        if (iter == _buffer_map.end()) {
+            return false;
+        }
+        buffer = std::move(iter->second);
         _buffer_map.erase(iter);
     }
-    return exist;
+    // Outfile rollback can perform remote I/O, so it must not hold the manager-wide map lock.
+    buffer->cancel(reason);
+    return true;
+}
+
+bool ResultBufferMgr::finish_outfile(const TUniqueId& unique_id, bool success) {
+    auto buffer = _find_control_block<ResultBlockBufferBase>(unique_id);
+    if (buffer == nullptr) {
+        return false;
+    }
+    buffer->finish_outfile(success);
+    return true;
 }
 
 void ResultBufferMgr::cancel_at_time(time_t cancel_time, const TUniqueId& unique_id) {

--- a/be/src/runtime/result_buffer_mgr.h
+++ b/be/src/runtime/result_buffer_mgr.h
@@ -90,6 +90,7 @@ private:
     std::shared_mutex _buffer_map_lock;
     // buffer block map
     BufferMap _buffer_map;
+    bool _stopping = false;
 
     // lock for timeout map
     std::mutex _timeout_lock;

--- a/be/src/runtime/result_buffer_mgr.h
+++ b/be/src/runtime/result_buffer_mgr.h
@@ -70,6 +70,7 @@ public:
     Status find_buffer(const TUniqueId& unique_id, std::shared_ptr<ResultBlockBufferType>& buffer);
     // cancel
     bool cancel(const TUniqueId& unique_id, const Status& reason);
+    bool finish_outfile(const TUniqueId& unique_id, bool success);
 
     // cancel one query at a future time.
     void cancel_at_time(time_t cancel_time, const TUniqueId& unique_id);

--- a/be/src/runtime/result_buffer_mgr.h
+++ b/be/src/runtime/result_buffer_mgr.h
@@ -69,8 +69,8 @@ public:
     template <typename ResultBlockBufferType>
     Status find_buffer(const TUniqueId& unique_id, std::shared_ptr<ResultBlockBufferType>& buffer);
     // cancel
-    bool cancel(const TUniqueId& unique_id, const Status& reason);
-    bool finish_outfile(const TUniqueId& unique_id, bool success);
+    bool cancel(const TUniqueId& unique_id, const Status& reason, bool cleanup_async = false);
+    Status finish_outfile(const TUniqueId& unique_id, OutfileOperation operation);
 
     // cancel one query at a future time.
     void cancel_at_time(time_t cancel_time, const TUniqueId& unique_id);

--- a/be/src/runtime/result_buffer_mgr.h
+++ b/be/src/runtime/result_buffer_mgr.h
@@ -46,6 +46,7 @@ class PUniqueId;
 class RuntimeState;
 class MemTrackerLimiter;
 class Thread;
+class PendingOutfileCleanupRegistry;
 class GetArrowResultBatchCtx;
 class GetResultBatchCtx;
 class Block;
@@ -101,6 +102,7 @@ private:
 
     CountDownLatch _stop_background_threads_latch;
     std::shared_ptr<Thread> _clean_thread;
+    std::shared_ptr<PendingOutfileCleanupRegistry> _pending_outfile_cleanup_registry;
 };
 
 } // namespace doris

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -773,11 +773,12 @@ void PInternalService::outfile_write_success(google::protobuf::RpcController* co
         std::stringstream ss;
         ss << file_options.file_path << file_options.success_file_name;
         std::string file_name = ss.str();
+        const bool atomic_outfile_marker = file_options.enable_atomic_outfile;
         const std::string marker_token =
                 request->marker_token().empty() ? file_name : request->marker_token();
         const auto now = std::chrono::steady_clock::now();
         std::shared_ptr<std::mutex> operation_lock;
-        {
+        if (atomic_outfile_marker) {
             std::lock_guard marker_guard(outfile_marker_lock);
             cleanup_expired_outfile_marker_states(now);
             operation_lock = outfile_marker_operation_locks[marker_token].lock();
@@ -789,9 +790,12 @@ void PInternalService::outfile_write_success(google::protobuf::RpcController* co
 
         // Serialize only requests for the same query marker. Remote file-system calls can be slow,
         // so unrelated OUTFILE queries must not block behind them.
-        std::unique_lock operation_guard(*operation_lock);
+        std::unique_lock<std::mutex> operation_guard;
+        if (atomic_outfile_marker) {
+            operation_guard = std::unique_lock(*operation_lock);
+        }
         std::string owned_marker_path;
-        {
+        if (atomic_outfile_marker) {
             std::lock_guard marker_guard(outfile_marker_lock);
             auto& marker_state = outfile_marker_states[marker_token];
             marker_state.updated_at = now;
@@ -833,6 +837,11 @@ void PInternalService::outfile_write_success(google::protobuf::RpcController* co
         auto file_system = std::move(fs_res).value();
 
         if (request->operation() == OUTFILE_MARKER_DELETE) {
+            if (!atomic_outfile_marker) {
+                Status::InvalidArgument("legacy OUTFILE has no marker rollback operation")
+                        .to_protobuf(result->mutable_status());
+                return;
+            }
             // Delete only a path created by this token. A blind rollback could otherwise remove a
             // pre-existing user file when CREATE failed before acquiring ownership.
             if (owned_marker_path.empty()) {
@@ -859,15 +868,18 @@ void PInternalService::outfile_write_success(google::protobuf::RpcController* co
             return;
         }
 
-        // Never claim an existing marker path; rollback is restricted to token-owned paths below.
-        bool exists = true;
-        st = file_system->exists(file_name, &exists);
-        if (st.ok() && exists) {
-            st = Status::InternalError("File already exists: {}", file_name);
-        }
-        if (!st.ok()) {
-            st.to_protobuf(result->mutable_status());
-            return;
+        if (should_check_outfile_marker_existence(file_options,
+                                                  result_file_sink.storage_backend_type)) {
+            // Never claim an existing marker path; rollback is restricted to token-owned paths.
+            bool exists = true;
+            st = file_system->exists(file_name, &exists);
+            if (st.ok() && exists) {
+                st = Status::InternalError("File already exists: {}", file_name);
+            }
+            if (!st.ok()) {
+                st.to_protobuf(result->mutable_status());
+                return;
+            }
         }
 
         io::FileWriterPtr file_writer;
@@ -904,7 +916,7 @@ void PInternalService::outfile_write_success(google::protobuf::RpcController* co
             st.to_protobuf(result->mutable_status());
             return;
         }
-        {
+        if (atomic_outfile_marker) {
             std::lock_guard marker_guard(outfile_marker_lock);
             auto& marker_state = outfile_marker_states[marker_token];
             marker_state.updated_at = std::chrono::steady_clock::now();

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -849,14 +849,17 @@ void PInternalService::outfile_write_success(google::protobuf::RpcController* co
                 return;
             }
             st = file_system->delete_file(owned_marker_path);
-            if (st.ok() || st.is<ErrorCode::NOT_FOUND>()) {
+            const bool delete_succeeded = st.ok() || st.is<ErrorCode::NOT_FOUND>();
+            {
                 std::lock_guard marker_guard(outfile_marker_lock);
                 auto state_it = outfile_marker_states.find(marker_token);
-                if (state_it != outfile_marker_states.end() &&
-                    state_it->second.owned_path == owned_marker_path) {
-                    state_it->second.owned_path.clear();
-                    state_it->second.updated_at = std::chrono::steady_clock::now();
+                if (state_it != outfile_marker_states.end()) {
+                    complete_outfile_marker_delete(&state_it->second, owned_marker_path,
+                                                   delete_succeeded,
+                                                   std::chrono::steady_clock::now());
                 }
+            }
+            if (delete_succeeded) {
                 st = Status::OK();
             }
             st.to_protobuf(result->mutable_status());
@@ -896,14 +899,35 @@ void PInternalService::outfile_write_success(google::protobuf::RpcController* co
             return;
         }
 
+        if (atomic_outfile_marker) {
+            // Claim the path before append/close because either call can publish data before
+            // reporting failure, and a failed immediate delete must remain retryable.
+            std::lock_guard marker_guard(outfile_marker_lock);
+            record_outfile_marker_ownership(&outfile_marker_states[marker_token], file_name,
+                                            std::chrono::steady_clock::now());
+        }
+
+        auto remove_incomplete_marker = [&]() {
+            Status delete_status = file_system->delete_file(file_name);
+            if (atomic_outfile_marker) {
+                std::lock_guard marker_guard(outfile_marker_lock);
+                auto state_it = outfile_marker_states.find(marker_token);
+                if (state_it != outfile_marker_states.end()) {
+                    complete_outfile_marker_delete(
+                            &state_it->second, file_name,
+                            delete_status.ok() || delete_status.is<ErrorCode::NOT_FOUND>(),
+                            std::chrono::steady_clock::now());
+                }
+            }
+            WARN_IF_ERROR(delete_status, "failed to remove incomplete outfile success file");
+        };
+
         // must write somthing because s3 file writer can not writer empty file
         st = file_writer->append({"success"});
         if (!st.ok()) {
             LOG(WARNING) << "outfile write success filefailed, errmsg=" << st;
             WARN_IF_ERROR(file_writer->abort(), "failed to abort outfile success file writer");
-            // The marker belongs to this request, so a failed write must not outlive the query.
-            WARN_IF_ERROR(file_system->delete_file(file_name),
-                          "failed to remove incomplete outfile success file");
+            remove_incomplete_marker();
             st.to_protobuf(result->mutable_status());
             return;
         }
@@ -911,16 +935,9 @@ void PInternalService::outfile_write_success(google::protobuf::RpcController* co
         if (!st.ok()) {
             LOG(WARNING) << "outfile write success filefailed, errmsg=" << st;
             WARN_IF_ERROR(file_writer->abort(), "failed to abort outfile success file writer");
-            WARN_IF_ERROR(file_system->delete_file(file_name),
-                          "failed to remove incomplete outfile success file");
+            remove_incomplete_marker();
             st.to_protobuf(result->mutable_status());
             return;
-        }
-        if (atomic_outfile_marker) {
-            std::lock_guard marker_guard(outfile_marker_lock);
-            auto& marker_state = outfile_marker_states[marker_token];
-            marker_state.updated_at = std::chrono::steady_clock::now();
-            marker_state.owned_path = file_name;
         }
         Status::OK().to_protobuf(result->mutable_status());
     });

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -167,7 +167,10 @@ void cleanup_expired_outfile_marker_states(std::chrono::steady_clock::time_point
         }
     }
     for (auto it = outfile_marker_states.begin(); it != outfile_marker_states.end();) {
-        if (now - it->second.updated_at >= OUTFILE_MARKER_TOMBSTONE_TTL) {
+        // A failed marker delete retains the only in-process rollback fence and ownership record.
+        // Expire state only after the owned path has been deleted successfully.
+        if (it->second.owned_path.empty() &&
+            now - it->second.updated_at >= OUTFILE_MARKER_TOMBSTONE_TTL) {
             it = outfile_marker_states.erase(it);
         } else {
             ++it;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -42,11 +42,14 @@
 #include <sys/stat.h>
 
 #include <algorithm>
+#include <chrono>
 #include <exception>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -135,6 +138,44 @@ class RpcController;
 } // namespace google
 
 namespace doris {
+
+namespace {
+
+std::mutex outfile_marker_lock;
+struct OutfileMarkerState {
+    std::chrono::steady_clock::time_point updated_at;
+    std::string owned_path;
+    bool tombstoned = false;
+};
+std::unordered_map<std::string, std::weak_ptr<std::mutex>> outfile_marker_operation_locks;
+std::unordered_map<std::string, OutfileMarkerState> outfile_marker_states;
+constexpr auto OUTFILE_MARKER_TOMBSTONE_TTL = std::chrono::hours(1);
+constexpr auto OUTFILE_MARKER_CLEANUP_INTERVAL = std::chrono::minutes(1);
+auto outfile_marker_last_cleanup = std::chrono::steady_clock::now();
+
+void cleanup_expired_outfile_marker_states(std::chrono::steady_clock::time_point now) {
+    if (now - outfile_marker_last_cleanup < OUTFILE_MARKER_CLEANUP_INTERVAL) {
+        return;
+    }
+    outfile_marker_last_cleanup = now;
+    for (auto it = outfile_marker_operation_locks.begin();
+         it != outfile_marker_operation_locks.end();) {
+        if (it->second.expired()) {
+            it = outfile_marker_operation_locks.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    for (auto it = outfile_marker_states.begin(); it != outfile_marker_states.end();) {
+        if (now - it->second.updated_at >= OUTFILE_MARKER_TOMBSTONE_TTL) {
+            it = outfile_marker_states.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+} // namespace
 #include "common/compile_check_avoid_begin.h"
 using namespace ErrorCode;
 
@@ -737,25 +778,38 @@ void PInternalService::outfile_write_success(google::protobuf::RpcController* co
         std::stringstream ss;
         ss << file_options.file_path << file_options.success_file_name;
         std::string file_name = ss.str();
-        if (result_file_sink.storage_backend_type == TStorageBackendType::LOCAL) {
-            // For local file writer, the file_path is a local dir.
-            // Here we do a simple security verification by checking whether the file exists.
-            // Because the file path is currently arbitrarily specified by the user,
-            // Doris is not responsible for ensuring the correctness of the path.
-            // This is just to prevent overwriting the existing file.
-            bool exists = true;
-            st = io::global_local_filesystem()->exists(file_name, &exists);
-            if (!st.ok()) {
-                LOG(WARNING) << "outfile write success filefailed, errmsg = " << st;
-                st.to_protobuf(result->mutable_status());
-                return;
+        const std::string marker_token =
+                request->marker_token().empty() ? file_name : request->marker_token();
+        const auto now = std::chrono::steady_clock::now();
+        std::shared_ptr<std::mutex> operation_lock;
+        {
+            std::lock_guard marker_guard(outfile_marker_lock);
+            cleanup_expired_outfile_marker_states(now);
+            operation_lock = outfile_marker_operation_locks[marker_token].lock();
+            if (operation_lock == nullptr) {
+                operation_lock = std::make_shared<std::mutex>();
+                outfile_marker_operation_locks[marker_token] = operation_lock;
             }
-            if (exists) {
-                st = Status::InternalError("File already exists: {}", file_name);
-            }
-            if (!st.ok()) {
-                LOG(WARNING) << "outfile write success file failed, errmsg = " << st;
-                st.to_protobuf(result->mutable_status());
+        }
+
+        // Serialize only requests for the same query marker. Remote file-system calls can be slow,
+        // so unrelated OUTFILE queries must not block behind them.
+        std::unique_lock operation_guard(*operation_lock);
+        std::string owned_marker_path;
+        {
+            std::lock_guard marker_guard(outfile_marker_lock);
+            auto& marker_state = outfile_marker_states[marker_token];
+            marker_state.updated_at = now;
+            if (request->operation() == OUTFILE_MARKER_DELETE) {
+                // A delete may overtake a timed-out create in the heavy-work pool. The tombstone
+                // makes that delayed create observe rollback instead of recreating the marker.
+                marker_state.tombstoned = true;
+                if (marker_state.owned_path == file_name) {
+                    owned_marker_path = marker_state.owned_path;
+                }
+            } else if (marker_state.tombstoned) {
+                Status::Cancelled("OUTFILE success marker was already rolled back")
+                        .to_protobuf(result->mutable_status());
                 return;
             }
         }
@@ -782,10 +836,53 @@ void PInternalService::outfile_write_success(google::protobuf::RpcController* co
             return;
         }
         auto file_system = std::move(fs_res).value();
+
+        if (request->operation() == OUTFILE_MARKER_DELETE) {
+            // Delete only a path created by this token. A blind rollback could otherwise remove a
+            // pre-existing user file when CREATE failed before acquiring ownership.
+            if (owned_marker_path.empty()) {
+                Status::OK().to_protobuf(result->mutable_status());
+                return;
+            }
+            st = file_system->delete_file(owned_marker_path);
+            if (st.ok() || st.is<ErrorCode::NOT_FOUND>()) {
+                std::lock_guard marker_guard(outfile_marker_lock);
+                auto state_it = outfile_marker_states.find(marker_token);
+                if (state_it != outfile_marker_states.end() &&
+                    state_it->second.owned_path == owned_marker_path) {
+                    state_it->second.owned_path.clear();
+                    state_it->second.updated_at = std::chrono::steady_clock::now();
+                }
+                st = Status::OK();
+            }
+            st.to_protobuf(result->mutable_status());
+            return;
+        }
+        if (request->operation() != OUTFILE_MARKER_CREATE) {
+            Status::InvalidArgument("unknown OUTFILE success marker operation")
+                    .to_protobuf(result->mutable_status());
+            return;
+        }
+
+        // Never claim an existing marker path; rollback is restricted to token-owned paths below.
+        bool exists = true;
+        st = file_system->exists(file_name, &exists);
+        if (st.ok() && exists) {
+            st = Status::InternalError("File already exists: {}", file_name);
+        }
+        if (!st.ok()) {
+            st.to_protobuf(result->mutable_status());
+            return;
+        }
+
         io::FileWriterPtr file_writer;
         const io::FileWriterOptions options {.write_file_cache = false, .sync_file_data = false};
+        // The create acknowledgement can be lost after publishing the marker, so ownership is
+        // retained by marker_token for a compensating DELETE.
         st = file_system->create_file(file_name, &file_writer, &options);
         if (!st.ok()) {
+            // A failed create does not prove ownership; deleting here could remove a file that won
+            // a concurrent exclusive create or existed before this query.
             st.to_protobuf(result->mutable_status());
             return;
         }
@@ -810,6 +907,13 @@ void PInternalService::outfile_write_success(google::protobuf::RpcController* co
             st.to_protobuf(result->mutable_status());
             return;
         }
+        {
+            std::lock_guard marker_guard(outfile_marker_lock);
+            auto& marker_state = outfile_marker_states[marker_token];
+            marker_state.updated_at = std::chrono::steady_clock::now();
+            marker_state.owned_path = file_name;
+        }
+        Status::OK().to_protobuf(result->mutable_status());
     });
     if (!ret) {
         offer_failed(result, done, _heavy_work_pool);
@@ -824,14 +928,41 @@ void PInternalService::outfile_write_finished(google::protobuf::RpcController* c
     bool ret = _heavy_work_pool.try_offer([request, result, done]() {
         brpc::ClosureGuard closure_guard(done);
         Status status = Status::OK();
+        OutfileOperation operation;
+        if (!request->has_operation()) {
+            operation = request->success() ? OutfileOperation::COMMIT : OutfileOperation::ABORT;
+        } else {
+            switch (request->operation()) {
+            case OUTFILE_PREPARE:
+                operation = OutfileOperation::PREPARE;
+                break;
+            case OUTFILE_COMMIT:
+                operation = OutfileOperation::COMMIT;
+                break;
+            case OUTFILE_ABORT:
+                operation = OutfileOperation::ABORT;
+                break;
+            default:
+                status = Status::InvalidArgument("unknown outfile write operation");
+                status.to_protobuf(result->mutable_status());
+                return;
+            }
+        }
         for (const auto& buffer_id : request->buffer_ids()) {
             TUniqueId id;
             id.__set_hi(buffer_id.hi());
             id.__set_lo(buffer_id.lo());
-            if (!ExecEnv::GetInstance()->result_mgr()->finish_outfile(id, request->success()) &&
-                request->success()) {
-                status = Status::InternalError("outfile result buffer no longer exists");
-                break;
+            Status buffer_status = Status::OK();
+            if (!request->has_operation() && operation == OutfileOperation::COMMIT) {
+                // Legacy FE has no PREPARE phase; synthesize it before accepting its final success.
+                buffer_status = ExecEnv::GetInstance()->result_mgr()->finish_outfile(
+                        id, OutfileOperation::PREPARE);
+            }
+            if (buffer_status.ok()) {
+                buffer_status = ExecEnv::GetInstance()->result_mgr()->finish_outfile(id, operation);
+            }
+            if (!buffer_status.ok() && status.ok()) {
+                status = buffer_status;
             }
         }
         status.to_protobuf(result->mutable_status());

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -770,31 +770,43 @@ void PInternalService::outfile_write_success(google::protobuf::RpcController* co
             return;
         }
 
-        auto&& res = FileFactory::create_file_writer(file_type_res.value(), ExecEnv::GetInstance(),
-                                                     file_options.broker_addresses,
-                                                     file_options.broker_properties, file_name,
-                                                     {
-                                                             .write_file_cache = false,
-                                                             .sync_file_data = false,
-                                                     });
-        using T = std::decay_t<decltype(res)>;
-        if (!res.has_value()) [[unlikely]] {
-            st = std::forward<T>(res).error();
+        io::FSPropertiesRef properties(file_type_res.value());
+        properties.broker_addresses = &file_options.broker_addresses;
+        properties.properties = &file_options.broker_properties;
+        io::FileDescription file_description;
+        file_description.path = file_name;
+        auto fs_res = FileFactory::create_fs(properties, file_description);
+        if (!fs_res.has_value()) [[unlikely]] {
+            st = std::move(fs_res).error();
+            st.to_protobuf(result->mutable_status());
+            return;
+        }
+        auto file_system = std::move(fs_res).value();
+        io::FileWriterPtr file_writer;
+        const io::FileWriterOptions options {.write_file_cache = false, .sync_file_data = false};
+        st = file_system->create_file(file_name, &file_writer, &options);
+        if (!st.ok()) {
             st.to_protobuf(result->mutable_status());
             return;
         }
 
-        std::unique_ptr<doris::io::FileWriter> _file_writer_impl = std::forward<T>(res).value();
         // must write somthing because s3 file writer can not writer empty file
-        st = _file_writer_impl->append({"success"});
+        st = file_writer->append({"success"});
         if (!st.ok()) {
             LOG(WARNING) << "outfile write success filefailed, errmsg=" << st;
+            WARN_IF_ERROR(file_writer->abort(), "failed to abort outfile success file writer");
+            // The marker belongs to this request, so a failed write must not outlive the query.
+            WARN_IF_ERROR(file_system->delete_file(file_name),
+                          "failed to remove incomplete outfile success file");
             st.to_protobuf(result->mutable_status());
             return;
         }
-        st = _file_writer_impl->close();
+        st = file_writer->close();
         if (!st.ok()) {
             LOG(WARNING) << "outfile write success filefailed, errmsg=" << st;
+            WARN_IF_ERROR(file_writer->abort(), "failed to abort outfile success file writer");
+            WARN_IF_ERROR(file_system->delete_file(file_name),
+                          "failed to remove incomplete outfile success file");
             st.to_protobuf(result->mutable_status());
             return;
         }
@@ -802,6 +814,30 @@ void PInternalService::outfile_write_success(google::protobuf::RpcController* co
     if (!ret) {
         offer_failed(result, done, _heavy_work_pool);
         return;
+    }
+}
+
+void PInternalService::outfile_write_finished(google::protobuf::RpcController* controller,
+                                              const POutfileWriteFinishedRequest* request,
+                                              POutfileWriteFinishedResult* result,
+                                              google::protobuf::Closure* done) {
+    bool ret = _heavy_work_pool.try_offer([request, result, done]() {
+        brpc::ClosureGuard closure_guard(done);
+        Status status = Status::OK();
+        for (const auto& buffer_id : request->buffer_ids()) {
+            TUniqueId id;
+            id.__set_hi(buffer_id.hi());
+            id.__set_lo(buffer_id.lo());
+            if (!ExecEnv::GetInstance()->result_mgr()->finish_outfile(id, request->success()) &&
+                request->success()) {
+                status = Status::InternalError("outfile result buffer no longer exists");
+                break;
+            }
+        }
+        status.to_protobuf(result->mutable_status());
+    });
+    if (!ret) {
+        offer_failed(result, done, _heavy_work_pool);
     }
 }
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -105,6 +105,7 @@
 #include "runtime/workload_group/workload_group.h"
 #include "runtime/workload_group/workload_group_manager.h"
 #include "service/backend_options.h"
+#include "service/outfile_marker_state.h"
 #include "service/point_query_executor.h"
 #include "storage/data_dir.h"
 #include "storage/olap_common.h"
@@ -142,14 +143,8 @@ namespace doris {
 namespace {
 
 std::mutex outfile_marker_lock;
-struct OutfileMarkerState {
-    std::chrono::steady_clock::time_point updated_at;
-    std::string owned_path;
-    bool tombstoned = false;
-};
 std::unordered_map<std::string, std::weak_ptr<std::mutex>> outfile_marker_operation_locks;
 std::unordered_map<std::string, OutfileMarkerState> outfile_marker_states;
-constexpr auto OUTFILE_MARKER_TOMBSTONE_TTL = std::chrono::hours(1);
 constexpr auto OUTFILE_MARKER_CLEANUP_INTERVAL = std::chrono::minutes(1);
 auto outfile_marker_last_cleanup = std::chrono::steady_clock::now();
 
@@ -167,10 +162,7 @@ void cleanup_expired_outfile_marker_states(std::chrono::steady_clock::time_point
         }
     }
     for (auto it = outfile_marker_states.begin(); it != outfile_marker_states.end();) {
-        // A failed marker delete retains the only in-process rollback fence and ownership record.
-        // Expire state only after the owned path has been deleted successfully.
-        if (it->second.owned_path.empty() &&
-            now - it->second.updated_at >= OUTFILE_MARKER_TOMBSTONE_TTL) {
+        if (should_expire_outfile_marker_state(it->second, now)) {
             it = outfile_marker_states.erase(it);
         } else {
             ++it;
@@ -879,7 +871,9 @@ void PInternalService::outfile_write_success(google::protobuf::RpcController* co
         }
 
         io::FileWriterPtr file_writer;
-        const io::FileWriterOptions options {.write_file_cache = false, .sync_file_data = false};
+        const io::FileWriterOptions options {.write_file_cache = false,
+                                             .sync_file_data = should_sync_outfile_marker(
+                                                     result_file_sink.storage_backend_type)};
         // The create acknowledgement can be lost after publishing the marker, so ownership is
         // retained by marker_token for a compensating DELETE.
         st = file_system->create_file(file_name, &file_writer, &options);

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -75,6 +75,11 @@ public:
                                POutfileWriteSuccessResult* result,
                                google::protobuf::Closure* done) override;
 
+    void outfile_write_finished(google::protobuf::RpcController* controller,
+                                const POutfileWriteFinishedRequest* request,
+                                POutfileWriteFinishedResult* result,
+                                google::protobuf::Closure* done) override;
+
     void fetch_table_schema(google::protobuf::RpcController* controller,
                             const PFetchTableSchemaRequest* request,
                             PFetchTableSchemaResult* result,

--- a/be/src/service/outfile_marker_state.h
+++ b/be/src/service/outfile_marker_state.h
@@ -1,0 +1,49 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <gen_cpp/DataSinks_types.h>
+
+#include <chrono>
+#include <string>
+
+namespace doris {
+
+struct OutfileMarkerState {
+    std::chrono::steady_clock::time_point updated_at;
+    std::string owned_path;
+    bool tombstoned = false;
+};
+
+constexpr auto OUTFILE_MARKER_STATE_TTL = std::chrono::hours(1);
+
+inline bool should_expire_outfile_marker_state(const OutfileMarkerState& state,
+                                               std::chrono::steady_clock::time_point now) {
+    if (now - state.updated_at < OUTFILE_MARKER_STATE_TTL) {
+        return false;
+    }
+    // A failed delete is the only terminal state that still owns rollback work.
+    return !state.tombstoned || state.owned_path.empty();
+}
+
+inline bool should_sync_outfile_marker(TStorageBackendType::type storage_type) {
+    // Local OUTFILE historically made the completion marker durable before acknowledging it.
+    return storage_type == TStorageBackendType::LOCAL;
+}
+
+} // namespace doris

--- a/be/src/service/outfile_marker_state.h
+++ b/be/src/service/outfile_marker_state.h
@@ -46,4 +46,11 @@ inline bool should_sync_outfile_marker(TStorageBackendType::type storage_type) {
     return storage_type == TStorageBackendType::LOCAL;
 }
 
+inline bool should_check_outfile_marker_existence(const TResultFileSinkOptions& file_options,
+                                                  TStorageBackendType::type storage_type) {
+    // Legacy remote writers keep their historical overwrite/append semantics during rolling
+    // upgrades; only atomic requests opt into the cross-storage ownership check.
+    return storage_type == TStorageBackendType::LOCAL || file_options.enable_atomic_outfile;
+}
+
 } // namespace doris

--- a/be/src/service/outfile_marker_state.h
+++ b/be/src/service/outfile_marker_state.h
@@ -41,6 +41,27 @@ inline bool should_expire_outfile_marker_state(const OutfileMarkerState& state,
     return !state.tombstoned || state.owned_path.empty();
 }
 
+inline void record_outfile_marker_ownership(OutfileMarkerState* state, const std::string& path,
+                                            std::chrono::steady_clock::time_point now) {
+    state->updated_at = now;
+    state->owned_path = path;
+}
+
+inline void complete_outfile_marker_delete(OutfileMarkerState* state, const std::string& path,
+                                           bool delete_succeeded,
+                                           std::chrono::steady_clock::time_point now) {
+    if (state->owned_path != path) {
+        return;
+    }
+    state->updated_at = now;
+    // A failed delete must retain ownership so a later compensating DELETE can retry it.
+    if (!delete_succeeded) {
+        state->tombstoned = true;
+        return;
+    }
+    state->owned_path.clear();
+}
+
 inline bool should_sync_outfile_marker(TStorageBackendType::type storage_type) {
     // Local OUTFILE historically made the completion marker durable before acknowledging it.
     return storage_type == TStorageBackendType::LOCAL;

--- a/be/test/exec/sink/writer/vfile_result_writer_test.cpp
+++ b/be/test/exec/sink/writer/vfile_result_writer_test.cpp
@@ -21,10 +21,13 @@
 
 #include <filesystem>
 
+#include "exec/operator/result_sink_operator.h"
 #include "format/transformer/vorc_transformer.h"
 #include "format/transformer/vparquet_transformer.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
+#include "io/fs/local_file_writer.h"
+#include "runtime/runtime_state.h"
 #include "util/slice.h"
 
 namespace doris {
@@ -129,6 +132,36 @@ TEST(VFileResultWriterTest, AbortedFormatStreamsDoNotCloseRawWriter) {
         output_stream.abort();
     }
     EXPECT_EQ(orc_writer.close_count, 0);
+}
+
+TEST(VFileResultWriterTest, LocalOutfilePreservesSynchronousClose) {
+    const auto directory =
+            std::filesystem::temp_directory_path() / "doris_vfile_result_writer_sync_close";
+    const auto path = directory / "part.csv";
+    std::filesystem::remove_all(directory);
+    std::filesystem::create_directories(directory);
+
+    TResultFileSinkOptions thrift_options;
+    thrift_options.file_path = directory.string() + "/";
+    thrift_options.file_format = TFileFormatType::FORMAT_CSV_PLAIN;
+    thrift_options.file_suffix = "csv";
+    thrift_options.with_bom = false;
+    ResultFileOptions file_options(thrift_options);
+    RuntimeState state;
+    VExprContextSPtrs output_exprs;
+    VFileResultWriter writer(TDataSink {}, output_exprs, nullptr, nullptr);
+    writer._state = &state;
+    writer._file_opts = &file_options;
+    writer._storage_type = TStorageBackendType::LOCAL;
+
+    ASSERT_TRUE(writer._create_file_writer(path.string()).ok());
+    const auto* local_writer =
+            dynamic_cast<const io::LocalFileWriter*>(writer._file_writer_impl.get());
+    ASSERT_NE(local_writer, nullptr);
+    EXPECT_TRUE(local_writer->_sync_data);
+
+    ASSERT_FALSE(writer.close(Status::Cancelled("test cleanup")).ok());
+    std::filesystem::remove_all(directory);
 }
 
 } // namespace doris

--- a/be/test/exec/sink/writer/vfile_result_writer_test.cpp
+++ b/be/test/exec/sink/writer/vfile_result_writer_test.cpp
@@ -1,0 +1,96 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exec/sink/writer/vfile_result_writer.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "io/fs/file_writer.h"
+#include "io/fs/local_file_system.h"
+#include "util/slice.h"
+
+namespace doris {
+
+namespace {
+
+void create_closed_file(const std::filesystem::path& path) {
+    io::FileWriterPtr file_writer;
+    ASSERT_TRUE(io::global_local_filesystem()->create_file(path, &file_writer).ok());
+    ASSERT_TRUE(file_writer->append(Slice("partial", 7)).ok());
+    ASSERT_TRUE(file_writer->close().ok());
+}
+
+bool file_exists(const std::filesystem::path& path) {
+    bool exists = false;
+    EXPECT_TRUE(io::global_local_filesystem()->exists(path, &exists).ok());
+    return exists;
+}
+
+} // namespace
+
+TEST(VFileResultWriterTest, FailedCloseRemovesClosedOutputFile) {
+    const auto directory =
+            std::filesystem::temp_directory_path() / "doris_vfile_result_writer_failed_close";
+    const auto path = directory / "part.csv";
+    std::filesystem::remove_all(directory);
+    std::filesystem::create_directories(directory);
+
+    io::FileWriterPtr file_writer;
+    ASSERT_TRUE(io::global_local_filesystem()->create_file(path, &file_writer).ok());
+    ASSERT_TRUE(file_writer->append(Slice("partial", 7)).ok());
+    ASSERT_TRUE(file_writer->close().ok());
+
+    VFileResultWriter writer(TDataSink {}, {}, nullptr, nullptr);
+    writer._storage_type = TStorageBackendType::LOCAL;
+    writer._file_writer_impl = std::move(file_writer);
+    const auto original_error = Status::IOError("injected outfile failure");
+
+    const auto status = writer.close(original_error);
+
+    EXPECT_EQ(status.to_string(), original_error.to_string());
+    EXPECT_FALSE(file_exists(path));
+    std::filesystem::remove_all(directory);
+}
+
+TEST(VFileResultWriterTest, FailedCloseRemovesOnlyOwnedOutputFiles) {
+    const auto directory =
+            std::filesystem::temp_directory_path() / "doris_vfile_result_writer_owned_files";
+    const auto first_path = directory / "part-0.csv";
+    const auto second_path = directory / "part-1.csv";
+    const auto unrelated_path = directory / "other-query.csv";
+    std::filesystem::remove_all(directory);
+    std::filesystem::create_directories(directory);
+    create_closed_file(first_path);
+    create_closed_file(second_path);
+    create_closed_file(unrelated_path);
+
+    VFileResultWriter writer(TDataSink {}, {}, nullptr, nullptr);
+    writer._storage_type = TStorageBackendType::LOCAL;
+    writer._file_system = io::global_local_filesystem();
+    writer._created_file_paths = {first_path, second_path};
+
+    ASSERT_FALSE(writer.close(Status::IOError("injected outfile failure")).ok());
+
+    EXPECT_FALSE(file_exists(first_path));
+    EXPECT_FALSE(file_exists(second_path));
+    EXPECT_TRUE(file_exists(unrelated_path));
+    std::filesystem::remove_all(directory);
+}
+
+} // namespace doris

--- a/be/test/exec/sink/writer/vfile_result_writer_test.cpp
+++ b/be/test/exec/sink/writer/vfile_result_writer_test.cpp
@@ -21,6 +21,8 @@
 
 #include <filesystem>
 
+#include "format/transformer/vorc_transformer.h"
+#include "format/transformer/vparquet_transformer.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
 #include "util/slice.h"
@@ -41,6 +43,26 @@ bool file_exists(const std::filesystem::path& path) {
     EXPECT_TRUE(io::global_local_filesystem()->exists(path, &exists).ok());
     return exists;
 }
+
+class TrackingFileWriter final : public io::FileWriter {
+public:
+    Status close(bool) override {
+        ++close_count;
+        _state = State::CLOSED;
+        return Status::OK();
+    }
+
+    Status appendv(const Slice*, size_t) override { return Status::OK(); }
+    const io::Path& path() const override { return _path; }
+    size_t bytes_appended() const override { return 0; }
+    State state() const override { return _state; }
+
+    int close_count = 0;
+
+private:
+    io::Path _path = "tracking-output";
+    State _state = State::OPENED;
+};
 
 } // namespace
 
@@ -83,7 +105,7 @@ TEST(VFileResultWriterTest, FailedCloseRemovesOnlyOwnedOutputFiles) {
     VFileResultWriter writer(TDataSink {}, {}, nullptr, nullptr);
     writer._storage_type = TStorageBackendType::LOCAL;
     writer._file_system = io::global_local_filesystem();
-    writer._created_file_paths = {first_path, second_path};
+    writer._created_files = {{writer._file_system, first_path}, {writer._file_system, second_path}};
 
     ASSERT_FALSE(writer.close(Status::IOError("injected outfile failure")).ok());
 
@@ -91,6 +113,22 @@ TEST(VFileResultWriterTest, FailedCloseRemovesOnlyOwnedOutputFiles) {
     EXPECT_FALSE(file_exists(second_path));
     EXPECT_TRUE(file_exists(unrelated_path));
     std::filesystem::remove_all(directory);
+}
+
+TEST(VFileResultWriterTest, AbortedFormatStreamsDoNotCloseRawWriter) {
+    TrackingFileWriter parquet_writer;
+    {
+        ParquetOutputStream output_stream(&parquet_writer);
+        ASSERT_TRUE(output_stream.Abort().ok());
+    }
+    EXPECT_EQ(parquet_writer.close_count, 0);
+
+    TrackingFileWriter orc_writer;
+    {
+        VOrcOutputStream output_stream(&orc_writer);
+        output_stream.abort();
+    }
+    EXPECT_EQ(orc_writer.close_count, 0);
 }
 
 } // namespace doris

--- a/be/test/exec/sink/writer/vfile_result_writer_test.cpp
+++ b/be/test/exec/sink/writer/vfile_result_writer_test.cpp
@@ -17,13 +17,18 @@
 
 #include "exec/sink/writer/vfile_result_writer.h"
 
+#include <fmt/format.h>
 #include <gtest/gtest.h>
 
 #include <filesystem>
+#include <set>
+#include <type_traits>
 
 #include "exec/operator/result_sink_operator.h"
 #include "format/transformer/vorc_transformer.h"
 #include "format/transformer/vparquet_transformer.h"
+#include "io/file_factory.h"
+#include "io/fs/broker_file_system.h"
 #include "io/fs/file_writer.h"
 #include "io/fs/local_file_system.h"
 #include "io/fs/local_file_writer.h"
@@ -108,7 +113,8 @@ TEST(VFileResultWriterTest, FailedCloseRemovesOnlyOwnedOutputFiles) {
     VFileResultWriter writer(TDataSink {}, {}, nullptr, nullptr);
     writer._storage_type = TStorageBackendType::LOCAL;
     writer._file_system = io::global_local_filesystem();
-    writer._created_files = {{writer._file_system, first_path}, {writer._file_system, second_path}};
+    writer._created_file_systems.emplace(0, writer._file_system);
+    writer._created_files = {{0, first_path}, {0, second_path}};
 
     ASSERT_FALSE(writer.close(Status::IOError("injected outfile failure")).ok());
 
@@ -162,6 +168,44 @@ TEST(VFileResultWriterTest, LocalOutfilePreservesSynchronousClose) {
 
     ASSERT_FALSE(writer.close(Status::Cancelled("test cleanup")).ok());
     std::filesystem::remove_all(directory);
+}
+
+TEST(VFileResultWriterTest, DeferredBrokerCleanupOwnsConfiguration) {
+    EXPECT_FALSE((std::is_reference_v<decltype(io::BrokerFileSystem::_broker_addr)>));
+    EXPECT_FALSE((std::is_reference_v<decltype(io::BrokerFileSystem::_broker_prop)>));
+
+    std::unique_ptr<io::BrokerFileSystem> file_system;
+    {
+        TNetworkAddress address;
+        address.__set_hostname("broker.test");
+        address.__set_port(8000);
+        std::map<std::string, std::string> properties {{"key", "value"}};
+        file_system.reset(new io::BrokerFileSystem(address, properties, "test"));
+    }
+    EXPECT_EQ(file_system->_broker_addr.hostname, "broker.test");
+    EXPECT_EQ(file_system->_broker_prop.at("key"), "value");
+}
+
+TEST(VFileResultWriterTest, ManyRotationsRetainBoundedFileSystems) {
+    VFileResultWriter writer(TDataSink {}, {}, nullptr, nullptr);
+    auto file_system = io::global_local_filesystem();
+    std::vector<TNetworkAddress> brokers(2);
+    brokers[0].__set_hostname("broker-a.test");
+    brokers[0].__set_port(8000);
+    brokers[1].__set_hostname("broker-b.test");
+    brokers[1].__set_port(8001);
+    std::set<int32_t> selected_brokers;
+
+    for (int part = 0; part < 1000; ++part) {
+        std::string path = fmt::format("part-{}.csv", part);
+        int32_t broker_index = get_broker_index(brokers, path);
+        selected_brokers.emplace(broker_index);
+        writer._record_created_file(broker_index, file_system, path);
+    }
+
+    ASSERT_EQ(selected_brokers.size(), brokers.size());
+    EXPECT_EQ(writer._created_files.size(), 1000);
+    EXPECT_EQ(writer._created_file_systems.size(), brokers.size());
 }
 
 } // namespace doris

--- a/be/test/io/fs/s3_file_writer_test.cpp
+++ b/be/test/io/fs/s3_file_writer_test.cpp
@@ -1208,6 +1208,9 @@ public:
 
     ObjStorageHeadResult head_object(const ObjStoragePath& opts) override {
         std::lock_guard lock(_mutex);
+        if (on_head) {
+            on_head();
+        }
         return {.resp = ObjStorageResponse::OK(),
                 .file_size = static_cast<int64_t>(objects[opts.path.native()].size())};
     }
@@ -1272,6 +1275,7 @@ public:
     int complete_multipart_count = 0;
     int abort_multipart_count = 0;
     int abort_failures_remaining = 0;
+    std::function<void()> on_head;
     std::vector<std::string> abort_upload_ids;
 
     // Structures to store input parameters for each call
@@ -1314,6 +1318,7 @@ public:
         complete_multipart_count = 0;
         abort_multipart_count = 0;
         abort_failures_remaining = 0;
+        on_head = nullptr;
         abort_upload_ids.clear();
 
         create_multipart_params.clear();
@@ -1380,6 +1385,25 @@ TEST_F(S3FileWriterTest, AbortRetryReusesMultipartUploadId) {
     ASSERT_EQ(mock_client->abort_upload_ids.size(), 2);
     EXPECT_EQ(mock_client->abort_upload_ids[0], mock_client->abort_upload_ids[1]);
     EXPECT_EQ(mock_client->complete_multipart_count, 0);
+}
+
+TEST_F(S3FileWriterTest, MarksMultipartCompletedBeforePostUploadCheck) {
+    auto [mock_client, writer] = create_s3_client("complete-before-post-upload-check");
+    std::string content(config::s3_write_buffer_size, 'a');
+    const bool original_check_after_upload = config::enable_s3_object_check_after_upload;
+    Defer restore_config {
+            [&] { config::enable_s3_object_check_after_upload = original_check_after_upload; }};
+    config::enable_s3_object_check_after_upload = true;
+    bool completion_flag_during_head = false;
+    mock_client->on_head = [&] {
+        completion_flag_during_head = writer->_multipart_upload_completed;
+    };
+
+    ASSERT_TRUE(writer->append(content).ok());
+    ASSERT_TRUE(writer->close().ok());
+
+    EXPECT_EQ(mock_client->complete_multipart_count, 1);
+    EXPECT_TRUE(completion_flag_during_head);
 }
 
 /**

--- a/be/test/io/fs/s3_file_writer_test.cpp
+++ b/be/test/io/fs/s3_file_writer_test.cpp
@@ -1190,6 +1190,16 @@ public:
         return default_response;
     }
 
+    ObjStorageResponse abort_multipart_upload(const ObjStoragePath& opts,
+                                              const std::string& upload_id) override {
+        std::lock_guard lock(_mutex);
+        abort_multipart_count++;
+        last_opts = opts;
+        last_upload_id = upload_id;
+        parts.clear();
+        return default_response;
+    }
+
     ObjStorageHeadResult head_object(const ObjStoragePath& opts) override {
         std::lock_guard lock(_mutex);
         return {.resp = ObjStorageResponse::OK(),
@@ -1254,6 +1264,7 @@ public:
     int put_object_count = 0;
     int upload_part_count = 0;
     int complete_multipart_count = 0;
+    int abort_multipart_count = 0;
 
     // Structures to store input parameters for each call
     struct UploadPartParams {
@@ -1293,6 +1304,7 @@ public:
         put_object_count = 0;
         upload_part_count = 0;
         complete_multipart_count = 0;
+        abort_multipart_count = 0;
 
         create_multipart_params.clear();
         put_object_params.clear();
@@ -1332,6 +1344,18 @@ create_s3_client(const std::string& path) {
     holder->_client = mock_client;
     s3_file_writer->_obj_client = holder;
     return {mock_client, s3_file_writer};
+}
+
+TEST_F(S3FileWriterTest, AbortCancelsMultipartUpload) {
+    auto [mock_client, writer] = create_s3_client("abort-multipart");
+    std::string content(config::s3_write_buffer_size, 'a');
+
+    ASSERT_TRUE(writer->append(content).ok());
+    ASSERT_TRUE(writer->abort().ok());
+
+    EXPECT_EQ(mock_client->create_multipart_count, 1);
+    EXPECT_EQ(mock_client->abort_multipart_count, 1);
+    EXPECT_EQ(mock_client->complete_multipart_count, 0);
 }
 
 /**

--- a/be/test/io/fs/s3_file_writer_test.cpp
+++ b/be/test/io/fs/s3_file_writer_test.cpp
@@ -1196,6 +1196,12 @@ public:
         abort_multipart_count++;
         last_opts = opts;
         last_upload_id = upload_id;
+        abort_upload_ids.emplace_back(upload_id);
+        if (abort_failures_remaining > 0) {
+            --abort_failures_remaining;
+            return {.status = ObjStorageStatus {ObjStorageStatus::IO_ERROR,
+                                                "injected abort failure"}};
+        }
         parts.clear();
         return default_response;
     }
@@ -1265,6 +1271,8 @@ public:
     int upload_part_count = 0;
     int complete_multipart_count = 0;
     int abort_multipart_count = 0;
+    int abort_failures_remaining = 0;
+    std::vector<std::string> abort_upload_ids;
 
     // Structures to store input parameters for each call
     struct UploadPartParams {
@@ -1305,6 +1313,8 @@ public:
         upload_part_count = 0;
         complete_multipart_count = 0;
         abort_multipart_count = 0;
+        abort_failures_remaining = 0;
+        abort_upload_ids.clear();
 
         create_multipart_params.clear();
         put_object_params.clear();
@@ -1355,6 +1365,20 @@ TEST_F(S3FileWriterTest, AbortCancelsMultipartUpload) {
 
     EXPECT_EQ(mock_client->create_multipart_count, 1);
     EXPECT_EQ(mock_client->abort_multipart_count, 1);
+    EXPECT_EQ(mock_client->complete_multipart_count, 0);
+}
+
+TEST_F(S3FileWriterTest, AbortRetryReusesMultipartUploadId) {
+    auto [mock_client, writer] = create_s3_client("abort-multipart-retry");
+    std::string content(config::s3_write_buffer_size, 'a');
+    mock_client->abort_failures_remaining = 1;
+
+    ASSERT_TRUE(writer->append(content).ok());
+    ASSERT_FALSE(writer->abort().ok());
+    ASSERT_TRUE(writer->abort().ok());
+
+    ASSERT_EQ(mock_client->abort_upload_ids.size(), 2);
+    EXPECT_EQ(mock_client->abort_upload_ids[0], mock_client->abort_upload_ids[1]);
     EXPECT_EQ(mock_client->complete_multipart_count, 0);
 }
 

--- a/be/test/runtime/result_buffer_mgr_test.cpp
+++ b/be/test/runtime/result_buffer_mgr_test.cpp
@@ -115,6 +115,41 @@ TEST_F(ResultBufferMgrTest, cancel_no_block) {
     EXPECT_FALSE(buffer_mgr.cancel(query_id, Status::InternalError("")));
 }
 
+TEST_F(ResultBufferMgrTest, RejectsNewSenderAfterStop) {
+    ResultBufferMgr buffer_mgr;
+    buffer_mgr.stop();
+
+    TUniqueId query_id;
+    query_id.lo = 10;
+    query_id.hi = 100;
+    std::shared_ptr<ResultBlockBufferBase> control_block;
+
+    EXPECT_FALSE(buffer_mgr.create_sender(query_id, 1024, &control_block, &_state, false).ok());
+    EXPECT_EQ(control_block, nullptr);
+}
+
+TEST_F(ResultBufferMgrTest, LateOutfileCleanupRetriesAfterCancellation) {
+    ResultBufferMgr buffer_mgr;
+    TUniqueId query_id;
+    query_id.lo = 11;
+    query_id.hi = 101;
+
+    std::shared_ptr<ResultBlockBufferBase> control_block;
+    ASSERT_TRUE(buffer_mgr.create_sender(query_id, 1024, &control_block, &_state, false).ok());
+    ASSERT_TRUE(buffer_mgr.cancel(query_id, Status::Cancelled("injected cancellation")));
+
+    int cleanup_attempts = 0;
+    EXPECT_TRUE(control_block
+                        ->add_outfile_cleanup([&] {
+                            ++cleanup_attempts;
+                            return cleanup_attempts == 1
+                                           ? Status::IOError("injected transient cleanup failure")
+                                           : Status::OK();
+                        })
+                        .ok());
+    EXPECT_EQ(cleanup_attempts, 2);
+}
+
 TEST_F(ResultBufferMgrTest, OutfileAbortCleansRegisteredAndLateFiles) {
     ResultBufferMgr buffer_mgr;
     TUniqueId query_id;

--- a/be/test/runtime/result_buffer_mgr_test.cpp
+++ b/be/test/runtime/result_buffer_mgr_test.cpp
@@ -28,9 +28,12 @@
 #include "core/block/block.h"
 #include "exec/sink/writer/varrow_flight_result_writer.h"
 #include "exec/sink/writer/vmysql_result_writer.h"
+#include "runtime/exec_env.h"
 #include "runtime/result_block_buffer.h"
 #include "util/cpu_info.h"
+#include "util/defer_op.h"
 #include "util/thread.h"
+#include "util/threadpool.h"
 
 namespace doris {
 
@@ -336,6 +339,52 @@ TEST_F(ResultBufferMgrTest, ConcurrentCancellationWaitsForOutfileAbortDrain) {
     EXPECT_FALSE(abort_future.get().ok());
     EXPECT_TRUE(cancel_future.get());
     EXPECT_EQ(cleanup_attempts.load(), 2);
+}
+
+TEST_F(ResultBufferMgrTest, StopDrainsCleanupQueuedBehindBlockedWorker) {
+    ExecEnv* exec_env = ExecEnv::GetInstance();
+    auto original_pool = std::move(exec_env->_lazy_release_obj_pool);
+    CountDownLatch release_worker(1);
+    Defer restore_pool {[&] {
+        release_worker.count_down();
+        if (exec_env->_lazy_release_obj_pool != nullptr) {
+            exec_env->_lazy_release_obj_pool->shutdown();
+        }
+        exec_env->_lazy_release_obj_pool = std::move(original_pool);
+    }};
+    ASSERT_TRUE(ThreadPoolBuilder("outfile-cleanup-shutdown-test")
+                        .set_min_threads(1)
+                        .set_max_threads(1)
+                        .build(&exec_env->_lazy_release_obj_pool)
+                        .ok());
+
+    CountDownLatch worker_started(1);
+    ASSERT_TRUE(exec_env->_lazy_release_obj_pool
+                        ->submit_func([&] {
+                            worker_started.count_down();
+                            release_worker.wait();
+                        })
+                        .ok());
+    ASSERT_TRUE(worker_started.wait_for(std::chrono::seconds(5)));
+
+    ResultBufferMgr buffer_mgr;
+    TUniqueId query_id;
+    query_id.lo = 90;
+    query_id.hi = 900;
+    std::shared_ptr<ResultBlockBufferBase> buffer;
+    ASSERT_TRUE(buffer_mgr.create_sender(query_id, 1024, &buffer, &_state, false).ok());
+    std::atomic<int> cleanup_count = 0;
+    ASSERT_TRUE(buffer->add_outfile_cleanup([&] {
+                          ++cleanup_count;
+                          return Status::OK();
+                      }).ok());
+
+    ASSERT_TRUE(buffer_mgr.cancel(query_id, Status::Cancelled("injected expiration"), true));
+    ASSERT_EQ(exec_env->_lazy_release_obj_pool->get_queue_size(), 1);
+
+    buffer_mgr.stop();
+
+    EXPECT_EQ(cleanup_count.load(), 1);
 }
 
 } // namespace doris

--- a/be/test/runtime/result_buffer_mgr_test.cpp
+++ b/be/test/runtime/result_buffer_mgr_test.cpp
@@ -20,6 +20,11 @@
 #include <gen_cpp/PaloInternalService_types.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <thread>
+
 #include "core/block/block.h"
 #include "exec/sink/writer/varrow_flight_result_writer.h"
 #include "exec/sink/writer/vmysql_result_writer.h"
@@ -288,6 +293,49 @@ TEST_F(ResultBufferMgrTest, OutfileAbortRetainsFailedCleanupForRetry) {
     EXPECT_FALSE(buffer_mgr.finish_outfile(query_id, OutfileOperation::ABORT).ok());
     EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, OutfileOperation::ABORT).ok());
     EXPECT_EQ(cleanup_count, 2);
+}
+
+TEST_F(ResultBufferMgrTest, ConcurrentCancellationWaitsForOutfileAbortDrain) {
+    ResultBufferMgr buffer_mgr;
+    TUniqueId query_id;
+    query_id.lo = 80;
+    query_id.hi = 800;
+
+    std::shared_ptr<ResultBlockBufferBase> buffer;
+    ASSERT_TRUE(buffer_mgr.create_sender(query_id, 1024, &buffer, &_state, false).ok());
+    CountDownLatch cleanup_started(1);
+    CountDownLatch release_cleanup(1);
+    std::atomic<int> cleanup_attempts = 0;
+    ASSERT_TRUE(buffer->add_outfile_cleanup([&] {
+                          int attempt = ++cleanup_attempts;
+                          if (attempt == 1) {
+                              cleanup_started.count_down();
+                              release_cleanup.wait();
+                              return Status::IOError("injected cleanup failure");
+                          }
+                          return Status::OK();
+                      }).ok());
+
+    auto abort_future = std::async(std::launch::async, [&] {
+        return buffer_mgr.finish_outfile(query_id, OutfileOperation::ABORT);
+    });
+    ASSERT_TRUE(cleanup_started.wait_for(std::chrono::seconds(5)));
+    auto cancel_future = std::async(std::launch::async, [&] {
+        return buffer_mgr.cancel(query_id, Status::Cancelled("injected cancellation"));
+    });
+
+    std::shared_ptr<MySQLResultBlockBuffer> observed_buffer;
+    for (int attempt = 0; attempt < 5000 && buffer_mgr.find_buffer(query_id, observed_buffer).ok();
+         ++attempt) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    bool buffer_removed = !buffer_mgr.find_buffer(query_id, observed_buffer).ok();
+    release_cleanup.count_down();
+
+    ASSERT_TRUE(buffer_removed);
+    EXPECT_FALSE(abort_future.get().ok());
+    EXPECT_TRUE(cancel_future.get());
+    EXPECT_EQ(cleanup_attempts.load(), 2);
 }
 
 } // namespace doris

--- a/be/test/runtime/result_buffer_mgr_test.cpp
+++ b/be/test/runtime/result_buffer_mgr_test.cpp
@@ -115,4 +115,53 @@ TEST_F(ResultBufferMgrTest, cancel_no_block) {
     EXPECT_FALSE(buffer_mgr.cancel(query_id, Status::InternalError("")));
 }
 
+TEST_F(ResultBufferMgrTest, OutfileAbortCleansRegisteredAndLateFiles) {
+    ResultBufferMgr buffer_mgr;
+    TUniqueId query_id;
+    query_id.lo = 20;
+    query_id.hi = 200;
+
+    std::shared_ptr<ResultBlockBufferBase> buffer;
+    ASSERT_TRUE(buffer_mgr.create_sender(query_id, 1024, &buffer, &_state, false).ok());
+    int cleanup_count = 0;
+    buffer->add_outfile_cleanup([&] { ++cleanup_count; });
+
+    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, false));
+    EXPECT_EQ(cleanup_count, 1);
+    buffer->add_outfile_cleanup([&] { ++cleanup_count; });
+    EXPECT_EQ(cleanup_count, 2);
+}
+
+TEST_F(ResultBufferMgrTest, OutfileCommitSurvivesDeferredBufferCleanup) {
+    ResultBufferMgr buffer_mgr;
+    TUniqueId query_id;
+    query_id.lo = 30;
+    query_id.hi = 300;
+
+    std::shared_ptr<ResultBlockBufferBase> buffer;
+    ASSERT_TRUE(buffer_mgr.create_sender(query_id, 1024, &buffer, &_state, false).ok());
+    int cleanup_count = 0;
+    buffer->add_outfile_cleanup([&] { ++cleanup_count; });
+
+    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, true));
+    EXPECT_TRUE(buffer_mgr.cancel(query_id, Status::Cancelled("deferred cleanup")));
+    EXPECT_EQ(cleanup_count, 0);
+}
+
+TEST_F(ResultBufferMgrTest, OutfileAbortOverridesPartialCommit) {
+    ResultBufferMgr buffer_mgr;
+    TUniqueId query_id;
+    query_id.lo = 40;
+    query_id.hi = 400;
+
+    std::shared_ptr<ResultBlockBufferBase> buffer;
+    ASSERT_TRUE(buffer_mgr.create_sender(query_id, 1024, &buffer, &_state, false).ok());
+    int cleanup_count = 0;
+    buffer->add_outfile_cleanup([&] { ++cleanup_count; });
+
+    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, true));
+    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, false));
+    EXPECT_EQ(cleanup_count, 1);
+}
+
 } // namespace doris

--- a/be/test/runtime/result_buffer_mgr_test.cpp
+++ b/be/test/runtime/result_buffer_mgr_test.cpp
@@ -124,15 +124,21 @@ TEST_F(ResultBufferMgrTest, OutfileAbortCleansRegisteredAndLateFiles) {
     std::shared_ptr<ResultBlockBufferBase> buffer;
     ASSERT_TRUE(buffer_mgr.create_sender(query_id, 1024, &buffer, &_state, false).ok());
     int cleanup_count = 0;
-    buffer->add_outfile_cleanup([&] { ++cleanup_count; });
+    ASSERT_TRUE(buffer->add_outfile_cleanup([&] {
+                          ++cleanup_count;
+                          return Status::OK();
+                      }).ok());
 
-    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, false));
+    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, OutfileOperation::ABORT).ok());
     EXPECT_EQ(cleanup_count, 1);
-    buffer->add_outfile_cleanup([&] { ++cleanup_count; });
+    ASSERT_TRUE(buffer->add_outfile_cleanup([&] {
+                          ++cleanup_count;
+                          return Status::OK();
+                      }).ok());
     EXPECT_EQ(cleanup_count, 2);
 }
 
-TEST_F(ResultBufferMgrTest, OutfileCommitSurvivesDeferredBufferCleanup) {
+TEST_F(ResultBufferMgrTest, OutfilePrepareKeepsRollbackOwnership) {
     ResultBufferMgr buffer_mgr;
     TUniqueId query_id;
     query_id.lo = 30;
@@ -141,14 +147,37 @@ TEST_F(ResultBufferMgrTest, OutfileCommitSurvivesDeferredBufferCleanup) {
     std::shared_ptr<ResultBlockBufferBase> buffer;
     ASSERT_TRUE(buffer_mgr.create_sender(query_id, 1024, &buffer, &_state, false).ok());
     int cleanup_count = 0;
-    buffer->add_outfile_cleanup([&] { ++cleanup_count; });
+    ASSERT_TRUE(buffer->add_outfile_cleanup([&] {
+                          ++cleanup_count;
+                          return Status::OK();
+                      }).ok());
 
-    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, true));
+    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, OutfileOperation::PREPARE).ok());
+    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, OutfileOperation::ABORT).ok());
+    EXPECT_EQ(cleanup_count, 1);
+}
+
+TEST_F(ResultBufferMgrTest, OutfileCommitSurvivesDeferredBufferCleanup) {
+    ResultBufferMgr buffer_mgr;
+    TUniqueId query_id;
+    query_id.lo = 35;
+    query_id.hi = 350;
+
+    std::shared_ptr<ResultBlockBufferBase> buffer;
+    ASSERT_TRUE(buffer_mgr.create_sender(query_id, 1024, &buffer, &_state, false).ok());
+    int cleanup_count = 0;
+    ASSERT_TRUE(buffer->add_outfile_cleanup([&] {
+                          ++cleanup_count;
+                          return Status::OK();
+                      }).ok());
+
+    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, OutfileOperation::PREPARE).ok());
+    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, OutfileOperation::COMMIT).ok());
     EXPECT_TRUE(buffer_mgr.cancel(query_id, Status::Cancelled("deferred cleanup")));
     EXPECT_EQ(cleanup_count, 0);
 }
 
-TEST_F(ResultBufferMgrTest, OutfileAbortOverridesPartialCommit) {
+TEST_F(ResultBufferMgrTest, OutfileCommitRequiresPrepare) {
     ResultBufferMgr buffer_mgr;
     TUniqueId query_id;
     query_id.lo = 40;
@@ -157,11 +186,73 @@ TEST_F(ResultBufferMgrTest, OutfileAbortOverridesPartialCommit) {
     std::shared_ptr<ResultBlockBufferBase> buffer;
     ASSERT_TRUE(buffer_mgr.create_sender(query_id, 1024, &buffer, &_state, false).ok());
     int cleanup_count = 0;
-    buffer->add_outfile_cleanup([&] { ++cleanup_count; });
+    ASSERT_TRUE(buffer->add_outfile_cleanup([&] {
+                          ++cleanup_count;
+                          return Status::OK();
+                      }).ok());
 
-    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, true));
-    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, false));
+    EXPECT_FALSE(buffer_mgr.finish_outfile(query_id, OutfileOperation::COMMIT).ok());
+    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, OutfileOperation::ABORT).ok());
     EXPECT_EQ(cleanup_count, 1);
+}
+
+TEST_F(ResultBufferMgrTest, OutfilePrepareRejectsAbortedBuffer) {
+    ResultBufferMgr buffer_mgr;
+    TUniqueId query_id;
+    query_id.lo = 50;
+    query_id.hi = 500;
+
+    std::shared_ptr<ResultBlockBufferBase> buffer;
+    ASSERT_TRUE(buffer_mgr.create_sender(query_id, 1024, &buffer, &_state, false).ok());
+    int cleanup_count = 0;
+    ASSERT_TRUE(buffer->add_outfile_cleanup([&] {
+                          ++cleanup_count;
+                          return Status::OK();
+                      }).ok());
+
+    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, OutfileOperation::ABORT).ok());
+    EXPECT_FALSE(buffer_mgr.finish_outfile(query_id, OutfileOperation::PREPARE).ok());
+    EXPECT_EQ(cleanup_count, 1);
+}
+
+TEST_F(ResultBufferMgrTest, OutfileAbortCanCompensatePartialCommit) {
+    ResultBufferMgr buffer_mgr;
+    TUniqueId query_id;
+    query_id.lo = 60;
+    query_id.hi = 600;
+
+    std::shared_ptr<ResultBlockBufferBase> buffer;
+    ASSERT_TRUE(buffer_mgr.create_sender(query_id, 1024, &buffer, &_state, false).ok());
+    int cleanup_count = 0;
+    ASSERT_TRUE(buffer->add_outfile_cleanup([&] {
+                          ++cleanup_count;
+                          return Status::OK();
+                      }).ok());
+
+    ASSERT_TRUE(buffer_mgr.finish_outfile(query_id, OutfileOperation::PREPARE).ok());
+    ASSERT_TRUE(buffer_mgr.finish_outfile(query_id, OutfileOperation::COMMIT).ok());
+    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, OutfileOperation::ABORT).ok());
+    EXPECT_EQ(cleanup_count, 1);
+}
+
+TEST_F(ResultBufferMgrTest, OutfileAbortRetainsFailedCleanupForRetry) {
+    ResultBufferMgr buffer_mgr;
+    TUniqueId query_id;
+    query_id.lo = 70;
+    query_id.hi = 700;
+
+    std::shared_ptr<ResultBlockBufferBase> buffer;
+    ASSERT_TRUE(buffer_mgr.create_sender(query_id, 1024, &buffer, &_state, false).ok());
+    int cleanup_count = 0;
+    ASSERT_TRUE(buffer->add_outfile_cleanup([&] {
+                          ++cleanup_count;
+                          return cleanup_count == 1 ? Status::IOError("injected cleanup failure")
+                                                    : Status::OK();
+                      }).ok());
+
+    EXPECT_FALSE(buffer_mgr.finish_outfile(query_id, OutfileOperation::ABORT).ok());
+    EXPECT_TRUE(buffer_mgr.finish_outfile(query_id, OutfileOperation::ABORT).ok());
+    EXPECT_EQ(cleanup_count, 2);
 }
 
 } // namespace doris

--- a/be/test/service/outfile_marker_state_test.cpp
+++ b/be/test/service/outfile_marker_state_test.cpp
@@ -1,0 +1,50 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "service/outfile_marker_state.h"
+
+#include <gtest/gtest.h>
+
+namespace doris {
+
+TEST(OutfileMarkerStateTest, ReclaimsSuccessfulStateAfterProtectionWindow) {
+    const auto now = std::chrono::steady_clock::now();
+    OutfileMarkerState state {.updated_at = now - OUTFILE_MARKER_STATE_TTL,
+                              .owned_path = "success-marker",
+                              .tombstoned = false};
+
+    EXPECT_TRUE(should_expire_outfile_marker_state(state, now));
+}
+
+TEST(OutfileMarkerStateTest, RetainsFailedDeleteTombstone) {
+    const auto now = std::chrono::steady_clock::now();
+    OutfileMarkerState state {.updated_at = now - OUTFILE_MARKER_STATE_TTL,
+                              .owned_path = "success-marker",
+                              .tombstoned = true};
+
+    EXPECT_FALSE(should_expire_outfile_marker_state(state, now));
+
+    state.owned_path.clear();
+    EXPECT_TRUE(should_expire_outfile_marker_state(state, now));
+}
+
+TEST(OutfileMarkerStateTest, SyncsOnlyLocalSuccessMarker) {
+    EXPECT_TRUE(should_sync_outfile_marker(TStorageBackendType::LOCAL));
+    EXPECT_FALSE(should_sync_outfile_marker(TStorageBackendType::S3));
+}
+
+} // namespace doris

--- a/be/test/service/outfile_marker_state_test.cpp
+++ b/be/test/service/outfile_marker_state_test.cpp
@@ -47,4 +47,22 @@ TEST(OutfileMarkerStateTest, SyncsOnlyLocalSuccessMarker) {
     EXPECT_FALSE(should_sync_outfile_marker(TStorageBackendType::S3));
 }
 
+TEST(OutfileMarkerStateTest, ExistingMarkerPolicyPreservesLegacyRemoteBehavior) {
+    TResultFileSinkOptions legacy_options;
+    EXPECT_TRUE(should_check_outfile_marker_existence(legacy_options, TStorageBackendType::LOCAL));
+    EXPECT_FALSE(should_check_outfile_marker_existence(legacy_options, TStorageBackendType::S3));
+    EXPECT_FALSE(should_check_outfile_marker_existence(legacy_options, TStorageBackendType::HDFS));
+    EXPECT_FALSE(
+            should_check_outfile_marker_existence(legacy_options, TStorageBackendType::BROKER));
+
+    legacy_options.__set_enable_atomic_outfile(false);
+    EXPECT_FALSE(should_check_outfile_marker_existence(legacy_options, TStorageBackendType::S3));
+
+    TResultFileSinkOptions atomic_options;
+    atomic_options.__set_enable_atomic_outfile(true);
+    EXPECT_TRUE(should_check_outfile_marker_existence(atomic_options, TStorageBackendType::S3));
+    EXPECT_TRUE(should_check_outfile_marker_existence(atomic_options, TStorageBackendType::HDFS));
+    EXPECT_TRUE(should_check_outfile_marker_existence(atomic_options, TStorageBackendType::BROKER));
+}
+
 } // namespace doris

--- a/be/test/service/outfile_marker_state_test.cpp
+++ b/be/test/service/outfile_marker_state_test.cpp
@@ -42,6 +42,23 @@ TEST(OutfileMarkerStateTest, RetainsFailedDeleteTombstone) {
     EXPECT_TRUE(should_expire_outfile_marker_state(state, now));
 }
 
+TEST(OutfileMarkerStateTest, AppendFailureRetainsOwnershipUntilDeleteRetrySucceeds) {
+    const auto created_at = std::chrono::steady_clock::now();
+    OutfileMarkerState state {.updated_at = created_at, .owned_path = "", .tombstoned = false};
+    record_outfile_marker_ownership(&state, "success-marker", created_at);
+
+    const auto failed_delete_at = created_at + std::chrono::seconds(1);
+    complete_outfile_marker_delete(&state, "success-marker", false, failed_delete_at);
+    EXPECT_EQ(state.owned_path, "success-marker");
+    EXPECT_TRUE(state.tombstoned);
+    EXPECT_EQ(state.updated_at, failed_delete_at);
+
+    const auto successful_retry_at = failed_delete_at + std::chrono::seconds(1);
+    complete_outfile_marker_delete(&state, "success-marker", true, successful_retry_at);
+    EXPECT_TRUE(state.owned_path.empty());
+    EXPECT_EQ(state.updated_at, successful_retry_at);
+}
+
 TEST(OutfileMarkerStateTest, SyncsOnlyLocalSuccessMarker) {
     EXPECT_TRUE(should_sync_outfile_marker(TStorageBackendType::LOCAL));
     EXPECT_FALSE(should_sync_outfile_marker(TStorageBackendType::S3));

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1996,7 +1996,7 @@ public class Config extends ConfigBase {
      * Max data version of backends serialize block.
      */
     @ConfField(mutable = false)
-    public static int max_be_exec_version = 13;
+    public static int max_be_exec_version = 14;
 
     /**
      * Min data version of backends serialize block.

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
@@ -145,6 +145,7 @@ public class OutFileClause {
     private boolean isAnalyzed = false;
 
     private FileFormatProperties fileFormatProperties;
+    private Integer beExecVersion;
 
     public OutFileClause(String filePath, String format, Map<String, String> properties) {
         this.filePath = filePath;
@@ -162,6 +163,7 @@ public class OutFileClause {
         this.fileFormatProperties = other.fileFormatProperties;
         this.properties = other.properties == null ? null : Maps.newHashMap(other.properties);
         this.isAnalyzed = other.isAnalyzed;
+        this.beExecVersion = other.beExecVersion;
     }
 
     public String getColumnSeparator() {
@@ -190,6 +192,18 @@ public class OutFileClause {
 
     public BrokerDesc getBrokerDesc() {
         return brokerDesc;
+    }
+
+    public int getBeExecVersion() {
+        if (beExecVersion == null) {
+            // Planning and finalization must use one snapshot of the mutable protocol version.
+            beExecVersion = Config.be_exec_version;
+        }
+        return beExecVersion;
+    }
+
+    public boolean isAtomicOutfileEnabled() {
+        return getBeExecVersion() >= SUPPORT_ATOMIC_OUTFILE_VERSION;
     }
 
     public void analyze(List<Expr> resultExprs, List<String> colLabels, boolean needFormat) throws UserException {
@@ -757,7 +771,7 @@ public class OutFileClause {
         sinkOptions.setDeleteExistingFiles(deleteExistingFiles);
         sinkOptions.setFileSuffix(fileSuffix);
         sinkOptions.setWithBom(withBom);
-        sinkOptions.setEnableAtomicOutfile(Config.be_exec_version >= SUPPORT_ATOMIC_OUTFILE_VERSION);
+        sinkOptions.setEnableAtomicOutfile(isAtomicOutfileEnabled());
 
         if (brokerDesc != null) {
             sinkOptions.setBrokerProperties(brokerDesc.getBackendConfigProperties());

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
@@ -68,6 +68,7 @@ public class OutFileClause {
     public static final String URL = "URL";
     public static final String WRITE_TIME_SEC = "WriteTimeSec";
     public static final String WRITE_SPEED_KB = "WriteSpeedKB";
+    public static final int SUPPORT_ATOMIC_OUTFILE_VERSION = 14;
 
     static {
         RESULT_COL_NAMES.add(FILE_NUMBER);
@@ -756,6 +757,7 @@ public class OutFileClause {
         sinkOptions.setDeleteExistingFiles(deleteExistingFiles);
         sinkOptions.setFileSuffix(fileSuffix);
         sinkOptions.setWithBom(withBom);
+        sinkOptions.setEnableAtomicOutfile(Config.be_exec_version >= SUPPORT_ATOMIC_OUTFILE_VERSION);
 
         if (brokerDesc != null) {
             sinkOptions.setBrokerProperties(brokerDesc.getBackendConfigProperties());

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/OutFileClause.java
@@ -145,12 +145,19 @@ public class OutFileClause {
     private boolean isAnalyzed = false;
 
     private FileFormatProperties fileFormatProperties;
-    private Integer beExecVersion;
+    private final int beExecVersion;
 
     public OutFileClause(String filePath, String format, Map<String, String> properties) {
+        // One statement must keep the same capability decision even if the mutable cluster
+        // protocol version changes while the statement is being planned.
+        this(filePath, format, properties, Config.be_exec_version);
+    }
+
+    public OutFileClause(String filePath, String format, Map<String, String> properties, int beExecVersion) {
         this.filePath = filePath;
         this.properties = properties;
         this.isAnalyzed = false;
+        this.beExecVersion = beExecVersion;
         if (Strings.isNullOrEmpty(format)) {
             fileFormatProperties = FileFormatProperties.createFileFormatProperties("csv");
         } else {
@@ -195,10 +202,6 @@ public class OutFileClause {
     }
 
     public int getBeExecVersion() {
-        if (beExecVersion == null) {
-            // Planning and finalization must use one snapshot of the mutable protocol version.
-            beExecVersion = Config.be_exec_version;
-        }
         return beExecVersion;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/LogicalPlanAdapter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/LogicalPlanAdapter.java
@@ -78,7 +78,8 @@ public class LogicalPlanAdapter extends StatementBase implements Queriable {
             OutFileClause outFile = new OutFileClause(
                     fileSink.getFilePath(),
                     fileSink.getFormat(),
-                    fileSink.getProperties()
+                    fileSink.getProperties(),
+                    fileSink.getBeExecVersion()
             );
             try {
                 outFile.analyze(Lists.newArrayList(), Lists.newArrayList(), false);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -773,7 +773,8 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         OutFileClause outFile = new OutFileClause(
                 fileSink.getFilePath(),
                 fileSink.getFormat(),
-                fileSink.getProperties()
+                fileSink.getProperties(),
+                fileSink.getBeExecVersion()
         );
 
         List<Expr> outputExprs = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalFileSinkToPhysicalFileSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/implementation/LogicalFileSinkToPhysicalFileSink.java
@@ -38,6 +38,7 @@ public class LogicalFileSinkToPhysicalFileSink extends OneImplementationRuleFact
                     sink.getFilePath(),
                     sink.getFormat(),
                     sink.getProperties(),
+                    sink.getBeExecVersion(),
                     Optional.empty(),
                     sink.getLogicalProperties(),
                     sink.child());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalFileSink.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.plans.logical;
 
+import org.apache.doris.common.Config;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
@@ -45,32 +46,45 @@ public class LogicalFileSink<CHILD_TYPE extends Plan> extends LogicalSink<CHILD_
     private final String filePath;
     private final String format;
     private final Map<String, String> properties;
+    private final int beExecVersion;
 
     public LogicalFileSink(String filePath, String format,
             Map<String, String> properties, List<NamedExpression> outputExprs, CHILD_TYPE child) {
-        this(filePath, format, properties, outputExprs, Optional.empty(), Optional.empty(), child);
+        this(filePath, format, properties, Config.be_exec_version, outputExprs,
+                Optional.empty(), Optional.empty(), child);
     }
 
     public LogicalFileSink(String filePath, String format, Map<String, String> properties,
             List<NamedExpression> outputExprs,
             Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties,
             CHILD_TYPE child) {
+        this(filePath, format, properties, Config.be_exec_version, outputExprs,
+                groupExpression, logicalProperties, child);
+    }
+
+    private LogicalFileSink(String filePath, String format, Map<String, String> properties,
+            int beExecVersion, List<NamedExpression> outputExprs,
+            Optional<GroupExpression> groupExpression, Optional<LogicalProperties> logicalProperties,
+            CHILD_TYPE child) {
         super(PlanType.LOGICAL_FILE_SINK, outputExprs, groupExpression, logicalProperties, child);
         this.filePath = Objects.requireNonNull(filePath);
         this.format = Objects.requireNonNull(format);
         this.properties = ImmutableMap.copyOf(Objects.requireNonNull(properties));
+        this.beExecVersion = beExecVersion;
     }
 
     public LogicalFileSink<CHILD_TYPE> withOutputExprs(List<NamedExpression> outputExprs) {
         return AbstractPlan.copyWithSameId(this, () ->
-                new LogicalFileSink<>(filePath, format, properties, outputExprs, child()));
+                new LogicalFileSink<>(filePath, format, properties, beExecVersion, outputExprs,
+                        Optional.empty(), Optional.empty(), child()));
     }
 
     @Override
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
         return AbstractPlan.copyWithSameId(this, () ->
-                new LogicalFileSink<>(filePath, format, properties, outputExprs, children.get(0)));
+                new LogicalFileSink<>(filePath, format, properties, beExecVersion, outputExprs,
+                        Optional.empty(), Optional.empty(), children.get(0)));
     }
 
     @Override
@@ -90,19 +104,20 @@ public class LogicalFileSink<CHILD_TYPE extends Plan> extends LogicalSink<CHILD_
             return false;
         }
         LogicalFileSink<?> that = (LogicalFileSink<?>) o;
-        return Objects.equals(filePath, that.filePath) && Objects.equals(format, that.format)
+        return beExecVersion == that.beExecVersion
+                && Objects.equals(filePath, that.filePath) && Objects.equals(format, that.format)
                 && Objects.equals(properties, that.properties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), filePath, format, properties);
+        return Objects.hash(super.hashCode(), filePath, format, properties, beExecVersion);
     }
 
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
         return AbstractPlan.copyWithSameId(this, () ->
-                new LogicalFileSink<>(filePath, format, properties, outputExprs,
+                new LogicalFileSink<>(filePath, format, properties, beExecVersion, outputExprs,
                 groupExpression, Optional.of(getLogicalProperties()), child()));
     }
 
@@ -111,7 +126,7 @@ public class LogicalFileSink<CHILD_TYPE extends Plan> extends LogicalSink<CHILD_
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1);
         return AbstractPlan.copyWithSameId(this, () ->
-                new LogicalFileSink<>(filePath, format, properties, outputExprs,
+                new LogicalFileSink<>(filePath, format, properties, beExecVersion, outputExprs,
                 groupExpression, logicalProperties, children.get(0)));
     }
 
@@ -125,6 +140,10 @@ public class LogicalFileSink<CHILD_TYPE extends Plan> extends LogicalSink<CHILD_
 
     public Map<String, String> getProperties() {
         return properties;
+    }
+
+    public int getBeExecVersion() {
+        return beExecVersion;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFileSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/physical/PhysicalFileSink.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.nereids.trees.plans.physical;
 
+import org.apache.doris.common.Config;
 import org.apache.doris.nereids.memo.GroupExpression;
 import org.apache.doris.nereids.properties.LogicalProperties;
 import org.apache.doris.nereids.properties.PhysicalProperties;
@@ -47,6 +48,7 @@ public class PhysicalFileSink<CHILD_TYPE extends Plan> extends PhysicalSink<CHIL
     private final String filePath;
     private final String format;
     private final Map<String, String> properties;
+    private final int beExecVersion;
 
     public PhysicalFileSink(List<NamedExpression> outputExprs, String filePath, String format,
             Map<String, String> properties,
@@ -63,7 +65,23 @@ public class PhysicalFileSink<CHILD_TYPE extends Plan> extends PhysicalSink<CHIL
     }
 
     public PhysicalFileSink(List<NamedExpression> outputExprs, String filePath, String format,
+            Map<String, String> properties, int beExecVersion,
+            Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties,
+            CHILD_TYPE child) {
+        this(outputExprs, filePath, format, properties, beExecVersion,
+                groupExpression, logicalProperties, PhysicalProperties.GATHER, null, child);
+    }
+
+    public PhysicalFileSink(List<NamedExpression> outputExprs, String filePath, String format,
             Map<String, String> properties,
+            Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties,
+            PhysicalProperties physicalProperties, Statistics statistics, CHILD_TYPE child) {
+        this(outputExprs, filePath, format, properties, Config.be_exec_version,
+                groupExpression, logicalProperties, physicalProperties, statistics, child);
+    }
+
+    private PhysicalFileSink(List<NamedExpression> outputExprs, String filePath, String format,
+            Map<String, String> properties, int beExecVersion,
             Optional<GroupExpression> groupExpression, LogicalProperties logicalProperties,
             PhysicalProperties physicalProperties, Statistics statistics, CHILD_TYPE child) {
         super(PlanType.PHYSICAL_FILE_SINK, outputExprs,
@@ -71,6 +89,7 @@ public class PhysicalFileSink<CHILD_TYPE extends Plan> extends PhysicalSink<CHIL
         this.filePath = filePath;
         this.format = format;
         this.properties = properties;
+        this.beExecVersion = beExecVersion;
     }
 
     public String getFilePath() {
@@ -85,6 +104,10 @@ public class PhysicalFileSink<CHILD_TYPE extends Plan> extends PhysicalSink<CHIL
         return properties;
     }
 
+    public int getBeExecVersion() {
+        return beExecVersion;
+    }
+
     public PhysicalProperties requestProperties(ConnectContext ctx) {
         if (!ctx.getSessionVariable().enableParallelOutfile) {
             return PhysicalProperties.GATHER;
@@ -97,7 +120,7 @@ public class PhysicalFileSink<CHILD_TYPE extends Plan> extends PhysicalSink<CHIL
     public Plan withChildren(List<Plan> children) {
         Preconditions.checkArgument(children.size() == 1, "PhysicalFileSink only accepts one child");
         return AbstractPlan.copyWithSameId(this, () -> new PhysicalFileSink<>(outputExprs, filePath, format,
-                properties, getLogicalProperties(), children.get(0)));
+                properties, beExecVersion, Optional.empty(), getLogicalProperties(), children.get(0)));
     }
 
     @Override
@@ -121,12 +144,13 @@ public class PhysicalFileSink<CHILD_TYPE extends Plan> extends PhysicalSink<CHIL
         PhysicalFileSink<?> that = (PhysicalFileSink<?>) o;
         return Objects.equals(filePath, that.filePath)
                 && Objects.equals(format, that.format)
-                && Objects.equals(properties, that.properties);
+                && Objects.equals(properties, that.properties)
+                && beExecVersion == that.beExecVersion;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(filePath, format, properties);
+        return Objects.hash(filePath, format, properties, beExecVersion);
     }
 
     @Override
@@ -141,25 +165,26 @@ public class PhysicalFileSink<CHILD_TYPE extends Plan> extends PhysicalSink<CHIL
     @Override
     public Plan withGroupExpression(Optional<GroupExpression> groupExpression) {
         return AbstractPlan.copyWithSameId(this, () -> new PhysicalFileSink<>(outputExprs, filePath, format,
-                properties, groupExpression, getLogicalProperties(), child()));
+                properties, beExecVersion, groupExpression, getLogicalProperties(), child()));
     }
 
     @Override
     public Plan withGroupExprLogicalPropChildren(Optional<GroupExpression> groupExpression,
             Optional<LogicalProperties> logicalProperties, List<Plan> children) {
         return AbstractPlan.copyWithSameId(this, () -> new PhysicalFileSink<>(outputExprs, filePath, format,
-                properties, groupExpression, logicalProperties.get(), children.get(0)));
+                properties, beExecVersion, groupExpression, logicalProperties.get(), children.get(0)));
     }
 
     @Override
     public PhysicalPlan withPhysicalPropertiesAndStats(PhysicalProperties physicalProperties, Statistics statistics) {
         return AbstractPlan.copyWithSameId(this, () -> new PhysicalFileSink<>(outputExprs, filePath, format,
-                properties, groupExpression, getLogicalProperties(), physicalProperties, statistics, child()));
+                properties, beExecVersion, groupExpression, getLogicalProperties(), physicalProperties,
+                statistics, child()));
     }
 
     @Override
     public PhysicalFileSink<CHILD_TYPE> resetLogicalProperties() {
-        return new PhysicalFileSink<>(outputExprs, filePath, format, properties, groupExpression, null,
+        return new PhysicalFileSink<>(outputExprs, filePath, format, properties, beExecVersion, groupExpression, null,
                 physicalProperties, statistics, child());
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/CoordInterface.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/CoordInterface.java
@@ -40,6 +40,10 @@ public interface CoordInterface {
         throw new UnsupportedOperationException("Atomic OUTFILE finalization is not supported");
     }
 
+    public default long getOutfileTimeoutDeadline() {
+        throw new UnsupportedOperationException("Atomic OUTFILE deadline is not supported");
+    }
+
     List<TNetworkAddress> getInvolvedBackends();
 
     void setIsProfileSafeStmt(boolean isSafe);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/CoordInterface.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/CoordInterface.java
@@ -18,6 +18,7 @@
 package org.apache.doris.qe;
 
 import org.apache.doris.common.Status;
+import org.apache.doris.proto.InternalService.POutfileWriteOperation;
 import org.apache.doris.thrift.TNetworkAddress;
 
 import java.util.List;
@@ -34,7 +35,10 @@ public interface CoordInterface {
     // some resource.
     public default void close() {}
 
-    public default void finishOutfile(boolean success) throws Exception {}
+    public default void finishOutfile(POutfileWriteOperation operation) throws Exception {
+        // Atomic OUTFILE must never silently skip a coordinator implementation without receivers.
+        throw new UnsupportedOperationException("Atomic OUTFILE finalization is not supported");
+    }
 
     List<TNetworkAddress> getInvolvedBackends();
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/CoordInterface.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/CoordInterface.java
@@ -34,6 +34,8 @@ public interface CoordInterface {
     // some resource.
     public default void close() {}
 
+    public default void finishOutfile(boolean success) throws Exception {}
+
     List<TNetworkAddress> getInvolvedBackends();
 
     void setIsProfileSafeStmt(boolean isSafe);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -1459,6 +1459,38 @@ public class Coordinator implements CoordInterface {
         cancelLatch();
     }
 
+    @Override
+    public void finishOutfile(boolean success) throws Exception {
+        Map<TNetworkAddress, InternalService.POutfileWriteFinishedRequest.Builder> requests = new HashMap<>();
+        for (ResultReceiver receiver : receivers) {
+            requests.computeIfAbsent(receiver.getAddress(), address ->
+                            InternalService.POutfileWriteFinishedRequest.newBuilder().setSuccess(success))
+                    .addBufferIds(receiver.getRealFinstId());
+        }
+        Exception firstFailure = null;
+        for (Entry<TNetworkAddress, InternalService.POutfileWriteFinishedRequest.Builder> entry
+                : requests.entrySet()) {
+            try {
+                InternalService.POutfileWriteFinishedResult result = BackendServiceProxy.getInstance()
+                        .outfileWriteFinishedAsync(entry.getKey(), entry.getValue().build()).get();
+                Status status = new Status(result.getStatus());
+                if (!status.ok()) {
+                    throw new UserException(status.getErrorMsg());
+                }
+            } catch (Exception e) {
+                if (firstFailure == null) {
+                    firstFailure = e;
+                }
+                if (success) {
+                    break;
+                }
+            }
+        }
+        if (firstFailure != null) {
+            throw firstFailure;
+        }
+    }
+
     private void cancelRemoteFragmentsAsync(Status cancelReason) {
         for (PipelineExecContexts ctx : beToPipelineExecCtxs.values()) {
             LOG.debug("Cancel query {} on BE {}. Reason: {}", DebugUtil.printId(queryId), ctx.brpcAddr,

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -1465,6 +1465,10 @@ public class Coordinator implements CoordInterface {
         return receivers;
     }
 
+    protected long getOutfileTimeoutDeadline() {
+        return timeoutDeadline;
+    }
+
     @Override
     public void finishOutfile(InternalService.POutfileWriteOperation operation) throws Exception {
         Map<TNetworkAddress, InternalService.POutfileWriteFinishedRequest.Builder> requests = new HashMap<>();
@@ -1484,7 +1488,7 @@ public class Coordinator implements CoordInterface {
         long timeoutMs = operation == InternalService.POutfileWriteOperation.OUTFILE_ABORT
                 ? Math.max(1, Math.min(Config.remote_fragment_exec_timeout_ms, OUTFILE_CLEANUP_TIMEOUT_MS))
                 : Math.max(1, Math.min(Config.remote_fragment_exec_timeout_ms,
-                        timeoutDeadline - System.currentTimeMillis()));
+                        getOutfileTimeoutDeadline() - System.currentTimeMillis()));
         Map<TNetworkAddress, Future<InternalService.POutfileWriteFinishedResult>> futures = new HashMap<>();
         Exception firstFailure = null;
         for (Entry<TNetworkAddress, InternalService.POutfileWriteFinishedRequest.Builder> entry

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -19,7 +19,6 @@ package org.apache.doris.qe;
 
 import org.apache.doris.analysis.DescriptorTable;
 import org.apache.doris.analysis.DescriptorToThriftConverter;
-import org.apache.doris.analysis.OutFileClause;
 import org.apache.doris.analysis.StorageBackend;
 import org.apache.doris.catalog.AIResource;
 import org.apache.doris.catalog.Env;
@@ -1465,7 +1464,8 @@ public class Coordinator implements CoordInterface {
         return receivers;
     }
 
-    protected long getOutfileTimeoutDeadline() {
+    @Override
+    public long getOutfileTimeoutDeadline() {
         return timeoutDeadline;
     }
 
@@ -1477,9 +1477,8 @@ public class Coordinator implements CoordInterface {
                     receiver.getAddress(), address -> InternalService.POutfileWriteFinishedRequest.newBuilder()
                             // Old BEs ignore operation, so preserve their success field during upgrades.
                             .setSuccess(operation == InternalService.POutfileWriteOperation.OUTFILE_COMMIT));
-            if (Config.be_exec_version >= OutFileClause.SUPPORT_ATOMIC_OUTFILE_VERSION) {
-                request.setOperation(operation);
-            }
+            // This method is reached only when the query's snapshotted protocol supports it.
+            request.setOperation(operation);
             request.addBufferIds(receiver.getRealFinstId());
         }
         if (requests.isEmpty()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/Coordinator.java
@@ -19,6 +19,7 @@ package org.apache.doris.qe;
 
 import org.apache.doris.analysis.DescriptorTable;
 import org.apache.doris.analysis.DescriptorToThriftConverter;
+import org.apache.doris.analysis.OutFileClause;
 import org.apache.doris.analysis.StorageBackend;
 import org.apache.doris.catalog.AIResource;
 import org.apache.doris.catalog.Env;
@@ -186,6 +187,7 @@ import java.util.stream.Collectors;
 
 public class Coordinator implements CoordInterface {
     private static final Logger LOG = LogManager.getLogger(Coordinator.class);
+    private static final long OUTFILE_CLEANUP_TIMEOUT_MS = 5000;
 
     public static final String localIP = FrontendOptions.getLocalHostAddress();
 
@@ -1459,20 +1461,50 @@ public class Coordinator implements CoordInterface {
         cancelLatch();
     }
 
+    protected List<ResultReceiver> getOutfileResultReceivers() {
+        return receivers;
+    }
+
     @Override
-    public void finishOutfile(boolean success) throws Exception {
+    public void finishOutfile(InternalService.POutfileWriteOperation operation) throws Exception {
         Map<TNetworkAddress, InternalService.POutfileWriteFinishedRequest.Builder> requests = new HashMap<>();
-        for (ResultReceiver receiver : receivers) {
-            requests.computeIfAbsent(receiver.getAddress(), address ->
-                            InternalService.POutfileWriteFinishedRequest.newBuilder().setSuccess(success))
-                    .addBufferIds(receiver.getRealFinstId());
+        for (ResultReceiver receiver : getOutfileResultReceivers()) {
+            InternalService.POutfileWriteFinishedRequest.Builder request = requests.computeIfAbsent(
+                    receiver.getAddress(), address -> InternalService.POutfileWriteFinishedRequest.newBuilder()
+                            // Old BEs ignore operation, so preserve their success field during upgrades.
+                            .setSuccess(operation == InternalService.POutfileWriteOperation.OUTFILE_COMMIT));
+            if (Config.be_exec_version >= OutFileClause.SUPPORT_ATOMIC_OUTFILE_VERSION) {
+                request.setOperation(operation);
+            }
+            request.addBufferIds(receiver.getRealFinstId());
         }
+        if (requests.isEmpty()) {
+            throw new UserException("No OUTFILE result receiver participates in finalization");
+        }
+        long timeoutMs = operation == InternalService.POutfileWriteOperation.OUTFILE_ABORT
+                ? Math.max(1, Math.min(Config.remote_fragment_exec_timeout_ms, OUTFILE_CLEANUP_TIMEOUT_MS))
+                : Math.max(1, Math.min(Config.remote_fragment_exec_timeout_ms,
+                        timeoutDeadline - System.currentTimeMillis()));
+        Map<TNetworkAddress, Future<InternalService.POutfileWriteFinishedResult>> futures = new HashMap<>();
         Exception firstFailure = null;
         for (Entry<TNetworkAddress, InternalService.POutfileWriteFinishedRequest.Builder> entry
                 : requests.entrySet()) {
             try {
-                InternalService.POutfileWriteFinishedResult result = BackendServiceProxy.getInstance()
-                        .outfileWriteFinishedAsync(entry.getKey(), entry.getValue().build()).get();
+                futures.put(entry.getKey(), BackendServiceProxy.getInstance()
+                        .outfileWriteFinishedAsync(entry.getKey(), entry.getValue().build(), timeoutMs));
+            } catch (Exception e) {
+                // One unavailable backend must not prevent rollback from reaching other receivers.
+                if (firstFailure == null) {
+                    firstFailure = e;
+                }
+            }
+        }
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        for (Entry<TNetworkAddress, Future<InternalService.POutfileWriteFinishedResult>> entry
+                : futures.entrySet()) {
+            try {
+                InternalService.POutfileWriteFinishedResult result = entry.getValue()
+                        .get(Math.max(1, deadline - System.currentTimeMillis()), TimeUnit.MILLISECONDS);
                 Status status = new Status(result.getStatus());
                 if (!status.ok()) {
                     throw new UserException(status.getErrorMsg());
@@ -1480,9 +1512,6 @@ public class Coordinator implements CoordInterface {
             } catch (Exception e) {
                 if (firstFailure == null) {
                     firstFailure = e;
-                }
-                if (success) {
-                    break;
                 }
             }
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
@@ -544,6 +544,11 @@ public class NereidsCoordinator extends Coordinator {
         this.coordinatorContext.setJobProcessor(jobProc);
     }
 
+    @Override
+    protected List<ResultReceiver> getOutfileResultReceivers() {
+        return coordinatorContext.asQueryProcessor().getResultReceivers();
+    }
+
     private void setForBroker(
             CoordinatorContext coordinatorContext, PipelineDistributedPlan topPlan) throws AnalysisException {
         DataSink dataSink = coordinatorContext.dataSink;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
@@ -550,7 +550,7 @@ public class NereidsCoordinator extends Coordinator {
     }
 
     @Override
-    protected long getOutfileTimeoutDeadline() {
+    public long getOutfileTimeoutDeadline() {
         // Nereids owns its deadline in CoordinatorContext instead of the legacy Coordinator field.
         return coordinatorContext.timeoutDeadline.get();
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/NereidsCoordinator.java
@@ -549,6 +549,12 @@ public class NereidsCoordinator extends Coordinator {
         return coordinatorContext.asQueryProcessor().getResultReceivers();
     }
 
+    @Override
+    protected long getOutfileTimeoutDeadline() {
+        // Nereids owns its deadline in CoordinatorContext instead of the legacy Coordinator field.
+        return coordinatorContext.timeoutDeadline.get();
+    }
+
     private void setForBroker(
             CoordinatorContext coordinatorContext, PipelineDistributedPlan topPlan) throws AnalysisException {
         DataSink dataSink = coordinatorContext.dataSink;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ResultReceiver.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ResultReceiver.java
@@ -78,6 +78,10 @@ public class ResultReceiver {
         return instanceId;
     }
 
+    TNetworkAddress getAddress() {
+        return address;
+    }
+
     public void createFuture(
             FutureCallback<InternalService.PFetchDataResult> callback) throws RpcException {
         InternalService.PFetchDataRequest request = InternalService.PFetchDataRequest.newBuilder()

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -171,6 +171,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -180,6 +181,7 @@ import java.util.stream.Collectors;
 // first: Parse receive byte array to statement struct.
 // second: Do handle function for statement.
 public class StmtExecutor {
+    private static final long OUTFILE_CLEANUP_TIMEOUT_MS = 5000;
     private static final Logger LOG = LogManager.getLogger(StmtExecutor.class);
 
     private static final AtomicLong STMT_ID_GENERATOR = new AtomicLong(0);
@@ -1519,9 +1521,18 @@ public class StmtExecutor {
         if (isOutfileQuery) {
             outFileClause = queryStmt.getOutFileClause();
             Preconditions.checkState(outFileClause != null, "OUTFILE query must have OutFileClause");
+            if (Config.be_exec_version >= OutFileClause.SUPPORT_ATOMIC_OUTFILE_VERSION
+                    && context.getConnectType().equals(ConnectType.ARROW_FLIGHT_SQL)) {
+                throw new UserException("Atomic OUTFILE is not supported over Arrow Flight SQL");
+            }
         }
 
+        boolean atomicOutfile = isOutfileQuery
+                && Config.be_exec_version >= OutFileClause.SUPPORT_ATOMIC_OUTFILE_VERSION;
         boolean outfileCommitted = false;
+        boolean outfileMarkerMayExist = false;
+        TNetworkAddress outfileMarkerBackend = null;
+        List<ByteBuffer> deferredOutfileRows = new ArrayList<>();
         try {
             if (outFileClause != null) {
                 deleteExistingOutfileFilesInFe(outFileClause);
@@ -1570,17 +1581,25 @@ public class StmtExecutor {
                     // For some language driver, getting error packet after fields packet
                     // will be recognized as a success result
                     // so We need to send fields after first batch arrived
-                    if (!isSendFields) {
+                    if (!isSendFields && !atomicOutfile) {
                         if (!isOutfileQuery) {
                             sendFields(queryStmt.getColLabels(), queryStmt.getFieldInfos(),
                                     getReturnTypes(queryStmt));
                         } else {
+                            if (!Strings.isNullOrEmpty(outFileClause.getSuccessFileName())) {
+                                outfileWriteSuccess(outFileClause, selectOutfileSuccessBackend(),
+                                        InternalService.POutfileSuccessOperation.OUTFILE_MARKER_CREATE);
+                            }
                             sendFields(OutFileClause.RESULT_COL_NAMES, OutFileClause.RESULT_COL_TYPES);
                         }
                         isSendFields = true;
                     }
-                    for (ByteBuffer row : batch.getBatch().getRows()) {
-                        channel.sendOnePacket(row);
+                    if (atomicOutfile) {
+                        deferredOutfileRows.addAll(batch.getBatch().getRows());
+                    } else {
+                        for (ByteBuffer row : batch.getBatch().getRows()) {
+                            channel.sendOnePacket(row);
+                        }
                     }
                     profile.getSummaryProfile().freshWriteResultConsumeTime();
                     context.updateReturnRows(batch.getBatch().getRows().size());
@@ -1591,11 +1610,31 @@ public class StmtExecutor {
                 }
             }
             if (isOutfileQuery) {
-                coordBase.finishOutfile(true);
-                if (!Strings.isNullOrEmpty(outFileClause.getSuccessFileName())) {
-                    outfileWriteSuccess(outFileClause);
+                if (atomicOutfile) {
+                    coordBase.finishOutfile(InternalService.POutfileWriteOperation.OUTFILE_PREPARE);
                 }
+                if (atomicOutfile && !Strings.isNullOrEmpty(outFileClause.getSuccessFileName())) {
+                    outfileMarkerBackend = selectOutfileSuccessBackend();
+                    // The create response may be lost after the marker is durable, so rollback must
+                    // conservatively delete it whenever this call does not complete successfully.
+                    outfileMarkerMayExist = true;
+                    outfileWriteSuccess(outFileClause, outfileMarkerBackend,
+                            InternalService.POutfileSuccessOperation.OUTFILE_MARKER_CREATE);
+                }
+                // This also carries the legacy success acknowledgement needed by old BEs during
+                // rolling upgrades; atomic-capable BEs interpret it as the global COMMIT phase.
+                coordBase.finishOutfile(InternalService.POutfileWriteOperation.OUTFILE_COMMIT);
                 outfileCommitted = true;
+                outfileMarkerMayExist = false;
+                if (atomicOutfile) {
+                    if (!isSendFields) {
+                        sendFields(OutFileClause.RESULT_COL_NAMES, OutFileClause.RESULT_COL_TYPES);
+                        isSendFields = true;
+                    }
+                    for (ByteBuffer row : deferredOutfileRows) {
+                        channel.sendOnePacket(row);
+                    }
+                }
             }
             if (cacheAnalyzer != null && !isDryRun) {
                 if (cacheResult != null && cacheAnalyzer.getHitRange() == Cache.HitRange.Right) {
@@ -1648,7 +1687,10 @@ public class StmtExecutor {
                     DebugUtil.printId(context.queryId()));
             LOG.warn(internalErrorSt.getErrorMsg());
             if (isOutfileQuery && !outfileCommitted) {
-                abortOutfile(coordBase);
+                abortOutfile(coordBase, atomicOutfile);
+                if (outfileMarkerMayExist) {
+                    deleteOutfileMarker(outFileClause, outfileMarkerBackend);
+                }
             }
             coordBase.cancel(internalErrorSt);
             throw e;
@@ -1661,7 +1703,10 @@ public class StmtExecutor {
                     DebugUtil.printId(context.queryId()), e.getMessage());
             LOG.warn(internalErrorSt.getErrorMsg());
             if (isOutfileQuery && !outfileCommitted) {
-                abortOutfile(coordBase);
+                abortOutfile(coordBase, atomicOutfile);
+                if (outfileMarkerMayExist) {
+                    deleteOutfileMarker(outFileClause, outfileMarkerBackend);
+                }
             }
             coordBase.cancel(internalErrorSt);
             // set to null so that the retry logic will generate a new coordinator
@@ -1677,16 +1722,46 @@ public class StmtExecutor {
         }
     }
 
-    private void abortOutfile(CoordInterface coordBase) {
+    private void abortOutfile(CoordInterface coordBase, boolean atomicOutfile) {
+        if (!atomicOutfile) {
+            return;
+        }
         try {
-            coordBase.finishOutfile(false);
+            coordBase.finishOutfile(InternalService.POutfileWriteOperation.OUTFILE_ABORT);
         } catch (Exception cleanupError) {
             // Cleanup diagnostics must not hide the execution error that caused the rollback.
             LOG.warn("Failed to clean up files from aborted OUTFILE query", cleanupError);
         }
     }
 
-    private void outfileWriteSuccess(OutFileClause outFileClause) throws Exception {
+    private TNetworkAddress selectOutfileSuccessBackend() throws AnalysisException {
+        for (Backend be : Env.getCurrentSystemInfo().getBackendsByCurrentCluster().values()) {
+            if (be.isAlive()) {
+                return new TNetworkAddress(be.getHost(), be.getBrpcPort());
+            }
+        }
+        String computeGroupHints = "";
+        if (Config.isCloudMode()) {
+            computeGroupHints = ComputeGroupMgr.computeGroupNotFoundPromptMsg(null);
+        }
+        throw new AnalysisException("No Alive backends" + computeGroupHints);
+    }
+
+    private void deleteOutfileMarker(OutFileClause outFileClause, TNetworkAddress address) {
+        for (int attempt = 0; attempt < 3; ++attempt) {
+            try {
+                outfileWriteSuccess(outFileClause, address,
+                        InternalService.POutfileSuccessOperation.OUTFILE_MARKER_DELETE);
+                return;
+            } catch (Exception cleanupError) {
+                LOG.warn("Failed to remove OUTFILE success marker during rollback, attempt {}",
+                        attempt + 1, cleanupError);
+            }
+        }
+    }
+
+    private void outfileWriteSuccess(OutFileClause outFileClause, TNetworkAddress address,
+            InternalService.POutfileSuccessOperation operation) throws Exception {
         // 1. set TResultFileSinkOptions
         TResultFileSinkOptions sinkOptions = outFileClause.toSinkOptions();
 
@@ -1706,28 +1781,17 @@ public class StmtExecutor {
         sink.setStorageBackendType(storageType.toThrift());
 
         // 4. get BE
-        TNetworkAddress address = null;
-        for (Backend be : Env.getCurrentSystemInfo().getBackendsByCurrentCluster().values()) {
-            if (be.isAlive()) {
-                address = new TNetworkAddress(be.getHost(), be.getBrpcPort());
-                break;
-            }
-        }
-        if (address == null) {
-            String computeGroupHints = "";
-            if (Config.isCloudMode()) {
-                // null: computeGroupNotFoundPromptMsg select cluster for hint msg
-                computeGroupHints = ComputeGroupMgr.computeGroupNotFoundPromptMsg(null);
-            }
-            throw new AnalysisException("No Alive backends" + computeGroupHints);
-        }
-
         // 5. send rpc to BE
         POutfileWriteSuccessRequest request = POutfileWriteSuccessRequest.newBuilder()
-                .setResultFileSink(ByteString.copyFrom(new TSerializer().serialize(sink))).build();
+                .setResultFileSink(ByteString.copyFrom(new TSerializer().serialize(sink)))
+                .setOperation(operation)
+                .setMarkerToken(DebugUtil.printId(context.queryId())).build();
+        long timeoutMs = operation == InternalService.POutfileSuccessOperation.OUTFILE_MARKER_DELETE
+                ? Math.max(1, Math.min(Config.remote_fragment_exec_timeout_ms, OUTFILE_CLEANUP_TIMEOUT_MS))
+                : Math.max(1, Config.remote_fragment_exec_timeout_ms);
         Future<POutfileWriteSuccessResult> future = BackendServiceProxy.getInstance()
-                .outfileWriteSuccessAsync(address, request);
-        POutfileWriteSuccessResult result = future.get();
+                .outfileWriteSuccessAsync(address, request, timeoutMs);
+        POutfileWriteSuccessResult result = future.get(timeoutMs, TimeUnit.MILLISECONDS);
         TStatusCode code = TStatusCode.findByValue(result.getStatus().getStatusCode());
         String errMsg;
         if (code != TStatusCode.OK) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1521,6 +1521,7 @@ public class StmtExecutor {
             Preconditions.checkState(outFileClause != null, "OUTFILE query must have OutFileClause");
         }
 
+        boolean outfileCommitted = false;
         try {
             if (outFileClause != null) {
                 deleteExistingOutfileFilesInFe(outFileClause);
@@ -1574,9 +1575,6 @@ public class StmtExecutor {
                             sendFields(queryStmt.getColLabels(), queryStmt.getFieldInfos(),
                                     getReturnTypes(queryStmt));
                         } else {
-                            if (!Strings.isNullOrEmpty(outFileClause.getSuccessFileName())) {
-                                outfileWriteSuccess(outFileClause);
-                            }
                             sendFields(OutFileClause.RESULT_COL_NAMES, OutFileClause.RESULT_COL_TYPES);
                         }
                         isSendFields = true;
@@ -1591,6 +1589,13 @@ public class StmtExecutor {
                 if (batch.isEos()) {
                     break;
                 }
+            }
+            if (isOutfileQuery) {
+                coordBase.finishOutfile(true);
+                if (!Strings.isNullOrEmpty(outFileClause.getSuccessFileName())) {
+                    outfileWriteSuccess(outFileClause);
+                }
+                outfileCommitted = true;
             }
             if (cacheAnalyzer != null && !isDryRun) {
                 if (cacheResult != null && cacheAnalyzer.getHitRange() == Cache.HitRange.Right) {
@@ -1642,6 +1647,9 @@ public class StmtExecutor {
                     "cancel fragment query_id:{} cause query timeout",
                     DebugUtil.printId(context.queryId()));
             LOG.warn(internalErrorSt.getErrorMsg());
+            if (isOutfileQuery && !outfileCommitted) {
+                abortOutfile(coordBase);
+            }
             coordBase.cancel(internalErrorSt);
             throw e;
         } catch (Exception e) {
@@ -1652,6 +1660,9 @@ public class StmtExecutor {
                     "cancel fragment query_id:{} cause {}",
                     DebugUtil.printId(context.queryId()), e.getMessage());
             LOG.warn(internalErrorSt.getErrorMsg());
+            if (isOutfileQuery && !outfileCommitted) {
+                abortOutfile(coordBase);
+            }
             coordBase.cancel(internalErrorSt);
             // set to null so that the retry logic will generate a new coordinator
             this.coord = null;
@@ -1663,6 +1674,15 @@ public class StmtExecutor {
             if (!deferredForArrowFlight) {
                 coordBase.close();
             }
+        }
+    }
+
+    private void abortOutfile(CoordInterface coordBase) {
+        try {
+            coordBase.finishOutfile(false);
+        } catch (Exception cleanupError) {
+            // Cleanup diagnostics must not hide the execution error that caused the rollback.
+            LOG.warn("Failed to clean up files from aborted OUTFILE query", cleanupError);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1611,22 +1611,24 @@ public class StmtExecutor {
             }
             if (isOutfileQuery) {
                 if (atomicOutfile) {
-                    coordBase.finishOutfile(InternalService.POutfileWriteOperation.OUTFILE_PREPARE);
+                    if (!Strings.isNullOrEmpty(outFileClause.getSuccessFileName())) {
+                        outfileMarkerBackend = selectOutfileSuccessBackend();
+                        // Establish rollback intent before entering the fallible finalization sequence:
+                        // a lost marker response must still trigger a conservative marker deletion.
+                        outfileMarkerMayExist = true;
+                    }
                 }
-                if (atomicOutfile && !Strings.isNullOrEmpty(outFileClause.getSuccessFileName())) {
-                    outfileMarkerBackend = selectOutfileSuccessBackend();
-                    // The create response may be lost after the marker is durable, so rollback must
-                    // conservatively delete it whenever this call does not complete successfully.
-                    outfileMarkerMayExist = true;
-                    outfileWriteSuccess(outFileClause, outfileMarkerBackend,
-                            InternalService.POutfileSuccessOperation.OUTFILE_MARKER_CREATE);
-                }
-                // This also carries the legacy success acknowledgement needed by old BEs during
-                // rolling upgrades; atomic-capable BEs interpret it as the global COMMIT phase.
-                coordBase.finishOutfile(InternalService.POutfileWriteOperation.OUTFILE_COMMIT);
-                outfileCommitted = true;
-                outfileMarkerMayExist = false;
+                OutFileClause finalOutFileClause = outFileClause;
+                TNetworkAddress finalMarkerBackend = outfileMarkerBackend;
+                finishOutfileTransaction(atomicOutfile, coordBase, () -> {
+                    if (finalMarkerBackend != null) {
+                        outfileWriteSuccess(finalOutFileClause, finalMarkerBackend,
+                                InternalService.POutfileSuccessOperation.OUTFILE_MARKER_CREATE);
+                    }
+                });
                 if (atomicOutfile) {
+                    outfileCommitted = true;
+                    outfileMarkerMayExist = false;
                     if (!isSendFields) {
                         sendFields(OutFileClause.RESULT_COL_NAMES, OutFileClause.RESULT_COL_TYPES);
                         isSendFields = true;
@@ -1720,6 +1722,23 @@ public class StmtExecutor {
                 coordBase.close();
             }
         }
+    }
+
+    @FunctionalInterface
+    interface OutfileMarkerPublisher {
+        void publish() throws Exception;
+    }
+
+    static void finishOutfileTransaction(boolean atomicOutfile, CoordInterface coordBase,
+            OutfileMarkerPublisher markerPublisher) throws Exception {
+        if (!atomicOutfile) {
+            return;
+        }
+        coordBase.finishOutfile(InternalService.POutfileWriteOperation.OUTFILE_PREPARE);
+        // COMMIT acknowledgements remain compensatable until the marker is published, so any
+        // receiver or marker failure can still roll the distributed OUTFILE back as one unit.
+        coordBase.finishOutfile(InternalService.POutfileWriteOperation.OUTFILE_COMMIT);
+        markerPublisher.publish();
     }
 
     private void abortOutfile(CoordInterface coordBase, boolean atomicOutfile) {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1092,10 +1092,22 @@ public class StmtExecutor {
         }
     }
 
+    @FunctionalInterface
+    interface QueryAttempt {
+        void execute() throws Exception;
+    }
+
     private void handleQueryWithRetry(TUniqueId queryId) throws Exception {
+        handleQueryWithRetry(queryId, this::handleQueryStmt);
+    }
+
+    void handleQueryWithRetry(TUniqueId queryId, QueryAttempt queryAttempt) throws Exception {
         // queue query here
         int retryTime = Config.max_query_retry_time;
         retryTime = retryTime <= 0 ? 1 : retryTime + 1;
+        OutFileClause retryOutfileClause = parsedStmt instanceof Queriable
+                ? ((Queriable) parsedStmt).getOutFileClause() : null;
+        boolean atomicOutfile = retryOutfileClause != null && retryOutfileClause.isAtomicOutfileEnabled();
         for (int i = 0; i < retryTime; i++) {
             try {
                 // reset query id for each retry
@@ -1133,7 +1145,7 @@ public class StmtExecutor {
                 if (context.getConnectType() == ConnectType.ARROW_FLIGHT_SQL) {
                     context.setReturnResultFromLocal(false);
                 }
-                handleQueryStmt();
+                queryAttempt.execute();
                 LOG.info("Query {} finished", DebugUtil.printId(context.queryId));
                 break;
             } catch (RpcException | UserException e) {
@@ -1144,6 +1156,10 @@ public class StmtExecutor {
                 }
                 // If the previous try is timeout or cancelled, then do not need try again.
                 if (this.coord != null && (this.coord.isQueryCancelled() || this.coord.isTimeout())) {
+                    throw e;
+                }
+                // A failed atomic attempt may still own late files, so it must not overlap a retry.
+                if (atomicOutfile) {
                     throw e;
                 }
                 LOG.warn("retry due to exception {}. retried {} times. is rpc error: {}, is user error: {}.",

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -1490,6 +1490,15 @@ public class StmtExecutor {
         //          Query OK, 10 rows affected (0.01 sec)
         //
         // 2. If this is a query, send the result expr fields first, and send result data back to client.
+        OutFileClause outFileClause = null;
+        if (isOutfileQuery) {
+            outFileClause = queryStmt.getOutFileClause();
+            Preconditions.checkState(outFileClause != null, "OUTFILE query must have OutFileClause");
+        }
+        boolean atomicOutfile = outFileClause != null && outFileClause.isAtomicOutfileEnabled();
+        // Reject before coordinator construction because registration is outside the cleanup try/finally.
+        validateAtomicOutfileConnectType(atomicOutfile, context.getConnectType());
+
         RowBatch batch;
         CoordInterface coordBase = null;
         if (statementContext.isShortCircuitQuery()) {
@@ -1516,19 +1525,11 @@ public class StmtExecutor {
             coordBase = coord;
         }
 
-        coordBase.setIsProfileSafeStmt(this.isProfileSafeStmt());
-        OutFileClause outFileClause = null;
-        if (isOutfileQuery) {
-            outFileClause = queryStmt.getOutFileClause();
-            Preconditions.checkState(outFileClause != null, "OUTFILE query must have OutFileClause");
-            if (Config.be_exec_version >= OutFileClause.SUPPORT_ATOMIC_OUTFILE_VERSION
-                    && context.getConnectType().equals(ConnectType.ARROW_FLIGHT_SQL)) {
-                throw new UserException("Atomic OUTFILE is not supported over Arrow Flight SQL");
-            }
+        if (outFileClause != null && coordBase instanceof Coordinator) {
+            // Keep the BE query option aligned with the sink option captured while planning this query.
+            ((Coordinator) coordBase).getQueryOptions().setBeExecVersion(outFileClause.getBeExecVersion());
         }
-
-        boolean atomicOutfile = isOutfileQuery
-                && Config.be_exec_version >= OutFileClause.SUPPORT_ATOMIC_OUTFILE_VERSION;
+        coordBase.setIsProfileSafeStmt(this.isProfileSafeStmt());
         boolean outfileCommitted = false;
         boolean outfileMarkerMayExist = false;
         TNetworkAddress outfileMarkerBackend = null;
@@ -1620,10 +1621,12 @@ public class StmtExecutor {
                 }
                 OutFileClause finalOutFileClause = outFileClause;
                 TNetworkAddress finalMarkerBackend = outfileMarkerBackend;
+                long outfileDeadlineMs = atomicOutfile ? coordBase.getOutfileTimeoutDeadline() : Long.MAX_VALUE;
                 finishOutfileTransaction(atomicOutfile, coordBase, () -> {
                     if (finalMarkerBackend != null) {
                         outfileWriteSuccess(finalOutFileClause, finalMarkerBackend,
-                                InternalService.POutfileSuccessOperation.OUTFILE_MARKER_CREATE);
+                                InternalService.POutfileSuccessOperation.OUTFILE_MARKER_CREATE,
+                                outfileDeadlineMs);
                     }
                 });
                 if (atomicOutfile) {
@@ -1729,6 +1732,22 @@ public class StmtExecutor {
         void publish() throws Exception;
     }
 
+    static void validateAtomicOutfileConnectType(boolean atomicOutfile, ConnectType connectType)
+            throws UserException {
+        if (atomicOutfile && ConnectType.ARROW_FLIGHT_SQL.equals(connectType)) {
+            throw new UserException("Atomic OUTFILE is not supported over Arrow Flight SQL");
+        }
+    }
+
+    static long calculateOutfileCreateTimeoutMs(long deadlineMs, long nowMs, long maxTimeoutMs)
+            throws QueryTimeoutException {
+        long remainingMs = deadlineMs - nowMs;
+        if (remainingMs <= 0) {
+            throw new QueryTimeoutException();
+        }
+        return Math.min(remainingMs, maxTimeoutMs);
+    }
+
     static void finishOutfileTransaction(boolean atomicOutfile, CoordInterface coordBase,
             OutfileMarkerPublisher markerPublisher) throws Exception {
         if (!atomicOutfile) {
@@ -1781,6 +1800,11 @@ public class StmtExecutor {
 
     private void outfileWriteSuccess(OutFileClause outFileClause, TNetworkAddress address,
             InternalService.POutfileSuccessOperation operation) throws Exception {
+        outfileWriteSuccess(outFileClause, address, operation, Long.MAX_VALUE);
+    }
+
+    private void outfileWriteSuccess(OutFileClause outFileClause, TNetworkAddress address,
+            InternalService.POutfileSuccessOperation operation, long deadlineMs) throws Exception {
         // 1. set TResultFileSinkOptions
         TResultFileSinkOptions sinkOptions = outFileClause.toSinkOptions();
 
@@ -1805,9 +1829,15 @@ public class StmtExecutor {
                 .setResultFileSink(ByteString.copyFrom(new TSerializer().serialize(sink)))
                 .setOperation(operation)
                 .setMarkerToken(DebugUtil.printId(context.queryId())).build();
-        long timeoutMs = operation == InternalService.POutfileSuccessOperation.OUTFILE_MARKER_DELETE
-                ? Math.max(1, Math.min(Config.remote_fragment_exec_timeout_ms, OUTFILE_CLEANUP_TIMEOUT_MS))
-                : Math.max(1, Config.remote_fragment_exec_timeout_ms);
+        long timeoutMs;
+        if (operation == InternalService.POutfileSuccessOperation.OUTFILE_MARKER_DELETE) {
+            timeoutMs = Math.max(1, Math.min(Config.remote_fragment_exec_timeout_ms, OUTFILE_CLEANUP_TIMEOUT_MS));
+        } else if (deadlineMs == Long.MAX_VALUE) {
+            timeoutMs = Math.max(1, Config.remote_fragment_exec_timeout_ms);
+        } else {
+            timeoutMs = calculateOutfileCreateTimeoutMs(deadlineMs, System.currentTimeMillis(),
+                    Math.max(1, Config.remote_fragment_exec_timeout_ms));
+        }
         Future<POutfileWriteSuccessResult> future = BackendServiceProxy.getInstance()
                 .outfileWriteSuccessAsync(address, request, timeoutMs);
         POutfileWriteSuccessResult result = future.get(timeoutMs, TimeUnit.MILLISECONDS);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/QueryProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/runtime/QueryProcessor.java
@@ -56,11 +56,14 @@ public class QueryProcessor extends AbstractJobProcessor {
 
     // mutable field
     private ResultReceiverConsumer receiverConsumer;
+    private final List<ResultReceiver> receivers;
 
     private long numReceivedRows;
 
-    public QueryProcessor(CoordinatorContext coordinatorContext, ResultReceiverConsumer consumer) {
+    public QueryProcessor(CoordinatorContext coordinatorContext, List<ResultReceiver> receivers,
+            ResultReceiverConsumer consumer) {
         super(coordinatorContext);
+        this.receivers = receivers;
         receiverConsumer = consumer;
 
         this.limitRows = coordinatorContext.fragments.get(0)
@@ -110,7 +113,11 @@ public class QueryProcessor extends AbstractJobProcessor {
         }
         ResultReceiverConsumer consumer = new ResultReceiverConsumer(receivers,
                 coordinatorContext.timeoutDeadline.get());
-        return new QueryProcessor(coordinatorContext, consumer);
+        return new QueryProcessor(coordinatorContext, receivers, consumer);
+    }
+
+    public List<ResultReceiver> getResultReceivers() {
+        return receivers;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
@@ -109,13 +109,13 @@ public class BackendServiceClient {
     }
 
     public Future<InternalService.POutfileWriteSuccessResult> outfileWriteSuccessAsync(
-            InternalService.POutfileWriteSuccessRequest request) {
-        return stub.outfileWriteSuccess(request);
+            InternalService.POutfileWriteSuccessRequest request, long timeoutMs) {
+        return stub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).outfileWriteSuccess(request);
     }
 
     public Future<InternalService.POutfileWriteFinishedResult> outfileWriteFinishedAsync(
-            InternalService.POutfileWriteFinishedRequest request) {
-        return stub.outfileWriteFinished(request);
+            InternalService.POutfileWriteFinishedRequest request, long timeoutMs) {
+        return stub.withDeadlineAfter(timeoutMs, TimeUnit.MILLISECONDS).outfileWriteFinished(request);
     }
 
     public Future<InternalService.PFetchTableSchemaResult> fetchTableStructureAsync(

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
@@ -113,6 +113,11 @@ public class BackendServiceClient {
         return stub.outfileWriteSuccess(request);
     }
 
+    public Future<InternalService.POutfileWriteFinishedResult> outfileWriteFinishedAsync(
+            InternalService.POutfileWriteFinishedRequest request) {
+        return stub.outfileWriteFinished(request);
+    }
+
     public Future<InternalService.PFetchTableSchemaResult> fetchTableStructureAsync(
             InternalService.PFetchTableSchemaRequest request) {
         return stub.fetchTableSchema(request);

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
@@ -346,6 +346,17 @@ public class BackendServiceProxy {
         }
     }
 
+    public Future<InternalService.POutfileWriteFinishedResult> outfileWriteFinishedAsync(TNetworkAddress address,
+            InternalService.POutfileWriteFinishedRequest request) throws RpcException {
+        try {
+            return getProxy(address).outfileWriteFinishedAsync(request);
+        } catch (Throwable e) {
+            LOG.warn("outfile write finished catch an exception, address={}:{}",
+                    address.getHostname(), address.getPort(), e);
+            throw new RpcException(address.hostname, e.getMessage());
+        }
+    }
+
     public Future<InternalService.PFetchTableSchemaResult> fetchTableStructureAsync(
             TNetworkAddress address, InternalService.PFetchTableSchemaRequest request) throws RpcException {
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
@@ -335,10 +335,10 @@ public class BackendServiceProxy {
     }
 
     public Future<InternalService.POutfileWriteSuccessResult> outfileWriteSuccessAsync(TNetworkAddress address,
-            InternalService.POutfileWriteSuccessRequest request)  throws RpcException {
+            InternalService.POutfileWriteSuccessRequest request, long timeoutMs) throws RpcException {
         try {
             final BackendServiceClient client = getProxy(address);
-            return client.outfileWriteSuccessAsync(request);
+            return client.outfileWriteSuccessAsync(request, timeoutMs);
         } catch (Throwable e) {
             LOG.warn("outfile write success file catch a exception, address={}:{}",
                     address.getHostname(), address.getPort(), e);
@@ -347,9 +347,9 @@ public class BackendServiceProxy {
     }
 
     public Future<InternalService.POutfileWriteFinishedResult> outfileWriteFinishedAsync(TNetworkAddress address,
-            InternalService.POutfileWriteFinishedRequest request) throws RpcException {
+            InternalService.POutfileWriteFinishedRequest request, long timeoutMs) throws RpcException {
         try {
-            return getProxy(address).outfileWriteFinishedAsync(request);
+            return getProxy(address).outfileWriteFinishedAsync(request, timeoutMs);
         } catch (Throwable e) {
             LOG.warn("outfile write finished catch an exception, address={}:{}",
                     address.getHostname(), address.getPort(), e);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/OutFileTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/OutFileTest.java
@@ -17,13 +17,17 @@
 
 package org.apache.doris.nereids.trees.plans;
 
+import org.apache.doris.analysis.OutFileClause;
+import org.apache.doris.common.Config;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.nereids.glue.LogicalPlanAdapter;
 import org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator;
 import org.apache.doris.nereids.glue.translator.PlanTranslatorContext;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.physical.PhysicalPlan;
 import org.apache.doris.nereids.util.MemoTestUtils;
 import org.apache.doris.nereids.util.PlanPatternMatchSupported;
@@ -95,6 +99,37 @@ public class OutFileTest extends TestWithFeService implements PlanPatternMatchSu
         field.setAccessible(true);
         TResultFileSinkOptions sinkOptions = (TResultFileSinkOptions) field.get(fragment.getSink());
         Assertions.assertEquals("hdfs://127.0.0.1:8020", sinkOptions.getBrokerProperties().get("fs.defaultFS"));
+    }
+
+    @Test
+    public void testOutfileCapabilitySurvivesConfigChangeBetweenParsingAndPlanning() throws Exception {
+        int originalVersion = Config.be_exec_version;
+        boolean originalEnableOutfileToLocal = Config.enable_outfile_to_local;
+        try {
+            Config.enable_outfile_to_local = true;
+            Config.be_exec_version = OutFileClause.SUPPORT_ATOMIC_OUTFILE_VERSION;
+            String sql = "select * from T1 into outfile 'file:///tmp/outfile-snapshot/' format as csv";
+            StatementScopeIdGenerator.clear();
+            StatementContext statementContext = MemoTestUtils.createStatementContext(connectContext, sql);
+            LogicalPlan parsedPlan = parser.parseSingle(sql);
+            LogicalPlanAdapter adapter = new LogicalPlanAdapter(parsedPlan, statementContext);
+            Assertions.assertTrue(adapter.getOutFileClause().isAtomicOutfileEnabled());
+
+            Config.be_exec_version = OutFileClause.SUPPORT_ATOMIC_OUTFILE_VERSION - 1;
+            NereidsPlanner planner = new NereidsPlanner(statementContext);
+            PhysicalPlan physicalPlan = planner.planWithLock(parsedPlan, PhysicalProperties.ANY);
+            PlanFragment fragment = new PhysicalPlanTranslator(
+                    new PlanTranslatorContext(planner.getCascadesContext())).translatePlan(physicalPlan);
+            Field field = ResultFileSink.class.getDeclaredField("fileSinkOptions");
+            field.setAccessible(true);
+            TResultFileSinkOptions sinkOptions = (TResultFileSinkOptions) field.get(fragment.getSink());
+
+            Assertions.assertTrue(sinkOptions.isEnableAtomicOutfile());
+            Assertions.assertTrue(adapter.getOutFileClause().isAtomicOutfileEnabled());
+        } finally {
+            Config.be_exec_version = originalVersion;
+            Config.enable_outfile_to_local = originalEnableOutfileToLocal;
+        }
     }
 
     private PlanFragment getOutputFragment(String sql) throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/OutFileTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/OutFileTest.java
@@ -102,7 +102,7 @@ public class OutFileTest extends TestWithFeService implements PlanPatternMatchSu
     }
 
     @Test
-    public void testOutfileCapabilitySurvivesConfigChangeBetweenParsingAndPlanning() throws Exception {
+    public void testOutfileCapabilitySurvivesConfigChangeAfterPlanning() throws Exception {
         int originalVersion = Config.be_exec_version;
         boolean originalEnableOutfileToLocal = Config.enable_outfile_to_local;
         try {
@@ -115,9 +115,10 @@ public class OutFileTest extends TestWithFeService implements PlanPatternMatchSu
             LogicalPlanAdapter adapter = new LogicalPlanAdapter(parsedPlan, statementContext);
             Assertions.assertTrue(adapter.getOutFileClause().isAtomicOutfileEnabled());
 
-            Config.be_exec_version = OutFileClause.SUPPORT_ATOMIC_OUTFILE_VERSION - 1;
             NereidsPlanner planner = new NereidsPlanner(statementContext);
             PhysicalPlan physicalPlan = planner.planWithLock(parsedPlan, PhysicalProperties.ANY);
+
+            Config.be_exec_version = OutFileClause.SUPPORT_ATOMIC_OUTFILE_VERSION - 1;
             PlanFragment fragment = new PhysicalPlanTranslator(
                     new PlanTranslatorContext(planner.getCascadesContext())).translatePlan(physicalPlan);
             Field field = ResultFileSink.class.getDeclaredField("fileSinkOptions");

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/NereidsCoordinatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/NereidsCoordinatorTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.UUID;
 
 public class NereidsCoordinatorTest extends TestWithFeService {
@@ -59,6 +60,18 @@ public class NereidsCoordinatorTest extends TestWithFeService {
                 .createCoordinator(connectContext, planner, null);
         int scanRangeNum = coordinator.getScanRangeNum();
         Assertions.assertEquals(0, scanRangeNum);
+    }
+
+    @Test
+    public void testOutfileFinalizationUsesNereidsDeadline() throws Exception {
+        NereidsPlanner planner = plan("select * from test.tbl");
+        NereidsCoordinator coordinator = (NereidsCoordinator) EnvFactory.getInstance()
+                .createCoordinator(connectContext, planner, null);
+        Field legacyDeadline = Coordinator.class.getDeclaredField("timeoutDeadline");
+        legacyDeadline.setAccessible(true);
+        Assertions.assertEquals(0L, legacyDeadline.getLong(coordinator));
+
+        Assertions.assertTrue(coordinator.getOutfileTimeoutDeadline() > System.currentTimeMillis());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -31,12 +31,14 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.authenticate.TestLogAppender;
+import org.apache.doris.nereids.glue.LogicalPlanAdapter;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.planner.ResultFileSink;
 import org.apache.doris.proto.InternalService;
 import org.apache.doris.qe.CommonResultSet.CommonResultSetMetaData;
 import org.apache.doris.qe.ConnectContext.ConnectType;
+import org.apache.doris.rpc.RpcException;
 import org.apache.doris.thrift.TQueryOptions;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.utframe.TestWithFeService;
@@ -211,6 +213,50 @@ public class StmtExecutorTest extends TestWithFeService {
         Assertions.assertEquals(100L, StmtExecutor.calculateOutfileCreateTimeoutMs(1200L, 1000L, 100L));
         Assertions.assertThrows(QueryTimeoutException.class,
                 () -> StmtExecutor.calculateOutfileCreateTimeoutMs(1000L, 1000L, 100L));
+    }
+
+    @Test
+    public void testAtomicOutfileRpcFailureDoesNotRetry() throws Exception {
+        int originalVersion = Config.be_exec_version;
+        int originalRetryTime = Config.max_query_retry_time;
+        String originalCloudUniqueId = Config.cloud_unique_id;
+        String originalDeployMode = Config.deploy_mode;
+        TUniqueId originalQueryId = connectContext.queryId();
+        org.apache.doris.nereids.StatementContext originalStatementContext = connectContext.getStatementContext();
+        try {
+            Config.be_exec_version = OutFileClause.SUPPORT_ATOMIC_OUTFILE_VERSION;
+            Config.max_query_retry_time = 1;
+            Config.cloud_unique_id = "";
+            Config.deploy_mode = "";
+            OutFileClause outFileClause = new OutFileClause("file:///tmp/retry-outfile/", "csv",
+                    Collections.emptyMap());
+            outFileClause.toSinkOptions();
+            LogicalPlanAdapter query = Mockito.mock(LogicalPlanAdapter.class);
+            Mockito.when(query.hasOutFileClause()).thenReturn(true);
+            Mockito.when(query.getOutFileClause()).thenReturn(outFileClause);
+            Mockito.when(query.getOrigStmt()).thenReturn(new OriginStatement("select 1 into outfile", 0));
+            Mockito.when(query.getStatementContext()).thenReturn(new org.apache.doris.nereids.StatementContext());
+            StmtExecutor stmtExecutor = new StmtExecutor(connectContext, query);
+            TUniqueId queryId = new TUniqueId(1, 2);
+            connectContext.setQueryId(queryId);
+            AtomicInteger attempts = new AtomicInteger();
+            RpcException injectedFailure = new RpcException("test-host", "injected finalization failure");
+
+            Assertions.assertThrows(RpcException.class,
+                    () -> stmtExecutor.handleQueryWithRetry(queryId, () -> {
+                        attempts.incrementAndGet();
+                        throw injectedFailure;
+                    }));
+
+            Assertions.assertEquals(1, attempts.get());
+        } finally {
+            Config.be_exec_version = originalVersion;
+            Config.max_query_retry_time = originalRetryTime;
+            Config.cloud_unique_id = originalCloudUniqueId;
+            Config.deploy_mode = originalDeployMode;
+            connectContext.setQueryId(originalQueryId);
+            connectContext.setStatementContext(originalStatementContext);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.qe;
 
+import org.apache.doris.analysis.OutFileClause;
+import org.apache.doris.analysis.Queriable;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InternalSchemaInitializer;
@@ -24,6 +26,7 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ResourceMgr;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.QueryTimeoutException;
 import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlSerializer;
@@ -51,6 +54,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -151,6 +155,62 @@ public class StmtExecutorTest extends TestWithFeService {
                         () -> markerPublished.set(true)));
 
         Assertions.assertFalse(markerPublished.get());
+    }
+
+    @Test
+    public void testOutfileCapabilityIsStableWhenExecVersionChanges() {
+        int originalVersion = Config.be_exec_version;
+        try {
+            Config.be_exec_version = OutFileClause.SUPPORT_ATOMIC_OUTFILE_VERSION;
+            OutFileClause atomicClause = new OutFileClause("file:///tmp/atomic-outfile/", "csv",
+                    Collections.emptyMap());
+            Assertions.assertTrue(atomicClause.toSinkOptions().isEnableAtomicOutfile());
+
+            Config.be_exec_version = OutFileClause.SUPPORT_ATOMIC_OUTFILE_VERSION - 1;
+            Assertions.assertTrue(atomicClause.toSinkOptions().isEnableAtomicOutfile());
+
+            OutFileClause legacyClause = new OutFileClause("file:///tmp/legacy-outfile/", "csv",
+                    Collections.emptyMap());
+            Assertions.assertFalse(legacyClause.toSinkOptions().isEnableAtomicOutfile());
+            Config.be_exec_version = OutFileClause.SUPPORT_ATOMIC_OUTFILE_VERSION;
+            Assertions.assertFalse(legacyClause.toSinkOptions().isEnableAtomicOutfile());
+        } finally {
+            Config.be_exec_version = originalVersion;
+        }
+    }
+
+    @Test
+    public void testAtomicOutfileArrowFlightRejectionDoesNotRegisterQuery() throws Exception {
+        int originalVersion = Config.be_exec_version;
+        TUniqueId queryId = new TUniqueId(0x67328L, 0x28298L);
+        ConnectContext flightContext = Mockito.spy(connectContext);
+        Mockito.doReturn(ConnectType.MYSQL).when(flightContext).getConnectType();
+        StmtExecutor stmtExecutor = new StmtExecutor(flightContext, "");
+        try {
+            Config.be_exec_version = OutFileClause.SUPPORT_ATOMIC_OUTFILE_VERSION;
+            OutFileClause outFileClause = new OutFileClause("file:///tmp/flight-outfile/", "csv",
+                    Collections.emptyMap());
+            outFileClause.toSinkOptions();
+            Queriable query = Mockito.mock(Queriable.class);
+            Mockito.when(query.getOutFileClause()).thenReturn(outFileClause);
+            flightContext.setQueryId(queryId);
+            Mockito.doReturn(ConnectType.ARROW_FLIGHT_SQL).when(flightContext).getConnectType();
+
+            Assertions.assertThrows(UserException.class,
+                    () -> stmtExecutor.executeAndSendResult(true, false, query, null, null, null));
+            Assertions.assertNull(QeProcessorImpl.INSTANCE.getCoordinator(queryId));
+        } finally {
+            QeProcessorImpl.INSTANCE.unregisterQuery(queryId);
+            Config.be_exec_version = originalVersion;
+        }
+    }
+
+    @Test
+    public void testAtomicOutfileMarkerUsesRemainingQueryDeadline() throws Exception {
+        Assertions.assertEquals(25L, StmtExecutor.calculateOutfileCreateTimeoutMs(1025L, 1000L, 100L));
+        Assertions.assertEquals(100L, StmtExecutor.calculateOutfileCreateTimeoutMs(1200L, 1000L, 100L));
+        Assertions.assertThrows(QueryTimeoutException.class,
+                () -> StmtExecutor.calculateOutfileCreateTimeoutMs(1000L, 1000L, 100L));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -24,12 +24,14 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ResourceMgr;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.UserException;
 import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.authenticate.TestLogAppender;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.planner.ResultFileSink;
+import org.apache.doris.proto.InternalService;
 import org.apache.doris.qe.CommonResultSet.CommonResultSetMetaData;
 import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.thrift.TQueryOptions;
@@ -48,7 +50,9 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class StmtExecutorTest extends TestWithFeService {
@@ -110,6 +114,43 @@ public class StmtExecutorTest extends TestWithFeService {
         Mockito.verify(coord).close();
         // ... and despite it failing, the query registration was still released (no leak).
         Assert.assertNull(QeProcessorImpl.INSTANCE.getCoordinator(queryId));
+    }
+
+    @Test
+    public void testLegacyOutfileSkipsAtomicFinalizationRpc() throws Exception {
+        CoordInterface coordinator = Mockito.mock(CoordInterface.class);
+
+        StmtExecutor.finishOutfileTransaction(false, coordinator, () -> Assert.fail("unexpected marker"));
+
+        Mockito.verifyNoInteractions(coordinator);
+    }
+
+    @Test
+    public void testAtomicOutfilePublishesMarkerAfterAllCommits() throws Exception {
+        CoordInterface coordinator = Mockito.mock(CoordInterface.class);
+        List<String> operations = new ArrayList<>();
+        Mockito.doAnswer(invocation -> {
+            operations.add(((InternalService.POutfileWriteOperation) invocation.getArgument(0)).name());
+            return null;
+        }).when(coordinator).finishOutfile(Mockito.any());
+
+        StmtExecutor.finishOutfileTransaction(true, coordinator, () -> operations.add("MARKER"));
+
+        Assertions.assertEquals(List.of("OUTFILE_PREPARE", "OUTFILE_COMMIT", "MARKER"), operations);
+    }
+
+    @Test
+    public void testAtomicOutfileDoesNotPublishMarkerAfterCommitFailure() throws Exception {
+        CoordInterface coordinator = Mockito.mock(CoordInterface.class);
+        Mockito.doThrow(new UserException("injected commit failure")).when(coordinator)
+                .finishOutfile(InternalService.POutfileWriteOperation.OUTFILE_COMMIT);
+        AtomicBoolean markerPublished = new AtomicBoolean(false);
+
+        Assertions.assertThrows(UserException.class,
+                () -> StmtExecutor.finishOutfileTransaction(true, coordinator,
+                        () -> markerPublished.set(true)));
+
+        Assertions.assertFalse(markerPublished.get());
     }
 
     @Test

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -780,6 +780,15 @@ message POutfileWriteSuccessResult {
     optional PStatus status = 1;
 }
 
+message POutfileWriteFinishedRequest {
+    repeated PUniqueId buffer_ids = 1;
+    optional bool success = 2;
+}
+
+message POutfileWriteFinishedResult {
+    optional PStatus status = 1;
+}
+
 message PJdbcTestConnectionRequest {
     optional bytes jdbc_table = 1;
     optional int32 jdbc_table_type = 2;
@@ -1260,6 +1269,7 @@ service PBackendService {
     rpc request_slave_tablet_pull_rowset(PTabletWriteSlaveRequest) returns (PTabletWriteSlaveResult);
     rpc response_slave_tablet_pull_rowset(PTabletWriteSlaveDoneRequest) returns (PTabletWriteSlaveDoneResult);
     rpc outfile_write_success(POutfileWriteSuccessRequest) returns (POutfileWriteSuccessResult);
+    rpc outfile_write_finished(POutfileWriteFinishedRequest) returns (POutfileWriteFinishedResult);
     rpc fetch_table_schema(PFetchTableSchemaRequest) returns (PFetchTableSchemaResult);
     rpc multiget_data(PMultiGetRequest) returns (PMultiGetResponse) {
         option deprecated = true;

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -772,17 +772,32 @@ message PFetchTableSchemaResult {
   repeated PTypeDesc column_types = 4;
 }
 
+enum POutfileSuccessOperation {
+    OUTFILE_MARKER_CREATE = 0;
+    OUTFILE_MARKER_DELETE = 1;
+}
+
 message POutfileWriteSuccessRequest {
     optional bytes result_file_sink = 1;
+    optional POutfileSuccessOperation operation = 2;
+    optional string marker_token = 3;
 }
 
 message POutfileWriteSuccessResult {
     optional PStatus status = 1;
 }
 
+enum POutfileWriteOperation {
+    OUTFILE_PREPARE = 0;
+    OUTFILE_COMMIT = 1;
+    OUTFILE_ABORT = 2;
+}
+
 message POutfileWriteFinishedRequest {
     repeated PUniqueId buffer_ids = 1;
+    // Kept for rolling upgrades: old BEs use this field and ignore operation.
     optional bool success = 2;
+    optional POutfileWriteOperation operation = 3;
 }
 
 message POutfileWriteFinishedResult {

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -159,6 +159,8 @@ struct TResultFileSinkOptions {
     // currently only for csv
     // TODO: merge with parquet_compression_type and orc_compression_type
     22: optional PlanNodes.TFileCompressType compression_type
+    // New FE enables deferred cleanup only after every executing BE supports the atomic protocol.
+    23: optional bool enable_atomic_outfile
 }
 
 struct TMemoryScratchSink {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

A distributed OUTFILE could leave files from successful receivers behind when another BE or receiver failed. Cleanup ownership could also be lost across partial finalization, late writer close, graceful result-buffer shutdown, multipart abort failure, or a lost success-marker response.

This change adds a version-gated distributed finalization and compensation protocol:

- FE buffers the OUTFILE summary, sends PREPARE to every actual receiver, waits for every COMMIT acknowledgement, publishes the success marker, and only then sends the result to the client.
- Any receiver, finalization, or marker failure before success publication sends compensating ABORT to every participant, including receivers that already acknowledged the provisional COMMIT.
- BE retains exact per-file rollback ownership, attempts all cleanup paths with bounded retries, safely aborts Parquet/ORC and S3 multipart writes, and preserves per-path Broker selection. Concurrent ABORT drains are serialized so a timeout or shutdown retry cannot mistake an in-flight drain for completed cleanup.
- Pending asynchronous result-buffer cleanup is registered before the buffer leaves the manager and synchronously drained during manager shutdown, so a queued lazy-release task cannot lose the last cleanup owner.
- Deferred cleanup retains one filesystem wrapper per storage identity or selected Broker endpoint rather than per rotated part, and Broker filesystem instances own immutable copies of routing and credential configuration.
- Legacy remote success-marker writes keep their previous overwrite/append behavior when atomic OUTFILE is disabled; the cross-storage nonexistence and ownership policy is enabled only for atomic requests.
- Success-marker create/delete operations are ordered by query token. Ownership is recorded immediately after create, before fallible append/close, and a failed delete retains a tombstoned owner until a later DELETE succeeds or reports NOT_FOUND.
- The negotiated execution version is snapshotted per query and propagated through Nereids logical and physical file sinks, marker CREATE shares the query absolute deadline, unsupported Arrow Flight requests are rejected before registration, successful marker state is reclaimed after a bounded protection window, and local OUTFILE preserves synchronous-close durability. Atomic OUTFILE failures are not automatically retried because an aborted attempt may still produce late files or cleanup callbacks.
- Nereids uses its own timeout deadline, old execution versions stay on the legacy path without the new RPC, and result-buffer shutdown rejects late senders.

#### Atomicity scope

The atomicity guarantee applies when the negotiated execution version supports this protocol, the FE/BE processes remain alive during the query lifecycle, and cleanup storage operations succeed within the bounded retries: if any BE/receiver, finalization RPC, or success-marker publication fails, the task fails and all query-owned OUTFILE files are rolled back. The success marker and client result are not published before every receiver acknowledges COMMIT.

The following are intentionally outside this PR:

- Hard FE or BE crash/restart recovery while an OUTFILE transaction is in flight.
- Recovery from permanent network or external-storage failures after the bounded retries are exhausted.
- A durable WAL, persistent orphan-file manifest/sweeper, or a storage-native atomic namespace transaction.
- Concurrent OUTFILE queries targeting the same destination directory or success-marker path; this protocol does not provide cross-query namespace isolation.
- Atomic behavior on older execution versions; those versions retain their previous legacy behavior and do not receive the new finalization RPC.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
      - Ran focused FE unit tests for legacy-version compatibility, finalization/marker ordering, commit failure, execution-version snapshots, Arrow Flight pre-registration rejection, remaining-deadline enforcement, atomic-attempt retry suppression, and the Nereids deadline. The Nereids parse-to-translation test also verifies that a mutable execution-version change cannot alter the query capability snapshot. FE Checkstyle and source/test compilation passed.
      - Ran 28 focused ASAN BE unit tests for result-buffer lifecycle and concurrent ABORT draining, OUTFILE writer cleanup/durability and bounded filesystem retention, Broker configuration lifetime, and success-marker compatibility/state retention. Added coverage verifies shutdown with cleanup queued behind a blocked lazy-release worker and marker ownership retention across a failed immediate delete followed by a successful retry. The concurrent cancellation regression test also passed 100 consecutive iterations.
      - Build hygiene and clang-format 16 passed for all affected BE files. Clang-tidy was attempted, but the configured analyzers could not process the existing source tree because of unrelated toolchain/header diagnostics.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [ ] No.
    - [x] Yes. On supported execution versions, failure of any BE/receiver rolls back all files owned by the distributed OUTFILE task before success is exposed.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
