### PR TITLE
[improvement](jsonb) Evaluate json_extract_string on VARCHAR without casting to JSONB

### DIFF
--- a/be/src/exprs/function/function_jsonb.cpp
+++ b/be/src/exprs/function/function_jsonb.cpp
@@ -3063,10 +3063,12 @@ public:
 // json_extract_string / jsonb_extract_string over a raw VARCHAR/STRING column carrying JSON text.
 // The path is parsed with the authoritative JsonbPath grammar so invalid paths raise the same error
 // as the JSON-typed route. Paths whose legs are all plain object members or non-negative array
-// indices take a fast simdjson at_pointer navigation that reparses only the extracted slice; the
-// root path, wildcards, [last], negative indices, and any at_pointer miss fall back to the exact
-// Cast(JsonbExtract(...) AS String) route (full parse + JsonbPath findValue + format), so the result
-// matches that route for every JsonbPath-supported form.
+// indices take a fast simdjson on-demand traversal that walks the legs one by one, dispatching by
+// JsonbPath leg TYPE (a MEMBER leg requires an object, an ARRAY leg requires an array) rather than
+// by the runtime container, and reparses only the extracted slice. The root path, wildcards,
+// [last], negative indices, and ANY traversal miss (type mismatch, missing key, out-of-range index)
+// fall back to the exact Cast(JsonbExtract(...) AS String) route (full parse + JsonbPath findValue +
+// format), which reproduces the index==0-on-non-array self quirk and NULL/error semantics exactly.
 class FunctionJsonExtractStringFromVarchar : public IFunction {
 public:
     static constexpr auto name = "jsonb_extract_string";
@@ -3144,7 +3146,6 @@ public:
 private:
     struct PreparedPath {
         JsonbPath path;
-        std::string pointer;
         bool simple = false;
     };
 
@@ -3164,13 +3165,15 @@ private:
             return Status::InvalidArgument("Json path error: Invalid Json Path for value: {}",
                                            std::string_view(path_ref.data, path_ref.size));
         }
-        out.simple = build_pointer_if_simple(out.path, out.pointer);
+        out.simple = is_simple_path(out.path);
         return Status::OK();
     }
 
-    // true only when the whole path can be navigated by JSON Pointer: no wildcard, no [last], no
-    // negative index, at least one leg. The root path returns false and takes the JSONB fallback.
-    static bool build_pointer_if_simple(const JsonbPath& jpath, std::string& pointer) {
+    // true only when the leg-by-leg fast traversal can reproduce JsonbPath exactly: no wildcard, no
+    // [last], no negative index, at least one leg. The root path returns false and takes the JSONB
+    // fallback. The traversal still verifies each leg's container type at runtime and falls back on
+    // any mismatch, so this only gates which paths are eligible to attempt the fast route.
+    static bool is_simple_path(const JsonbPath& jpath) {
         if (jpath.is_wildcard() || jpath.is_supper_wildcard()) {
             return false;
         }
@@ -3184,29 +3187,11 @@ private:
                 if (leg->array_index < 0) {
                     return false;
                 }
-                pointer.push_back('/');
-                pointer.append(std::to_string(leg->array_index));
-            } else if (leg->type == MEMBER_CODE) {
-                pointer.push_back('/');
-                append_pointer_token(pointer, leg->leg_ptr, leg->leg_len);
-            } else {
+            } else if (leg->type != MEMBER_CODE) {
                 return false;
             }
         }
         return true;
-    }
-
-    static void append_pointer_token(std::string& out, const char* key, unsigned int len) {
-        for (unsigned int i = 0; i < len; ++i) {
-            char c = key[i];
-            if (c == '~') {
-                out.append("~0");
-            } else if (c == '/') {
-                out.append("~1");
-            } else {
-                out.push_back(c);
-            }
-        }
     }
 
     static void extract_one(simdjson::ondemand::parser& parser, JsonbWriter& writer,
@@ -3217,30 +3202,50 @@ private:
             StringOP::push_null_string(row_idx, res_data, res_offsets, res_null_map);
             return;
         }
-        if (prepared.simple && try_pointer_extract(parser, writer, json_ref, prepared.pointer,
-                                                   row_idx, res_data, res_offsets, res_null_map)) {
+        if (prepared.simple && try_leg_navigate(parser, writer, json_ref, prepared.path, row_idx,
+                                                res_data, res_offsets, res_null_map)) {
             return;
         }
         jsonb_fallback(writer, json_ref, prepared.path, row_idx, res_data, res_offsets,
                        res_null_map);
     }
 
