### PR TITLE
[fix](view) Skip dangling views when querying information_schema.view_dependency

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -876,7 +876,16 @@ public class MetadataGenerator {
                         continue;
                     }
                     String inlineViewDef = ((View) table).getInlineViewDef();
-                    Map<List<String>, TableIf> tablesMap = PlanUtils.tableCollect(inlineViewDef, ctx);
+                    Map<List<String>, TableIf> tablesMap;
+                    try {
+                        tablesMap = PlanUtils.tableCollect(inlineViewDef, ctx);
+                    } catch (Exception e) {
+                        // A view may reference tables that no longer exist (dangling view).
+                        // Skip it so the whole metadata query does not fail.
+                        LOG.warn("Failed to collect base tables of view {} in database {}, skip it. exception: {}",
+                                tableName, dbName, e);
+                        continue;
+                    }
                     for (Map.Entry<List<String>, TableIf> info : tablesMap.entrySet()) {
                         List<String> fullName = info.getKey();
                         TableIf tbl = info.getValue();


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
`information_schema.view_dependency` re-parses each view definition to collect
its base tables. When a view references a table that no longer exists
(dangling view), the parse throws an exception and the whole metadata query
fails instead of skipping the bad view.

For example, after `CREATE VIEW v1 AS SELECT * FROM t1; DROP TABLE t1;`,
`SELECT * FROM information_schema.view_dependency` fails with
`Table [t1] does not exist in database [xxx]`.

### How to test this PR?

1. Create a database, a base table, and a view on top of it.
2. Drop the base table (the view becomes dangling).
3. Query `information_schema.view_dependency`: before the fix the query fails
   entirely; after the fix it succeeds, the dangling view is skipped with a
   WARN log, and normal views are still returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
