### PR TITLE
[Fix](python udf) Fix module cache cleanup and error propagation

### DIFF
--- a/be/src/udf/python/python_server.cpp
+++ b/be/src/udf/python/python_server.cpp
@@ -21,6 +21,7 @@
 #include <butil/fd_utility.h>
 #include <dirent.h>
 #include <fmt/core.h>
+#include <rapidjson/document.h>
 #include <signal.h>
 #include <sys/poll.h>
 #include <sys/stat.h>
@@ -31,7 +32,6 @@
 #include <boost/process.hpp>
 #include <chrono>
 #include <fstream>
-#include <rapidjson/document.h>
 #include <thread>
 
 #include "arrow/flight/client.h"

--- a/be/src/udf/python/python_server.cpp
+++ b/be/src/udf/python/python_server.cpp
@@ -31,6 +31,7 @@
 #include <boost/process.hpp>
 #include <chrono>
 #include <fstream>
+#include <rapidjson/document.h>
 #include <thread>
 
 #include "arrow/flight/client.h"
@@ -707,6 +708,7 @@ Status PythonServerManager::_broadcast_action_to_processes(const std::string& ac
     int success_count = 0;
     int fail_count = 0;
     bool has_active_process = false;
+    std::string failure_details;
 
     for (auto& [version, versioned_pool] : _snapshot_process_pools()) {
         std::lock_guard<std::mutex> lock(versioned_pool->mutex);
@@ -741,12 +743,39 @@ Status PythonServerManager::_broadcast_action_to_processes(const std::string& ac
                 }
 
                 auto result = (*result_stream)->Next();
-                if (result.ok() && *result) {
-                    success_count++;
-                } else {
+                if (!result.ok() || !*result || !(*result)->body) {
                     fail_count++;
+                    continue;
                 }
 
+                std::string result_body = (*result)->body->ToString();
+                rapidjson::Document result_json;
+                result_json.Parse(result_body.data(), result_body.size());
+                bool action_succeeded = false;
+                if (!result_json.HasParseError() && result_json.IsObject()) {
+                    auto success = result_json.FindMember("success");
+                    action_succeeded = success != result_json.MemberEnd() &&
+                                       success->value.IsBool() && success->value.GetBool();
+                }
+                if (!action_succeeded) {
+                    fail_count++;
+                    std::string error = "invalid action result";
+                    if (!result_json.HasParseError() && result_json.IsObject()) {
+                        auto error_member = result_json.FindMember("error");
+                        if (error_member != result_json.MemberEnd() &&
+                            error_member->value.IsString()) {
+                            error.assign(error_member->value.GetString(),
+                                         error_member->value.GetStringLength());
+                        }
+                    }
+                    if (!failure_details.empty()) {
+                        failure_details.append("; ");
+                    }
+                    failure_details.append(fmt::format("{}: {}", process->get_uri(), error));
+                    continue;
+                }
+
+                success_count++;
             } catch (...) {
                 fail_count++;
             }
@@ -761,8 +790,9 @@ Status PythonServerManager::_broadcast_action_to_processes(const std::string& ac
               << ", failed=" << fail_count;
 
     if (fail_count > 0) {
-        return Status::InternalError("{} failed for {}, success={}, failed={}", action_type,
-                                     log_name, success_count, fail_count);
+        return Status::InternalError("{} failed for {}, success={}, failed={}, errors=[{}]",
+                                     action_type, log_name, success_count, fail_count,
+                                     failure_details);
     }
 
     return Status::OK();

--- a/be/src/udf/python/python_server.py
+++ b/be/src/udf/python/python_server.py
@@ -2701,22 +2701,21 @@ class FlightServer(flight.FlightServerBase):
         cleared = []
 
         with ModuleUDFLoader._module_cache_lock:
-            keys_to_remove = [
-                key for key in ModuleUDFLoader._module_cache
-                if key[0] == location
+            module_names_to_remove = [
+                module.__name__
+                for key, module in ModuleUDFLoader._module_cache.items()
+                if key == location
             ]
 
         # For each module, acquire its import lock before clearing.
         # This ensures no concurrent _get_or_import_module is in progress
-        # for this (location, module_name) pair.
-        for key in keys_to_remove:
-            _, module_name = key
+        # for this module.
+        for module_name in module_names_to_remove:
             import_lock = ModuleUDFLoader._get_import_lock(module_name)
 
             with import_lock:
                 with ModuleUDFLoader._module_cache_lock:
-                    if key in ModuleUDFLoader._module_cache:
-                        del ModuleUDFLoader._module_cache[key]
+                    ModuleUDFLoader._module_cache.pop(location, None)
 
                 modules_to_remove = [
                     name for name, mod in sys.modules.items()

--- a/be/test/udf/python/python_server_test.cpp
+++ b/be/test/udf/python/python_server_test.cpp
@@ -60,8 +60,7 @@ public:
 
     ~ActionResultFlightServer() override { static_cast<void>(Shutdown()); }
 
-    arrow::Status DoAction(const arrow::flight::ServerCallContext&,
-                           const arrow::flight::Action&,
+    arrow::Status DoAction(const arrow::flight::ServerCallContext&, const arrow::flight::Action&,
                            std::unique_ptr<arrow::flight::ResultStream>* result) override {
         std::vector<arrow::flight::Result> flight_results;
         flight_results.reserve(_results.size());
@@ -267,8 +266,8 @@ protected:
         try {
             bp::child child(python, "-u", get_fight_server_path(), get_base_unix_socket_path(),
                             bp::std_out > output_stream);
-            auto candidate = std::make_shared<PythonUDFProcess>(std::move(child),
-                                                                std::move(output_stream));
+            auto candidate =
+                    std::make_shared<PythonUDFProcess>(std::move(child), std::move(output_stream));
             auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
             while (std::chrono::steady_clock::now() < deadline) {
                 if (fs::exists(candidate->get_socket_file_path())) {

--- a/be/test/udf/python/python_server_test.cpp
+++ b/be/test/udf/python/python_server_test.cpp
@@ -17,6 +17,7 @@
 
 #include "udf/python/python_server.h"
 
+#include <arrow/api.h>
 #include <gtest/gtest.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -26,11 +27,14 @@
 #include <filesystem>
 #include <fstream>
 #include <future>
+#include <optional>
+#include <sstream>
 #include <string>
 #include <vector>
 
 #include "common/config.h"
 #include "common/status.h"
+#include "core/data_type/data_type_number.h"
 #include "udf/python/python_env.h"
 #include "udf/python/python_udf_client.h"
 #include "udf/python/python_udf_meta.h"
@@ -194,6 +198,86 @@ protected:
         std::string sleep_path = fs::exists("/bin/sleep") ? "/bin/sleep" : "/usr/bin/sleep";
         bp::child child(sleep_path, "60", bp::std_out > output_stream, bp::std_err > bp::null);
         return std::make_shared<PythonUDFProcess>(std::move(child), std::move(output_stream));
+    }
+
+    std::optional<std::string> find_python_udf_interpreter() {
+        std::vector<std::string> candidates;
+        if (const char* configured = std::getenv("DORIS_PYTHON_UDF_TEST_PYTHON")) {
+            candidates.emplace_back(configured);
+        }
+        if (const char* path_env = std::getenv("PATH")) {
+            std::stringstream paths(path_env);
+            std::string path;
+            while (std::getline(paths, path, ':')) {
+                fs::path python3 = fs::path(path) / "python3";
+                if (fs::exists(python3)) {
+                    candidates.emplace_back(python3.string());
+                }
+            }
+        }
+
+        for (const auto& candidate : candidates) {
+            if (!fs::exists(candidate)) {
+                continue;
+            }
+            bp::child check(candidate, "-c", "import pandas, pyarrow", bp::std_out > bp::null,
+                            bp::std_err > bp::null);
+            check.wait();
+            if (check.exit_code() == 0) {
+                return candidate;
+            }
+        }
+        return std::nullopt;
+    }
+
+    Status start_python_udf_server(const std::string& python, ProcessPtr* process) {
+        bp::ipstream output_stream;
+        try {
+            bp::child child(python, "-u", get_fight_server_path(), get_base_unix_socket_path(),
+                            bp::std_out > output_stream);
+            auto candidate = std::make_shared<PythonUDFProcess>(std::move(child),
+                                                                std::move(output_stream));
+            auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+            while (std::chrono::steady_clock::now() < deadline) {
+                if (fs::exists(candidate->get_socket_file_path())) {
+                    *process = std::move(candidate);
+                    return Status::OK();
+                }
+                if (!candidate->is_alive()) {
+                    return Status::InternalError("Python UDF server exited before becoming ready");
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
+            return Status::InternalError("Timed out waiting for Python UDF server at {}",
+                                         candidate->get_socket_file_path());
+        } catch (const std::exception& e) {
+            return Status::InternalError("Failed to start Python UDF server: {}", e.what());
+        }
+    }
+
+    Status evaluate_int_module_udf(const PythonUDFMeta& meta, const ProcessPtr& process,
+                                   int32_t input, int32_t* result) {
+        PythonUDFClientPtr client;
+        RETURN_IF_ERROR(PythonUDFClient::create(meta, process, &client));
+
+        arrow::Int32Builder builder;
+        RETURN_DORIS_STATUS_IF_ERROR(builder.Append(input));
+        std::shared_ptr<arrow::Array> input_array;
+        RETURN_DORIS_STATUS_IF_ERROR(builder.Finish(&input_array));
+        auto input_batch = arrow::RecordBatch::Make(
+                arrow::schema({arrow::field("arg0", arrow::int32(), false)}), 1, {input_array});
+
+        std::shared_ptr<arrow::RecordBatch> output_batch;
+        Status evaluate_status = client->evaluate(*input_batch, &output_batch);
+        static_cast<void>(client->close());
+        RETURN_IF_ERROR(evaluate_status);
+        if (!output_batch || output_batch->num_columns() != 1 || output_batch->num_rows() != 1 ||
+            output_batch->column(0)->type_id() != arrow::Type::INT32) {
+            return Status::InternalError("Unexpected Python UDF output batch");
+        }
+
+        *result = std::static_pointer_cast<arrow::Int32Array>(output_batch->column(0))->Value(0);
+        return Status::OK();
     }
 
     template <typename VersionedPoolPtr>
@@ -497,6 +581,75 @@ TEST_F(PythonServerTest, ClearModuleCacheWithoutProcessesIsNoOp) {
 
     auto status = mgr.clear_module_cache("/tmp/python_udf_cache");
     EXPECT_TRUE(status.ok()) << status.to_string();
+}
+
+TEST_F(PythonServerTest, ClearModuleCacheReloadsModuleOnNextUdfExecution) {
+    auto python = find_python_udf_interpreter();
+    if (!python) {
+        GTEST_SKIP() << "Python with pandas and pyarrow is required";
+    }
+
+    fs::path source_root = fs::current_path();
+    fs::path server_script;
+    while (!source_root.empty()) {
+        server_script = source_root / "be/src/udf/python/python_server.py";
+        if (fs::exists(server_script) || source_root == source_root.parent_path()) {
+            break;
+        }
+        source_root = source_root.parent_path();
+    }
+    ASSERT_TRUE(fs::exists(server_script)) << server_script;
+    setenv("DORIS_HOME", test_dir_.c_str(), 1);
+    fs::path plugin_dir = fs::path(test_dir_) / "plugins/python_udf";
+    fs::create_directories(plugin_dir);
+    fs::copy_file(server_script, plugin_dir / "python_server.py",
+                  fs::copy_options::overwrite_existing);
+
+    fs::path module_dir = fs::path(test_dir_) / "module_cache";
+    fs::create_directories(module_dir);
+    auto write_module = [&module_dir](int offset) {
+        std::ofstream module(module_dir / "cache_reload_udf.py", std::ios::trunc);
+        module << "def evaluate(value):\n"
+               << "    return value + " << offset << "\n";
+    };
+
+    write_module(1);
+    PythonVersion version("test-runtime", fs::path(*python).parent_path().parent_path().string(),
+                          *python);
+    PythonServerManager mgr;
+    ProcessPtr process;
+    Status fork_status = start_python_udf_server(*python, &process);
+    ASSERT_TRUE(fork_status.ok()) << fork_status.to_string();
+    ASSERT_NE(process, nullptr);
+    mgr.set_process_pool_for_test(version, {process});
+
+    PythonUDFMeta meta;
+    meta.id = 1;
+    meta.name = "cache_reload_udf";
+    meta.symbol = "cache_reload_udf.evaluate";
+    meta.location = module_dir.string();
+    meta.checksum = "test-checksum";
+    meta.runtime_version = version.full_version;
+    meta.input_types = {std::make_shared<DataTypeInt32>()};
+    meta.return_type = std::make_shared<DataTypeInt32>();
+    meta.type = PythonUDFLoadType::MODULE;
+    meta.client_type = PythonClientType::UDF;
+
+    int32_t result = 0;
+    Status evaluate_status = evaluate_int_module_udf(meta, process, 10, &result);
+    ASSERT_TRUE(evaluate_status.ok()) << evaluate_status.to_string();
+    ASSERT_EQ(result, 11);
+
+    // DROP clears the Python module before UserFunctionCache deletes its extracted directory.
+    ASSERT_TRUE(mgr.clear_module_cache(meta.location).ok());
+    fs::remove_all(module_dir);
+    fs::create_directories(module_dir);
+    write_module(100);
+
+    evaluate_status = evaluate_int_module_udf(meta, process, 10, &result);
+    ASSERT_TRUE(evaluate_status.ok()) << evaluate_status.to_string();
+    EXPECT_EQ(result, 110);
+    mgr.shutdown();
 }
 
 TEST_F(PythonServerTest, BroadcastActionWithInvalidProcessUriReturnsError) {

--- a/be/test/udf/python/python_server_test.cpp
+++ b/be/test/udf/python/python_server_test.cpp
@@ -18,6 +18,7 @@
 #include "udf/python/python_server.h"
 
 #include <arrow/api.h>
+#include <arrow/flight/server.h>
 #include <gtest/gtest.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -43,6 +44,37 @@ namespace doris {
 
 namespace fs = std::filesystem;
 namespace bp = boost::process;
+
+class ActionResultFlightServer final : public arrow::flight::FlightServerBase {
+public:
+    explicit ActionResultFlightServer(std::vector<std::string> results)
+            : _results(std::move(results)) {}
+
+    arrow::Status start() {
+        auto location = arrow::flight::Location::ForGrpcTcp("localhost", 0);
+        if (!location.ok()) {
+            return location.status();
+        }
+        return Init(arrow::flight::FlightServerOptions(*location));
+    }
+
+    ~ActionResultFlightServer() override { static_cast<void>(Shutdown()); }
+
+    arrow::Status DoAction(const arrow::flight::ServerCallContext&,
+                           const arrow::flight::Action&,
+                           std::unique_ptr<arrow::flight::ResultStream>* result) override {
+        std::vector<arrow::flight::Result> flight_results;
+        flight_results.reserve(_results.size());
+        for (const auto& body : _results) {
+            flight_results.emplace_back(arrow::Buffer::FromString(body));
+        }
+        *result = std::make_unique<arrow::flight::SimpleResultStream>(std::move(flight_results));
+        return arrow::Status::OK();
+    }
+
+private:
+    std::vector<std::string> _results;
+};
 
 class PythonServerTest : public ::testing::Test {
 protected:
@@ -668,6 +700,34 @@ TEST_F(PythonServerTest, BroadcastActionWithInvalidProcessUriReturnsError) {
     EXPECT_NE(status.to_string().find("clear_udaf_state_cache failed for function_id=12345"),
               std::string::npos);
     EXPECT_NE(status.to_string().find("success=0, failed=1"), std::string::npos);
+
+    mgr.shutdown();
+}
+
+TEST_F(PythonServerTest, BroadcastActionReportsFailedFlightResults) {
+    ActionResultFlightServer success_server({R"({"success": true})"});
+    ASSERT_TRUE(success_server.start().ok());
+    ActionResultFlightServer failed_server(
+            {R"({"success": false, "error": "cache clear failed"})"});
+    ASSERT_TRUE(failed_server.start().ok());
+
+    PythonServerManager mgr;
+    PythonVersion version("3.9.16", test_dir_, test_dir_ + "/bin/python3");
+    ProcessPtr success_process = create_sleep_process();
+    ASSERT_NE(success_process, nullptr);
+    ASSERT_TRUE(success_process->is_alive());
+    success_process->set_uri_for_test(success_server.location().ToString());
+    ProcessPtr failed_process = create_sleep_process();
+    ASSERT_NE(failed_process, nullptr);
+    ASSERT_TRUE(failed_process->is_alive());
+    failed_process->set_uri_for_test(failed_server.location().ToString());
+
+    mgr.set_process_pool_for_test(version, {success_process, failed_process});
+    auto status = mgr.clear_module_cache("/tmp/test_udf");
+
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.to_string().find("success=1, failed=1"), std::string::npos);
+    EXPECT_NE(status.to_string().find("cache clear failed"), std::string::npos);
 
     mgr.shutdown();
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #61280 

Problem Summary:

This PR fixes two issues in Python UDF module cache cleanup:

1. The Python module cache uses the complete UDF location string as its key, but the cleanup logic incorrectly treated the key as a tuple, introduced by: https://github.com/apache/doris/issues/61280. As a result, `DROP FUNCTION` could fail to remove the cached module, and subsequent executions could continue using stale Python code.

2. The BE only checked whether an Arrow Flight action returned a result successfully. It did not inspect the JSON payload returned by the Python server, so a response such as `{"success": false, "error": "..."}` was incorrectly counted as successful.

The fix:

- Matches cache entries using the complete UDF location and obtains the module name from the cached module before eviction.
- Parses the Flight action result and requires `success` to be `true`.
- Propagates Python-side cache cleanup errors through the returned BE status and includes the error details in logs.

### Release note

Fix Python UDF module cache cleanup and properly report Python server cleanup failures.