### PR TITLE
[fix](cloud) Balance colocate placement with bounded HRW

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudColocatePlacement.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudColocatePlacement.java
@@ -23,6 +23,8 @@ import com.google.common.hash.Hashing;
 import java.util.Arrays;
 
 public class CloudColocatePlacement {
+    private static final long EXTRA_QUOTA_SCORE_IDX = -1L;
+
     @FunctionalInterface
     interface ScoreFunction {
         long score(long grpId, long idx, long beId);
@@ -40,25 +42,52 @@ public class CloudColocatePlacement {
                 .asLong();
     }
 
-    public static long pickBackendId(long grpId, long idx, long[] candidateBeIds) {
-        return pickBackendId(grpId, idx, candidateBeIds, CloudColocatePlacement::score);
+    public static long[] buildPlacement(long grpId, long[] candidateBeIds, int bucketNum) {
+        return buildPlacement(grpId, candidateBeIds, bucketNum, CloudColocatePlacement::score);
     }
 
-    static long pickBackendId(long grpId, long idx, long[] candidateBeIds, ScoreFunction scoreFunction) {
+    static long[] buildPlacement(long grpId, long[] candidateBeIds, int bucketNum, ScoreFunction scoreFunction) {
         Preconditions.checkArgument(candidateBeIds.length > 0);
+        Preconditions.checkArgument(bucketNum > 0);
         long[] sortedBeIds = Arrays.copyOf(candidateBeIds, candidateBeIds.length);
         Arrays.sort(sortedBeIds);
 
-        long pickedBeId = sortedBeIds[0];
-        long maxScore = scoreFunction.score(grpId, idx, pickedBeId);
-        for (int i = 1; i < sortedBeIds.length; i++) {
-            long beId = sortedBeIds[i];
-            long score = scoreFunction.score(grpId, idx, beId);
-            if (score > maxScore || (score == maxScore && beId < pickedBeId)) {
-                maxScore = score;
-                pickedBeId = beId;
+        int[] remainingQuota = new int[sortedBeIds.length];
+        Arrays.fill(remainingQuota, bucketNum / sortedBeIds.length);
+        int[] extraQuotaCandidates = new int[sortedBeIds.length];
+        Arrays.fill(extraQuotaCandidates, 1);
+        for (int i = 0; i < bucketNum % sortedBeIds.length; i++) {
+            int pickedIndex = pickBackendIndex(grpId, EXTRA_QUOTA_SCORE_IDX, sortedBeIds,
+                    extraQuotaCandidates, scoreFunction);
+            remainingQuota[pickedIndex]++;
+            extraQuotaCandidates[pickedIndex] = 0;
+        }
+
+        long[] placement = new long[bucketNum];
+        for (int idx = 0; idx < bucketNum; idx++) {
+            int pickedIndex = pickBackendIndex(grpId, idx, sortedBeIds, remainingQuota, scoreFunction);
+            placement[idx] = sortedBeIds[pickedIndex];
+            remainingQuota[pickedIndex]--;
+        }
+        return placement;
+    }
+
+    private static int pickBackendIndex(long grpId, long idx, long[] sortedBeIds, int[] remainingQuota,
+            ScoreFunction scoreFunction) {
+        int pickedIndex = 0;
+        while (remainingQuota[pickedIndex] == 0) {
+            pickedIndex++;
+        }
+        long maxScore = scoreFunction.score(grpId, idx, sortedBeIds[pickedIndex]);
+        for (int i = pickedIndex + 1; i < sortedBeIds.length; i++) {
+            if (remainingQuota[i] > 0) {
+                long score = scoreFunction.score(grpId, idx, sortedBeIds[i]);
+                if (score > maxScore) {
+                    maxScore = score;
+                    pickedIndex = i;
+                }
             }
         }
-        return pickedBeId;
+        return pickedIndex;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudReplica.java
@@ -189,10 +189,9 @@ public class CloudReplica extends Replica implements GsonPostProcessable {
         if (!Config.enable_cloud_colocate_consistent_hash) {
             return pickColocatedBackend(infoService, groupId, clusterId, availableBes);
         }
-        int bucketNum = infoService.getCloudColocateBucketsNum(groupId);
-        CloudSystemInfoService.checkCloudColocateBucketIdx(groupId, clusterId, idx, bucketNum);
-        long[] availableBeIds = availableBes.stream().mapToLong(Backend::getId).toArray();
-        long pickedBeId = CloudColocatePlacement.pickBackendId(groupId.grpId, idx, availableBeIds);
+        List<Long> availableBeIds = availableBes.stream().map(Backend::getId).collect(Collectors.toList());
+        long pickedBeId = infoService.getCloudColocateHrwBeIdForDeadGrace(
+                groupId, clusterId, availableBeIds, idx);
         return findPickedBackend(pickedBeId, groupId, clusterId, availableBes);
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/system/CloudSystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/system/CloudSystemInfoService.java
@@ -108,19 +108,24 @@ public class CloudSystemInfoService extends SystemInfoService {
     private InstanceInfoPB.Status instanceStatus;
 
     public long getCloudColocateHrwBeId(GroupId groupId, String clusterId, List<Long> availableBeIds, long idx) {
-        return getCloudColocateHrwBeIdInternal(groupId, clusterId, availableBeIds, idx, -1);
+        return getCloudColocateHrwBeIdInternal(groupId, clusterId, availableBeIds, idx, -1, false);
+    }
+
+    public long getCloudColocateHrwBeIdForDeadGrace(GroupId groupId, String clusterId,
+            List<Long> availableBeIds, long idx) {
+        return getCloudColocateHrwBeIdInternal(groupId, clusterId, availableBeIds, idx, -1, true);
     }
 
     @VisibleForTesting
     public long getCloudColocateHrwBeIdForTest(GroupId groupId, String clusterId, List<Long> availableBeIds,
             long idx, int bucketNumForTest) {
-        return getCloudColocateHrwBeIdInternal(groupId, clusterId, availableBeIds, idx, bucketNumForTest);
+        return getCloudColocateHrwBeIdInternal(groupId, clusterId, availableBeIds, idx, bucketNumForTest, false);
     }
 
     private long getCloudColocateHrwBeIdInternal(GroupId groupId, String clusterId, List<Long> availableBeIds,
-            long idx, int bucketNumForTest) {
+            long idx, int bucketNumForTest, boolean deadGrace) {
         long[] candidateBeIds = availableBeIds.stream().mapToLong(Long::longValue).toArray();
-        ColocatePlacementKey key = new ColocatePlacementKey(groupId, clusterId);
+        ColocatePlacementKey key = new ColocatePlacementKey(groupId, clusterId, deadGrace);
         long fingerprint = fingerprintBackendIds(candidateBeIds);
         ColocatePlacementCache cache = colocatePlacementCache.get(key);
         if (cache != null && cache.same(fingerprint)) {
@@ -132,7 +137,7 @@ public class CloudSystemInfoService extends SystemInfoService {
         // read lock, while removeTable() evicts this cache holding the colocate-index write lock.
         // Acquiring the colocate lock inside the ConcurrentHashMap compute() bin lock would invert
         // that order and risk an ABBA deadlock, so the locked fetch must stay outside compute().
-        int bucketNum = bucketNumForTest > 0 ? bucketNumForTest : getColocateBucketsNum(groupId);
+        int bucketNum = bucketNumForTest > 0 ? bucketNumForTest : getCloudColocateBucketsNum(groupId);
         cache = colocatePlacementCache.compute(key, (ignored, oldCache) -> {
             if (oldCache != null && oldCache.same(fingerprint, bucketNum)) {
                 return oldCache;
@@ -190,10 +195,12 @@ public class CloudSystemInfoService extends SystemInfoService {
     private static class ColocatePlacementKey {
         private final GroupId groupId;
         private final String clusterId;
+        private final boolean deadGrace;
 
-        private ColocatePlacementKey(GroupId groupId, String clusterId) {
+        private ColocatePlacementKey(GroupId groupId, String clusterId, boolean deadGrace) {
             this.groupId = groupId;
             this.clusterId = clusterId;
+            this.deadGrace = deadGrace;
         }
 
         @Override
@@ -202,12 +209,14 @@ public class CloudSystemInfoService extends SystemInfoService {
                 return false;
             }
             ColocatePlacementKey other = (ColocatePlacementKey) obj;
-            return groupId.equals(other.groupId) && clusterId.equals(other.clusterId);
+            return groupId.equals(other.groupId)
+                    && clusterId.equals(other.clusterId)
+                    && deadGrace == other.deadGrace;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(groupId, clusterId);
+            return Objects.hash(groupId, clusterId, deadGrace);
         }
     }
 
@@ -224,10 +233,7 @@ public class CloudSystemInfoService extends SystemInfoService {
 
         private static ColocatePlacementCache build(long fingerprint, long[] candidateBeIds, long grpId,
                 int bucketNum) {
-            long[] beIdByBucket = new long[bucketNum];
-            for (int i = 0; i < bucketNum; i++) {
-                beIdByBucket[i] = CloudColocatePlacement.pickBackendId(grpId, i, candidateBeIds);
-            }
+            long[] beIdByBucket = CloudColocatePlacement.buildPlacement(grpId, candidateBeIds, bucketNum);
             return new ColocatePlacementCache(fingerprint, bucketNum, beIdByBucket);
         }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudColocatePlacementTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudColocatePlacementTest.java
@@ -68,12 +68,20 @@ public class CloudColocatePlacementTest {
     }
 
     @Test
+    public void testHrwPlacementBalancesBucketsAcrossBackends() {
+        assertBalanced(100L, 120, new long[] {1L, 2L, 3L});
+        assertBalanced(100L, 121, new long[] {1L, 2L, 3L});
+        assertBalanced(100L, 2, new long[] {1L, 2L, 3L});
+    }
+
+    @Test
     public void testTieBreakPicksSmallerBackendId() {
         long[] beIds = new long[] {30L, 20L, 10L};
 
-        long pickedBeId = CloudColocatePlacement.pickBackendId(100L, 1L, beIds, (groupId, idx, beId) -> 1L);
+        long[] placement = CloudColocatePlacement.buildPlacement(100L, beIds, 1,
+                (groupId, idx, beId) -> 1L);
 
-        Assertions.assertEquals(10L, pickedBeId);
+        Assertions.assertEquals(10L, placement[0]);
     }
 
     @Test
@@ -178,12 +186,28 @@ public class CloudColocatePlacementTest {
         return values;
     }
 
+    private static void assertBalanced(long groupId, int bucketNum, long[] beIds) {
+        long[] placement = CloudColocatePlacement.buildPlacement(groupId, beIds, bucketNum);
+        long min = Long.MAX_VALUE;
+        long max = Long.MIN_VALUE;
+        long total = 0;
+        for (long beId : beIds) {
+            long count = Arrays.stream(placement).filter(value -> value == beId).count();
+            min = Math.min(min, count);
+            max = Math.max(max, count);
+            total += count;
+        }
+        Assertions.assertEquals(bucketNum, total);
+        Assertions.assertTrue(max - min <= 1,
+                "Placement should differ by at most one bucket, but counts range from " + min + " to " + max);
+    }
+
     private static int changedBucketsByHrw(long groupId, int bucketNum, long[] originalBeIds, long[] changedBeIds) {
+        long[] before = CloudColocatePlacement.buildPlacement(groupId, originalBeIds, bucketNum);
+        long[] after = CloudColocatePlacement.buildPlacement(groupId, changedBeIds, bucketNum);
         int changed = 0;
         for (int idx = 0; idx < bucketNum; idx++) {
-            long before = CloudColocatePlacement.pickBackendId(groupId, idx, originalBeIds);
-            long after = CloudColocatePlacement.pickBackendId(groupId, idx, changedBeIds);
-            if (before != after) {
+            if (before[idx] != after[idx]) {
                 changed++;
             }
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudReplicaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/catalog/CloudReplicaTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -86,14 +87,17 @@ public class CloudReplicaTest {
         envMockedStatic.when(Env::getCurrentSystemInfo).thenReturn(mockInfoService);
 
         Mockito.when(mockInfoService.getCloudColocateBucketsNum(Mockito.any(GroupId.class))).thenReturn(BUCKET_NUM);
+        Answer<Long> placementAnswer = invocation -> {
+            GroupId groupId = invocation.getArgument(0);
+            List<Long> candidateBeIds = invocation.getArgument(2);
+            long bucketIdx = invocation.getArgument(3);
+            return CloudColocatePlacement.buildPlacement(groupId.grpId,
+                    candidateBeIds.stream().mapToLong(Long::longValue).toArray(), BUCKET_NUM)[(int) bucketIdx];
+        };
         Mockito.when(mockInfoService.getCloudColocateHrwBeId(Mockito.any(GroupId.class), Mockito.anyString(),
-                Mockito.anyList(), Mockito.anyLong())).thenAnswer(invocation -> {
-                    GroupId groupId = invocation.getArgument(0);
-                    List<Long> candidateBeIds = invocation.getArgument(2);
-                    long bucketIdx = invocation.getArgument(3);
-                    return CloudColocatePlacement.pickBackendId(groupId.grpId, bucketIdx,
-                            candidateBeIds.stream().mapToLong(Long::longValue).toArray());
-                });
+                Mockito.anyList(), Mockito.anyLong())).thenAnswer(placementAnswer);
+        Mockito.when(mockInfoService.getCloudColocateHrwBeIdForDeadGrace(Mockito.any(GroupId.class),
+                Mockito.anyString(), Mockito.anyList(), Mockito.anyLong())).thenAnswer(placementAnswer);
     }
 
     @AfterEach


### PR DESCRIPTION
Problem Summary: Cloud colocate placement scored each bucket independently, so a 120-bucket group on three backends could be distributed as 47/43/30 and put the most-loaded backend on the query critical path. Build the complete placement with deterministic hard quotas so the same case is 40/40/40, while retaining HRW preference and low remapping when backends change. Route the dead-backend grace path through the same placement cache with a separate bounded cache slot for its candidate set.

### Release note

Cloud colocate placement now limits backend bucket counts to differ by at most one while retaining low-remap HRW behavior.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

