### PR TITLE
[fix](udf) Reject variadic user-defined functions

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/parser/LogicalPlanBuilder.java
@@ -5610,12 +5610,9 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
         boolean isAggFunction = ctx.AGGREGATE() != null;
         boolean isTableFunction = ctx.TABLES() != null;
         FunctionName function = visitFunctionIdentifier(ctx.functionIdentifier());
-        FunctionArgTypesInfo functionArgTypesInfo;
-        if (ctx.functionArguments() != null) {
-            functionArgTypesInfo = visitFunctionArguments(ctx.functionArguments());
-        } else {
-            functionArgTypesInfo = new FunctionArgTypesInfo(new ArrayList<>(), false);
-        }
+        List<DataType> argTypes = ctx.dataTypeList() == null
+                ? new ArrayList<>() : visitDataTypeList(ctx.dataTypeList());
+        FunctionArgTypesInfo functionArgTypesInfo = new FunctionArgTypesInfo(argTypes, false);
         DataType returnType = typedVisit(ctx.returnType);
         returnType = returnType.conversion();
         DataType intermediateType = ctx.intermediateType != null ? typedVisit(ctx.intermediateType) : null;
@@ -5636,12 +5633,9 @@ public class LogicalPlanBuilder extends DorisParserBaseVisitor<Object> {
         SetType statementScope = visitStatementScope(ctx.statementScope());
         boolean ifNotExists = ctx.EXISTS() != null;
         FunctionName function = visitFunctionIdentifier(ctx.functionIdentifier());
-        FunctionArgTypesInfo functionArgTypesInfo;
-        if (ctx.functionArguments() != null) {
-            functionArgTypesInfo = visitFunctionArguments(ctx.functionArguments());
-        } else {
-            functionArgTypesInfo = new FunctionArgTypesInfo(new ArrayList<>(), false);
-        }
+        List<DataType> argTypes = ctx.dataTypeList() == null
+                ? new ArrayList<>() : visitDataTypeList(ctx.dataTypeList());
+        FunctionArgTypesInfo functionArgTypesInfo = new FunctionArgTypesInfo(argTypes, false);
         List<String> parameters = ctx.parameters != null ? visitIdentifierSeq(ctx.parameters) : new ArrayList<>();
         Expression originFunction = getExpression(ctx.expression());
         return new CreateFunctionCommand(statementScope, ifNotExists, false, true, false,

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdafBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdafBuilder.java
@@ -63,7 +63,7 @@ public class JavaUdafBuilder extends UdfBuilder {
 
     @Override
     public boolean canApply(List<?> arguments) {
-        if ((isVarArgs && arity > arguments.size() + 1) || (!isVarArgs && arguments.size() != arity)) {
+        if (arguments.size() != arity) {
             return false;
         }
         for (Object argument : arguments) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdfBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdfBuilder.java
@@ -65,7 +65,7 @@ public class JavaUdfBuilder extends UdfBuilder {
 
     @Override
     public boolean canApply(List<?> arguments) {
-        if ((isVarArgs && arity > arguments.size() + 1) || (!isVarArgs && arguments.size() != arity)) {
+        if (arguments.size() != arity) {
             return false;
         }
         for (Object argument : arguments) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdtfBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/JavaUdtfBuilder.java
@@ -65,7 +65,7 @@ public class JavaUdtfBuilder extends UdfBuilder {
 
     @Override
     public boolean canApply(List<?> arguments) {
-        if ((isVarArgs && arity > arguments.size() + 1) || (!isVarArgs && arguments.size() != arity)) {
+        if (arguments.size() != arity) {
             return false;
         }
         for (Object argument : arguments) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/PythonUdafBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/PythonUdafBuilder.java
@@ -63,7 +63,7 @@ public class PythonUdafBuilder extends UdfBuilder {
 
     @Override
     public boolean canApply(List<?> arguments) {
-        if ((isVarArgs && arity > arguments.size() + 1) || (!isVarArgs && arguments.size() != arity)) {
+        if (arguments.size() != arity) {
             return false;
         }
         for (Object argument : arguments) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/PythonUdfBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/PythonUdfBuilder.java
@@ -65,7 +65,7 @@ public class PythonUdfBuilder extends UdfBuilder {
 
     @Override
     public boolean canApply(List<?> arguments) {
-        if ((isVarArgs && arity > arguments.size() + 1) || (!isVarArgs && arguments.size() != arity)) {
+        if (arguments.size() != arity) {
             return false;
         }
         for (Object argument : arguments) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/PythonUdtfBuilder.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/udf/PythonUdtfBuilder.java
@@ -65,7 +65,7 @@ public class PythonUdtfBuilder extends UdfBuilder {
 
     @Override
     public boolean canApply(List<?> arguments) {
-        if ((isVarArgs && arity > arguments.size() + 1) || (!isVarArgs && arguments.size() != arity)) {
+        if (arguments.size() != arity) {
             return false;
         }
         for (Object argument : arguments) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateFunctionCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/CreateFunctionCommand.java
@@ -529,7 +529,7 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
         }
         function = ScalarFunction.createUdf(binaryType,
                 functionName, argsDef.getArgTypes(),
-                ((ArrayType) (returnType.toCatalogDataType())).getItemType(), argsDef.isVariadic(),
+                ((ArrayType) (returnType.toCatalogDataType())).getItemType(), false,
                 location, symbol, null, null);
         function.setChecksum(checksum);
         function.setNullableMode(returnNullMode);
@@ -551,7 +551,7 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
             location = null;
         }
         builder.name(functionName).argsType(argsDef.getArgTypes()).retType(returnType.toCatalogDataType())
-                .hasVarArgs(argsDef.isVariadic()).intermediateType(intermediateType.toCatalogDataType())
+                .hasVarArgs(false).intermediateType(intermediateType.toCatalogDataType())
                 .location(location);
         String initFnSymbol = properties.get(INIT_KEY);
         if (initFnSymbol == null && !(binaryType == Function.BinaryType.JAVA_UDF
@@ -641,7 +641,7 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
         }
         function = ScalarFunction.createUdf(binaryType,
                 functionName, argsDef.getArgTypes(),
-                returnType.toCatalogDataType(), argsDef.isVariadic(),
+                returnType.toCatalogDataType(), false,
                 location, symbol, prepareFnSymbol, closeFnSymbol);
         function.setChecksum(checksum);
         function.setNullableMode(returnNullMode);
@@ -1174,7 +1174,7 @@ public class CreateFunctionCommand extends Command implements ForwardWithSync {
         }
         Map<String, String> sessionVariables = ConnectContextUtil.getAffectQueryResultInPlanVariables(ctx);
         function = AliasFunction.createFunction(functionName, argsDef.getArgTypes(),
-                Type.VARCHAR, argsDef.isVariadic(), parameters, translateToLegacyExpr(originFunction, ctx),
+                Type.VARCHAR, false, parameters, translateToLegacyExpr(originFunction, ctx),
                 sessionVariables);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/NereidsParserTest.java
@@ -965,14 +965,23 @@ public class NereidsParserTest extends ParserTestBase {
     @Test
     public void testCreateFunction() {
         NereidsParser nereidsParser = new NereidsParser();
-        String sql = "create session tables function func_a (int, ...) returns boolean properties('k'='v')";
-        nereidsParser.parseSingle(sql);
+        nereidsParser.parseSingle(
+                "create session tables function func_a(int) returns boolean properties('k'='v')");
+        nereidsParser.parseSingle("create local aggregate function func_a(int) returns boolean "
+                + "intermediate varchar properties('k'='v')");
+        nereidsParser.parseSingle("create alias function func_a(int) with parameter(id) as abs(id)");
 
-        sql = "create local aggregate function func_a (int, ...) returns boolean intermediate varchar properties('k'='v')";
-        nereidsParser.parseSingle(sql);
+        Assertions.assertThrows(ParseException.class, () -> nereidsParser.parseSingle(
+                "create function func_a(int, ...) returns boolean properties('k'='v')"));
+        Assertions.assertThrows(ParseException.class, () -> nereidsParser.parseSingle(
+                "create aggregate function func_a(int, ...) returns boolean properties('k'='v')"));
+        Assertions.assertThrows(ParseException.class, () -> nereidsParser.parseSingle(
+                "create tables function func_a(int, ...) returns boolean properties('k'='v')"));
+        Assertions.assertThrows(ParseException.class, () -> nereidsParser.parseSingle(
+                "create alias function func_a(int, ...) with parameter(id) as abs(id)"));
 
-        sql = "create alias function func_a (int) with parameter(id) as abs(id)";
-        nereidsParser.parseSingle(sql);
+        nereidsParser.parseSingle("drop function func_a(int, ...)");
+        nereidsParser.parseSingle("show create function func_a(int, ...)");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/udf/UdfBuilderArityTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/udf/UdfBuilderArityTest.java
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.functions.udf;
+
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class UdfBuilderArityTest {
+
+    @Test
+    void testVariadicMetadataDoesNotEnableVariableArity() {
+        JavaUdf javaUdf = Mockito.mock(JavaUdf.class);
+        Mockito.when(javaUdf.hasVarArguments()).thenReturn(true);
+        Mockito.when(javaUdf.arity()).thenReturn(2);
+        assertFixedArity(new JavaUdfBuilder(javaUdf));
+
+        JavaUdaf javaUdaf = Mockito.mock(JavaUdaf.class);
+        Mockito.when(javaUdaf.hasVarArguments()).thenReturn(true);
+        Mockito.when(javaUdaf.arity()).thenReturn(2);
+        assertFixedArity(new JavaUdafBuilder(javaUdaf));
+
+        JavaUdtf javaUdtf = Mockito.mock(JavaUdtf.class);
+        Mockito.when(javaUdtf.hasVarArguments()).thenReturn(true);
+        Mockito.when(javaUdtf.arity()).thenReturn(2);
+        assertFixedArity(new JavaUdtfBuilder(javaUdtf));
+
+        PythonUdf pythonUdf = Mockito.mock(PythonUdf.class);
+        Mockito.when(pythonUdf.hasVarArguments()).thenReturn(true);
+        Mockito.when(pythonUdf.arity()).thenReturn(2);
+        assertFixedArity(new PythonUdfBuilder(pythonUdf));
+
+        PythonUdaf pythonUdaf = Mockito.mock(PythonUdaf.class);
+        Mockito.when(pythonUdaf.hasVarArguments()).thenReturn(true);
+        Mockito.when(pythonUdaf.arity()).thenReturn(2);
+        assertFixedArity(new PythonUdafBuilder(pythonUdaf));
+
+        PythonUdtf pythonUdtf = Mockito.mock(PythonUdtf.class);
+        Mockito.when(pythonUdtf.hasVarArguments()).thenReturn(true);
+        Mockito.when(pythonUdtf.arity()).thenReturn(2);
+        assertFixedArity(new PythonUdtfBuilder(pythonUdtf));
+    }
+
+    private void assertFixedArity(UdfBuilder builder) {
+        Assertions.assertFalse(builder.canApply(ImmutableList.of(new IntegerLiteral(1))));
+        Assertions.assertTrue(builder.canApply(ImmutableList.of(new IntegerLiteral(1), new IntegerLiteral(2))));
+        Assertions.assertFalse(builder.canApply(
+                ImmutableList.of(new IntegerLiteral(1), new IntegerLiteral(2), new IntegerLiteral(3))));
+    }
+}

--- a/fe/fe-sql-parser/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-sql-parser/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -385,12 +385,12 @@ createStatement
     | CREATE ENCRYPTKEY (IF NOT EXISTS)? multipartIdentifier AS STRING_LITERAL  #createEncryptkey
     | CREATE statementScope?
             (TABLES | AGGREGATE)? FUNCTION (IF NOT EXISTS)?
-            functionIdentifier LEFT_PAREN functionArguments? RIGHT_PAREN
+            functionIdentifier LEFT_PAREN dataTypeList? RIGHT_PAREN
             RETURNS returnType=dataType (INTERMEDIATE intermediateType=dataType)?
             properties=propertyClause?
             (AS functionCode=dollarQuotedString)?                                   #createUserDefineFunction
     | CREATE statementScope? ALIAS FUNCTION (IF NOT EXISTS)?
-            functionIdentifier LEFT_PAREN functionArguments? RIGHT_PAREN
+            functionIdentifier LEFT_PAREN dataTypeList? RIGHT_PAREN
             WITH PARAMETER LEFT_PAREN parameters=identifierSeq? RIGHT_PAREN
             AS expression                                                           #createAliasFunction
     | CREATE USER (IF NOT EXISTS)? grantUserIdentify


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Problem Summary:

 User-defined functions exposed variadic DDL metadata without reliable end-to-end support. Reject variadic declarations during `CREATE FUNCTION` analysis for scalar, aggregate, table, and alias functions while retaining variadic signature parsing for `DROP`, `SHOW`, and historical metadata compatibility.

before:
```sql
CREATE FUNCTION py_add(INT, INT, ...)
RETURNS INT
PROPERTIES (
    "type" = "PYTHON_UDF",
    "symbol" = "evaluate",
    "runtime_version" = "3.12.11",
    "volatility" = "immutable"
)
AS $$
def evaluate(a, b, c):
    return a + b + c
$$;

SELECT py_add(1, 2, 3);
-- ERROR 1105 (HY000): errCode = 2, detailMessage = Index 2 out of bounds for length 2
```

In `PythonUdfBuilder.java:82`:

```java
public Pair<PythonUdf, PythonUdf> build(String name, List<?> arguments) {
    // exprs = (1, 2, 3), size = 3
    // argTypes = [INT, INT], size = 2
    List<Expression> exprs = arguments.stream().map(Expression.class::cast).collect(Collectors.toList());
    List<DataType> argTypes = udf.getSignatures().get(0).argumentsTypes;

    List<Expression> processedExprs = Lists.newArrayList();
    for (int i = 0; i < exprs.size(); ++i) {
        // when i = 2, argTypes.get(2), err occur!
        processedExprs.add(TypeCoercionUtils.castIfNotSameType(exprs.get(i), argTypes.get(i)));
    }
    return Pair.ofSame(udf.withFreshVolatileIdentity().withChildren(processedExprs));
}
```

now:
```sql
CREATE FUNCTION py_add(INT, INT, ...)
RETURNS INT
PROPERTIES (
    "type" = "PYTHON_UDF",
    "symbol" = "evaluate",
    "runtime_version" = "3.12.11",
    "volatility" = "immutable"
)
AS $$
def evaluate(a, b, c):
    return a + b + c
$$;
-- ERROR 1105 (HY000): errCode = 2, detailMessage = mismatched input ',' expecting ')'(line 1, pos 31)
```

### Release note

Reject variadic declarations for user-defined functions.

### Check List (For Author)

- Test: Unit Test
  - ./run-fe-ut.sh --run org.apache.doris.catalog.CreateFunctionTest
- Behavior changed: Yes. Variadic user-defined function declarations are rejected during analysis.
- Does this need documentation: https://github.com/apache/doris-website/pull/4103