### PR TITLE
[fix](profile) Fix broker load profile output

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/SqlStatementMasker.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/SqlStatementMasker.java
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.common.util;
+
+import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.nereids.trees.plans.commands.NeedAuditEncryption;
+import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
+
+import com.google.common.base.Preconditions;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/** Masks sensitive values in SQL before the statement leaves the execution path. */
+public class SqlStatementMasker {
+    public static final String MASKED_STATEMENT = "/* masked statement unavailable */";
+
+    private static final Logger LOG = LogManager.getLogger(SqlStatementMasker.class);
+
+    private SqlStatementMasker() {
+    }
+
+    /** Parse and mask a statement, failing closed when either step fails. */
+    public static String mask(String statement) {
+        if (statement == null || statement.isEmpty()) {
+            return statement;
+        }
+        try {
+            return maskInternal(statement, new NereidsParser().parseSingle(statement));
+        } catch (Exception e) {
+            LOG.warn("failed to prepare masked SQL statement, exception type: {}",
+                    e.getClass().getSimpleName());
+            return MASKED_STATEMENT;
+        }
+    }
+
+    /** Mask a statement using its parsed logical plan, failing closed when masking fails. */
+    public static String mask(String statement, LogicalPlan logicalPlan) {
+        if (statement == null || statement.isEmpty()) {
+            return statement;
+        }
+        try {
+            return maskInternal(statement,
+                    Preconditions.checkNotNull(logicalPlan, "logical plan must not be null"));
+        } catch (Exception e) {
+            LOG.warn("failed to mask SQL statement, exception type: {}", e.getClass().getSimpleName());
+            return MASKED_STATEMENT;
+        }
+    }
+
+    private static String maskInternal(String statement, LogicalPlan logicalPlan) {
+        if (!(logicalPlan instanceof NeedAuditEncryption)) {
+            return statement;
+        }
+        return ((NeedAuditEncryption) logicalPlan).geneEncryptionSQL(statement);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BrokerLoadJob.java
@@ -43,6 +43,7 @@ import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.LogBuilder;
 import org.apache.doris.common.util.LogKey;
 import org.apache.doris.common.util.MetaLockUtils;
+import org.apache.doris.common.util.SqlStatementMasker;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.storage.S3ResourceCompat;
@@ -92,6 +93,9 @@ public class BrokerLoadJob extends BulkLoadJob {
     protected Profile jobProfile;
     // If set to true, the profile of load job with be pushed to ProfileManager
     protected boolean enableProfile = false;
+
+    // Runtime-only masked copy. The original statement remains available for execution and replay.
+    private transient String maskedProfileSql;
 
     // Runtime-only selection result recorded by a loading task's coordinator.
     private transient volatile String loadBackendSelectionSummary;
@@ -556,11 +560,23 @@ public class BrokerLoadJob extends BulkLoadJob {
         builder.user(getUserInfo() != null ? getUserInfo().getQualifiedUser() : "N/A");
         builder.defaultCatalog(InternalCatalog.INTERNAL_CATALOG_NAME);
         builder.defaultDb(getDefaultDb());
-        builder.sqlStatement(getOriginStmt().originStmt);
+        builder.sqlStatement(getSqlForProfile());
         if (loadBackendSelectionSummary != null) {
             builder.loadBackendSelection(loadBackendSelectionSummary);
         }
         return builder.build();
+    }
+
+    void setMaskedProfileSql(String maskedProfileSql) {
+        this.maskedProfileSql = maskedProfileSql;
+    }
+
+    private String getSqlForProfile() {
+        if (getJobType() != EtlJobType.BROKER) {
+            return getOriginStmt().originStmt;
+        }
+        return StringUtils.isEmpty(maskedProfileSql)
+                ? SqlStatementMasker.MASKED_STATEMENT : maskedProfileSql;
     }
 
     private String getDefaultDb() {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/loadv2/BulkLoadJob.java
@@ -30,6 +30,7 @@ import org.apache.doris.common.DdlException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.util.LogBuilder;
 import org.apache.doris.common.util.LogKey;
+import org.apache.doris.common.util.SqlStatementMasker;
 import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.load.BrokerFileGroupAggInfo;
 import org.apache.doris.load.EtlJobType;
@@ -127,7 +128,7 @@ public abstract class BulkLoadJob extends LoadJob implements GsonPostProcessable
         Database db = Env.getCurrentInternalCatalog().getDbOrDdlException(dbName);
 
         // create job
-        BulkLoadJob bulkLoadJob;
+        BrokerLoadJob bulkLoadJob;
         try {
             switch (command.getEtlJobType()) {
                 case BROKER:
@@ -140,6 +141,10 @@ public abstract class BulkLoadJob extends LoadJob implements GsonPostProcessable
                     throw new DdlException("LoadManager only support create broker load job from stmt.");
                 default:
                     throw new DdlException("Unknown load job type.");
+            }
+            if (ctx.getSessionVariable().enableProfile()) {
+                bulkLoadJob.setMaskedProfileSql(
+                        SqlStatementMasker.mask(executor.getOriginStmt().originStmt, command));
             }
             bulkLoadJob.setComment(command.getComment());
             bulkLoadJob.setJobProperties(command.getProperties());

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -61,6 +61,7 @@ import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.DebugPointUtil.DebugPoint;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.common.util.NetUtils;
+import org.apache.doris.common.util.SqlStatementMasker;
 import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.common.util.UniqueIdUtils;
 import org.apache.doris.common.util.Util;
@@ -99,8 +100,6 @@ import org.apache.doris.nereids.trees.plans.commands.DeleteFromCommand;
 import org.apache.doris.nereids.trees.plans.commands.DeleteFromUsingCommand;
 import org.apache.doris.nereids.trees.plans.commands.EmptyCommand;
 import org.apache.doris.nereids.trees.plans.commands.Forward;
-import org.apache.doris.nereids.trees.plans.commands.LoadCommand;
-import org.apache.doris.nereids.trees.plans.commands.NeedAuditEncryption;
 import org.apache.doris.nereids.trees.plans.commands.PrepareCommand;
 import org.apache.doris.nereids.trees.plans.commands.Redirect;
 import org.apache.doris.nereids.trees.plans.commands.SupportProfile;
@@ -183,7 +182,6 @@ public class StmtExecutor {
     private static final Logger LOG = LogManager.getLogger(StmtExecutor.class);
 
     private static final AtomicLong STMT_ID_GENERATOR = new AtomicLong(0);
-    private static final String MASKED_STMT_FALLBACK = "/* masked statement unavailable */";
     public static final int MAX_DATA_TO_SEND_FOR_TXN = 100;
     private static Set<String> blockSqlAstNames = Sets.newHashSet();
 
@@ -360,7 +358,7 @@ public class StmtExecutor {
         if (loadBackendSelection != null) {
             builder.loadBackendSelection(loadBackendSelection);
         }
-        builder.sqlStatement(originStmt == null ? "" : originStmt.originStmt);
+        builder.sqlStatement(originStmt == null ? "" : getStmtForLogging(originStmt.originStmt));
         builder.isCached(isCached ? "Yes" : "No");
 
         Map<String, Integer> beToInstancesNum = coord == null ? Maps.newTreeMap() : coord.getBeToInstancesNum();
@@ -1250,16 +1248,15 @@ public class StmtExecutor {
 
         // Generate profile for:
         // 1. CreateTableCommand(mainly for create as select).
-        // 2. LoadCommand.
-        // 3. InsertOverwriteTableCommand.
-        // 4. MergeIntoCommand (merge into ... using ...).
-        if ((plan instanceof Command) && !(plan instanceof LoadCommand)
-                && !(plan instanceof CreateTableCommand) && !(plan instanceof InsertOverwriteTableCommand)
+        // 2. InsertOverwriteTableCommand.
+        // 3. MergeIntoCommand (merge into ... using ...).
+        if ((plan instanceof Command) && !(plan instanceof CreateTableCommand)
+                && !(plan instanceof InsertOverwriteTableCommand)
                 && !(plan instanceof MergeIntoCommand)) {
             // Commands like SHOW QUERY PROFILE will not have profile.
             return false;
         } else {
-            // 4. For all the other statements.
+            // Generate profiles for all the other statements.
             return true;
         }
     }
@@ -2432,27 +2429,11 @@ public class StmtExecutor {
     }
 
     private String getStmtForLogging(String stmt) {
-        if (stmt == null) {
-            return stmt;
-        }
         if (!(parsedStmt instanceof LogicalPlanAdapter)) {
             return getStmtForLoggingBeforeParse(stmt);
         }
-        // Internal export outfile tasks use an empty origin SQL, so audit masking must skip reparsing here.
-        if (stmt.isEmpty()) {
-            return stmt;
-        }
         LogicalPlan logicalPlan = ((LogicalPlanAdapter) parsedStmt).getLogicalPlan();
-        if (!(logicalPlan instanceof NeedAuditEncryption)) {
-            return stmt;
-        }
-        try {
-            return ((NeedAuditEncryption) logicalPlan).geneEncryptionSQL(stmt);
-        } catch (Exception e) {
-            // Logging must not leak plaintext or change command behavior when masking fails.
-            LOG.warn("failed to mask statement for FE logging", e);
-            return MASKED_STMT_FALLBACK;
-        }
+        return SqlStatementMasker.mask(stmt, logicalPlan);
     }
 
     private String getStmtForLoggingBeforeParse() {
@@ -2460,24 +2441,7 @@ public class StmtExecutor {
     }
 
     private String getStmtForLoggingBeforeParse(String stmt) {
-        if (stmt == null) {
-            return null;
-        }
-        // Empty SQL cannot produce a valid parse tree for audit masking, so keep the original text.
-        if (stmt.isEmpty()) {
-            return stmt;
-        }
-        try {
-            LogicalPlan logicalPlan = new NereidsParser().parseSingle(stmt);
-            if (!(logicalPlan instanceof NeedAuditEncryption)) {
-                return stmt;
-            }
-            return ((NeedAuditEncryption) logicalPlan).geneEncryptionSQL(stmt);
-        } catch (Exception e) {
-            // Logging must fail closed before parsing so secrets never fall back to plaintext.
-            LOG.warn("failed to prepare masked statement for FE logging", e);
-            return MASKED_STMT_FALLBACK;
-        }
+        return SqlStatementMasker.mask(stmt);
     }
 
     public List<ByteBuffer> getProxyQueryResultBufList() {

--- a/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/loadv2/BrokerLoadJobTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.analysis.BrokerDesc;
 import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.EnvFactory;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TableProperty;
@@ -29,19 +30,28 @@ import org.apache.doris.common.LabelAlreadyUsedException;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.Status;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.common.profile.SummaryProfile;
+import org.apache.doris.common.util.SqlStatementMasker;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.load.BrokerFileGroup;
 import org.apache.doris.load.BrokerFileGroupAggInfo;
 import org.apache.doris.load.BrokerFileGroupAggInfo.FileGroupAggKey;
+import org.apache.doris.load.EtlJobType;
 import org.apache.doris.load.EtlStatus;
 import org.apache.doris.load.FailMsg;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.nereids.load.NereidsBrokerFileGroup;
 import org.apache.doris.nereids.load.NereidsLoadingTaskPlanner;
+import org.apache.doris.nereids.trees.plans.commands.LoadCommand;
+import org.apache.doris.nereids.trees.plans.commands.info.LabelNameInfo;
 import org.apache.doris.persist.EditLog;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.OriginStatement;
+import org.apache.doris.qe.SessionVariable;
+import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.resource.BackendSelection;
+import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.resource.computegroup.ComputeGroup;
 import org.apache.doris.resource.computegroup.ComputeGroupMgr;
 import org.apache.doris.task.MasterTaskExecutor;
@@ -58,6 +68,7 @@ import com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -145,6 +156,109 @@ public class BrokerLoadJobTest {
         BrokerLoadJob unknownMode = GsonUtils.GSON.fromJson(
                 serialized.replace("\"m\":\"PREFER\"", "\"m\":\"FUTURE\""), BrokerLoadJob.class);
         Assert.assertEquals(BackendSelection.Mode.DEFAULT, unknownMode.getLoadBackendSelectionHint().getMode());
+    }
+
+    @Test
+    public void testProfileSummaryMasksS3Credentials() {
+        String accessKey = "profile-test-access-key";
+        String secretKey = "profile-test-secret-key";
+        String loadSql = "LOAD LABEL profile_mask_test("
+                + " DATA INFILE(\"s3://bucket/path\")"
+                + " INTO TABLE target_table"
+                + ") WITH S3("
+                + " \"provider\" = \"S3\","
+                + " \"AWS_ENDPOINT\" = \"s3.test\","
+                + " \"AWS_ACCESS_KEY\" = \"" + accessKey + "\","
+                + " \"AWS_SECRET_KEY\" = \"" + secretKey + "\","
+                + " \"AWS_REGION\" = \"test-region\""
+                + ")";
+        String maskedSql = "LOAD LABEL profile_mask_test("
+                + " DATA INFILE(\"s3://bucket/path\")"
+                + " INTO TABLE target_table"
+                + ") WITH S3(\"provider\" = \"S3\")";
+        BrokerLoadJob job = new BrokerLoadJob();
+        Deencapsulation.setField(job, "id", 1L);
+        Deencapsulation.setField(job, "dbId", 2L);
+        Deencapsulation.setField(job, "originStmt", new OriginStatement(loadSql, 0));
+
+        Env env = Mockito.mock(Env.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class)) {
+            envMockedStatic.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getInternalCatalog()).thenReturn(catalog);
+            Mockito.when(catalog.getDb(2L)).thenReturn(Optional.empty());
+
+            Map<String, String> missingMaskedSqlSummary =
+                    Deencapsulation.invoke(job, "getSummaryInfo", true);
+            Assert.assertEquals(SqlStatementMasker.MASKED_STATEMENT,
+                    missingMaskedSqlSummary.get(SummaryProfile.SQL_STATEMENT));
+
+            job.setMaskedProfileSql(maskedSql);
+            Map<String, String> summary = Deencapsulation.invoke(job, "getSummaryInfo", true);
+            String profileSql = summary.get(SummaryProfile.SQL_STATEMENT);
+
+            Assert.assertEquals(maskedSql, profileSql);
+            Assert.assertFalse(profileSql.contains(accessKey));
+            Assert.assertFalse(profileSql.contains(secretKey));
+            Assert.assertTrue(profileSql.contains("\"provider\" = \"S3\""));
+            Assert.assertEquals(loadSql, job.getOriginStmt().originStmt);
+        }
+    }
+
+    @Test
+    public void testFromLoadCommandCachesMaskedProfileSql() throws Exception {
+        String accessKey = "profile-wiring-access-key";
+        String secretKey = "profile-wiring-secret-key";
+        String loadSql = "LOAD LABEL profile_mask_test("
+                + " DATA INFILE(\"s3://bucket/path\")"
+                + " INTO TABLE target_table"
+                + ") WITH S3("
+                + " \"AWS_ACCESS_KEY\" = \"" + accessKey + "\","
+                + " \"AWS_SECRET_KEY\" = \"" + secretKey + "\")";
+        String maskedSql = "LOAD LABEL profile_mask_test("
+                + " DATA INFILE(\"s3://bucket/path\")"
+                + " INTO TABLE target_table"
+                + ") WITH S3()";
+
+        LoadCommand command = Mockito.mock(LoadCommand.class);
+        LabelNameInfo label = Mockito.mock(LabelNameInfo.class);
+        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        ConnectContext context = Mockito.mock(ConnectContext.class);
+        SessionVariable sessionVariable = Mockito.mock(SessionVariable.class);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        EnvFactory envFactory = Mockito.mock(EnvFactory.class);
+        BrokerLoadJob job = Mockito.mock(BrokerLoadJob.class);
+
+        Mockito.when(command.getLabel()).thenReturn(label);
+        Mockito.when(label.getDb()).thenReturn("test_db");
+        Mockito.when(label.getLabel()).thenReturn("profile_mask_test");
+        Mockito.when(command.getEtlJobType()).thenReturn(EtlJobType.BROKER);
+        Mockito.when(command.geneEncryptionSQL(loadSql)).thenReturn(maskedSql);
+        Mockito.when(executor.getOriginStmt()).thenReturn(new OriginStatement(loadSql, 0));
+        Mockito.when(context.getSessionVariable()).thenReturn(sessionVariable);
+        Mockito.when(sessionVariable.enableProfile()).thenReturn(true);
+        Mockito.when(catalog.getDbOrDdlException("test_db")).thenReturn(database);
+        Mockito.when(envFactory.createBrokerLoadJob(Mockito.anyLong(), Mockito.anyString(), Mockito.any(),
+                Mockito.any(), Mockito.any())).thenReturn(job);
+
+        try (MockedStatic<Env> envMockedStatic = Mockito.mockStatic(Env.class);
+                MockedStatic<EnvFactory> envFactoryMockedStatic = Mockito.mockStatic(EnvFactory.class);
+                MockedStatic<BackendSelectionManager> selectionManagerMockedStatic =
+                        Mockito.mockStatic(BackendSelectionManager.class)) {
+            envMockedStatic.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+            envFactoryMockedStatic.when(EnvFactory::getInstance).thenReturn(envFactory);
+            selectionManagerMockedStatic.when(() -> BackendSelectionManager.captureLoadSelection(context))
+                    .thenReturn(null);
+
+            Assert.assertSame(job, BulkLoadJob.fromLoadCommand(command, executor, context));
+
+            ArgumentCaptor<String> maskedSqlCaptor = ArgumentCaptor.forClass(String.class);
+            Mockito.verify(job).setMaskedProfileSql(maskedSqlCaptor.capture());
+            Assert.assertEquals(maskedSql, maskedSqlCaptor.getValue());
+            Assert.assertFalse(maskedSqlCaptor.getValue().contains(accessKey));
+            Assert.assertFalse(maskedSqlCaptor.getValue().contains(secretKey));
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.qe;
 
+import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InternalSchemaInitializer;
@@ -24,9 +25,13 @@ import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ResourceMgr;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.profile.SummaryProfile;
 import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.authenticate.TestLogAppender;
+import org.apache.doris.nereids.glue.LogicalPlanAdapter;
+import org.apache.doris.nereids.parser.NereidsParser;
+import org.apache.doris.nereids.trees.plans.commands.LoadCommand;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.planner.ResultFileSink;
@@ -49,6 +54,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class StmtExecutorTest extends TestWithFeService {
@@ -577,6 +583,45 @@ public class StmtExecutorTest extends TestWithFeService {
         Method getStmtForLoggingBeforeParse = StmtExecutor.class.getDeclaredMethod("getStmtForLoggingBeforeParse");
         getStmtForLoggingBeforeParse.setAccessible(true);
         Assertions.assertEquals(MASKED_STMT_FALLBACK, getStmtForLoggingBeforeParse.invoke(executor));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLoadCommandDoesNotGenerateStmtProfileAndSummaryIsMasked() throws Exception {
+        useDatabase("testDb");
+        String accessKey = "profile-test-access-key";
+        String secretKey = "profile-test-secret-key";
+        String loadSql = "LOAD LABEL profile_mask_test("
+                + " DATA INFILE(\"s3://bucket/path\")"
+                + " INTO TABLE target_table"
+                + ") WITH S3("
+                + " \"provider\" = \"S3\","
+                + " \"AWS_ENDPOINT\" = \"s3.test\","
+                + " \"AWS_ACCESS_KEY\" = \"" + accessKey + "\","
+                + " \"AWS_SECRET_KEY\" = \"" + secretKey + "\","
+                + " \"AWS_REGION\" = \"test-region\""
+                + ")";
+
+        StatementBase parsedStmt = new NereidsParser().parseSQL(loadSql).get(0);
+        Assertions.assertInstanceOf(LogicalPlanAdapter.class, parsedStmt);
+        Assertions.assertInstanceOf(LoadCommand.class,
+                ((LogicalPlanAdapter) parsedStmt).getLogicalPlan());
+        parsedStmt.setOrigStmt(new OriginStatement(loadSql, 0));
+        StmtExecutor executor = new StmtExecutor(connectContext, parsedStmt);
+
+        Assertions.assertFalse(executor.isProfileSafeStmt());
+
+        connectContext.setQueryId(new TUniqueId(1L, 2L));
+        connectContext.setStartTime();
+        Method getSummaryInfo = StmtExecutor.class.getDeclaredMethod("getSummaryInfo", boolean.class);
+        getSummaryInfo.setAccessible(true);
+        Map<String, String> summary = (Map<String, String>) getSummaryInfo.invoke(executor, false);
+        String profileSql = summary.get(SummaryProfile.SQL_STATEMENT);
+
+        Assertions.assertFalse(profileSql.contains(accessKey));
+        Assertions.assertFalse(profileSql.contains(secretKey));
+        Assertions.assertTrue(profileSql.contains("\"provider\" = \"S3\""));
+        Assertions.assertEquals(loadSql, executor.getOriginStmtInString());
     }
 
     private void createResource(String sql) throws Exception {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: `LOAD LABEL` submits an asynchronous Broker Load job but also generated a generic UUID `QUERY` profile without a planner, coordinator, or execution profile. That entry completed immediately with zero instances and obscured the real load profile. Profile summaries also copied the original LOAD SQL directly, exposing sensitive object-storage properties.

This PR excludes `LoadCommand` from statement profiles and introduces a shared fail-closed SQL masker. It caches the masked SQL while the submit context and parsed `LoadCommand` are available, then uses it for the numeric Broker Load job profile without modifying the original statement needed for execution and replay.

### Release note

Fix Broker Load profiles to remove empty submission query entries and mask sensitive SQL properties.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - `./run-fe-ut.sh --run org.apache.doris.qe.StmtExecutorTest,org.apache.doris.load.loadv2.BrokerLoadJobTest,org.apache.doris.nereids.parser.EncryptSQLTest` (47 tests passed)
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
- Behavior changed:
    - [ ] No.
    - [x] Yes. `LOAD LABEL` no longer emits an empty UUID `QUERY` profile, and Broker Load profile SQL masks sensitive properties.
- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label