### PR TITLE
[fix](fe) Reject path partition keys for http_stream

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/HttpStreamTableValuedFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/HttpStreamTableValuedFunction.java
@@ -40,6 +40,10 @@ public class HttpStreamTableValuedFunction extends ExternalFileTableValuedFuncti
         // 1. analyze common properties
         super.parseCommonProperties(properties);
 
+        if (!getPathPartitionKeys().isEmpty()) {
+            throw new AnalysisException("http_stream does not support path_partition_keys");
+        }
+
         if (fileFormatProperties.getFileFormatType() == TFileFormatType.FORMAT_PARQUET
                 || fileFormatProperties.getFileFormatType() == TFileFormatType.FORMAT_AVRO
                 || fileFormatProperties.getFileFormatType() == TFileFormatType.FORMAT_ORC) {

--- a/fe/fe-core/src/test/java/org/apache/doris/tablefunction/HttpStreamTableValuedFunctionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/tablefunction/HttpStreamTableValuedFunctionTest.java
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.tablefunction;
+
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.util.FileFormatConstants;
+
+import com.google.common.collect.Maps;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class HttpStreamTableValuedFunctionTest {
+    @Test
+    public void testRejectPathPartitionKeys() {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(FileFormatConstants.PROP_FORMAT, FileFormatConstants.FORMAT_CSV);
+        properties.put(FileFormatConstants.PROP_PATH_PARTITION_KEYS, "pt");
+
+        AnalysisException exception = Assert.assertThrows(
+                AnalysisException.class, () -> new HttpStreamTableValuedFunction(properties));
+
+        Assert.assertTrue(exception.getMessage().contains("http_stream does not support path_partition_keys"));
+    }
+}

--- a/regression-test/suites/load_p0/http_stream/test_http_stream_path_partition_keys.groovy
+++ b/regression-test/suites/load_p0/http_stream/test_http_stream_path_partition_keys.groovy
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_http_stream_path_partition_keys", "p0") {
+    test {
+        sql """
+            select * from http_stream(
+                "format" = "csv_with_names",
+                "path_partition_keys" = "pt");
+        """
+        exception "http_stream does not support path_partition_keys"
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: `http_stream` accepted `path_partition_keys` even though streamed request bodies have no file path from which to derive partition values. The invalid property reached backend execution and failed after planning. Reject it while constructing the table-valued function so clients receive a clear analysis error before a transaction is created.

### Release note

`http_stream` now rejects the unsupported `path_partition_keys` property during analysis.

### Check List (For Author)

- Test: FE unit test, regression test, and manual HTTP stream test
    - FE unit test: `HttpStreamTableValuedFunctionTest`
    - Regression test: `test_http_stream_path_partition_keys`
    - Manual test: control load succeeded with 10 rows; unsupported property returned `ANALYSIS_ERROR`
- Behavior changed: Yes. An unsupported property is now rejected before execution.
- Does this need documentation: No