### PR TITLE
[fix](test) run search score TopN case in nonConcurrent group

### DIFF
--- a/regression-test/suites/inverted_index_p0/test_search_score_topn_predicates.groovy
+++ b/regression-test/suites/inverted_index_p0/test_search_score_topn_predicates.groovy
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-suite("test_search_score_topn_predicates", "p0") {
+suite("test_search_score_topn_predicates", "p0,nonConcurrent") {
     sql "DROP TABLE IF EXISTS test_search_score_topn_predicates"
 
     sql """


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #67363 (same fix on branch-4.1), #67327 (backported the suite to branch-4.1), #65821 (introduced the suite on master)

Problem Summary:

`test_search_score_topn_predicates` (added on master by #65821) runs in the shared **concurrent** P0 group. On branch-4.1 it fails intermittently on its very first query, right after `CREATE TABLE` + `INSERT` + `sync`, with:

```
errCode = 2, detailMessage = [INTERNAL_ERROR]SearchExpr should not be executed without inverted index
```

This was observed on branch-4.1 CI (2 failures out of 4 runs) and fixed there by #67363, which moves the case into the `nonConcurrent` group. master carries the **identical** suite grouping (`"p0"`), so it is exposed to the same intermittent failure when the case races other P0 cases. This PR applies the same one-line fix to master to keep it out of the concurrent group.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [x] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label