### PR TITLE
[improvement](compaction) Support preferred peer reads

### DIFF
--- a/be/src/io/cache/cached_remote_file_reader.cpp
+++ b/be/src/io/cache/cached_remote_file_reader.cpp
@@ -169,7 +169,7 @@ bool CachedRemoteFileReader::_can_read_cache_file_directly() const {
 bool CachedRemoteFileReader::_should_read_from_peer(const IOContext* io_ctx) const {
     return doris::config::is_cloud_mode() && _is_doris_table && _tablet_id > 0 &&
            !io_ctx->is_warmup && !io_ctx->bypass_peer_read &&
-           doris::config::enable_cache_read_from_peer;
+           (doris::config::enable_cache_read_from_peer || !io_ctx->preferred_peer_host.empty());
 }
 
 void CachedRemoteFileReader::_insert_file_reader(FileBlockSPtr file_block) {
@@ -663,6 +663,19 @@ Status CachedRemoteFileReader::_execute_remote_read(const std::vector<FileBlockS
         return _execute_s3_fallback(empty_start, span_size, buffer, peer_result, stats, io_ctx);
     }
 
+    if (!io_ctx->preferred_peer_host.empty()) {
+        const auto st = execute_peer_read(empty_blocks, peer_result, path().native(), this->size(),
+                                          _is_doris_table, stats, io_ctx,
+                                          io_ctx->preferred_peer_host, io_ctx->preferred_peer_port);
+        if (st.ok()) {
+            if (io_ctx->file_cache_stats != nullptr) {
+                io_ctx->file_cache_stats->peer_hosts.insert(io_ctx->preferred_peer_host);
+            }
+            return st;
+        }
+        return _execute_s3_fallback(empty_start, span_size, buffer, peer_result, stats, io_ctx);
+    }
+
     // --- UT debug point: injected peer address ---
     DBUG_EXECUTE_IF("PeerFileCacheReader::_fetch_from_peer_cache_blocks", {
         std::string dp_host = dp->param<std::string>("host", "127.0.0.1");
@@ -887,10 +900,14 @@ Status CachedRemoteFileReader::_read_remote_blocks_into_cache(
         }
     }
 
+    const bool skip_cache_write = !io_ctx->preferred_peer_host.empty();
+    if (skip_cache_write) {
+        stats.skip_cache = true;
+    }
     SCOPED_CONCURRENCY_COUNT(ConcurrencyStatsManager::instance().cached_remote_reader_write_back);
     for (size_t idx = 0; idx < empty_blocks.size(); ++idx) {
         auto& block = empty_blocks[idx];
-        if (block->state() == FileBlock::State::SKIP_CACHE) {
+        if (skip_cache_write || block->state() == FileBlock::State::SKIP_CACHE) {
             continue;
         }
 
@@ -1294,6 +1311,9 @@ Status CachedRemoteFileReader::read_at_impl(size_t offset, Slice result, size_t*
 }
 
 void CachedRemoteFileReader::prefetch_range(size_t offset, size_t size, const IOContext* io_ctx) {
+    if (io_ctx != nullptr && !io_ctx->preferred_peer_host.empty()) {
+        return;
+    }
     if (offset >= this->size() || size == 0) {
         return;
     }
@@ -1362,8 +1382,7 @@ void CachedRemoteFileReader::_update_stats(const ReadStatistics& read_stats,
         if (source_read_breakdown.peer_bytes != 0 || read_stats.from_peer_cache) {
             // Count peer IO whenever peer was used, even if its fetched blocks were entirely
             // outside the copy range (e.g., backward-aligned prefetch block before
-            // offset+already_read).  In that case peer_bytes==0 but the peer RPC did happen
-            // and wrote data into the local file cache.
+            // offset+already_read). In that case peer_bytes==0 but the peer RPC did happen.
             statis->num_peer_io_total++;
             statis->bytes_read_from_peer += source_read_breakdown.peer_bytes;
             statis->peer_io_timer += read_stats.peer_read_timer;

--- a/be/src/io/io_common.h
+++ b/be/src/io/io_common.h
@@ -251,6 +251,9 @@ struct IOContext {
     // Per-call override for cache write completion semantics. An unset value follows the reader
     // option and the global async file-cache write switch.
     std::optional<CacheWriteMode> cache_write_mode_override = std::nullopt;
+    // Optional per-request peer; try only this peer before falling back to remote storage.
+    std::string preferred_peer_host {};
+    int32_t preferred_peer_port {0};
     FileCacheMissPolicy file_cache_miss_policy = FileCacheMissPolicy::READ_THROUGH_AND_WRITE_BACK;
     // From session variable inverted_index_snii_read_no_write_file_cache: SNII index
     // reads of this query take REMOTE_ONLY_ON_MISS (hit served, miss reads remote

--- a/be/src/storage/rowset/beta_rowset_reader.h
+++ b/be/src/storage/rowset/beta_rowset_reader.h
@@ -53,6 +53,10 @@ public:
                                  std::vector<RowwiseIteratorUPtr>* out_iters,
                                  bool use_cache = false) override;
     void reset_read_options() override;
+    void set_preferred_file_cache_peer(const std::string& host, int32_t port) override {
+        _read_options.io_ctx.preferred_peer_host = host;
+        _read_options.io_ctx.preferred_peer_port = port;
+    }
     Status next_batch(Block* block) override { return _next_batch(block); }
     Status next_batch(BlockView* block_view) override { return _next_batch(block_view); }
     Status next_batch(BlockWithSameBit* block_with_same_bit) override {

--- a/be/src/storage/rowset/rowset_reader.h
+++ b/be/src/storage/rowset/rowset_reader.h
@@ -21,6 +21,7 @@
 #include <gen_cpp/olap_file.pb.h>
 
 #include <memory>
+#include <string>
 
 #include "core/block/block.h"
 #include "storage/iterators.h"
@@ -58,6 +59,7 @@ public:
                                          std::vector<RowwiseIteratorUPtr>* out_iters,
                                          bool use_cache = false) = 0;
     virtual void reset_read_options() = 0;
+    virtual void set_preferred_file_cache_peer(const std::string& host, int32_t port) = 0;
 
     virtual Status next_batch(Block* block) = 0;
     virtual Status next_batch(BlockView* block_view) = 0;

--- a/be/test/io/cache/cached_remote_file_reader_peer_test.cpp
+++ b/be/test/io/cache/cached_remote_file_reader_peer_test.cpp
@@ -551,7 +551,7 @@ private:
 
 } // namespace
 
-TEST_F(CachedRemoteFileReaderPeerTest, read_at_uses_peer_cache_when_available) {
+TEST_F(CachedRemoteFileReaderPeerTest, read_at_uses_preferred_peer_when_global_peer_read_disabled) {
     const std::string content = "abcdefghijklmnop";
     const fs::path file_path =
             create_peer_test_file("cached_remote_reader_peer_success.dat", content);
@@ -574,9 +574,7 @@ TEST_F(CachedRemoteFileReaderPeerTest, read_at_uses_peer_cache_when_available) {
     auto addr = start_peer_test_server(&server, &service);
     Defer stop_server {[&]() { stop_peer_test_server(&server); }};
 
-    DebugPoints::instance()->add_with_params(
-            "PeerFileCacheReader::_fetch_from_peer_cache_blocks",
-            {{"host", "127.0.0.1"}, {"port", std::to_string(addr.port)}});
+    config::enable_cache_read_from_peer = false;
 
     FileReaderSPtr local_reader;
     ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
@@ -591,6 +589,8 @@ TEST_F(CachedRemoteFileReaderPeerTest, read_at_uses_peer_cache_when_available) {
     std::string buffer(10, '#');
     size_t bytes_read = 0;
     IOContext io_ctx;
+    io_ctx.preferred_peer_host = "127.0.0.1";
+    io_ctx.preferred_peer_port = addr.port;
     FileCacheStatistics cache_stats;
     io_ctx.file_cache_stats = &cache_stats;
 
@@ -605,8 +605,10 @@ TEST_F(CachedRemoteFileReaderPeerTest, read_at_uses_peer_cache_when_available) {
     EXPECT_EQ(cache_stats.bytes_read_from_local, 0);
     EXPECT_EQ(cache_stats.num_peer_io_total, 1);
     EXPECT_EQ(cache_stats.bytes_read_from_peer, 10);
+    EXPECT_EQ(cache_stats.peer_hosts.count("127.0.0.1"), 1);
     EXPECT_EQ(cache_stats.num_remote_io_total, 0);
     EXPECT_EQ(cache_stats.bytes_read_from_remote, 0);
+    EXPECT_EQ(cache_stats.bytes_write_into_cache, 0);
 }
 
 TEST_F(CachedRemoteFileReaderPeerTest, read_at_peer_dryrun_downloads_cache_without_copying_result) {
@@ -2118,6 +2120,64 @@ TEST_F(CachedRemoteFileReaderPeerTest, read_at_falls_back_to_remote_when_peer_re
     EXPECT_EQ(cache_stats.bytes_read_from_peer, 0);
     EXPECT_EQ(cache_stats.num_remote_io_total, 1);
     EXPECT_EQ(cache_stats.bytes_read_from_remote, 10);
+}
+
+TEST_F(CachedRemoteFileReaderPeerTest,
+       read_at_falls_back_to_remote_when_preferred_peer_read_fails) {
+    const std::string content = "abcdefghijklmnop";
+    const fs::path file_path =
+            create_peer_test_file("cached_remote_reader_preferred_peer_fallback.dat", content);
+    Defer cleanup_file {[&]() {
+        std::error_code ec;
+        fs::remove(file_path, ec);
+    }};
+
+    const fs::path cache_path = caches_dir / "cached_remote_reader_preferred_peer_fallback_cache";
+    Defer cleanup_cache {[&]() {
+        std::error_code ec;
+        fs::remove_all(cache_path, ec);
+    }};
+
+    clear_cached_remote_reader_factory();
+    create_peer_test_cache(cache_path, kPeerTestBlockSize);
+
+    MockPeerCacheServiceOptions options;
+    options.fail_status = true;
+    MockPeerCacheService service(content, options);
+    brpc::Server server;
+    auto addr = start_peer_test_server(&server, &service);
+    Defer stop_server {[&]() { stop_peer_test_server(&server); }};
+
+    config::enable_cache_read_from_peer = false;
+
+    FileReaderSPtr local_reader;
+    ASSERT_TRUE(global_local_filesystem()->open_file(file_path.string(), &local_reader).ok());
+
+    FileReaderOptions opts;
+    opts.cache_type = FileCachePolicy::FILE_BLOCK_CACHE;
+    opts.is_doris_table = true;
+    opts.mtime = 1;
+    opts.tablet_id = kPeerTestTabletId;
+    CachedRemoteFileReader reader(local_reader, opts);
+
+    std::string buffer(10, '#');
+    size_t bytes_read = 0;
+    IOContext io_ctx;
+    io_ctx.preferred_peer_host = "127.0.0.1";
+    io_ctx.preferred_peer_port = addr.port;
+    FileCacheStatistics cache_stats;
+    io_ctx.file_cache_stats = &cache_stats;
+
+    ASSERT_TRUE(reader.read_at(1, Slice(buffer.data(), buffer.size()), &bytes_read, &io_ctx).ok());
+
+    EXPECT_EQ(buffer, content.substr(1, 10));
+    EXPECT_EQ(bytes_read, 10);
+    EXPECT_EQ(service.rpc_count.load(), 1);
+    EXPECT_EQ(cache_stats.num_peer_io_total, 0);
+    EXPECT_EQ(cache_stats.bytes_read_from_peer, 0);
+    EXPECT_EQ(cache_stats.num_remote_io_total, 1);
+    EXPECT_EQ(cache_stats.bytes_read_from_remote, 10);
+    EXPECT_EQ(cache_stats.bytes_write_into_cache, 0);
 }
 
 } // namespace doris::io

--- a/be/test/storage/index/inverted/similarity/collection_statistics_test.cpp
+++ b/be/test/storage/index/inverted/similarity/collection_statistics_test.cpp
@@ -264,6 +264,8 @@ public:
 
     void reset_read_options() override {}
 
+    void set_preferred_file_cache_peer(const std::string&, int32_t) override {}
+
     Status next_batch(Block* block) override {
         return Status::NotSupported("MockRowsetReader::next_batch not implemented");
     }

--- a/be/test/storage/iterator/block_reader_binlog_vcollect_merge_test.cpp
+++ b/be/test/storage/iterator/block_reader_binlog_vcollect_merge_test.cpp
@@ -182,6 +182,7 @@ public:
         return Status::OK();
     }
     void reset_read_options() override {}
+    void set_preferred_file_cache_peer(const std::string&, int32_t) override {}
 
     Status next_batch(Block* block) override {
         if (_emitted) {

--- a/be/test/storage/rowset/beta_rowset_test.cpp
+++ b/be/test/storage/rowset/beta_rowset_test.cpp
@@ -41,6 +41,7 @@
 
 #include "common/config.h"
 #include "common/status.h"
+#include "core/block/block.h"
 #include "cpp/obj-client/s3_obj_storage_client.h"
 #include "cpp/sync_point.h"
 #include "gtest/gtest_pred_impl.h"
@@ -56,6 +57,7 @@
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_meta.h"
 #include "storage/rowset/rowset_reader.h"
+#include "storage/rowset/rowset_reader_context.h"
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/segment/segment.h"
 #include "storage/storage_engine.h"
@@ -72,10 +74,6 @@ class HeadObjectRequest;
 } // namespace Model
 } // namespace S3
 } // namespace Aws
-namespace doris {
-struct RowsetReaderContext;
-} // namespace doris
-
 using std::string;
 
 namespace doris {
@@ -367,6 +365,63 @@ TEST_F(BetaRowsetTest, ReadTest) {
         Status st = rowset.load_segments(&segments);
         ASSERT_FALSE(st.ok());
     }
+}
+
+TEST_F(BetaRowsetTest, PreferredPeerPropagatesToSegmentIoContext) {
+    auto tablet_schema = std::make_shared<TabletSchema>();
+    create_tablet_schema(tablet_schema);
+    RowsetWriterContext writer_context;
+    create_rowset_writer_context(tablet_schema, &writer_context);
+
+    EngineOptions options;
+    StorageEngine engine(options);
+    BetaRowsetWriterForTest writer(engine);
+    ASSERT_TRUE(writer.init(writer_context).ok());
+
+    Block block = tablet_schema->create_storage_block();
+    auto columns = std::move(block).mutate_columns();
+    int32_t value = 1;
+    for (auto& column : columns) {
+        column->insert_data(reinterpret_cast<const char*>(&value), sizeof(value));
+    }
+    block.set_columns(std::move(columns));
+    ASSERT_TRUE(writer.add_block(&block).ok());
+    ASSERT_TRUE(writer.flush().ok());
+
+    RowsetSharedPtr rowset;
+    ASSERT_TRUE(writer.build(rowset).ok());
+    RowsetReaderSharedPtr reader;
+    ASSERT_TRUE(rowset->create_reader(&reader).ok());
+    reader->set_preferred_file_cache_peer("preferred-peer", 8060);
+
+    auto read_schema = std::make_shared<ReadSchema>(
+            project_columns_by_ordinal(tablet_schema->columns(), std::vector<ColumnId> {0, 1, 2}));
+    RowsetReaderContext reader_context;
+    reader_context.tablet_schema = tablet_schema;
+    reader_context.read_schema = read_schema;
+    reader_context.stats = &_stats;
+    ASSERT_TRUE(reader->init(&reader_context).ok());
+
+    auto* sp = SyncPoint::get_instance();
+    sp->enable_processing();
+    bool observed_io_ctx = false;
+    SyncPoint::CallbackGuard guard;
+    sp->set_call_back(
+            "Segment::_parse_footer::io_ctx",
+            [&](auto&& args) {
+                auto* io_ctx = try_any_cast<io::IOContext*>(args[0]);
+                observed_io_ctx = true;
+                EXPECT_EQ(io_ctx->preferred_peer_host, "preferred-peer");
+                EXPECT_EQ(io_ctx->preferred_peer_port, 8060);
+            },
+            &guard);
+
+    Block output_block = read_schema->create_read_block();
+    auto st = reader->next_batch(&output_block);
+    sp->disable_processing();
+
+    ASSERT_TRUE(st.ok()) << st;
+    EXPECT_TRUE(observed_io_ctx);
 }
 
 TEST_F(BetaRowsetTest, AddToBinlogTest) {


### PR DESCRIPTION
Later, we will support distributed parallel compaction. compaction workers may not have the input rowsets in their local file cache.
This PR allows workers to read cached input data from the coordinator when available. It propagates an optional preferred peer through RowsetReader and IOContext. When configured, the worker tries only that peer and falls back directly to remote storage if the peer read fails.

related pr: 
https://github.com/apache/doris/pull/67360