### PR TITLE
branch-4.1: [fix](test) run search score TopN case in nonConcurrent group

### DIFF
--- a/regression-test/suites/inverted_index_p0/test_search_score_topn_predicates.groovy
+++ b/regression-test/suites/inverted_index_p0/test_search_score_topn_predicates.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_score_topn_predicates", "p0") {
+suite("test_search_score_topn_predicates", "p0,nonConcurrent") {
     sql "DROP TABLE IF EXISTS test_search_score_topn_predicates"
 
     sql """


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #67327 (which backported #65821 and introduced this suite)

Problem Summary:

`test_search_score_topn_predicates` fails intermittently on the shared P0 pipeline of branch-4.1. It always fails on its very first query (line 59), right after `CREATE TABLE` + `INSERT` + `sync`, with:

```
errCode = 2, detailMessage = [INTERNAL_ERROR]SearchExpr should not be executed without inverted index
```

Observed on branch-4.1 CI, 2 failures out of 4 runs — builds `1034808` (PR #67327) and `1035495` (PR #67342) failed, while `1035120` (rerun of #67327, identical code, 5530 tests passed) and `1035335` (PR #67340, after the suite landed) passed. At roughly a 50% hit rate it randomly reddens unrelated branch-4.1 PRs, so it needs to stop running in the concurrent P0 group.

The case is not wrong on its own: it passes locally against both a 1-BE and a 3-BE cluster built from this branch, and the CI rerun with identical code passed as well. That points at contention on the shared P0 runner (the index of the freshly inserted rowset not being usable yet at query time) rather than at the query. branch-4.1 also lacks master's `prevent_search_row_fallback` path (added by #66052 together with the SNII format), so on this branch a search that does not take the index surfaces the internal error directly instead of falling back.

Fix: move the suite to the `nonConcurrent` group so it runs serialized, as 35 other `inverted_index_p0` cases on this branch already do. No test logic or expected output changes.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->