-    // Fast path: navigate with simdjson at_pointer. Returns false (so the caller falls back to the
-    // exact JSONB route) on any miss, type mismatch, or parse error, which keeps the result correct
-    // for escaped document keys and the "index a scalar" quirk that only JsonbPath::findValue knows.
-    static bool try_pointer_extract(simdjson::ondemand::parser& parser, JsonbWriter& writer,
-                                    const StringRef& json_ref, const std::string& pointer,
-                                    size_t row_idx, ColumnString::Chars& res_data,
-                                    ColumnString::Offsets& res_offsets, NullMap& res_null_map) {
+    // Fast path: walk the document leg by leg with simdjson on-demand, dispatching by JsonbPath leg
+    // TYPE. A MEMBER leg calls find_field_unordered (an object op) and an ARRAY leg calls get_array
+    // + at (an array op), so a leg whose container type does not match returns INCORRECT_TYPE and we
+    // fall back. Any miss (type mismatch, missing key, out-of-range index, scalar-root document, or
+    // parse error) returns false so the caller uses the authoritative JsonbPath::findValue fallback,
+    // which reproduces the index==0-on-non-array self quirk, escaped-key matching, and NULL exactly.
+    static bool try_leg_navigate(simdjson::ondemand::parser& parser, JsonbWriter& writer,
+                                 const StringRef& json_ref, const JsonbPath& jpath, size_t row_idx,
+                                 ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
+                                 NullMap& res_null_map) {
         try {
             simdjson::padded_string json_str {json_ref.data, json_ref.size};
             simdjson::ondemand::document doc = parser.iterate(json_str);
-            simdjson::ondemand::value target;
-            if (doc.at_pointer(pointer).get(target)) {
+            simdjson::ondemand::value current;
+            if (doc.get_value().get(current)) {
                 return false;
             }
+            size_t leg_count = jpath.get_leg_vector_size();
+            for (size_t i = 0; i < leg_count; ++i) {
+                const leg_info* leg = jpath.get_leg_from_leg_vector(i);
+                simdjson::ondemand::value next;
+                if (leg->type == MEMBER_CODE) {
+                    if (current.find_field_unordered(std::string_view(leg->leg_ptr, leg->leg_len))
+                                .get(next)) {
+                        return false;
+                    }
+                } else {
+                    simdjson::ondemand::array arr;
+                    if (current.get_array().get(arr) || arr.at(leg->array_index).get(next)) {
+                        return false;
+                    }
+                }
+                current = next;
+            }
             std::string_view raw;
-            if (simdjson::to_json_string(target).get(raw)) {
+            if (simdjson::to_json_string(current).get(raw)) {
                 return false;
             }
             if (!JsonbParser::parse(raw.data(), raw.size(), writer).ok()) {
@@ -3297,7 +3302,7 @@ private:
         }
         if (value->isString()) {
             const auto* str_val = value->unpack<JsonbStringVal>();
-            StringOP::push_value_string(std::string_view(str_val->getBlob(), str_val->length()),
+            StringOP::push_value_string(std::string_view(str_val->getBlob(), str_val->getBlobLen()),
                                         row_idx, res_data, res_offsets);
             return;
         }

--- a/be/src/exprs/function/function_jsonb.cpp
+++ b/be/src/exprs/function/function_jsonb.cpp
@@ -59,6 +59,7 @@
 #include "exprs/function/simple_function_factory.h"
 #include "exprs/function_context.h"
 #include "util/jsonb_document.h"
+#include "util/jsonb_parser_simd.h"
 #include "util/jsonb_utils.h"
 #include "util/jsonb_writer.h"
 #include "util/simd/bits.h"
@@ -3059,6 +3060,152 @@ public:
     }
 };
 
+// json_extract_string over a raw VARCHAR/STRING column carrying JSON text. Instead of first
+// casting the whole document to JSONB (the JsonbExtractString(JSON, path) path), it navigates the
+// document with simdjson on-demand and only touches the bytes on the way to the target value.
+class FunctionJsonExtractStringFromVarchar : public IFunction {
+public:
+    static constexpr auto name = "jsonb_extract_string";
+    String get_name() const override { return name; }
+    static FunctionPtr create() { return std::make_shared<FunctionJsonExtractStringFromVarchar>(); }
+
+    DataTypePtr get_return_type_impl(const DataTypes& arguments) const override {
+        return make_nullable(std::make_shared<DataTypeString>());
+    }
+
+    DataTypes get_variadic_argument_types_impl() const override {
+        return {std::make_shared<DataTypeString>(), std::make_shared<DataTypeString>()};
+    }
+
+    size_t get_number_of_arguments() const override { return 2; }
+
+    bool use_default_implementation_for_nulls() const override { return false; }
+
+    Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
+                        uint32_t result, size_t input_rows_count) const override {
+        bool json_data_const = false;
+        const NullMap* json_null_map = nullptr;
+        const auto* json_col = unwrap_string_arg(block.get_by_position(arguments[0]).column,
+                                                 json_data_const, json_null_map);
+
+        bool path_const = false;
+        const NullMap* path_null_map = nullptr;
+        const auto* path_col = unwrap_string_arg(block.get_by_position(arguments[1]).column,
+                                                 path_const, path_null_map);
+
+        auto result_column = ColumnString::create();
+        auto null_map = ColumnUInt8::create(input_rows_count, 0);
+        auto& res_data = result_column->get_chars();
+        auto& res_offsets = result_column->get_offsets();
+        res_offsets.resize(input_rows_count);
+        NullMap& res_null_map = null_map->get_data();
+
+        simdjson::ondemand::parser parser;
+        JsonbWriter writer;
+
+        for (size_t i = 0; i < input_rows_count; ++i) {
+            size_t json_idx = json_data_const ? 0 : i;
+            size_t path_idx = path_const ? 0 : i;
+
+            if ((json_null_map && (*json_null_map)[json_idx]) ||
+                (path_null_map && (*path_null_map)[path_idx])) {
+                StringOP::push_null_string(i, res_data, res_offsets, res_null_map);
+                continue;
+            }
+
+            StringRef json_ref = json_col->get_data_at(json_idx);
+            StringRef path_ref = path_col->get_data_at(path_idx);
+            if (json_ref.size == 0 || path_ref.size == 0 || path_ref.data[0] != '$') {
+                StringOP::push_null_string(i, res_data, res_offsets, res_null_map);
+                continue;
+            }
+
+            // Doris paths start with '$'; simdjson at_path() wants the remaining ".key"/"[idx]"
+            // suffix. An empty or "." suffix means the whole document (the "$" root path).
+            std::string_view simd_path(path_ref.data + 1, path_ref.size - 1);
+            bool is_root = simd_path.empty() || simd_path == ".";
+
+            try {
+                simdjson::padded_string json_str {json_ref.data, json_ref.size};
+                simdjson::ondemand::document doc = parser.iterate(json_str);
+
+                if (is_root) {
+                    write_extracted_value(json_ref.data, json_ref.size, writer, i, res_data,
+                                          res_offsets, res_null_map);
+                    continue;
+                }
+
+                simdjson::ondemand::value target;
+                if (doc.at_path(simd_path).get(target)) {
+                    StringOP::push_null_string(i, res_data, res_offsets, res_null_map);
+                    continue;
+                }
+                std::string_view raw;
+                if (simdjson::to_json_string(target).get(raw)) {
+                    StringOP::push_null_string(i, res_data, res_offsets, res_null_map);
+                    continue;
+                }
+                write_extracted_value(raw.data(), raw.size(), writer, i, res_data, res_offsets,
+                                      res_null_map);
+            } catch (const simdjson::simdjson_error&) {
+                StringOP::push_null_string(i, res_data, res_offsets, res_null_map);
+            }
+        }
+
+        block.replace_by_position(
+                result, ColumnNullable::create(std::move(result_column), std::move(null_map)));
+        return Status::OK();
+    }
+
+private:
+    static const ColumnString* unwrap_string_arg(const ColumnPtr& arg, bool& is_const,
+                                                 const NullMap*& null_map) {
+        ColumnPtr col;
+        std::tie(col, is_const) = unpack_if_const(arg);
+        if (const auto* nullable = check_and_get_column<ColumnNullable>(col.get())) {
+            null_map = &nullable->get_null_map_data();
+            col = nullable->get_nested_column_ptr();
+        }
+        return assert_cast<const ColumnString*>(col.get());
+    }
+
+    // Reparse the extracted JSON slice into JSONB and format it exactly like the
+    // Cast(JsonbExtract(...) AS String) path: JSON null -> SQL NULL, JSON string -> its raw
+    // unescaped text, everything else -> canonical compact JSON. Reparsing normalizes whitespace
+    // and numbers so the on-demand result stays byte-identical to the JSONB path.
+    static void write_extracted_value(const char* data, size_t size, JsonbWriter& writer,
+                                      size_t row_idx, ColumnString::Chars& res_data,
+                                      ColumnString::Offsets& res_offsets, NullMap& res_null_map) {
+        if (!JsonbParser::parse(data, size, writer).ok()) {
+            StringOP::push_null_string(row_idx, res_data, res_offsets, res_null_map);
+            return;
+        }
+        const char* jsonb_data = writer.getOutput()->getBuffer();
+        size_t jsonb_size = writer.getOutput()->getSize();
+
+        const JsonbDocument* jsonb_doc = nullptr;
+        if (!JsonbDocument::checkAndCreateDocument(jsonb_data, jsonb_size, &jsonb_doc).ok() ||
+            !jsonb_doc || !jsonb_doc->getValue()) {
+            StringOP::push_null_string(row_idx, res_data, res_offsets, res_null_map);
+            return;
+        }
+
+        const JsonbValue* value = jsonb_doc->getValue();
+        if (value->isNull()) {
+            StringOP::push_null_string(row_idx, res_data, res_offsets, res_null_map);
+            return;
+        }
+        if (value->isString()) {
+            const auto* blob = value->unpack<JsonbBinaryVal>();
+            StringOP::push_value_string(std::string_view(blob->getBlob(), blob->getBlobLen()),
+                                        row_idx, res_data, res_offsets);
+            return;
+        }
+        StringOP::push_value_string(JsonbToJson::jsonb_to_json_string(jsonb_data, jsonb_size),
+                                    row_idx, res_data, res_offsets);
+    }
+};
+
 void register_function_jsonb(SimpleFunctionFactory& factory) {
     factory.register_function<FunctionJsonbParse>(FunctionJsonbParse::name);
     factory.register_alias(FunctionJsonbParse::name, FunctionJsonbParse::alias);
@@ -3112,6 +3259,7 @@ void register_function_jsonb(SimpleFunctionFactory& factory) {
     factory.register_alias(FunctionJsonbRemove::name, FunctionJsonbRemove::alias);
 
     factory.register_function<FunctionStripNullValue>();
+    factory.register_function<FunctionJsonExtractStringFromVarchar>();
 }
 
 } // namespace doris

--- a/be/src/exprs/function/function_jsonb.cpp
+++ b/be/src/exprs/function/function_jsonb.cpp
@@ -3060,9 +3060,13 @@ public:
     }
 };
 
-// json_extract_string over a raw VARCHAR/STRING column carrying JSON text. Instead of first
-// casting the whole document to JSONB (the JsonbExtractString(JSON, path) path), it navigates the
-// document with simdjson on-demand and only touches the bytes on the way to the target value.
+// json_extract_string / jsonb_extract_string over a raw VARCHAR/STRING column carrying JSON text.
+// The path is parsed with the authoritative JsonbPath grammar so invalid paths raise the same error
+// as the JSON-typed route. Paths whose legs are all plain object members or non-negative array
+// indices take a fast simdjson at_pointer navigation that reparses only the extracted slice; the
+// root path, wildcards, [last], negative indices, and any at_pointer miss fall back to the exact
+// Cast(JsonbExtract(...) AS String) route (full parse + JsonbPath findValue + format), so the result
+// matches that route for every JsonbPath-supported form.
 class FunctionJsonExtractStringFromVarchar : public IFunction {
 public:
     static constexpr auto name = "jsonb_extract_string";
@@ -3103,6 +3107,13 @@ public:
         simdjson::ondemand::parser parser;
         JsonbWriter writer;
 
+        // Parse a constant path once; JsonbPath::seek rewrites escapes in place so it must run on
+        // each distinct path buffer, but a const column has a single shared buffer.
+        PreparedPath const_path;
+        if (path_const && !(path_null_map && (*path_null_map)[0])) {
+            RETURN_IF_ERROR(prepare_path(path_col->get_data_at(0), const_path));
+        }
+
         for (size_t i = 0; i < input_rows_count; ++i) {
             size_t json_idx = json_data_const ? 0 : i;
             size_t path_idx = path_const ? 0 : i;
@@ -3114,41 +3125,14 @@ public:
             }
 
             StringRef json_ref = json_col->get_data_at(json_idx);
-            StringRef path_ref = path_col->get_data_at(path_idx);
-            if (json_ref.size == 0 || path_ref.size == 0 || path_ref.data[0] != '$') {
-                StringOP::push_null_string(i, res_data, res_offsets, res_null_map);
-                continue;
-            }
-
-            // Doris paths start with '$'; simdjson at_path() wants the remaining ".key"/"[idx]"
-            // suffix. An empty or "." suffix means the whole document (the "$" root path).
-            std::string_view simd_path(path_ref.data + 1, path_ref.size - 1);
-            bool is_root = simd_path.empty() || simd_path == ".";
-
-            try {
-                simdjson::padded_string json_str {json_ref.data, json_ref.size};
-                simdjson::ondemand::document doc = parser.iterate(json_str);
-
-                if (is_root) {
-                    write_extracted_value(json_ref.data, json_ref.size, writer, i, res_data,
-                                          res_offsets, res_null_map);
-                    continue;
-                }
-
-                simdjson::ondemand::value target;
-                if (doc.at_path(simd_path).get(target)) {
-                    StringOP::push_null_string(i, res_data, res_offsets, res_null_map);
-                    continue;
-                }
-                std::string_view raw;
-                if (simdjson::to_json_string(target).get(raw)) {
-                    StringOP::push_null_string(i, res_data, res_offsets, res_null_map);
-                    continue;
-                }
-                write_extracted_value(raw.data(), raw.size(), writer, i, res_data, res_offsets,
-                                      res_null_map);
-            } catch (const simdjson::simdjson_error&) {
-                StringOP::push_null_string(i, res_data, res_offsets, res_null_map);
+            if (path_const) {
+                extract_one(parser, writer, json_ref, const_path, i, res_data, res_offsets,
+                            res_null_map);
+            } else {
+                PreparedPath row_path;
+                RETURN_IF_ERROR(prepare_path(path_col->get_data_at(path_idx), row_path));
+                extract_one(parser, writer, json_ref, row_path, i, res_data, res_offsets,
+                            res_null_map);
             }
         }
 
@@ -3158,6 +3142,12 @@ public:
     }
 
 private:
+    struct PreparedPath {
+        JsonbPath path;
+        std::string pointer;
+        bool simple = false;
+    };
+
     static const ColumnString* unwrap_string_arg(const ColumnPtr& arg, bool& is_const,
                                                  const NullMap*& null_map) {
         ColumnPtr col;
@@ -3169,40 +3159,150 @@ private:
         return assert_cast<const ColumnString*>(col.get());
     }
 
-    // Reparse the extracted JSON slice into JSONB and format it exactly like the
-    // Cast(JsonbExtract(...) AS String) path: JSON null -> SQL NULL, JSON string -> its raw
-    // unescaped text, everything else -> canonical compact JSON. Reparsing normalizes whitespace
-    // and numbers so the on-demand result stays byte-identical to the JSONB path.
-    static void write_extracted_value(const char* data, size_t size, JsonbWriter& writer,
-                                      size_t row_idx, ColumnString::Chars& res_data,
-                                      ColumnString::Offsets& res_offsets, NullMap& res_null_map) {
-        if (!JsonbParser::parse(data, size, writer).ok()) {
+    static Status prepare_path(const StringRef& path_ref, PreparedPath& out) {
+        if (!out.path.seek(path_ref.data, path_ref.size)) {
+            return Status::InvalidArgument("Json path error: Invalid Json Path for value: {}",
+                                           std::string_view(path_ref.data, path_ref.size));
+        }
+        out.simple = build_pointer_if_simple(out.path, out.pointer);
+        return Status::OK();
+    }
+
+    // true only when the whole path can be navigated by JSON Pointer: no wildcard, no [last], no
+    // negative index, at least one leg. The root path returns false and takes the JSONB fallback.
+    static bool build_pointer_if_simple(const JsonbPath& jpath, std::string& pointer) {
+        if (jpath.is_wildcard() || jpath.is_supper_wildcard()) {
+            return false;
+        }
+        size_t leg_count = jpath.get_leg_vector_size();
+        if (leg_count == 0) {
+            return false;
+        }
+        for (size_t i = 0; i < leg_count; ++i) {
+            const leg_info* leg = jpath.get_leg_from_leg_vector(i);
+            if (leg->type == ARRAY_CODE) {
+                if (leg->array_index < 0) {
+                    return false;
+                }
+                pointer.push_back('/');
+                pointer.append(std::to_string(leg->array_index));
+            } else if (leg->type == MEMBER_CODE) {
+                pointer.push_back('/');
+                append_pointer_token(pointer, leg->leg_ptr, leg->leg_len);
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static void append_pointer_token(std::string& out, const char* key, unsigned int len) {
+        for (unsigned int i = 0; i < len; ++i) {
+            char c = key[i];
+            if (c == '~') {
+                out.append("~0");
+            } else if (c == '/') {
+                out.append("~1");
+            } else {
+                out.push_back(c);
+            }
+        }
+    }
+
+    static void extract_one(simdjson::ondemand::parser& parser, JsonbWriter& writer,
+                            const StringRef& json_ref, PreparedPath& prepared, size_t row_idx,
+                            ColumnString::Chars& res_data, ColumnString::Offsets& res_offsets,
+                            NullMap& res_null_map) {
+        if (json_ref.size == 0) {
             StringOP::push_null_string(row_idx, res_data, res_offsets, res_null_map);
             return;
         }
-        const char* jsonb_data = writer.getOutput()->getBuffer();
-        size_t jsonb_size = writer.getOutput()->getSize();
+        if (prepared.simple && try_pointer_extract(parser, writer, json_ref, prepared.pointer,
+                                                   row_idx, res_data, res_offsets, res_null_map)) {
+            return;
+        }
+        jsonb_fallback(writer, json_ref, prepared.path, row_idx, res_data, res_offsets,
+                       res_null_map);
+    }
 
-        const JsonbDocument* jsonb_doc = nullptr;
-        if (!JsonbDocument::checkAndCreateDocument(jsonb_data, jsonb_size, &jsonb_doc).ok() ||
-            !jsonb_doc || !jsonb_doc->getValue()) {
+    // Fast path: navigate with simdjson at_pointer. Returns false (so the caller falls back to the
+    // exact JSONB route) on any miss, type mismatch, or parse error, which keeps the result correct
+    // for escaped document keys and the "index a scalar" quirk that only JsonbPath::findValue knows.
+    static bool try_pointer_extract(simdjson::ondemand::parser& parser, JsonbWriter& writer,
+                                    const StringRef& json_ref, const std::string& pointer,
+                                    size_t row_idx, ColumnString::Chars& res_data,
+                                    ColumnString::Offsets& res_offsets, NullMap& res_null_map) {
+        try {
+            simdjson::padded_string json_str {json_ref.data, json_ref.size};
+            simdjson::ondemand::document doc = parser.iterate(json_str);
+            simdjson::ondemand::value target;
+            if (doc.at_pointer(pointer).get(target)) {
+                return false;
+            }
+            std::string_view raw;
+            if (simdjson::to_json_string(target).get(raw)) {
+                return false;
+            }
+            if (!JsonbParser::parse(raw.data(), raw.size(), writer).ok()) {
+                return false;
+            }
+            const JsonbDocument* doc_reparsed = nullptr;
+            if (!JsonbDocument::checkAndCreateDocument(writer.getOutput()->getBuffer(),
+                                                       writer.getOutput()->getSize(), &doc_reparsed)
+                         .ok() ||
+                !doc_reparsed || !doc_reparsed->getValue()) {
+                return false;
+            }
+            format_jsonb_value(doc_reparsed->getValue(), row_idx, res_data, res_offsets,
+                               res_null_map);
+            return true;
+        } catch (const simdjson::simdjson_error&) {
+            return false;
+        }
+    }
+
+    // Exact Cast(JsonbExtract(...) AS String) behavior: parse the whole document to JSONB and
+    // navigate with JsonbPath::findValue (handles wildcards, [last], and the root path).
+    static void jsonb_fallback(JsonbWriter& writer, const StringRef& json_ref, JsonbPath& jpath,
+                               size_t row_idx, ColumnString::Chars& res_data,
+                               ColumnString::Offsets& res_offsets, NullMap& res_null_map) {
+        if (!JsonbParser::parse(json_ref.data, json_ref.size, writer).ok()) {
             StringOP::push_null_string(row_idx, res_data, res_offsets, res_null_map);
             return;
         }
+        const JsonbDocument* doc = nullptr;
+        if (!JsonbDocument::checkAndCreateDocument(writer.getOutput()->getBuffer(),
+                                                   writer.getOutput()->getSize(), &doc)
+                     .ok() ||
+            !doc || !doc->getValue()) {
+            StringOP::push_null_string(row_idx, res_data, res_offsets, res_null_map);
+            return;
+        }
+        JsonbFindResult find_result = doc->getValue()->findValue(jpath);
+        if (!find_result.value) {
+            StringOP::push_null_string(row_idx, res_data, res_offsets, res_null_map);
+            return;
+        }
+        format_jsonb_value(find_result.value, row_idx, res_data, res_offsets, res_null_map);
+    }
 
-        const JsonbValue* value = jsonb_doc->getValue();
+    // Format a found JSONB value exactly as Cast(JSONB AS String) does: JSON null -> SQL NULL,
+    // JSON string -> raw unescaped text, everything else -> canonical compact JSON.
+    static void format_jsonb_value(const JsonbValue* value, size_t row_idx,
+                                   ColumnString::Chars& res_data,
+                                   ColumnString::Offsets& res_offsets, NullMap& res_null_map) {
         if (value->isNull()) {
             StringOP::push_null_string(row_idx, res_data, res_offsets, res_null_map);
             return;
         }
         if (value->isString()) {
-            const auto* blob = value->unpack<JsonbBinaryVal>();
-            StringOP::push_value_string(std::string_view(blob->getBlob(), blob->getBlobLen()),
+            const auto* str_val = value->unpack<JsonbStringVal>();
+            StringOP::push_value_string(std::string_view(str_val->getBlob(), str_val->length()),
                                         row_idx, res_data, res_offsets);
             return;
         }
-        StringOP::push_value_string(JsonbToJson::jsonb_to_json_string(jsonb_data, jsonb_size),
-                                    row_idx, res_data, res_offsets);
+        StringOP::push_value_string(JsonbToJson {}.to_json_string(value), row_idx, res_data,
+                                    res_offsets);
     }
 };
 

--- a/be/test/exprs/function/function_jsonb_test.cpp
+++ b/be/test/exprs/function/function_jsonb_test.cpp
@@ -1147,6 +1147,19 @@ TEST(FunctionJsonbTEST, JsonExtractStringFromVarcharTest) {
             {{STRING(R"({"k":5})"), STRING("$.k[0]")}, STRING("5")},
     };
     static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+
+    // JsonbPath dispatches leg navigation by leg SYNTAX, not by the runtime container. An ARRAY leg
+    // [i] requires an array (with the index==0-on-non-array self quirk that returns the value
+    // itself), and a MEMBER leg .k requires an object. These must match the JSONB route, not a JSON
+    // Pointer that would index/key by whatever the container happens to be. Trailing-NUL string
+    // parity checks getBlobLen() rather than a strnlen-style length. Values are the JSONB-route output.
+    data_set = {
+            {{STRING(R"({"1":"b"})"), STRING("$[1]")}, Null()},
+            {{STRING(R"({"0":"a"})"), STRING("$[0]")}, STRING(R"({"0":"a"})")},
+            {{STRING("[10,20]"), STRING("$.0")}, Null()},
+            {{STRING(R"({"k":"ab\u0000"})"), STRING("$.k")}, std::string("ab\000", 3)},
+    };
+    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
 }
 
 // A path that JsonbPath rejects must raise INVALID_ARGUMENT, matching the JSON-typed route, rather

--- a/be/test/exprs/function/function_jsonb_test.cpp
+++ b/be/test/exprs/function/function_jsonb_test.cpp
@@ -1127,6 +1127,39 @@ TEST(FunctionJsonbTEST, JsonExtractStringFromVarcharTest) {
             {{STRING(R"({"k1":"v1"})"), Null()}, Null()},
     };
     static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+
+    // Exotic JsonbPath forms that the JSON Pointer fast path cannot express and that must fall back
+    // to the exact JsonbPath findValue route: quoted dotted keys, $.[i], wildcards, recursive
+    // wildcard, [last]/[last-N], and the "index a scalar" quirk. Values are the JSONB-route output.
+    data_set = {
+            {{STRING(R"({"k1":"v1", "my.key":["e1", "e2", "e3"]})"), STRING(R"($."my.key"[1])")},
+             STRING("e2")},
+            {{STRING(R"({"k1.key":{"k2":["v1", "v2"]}})"), STRING(R"($."k1.key".k2[0])")},
+             STRING("v1")},
+            {{STRING("[1, 2, 3]"), STRING("$.[1]")}, STRING("2")},
+            {{STRING(R"({"a":[1,2,3]})"), STRING("$.a[*]")}, STRING("[1,2,3]")},
+            {{STRING(R"({"a":1,"b":2})"), STRING("$.*")}, STRING("[1,2]")},
+            {{STRING(R"({"arr":[{"k":1},{"k":2}]})"), STRING("$.arr[*].k")}, STRING("[1,2]")},
+            {{STRING(R"({"a":{"b":1},"c":{"b":2}})"), STRING("$**.b")}, STRING("[1,2]")},
+            {{STRING(R"({"a":[10,20,30]})"), STRING("$.a[last]")}, STRING("30")},
+            {{STRING(R"({"a":[10,20,30]})"), STRING("$.a[last-1]")}, STRING("20")},
+            {{STRING(R"({"a":["x","y","z"]})"), STRING("$.a[last]")}, STRING("z")},
+            {{STRING(R"({"k":5})"), STRING("$.k[0]")}, STRING("5")},
+    };
+    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+}
+
+// A path that JsonbPath rejects must raise INVALID_ARGUMENT, matching the JSON-typed route, rather
+// than silently returning NULL.
+TEST(FunctionJsonbTEST, JsonExtractStringFromVarcharInvalidPathTest) {
+    std::string func_name = "jsonb_extract_string";
+    InputTypeSet input_types = {Nullable {PrimitiveType::TYPE_VARCHAR},
+                                Nullable {PrimitiveType::TYPE_VARCHAR}};
+
+    DataSet data_set = {{{STRING(R"({"a":1})"), STRING("a.b")}, Null()}};
+    EXPECT_FALSE((check_function<DataTypeString, true>(func_name, input_types, data_set, -1, -1,
+                                                       /*expect_execute_fail=*/true))
+                         .ok());
 }
 
 } // namespace doris

--- a/be/test/exprs/function/function_jsonb_test.cpp
+++ b/be/test/exprs/function/function_jsonb_test.cpp
@@ -1056,4 +1056,77 @@ TEST(FunctionJsonbTEST, JsonbModifyMissingPathParent) {
     }
 }
 
+// json_extract_string over a raw VARCHAR/STRING column must stay byte-identical to the existing
+// Cast(JsonbExtract(CAST(text AS JSON), path) AS String) path; expected values below are that
+// path's output (JSON null -> SQL NULL, strings unescaped, numbers/whitespace normalized).
+TEST(FunctionJsonbTEST, JsonExtractStringFromVarcharTest) {
+    std::string func_name = "jsonb_extract_string";
+    InputTypeSet input_types = {Nullable {PrimitiveType::TYPE_VARCHAR},
+                                Nullable {PrimitiveType::TYPE_VARCHAR}};
+
+    DataSet data_set = {
+            {{Null(), STRING("$.k1")}, Null()},
+            {{STRING("{}"), STRING("$.k1")}, Null()},
+            {{STRING(R"({"k1":"v31", "k2": 300})"), STRING("$.k1")}, STRING("v31")},
+            {{STRING(R"({"k1":"v31", "k2": 300})"), STRING("$.k2")}, STRING("300")},
+            {{STRING(R"({"k1":null})"), STRING("$.k1")}, Null()},
+            {{STRING(R"({"k1":"null"})"), STRING("$.k1")}, STRING("null")},
+            {{STRING(R"({"k1":true})"), STRING("$.k1")}, STRING("true")},
+            {{STRING(R"({"k1":false})"), STRING("$.k1")}, STRING("false")},
+            {{STRING(R"({"k1":123})"), STRING("$.k1")}, STRING("123")},
+            {{STRING(R"({"k1":3.14})"), STRING("$.k1")}, STRING("3.14")},
+            {{STRING(R"({"k1":3.140})"), STRING("$.k1")}, STRING("3.14")},
+            {{STRING(R"({"k1":1e2})"), STRING("$.k1")}, STRING("100")},
+            {{STRING(R"({"k1":10000000000})"), STRING("$.k1")}, STRING("10000000000")},
+            {{STRING(R"({"k1":[1, 2, 3]})"), STRING("$.k1")}, STRING("[1,2,3]")},
+            {{STRING(R"({"k1":{"nested" : "value"}})"), STRING("$.k1")},
+             STRING(R"({"nested":"value"})")},
+            {{STRING(R"({"k1":"caf\u00e9"})"), STRING("$.k1")}, STRING("caf\u00e9")},
+            {{STRING(R"({"k1":"a\"b"})"), STRING("$.k1")}, STRING(R"(a"b)")},
+    };
+    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+
+    data_set = {
+            {{STRING(R"({"k1":{"k2":"v2"}})"), STRING("$.k1.k2")}, STRING("v2")},
+            {{STRING(R"({"k1":{"k2":[1,2,3]}})"), STRING("$.k1.k2[0]")}, STRING("1")},
+            {{STRING(R"({"k1":{"k2":[1,2,3]}})"), STRING("$.k1.k2[1]")}, STRING("2")},
+            {{STRING(R"({"k1":[{"k2":"v1"},{"k2":"v2"}]})"), STRING("$.k1[0].k2")}, STRING("v1")},
+            {{STRING(R"({"k1":[{"k2":"v1"},{"k2":"v2"}]})"), STRING("$.k1[1].k2")}, STRING("v2")},
+            {{STRING(R"({"arr":[123, 456]})"), STRING("$.arr[0]")}, STRING("123")},
+            {{STRING(R"({"arr":[123, 456]})"), STRING("$.arr[1]")}, STRING("456")},
+            {{STRING(R"({"arr":[123, 456]})"), STRING("$.arr[2]")}, Null()},
+            {{STRING(R"({"arr":[{"k1":"v41", "k2": 400}, 1]})"), STRING("$.arr[0]")},
+             STRING(R"({"k1":"v41","k2":400})")},
+            {{STRING(R"({"k1":"v1"})"), STRING("$.nope")}, Null()},
+    };
+    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+
+    // top-level object, array and scalar roots must be preserved, not narrowed to NULL.
+    data_set = {
+            {{STRING(R"({"k1":"v1"})"), STRING("$")}, STRING(R"({"k1":"v1"})")},
+            {{STRING("[1, 2, 3]"), STRING("$")}, STRING("[1,2,3]")},
+            {{STRING("[]"), STRING("$")}, STRING("[]")},
+            {{STRING("[1,2,3]"), STRING("$[0]")}, STRING("1")},
+            {{STRING("[1,2,3]"), STRING("$[9]")}, Null()},
+            {{STRING(R"([{"k":1},{"k":2}])"), STRING("$[1].k")}, STRING("2")},
+            {{STRING("100"), STRING("$")}, STRING("100")},
+            {{STRING("6.18"), STRING("$")}, STRING("6.18")},
+            {{STRING(R"("abcd")"), STRING("$")}, STRING("abcd")},
+            {{STRING("true"), STRING("$")}, STRING("true")},
+            {{STRING("false"), STRING("$")}, STRING("false")},
+            {{STRING("null"), STRING("$")}, Null()},
+    };
+    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+
+    data_set = {
+            {{STRING("invalid"), STRING("$")}, Null()},
+            {{STRING("{invalid}"), STRING("$")}, Null()},
+            {{STRING("[1,2,"), STRING("$")}, Null()},
+            {{STRING(""), STRING("$")}, Null()},
+            {{STRING(""), STRING("$.k1")}, Null()},
+            {{STRING(R"({"k1":"v1"})"), Null()}, Null()},
+    };
+    static_cast<void>(check_function<DataTypeString, true>(func_name, input_types, data_set));
+}
+
 } // namespace doris

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/JsonbExtractString.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/JsonbExtractString.java
@@ -42,7 +42,9 @@ public class JsonbExtractString extends ScalarFunction
 
     public static final List<FunctionSignature> SIGNATURES = ImmutableList.of(
             FunctionSignature.ret(StringType.INSTANCE).args(JsonType.INSTANCE, VarcharType.SYSTEM_DEFAULT),
-            FunctionSignature.ret(StringType.INSTANCE).args(JsonType.INSTANCE, StringType.INSTANCE)
+            FunctionSignature.ret(StringType.INSTANCE).args(JsonType.INSTANCE, StringType.INSTANCE),
+            FunctionSignature.ret(StringType.INSTANCE).args(VarcharType.SYSTEM_DEFAULT, VarcharType.SYSTEM_DEFAULT),
+            FunctionSignature.ret(StringType.INSTANCE).args(StringType.INSTANCE, StringType.INSTANCE)
     );
 
     /**
@@ -78,6 +80,10 @@ public class JsonbExtractString extends ScalarFunction
 
     @Override
     public Expression rewriteWhenAnalyze() {
+        // Keep raw VARCHAR/STRING input unrewritten so the BE on-demand evaluator handles it.
+        if (!getSignature().getArgType(0).isJsonType()) {
+            return this;
+        }
         JsonbExtract jsonExtract = new JsonbExtract(children.get(0), children.get(1));
         return new Cast(jsonExtract, StringType.INSTANCE, false);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/scalar/JsonbExtractStringTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/scalar/JsonbExtractStringTest.java
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.expressions.functions.scalar;
+
+import org.apache.doris.catalog.FunctionSignature;
+import org.apache.doris.nereids.trees.expressions.Cast;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
+import org.apache.doris.nereids.types.JsonType;
+import org.apache.doris.nereids.types.StringType;
+import org.apache.doris.nereids.types.VarcharType;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class JsonbExtractStringTest {
+
+    @Test
+    public void testRewriteWhenAnalyzeJsonInputRewritesToCast() {
+        SlotReference jsonColumn = new SlotReference("json_col", JsonType.INSTANCE);
+        VarcharLiteral pathLiteral = new VarcharLiteral("$.key");
+        JsonbExtractString func = new JsonbExtractString(jsonColumn, pathLiteral);
+
+        Expression rewritten = func.rewriteWhenAnalyze();
+
+        Assertions.assertInstanceOf(Cast.class, rewritten);
+        Assertions.assertInstanceOf(JsonbExtract.class, ((Cast) rewritten).child());
+    }
+
+    @Test
+    public void testRewriteWhenAnalyzeVarcharInputKeepsSelf() {
+        SlotReference varcharColumn = new SlotReference("varchar_col", VarcharType.SYSTEM_DEFAULT);
+        VarcharLiteral pathLiteral = new VarcharLiteral("$.key");
+        JsonbExtractString func = new JsonbExtractString(varcharColumn, pathLiteral);
+
+        Expression rewritten = func.rewriteWhenAnalyze();
+
+        Assertions.assertSame(func, rewritten);
+    }
+
+    @Test
+    public void testRewriteWhenAnalyzeStringInputKeepsSelf() {
+        SlotReference stringColumn = new SlotReference("string_col", StringType.INSTANCE);
+        StringLiteral pathLiteral = new StringLiteral("$.key");
+        JsonbExtractString func = new JsonbExtractString(stringColumn, pathLiteral);
+
+        Expression rewritten = func.rewriteWhenAnalyze();
+
+        Assertions.assertSame(func, rewritten);
+    }
+
+    @Test
+    public void testVarcharInputSelectsNonJsonSignature() {
+        SlotReference varcharColumn = new SlotReference("varchar_col", VarcharType.SYSTEM_DEFAULT);
+        VarcharLiteral pathLiteral = new VarcharLiteral("$.key");
+        JsonbExtractString func = new JsonbExtractString(varcharColumn, pathLiteral);
+
+        FunctionSignature signature = func.getSignature();
+
+        Assertions.assertFalse(signature.getArgType(0).isJsonType());
+        Assertions.assertEquals(StringType.INSTANCE, signature.returnType);
+    }
+
+    @Test
+    public void testJsonInputSelectsJsonSignature() {
+        SlotReference jsonColumn = new SlotReference("json_col", JsonType.INSTANCE);
+        VarcharLiteral pathLiteral = new VarcharLiteral("$.key");
+        JsonbExtractString func = new JsonbExtractString(jsonColumn, pathLiteral);
+
+        FunctionSignature signature = func.getSignature();
+
+        Assertions.assertTrue(signature.getArgType(0).isJsonType());
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #59371

Problem Summary:

`json_extract_string` and its aliases on VARCHAR input currently parse and materialize the whole document as JSONB before extracting a value. This PR adds an on-demand VARCHAR extraction path:

- Parse paths with the authoritative `JsonbPath` parser, preserving existing invalid-path errors.
- Traverse simple paths leg by leg with simdjson. MEMBER legs require objects; non-negative ARRAY legs require arrays.
- Fall back to `JsonbParser::parse` + `JsonbPath::findValue` for root paths, wildcards, `[last]`, negative indices, misses, and type mismatches.
- Preserve existing formatting, JSON null handling, numeric-key/type-mismatch semantics, and embedded trailing-NUL bytes.

A previous attempt (#59371) was automatically closed as stale. This implementation targets current master and adds stronger BE, FE, and regression coverage.

#### Benchmark

A local throwaway RELEASE A/B harness generated 50,000 rows containing ~2.6 KB JSON documents. It extracted an early field before a large trailing array using `$.profile.prefs.theme`, with 3 warmups and 7 measured iterations.

| Metric | Cast to JSONB | On-demand traversal |
| --- | ---: | ---: |
| Median latency | 678.8 ms | 42.3 ms |
| Speedup | - | 16.04x |
| Peak RSS | ~509708 KB | ~509784 KB |
| Output | byte-identical | byte-identical |

The harness is not committed and is not Google Benchmark. This is a synthetic favorable shape: improvement varies with document layout and path depth. Root, wildcard, `[last]`, and negative-index paths use the compatibility fallback and receive no fast-path speedup.

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test
    - [x] Manual test

Testing performed:
- BE ASAN unit tests: 2 passed, including path parity, numeric-key/type-mismatch cases, trailing-NUL handling, and invalid-path errors.
- FE unit tests: 5 passed; FE build and checkstyle succeeded.
- Existing p0 `test_json_function`: 1 suite passed with 0 failures and unchanged expected output.
- Candidate-cluster SQL covered simple and fallback paths, aliases, JSON null/scalars, wildcards, `[last]`, invalid paths, and leg-type mismatch cases.
- BE ASAN/RELEASE builds passed; clang-format and changed-line clang-tidy were clean.

- Behavior changed:
    - [x] No.
    - [ ] Yes.

Results and errors remain compatible; only execution strategy and simple-path performance change.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
