### PR TITLE
[fix](cloud) Set file cache TTL on cloud schema change output

### DIFF
--- a/be/src/cloud/cloud_schema_change_job.cpp
+++ b/be/src/cloud/cloud_schema_change_job.cpp
@@ -401,6 +401,11 @@ Status CloudSchemaChangeJob::_convert_historical_rowsets(const SchemaChangeParam
         context.storage_resource = _cloud_storage_engine.get_storage_resource(sc_params.vault_id);
         context.job_id = _job_id;
         context.write_file_cache = sc_params.output_to_file_cache;
+        // Schema change output belongs to the new tablet, so it must carry the tablet TTL
+        // like the load and compaction output does. Otherwise it is cached in the
+        // NORMAL/INDEX queues here, while every warm-up path downloads it into the TTL
+        // queue on the destination cluster.
+        context.file_cache_ttl_sec = _new_tablet->ttl_seconds();
         context.tablet = _new_tablet;
         if (!context.storage_resource) {
             return Status::InternalError("vault id not found, maybe not sync, vault id {}",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

`CloudSchemaChangeJob::_convert_historical_rowsets()` builds its `RowsetWriterContext` with `write_file_cache` but never sets `file_cache_ttl_sec`. For a table with `file_cache_ttl_seconds`, the schema change output is therefore written into the NORMAL/INDEX file cache queues instead of the TTL queue. The other two cloud write paths both set it:

- load: `CloudRowsetBuilder::init()` — `context.file_cache_ttl_sec = _tablet->ttl_seconds();`
- compaction: `CloudCompactionMixin::construct_output_rowset_writer()` — `ctx.file_cache_ttl_sec = _tablet->ttl_seconds();`

Two consequences:

1. The schema change output cannot be retained by the table TTL on the cluster that runs the job, and can be evicted early by the NORMAL/INDEX LRU.
2. Every warm-up path on the destination cluster derives the expiration from `tablet_meta->ttl_seconds()` unconditionally — event driven (`CloudInternalService::warm_up_rowset`), sync rowset (`CloudTablet::add_rowsets`) and warm-up job (`CloudWarmUpManager`) — so the very same rowsets land in the TTL queue there. Source and destination end up with the same total cached bytes but different queue attribution.

This is what `test_warm_up_cluster_event_schema_change` catches. After the schema change, `checkTTLCacheSizeSumEqual()` fails because the destination `ttl_cache_size` exceeds the source by exactly the size of the schema change output:

```
test_warm_up_cluster_event_schema_change.groovy:132
assertEquals(srcSum, tgtSum)
expected: 229588
but was:  489694
```

`489694 - 229588 = 260106 = 148362 (data) + 111744 (index)`, which is exactly what the schema change job wrote (its log shows `input_hit_rate=1, should_cache=1`, so the output was cached — just in the wrong queue).

The fix takes the TTL from the new tablet, which is the same tablet the warm-up paths read it from.

### Release note

None

### Check List (For Author)

- Test
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

Covered by the existing `test_warm_up_cluster_event_schema_change`, which fails before this change and passes after it.

- Behavior changed:
    - [ ] No.
    - [x] Yes. For a table with `file_cache_ttl_seconds`, the cloud schema change output is now cached in the TTL queue instead of the NORMAL/INDEX queues, matching the load and compaction paths.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
