### PR TITLE
[Bug] Fix FE reports hardcoded field length 255 for VARCHAR columns in MySQL protocol

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlSerializer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlSerializer.java
@@ -322,9 +322,10 @@ public class MysqlSerializer {
             case VARBINARY: {
                 return type.getLength();
             }
-            // todo:It needs to be obtained according to the field length set during the actual creation,
-            // todo:which is not supported for the time being.default is 255
-            // CHAR,VARCHAR:
+            case VARCHAR:
+            case CHAR:
+            case STRING:
+                return type.getLength();
             default:
                 return 255;
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlSerializerVarbinaryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlSerializerVarbinaryTest.java
@@ -111,8 +111,7 @@ public class MysqlSerializerVarbinaryTest {
         Assertions.assertEquals(33, charset); // utf8_general_ci
         off += 2;
         long displayLen = leUInt4(out, off);
-        // current implementation defaults to 255 for non numeric/time types if not special-cased
-        Assertions.assertEquals(255L, displayLen);
+        Assertions.assertEquals(10L, displayLen);
         off += 4; // type
         off += 1;
         int flags = leUInt2(out, off);


### PR DESCRIPTION
## Proposed changes

Fix FE reports hardcoded field length 255 for all VARCHAR columns in the MySQL protocol column definition packet.

### Problem
When connecting via MySQL connector/ODBC, VARCHAR columns always show length 255 instead of the actual defined length. The `getMysqlTypeLength` method in `MysqlSerializer` had a hardcoded `return 255` in the default case for VARCHAR/CHAR/STRING types, ignoring the actual type length.

### Solution
Added explicit cases for `VARCHAR`, `CHAR`, and `STRING` in `getMysqlTypeLength` to return `type.getLength()` instead of the hardcoded 255. This reports the actual column length (e.g., 10 for VARCHAR(10)) in the MySQL protocol column definition packet.

### Changes
- `fe/fe-core/src/main/java/org/apache/doris/mysql/MysqlSerializer.java`: Added explicit cases for VARCHAR, CHAR, STRING to return actual type length
- `fe/fe-core/src/test/java/org/apache/doris/mysql/MysqlSerializerVarbinaryTest.java`: Updated test to expect actual VARCHAR length (10) instead of 255

Issue: #67349