### PR TITLE
[fix](binlog) Keep allocated LSN map alive during group flush cleanup

### DIFF
--- a/be/src/load/memtable/memtable_flush_executor.cpp
+++ b/be/src/load/memtable/memtable_flush_executor.cpp
@@ -120,8 +120,8 @@ SharedMemtable::~SharedMemtable() {
         return;
     }
     if (has_allocated_lsns) {
-        DCHECK(rowset_ctx != nullptr);
-        rowset_ctx->remove_segment_allocated_lsns(segment_id);
+        DCHECK(allocated_lsn_map != nullptr);
+        allocated_lsn_map->remove_segment(segment_id);
     }
     DCHECK(memtable != nullptr);
     SCOPED_SWITCH_THREAD_MEM_TRACKER_LIMITER(
@@ -187,8 +187,10 @@ Status FlushToken::submit(std::shared_ptr<MemTable> mem_table) {
 
         shared_memtable = std::make_shared<SharedMemtable>();
         shared_memtable->memtable = mem_table;
-        shared_memtable->rowset_ctx =
-                const_cast<RowsetWriterContext*>(&group_rowset_writer->context());
+        if (group_rowset_writer->context().need_allocated_lsn()) {
+            shared_memtable->allocated_lsn_map = group_rowset_writer->context().allocated_lsn_map;
+            DCHECK(shared_memtable->allocated_lsn_map != nullptr);
+        }
         // Keep data/binlog segment_id allocators in sync.
         auto segment_id = DORIS_TRY(data_writer->allocate_segment_id());
         auto binlog_segment_id = DORIS_TRY(binlog_writer->allocate_segment_id());
@@ -314,13 +316,12 @@ Status FlushToken::_memtable2block(MemTable* memtable, SharedMemtable* shared_me
         shared_memtable->block_status = memtable->to_block(&block);
         if (shared_memtable->block_status.ok()) {
             shared_memtable->block.reset(block.release());
-            auto* rowset_ctx = shared_memtable->rowset_ctx;
-            DCHECK(rowset_ctx != nullptr);
-            if (rowset_ctx->need_allocated_lsn() && shared_memtable->block->rows() > 0) {
+            if (shared_memtable->allocated_lsn_map != nullptr &&
+                shared_memtable->block->rows() > 0) {
                 auto memtable_lsns = memtable->allocated_lsns();
                 DCHECK_EQ(memtable_lsns->size(), shared_memtable->block->rows());
-                rowset_ctx->insert_segment_allocated_lsns(shared_memtable->segment_id,
-                                                          memtable_lsns);
+                shared_memtable->allocated_lsn_map->insert_segment_allocated_lsns(
+                        shared_memtable->segment_id, memtable_lsns);
                 shared_memtable->has_allocated_lsns = true;
             }
         }

--- a/be/src/load/memtable/memtable_flush_executor.h
+++ b/be/src/load/memtable/memtable_flush_executor.h
@@ -38,8 +38,10 @@ class MemTableMemoryLimiter;
 class Block;
 class GroupRowsetWriter;
 class OlapTableSchemaParam;
-struct RowsetWriterContext;
 class RowsetWriter;
+namespace segment_v2 {
+class SegmentAllocatedLsnMap;
+}
 class SystemMetrics;
 class WorkloadGroup;
 
@@ -64,7 +66,8 @@ struct SharedMemtable {
     std::once_flag block_once;
     Status block_status;
     std::shared_ptr<Block> block;
-    RowsetWriterContext* rowset_ctx = nullptr;
+    // Group flush tasks can outlive FlushToken and its RowsetWriterContext.
+    std::shared_ptr<segment_v2::SegmentAllocatedLsnMap> allocated_lsn_map;
     bool has_allocated_lsns = false;
 
     std::atomic<int> finished_sub_task_count {0};

--- a/be/test/load/memtable/memtable_flush_executor_test.cpp
+++ b/be/test/load/memtable/memtable_flush_executor_test.cpp
@@ -26,8 +26,10 @@
 
 #include <atomic>
 #include <chrono>
+#include <memory>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "common/config.h"
 #include "exec/sink/autoinc_buffer.h"
@@ -38,6 +40,7 @@
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
 #include "runtime/thread_context.h"
+#include "storage/binlog.h"
 #include "storage/options.h"
 #include "storage/rowset/group_rowset_writer.h"
 #include "storage/rowset/rowset_writer.h"
@@ -518,6 +521,60 @@ TEST_F(MemTableFlushExecutorGroupFlushTest, TestGroupFlushToken) {
 
         drop_tablet(ctx.request);
     }
+}
+
+TEST_F(MemTableFlushExecutorGroupFlushTest,
+       TestSharedMemtableKeepsAllocatedLsnMapAliveAfterWriterContextDestruction) {
+    SCOPED_INIT_THREAD_CONTEXT();
+
+    GroupFlushTestContext ctx;
+    prepare_group_flush_test_context(10004, 270068376, {4000, 4001}, &ctx);
+
+    auto shared_memtable = std::make_shared<SharedMemtable>();
+    shared_memtable->memtable = ctx.memtable;
+    shared_memtable->segment_id = 0;
+    shared_memtable->block = std::make_shared<Block>();
+    shared_memtable->has_allocated_lsns = true;
+
+    std::weak_ptr<segment_v2::SegmentAllocatedLsnMap> weak_lsn_map;
+    {
+        std::atomic<int> data_flush_cnt = 0;
+        std::atomic<int> binlog_flush_cnt = 0;
+        auto data_writer = std::make_shared<MockRowsetWriter>(&data_flush_cnt);
+        auto binlog_writer = std::make_shared<MockRowsetWriter>(&binlog_flush_cnt);
+        std::shared_ptr<GroupRowsetWriter> group_writer;
+        ASSERT_TRUE(
+                create_group_rowset_writer(ctx, 4, data_writer, binlog_writer, &group_writer).ok());
+
+        auto allocated_lsn_map = group_writer->context().allocated_lsn_map;
+        ASSERT_NE(allocated_lsn_map, nullptr);
+        allocated_lsn_map->insert_segment_allocated_lsns(shared_memtable->segment_id,
+                                                         ctx.memtable->allocated_lsns());
+        weak_lsn_map = allocated_lsn_map;
+        shared_memtable->allocated_lsn_map = std::move(allocated_lsn_map);
+
+        // FlushToken owns the GroupRowsetWriter and its context, while a queued group flush task
+        // can retain SharedMemtable until after FlushToken destruction.
+        group_writer.reset();
+        data_writer.reset();
+        binlog_writer.reset();
+    }
+
+    ASSERT_FALSE(weak_lsn_map.expired());
+    auto allocated_lsn_map = weak_lsn_map.lock();
+    ASSERT_NE(allocated_lsn_map, nullptr);
+
+    shared_memtable.reset();
+
+    auto replacement_lsns =
+            std::make_shared<const std::vector<int64_t>>(std::vector<int64_t> {4002, 4003});
+    allocated_lsn_map->insert_segment_allocated_lsns(0, replacement_lsns);
+    auto stored_lsns = allocated_lsn_map->get_segment_allocated_lsns(0);
+    ASSERT_EQ(2, stored_lsns->size());
+    EXPECT_EQ(4002, (*stored_lsns)[0]);
+    EXPECT_EQ(4003, (*stored_lsns)[1]);
+
+    drop_tablet(ctx.request);
 }
 
 TEST_F(MemTableFlushExecutorGroupFlushTest, TestGroupFlushTokenPartialSuccess) {


### PR DESCRIPTION
Problem Summary:
Group memtable flush stores a raw RowsetWriterContext* in SharedMemtable only to remove the segment’s allocated LSNs during teardown. A queued group flush task can retain SharedMemtable after FlushToken has released its GroupRowsetWriter and context, causing the later cleanup to dereference a freed context and crash the BE under ASan.

Solution:
Make SharedMemtable own the specific resource required for cleanup—the shared allocated-LSN map—rather than borrow the enclosing writer context. Capture the map only when the group writer requires allocated LSNs and assert that the map exists under that invariant. Both insertion during memtable conversion and removal during SharedMemtable teardown now operate directly on the retained map, so delayed task destruction remains safe after writer-context teardown.