### PR TITLE
[feature](row-binlog) Downlink explicit column mappings

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -2182,7 +2182,8 @@ void PublishVersionWorkerPool::publish_version_callback(const TAgentTaskRequest&
 
     for (auto& item : discontinuous_version_tablets) {
         _engine.add_async_publish_task(item.partition_id, item.tablet_id, item.publish_version,
-                                       publish_version_req.transaction_id, false, item.commit_tso);
+                                       publish_version_req.transaction_id, false, item.commit_tso,
+                                       std::move(item.row_binlog_column_mappings));
     }
     TFinishTaskRequest finish_task_request;
     if (!status.ok()) [[unlikely]] {

--- a/be/src/cloud/cloud_rowset_builder.cpp
+++ b/be/src/cloud/cloud_rowset_builder.cpp
@@ -29,6 +29,7 @@
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/storage_policy.h"
 #include "storage/tablet_info.h"
+#include "storage/transform/row_binlog_derive.h"
 
 namespace doris {
 using namespace ErrorCode;
@@ -152,6 +153,36 @@ Status CloudGroupRowsetBuilder::init() {
         cfg.source.is_transient_rowset_writer = data_ctx.is_transient_rowset_writer;
         cfg.source.source_write_type = data_ctx.write_type;
         cfg.source.base_tablet = _data_builder->tablet_sptr();
+
+        const OlapTableIndexSchema* source_index_schema = nullptr;
+        for (const auto* index_schema : _req.table_schema_param->indexes()) {
+            if (index_schema->index_id == data_ctx.index_id) {
+                source_index_schema = index_schema;
+                break;
+            }
+        }
+        DORIS_CHECK(source_index_schema != nullptr);
+        DORIS_CHECK_EQ(source_index_schema->row_binlog_id, binlog_ctx.index_id);
+        cfg.need_historical_value = source_index_schema->row_binlog_need_historical_value;
+        auto mappings = segment_v2::resolve_row_binlog_column_mappings(
+                *data_ctx.tablet_schema, *binlog_ctx.tablet_schema,
+                source_index_schema->row_binlog_column_mappings);
+        if (!mappings.has_value()) {
+            return mappings.error();
+        }
+        cfg.column_mappings = std::move(*mappings);
+
+        auto* persisted_mappings =
+                _data_builder->rowset_writer()->rowset_meta()->mutable_row_binlog_column_mappings();
+        persisted_mappings->set_need_historical_value(cfg.need_historical_value);
+        for (const auto& mapping : source_index_schema->row_binlog_column_mappings) {
+            auto* entry = persisted_mappings->add_entries();
+            entry->set_source_column_unique_id(mapping.source_uid);
+            entry->set_current_column_unique_id(mapping.current_uid);
+            if (mapping.before_uid.has_value()) {
+                entry->set_before_column_unique_id(*mapping.before_uid);
+            }
+        }
     }
 
     _rowset_writer = std::move(group_writer);

--- a/be/src/cloud/cloud_rowset_builder.cpp
+++ b/be/src/cloud/cloud_rowset_builder.cpp
@@ -172,17 +172,8 @@ Status CloudGroupRowsetBuilder::init() {
         }
         cfg.column_mappings = std::move(*mappings);
 
-        auto* persisted_mappings =
-                _data_builder->rowset_writer()->rowset_meta()->mutable_row_binlog_column_mappings();
-        persisted_mappings->set_need_historical_value(cfg.need_historical_value);
-        for (const auto& mapping : source_index_schema->row_binlog_column_mappings) {
-            auto* entry = persisted_mappings->add_entries();
-            entry->set_source_column_unique_id(mapping.source_uid);
-            entry->set_current_column_unique_id(mapping.current_uid);
-            if (mapping.before_uid.has_value()) {
-                entry->set_before_column_unique_id(*mapping.before_uid);
-            }
-        }
+        _attach_row_binlog.need_historical_value = cfg.need_historical_value;
+        _attach_row_binlog.column_mappings = source_index_schema->row_binlog_column_mappings;
     }
 
     _rowset_writer = std::move(group_writer);
@@ -214,14 +205,13 @@ Status CloudGroupRowsetBuilder::commit_rowset(const std::string& job_id, int64_t
 }
 
 Status CloudGroupRowsetBuilder::set_txn_related_info() {
-    RowBinlogTxnInfo attach_row_binlog;
-    attach_row_binlog.rowset = _row_binlog_builder->rowset();
-    attach_row_binlog.tablet = _row_binlog_builder->tablet_sptr();
+    _attach_row_binlog.rowset = _row_binlog_builder->rowset();
+    _attach_row_binlog.tablet = _row_binlog_builder->tablet_sptr();
     if (_data_builder->tablet()->enable_unique_key_merge_on_write()) {
-        attach_row_binlog.delete_bitmap =
+        _attach_row_binlog.delete_bitmap =
                 std::make_shared<DeleteBitmap>(_row_binlog_builder->tablet()->tablet_id());
     }
-    RETURN_IF_ERROR(_data_builder->attach_row_binlog_to_txn(attach_row_binlog));
+    RETURN_IF_ERROR(_data_builder->attach_row_binlog_to_txn(_attach_row_binlog));
     RETURN_IF_ERROR(_data_builder->set_txn_related_info());
     return _row_binlog_builder->set_txn_related_info();
 }

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -845,10 +845,6 @@ Result<std::unique_ptr<RowsetWriter>> CloudTablet::create_rowset_writer(
     context.partition_id = partition_id();
     context.enable_unique_key_merge_on_write = enable_unique_key_merge_on_write();
     context.encrypt_algorithm = tablet_meta()->encryption_algorithm();
-    if (context.write_binlog_opt().enable) {
-        context.write_binlog_opt().set_need_before(
-                tablet_meta()->binlog_config().need_historical_value());
-    }
     context.inverted_index_storage_format = tablet_meta()->inverted_index_storage_format();
     context.persist_inverted_index_storage_format =
             tablet_meta()->has_inverted_index_storage_format();
@@ -891,8 +887,6 @@ Result<std::unique_ptr<RowsetWriter>> CloudTablet::create_transient_rowset_write
     context.is_transient_rowset_writer = true;
     if (rowset.rowset_meta() != nullptr && rowset.rowset_meta()->is_row_binlog()) {
         context.write_binlog_opt().enable = true;
-        context.write_binlog_opt().set_need_before(
-                tablet_meta()->binlog_config().need_historical_value());
     }
     context.rowset_id = rowset.rowset_id();
     context.tablet_id = tablet_id();

--- a/be/src/cloud/pb_convert.cpp
+++ b/be/src/cloud/pb_convert.cpp
@@ -128,6 +128,9 @@ void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, const RowsetMetaPB& in) 
     if (in.has_is_row_binlog()) {
         out->set_is_row_binlog(in.is_row_binlog());
     }
+    if (in.has_row_binlog_column_mappings()) {
+        out->mutable_row_binlog_column_mappings()->CopyFrom(in.row_binlog_column_mappings());
+    }
     if (in.has_db_id()) {
         out->set_db_id(in.db_id());
     }
@@ -228,6 +231,9 @@ void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, RowsetMetaPB&& in) {
     }
     if (in.has_is_row_binlog()) {
         out->set_is_row_binlog(in.is_row_binlog());
+    }
+    if (in.has_row_binlog_column_mappings()) {
+        out->mutable_row_binlog_column_mappings()->Swap(in.mutable_row_binlog_column_mappings());
     }
     if (in.has_db_id()) {
         out->set_db_id(in.db_id());
@@ -340,6 +346,9 @@ void cloud_rowset_meta_to_doris(RowsetMetaPB* out, const RowsetMetaCloudPB& in) 
     if (in.has_is_row_binlog()) {
         out->set_is_row_binlog(in.is_row_binlog());
     }
+    if (in.has_row_binlog_column_mappings()) {
+        out->mutable_row_binlog_column_mappings()->CopyFrom(in.row_binlog_column_mappings());
+    }
     if (in.has_db_id()) {
         out->set_db_id(in.db_id());
     }
@@ -439,6 +448,9 @@ void cloud_rowset_meta_to_doris(RowsetMetaPB* out, RowsetMetaCloudPB&& in) {
     }
     if (in.has_is_row_binlog()) {
         out->set_is_row_binlog(in.is_row_binlog());
+    }
+    if (in.has_row_binlog_column_mappings()) {
+        out->mutable_row_binlog_column_mappings()->Swap(in.mutable_row_binlog_column_mappings());
     }
     if (in.has_db_id()) {
         out->set_db_id(in.db_id());

--- a/be/src/cloud/pb_convert.cpp
+++ b/be/src/cloud/pb_convert.cpp
@@ -128,9 +128,6 @@ void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, const RowsetMetaPB& in) 
     if (in.has_is_row_binlog()) {
         out->set_is_row_binlog(in.is_row_binlog());
     }
-    if (in.has_row_binlog_column_mappings()) {
-        out->mutable_row_binlog_column_mappings()->CopyFrom(in.row_binlog_column_mappings());
-    }
     if (in.has_db_id()) {
         out->set_db_id(in.db_id());
     }
@@ -231,9 +228,6 @@ void doris_rowset_meta_to_cloud(RowsetMetaCloudPB* out, RowsetMetaPB&& in) {
     }
     if (in.has_is_row_binlog()) {
         out->set_is_row_binlog(in.is_row_binlog());
-    }
-    if (in.has_row_binlog_column_mappings()) {
-        out->mutable_row_binlog_column_mappings()->Swap(in.mutable_row_binlog_column_mappings());
     }
     if (in.has_db_id()) {
         out->set_db_id(in.db_id());
@@ -346,9 +340,6 @@ void cloud_rowset_meta_to_doris(RowsetMetaPB* out, const RowsetMetaCloudPB& in) 
     if (in.has_is_row_binlog()) {
         out->set_is_row_binlog(in.is_row_binlog());
     }
-    if (in.has_row_binlog_column_mappings()) {
-        out->mutable_row_binlog_column_mappings()->CopyFrom(in.row_binlog_column_mappings());
-    }
     if (in.has_db_id()) {
         out->set_db_id(in.db_id());
     }
@@ -448,9 +439,6 @@ void cloud_rowset_meta_to_doris(RowsetMetaPB* out, RowsetMetaCloudPB&& in) {
     }
     if (in.has_is_row_binlog()) {
         out->set_is_row_binlog(in.is_row_binlog());
-    }
-    if (in.has_row_binlog_column_mappings()) {
-        out->mutable_row_binlog_column_mappings()->Swap(in.mutable_row_binlog_column_mappings());
     }
     if (in.has_db_id()) {
         out->set_db_id(in.db_id());

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -683,18 +683,12 @@ Status OlapScanner::_init_read_schema() {
         }
 
         const auto& tablet_schema = *_tablet_reader_params.tablet_schema;
-        const int32_t tso_ordinal = read_ordinal_by_tablet_cid(*read_schema, tablet_schema,
-                                                               tablet_schema.binlog_tso_col_idx());
-        const int32_t lsn_ordinal = read_ordinal_by_tablet_cid(*read_schema, tablet_schema,
-                                                               tablet_schema.binlog_lsn_col_idx());
-        const int32_t op_ordinal = read_ordinal_by_tablet_cid(*read_schema, tablet_schema,
-                                                              tablet_schema.binlog_op_col_idx());
-        if (merge_changes && (tso_ordinal < 0 || op_ordinal < 0)) {
+        RETURN_IF_ERROR(read_schema->init_row_binlog_column_mappings(std::move(value_pairs),
+                                                                     tablet_schema));
+        if (merge_changes && (read_schema->tso_ordinal() < 0 || read_schema->op_ordinal() < 0)) {
             return Status::InvalidArgument(
                     "Row-binlog TSO and OP columns must be present for change merging");
         }
-        RETURN_IF_ERROR(read_schema->init_row_binlog_column_mappings(
-                std::move(value_pairs), tso_ordinal, lsn_ordinal, op_ordinal));
         if (_tablet_reader_params.binlog_scan_type == TBinlogScanType::MIN_DELTA &&
             !read_schema->row_binlog_value_pairs_complete()) {
             return Status::InvalidArgument(

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -28,6 +28,7 @@
 #include <atomic>
 #include <ostream>
 #include <set>
+#include <unordered_map>
 
 #include "cloud/cloud_storage_engine.h"
 #include "cloud/cloud_tablet_hotspot.h"
@@ -584,8 +585,10 @@ Status OlapScanner::_init_read_schema() {
     // an extra column and can be removed by the projection output tuple.
     std::vector<TabletColumnPtr> read_columns;
     std::vector<DataTypePtr> expected_types;
+    std::unordered_map<TSlotId, ColumnId> slot_id_to_ordinal;
     read_columns.reserve(_output_tuple_desc->slots().size());
     expected_types.reserve(_output_tuple_desc->slots().size());
+    slot_id_to_ordinal.reserve(_output_tuple_desc->slots().size());
     for (uint32_t ordinal = 0; auto* slot : _output_tuple_desc->slots()) {
         // variant column using path to index a column
         int32_t index = 0;
@@ -631,6 +634,7 @@ Status OlapScanner::_init_read_schema() {
 
         read_columns.push_back(tablet_schema->columns()[index]);
         expected_types.push_back(slot->get_data_type_ptr());
+        slot_id_to_ordinal.emplace(slot->id(), ordinal);
         if (!slot->is_nullable() && tablet_schema->column(index).is_nullable()) {
             return Status::Error<ErrorCode::INVALID_SCHEMA>(
                     "slot(id: {}, name: {})'s nullable does not match "
@@ -647,8 +651,57 @@ Status OlapScanner::_init_read_schema() {
 
     // The FE physical scan tuple is the read-path schema. It already includes
     // every storage key, sequence, TSO and binlog column required below.
-    _tablet_reader_params.read_schema =
+    auto read_schema =
             std::make_shared<ReadSchema>(std::move(read_columns), std::move(expected_types));
+    if (_tablet_reader_params.read_row_binlog) {
+        const auto* olap_local_state = static_cast<OlapScanLocalState*>(_local_state);
+        const auto& olap_scan_node = olap_local_state->olap_scan_node();
+        const bool merge_changes =
+                _tablet_reader_params.binlog_scan_type == TBinlogScanType::MIN_DELTA ||
+                _tablet_reader_params.binlog_scan_type == TBinlogScanType::DETAIL;
+        ReadSchema::RowBinlogValueColumnPairs value_pairs;
+        if (merge_changes) {
+            if (!olap_scan_node.__isset.row_binlog_current_slot_ids ||
+                !olap_scan_node.__isset.row_binlog_before_slot_ids ||
+                olap_scan_node.row_binlog_current_slot_ids.size() !=
+                        olap_scan_node.row_binlog_before_slot_ids.size()) {
+                return Status::InvalidArgument(
+                        "Row-binlog current/before slot mappings must be present and aligned");
+            }
+            value_pairs.reserve(olap_scan_node.row_binlog_current_slot_ids.size());
+            for (size_t i = 0; i < olap_scan_node.row_binlog_current_slot_ids.size(); ++i) {
+                const auto current =
+                        slot_id_to_ordinal.find(olap_scan_node.row_binlog_current_slot_ids[i]);
+                const auto before =
+                        slot_id_to_ordinal.find(olap_scan_node.row_binlog_before_slot_ids[i]);
+                if (current == slot_id_to_ordinal.end() || before == slot_id_to_ordinal.end()) {
+                    return Status::InvalidArgument(
+                            "Row-binlog current/before slot mapping references an unknown slot");
+                }
+                value_pairs.emplace_back(current->second, before->second);
+            }
+        }
+
+        const auto& tablet_schema = *_tablet_reader_params.tablet_schema;
+        const int32_t tso_ordinal = read_ordinal_by_tablet_cid(*read_schema, tablet_schema,
+                                                               tablet_schema.binlog_tso_col_idx());
+        const int32_t lsn_ordinal = read_ordinal_by_tablet_cid(*read_schema, tablet_schema,
+                                                               tablet_schema.binlog_lsn_col_idx());
+        const int32_t op_ordinal = read_ordinal_by_tablet_cid(*read_schema, tablet_schema,
+                                                              tablet_schema.binlog_op_col_idx());
+        if (merge_changes && (tso_ordinal < 0 || op_ordinal < 0)) {
+            return Status::InvalidArgument(
+                    "Row-binlog TSO and OP columns must be present for change merging");
+        }
+        RETURN_IF_ERROR(read_schema->init_row_binlog_column_mappings(
+                std::move(value_pairs), tso_ordinal, lsn_ordinal, op_ordinal));
+        if (_tablet_reader_params.binlog_scan_type == TBinlogScanType::MIN_DELTA &&
+            !read_schema->row_binlog_value_pairs_complete()) {
+            return Status::InvalidArgument(
+                    "MIN_DELTA requires mappings for every materialized row-binlog value column");
+        }
+    }
+    _tablet_reader_params.read_schema = std::move(read_schema);
 
     return Status::OK();
 }

--- a/be/src/storage/binlog.h
+++ b/be/src/storage/binlog.h
@@ -23,6 +23,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -58,7 +59,7 @@ constexpr std::string_view kRowBinlogPrefix = "binlog_row_";
 namespace binlog {
 
 inline std::string build_before_column_name(std::string_view name) {
-    std::string before_name = "__BEFORE__";
+    std::string before_name = "__DORIS_BEFORE__";
     before_name.append(name.data(), name.size());
     before_name.append("__");
     return before_name;
@@ -169,6 +170,14 @@ inline int64_t extract_tso_physical_time(int64_t tso) {
 
 namespace segment_v2 {
 
+struct RowBinlogColumnCidMapping {
+    ColumnId source_cid;
+    ColumnId current_cid;
+    std::optional<ColumnId> before_cid;
+
+    bool operator==(const RowBinlogColumnCidMapping&) const = default;
+};
+
 class SegmentAllocatedLsnMap {
 public:
     void insert_segment_allocated_lsns(int64_t seg_id, ConstAllocatedLsnVectorSharedPtr lsn_ids) {
@@ -212,7 +221,8 @@ private:
 
 struct SegmentWriteBinlogOptions {
 public:
-    bool write_before = false;
+    bool need_historical_value = false;
+    std::vector<RowBinlogColumnCidMapping> column_mappings;
 
     // source context, used for retrieving historical row and building binlog<row> block
     struct SourceWriteDataOptions {

--- a/be/src/storage/binlog.h
+++ b/be/src/storage/binlog.h
@@ -59,7 +59,7 @@ constexpr std::string_view kRowBinlogPrefix = "binlog_row_";
 namespace binlog {
 
 inline std::string build_before_column_name(std::string_view name) {
-    std::string before_name = "__DORIS_BEFORE__";
+    std::string before_name = "__BEFORE__";
     before_name.append(name.data(), name.size());
     before_name.append("__");
     return before_name;

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -484,21 +484,25 @@ Status DataDir::load() {
         }
     }
 
-    auto load_pending_publish_info_func = [&engine = _engine](int64_t tablet_id,
-                                                              int64_t publish_version,
-                                                              std::string_view info) {
-        PendingPublishInfoPB pending_publish_info_pb;
-        bool parsed =
-                pending_publish_info_pb.ParseFromArray(info.data(), cast_set<int>(info.size()));
-        if (!parsed) {
-            LOG(WARNING) << "parse pending publish info failed, tablet_id: " << tablet_id
-                         << " publish_version: " << publish_version;
-        }
-        engine.add_async_publish_task(pending_publish_info_pb.partition_id(), tablet_id,
-                                      publish_version, pending_publish_info_pb.transaction_id(),
-                                      true, pending_publish_info_pb.commit_tso());
-        return true;
-    };
+    auto load_pending_publish_info_func =
+            [&engine = _engine](int64_t tablet_id, int64_t publish_version, std::string_view info) {
+                PendingPublishInfoPB pending_publish_info_pb;
+                bool parsed = pending_publish_info_pb.ParseFromArray(info.data(),
+                                                                     cast_set<int>(info.size()));
+                if (!parsed) {
+                    LOG(WARNING) << "parse pending publish info failed, tablet_id: " << tablet_id
+                                 << " publish_version: " << publish_version;
+                }
+                engine.add_async_publish_task(
+                        pending_publish_info_pb.partition_id(), tablet_id, publish_version,
+                        pending_publish_info_pb.transaction_id(), true,
+                        pending_publish_info_pb.commit_tso(),
+                        pending_publish_info_pb.has_row_binlog_column_mappings()
+                                ? std::make_shared<PRowBinlogWriteColumnMappings>(
+                                          pending_publish_info_pb.row_binlog_column_mappings())
+                                : nullptr);
+                return true;
+            };
     MonotonicStopWatch pending_publish_timer;
     pending_publish_timer.start();
     RETURN_IF_ERROR(

--- a/be/src/storage/iterator/block_reader.cpp
+++ b/be/src/storage/iterator/block_reader.cpp
@@ -113,7 +113,7 @@ Status BlockReader::_write_binlog_op(IColumn& col, int64_t op) const {
 }
 
 // Resolves which source-block column to read from for a given binlog row position.
-// When use_before is true, return the ordinal of its __BEFORE__ mirror.
+// When use_before is true, return the ordinal of its __DORIS_BEFORE__ mirror.
 // Binlog meta columns map to themselves.
 uint32_t BlockReader::_resolve_source_column_ordinal(uint32_t ordinal, bool use_before) const {
     return use_before ? _read_schema->before_column_ordinal(ordinal) : ordinal;
@@ -566,9 +566,6 @@ Status BlockReader::init(const ReaderParams& read_params) {
 
     if (read_params.binlog_scan_type == TBinlogScanType::MIN_DELTA ||
         read_params.binlog_scan_type == TBinlogScanType::DETAIL) {
-        auto read_schema = std::make_shared<ReadSchema>(*_read_schema);
-        read_schema->init_row_binlog_column_mappings(*_tablet_schema);
-        _read_schema = std::move(read_schema);
         _min_delta_value_compare_unsupported = false;
     }
 

--- a/be/src/storage/iterator/block_reader.cpp
+++ b/be/src/storage/iterator/block_reader.cpp
@@ -113,7 +113,7 @@ Status BlockReader::_write_binlog_op(IColumn& col, int64_t op) const {
 }
 
 // Resolves which source-block column to read from for a given binlog row position.
-// When use_before is true, return the ordinal of its __DORIS_BEFORE__ mirror.
+// When use_before is true, return the ordinal of its __BEFORE__ mirror.
 // Binlog meta columns map to themselves.
 uint32_t BlockReader::_resolve_source_column_ordinal(uint32_t ordinal, bool use_before) const {
     return use_before ? _read_schema->before_column_ordinal(ordinal) : ordinal;

--- a/be/src/storage/merger.cpp
+++ b/be/src/storage/merger.cpp
@@ -116,14 +116,8 @@ Status Merger::vmerge_rowsets(BaseTabletSPtr tablet, ReaderType reader_type,
 
     reader_params.read_schema = std::make_shared<ReadSchema>(cur_tablet_schema.columns());
     if (reader_params.read_row_binlog) {
-        RETURN_IF_ERROR(reader_params.read_schema->init_row_binlog_column_mappings(
-                {},
-                read_ordinal_by_tablet_cid(*reader_params.read_schema, cur_tablet_schema,
-                                           cur_tablet_schema.binlog_tso_col_idx()),
-                read_ordinal_by_tablet_cid(*reader_params.read_schema, cur_tablet_schema,
-                                           cur_tablet_schema.binlog_lsn_col_idx()),
-                read_ordinal_by_tablet_cid(*reader_params.read_schema, cur_tablet_schema,
-                                           cur_tablet_schema.binlog_op_col_idx())));
+        RETURN_IF_ERROR(
+                reader_params.read_schema->init_row_binlog_column_mappings({}, cur_tablet_schema));
     }
     RETURN_IF_ERROR(reader.init(reader_params));
 
@@ -314,14 +308,8 @@ Status Merger::vertical_compact_one_group(
     reader_params.read_schema = std::make_shared<ReadSchema>(
             project_columns_by_ordinal(tablet_schema.columns(), column_group));
     if (reader_params.read_row_binlog) {
-        RETURN_IF_ERROR(reader_params.read_schema->init_row_binlog_column_mappings(
-                {},
-                read_ordinal_by_tablet_cid(*reader_params.read_schema, tablet_schema,
-                                           tablet_schema.binlog_tso_col_idx()),
-                read_ordinal_by_tablet_cid(*reader_params.read_schema, tablet_schema,
-                                           tablet_schema.binlog_lsn_col_idx()),
-                read_ordinal_by_tablet_cid(*reader_params.read_schema, tablet_schema,
-                                           tablet_schema.binlog_op_col_idx())));
+        RETURN_IF_ERROR(
+                reader_params.read_schema->init_row_binlog_column_mappings({}, tablet_schema));
     }
     reader_params.batch_size = batch_size;
     RETURN_IF_ERROR(reader.init(reader_params, sample_info));

--- a/be/src/storage/merger.cpp
+++ b/be/src/storage/merger.cpp
@@ -115,6 +115,16 @@ Status Merger::vmerge_rowsets(BaseTabletSPtr tablet, ReaderType reader_type,
     }
 
     reader_params.read_schema = std::make_shared<ReadSchema>(cur_tablet_schema.columns());
+    if (reader_params.read_row_binlog) {
+        RETURN_IF_ERROR(reader_params.read_schema->init_row_binlog_column_mappings(
+                {},
+                read_ordinal_by_tablet_cid(*reader_params.read_schema, cur_tablet_schema,
+                                           cur_tablet_schema.binlog_tso_col_idx()),
+                read_ordinal_by_tablet_cid(*reader_params.read_schema, cur_tablet_schema,
+                                           cur_tablet_schema.binlog_lsn_col_idx()),
+                read_ordinal_by_tablet_cid(*reader_params.read_schema, cur_tablet_schema,
+                                           cur_tablet_schema.binlog_op_col_idx())));
+    }
     RETURN_IF_ERROR(reader.init(reader_params));
 
     Block block = reader_params.read_schema->create_read_block();
@@ -303,6 +313,16 @@ Status Merger::vertical_compact_one_group(
 
     reader_params.read_schema = std::make_shared<ReadSchema>(
             project_columns_by_ordinal(tablet_schema.columns(), column_group));
+    if (reader_params.read_row_binlog) {
+        RETURN_IF_ERROR(reader_params.read_schema->init_row_binlog_column_mappings(
+                {},
+                read_ordinal_by_tablet_cid(*reader_params.read_schema, tablet_schema,
+                                           tablet_schema.binlog_tso_col_idx()),
+                read_ordinal_by_tablet_cid(*reader_params.read_schema, tablet_schema,
+                                           tablet_schema.binlog_lsn_col_idx()),
+                read_ordinal_by_tablet_cid(*reader_params.read_schema, tablet_schema,
+                                           tablet_schema.binlog_op_col_idx())));
+    }
     reader_params.batch_size = batch_size;
     RETURN_IF_ERROR(reader.init(reader_params, sample_info));
 

--- a/be/src/storage/mow/key_probe.h
+++ b/be/src/storage/mow/key_probe.h
@@ -129,10 +129,11 @@ public:
     }
 
     // The row binlog history lookup: marks nothing, and keeps the old values of a sequence loser,
-    // and of a delete-signed row when a __BEFORE__* image is wanted.
+    // and of a delete-signed row when historical values are requested.
     static MowKeyProbe for_row_binlog(BaseTablet* tablet, TabletSchema* lookup_schema,
                                       bool has_sequence_col,
-                                      std::shared_ptr<MowContext> mow_context, bool write_before) {
+                                      std::shared_ptr<MowContext> mow_context,
+                                      bool need_historical_value) {
         return MowKeyProbe {tablet,
                             lookup_schema,
                             has_sequence_col,
@@ -141,7 +142,7 @@ public:
                             0,
                             Policy {
                                     .mark_deleted = MarkDeleted::NONE,
-                                    .use_defaults_for_delete_signed = !write_before,
+                                    .use_defaults_for_delete_signed = !need_historical_value,
                                     .use_defaults_for_seq_loser = false,
                                     .use_defaults_for_in_load_deleted = false,
                             }};

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -1699,9 +1699,10 @@ void StorageEngine::_follow_cooldown_meta(TabletSharedPtr t) {
     }
 }
 
-void StorageEngine::add_async_publish_task(int64_t partition_id, int64_t tablet_id,
-                                           int64_t publish_version, int64_t transaction_id,
-                                           bool is_recovery, int64_t commit_tso) {
+void StorageEngine::add_async_publish_task(
+        int64_t partition_id, int64_t tablet_id, int64_t publish_version, int64_t transaction_id,
+        bool is_recovery, int64_t commit_tso,
+        std::shared_ptr<const PRowBinlogWriteColumnMappings> row_binlog_column_mappings) {
     if (!is_recovery) {
         bool exists = false;
         {
@@ -1727,6 +1728,10 @@ void StorageEngine::add_async_publish_task(int64_t partition_id, int64_t tablet_
         pending_publish_info_pb.set_partition_id(partition_id);
         pending_publish_info_pb.set_transaction_id(transaction_id);
         pending_publish_info_pb.set_commit_tso(commit_tso);
+        if (row_binlog_column_mappings != nullptr) {
+            *pending_publish_info_pb.mutable_row_binlog_column_mappings() =
+                    *row_binlog_column_mappings;
+        }
         static_cast<void>(TabletMetaManager::save_pending_publish_info(
                 tablet->data_dir(), tablet->tablet_id(), publish_version,
                 pending_publish_info_pb.SerializeAsString()));
@@ -1735,7 +1740,8 @@ void StorageEngine::add_async_publish_task(int64_t partition_id, int64_t tablet_
               << " version: " << publish_version << " txn_id:" << transaction_id
               << " is_recovery: " << is_recovery;
     std::unique_lock<std::shared_mutex> wlock(_async_publish_lock);
-    _async_publish_tasks[tablet_id][publish_version] = {transaction_id, partition_id, commit_tso};
+    _async_publish_tasks[tablet_id][publish_version] = {transaction_id, partition_id, commit_tso,
+                                                        std::move(row_binlog_column_mappings)};
 }
 
 int64_t StorageEngine::get_pending_publish_min_version(int64_t tablet_id) {
@@ -1796,7 +1802,8 @@ void StorageEngine::_process_async_publish() {
             }
 
             auto async_publish_task = std::make_shared<AsyncTabletPublishTask>(
-                    *this, tablet, partition_id, transaction_id, version, commit_tso);
+                    *this, tablet, partition_id, transaction_id, version, commit_tso,
+                    std::get<3>(task_iter->second));
             static_cast<void>(_tablet_publish_txn_thread_pool->submit_func(
                     [=]() { async_publish_task->handle(); }));
             tablet_iter->second.erase(task_iter);

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -145,6 +145,20 @@ public:
         return _rowset_meta_pb.has_is_row_binlog() && _rowset_meta_pb.is_row_binlog();
     }
 
+    bool has_row_binlog_column_mappings() const {
+        return _rowset_meta_pb.has_row_binlog_column_mappings();
+    }
+
+    const PRowBinlogWriteColumnMappings& row_binlog_column_mappings() const {
+        return _rowset_meta_pb.row_binlog_column_mappings();
+    }
+
+    PRowBinlogWriteColumnMappings* mutable_row_binlog_column_mappings() {
+        return _rowset_meta_pb.mutable_row_binlog_column_mappings();
+    }
+
+    void clear_row_binlog_column_mappings() { _rowset_meta_pb.clear_row_binlog_column_mappings(); }
+
     RowsetTypePB rowset_type() const { return _rowset_meta_pb.rowset_type(); }
 
     void set_rowset_type(RowsetTypePB rowset_type) { _rowset_meta_pb.set_rowset_type(rowset_type); }

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -145,20 +145,6 @@ public:
         return _rowset_meta_pb.has_is_row_binlog() && _rowset_meta_pb.is_row_binlog();
     }
 
-    bool has_row_binlog_column_mappings() const {
-        return _rowset_meta_pb.has_row_binlog_column_mappings();
-    }
-
-    const PRowBinlogWriteColumnMappings& row_binlog_column_mappings() const {
-        return _rowset_meta_pb.row_binlog_column_mappings();
-    }
-
-    PRowBinlogWriteColumnMappings* mutable_row_binlog_column_mappings() {
-        return _rowset_meta_pb.mutable_row_binlog_column_mappings();
-    }
-
-    void clear_row_binlog_column_mappings() { _rowset_meta_pb.clear_row_binlog_column_mappings(); }
-
     RowsetTypePB rowset_type() const { return _rowset_meta_pb.rowset_type(); }
 
     void set_rowset_type(RowsetTypePB rowset_type) { _rowset_meta_pb.set_rowset_type(rowset_type); }

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -321,11 +321,6 @@ struct RowsetWriterContext {
     public:
         bool enable = false;
 
-        void set_need_before(bool need_before) {
-            this->_need_before = need_before;
-            _segment_write_binlog_opt.write_before = need_before;
-        }
-
         segment_v2::SegmentWriteBinlogOptions& write_binlog_config() {
             return _segment_write_binlog_opt;
         }
@@ -335,7 +330,6 @@ struct RowsetWriterContext {
         }
 
     private:
-        bool _need_before = false;
         segment_v2::SegmentWriteBinlogOptions _segment_write_binlog_opt;
     } _write_binlog_opt;
 

--- a/be/src/storage/rowset_builder.cpp
+++ b/be/src/storage/rowset_builder.cpp
@@ -54,6 +54,7 @@
 #include "storage/tablet/tablet_schema.h"
 #include "storage/tablet/tablet_schema_cache.h"
 #include "storage/tablet_info.h"
+#include "storage/transform/row_binlog_derive.h"
 #include "storage/txn/txn_manager.h"
 #include "util/brpc_client_cache.h"
 #include "util/brpc_closure.h"
@@ -583,6 +584,37 @@ Status GroupRowsetBuilder::init() {
         cfg.source.is_transient_rowset_writer = data_ctx.is_transient_rowset_writer;
         cfg.source.source_write_type = data_ctx.write_type;
         cfg.source.base_tablet = _txn_rs_builder->tablet_sptr();
+
+        const OlapTableIndexSchema* source_index_schema = nullptr;
+        for (const auto* index_schema : _req.table_schema_param->indexes()) {
+            if (index_schema->index_id == data_ctx.index_id) {
+                source_index_schema = index_schema;
+                break;
+            }
+        }
+        DORIS_CHECK(source_index_schema != nullptr);
+        DORIS_CHECK_EQ(source_index_schema->row_binlog_id, binlog_ctx.index_id);
+        cfg.need_historical_value = source_index_schema->row_binlog_need_historical_value;
+        auto mappings = segment_v2::resolve_row_binlog_column_mappings(
+                *data_ctx.tablet_schema, *binlog_ctx.tablet_schema,
+                source_index_schema->row_binlog_column_mappings);
+        if (!mappings.has_value()) {
+            return mappings.error();
+        }
+        cfg.column_mappings = std::move(*mappings);
+
+        auto* persisted_mappings = _txn_rs_builder->rowset_writer()
+                                           ->rowset_meta()
+                                           ->mutable_row_binlog_column_mappings();
+        persisted_mappings->set_need_historical_value(cfg.need_historical_value);
+        for (const auto& mapping : source_index_schema->row_binlog_column_mappings) {
+            auto* entry = persisted_mappings->add_entries();
+            entry->set_source_column_unique_id(mapping.source_uid);
+            entry->set_current_column_unique_id(mapping.current_uid);
+            if (mapping.before_uid.has_value()) {
+                entry->set_before_column_unique_id(*mapping.before_uid);
+            }
+        }
     }
 
     _rowset_writer = std::move(group_writer);

--- a/be/src/storage/rowset_builder.cpp
+++ b/be/src/storage/rowset_builder.cpp
@@ -602,19 +602,6 @@ Status GroupRowsetBuilder::init() {
             return mappings.error();
         }
         cfg.column_mappings = std::move(*mappings);
-
-        auto* persisted_mappings = _txn_rs_builder->rowset_writer()
-                                           ->rowset_meta()
-                                           ->mutable_row_binlog_column_mappings();
-        persisted_mappings->set_need_historical_value(cfg.need_historical_value);
-        for (const auto& mapping : source_index_schema->row_binlog_column_mappings) {
-            auto* entry = persisted_mappings->add_entries();
-            entry->set_source_column_unique_id(mapping.source_uid);
-            entry->set_current_column_unique_id(mapping.current_uid);
-            if (mapping.before_uid.has_value()) {
-                entry->set_before_column_unique_id(*mapping.before_uid);
-            }
-        }
     }
 
     _rowset_writer = std::move(group_writer);

--- a/be/src/storage/schema.cpp
+++ b/be/src/storage/schema.cpp
@@ -25,28 +25,8 @@
 #include "core/column/column_dictionary.h"
 #include "core/column/column_nothing.h"
 #include "core/column/column_nullable.h"
-#include "storage/binlog.h"
 
 namespace doris {
-
-namespace {
-
-bool row_binlog_value_columns_have_same_type(const TabletColumn& lhs, const TabletColumn& rhs) {
-    if (lhs.type() != rhs.type() || lhs.is_nullable() != rhs.is_nullable() ||
-        lhs.length() != rhs.length() || lhs.precision() != rhs.precision() ||
-        lhs.frac() != rhs.frac() || lhs.get_subtype_count() != rhs.get_subtype_count()) {
-        return false;
-    }
-    for (uint32_t i = 0; i < lhs.get_subtype_count(); ++i) {
-        if (!row_binlog_value_columns_have_same_type(lhs.get_sub_column(i),
-                                                     rhs.get_sub_column(i))) {
-            return false;
-        }
-    }
-    return true;
-}
-
-} // namespace
 
 std::vector<TabletColumnPtr> project_columns_by_ordinal(
         const std::vector<TabletColumnPtr>& columns,
@@ -57,6 +37,13 @@ std::vector<TabletColumnPtr> project_columns_by_ordinal(
         projected_columns.emplace_back(columns[ordinal]);
     }
     return projected_columns;
+}
+
+int32_t read_ordinal_by_tablet_cid(const ReadSchema& read_schema, const TabletSchema& tablet_schema,
+                                   int32_t tablet_cid) {
+    return tablet_cid < 0
+                   ? -1
+                   : read_schema.ordinal_by_uid(tablet_schema.column(tablet_cid).unique_id());
 }
 
 ReadSchema::ReadSchema(std::vector<TabletColumnPtr> columns)
@@ -96,92 +83,60 @@ void ReadSchema::append_dropped_columns(std::vector<TabletColumn> columns) {
     }
 }
 
-void ReadSchema::_init_before_column_ordinals() {
-    std::unordered_map<std::string_view, ColumnId> name_to_ordinal;
-    name_to_ordinal.reserve(_num_block_columns);
-    for (ColumnId ordinal = 0; ordinal < _num_block_columns; ++ordinal) {
-        name_to_ordinal.emplace(_read_columns[ordinal]->name(), ordinal);
-    }
-
-    _before_column_ordinals.resize(_num_block_columns);
-    for (ColumnId ordinal = 0; ordinal < _num_block_columns; ++ordinal) {
-        auto read_ordinal = static_cast<int32_t>(ordinal);
-        if (read_ordinal == _tso_ordinal || read_ordinal == _lsn_ordinal ||
-            read_ordinal == _op_ordinal) {
-            _before_column_ordinals[ordinal] = ordinal;
-            continue;
-        }
-        auto before_name = binlog::build_before_column_name(_read_columns[ordinal]->name());
-        auto before = name_to_ordinal.find(before_name);
-        _before_column_ordinals[ordinal] =
-                before == name_to_ordinal.end() ? ordinal : before->second;
-    }
-}
-
-void ReadSchema::init_row_binlog_column_mappings(const TabletSchema& tablet_schema) {
-    DORIS_CHECK_GE(_op_ordinal, 0);
-    DORIS_CHECK_EQ(_before_column_ordinals.size(), _num_block_columns);
-
+Status ReadSchema::init_row_binlog_column_mappings(RowBinlogValueColumnPairs value_pairs,
+                                                   int32_t tso_ordinal, int32_t lsn_ordinal,
+                                                   int32_t op_ordinal) {
     _row_binlog_value_column_pairs.clear();
     _row_binlog_value_pairs_complete = false;
-
-    std::vector<ColumnId> value_column_ids;
-    value_column_ids.reserve(tablet_schema.num_columns() - tablet_schema.num_key_columns());
-    for (ColumnId cid = 0; cid < tablet_schema.num_columns(); ++cid) {
-        if (static_cast<int32_t>(cid) == tablet_schema.binlog_tso_col_idx() ||
-            static_cast<int32_t>(cid) == tablet_schema.binlog_lsn_col_idx() ||
-            static_cast<int32_t>(cid) == tablet_schema.binlog_op_col_idx() ||
-            tablet_schema.column(cid).is_key()) {
-            continue;
-        }
-        value_column_ids.push_back(cid);
-    }
-
-    if (value_column_ids.empty() || value_column_ids.size() % 2 != 0) {
-        return;
-    }
-
-    const size_t value_column_count = value_column_ids.size() / 2;
-    for (size_t i = 0; i < value_column_count; ++i) {
-        const auto& after = tablet_schema.column(value_column_ids[i]);
-        const auto& before = tablet_schema.column(value_column_ids[i + value_column_count]);
-        if (before.name() != binlog::build_before_column_name(after.name()) ||
-            !row_binlog_value_columns_have_same_type(after, before)) {
-            return;
-        }
-    }
-
-    // A valid physical row-binlog layout starts from an identity mapping. Only AFTER value
-    // columns map to their BEFORE companions; keys, metadata and BEFORE columns map to themselves.
+    _tso_ordinal = -1;
+    _lsn_ordinal = -1;
+    _op_ordinal = -1;
     for (ColumnId ordinal = 0; ordinal < _num_block_columns; ++ordinal) {
         _before_column_ordinals[ordinal] = ordinal;
     }
 
-    bool complete = true;
-    _row_binlog_value_column_pairs.reserve(value_column_count);
-    for (size_t i = 0; i < value_column_count; ++i) {
-        const auto after_cid = value_column_ids[i];
-        const auto before_cid = value_column_ids[i + value_column_count];
-        const int32_t after_ordinal = ordinal_by_uid(tablet_schema.column(after_cid).unique_id());
-        const int32_t before_ordinal = ordinal_by_uid(tablet_schema.column(before_cid).unique_id());
-        if (after_ordinal < 0 || before_ordinal < 0 ||
-            static_cast<size_t>(after_ordinal) >= _num_block_columns ||
-            static_cast<size_t>(before_ordinal) >= _num_block_columns) {
-            complete = false;
+    std::vector<bool> used_ordinals(_num_block_columns, false);
+    for (int32_t ordinal : {tso_ordinal, lsn_ordinal, op_ordinal}) {
+        if (ordinal < -1 || (ordinal >= 0 && std::cmp_greater_equal(ordinal, _num_block_columns))) {
+            return Status::InvalidArgument("Invalid row-binlog special-column ordinal {}", ordinal);
+        }
+        if (ordinal < 0) {
             continue;
         }
-
-        const auto after = cast_set<ColumnId>(after_ordinal);
-        const auto before = cast_set<ColumnId>(before_ordinal);
-        _before_column_ordinals[after] = before;
-        if (!_read_types[after]->equals(*_read_types[before])) {
-            complete = false;
-            continue;
+        if (_read_columns[ordinal]->is_key() || used_ordinals[ordinal]) {
+            return Status::InvalidArgument("Invalid row-binlog special-column ordinal {}", ordinal);
         }
-        _row_binlog_value_column_pairs.emplace_back(after, before);
+        used_ordinals[ordinal] = true;
     }
-    _row_binlog_value_pairs_complete =
-            complete && _row_binlog_value_column_pairs.size() == value_column_count;
+
+    for (const auto& [current, before] : value_pairs) {
+        if (current >= _num_block_columns || before >= _num_block_columns || current == before ||
+            _read_columns[current]->is_key() || _read_columns[before]->is_key() ||
+            used_ordinals[current] || used_ordinals[before] ||
+            !_read_types[current]->equals(*_read_types[before])) {
+            return Status::InvalidArgument(
+                    "Invalid row-binlog current/before ordinal pair ({}, {})", current, before);
+        }
+        used_ordinals[current] = true;
+        used_ordinals[before] = true;
+    }
+
+    _tso_ordinal = tso_ordinal;
+    _lsn_ordinal = lsn_ordinal;
+    _op_ordinal = op_ordinal;
+    _row_binlog_value_column_pairs = std::move(value_pairs);
+    for (const auto& [current, before] : _row_binlog_value_column_pairs) {
+        _before_column_ordinals[current] = before;
+    }
+
+    _row_binlog_value_pairs_complete = true;
+    for (ColumnId ordinal = 0; ordinal < _num_block_columns; ++ordinal) {
+        if (!_read_columns[ordinal]->is_key() && !used_ordinals[ordinal]) {
+            _row_binlog_value_pairs_complete = false;
+            break;
+        }
+    }
+    return Status::OK();
 }
 
 Block ReadSchema::create_read_block() const {

--- a/be/src/storage/schema.cpp
+++ b/be/src/storage/schema.cpp
@@ -39,13 +39,6 @@ std::vector<TabletColumnPtr> project_columns_by_ordinal(
     return projected_columns;
 }
 
-int32_t read_ordinal_by_tablet_cid(const ReadSchema& read_schema, const TabletSchema& tablet_schema,
-                                   int32_t tablet_cid) {
-    return tablet_cid < 0
-                   ? -1
-                   : read_schema.ordinal_by_uid(tablet_schema.column(tablet_cid).unique_id());
-}
-
 ReadSchema::ReadSchema(std::vector<TabletColumnPtr> columns)
         : _read_columns(std::move(columns)), _num_block_columns(_read_columns.size()) {
     _init_read_types();
@@ -137,6 +130,17 @@ Status ReadSchema::init_row_binlog_column_mappings(RowBinlogValueColumnPairs val
         }
     }
     return Status::OK();
+}
+
+Status ReadSchema::init_row_binlog_column_mappings(RowBinlogValueColumnPairs value_pairs,
+                                                   const TabletSchema& tablet_schema) {
+    const auto read_ordinal_by_tablet_cid = [this, &tablet_schema](int32_t tablet_cid) {
+        return tablet_cid < 0 ? -1 : ordinal_by_uid(tablet_schema.column(tablet_cid).unique_id());
+    };
+    return init_row_binlog_column_mappings(
+            std::move(value_pairs), read_ordinal_by_tablet_cid(tablet_schema.binlog_tso_col_idx()),
+            read_ordinal_by_tablet_cid(tablet_schema.binlog_lsn_col_idx()),
+            read_ordinal_by_tablet_cid(tablet_schema.binlog_op_col_idx()));
 }
 
 Block ReadSchema::create_read_block() const {

--- a/be/src/storage/schema.h
+++ b/be/src/storage/schema.h
@@ -51,6 +51,11 @@ std::vector<TabletColumnPtr> project_columns_by_ordinal(
         const std::vector<TabletColumnPtr>& columns,
         const std::vector<ColumnId>& source_column_ordinals);
 
+// Resolve a physical TabletSchema column id to its dense ReadSchema ordinal. Returns -1 when the
+// physical column is absent or not projected.
+int32_t read_ordinal_by_tablet_cid(const ReadSchema& read_schema, const TabletSchema& tablet_schema,
+                                   int32_t tablet_cid);
+
 // The dense, ordered column layout consumed by one storage reader. For example, if the caller's
 // Block is [k1, v1] and a historical delete predicate needs dropped_v2, the layout is
 // [k1, v1, dropped_v2]: num_block_columns() is 2, num_read_columns() is 3, and every reader-side
@@ -89,15 +94,15 @@ public:
 
     const SequenceMap& sequence_map() const { return _sequence_map; }
 
-    // Initialize all row-binlog column relationships from the physical tablet schema and map
-    // them to this ReadSchema's dense ordinals. Physical pairing avoids ambiguous column-name
-    // lookup, while schemas without a complete physical layout retain the name-based BEFORE
-    // mapping initialized by the constructor.
-    void init_row_binlog_column_mappings(const TabletSchema& tablet_schema);
+    // Initialize row-binlog relationships using dense ordinals in this ReadSchema. Special
+    // ordinals are -1 when absent.
+    Status init_row_binlog_column_mappings(RowBinlogValueColumnPairs value_pairs,
+                                           int32_t tso_ordinal, int32_t lsn_ordinal,
+                                           int32_t op_ordinal);
 
     // Return the matching before-image ordinal for a Row Binlog value column. For example, in
-    // [v1, v2, __BEFORE__v1__, __BEFORE__v2__], 0 maps to 2 and 1 maps to 3. Columns without a
-    // before image, including TSO/LSN/OP, map to themselves.
+    // [v1, v2, __DORIS_BEFORE__v1__, __DORIS_BEFORE__v2__], 0 maps to 2 and 1 maps to 3.
+    // Columns without a before image, including TSO/LSN/OP, map to themselves.
     ColumnId before_column_ordinal(ColumnId ordinal) const {
         DCHECK_LT(ordinal, _before_column_ordinals.size());
         return _before_column_ordinals[ordinal];
@@ -125,7 +130,7 @@ public:
     size_t num_key_columns() const { return _num_key_columns; }
 
     // All special-column ordinals below address the caller-visible Block prefix and are -1 when
-    // absent. A Row Binlog layout may be [k1, v1, __BEFORE__v1__, TSO, LSN, OP]; a snapshot layout
+    // absent. A Row Binlog layout may be [k1, v1, __DORIS_BEFORE__v1__, TSO, LSN, OP]; a snapshot layout
     // may instead contain COMMIT_TSO.
     // Logical-delete marker used by unique-key reads.
     int32_t delete_sign_ordinal() const { return _delete_sign_ordinal; }
@@ -152,7 +157,6 @@ public:
 
 private:
     void _init_read_types();
-    void _init_before_column_ordinals();
 
     void _init_descriptors() {
         DORIS_CHECK_LE(_num_block_columns, _read_columns.size());
@@ -166,7 +170,7 @@ private:
         _lsn_ordinal = -1;
         _op_ordinal = -1;
         _commit_tso_ordinal = -1;
-        _before_column_ordinals.clear();
+        _before_column_ordinals.resize(_num_block_columns);
         _uid_to_ordinal.clear();
         for (uint32_t i = 0; i < _read_columns.size(); ++i) {
             const auto& col = *_read_columns[i];
@@ -176,6 +180,7 @@ private:
         }
         for (uint32_t i = 0; i < _num_block_columns; ++i) {
             const auto& col = *_read_columns[i];
+            _before_column_ordinals[i] = i;
             if (col.is_key()) {
                 ++_num_key_columns;
             }
@@ -191,21 +196,9 @@ private:
             if (col.name() == VERSION_COL) {
                 _version_ordinal = i;
             }
-            if (col.name() == BINLOG_TSO_COL) {
-                _tso_ordinal = i;
-            }
-            if (col.name() == BINLOG_LSN_COL) {
-                _lsn_ordinal = i;
-            }
-            if (col.name() == BINLOG_OP_COL) {
-                _op_ordinal = i;
-            }
             if (col.name() == COMMIT_TSO_COL) {
                 _commit_tso_ordinal = i;
             }
-        }
-        if (_op_ordinal >= 0) {
-            _init_before_column_ordinals();
         }
     }
 

--- a/be/src/storage/schema.h
+++ b/be/src/storage/schema.h
@@ -51,11 +51,6 @@ std::vector<TabletColumnPtr> project_columns_by_ordinal(
         const std::vector<TabletColumnPtr>& columns,
         const std::vector<ColumnId>& source_column_ordinals);
 
-// Resolve a physical TabletSchema column id to its dense ReadSchema ordinal. Returns -1 when the
-// physical column is absent or not projected.
-int32_t read_ordinal_by_tablet_cid(const ReadSchema& read_schema, const TabletSchema& tablet_schema,
-                                   int32_t tablet_cid);
-
 // The dense, ordered column layout consumed by one storage reader. For example, if the caller's
 // Block is [k1, v1] and a historical delete predicate needs dropped_v2, the layout is
 // [k1, v1, dropped_v2]: num_block_columns() is 2, num_read_columns() is 3, and every reader-side
@@ -99,6 +94,10 @@ public:
     Status init_row_binlog_column_mappings(RowBinlogValueColumnPairs value_pairs,
                                            int32_t tso_ordinal, int32_t lsn_ordinal,
                                            int32_t op_ordinal);
+
+    // Resolve TabletSchema special columns to dense ReadSchema ordinals by unique id.
+    Status init_row_binlog_column_mappings(RowBinlogValueColumnPairs value_pairs,
+                                           const TabletSchema& tablet_schema);
 
     // Return the matching before-image ordinal for a Row Binlog value column. For example, in
     // [v1, v2, __DORIS_BEFORE__v1__, __DORIS_BEFORE__v2__], 0 maps to 2 and 1 maps to 3.

--- a/be/src/storage/schema.h
+++ b/be/src/storage/schema.h
@@ -100,7 +100,7 @@ public:
                                            const TabletSchema& tablet_schema);
 
     // Return the matching before-image ordinal for a Row Binlog value column. For example, in
-    // [v1, v2, __DORIS_BEFORE__v1__, __DORIS_BEFORE__v2__], 0 maps to 2 and 1 maps to 3.
+    // [v1, v2, __BEFORE__v1__, __BEFORE__v2__], 0 maps to 2 and 1 maps to 3.
     // Columns without a before image, including TSO/LSN/OP, map to themselves.
     ColumnId before_column_ordinal(ColumnId ordinal) const {
         DCHECK_LT(ordinal, _before_column_ordinals.size());
@@ -129,7 +129,7 @@ public:
     size_t num_key_columns() const { return _num_key_columns; }
 
     // All special-column ordinals below address the caller-visible Block prefix and are -1 when
-    // absent. A Row Binlog layout may be [k1, v1, __DORIS_BEFORE__v1__, TSO, LSN, OP]; a snapshot layout
+    // absent. A Row Binlog layout may be [k1, v1, __BEFORE__v1__, TSO, LSN, OP]; a snapshot layout
     // may instead contain COMMIT_TSO.
     // Logical-delete marker used by unique-key reads.
     int32_t delete_sign_ordinal() const { return _delete_sign_ordinal; }

--- a/be/src/storage/segment/historical_row_retriever.cpp
+++ b/be/src/storage/segment/historical_row_retriever.cpp
@@ -90,14 +90,15 @@ Status PrimaryKeyModelRowRetriever::retrieve_historical_row(const Int8* delete_s
     std::vector<std::unique_ptr<SegmentCacheHandle>> segment_caches(specified_rowsets.size());
 
     CHECK(_context.rowset_writer_ctx != nullptr);
-    bool write_before =
-            _context.rowset_writer_ctx->write_binlog_opt().write_binlog_config().write_before;
+    bool need_historical_value = _context.rowset_writer_ctx->write_binlog_opt()
+                                         .write_binlog_config()
+                                         .need_historical_value;
     // The lookup uses the tablet's latest schema, the delete-sign rule the source schema. Hold the
     // shared pointer: tablet_schema() hands out a copy and the probe only borrows it.
     TabletSchemaSPtr lookup_schema = _context.tablet->tablet_schema();
     MowKeyProbe probe = MowKeyProbe::for_row_binlog(_context.tablet.get(), lookup_schema.get(),
                                                     tablet_schema->has_sequence_col(), _mow_context,
-                                                    write_before);
+                                                    need_historical_value);
     // the binlog retriever reports no partial update counters
     PartialUpdateStats discarded_stats;
 
@@ -174,12 +175,13 @@ Status PrimaryKeyModelRowRetriever::materialize_flexible_partial_update(
     std::vector<std::unique_ptr<SegmentCacheHandle>> segment_caches(specified_rowsets.size());
 
     CHECK(_context.rowset_writer_ctx != nullptr);
-    const bool write_before =
-            _context.rowset_writer_ctx->write_binlog_opt().write_binlog_config().write_before;
+    const bool need_historical_value = _context.rowset_writer_ctx->write_binlog_opt()
+                                                   .write_binlog_config()
+                                                   .need_historical_value;
     TabletSchemaSPtr lookup_schema = _context.tablet->tablet_schema();
     MowKeyProbe probe = MowKeyProbe::for_row_binlog(_context.tablet.get(), lookup_schema.get(),
                                                     tablet_schema->has_sequence_col(), _mow_context,
-                                                    write_before);
+                                                    need_historical_value);
     BlockAggregator aggregator(*tablet_schema, _context.tablet, _mow_context,
                                *_context.partial_update_info, *_key_encoder, probe, *_row_fetcher);
 

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -358,7 +358,9 @@ public:
     void gc_binlogs(const std::unordered_map<int64_t, int64_t>& gc_tablet_infos);
 
     void add_async_publish_task(int64_t partition_id, int64_t tablet_id, int64_t publish_version,
-                                int64_t transaction_id, bool is_recover, int64_t commit_tso);
+                                int64_t transaction_id, bool is_recover, int64_t commit_tso,
+                                std::shared_ptr<const PRowBinlogWriteColumnMappings>
+                                        row_binlog_column_mappings = nullptr);
     int64_t get_pending_publish_min_version(int64_t tablet_id);
 
     bool add_broken_path(std::string path);
@@ -590,8 +592,10 @@ private:
 
     std::mutex _cumu_compaction_delay_mtx;
 
-    // tablet_id, publish_version, transaction_id, partition_id, commit_tso
-    std::map<int64_t, std::map<int64_t, std::tuple<int64_t, int64_t, int64_t>>>
+    // tablet_id, publish_version, transaction_id, partition_id, commit_tso, mapping snapshot
+    std::map<int64_t,
+             std::map<int64_t, std::tuple<int64_t, int64_t, int64_t,
+                                          std::shared_ptr<const PRowBinlogWriteColumnMappings>>>>
             _async_publish_tasks;
     // aync publish for discontinuous versions of merge_on_write table
     std::shared_ptr<Thread> _async_publish_thread;

--- a/be/src/storage/tablet/base_tablet.cpp
+++ b/be/src/storage/tablet/base_tablet.cpp
@@ -58,6 +58,8 @@
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/segment/column_reader.h"
 #include "storage/tablet/tablet_fwd.h"
+#include "storage/tablet_info.h"
+#include "storage/transform/row_binlog_derive.h"
 #include "storage/txn/txn_manager.h"
 #include "util/bvar_helper.h"
 #include "util/debug_points.h"
@@ -1667,6 +1669,24 @@ Status BaseTablet::update_delete_bitmap(const BaseTabletSPtr& self, TabletTxnInf
         cfg.source.source_write_type = data_ctx.write_type;
         cfg.source.row_binlog_rowset = row_binlog_rowset;
         cfg.source.base_tablet = self;
+
+        DORIS_CHECK(rowset->rowset_meta()->has_row_binlog_column_mappings());
+        std::vector<RowBinlogColumnUidMapping> uid_mappings;
+        const auto& persisted_mappings = rowset->rowset_meta()->row_binlog_column_mappings();
+        DORIS_CHECK(persisted_mappings.has_need_historical_value());
+        cfg.need_historical_value = persisted_mappings.need_historical_value();
+        uid_mappings.reserve(persisted_mappings.entries_size());
+        for (const auto& entry : persisted_mappings.entries()) {
+            uid_mappings.push_back({
+                    .source_uid = entry.source_column_unique_id(),
+                    .current_uid = entry.current_column_unique_id(),
+                    .before_uid = entry.has_before_column_unique_id()
+                                          ? std::optional(entry.before_column_unique_id())
+                                          : std::nullopt,
+            });
+        }
+        cfg.column_mappings = DORIS_TRY(segment_v2::resolve_row_binlog_column_mappings(
+                *rowset->tablet_schema(), *row_binlog_rowset->tablet_schema(), uid_mappings));
 
         // Wrap two transient writers into a group writer for dual flush/build.
         RowsetWriterSharedPtr data_writer_sp(std::move(transient_rs_writer));

--- a/be/src/storage/tablet/base_tablet.cpp
+++ b/be/src/storage/tablet/base_tablet.cpp
@@ -1517,9 +1517,7 @@ Status BaseTablet::update_delete_bitmap(const BaseTabletSPtr& self, TabletTxnInf
         binlog_rs->rowset_meta()->is_row_binlog()) {
         DCHECK(txn_info->attach_row_binlog.tablet != nullptr);
         row_binlog_rowset = binlog_rs;
-        const auto& binlog_tablet_meta = txn_info->attach_row_binlog.tablet->tablet_meta();
-        build_row_binlog =
-                is_partial_update || binlog_tablet_meta->binlog_config().need_historical_value();
+        build_row_binlog = is_partial_update || txn_info->attach_row_binlog.need_historical_value;
     }
 
     // rewrite conflict only when partial update or need before
@@ -1670,23 +1668,10 @@ Status BaseTablet::update_delete_bitmap(const BaseTabletSPtr& self, TabletTxnInf
         cfg.source.row_binlog_rowset = row_binlog_rowset;
         cfg.source.base_tablet = self;
 
-        DORIS_CHECK(rowset->rowset_meta()->has_row_binlog_column_mappings());
-        std::vector<RowBinlogColumnUidMapping> uid_mappings;
-        const auto& persisted_mappings = rowset->rowset_meta()->row_binlog_column_mappings();
-        DORIS_CHECK(persisted_mappings.has_need_historical_value());
-        cfg.need_historical_value = persisted_mappings.need_historical_value();
-        uid_mappings.reserve(persisted_mappings.entries_size());
-        for (const auto& entry : persisted_mappings.entries()) {
-            uid_mappings.push_back({
-                    .source_uid = entry.source_column_unique_id(),
-                    .current_uid = entry.current_column_unique_id(),
-                    .before_uid = entry.has_before_column_unique_id()
-                                          ? std::optional(entry.before_column_unique_id())
-                                          : std::nullopt,
-            });
-        }
+        cfg.need_historical_value = txn_info->attach_row_binlog.need_historical_value;
         cfg.column_mappings = DORIS_TRY(segment_v2::resolve_row_binlog_column_mappings(
-                *rowset->tablet_schema(), *row_binlog_rowset->tablet_schema(), uid_mappings));
+                *rowset->tablet_schema(), *row_binlog_rowset->tablet_schema(),
+                txn_info->attach_row_binlog.column_mappings));
 
         // Wrap two transient writers into a group writer for dual flush/build.
         RowsetWriterSharedPtr data_writer_sp(std::move(transient_rs_writer));

--- a/be/src/storage/tablet/tablet.cpp
+++ b/be/src/storage/tablet/tablet.cpp
@@ -2074,11 +2074,6 @@ void Tablet::_init_context_common_fields(RowsetWriterContext& context) {
     context.enable_unique_key_merge_on_write = enable_unique_key_merge_on_write();
 
     context.encrypt_algorithm = tablet_meta()->encryption_algorithm();
-
-    if (context.write_binlog_opt().enable) {
-        context.write_binlog_opt().set_need_before(
-                tablet_meta()->binlog_config().need_historical_value());
-    }
 }
 
 Status Tablet::create_rowset(const RowsetMetaSharedPtr& rowset_meta, RowsetSharedPtr* rowset) {

--- a/be/src/storage/tablet_info.cpp
+++ b/be/src/storage/tablet_info.cpp
@@ -75,6 +75,16 @@ void OlapTableIndexSchema::to_protobuf(POlapTableIndexSchema* pindex) const {
     pindex->set_schema_hash(schema_hash);
     if (row_binlog_id > 0) {
         pindex->set_row_binlog_id(row_binlog_id);
+        auto* pmappings = pindex->mutable_row_binlog_column_mappings();
+        pmappings->set_need_historical_value(row_binlog_need_historical_value);
+        for (const auto& mapping : row_binlog_column_mappings) {
+            auto* pmapping = pmappings->add_entries();
+            pmapping->set_source_column_unique_id(mapping.source_uid);
+            pmapping->set_current_column_unique_id(mapping.current_uid);
+            if (mapping.before_uid.has_value()) {
+                pmapping->set_before_column_unique_id(*mapping.before_uid);
+            }
+        }
     }
     for (auto* slot : slots) {
         pindex->add_columns(slot->col_name());
@@ -197,6 +207,28 @@ Status OlapTableSchemaParam::init(const POlapTableSchemaParam& pschema) {
         index->schema_hash = p_index.schema_hash();
         if (p_index.has_row_binlog_id()) {
             index->row_binlog_id = p_index.row_binlog_id();
+        }
+        if (index->row_binlog_id > 0 && !p_index.has_row_binlog_column_mappings()) {
+            return Status::InvalidArgument(
+                    "Row-binlog column mappings are required for source index {}", index->index_id);
+        }
+        if (index->row_binlog_id > 0 &&
+            !p_index.row_binlog_column_mappings().has_need_historical_value()) {
+            return Status::InvalidArgument(
+                    "Row-binlog historical-value flag is required for source index {}",
+                    index->index_id);
+        }
+        if (p_index.has_row_binlog_column_mappings()) {
+            index->row_binlog_need_historical_value =
+                    p_index.row_binlog_column_mappings().need_historical_value();
+            for (const auto& pmapping : p_index.row_binlog_column_mappings().entries()) {
+                index->row_binlog_column_mappings.push_back(
+                        {.source_uid = pmapping.source_column_unique_id(),
+                         .current_uid = pmapping.current_column_unique_id(),
+                         .before_uid = pmapping.has_before_column_unique_id()
+                                               ? std::optional(pmapping.before_column_unique_id())
+                                               : std::nullopt});
+            }
         }
         for (const auto& pcolumn_desc : p_index.columns_desc()) {
             if (_unique_key_update_mode != UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS ||
@@ -358,6 +390,28 @@ Status OlapTableSchemaParam::init(const TOlapTableSchemaParam& tschema) {
         index->schema_hash = t_index.schema_hash;
         if (t_index.__isset.row_binlog_id) {
             index->row_binlog_id = t_index.row_binlog_id;
+        }
+        if (index->row_binlog_id > 0 && !t_index.__isset.row_binlog_column_mappings) {
+            return Status::InvalidArgument(
+                    "Row-binlog column mappings are required for source index {}", index->index_id);
+        }
+        if (index->row_binlog_id > 0 && !t_index.__isset.row_binlog_need_historical_value) {
+            return Status::InvalidArgument(
+                    "Row-binlog historical-value flag is required for source index {}",
+                    index->index_id);
+        }
+        if (t_index.__isset.row_binlog_need_historical_value) {
+            index->row_binlog_need_historical_value = t_index.row_binlog_need_historical_value;
+        }
+        if (t_index.__isset.row_binlog_column_mappings) {
+            for (const auto& tmapping : t_index.row_binlog_column_mappings) {
+                index->row_binlog_column_mappings.push_back(
+                        {.source_uid = tmapping.source_column_unique_id,
+                         .current_uid = tmapping.current_column_unique_id,
+                         .before_uid = tmapping.__isset.before_column_unique_id
+                                               ? std::optional(tmapping.before_column_unique_id)
+                                               : std::nullopt});
+            }
         }
         for (const auto& tcolumn_desc : t_index.columns_desc) {
             if (_unique_key_update_mode != UniqueKeyUpdateModePB::UPDATE_FIXED_COLUMNS ||

--- a/be/src/storage/tablet_info.h
+++ b/be/src/storage/tablet_info.h
@@ -28,6 +28,7 @@
 #include <iterator>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -55,9 +56,17 @@ class TabletColumn;
 class TabletIndex;
 class TupleDescriptor;
 
+struct RowBinlogColumnUidMapping {
+    int32_t source_uid;
+    int32_t current_uid;
+    std::optional<int32_t> before_uid;
+};
+
 struct OlapTableIndexSchema {
     int64_t index_id;
     int64_t row_binlog_id = 0;
+    bool row_binlog_need_historical_value = false;
+    std::vector<RowBinlogColumnUidMapping> row_binlog_column_mappings;
     std::vector<SlotDescriptor*> slots;
     int32_t schema_hash;
     std::vector<TabletColumn*> columns;

--- a/be/src/storage/task/engine_publish_version_task.cpp
+++ b/be/src/storage/task/engine_publish_version_task.cpp
@@ -140,6 +140,23 @@ Status EnginePublishVersionTask::execute() {
 #endif
 
     std::vector<std::shared_ptr<TabletPublishTxnTask>> tablet_tasks;
+    std::map<int64_t, std::shared_ptr<const PRowBinlogWriteColumnMappings>> mapping_snapshots;
+    for (const auto& [index_id, thrift_mappings] :
+         _publish_version_req.row_binlog_column_mappings) {
+        auto snapshot = std::make_shared<PRowBinlogWriteColumnMappings>();
+        if (thrift_mappings.__isset.need_historical_value) {
+            snapshot->set_need_historical_value(thrift_mappings.need_historical_value);
+        }
+        for (const auto& mapping : thrift_mappings.entries) {
+            auto* entry = snapshot->add_entries();
+            entry->set_source_column_unique_id(mapping.source_column_unique_id);
+            entry->set_current_column_unique_id(mapping.current_column_unique_id);
+            if (mapping.__isset.before_column_unique_id) {
+                entry->set_before_column_unique_id(mapping.before_column_unique_id);
+            }
+        }
+        mapping_snapshots.emplace(index_id, std::move(snapshot));
+    }
     // each partition
     for (auto& par_ver_info : _publish_version_req.partition_version_infos) {
         int64_t partition_id = par_ver_info.partition_id;
@@ -194,6 +211,11 @@ Status EnginePublishVersionTask::execute() {
                         tablet_info.tablet_id);
                 continue;
             }
+            std::shared_ptr<const PRowBinlogWriteColumnMappings> row_binlog_column_mappings;
+            auto mapping_it = mapping_snapshots.find(rowset->rowset_meta()->index_id());
+            if (mapping_it != mapping_snapshots.end()) {
+                row_binlog_column_mappings = mapping_it->second;
+            }
             // in uniq key model with merge-on-write, we should see all
             // previous version when update delete bitmap, so add a check
             // here and wait pre version publish or lock timeout
@@ -229,13 +251,14 @@ Status EnginePublishVersionTask::execute() {
                             max_continuous_version.second != max_version) {
                             _handle_publish_version_not_continuous(
                                     partition_id, tablet_info, tablet, version,
-                                    par_ver_info.commit_tso, max_version, first_time_update, res);
+                                    par_ver_info.commit_tso, max_version, first_time_update, res,
+                                    row_binlog_column_mappings);
                             continue;
                         }
                     } else {
-                        _handle_publish_version_not_continuous(partition_id, tablet_info, tablet,
-                                                               version, par_ver_info.commit_tso,
-                                                               max_version, first_time_update, res);
+                        _handle_publish_version_not_continuous(
+                                partition_id, tablet_info, tablet, version, par_ver_info.commit_tso,
+                                max_version, first_time_update, res, row_binlog_column_mappings);
                         continue;
                     }
                 }
@@ -250,8 +273,9 @@ Status EnginePublishVersionTask::execute() {
             }
 
             auto tablet_publish_txn_ptr = std::make_shared<TabletPublishTxnTask>(
-                    _engine, this, tablet, rowset, txn_info_it->second->attach_row_binlog,
-                    partition_id, transaction_id, version, tablet_info, par_ver_info.commit_tso);
+                    _engine, this, tablet, rowset, txn_info_it->second->attach_row_binlog.tablet,
+                    partition_id, transaction_id, version, tablet_info, par_ver_info.commit_tso,
+                    row_binlog_column_mappings);
             tablet_tasks.push_back(tablet_publish_txn_ptr);
             auto submit_st = token->submit_func([=]() { tablet_publish_txn_ptr->handle(); });
 #ifndef NDEBUG
@@ -332,7 +356,8 @@ Status EnginePublishVersionTask::execute() {
 void EnginePublishVersionTask::_handle_publish_version_not_continuous(
         int64_t partition_id, const TabletInfo& tablet_info, const TabletSharedPtr& tablet,
         const Version& version, const int64_t commit_tso, int64_t max_version,
-        bool first_time_update, Status& res) {
+        bool first_time_update, Status& res,
+        std::shared_ptr<const PRowBinlogWriteColumnMappings> row_binlog_column_mappings) {
     if (config::enable_auto_clone_on_mow_publish_missing_version) {
         LOG_INFO("mow publish submit missing rowset clone task.")
                 .tag("tablet_id", tablet->tablet_id())
@@ -358,13 +383,15 @@ void EnginePublishVersionTask::_handle_publish_version_not_continuous(
     // publish and handle it through async publish.
     if (max_version + config::mow_publish_max_discontinuous_version_num < version.first) {
         _engine.add_async_publish_task(partition_id, tablet_info.tablet_id, version.first,
-                                       _publish_version_req.transaction_id, false, commit_tso);
+                                       _publish_version_req.transaction_id, false, commit_tso,
+                                       std::move(row_binlog_column_mappings));
     } else {
-        _discontinuous_version_tablets->emplace_back(
-                DiscontinuousVersionTablet {.partition_id = partition_id,
-                                            .tablet_id = tablet_info.tablet_id,
-                                            .publish_version = version.first,
-                                            .commit_tso = commit_tso});
+        _discontinuous_version_tablets->emplace_back(DiscontinuousVersionTablet {
+                .partition_id = partition_id,
+                .tablet_id = tablet_info.tablet_id,
+                .publish_version = version.first,
+                .commit_tso = commit_tso,
+                .row_binlog_column_mappings = std::move(row_binlog_column_mappings)});
     }
     res = Status::Error<PUBLISH_VERSION_NOT_CONTINUOUS>(
             "version not continuous for mow, tablet_id={}, "
@@ -409,13 +436,14 @@ void EnginePublishVersionTask::_calculate_tbl_num_delta_rows(
 
 TabletPublishTxnTask::TabletPublishTxnTask(
         StorageEngine& engine, EnginePublishVersionTask* engine_task, TabletSharedPtr tablet,
-        RowsetSharedPtr rowset, const RowBinlogTxnInfo& attach_row_binlog, int64_t partition_id,
-        int64_t transaction_id, Version version, const TabletInfo& tablet_info, int64_t commit_tso)
+        RowsetSharedPtr rowset, BaseTabletSPtr row_binlog_tablet, int64_t partition_id,
+        int64_t transaction_id, Version version, const TabletInfo& tablet_info, int64_t commit_tso,
+        std::shared_ptr<const PRowBinlogWriteColumnMappings> row_binlog_column_mappings)
         : _engine(engine),
           _engine_publish_version_task(engine_task),
           _tablet(std::move(tablet)),
           _rowset(std::move(rowset)),
-          _attach_row_binlog(attach_row_binlog),
+          _row_binlog_tablet(std::move(row_binlog_tablet)),
           _partition_id(partition_id),
           _transaction_id(transaction_id),
           _version(version),
@@ -425,25 +453,26 @@ TabletPublishTxnTask::TabletPublishTxnTask(
                   fmt::format("TabletPublishTxnTask-partitionID_{}-transactionID_{}-version_{}",
                               std::to_string(partition_id), std::to_string(transaction_id),
                               version.to_string()))),
-          _commit_tso(commit_tso) {
+          _commit_tso(commit_tso),
+          _row_binlog_column_mappings(std::move(row_binlog_column_mappings)) {
     _stats.submit_time_us = MonotonicMicros();
 }
 
 TabletPublishTxnTask::~TabletPublishTxnTask() = default;
 
-Status publish_version_and_add_rowset(StorageEngine& engine, int64_t partition_id,
-                                      const TabletSharedPtr& tablet, const RowsetSharedPtr& rowset,
-                                      int64_t transaction_id, const Version& version,
-                                      EnginePublishVersionTask* engine_publish_version_task,
-                                      TabletPublishStatistics& stats, int64_t commit_tso) {
+Status publish_version_and_add_rowset(
+        StorageEngine& engine, int64_t partition_id, const TabletSharedPtr& tablet,
+        const RowsetSharedPtr& rowset, int64_t transaction_id, const Version& version,
+        EnginePublishVersionTask* engine_publish_version_task, TabletPublishStatistics& stats,
+        int64_t commit_tso, const PRowBinlogWriteColumnMappings* row_binlog_column_mappings) {
     // ATTN: Here, the life cycle needs to be extended to prevent tablet_txn_info.pending_rs_guard in txn
     // from being released prematurely, causing path gc to mistakenly delete the dat file
     std::shared_ptr<TabletTxnInfo> extend_tablet_txn_info_lifetime = nullptr;
 
     // Publish the transaction
-    auto result =
-            engine.txn_manager()->publish_txn(partition_id, tablet, transaction_id, version, &stats,
-                                              extend_tablet_txn_info_lifetime, commit_tso);
+    auto result = engine.txn_manager()->publish_txn(partition_id, tablet, transaction_id, version,
+                                                    &stats, extend_tablet_txn_info_lifetime,
+                                                    commit_tso, row_binlog_column_mappings);
     if (!result.ok()) {
         LOG(WARNING) << "failed to publish version. rowset_id=" << rowset->rowset_id()
                      << ", tablet_id=" << tablet->tablet_id() << ", txn_id=" << transaction_id
@@ -513,7 +542,7 @@ void TabletPublishTxnTask::handle() {
     SCOPED_ATTACH_TASK(_mem_tracker);
     // the row binlog is published to its own binlog tablet together with the base tablet, acquire
     // both tablets' locks in binlog-first order.
-    auto binlog_tablet = std::static_pointer_cast<Tablet>(_attach_row_binlog.tablet);
+    auto binlog_tablet = std::static_pointer_cast<Tablet>(_row_binlog_tablet);
     std::shared_lock<std::shared_timed_mutex> binlog_migration_rlock;
     std::shared_lock<std::shared_timed_mutex> migration_rlock;
     if (binlog_tablet != nullptr) {
@@ -537,9 +566,9 @@ void TabletPublishTxnTask::handle() {
         rowset_update_lock.lock();
     }
     _stats.schedule_time_us = MonotonicMicros() - _stats.submit_time_us;
-    _result = publish_version_and_add_rowset(_engine, _partition_id, _tablet, _rowset,
-                                             _transaction_id, _version,
-                                             _engine_publish_version_task, _stats, _commit_tso);
+    _result = publish_version_and_add_rowset(
+            _engine, _partition_id, _tablet, _rowset, _transaction_id, _version,
+            _engine_publish_version_task, _stats, _commit_tso, _row_binlog_column_mappings.get());
 
     if (!_result.ok()) {
         return;
@@ -596,9 +625,9 @@ void AsyncTabletPublishTask::handle() {
     std::lock_guard<std::mutex> wrlock(_tablet->get_rowset_update_lock());
     _stats.schedule_time_us = MonotonicMicros() - _stats.submit_time_us;
 
-    auto publish_status =
-            publish_version_and_add_rowset(_engine, _partition_id, _tablet, rowset, _transaction_id,
-                                           version, nullptr, _stats, _commit_tso);
+    auto publish_status = publish_version_and_add_rowset(
+            _engine, _partition_id, _tablet, rowset, _transaction_id, version, nullptr, _stats,
+            _commit_tso, _row_binlog_column_mappings.get());
 
     if (!publish_status.ok()) {
         return;

--- a/be/src/storage/task/engine_publish_version_task.h
+++ b/be/src/storage/task/engine_publish_version_task.h
@@ -64,11 +64,12 @@ struct TabletPublishStatistics {
 
 class TabletPublishTxnTask {
 public:
-    TabletPublishTxnTask(StorageEngine& engine, EnginePublishVersionTask* engine_task,
-                         TabletSharedPtr tablet, RowsetSharedPtr rowset,
-                         const RowBinlogTxnInfo& attach_row_binlog, int64_t partition_id,
-                         int64_t transaction_id, Version version, const TabletInfo& tablet_info,
-                         int64_t commit_tso);
+    TabletPublishTxnTask(
+            StorageEngine& engine, EnginePublishVersionTask* engine_task, TabletSharedPtr tablet,
+            RowsetSharedPtr rowset, BaseTabletSPtr row_binlog_tablet, int64_t partition_id,
+            int64_t transaction_id, Version version, const TabletInfo& tablet_info,
+            int64_t commit_tso,
+            std::shared_ptr<const PRowBinlogWriteColumnMappings> row_binlog_column_mappings);
     ~TabletPublishTxnTask();
 
     void handle();
@@ -81,7 +82,7 @@ private:
     TabletSharedPtr _tablet;
     RowsetSharedPtr _rowset;
     // the row binlog published together with the base tablet.
-    RowBinlogTxnInfo _attach_row_binlog;
+    BaseTabletSPtr _row_binlog_tablet;
     int64_t _partition_id;
     int64_t _transaction_id;
     Version _version;
@@ -90,6 +91,7 @@ private:
     Status _result;
     std::shared_ptr<MemTrackerLimiter> _mem_tracker;
     int64_t _commit_tso;
+    std::shared_ptr<const PRowBinlogWriteColumnMappings> _row_binlog_column_mappings;
 };
 
 struct DiscontinuousVersionTablet {
@@ -97,6 +99,7 @@ struct DiscontinuousVersionTablet {
     int64_t tablet_id;
     int64_t publish_version;
     int64_t commit_tso;
+    std::shared_ptr<const PRowBinlogWriteColumnMappings> row_binlog_column_mappings;
 };
 
 class EnginePublishVersionTask final : public EngineTask {
@@ -115,11 +118,11 @@ public:
     void add_error_tablet_id(int64_t tablet_id);
 
 private:
-    void _handle_publish_version_not_continuous(int64_t partition_id, const TabletInfo& tablet_info,
-                                                const TabletSharedPtr& tablet,
-                                                const Version& version, const int64_t commit_tso,
-                                                int64_t max_version, bool first_time_update,
-                                                Status& res);
+    void _handle_publish_version_not_continuous(
+            int64_t partition_id, const TabletInfo& tablet_info, const TabletSharedPtr& tablet,
+            const Version& version, const int64_t commit_tso, int64_t max_version,
+            bool first_time_update, Status& res,
+            std::shared_ptr<const PRowBinlogWriteColumnMappings> row_binlog_column_mappings);
     void _calculate_tbl_num_delta_rows(
             const std::unordered_map<int64_t, int64_t>& tablet_id_to_num_delta_rows);
 
@@ -136,7 +139,9 @@ private:
 class AsyncTabletPublishTask {
 public:
     AsyncTabletPublishTask(StorageEngine& engine, TabletSharedPtr tablet, int64_t partition_id,
-                           int64_t transaction_id, int64_t version, int64_t commit_tso)
+                           int64_t transaction_id, int64_t version, int64_t commit_tso,
+                           std::shared_ptr<const PRowBinlogWriteColumnMappings>
+                                   row_binlog_column_mappings = nullptr)
             : _engine(engine),
               _tablet(std::move(tablet)),
               _partition_id(partition_id),
@@ -144,7 +149,8 @@ public:
               _version(version),
               _mem_tracker(MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::OTHER,
                                                             "AsyncTabletPublishTask")),
-              _commit_tso(commit_tso) {
+              _commit_tso(commit_tso),
+              _row_binlog_column_mappings(std::move(row_binlog_column_mappings)) {
         _stats.submit_time_us = MonotonicMicros();
     }
     ~AsyncTabletPublishTask() = default;
@@ -160,6 +166,7 @@ private:
     TabletPublishStatistics _stats;
     std::shared_ptr<MemTrackerLimiter> _mem_tracker;
     int64_t _commit_tso;
+    std::shared_ptr<const PRowBinlogWriteColumnMappings> _row_binlog_column_mappings;
 };
 
 } // namespace doris

--- a/be/src/storage/transform/row_binlog_derive.cpp
+++ b/be/src/storage/transform/row_binlog_derive.cpp
@@ -18,6 +18,7 @@
 #include "storage/transform/row_binlog_derive.h"
 
 #include <algorithm>
+#include <array>
 #include <optional>
 #include <span>
 
@@ -35,6 +36,7 @@
 #include "storage/rowset/rowset_writer_context.h"
 #include "storage/segment/historical_row_retriever.h"
 #include "storage/tablet/tablet_schema.h"
+#include "storage/tablet_info.h"
 #include "storage/transform/transform_util.h"
 #include "util/time.h"
 
@@ -42,8 +44,105 @@ namespace doris::segment_v2 {
 
 namespace {
 
-// Number of row-binlog system columns: TSO, LSN, op.
-constexpr uint32_t BINLOG_COLNUM = 3;
+bool row_binlog_columns_have_compatible_shape(const TabletColumn& source,
+                                              const TabletColumn& target,
+                                              bool allow_top_level_nullable_widening) {
+    if (source.type() != target.type() || source.length() != target.length() ||
+        source.precision() != target.precision() || source.frac() != target.frac() ||
+        source.get_subtype_count() != target.get_subtype_count() ||
+        (source.is_nullable() != target.is_nullable() &&
+         !(allow_top_level_nullable_widening && !source.is_nullable() && target.is_nullable()))) {
+        return false;
+    }
+    for (uint32_t i = 0; i < source.get_subtype_count(); ++i) {
+        if (!row_binlog_columns_have_compatible_shape(source.get_sub_column(i),
+                                                      target.get_sub_column(i), false)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+Result<std::vector<RowBinlogColumnCidMapping>> resolve_row_binlog_column_mappings(
+        const TabletSchema& source_schema, const TabletSchema& row_binlog_schema,
+        const std::vector<RowBinlogColumnUidMapping>& uid_mappings) {
+    const std::array<int32_t, 3> special_cids {row_binlog_schema.binlog_tso_col_idx(),
+                                               row_binlog_schema.binlog_lsn_col_idx(),
+                                               row_binlog_schema.binlog_op_col_idx()};
+    std::vector<bool> used_target_cids(row_binlog_schema.num_columns(), false);
+    for (int32_t cid : special_cids) {
+        if (cid < 0 || std::cmp_greater_equal(cid, row_binlog_schema.num_columns()) ||
+            row_binlog_schema.column(cid).is_key() || used_target_cids[cid]) {
+            return ResultError(
+                    Status::InvalidArgument("Invalid row-binlog special column cid {}", cid));
+        }
+        used_target_cids[cid] = true;
+    }
+
+    std::vector<bool> used_source_cids(source_schema.num_columns(), false);
+    std::vector<RowBinlogColumnCidMapping> cid_mappings;
+    cid_mappings.reserve(uid_mappings.size());
+    for (const auto& uid_mapping : uid_mappings) {
+        const int32_t source_cid = source_schema.field_index(uid_mapping.source_uid);
+        const int32_t current_cid = row_binlog_schema.field_index(uid_mapping.current_uid);
+        const int32_t before_cid = uid_mapping.before_uid.has_value()
+                                           ? row_binlog_schema.field_index(*uid_mapping.before_uid)
+                                           : -1;
+        if (source_cid < 0 || current_cid < 0 ||
+            (uid_mapping.before_uid.has_value() && before_cid < 0)) {
+            return ResultError(Status::InvalidArgument(
+                    "Row-binlog mapping references a missing column uid ({}, {}, {})",
+                    uid_mapping.source_uid, uid_mapping.current_uid,
+                    uid_mapping.before_uid.value_or(-1)));
+        }
+
+        const auto& source_column = source_schema.column(source_cid);
+        const auto& current_column = row_binlog_schema.column(current_cid);
+        if ((!source_column.visible() && !source_column.is_key()) || used_source_cids[source_cid] ||
+            used_target_cids[current_cid] || source_column.is_key() != current_column.is_key() ||
+            !row_binlog_columns_have_compatible_shape(source_column, current_column,
+                                                      !source_column.is_key())) {
+            return ResultError(Status::InvalidArgument(
+                    "Invalid row-binlog source/current mapping ({}, {})", source_cid, current_cid));
+        }
+        used_source_cids[source_cid] = true;
+        used_target_cids[current_cid] = true;
+
+        std::optional<ColumnId> resolved_before_cid;
+        if (before_cid >= 0) {
+            const auto& before_column = row_binlog_schema.column(before_cid);
+            if (source_column.is_key() || !source_column.visible() || before_column.is_key() ||
+                used_target_cids[before_cid] ||
+                !row_binlog_columns_have_compatible_shape(current_column, before_column, false)) {
+                return ResultError(Status::InvalidArgument(
+                        "Invalid row-binlog before mapping ({}, {})", source_cid, before_cid));
+            }
+            used_target_cids[before_cid] = true;
+            resolved_before_cid = cast_set<ColumnId>(before_cid);
+        }
+        cid_mappings.push_back({cast_set<ColumnId>(source_cid), cast_set<ColumnId>(current_cid),
+                                resolved_before_cid});
+    }
+
+    for (ColumnId cid = 0; cid < source_schema.num_columns(); ++cid) {
+        const auto& column = source_schema.column(cid);
+        if ((column.visible() || column.is_key()) && !used_source_cids[cid]) {
+            return ResultError(Status::InvalidArgument(
+                    "Row-binlog mapping does not cover source cid {}", cid));
+        }
+    }
+    for (ColumnId cid = 0; cid < row_binlog_schema.num_columns(); ++cid) {
+        if (!used_target_cids[cid]) {
+            return ResultError(Status::InvalidArgument(
+                    "Row-binlog mapping does not cover target cid {}", cid));
+        }
+    }
+    return cid_mappings;
+}
+
+namespace {
 
 // Runs the primary-key historical lookup over `block`'s source key (+seq)
 // columns, leaving the planned reads and the op for each row in `retriever` for
@@ -88,21 +187,23 @@ Status setup_retriever_and_lookup(TransformExecContext& ctx, const SegmentWriteB
 // reads. No-op when the source schema has no value columns. The retriever is
 // not const: reading BEFORE also loads the old delete signs it keeps.
 Status fill_before_columns(Block& out, const TabletSchema& binlog_schema,
-                           PrimaryKeyModelRowRetriever* retriever, uint32_t before_col_start,
-                           const std::vector<uint32_t>& value_source_cids, size_t num_rows) {
-    size_t value_column_num = value_source_cids.size();
-    if (value_column_num == 0) {
-        return Status::OK();
-    }
+                           PrimaryKeyModelRowRetriever* retriever,
+                           const std::vector<RowBinlogColumnCidMapping>& column_mappings,
+                           size_t num_rows) {
+    std::vector<uint32_t> source_cids;
     std::vector<uint32_t> before_cids;
-    for (uint32_t cid = before_col_start;
-         cid < before_col_start + cast_set<uint32_t>(value_column_num); ++cid) {
-        before_cids.emplace_back(cid);
+    for (const auto& mapping : column_mappings) {
+        if (mapping.before_cid.has_value()) {
+            source_cids.push_back(mapping.source_cid);
+            before_cids.push_back(*mapping.before_cid);
+        }
+    }
+    if (before_cids.empty()) {
+        return Status::OK();
     }
     Block before_block = binlog_schema.create_storage_block(before_cids);
     DCHECK(retriever != nullptr);
-    DCHECK_EQ(before_cids.size(), value_source_cids.size());
-    RETURN_IF_ERROR(retriever->build_before_block(&before_block, value_source_cids, 0, num_rows));
+    RETURN_IF_ERROR(retriever->build_before_block(&before_block, source_cids, 0, num_rows));
     size_t col_pos_in_block = 0;
     for (auto cid : before_cids) {
         out.replace_by_position(cid, before_block.get_by_position(col_pos_in_block++).column);
@@ -195,9 +296,6 @@ Status resolve_binlog_context(TransformExecContext& ctx, const Block* block,
     ctx.rowset_ctx->remove_segment_allocated_lsns(ctx.segment_id);
     CHECK(c->lsn_ids->size() >= c->num_rows) << c->lsn_ids->size() << " vs " << c->num_rows;
 
-    // Preserve the source writer's layout: system columns may be a prefix or
-    // suffix, and source hidden non-key columns are omitted while hidden keys
-    // remain part of the normal row image.
     int tso_col_id = c->binlog_schema->binlog_tso_col_idx();
     int lsn_col_id = c->binlog_schema->binlog_lsn_col_idx();
     int op_col_id = c->binlog_schema->binlog_op_col_idx();
@@ -207,33 +305,8 @@ Status resolve_binlog_context(TransformExecContext& ctx, const Block* block,
     c->binlog_tso_cid = cast_set<uint32_t>(tso_col_id);
     c->binlog_lsn_cid = cast_set<uint32_t>(lsn_col_id);
     c->binlog_op_cid = cast_set<uint32_t>(op_col_id);
-    c->normal_col_start = tso_col_id == 0 ? BINLOG_COLNUM : 0;
-    for (uint32_t cid = 0; cid < c->source_schema->num_columns(); ++cid) {
-        const auto& column = c->source_schema->column(cid);
-        if (column.visible() || column.is_key()) {
-            c->normal_source_cids.emplace_back(cid);
-        }
-        if (column.visible() && !column.is_key()) {
-            c->value_source_cids.emplace_back(cid);
-        }
-    }
-    c->before_col_start = c->normal_col_start + cast_set<uint32_t>(c->normal_source_cids.size());
-    c->write_before = cfg.write_before;
-    // The schema must carry exactly the BEFORE columns this flush fills: one per
-    // source value column when write_before is on, none otherwise. Too few and
-    // the BEFORE fill would write over the TSO/LSN columns; too many and those
-    // columns would stay empty in an otherwise full block, leaving the writer a
-    // block whose columns hold different row counts.
-    const size_t expected_before_columns = c->write_before ? c->value_source_cids.size() : 0;
-    const size_t expected_columns =
-            c->normal_source_cids.size() + expected_before_columns + BINLOG_COLNUM;
-    if (c->binlog_schema->num_columns() != expected_columns) {
-        return Status::InternalError<false>(
-                "binlog<row> schema does not match the derived block: num_columns={}, expected={} "
-                "(normal={}, before={}, system={}), write_before={}, tablet_id={}",
-                c->binlog_schema->num_columns(), expected_columns, c->normal_source_cids.size(),
-                expected_before_columns, BINLOG_COLNUM, c->write_before, ctx.rowset_ctx->tablet_id);
-    }
+    c->column_mappings = cfg.column_mappings;
+    DORIS_CHECK(!c->column_mappings.empty());
     return Status::OK();
 }
 
@@ -265,21 +338,19 @@ Status emit_binlog_block(const BinlogDeriveContext& c, const Block* after_src,
                 "binlog<row> block width {} does not match its schema's {} columns", out.columns(),
                 c.binlog_schema->num_columns());
     }
-    // key + AFTER columns: COW pointers of the source-layout visible columns
-    for (size_t ordinal = 0; ordinal < c.normal_source_cids.size(); ++ordinal) {
-        const uint32_t source_cid = c.normal_source_cids[ordinal];
+    for (const auto& mapping : c.column_mappings) {
+        const uint32_t source_cid = mapping.source_cid;
         ColumnPtr after_column = after_src->get_by_position(source_cid).column;
-        // The binlog schema declares every AFTER value column nullable, so a NOT
-        // NULL source column has to be wrapped: the segment writer converts by
-        // the binlog schema. Keys keep their own nullability.
-        if (!c.source_schema->column(source_cid).is_key()) {
+        if (!c.source_schema->column(source_cid).is_nullable() &&
+            c.binlog_schema->column(mapping.current_cid).is_nullable()) {
             after_column = make_nullable(after_column);
         }
-        out.replace_by_position(c.normal_col_start + ordinal, std::move(after_column));
+        out.replace_by_position(mapping.current_cid, std::move(after_column));
     }
-    if (c.write_before) {
-        RETURN_IF_ERROR(fill_before_columns(out, *c.binlog_schema, retriever, c.before_col_start,
-                                            c.value_source_cids, c.num_rows));
+    if (std::ranges::any_of(c.column_mappings,
+                            [](const auto& mapping) { return mapping.before_cid.has_value(); })) {
+        RETURN_IF_ERROR(fill_before_columns(out, *c.binlog_schema, retriever, c.column_mappings,
+                                            c.num_rows));
     }
     // An insert whose old row is a tombstone is an append, not an update. Run
     // this after the BEFORE read, which already loaded the old delete signs.
@@ -306,7 +377,7 @@ bool binlog_needs_historical_lookup(const RowsetWriterContext& context) {
     const bool is_partial_update = cfg.source.partial_update_info != nullptr &&
                                    cfg.source.partial_update_info->is_partial_update() &&
                                    is_source_direct_write;
-    return is_partial_update || cfg.write_before;
+    return is_partial_update || cfg.need_historical_value;
 }
 
 Status RowBinlogDeriveStage::apply(TransformExecContext& ctx, Block* block) const {
@@ -317,7 +388,8 @@ Status RowBinlogDeriveStage::apply(TransformExecContext& ctx, Block* block) cons
 
 Status PlainRowBinlogDeriveStage::derive(TransformExecContext& /*ctx*/, Block* block,
                                          const BinlogDeriveContext& c) const {
-    DCHECK(!c.write_before);
+    DCHECK(std::ranges::none_of(
+            c.column_mappings, [](const auto& mapping) { return mapping.before_cid.has_value(); }));
 
     // No probe: op is APPEND, or DELETE when the row carries a delete sign. DUP
     // tables have no delete-sign column, so every row is APPEND.

--- a/be/src/storage/transform/row_binlog_derive.h
+++ b/be/src/storage/transform/row_binlog_derive.h
@@ -17,16 +17,22 @@
 
 #pragma once
 
+#include "storage/binlog.h"
 #include "storage/rowset/rowset_fwd.h"
 #include "storage/transform/block_transform.h"
 
 namespace doris {
+struct RowBinlogColumnUidMapping;
 struct RowsetWriterContext;
 
 namespace segment_v2 {
 
+Result<std::vector<RowBinlogColumnCidMapping>> resolve_row_binlog_column_mappings(
+        const TabletSchema& source_schema, const TabletSchema& row_binlog_schema,
+        const std::vector<RowBinlogColumnUidMapping>& uid_mappings);
+
 // The binlog<Row> derive stages rebuild the load block into a full-width block
-// over the binlog schema -- key + AFTER values, optional __BEFORE__* values, and
+// over the binlog schema -- key + AFTER values, optional __DORIS_BEFORE__* values, and
 // the TSO / LSN / op columns -- so the ordinary segment writers can write
 // it like any DUP_KEYS block. build_transform_chain picks Plain (no historical
 // probe) or Mow (with probe) via binlog_needs_historical_lookup().
@@ -37,7 +43,7 @@ bool binlog_needs_historical_lookup(const RowsetWriterContext& context);
 
 // Context for each flush that the base stage works out once and passes to
 // derive(): the binlog/source schemas, the consumed LSN range, row count, and
-// column layout [keys..., AFTER..., (BEFORE...), TSO, LSN, OP].
+// resolved source/current/before column ids.
 struct BinlogDeriveContext {
     TabletSchemaSPtr binlog_schema;
     TabletSchemaSPtr source_schema;
@@ -46,11 +52,7 @@ struct BinlogDeriveContext {
     uint32_t binlog_tso_cid = 0;
     uint32_t binlog_lsn_cid = 0;
     uint32_t binlog_op_cid = 0;
-    uint32_t normal_col_start = 0;
-    uint32_t before_col_start = 0;
-    std::vector<uint32_t> normal_source_cids;
-    std::vector<uint32_t> value_source_cids;
-    bool write_before = false;
+    std::vector<RowBinlogColumnCidMapping> column_mappings;
 };
 
 // Base for the derive stages: apply() runs the setup steps (schema layout + LSN

--- a/be/src/storage/transform/row_binlog_derive.h
+++ b/be/src/storage/transform/row_binlog_derive.h
@@ -32,7 +32,7 @@ Result<std::vector<RowBinlogColumnCidMapping>> resolve_row_binlog_column_mapping
         const std::vector<RowBinlogColumnUidMapping>& uid_mappings);
 
 // The binlog<Row> derive stages rebuild the load block into a full-width block
-// over the binlog schema -- key + AFTER values, optional __DORIS_BEFORE__* values, and
+// over the binlog schema -- key + AFTER values, optional __BEFORE__* values, and
 // the TSO / LSN / op columns -- so the ordinary segment writers can write
 // it like any DUP_KEYS block. build_transform_chain picks Plain (no historical
 // probe) or Mow (with probe) via binlog_needs_historical_lookup().

--- a/be/src/storage/txn/txn_manager.cpp
+++ b/be/src/storage/txn/txn_manager.cpp
@@ -679,15 +679,17 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
     }
 
     /// Step 4: save meta
+    RowsetMetaPB visible_meta = rowset->rowset_meta()->get_rowset_pb();
+    visible_meta.clear_row_binlog_column_mappings();
     int64_t t5 = MonotonicMicros();
-    auto status = RowsetMetaManager::save(meta, tablet_uid, rowset->rowset_id(),
-                                          rowset->rowset_meta()->get_rowset_pb(), binlog_format,
-                                          attach_row_binlog_rowset_meta);
+    auto status = RowsetMetaManager::save(meta, tablet_uid, rowset->rowset_id(), visible_meta,
+                                          binlog_format, attach_row_binlog_rowset_meta);
     stats->save_meta_time_us += MonotonicMicros() - t5;
     if (!status.ok()) {
         status.append(fmt::format(", txn id: {}", transaction_id));
         return status;
     }
+    rowset->rowset_meta()->clear_row_binlog_column_mappings();
 
     if (tablet_txn_info->unique_key_merge_on_write && tablet_txn_info->partial_update_info &&
         tablet_txn_info->partial_update_info->is_partial_update()) {

--- a/be/src/storage/txn/txn_manager.cpp
+++ b/be/src/storage/txn/txn_manager.cpp
@@ -52,6 +52,7 @@
 #include "storage/tablet/tablet_meta.h"
 #include "storage/tablet/tablet_meta_manager.h"
 #include "storage/task/engine_publish_version_task.h"
+#include "storage/transform/row_binlog_derive.h"
 #include "util/debug_points.h"
 #include "util/time.h"
 
@@ -245,10 +246,11 @@ Status TxnManager::publish_txn(TPartitionId partition_id, const TabletSharedPtr&
                                TTransactionId transaction_id, const Version& version,
                                TabletPublishStatistics* stats,
                                std::shared_ptr<TabletTxnInfo>& extend_tablet_txn_info,
-                               const int64_t commit_tso) {
+                               const int64_t commit_tso,
+                               const PRowBinlogWriteColumnMappings* row_binlog_column_mappings) {
     return publish_txn(tablet->data_dir()->get_meta(), partition_id, transaction_id,
                        tablet->tablet_id(), tablet->tablet_uid(), version, stats,
-                       extend_tablet_txn_info, commit_tso);
+                       extend_tablet_txn_info, commit_tso, row_binlog_column_mappings);
 }
 
 void TxnManager::abort_txn(TPartitionId partition_id, TTransactionId transaction_id,
@@ -537,7 +539,8 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
                                TabletUid tablet_uid, const Version& version,
                                TabletPublishStatistics* stats,
                                std::shared_ptr<TabletTxnInfo>& extend_tablet_txn_info,
-                               const int64_t commit_tso) {
+                               const int64_t commit_tso,
+                               const PRowBinlogWriteColumnMappings* row_binlog_column_mappings) {
     auto tablet = _engine.tablet_manager()->get_tablet(tablet_id);
     if (tablet == nullptr) {
         return Status::OK();
@@ -592,6 +595,38 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
         }
     });
 
+    // Publish owns both tablets' rowset-update locks. Validate the FE snapshot against the
+    // transaction schemas before changing visibility, including after committed-rowset recovery.
+    if (tablet_txn_info->unique_key_merge_on_write &&
+        tablet_txn_info->attach_row_binlog.rowset != nullptr) {
+        if (row_binlog_column_mappings == nullptr ||
+            !row_binlog_column_mappings->has_need_historical_value() ||
+            !row_binlog_column_mappings->IsInitialized()) {
+            return Status::InvalidArgument(
+                    "Missing row-binlog publish mapping snapshot, tablet_id={}, txn_id={}",
+                    tablet_id, transaction_id);
+        }
+        std::vector<RowBinlogColumnUidMapping> mappings;
+        mappings.reserve(row_binlog_column_mappings->entries_size());
+        for (const auto& entry : row_binlog_column_mappings->entries()) {
+            mappings.push_back({
+                    .source_uid = entry.source_column_unique_id(),
+                    .current_uid = entry.current_column_unique_id(),
+                    .before_uid = entry.has_before_column_unique_id()
+                                          ? std::optional(entry.before_column_unique_id())
+                                          : std::nullopt,
+            });
+        }
+        auto& binlog_info = tablet_txn_info->attach_row_binlog;
+        auto resolved = segment_v2::resolve_row_binlog_column_mappings(
+                *rowset->tablet_schema(), *binlog_info.rowset->tablet_schema(), mappings);
+        if (!resolved.has_value()) {
+            return resolved.error();
+        }
+        binlog_info.need_historical_value = row_binlog_column_mappings->need_historical_value();
+        binlog_info.column_mappings = std::move(mappings);
+    }
+
     /// Step 2: make rowset visible
     // save meta need access disk, it maybe very slow, so that it is not in global txn lock
     // it is under a single txn lock
@@ -624,26 +659,6 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
     // update delete_bitmap
     if (tablet_txn_info->unique_key_merge_on_write) {
         int64_t t2 = MonotonicMicros();
-        auto& binlog_info = tablet_txn_info->attach_row_binlog;
-        if (binlog_info.rowset != nullptr) {
-            // Local publish still restores its write-time snapshot from committed rowset meta.
-            // Cloud already carries this snapshot in its transaction cache.
-            DORIS_CHECK(rowset->rowset_meta()->has_row_binlog_column_mappings());
-            const auto& persisted_mappings = rowset->rowset_meta()->row_binlog_column_mappings();
-            DORIS_CHECK(persisted_mappings.has_need_historical_value());
-            binlog_info.need_historical_value = persisted_mappings.need_historical_value();
-            binlog_info.column_mappings.clear();
-            binlog_info.column_mappings.reserve(persisted_mappings.entries_size());
-            for (const auto& entry : persisted_mappings.entries()) {
-                binlog_info.column_mappings.push_back({
-                        .source_uid = entry.source_column_unique_id(),
-                        .current_uid = entry.current_column_unique_id(),
-                        .before_uid = entry.has_before_column_unique_id()
-                                              ? std::optional(entry.before_column_unique_id())
-                                              : std::nullopt,
-                });
-            }
-        }
         if (rowset->num_segments() > 1 &&
             !tablet_txn_info->delete_bitmap->has_calculated_for_multi_segments(
                     rowset->rowset_id())) {
@@ -700,7 +715,6 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
 
     /// Step 4: save meta
     RowsetMetaPB visible_meta = rowset->rowset_meta()->get_rowset_pb();
-    visible_meta.clear_row_binlog_column_mappings();
     int64_t t5 = MonotonicMicros();
     auto status = RowsetMetaManager::save(meta, tablet_uid, rowset->rowset_id(), visible_meta,
                                           binlog_format, attach_row_binlog_rowset_meta);
@@ -709,7 +723,6 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
         status.append(fmt::format(", txn id: {}", transaction_id));
         return status;
     }
-    rowset->rowset_meta()->clear_row_binlog_column_mappings();
 
     if (tablet_txn_info->unique_key_merge_on_write && tablet_txn_info->partial_update_info &&
         tablet_txn_info->partial_update_info->is_partial_update()) {

--- a/be/src/storage/txn/txn_manager.cpp
+++ b/be/src/storage/txn/txn_manager.cpp
@@ -624,6 +624,26 @@ Status TxnManager::publish_txn(OlapMeta* meta, TPartitionId partition_id,
     // update delete_bitmap
     if (tablet_txn_info->unique_key_merge_on_write) {
         int64_t t2 = MonotonicMicros();
+        auto& binlog_info = tablet_txn_info->attach_row_binlog;
+        if (binlog_info.rowset != nullptr) {
+            // Local publish still restores its write-time snapshot from committed rowset meta.
+            // Cloud already carries this snapshot in its transaction cache.
+            DORIS_CHECK(rowset->rowset_meta()->has_row_binlog_column_mappings());
+            const auto& persisted_mappings = rowset->rowset_meta()->row_binlog_column_mappings();
+            DORIS_CHECK(persisted_mappings.has_need_historical_value());
+            binlog_info.need_historical_value = persisted_mappings.need_historical_value();
+            binlog_info.column_mappings.clear();
+            binlog_info.column_mappings.reserve(persisted_mappings.entries_size());
+            for (const auto& entry : persisted_mappings.entries()) {
+                binlog_info.column_mappings.push_back({
+                        .source_uid = entry.source_column_unique_id(),
+                        .current_uid = entry.current_column_unique_id(),
+                        .before_uid = entry.has_before_column_unique_id()
+                                              ? std::optional(entry.before_column_unique_id())
+                                              : std::nullopt,
+                });
+            }
+        }
         if (rowset->num_segments() > 1 &&
             !tablet_txn_info->delete_bitmap->has_calculated_for_multi_segments(
                     rowset->rowset_id())) {

--- a/be/src/storage/txn/txn_manager.h
+++ b/be/src/storage/txn/txn_manager.h
@@ -45,6 +45,7 @@
 #include "storage/segment/vertical_segment_writer.h"
 #include "storage/tablet/tablet.h"
 #include "storage/tablet/tablet_meta.h"
+#include "storage/tablet_info.h"
 #include "util/time.h"
 
 namespace doris {
@@ -68,6 +69,9 @@ struct RowBinlogTxnInfo {
     BaseTabletSPtr tablet;
     // Delete bitmap deltas that should be applied to the independent binlog tablet.
     DeleteBitmapPtr delete_bitmap;
+    // Write-time snapshot, owned by the transaction independently of the writer and bitmap LRU.
+    bool need_historical_value = false;
+    std::vector<RowBinlogColumnUidMapping> column_mappings;
 };
 
 struct TxnPublishInfo {

--- a/be/src/storage/txn/txn_manager.h
+++ b/be/src/storage/txn/txn_manager.h
@@ -192,7 +192,8 @@ public:
                        TTransactionId transaction_id, const Version& version,
                        TabletPublishStatistics* stats,
                        std::shared_ptr<TabletTxnInfo>& extend_tablet_txn_info,
-                       const int64_t commit_tso = -1);
+                       const int64_t commit_tso = -1,
+                       const PRowBinlogWriteColumnMappings* row_binlog_column_mappings = nullptr);
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
     Status rollback_txn(TPartitionId partition_id, const Tablet& tablet,
@@ -213,7 +214,8 @@ public:
                        TTabletId tablet_id, TabletUid tablet_uid, const Version& version,
                        TabletPublishStatistics* stats,
                        std::shared_ptr<TabletTxnInfo>& extend_tablet_txn_info,
-                       const int64_t commit_tso = -1);
+                       const int64_t commit_tso = -1,
+                       const PRowBinlogWriteColumnMappings* row_binlog_column_mappings = nullptr);
 
     // only abort not committed txn
     void abort_txn(TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,

--- a/be/test/olap/rowset/cloud_group_rowset_builder_writer_test.cpp
+++ b/be/test/olap/rowset/cloud_group_rowset_builder_writer_test.cpp
@@ -22,6 +22,7 @@
 #include <unistd.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -47,6 +48,8 @@
 #include "storage/storage_policy.h"
 #include "storage/tablet/tablet_meta.h"
 #include "storage/tablet/tablet_schema.h"
+#include "storage/tablet_info.h"
+#include "storage/transform/row_binlog_derive.h"
 #include "testutil/creators.h"
 #include "util/uid_util.h"
 
@@ -128,14 +131,20 @@ private:
     }
 };
 
-TabletMetaSharedPtr create_tablet_meta(const TCreateTabletReq& request, TabletRolePB tablet_role) {
+TabletMetaSharedPtr create_tablet_meta(const TCreateTabletReq& request, int64_t index_id,
+                                       TabletRolePB tablet_role) {
     std::unordered_map<uint32_t, uint32_t> col_idx_to_unique_id;
     for (uint32_t col_idx = 0; col_idx < request.tablet_schema.columns.size(); ++col_idx) {
         col_idx_to_unique_id[col_idx] = col_idx;
     }
-    auto tablet_meta = TabletMeta::create(request, TabletUid::gen_uid(), 0,
+    auto source_meta = TabletMeta::create(request, TabletUid::gen_uid(), 0,
                                           cast_set<uint32_t>(request.tablet_schema.columns.size()),
                                           col_idx_to_unique_id);
+    TabletMetaPB tablet_meta_pb;
+    source_meta->to_meta_pb(&tablet_meta_pb, false);
+    tablet_meta_pb.set_index_id(index_id);
+    auto tablet_meta = std::make_shared<TabletMeta>();
+    tablet_meta->init_from_pb(tablet_meta_pb);
     tablet_meta->set_tablet_role(tablet_role);
     return tablet_meta;
 }
@@ -187,9 +196,9 @@ protected:
                 _request.tablet_schema, _request.tablet_schema.schema_hash + 1);
         _row_binlog_request.__set_tablet_role(TTabletRole::TABLET_ROLE_ROW_BINLOG);
 
-        auto data_meta = create_tablet_meta(_request, TabletRolePB::TABLET_ROLE_DATA);
-        auto row_binlog_meta =
-                create_tablet_meta(_row_binlog_request, TabletRolePB::TABLET_ROLE_ROW_BINLOG);
+        auto data_meta = create_tablet_meta(_request, kDataIndexId, TabletRolePB::TABLET_ROLE_DATA);
+        auto row_binlog_meta = create_tablet_meta(_row_binlog_request, kRowBinlogIndexId,
+                                                  TabletRolePB::TABLET_ROLE_ROW_BINLOG);
         _tablet = std::make_shared<CloudTablet>(*_engine, data_meta);
         _row_binlog_tablet = std::make_shared<CloudTablet>(*_engine, row_binlog_meta);
         add_initial_rowset(_tablet, _request.version);
@@ -294,6 +303,23 @@ protected:
         cfg.source.tablet_schema = _tablet->tablet_schema();
         cfg.source.base_tablet = _tablet;
         cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
+        std::vector<RowBinlogColumnUidMapping> uid_mappings;
+        for (ColumnId source_cid = 0; source_cid < cfg.source.tablet_schema->num_columns();
+             ++source_cid) {
+            const auto& source_column = cfg.source.tablet_schema->column(source_cid);
+            if (!source_column.visible() && !source_column.is_key()) {
+                continue;
+            }
+            const int32_t current_cid =
+                    row_binlog_context.tablet_schema->field_index(source_column.name());
+            DORIS_CHECK_GE(current_cid, 0);
+            uid_mappings.push_back(
+                    {source_column.unique_id(),
+                     row_binlog_context.tablet_schema->column(current_cid).unique_id(),
+                     std::nullopt});
+        }
+        cfg.column_mappings = DORIS_TRY(segment_v2::resolve_row_binlog_column_mappings(
+                *cfg.source.tablet_schema, *row_binlog_context.tablet_schema, uid_mappings));
         auto lsn_buffer = AutoIncIDBuffer::create_shared(1, 1, kBinlogLsnAutoIncId);
         lsn_buffer->append_range_for_test(1000, num_rows);
         std::vector<int64_t> allocated_lsns;
@@ -355,11 +381,44 @@ TEST_F(CloudGroupRowsetBuilderWriterTest, builderBuildsRowBinlogMeta) {
     builder.set_skip_writing_rowset_metadata(true);
     auto st = builder.init();
     ASSERT_TRUE(st.ok()) << st;
+    const auto& mappings = builder.row_binlog_builder()
+                                   ->rowset_writer()
+                                   ->context()
+                                   .write_binlog_opt()
+                                   .write_binlog_config()
+                                   .column_mappings;
+    ASSERT_EQ(mappings.size(), 2U);
+    EXPECT_EQ(mappings[0], (segment_v2::RowBinlogColumnCidMapping {0, 0, std::nullopt}));
+    EXPECT_EQ(mappings[1], (segment_v2::RowBinlogColumnCidMapping {1, 1, std::nullopt}));
+    const auto& data_writer_meta = builder.data_builder()->rowset_writer()->rowset_meta();
+    ASSERT_TRUE(data_writer_meta->has_row_binlog_column_mappings());
+    const auto& persisted_mappings = data_writer_meta->row_binlog_column_mappings();
+    ASSERT_TRUE(persisted_mappings.has_need_historical_value());
+    EXPECT_FALSE(persisted_mappings.need_historical_value());
+    ASSERT_EQ(persisted_mappings.entries_size(), 2);
+    const auto& requested_mappings =
+            data_req.table_schema_param->indexes()[0]->row_binlog_column_mappings;
+    for (int i = 0; i < persisted_mappings.entries_size(); ++i) {
+        EXPECT_EQ(persisted_mappings.entries(i).source_column_unique_id(),
+                  requested_mappings[i].source_uid);
+        EXPECT_EQ(persisted_mappings.entries(i).current_column_unique_id(),
+                  requested_mappings[i].current_uid);
+        EXPECT_FALSE(persisted_mappings.entries(i).has_before_column_unique_id());
+    }
+    EXPECT_FALSE(builder.row_binlog_builder()
+                         ->rowset_writer()
+                         ->rowset_meta()
+                         ->has_row_binlog_column_mappings());
 
     ASSERT_TRUE(builder.rowset_writer()->flush().ok());
     ASSERT_TRUE(builder.build_rowset().ok());
 
     assert_rowset_meta(builder.data_builder()->rowset(), builder.row_binlog_builder()->rowset());
+    EXPECT_TRUE(builder.data_builder()->rowset()->rowset_meta()->has_row_binlog_column_mappings());
+    EXPECT_FALSE(builder.row_binlog_builder()
+                         ->rowset()
+                         ->rowset_meta()
+                         ->has_row_binlog_column_mappings());
 }
 
 TEST_F(CloudGroupRowsetBuilderWriterTest, writerBuildsRowBinlogMeta) {

--- a/be/test/olap/rowset/cloud_group_rowset_builder_writer_test.cpp
+++ b/be/test/olap/rowset/cloud_group_rowset_builder_writer_test.cpp
@@ -31,6 +31,7 @@
 #include "cloud/cloud_storage_engine.h"
 #include "cloud/cloud_tablet.h"
 #include "cloud/cloud_tablet_mgr.h"
+#include "cloud/cloud_txn_delete_bitmap_cache.h"
 #include "common/cast_set.h"
 #include "common/config.h"
 #include "core/block/block.h"
@@ -51,6 +52,8 @@
 #include "storage/tablet_info.h"
 #include "storage/transform/row_binlog_derive.h"
 #include "testutil/creators.h"
+#include "util/debug_points.h"
+#include "util/defer_op.h"
 #include "util/uid_util.h"
 
 namespace doris {
@@ -184,9 +187,16 @@ protected:
         _engine->init_calc_delete_bitmap_executor_for_UT();
         _engine->set_latest_fs(std::make_shared<LocalRemoteFileSystem>(_storage_root_path));
 
+        init_tablets();
+    }
+
+    void init_tablets(bool key_only = false, bool historical = false) {
         _request = testutil::create_tablet_request(
                 kDataTabletId, 270068390, 10001, 1, TKeysType::UNIQUE_KEYS,
                 {{"k1", TPrimitiveType::INT, true}, {"v1", TPrimitiveType::INT, false}});
+        if (key_only) {
+            _request.tablet_schema.columns.resize(1);
+        }
         _request.__set_enable_unique_key_merge_on_write(true);
         testutil::enable_row_binlog(&_request);
 
@@ -195,6 +205,12 @@ protected:
         _row_binlog_request.tablet_schema = testutil::create_row_binlog_tablet_schema(
                 _request.tablet_schema, _request.tablet_schema.schema_hash + 1);
         _row_binlog_request.__set_tablet_role(TTabletRole::TABLET_ROLE_ROW_BINLOG);
+        if (historical && !key_only) {
+            // Put BEFORE after the special columns to exercise an explicit, nonstandard layout.
+            auto before = _row_binlog_request.tablet_schema.columns[1];
+            before.column_name = binlog::build_before_column_name("v1");
+            _row_binlog_request.tablet_schema.columns.push_back(before);
+        }
 
         auto data_meta = create_tablet_meta(_request, kDataIndexId, TabletRolePB::TABLET_ROLE_DATA);
         auto row_binlog_meta = create_tablet_meta(_row_binlog_request, kRowBinlogIndexId,
@@ -225,8 +241,11 @@ protected:
     }
 
     std::shared_ptr<OlapTableSchemaParam> create_schema_param() {
-        TDescriptorTable tdesc_tbl = testutil::create_descriptor_table(
-                {{TYPE_INT, "k1", false}, {TYPE_INT, "v1", false}});
+        TDescriptorTable tdesc_tbl =
+                _request.tablet_schema.columns.size() == 1
+                        ? testutil::create_descriptor_table({{TYPE_INT, "k1", false}})
+                        : testutil::create_descriptor_table(
+                                  {{TYPE_INT, "k1", false}, {TYPE_INT, "v1", false}});
         return testutil::create_table_schema_param(
                 tdesc_tbl, kDataIndexId, _request.tablet_schema.schema_hash,
                 _request.tablet_schema.columns, kRowBinlogIndexId,
@@ -362,6 +381,114 @@ protected:
                   0);
     }
 
+    void check_txn_mapping_lifetime(bool historical, bool key_only) {
+        init_tablets(key_only, historical);
+        _engine->_txn_delete_bitmap_cache = std::make_unique<CloudTxnDeleteBitmapCache>(1 << 20);
+        auto& cache = _engine->txn_delete_bitmap_cache();
+        ASSERT_TRUE(cache.init().ok());
+        {
+            WriteRequest data_req;
+            WriteRequest binlog_req;
+            WriteRequest group_req;
+            init_write_requests(&data_req, &binlog_req, &group_req);
+            auto* source_index = data_req.table_schema_param->indexes()[0];
+            source_index->row_binlog_need_historical_value = historical;
+            if (historical && !key_only) {
+                source_index->row_binlog_column_mappings[1].before_uid = 5;
+            }
+            RuntimeProfile profile("CloudTxnMappingLifetime");
+            CloudGroupRowsetBuilder builder(*_engine, group_req, data_req, binlog_req, &profile);
+            builder.set_skip_writing_rowset_metadata(true);
+            ASSERT_TRUE(builder.init().ok());
+            // The snapshot must be captured at init, not reread when the writer closes.
+            source_index->row_binlog_column_mappings.clear();
+            source_index->row_binlog_need_historical_value = !historical;
+            ASSERT_TRUE(builder.rowset_writer()->flush().ok());
+            ASSERT_TRUE(builder.build_rowset().ok());
+            builder.set_skip_writing_rowset_metadata(false);
+            ASSERT_TRUE(builder.set_txn_related_info().ok());
+        }
+
+        // The writer and its schema request have both been destroyed.
+        TabletTxnInfo txn_info;
+        int64_t expiration;
+        auto get_txn_info = [&] {
+            return cache.get_tablet_txn_info(
+                    20010, kDataTabletId, &txn_info.rowset, &txn_info.delete_bitmap,
+                    &txn_info.rowset_ids, &expiration, &txn_info.partial_update_info,
+                    &txn_info.publish_status, &txn_info.publish_info, &txn_info.attach_row_binlog);
+        };
+        for (bool evict_bitmap : {false, true}) {
+            SCOPED_TRACE(evict_bitmap);
+            if (evict_bitmap) {
+                ASSERT_TRUE(
+                        cache.update_tablet_txn_info(20010, kDataTabletId, txn_info.delete_bitmap,
+                                                     txn_info.rowset_ids, PublishStatus::SUCCEED)
+                                .ok());
+                cache.erase(CacheKey("20010/10010"));
+            }
+            ASSERT_TRUE(get_txn_info().ok());
+            EXPECT_EQ(*txn_info.publish_status, PublishStatus::INIT);
+            const auto& attached = txn_info.attach_row_binlog;
+            EXPECT_EQ(attached.need_historical_value, historical);
+            ASSERT_EQ(attached.column_mappings.size(), key_only ? 1U : 2U);
+            EXPECT_EQ(attached.column_mappings[0].source_uid, 0);
+            EXPECT_EQ(attached.column_mappings[0].current_uid, 0);
+            EXPECT_FALSE(attached.column_mappings[0].before_uid.has_value());
+            auto resolved = segment_v2::resolve_row_binlog_column_mappings(
+                    *txn_info.rowset->tablet_schema(), *attached.rowset->tablet_schema(),
+                    attached.column_mappings);
+            ASSERT_TRUE(resolved.has_value()) << resolved.error();
+            EXPECT_EQ((*resolved)[0], (segment_v2::RowBinlogColumnCidMapping {0, 0, std::nullopt}));
+            if (!key_only) {
+                EXPECT_EQ(attached.column_mappings[1].source_uid, 1);
+                EXPECT_EQ(attached.column_mappings[1].current_uid, 1);
+                EXPECT_EQ(attached.column_mappings[1].before_uid,
+                          historical ? std::optional<int32_t>(5) : std::nullopt);
+                EXPECT_EQ((*resolved)[1],
+                          (segment_v2::RowBinlogColumnCidMapping {
+                                  1, 1, historical ? std::optional<ColumnId>(5) : std::nullopt}));
+            }
+            EXPECT_FALSE(txn_info.rowset->rowset_meta()->has_row_binlog_column_mappings());
+            EXPECT_FALSE(attached.rowset->rowset_meta()->has_row_binlog_column_mappings());
+        }
+        if (historical) {
+            const bool debug_points_enabled = config::enable_debug_points;
+            config::enable_debug_points = true;
+            const std::string rewrite_failure =
+                    "Tablet.update_delete_bitmap.partial_update_write_rowset_fail";
+            const std::string rpc_failure = "CloudMetaMgr::test_update_delete_bitmap_fail";
+            DebugPoints::instance()->add_with_params(rewrite_failure, {{"percent", "1.0"}});
+            // A regressed branch must fail the assertion below, not contact an external MS.
+            DebugPoints::instance()->add(rpc_failure);
+            Defer clear_debug_points([&] {
+                DebugPoints::instance()->remove(rewrite_failure);
+                DebugPoints::instance()->remove(rpc_failure);
+                config::enable_debug_points = debug_points_enabled;
+            });
+            txn_info.rowset->set_version({2, 2});
+            EXPECT_FALSE(
+                    _row_binlog_tablet->tablet_meta()->binlog_config().need_historical_value());
+            auto st = BaseTablet::update_delete_bitmap(_tablet, &txn_info, 20010, expiration);
+            EXPECT_TRUE(st.is<ErrorCode::INTERNAL_ERROR>()) << st;
+            EXPECT_NE(
+                    st.to_string().find(
+                            "debug update_delete_bitmap partial update write rowset random failed"),
+                    std::string::npos)
+                    << st;
+
+            // The real transient writer must resolve the transaction snapshot, not rowset meta.
+            txn_info.attach_row_binlog.column_mappings[0].current_uid = 999999;
+            st = BaseTablet::update_delete_bitmap(_tablet, &txn_info, 20010, expiration);
+            EXPECT_TRUE(st.is<ErrorCode::INVALID_ARGUMENT>()) << st;
+            EXPECT_NE(st.to_string().find("Row-binlog mapping references a missing column uid"),
+                      std::string::npos)
+                    << st;
+        }
+        cache.remove_unused_tablet_txn_info(20010, kDataTabletId);
+        EXPECT_TRUE(get_txn_info().is<ErrorCode::NOT_FOUND>());
+    }
+
     std::unique_ptr<CloudStorageEngine> _engine;
     CloudTabletSPtr _tablet;
     CloudTabletSPtr _row_binlog_tablet;
@@ -391,20 +518,7 @@ TEST_F(CloudGroupRowsetBuilderWriterTest, builderBuildsRowBinlogMeta) {
     EXPECT_EQ(mappings[0], (segment_v2::RowBinlogColumnCidMapping {0, 0, std::nullopt}));
     EXPECT_EQ(mappings[1], (segment_v2::RowBinlogColumnCidMapping {1, 1, std::nullopt}));
     const auto& data_writer_meta = builder.data_builder()->rowset_writer()->rowset_meta();
-    ASSERT_TRUE(data_writer_meta->has_row_binlog_column_mappings());
-    const auto& persisted_mappings = data_writer_meta->row_binlog_column_mappings();
-    ASSERT_TRUE(persisted_mappings.has_need_historical_value());
-    EXPECT_FALSE(persisted_mappings.need_historical_value());
-    ASSERT_EQ(persisted_mappings.entries_size(), 2);
-    const auto& requested_mappings =
-            data_req.table_schema_param->indexes()[0]->row_binlog_column_mappings;
-    for (int i = 0; i < persisted_mappings.entries_size(); ++i) {
-        EXPECT_EQ(persisted_mappings.entries(i).source_column_unique_id(),
-                  requested_mappings[i].source_uid);
-        EXPECT_EQ(persisted_mappings.entries(i).current_column_unique_id(),
-                  requested_mappings[i].current_uid);
-        EXPECT_FALSE(persisted_mappings.entries(i).has_before_column_unique_id());
-    }
+    EXPECT_FALSE(data_writer_meta->has_row_binlog_column_mappings());
     EXPECT_FALSE(builder.row_binlog_builder()
                          ->rowset_writer()
                          ->rowset_meta()
@@ -414,7 +528,7 @@ TEST_F(CloudGroupRowsetBuilderWriterTest, builderBuildsRowBinlogMeta) {
     ASSERT_TRUE(builder.build_rowset().ok());
 
     assert_rowset_meta(builder.data_builder()->rowset(), builder.row_binlog_builder()->rowset());
-    EXPECT_TRUE(builder.data_builder()->rowset()->rowset_meta()->has_row_binlog_column_mappings());
+    EXPECT_FALSE(builder.data_builder()->rowset()->rowset_meta()->has_row_binlog_column_mappings());
     EXPECT_FALSE(builder.row_binlog_builder()
                          ->rowset()
                          ->rowset_meta()
@@ -436,6 +550,18 @@ TEST_F(CloudGroupRowsetBuilderWriterTest, writerBuildsRowBinlogMeta) {
     ASSERT_EQ(2, rowsets.size());
 
     assert_rowset_meta(rowsets[0], rowsets[1]);
+}
+
+TEST_F(CloudGroupRowsetBuilderWriterTest, txnMappingSurvivesWriterAndBitmapEviction) {
+    check_txn_mapping_lifetime(false, false);
+}
+
+TEST_F(CloudGroupRowsetBuilderWriterTest, historicalTxnMappingSurvivesWriterAndBitmapEviction) {
+    check_txn_mapping_lifetime(true, false);
+}
+
+TEST_F(CloudGroupRowsetBuilderWriterTest, keyOnlyHistoricalTxnMappingKeepsHistoricalMode) {
+    check_txn_mapping_lifetime(true, true);
 }
 
 } // namespace doris

--- a/be/test/olap/rowset/cloud_group_rowset_builder_writer_test.cpp
+++ b/be/test/olap/rowset/cloud_group_rowset_builder_writer_test.cpp
@@ -449,8 +449,6 @@ protected:
                           (segment_v2::RowBinlogColumnCidMapping {
                                   1, 1, historical ? std::optional<ColumnId>(5) : std::nullopt}));
             }
-            EXPECT_FALSE(txn_info.rowset->rowset_meta()->has_row_binlog_column_mappings());
-            EXPECT_FALSE(attached.rowset->rowset_meta()->has_row_binlog_column_mappings());
         }
         if (historical) {
             const bool debug_points_enabled = config::enable_debug_points;
@@ -517,22 +515,11 @@ TEST_F(CloudGroupRowsetBuilderWriterTest, builderBuildsRowBinlogMeta) {
     ASSERT_EQ(mappings.size(), 2U);
     EXPECT_EQ(mappings[0], (segment_v2::RowBinlogColumnCidMapping {0, 0, std::nullopt}));
     EXPECT_EQ(mappings[1], (segment_v2::RowBinlogColumnCidMapping {1, 1, std::nullopt}));
-    const auto& data_writer_meta = builder.data_builder()->rowset_writer()->rowset_meta();
-    EXPECT_FALSE(data_writer_meta->has_row_binlog_column_mappings());
-    EXPECT_FALSE(builder.row_binlog_builder()
-                         ->rowset_writer()
-                         ->rowset_meta()
-                         ->has_row_binlog_column_mappings());
 
     ASSERT_TRUE(builder.rowset_writer()->flush().ok());
     ASSERT_TRUE(builder.build_rowset().ok());
 
     assert_rowset_meta(builder.data_builder()->rowset(), builder.row_binlog_builder()->rowset());
-    EXPECT_FALSE(builder.data_builder()->rowset()->rowset_meta()->has_row_binlog_column_mappings());
-    EXPECT_FALSE(builder.row_binlog_builder()
-                         ->rowset()
-                         ->rowset_meta()
-                         ->has_row_binlog_column_mappings());
 }
 
 TEST_F(CloudGroupRowsetBuilderWriterTest, writerBuildsRowBinlogMeta) {

--- a/be/test/olap/rowset/group_rowset_builder_test.cpp
+++ b/be/test/olap/rowset/group_rowset_builder_test.cpp
@@ -44,6 +44,7 @@
 #include "storage/tablet/tablet_manager.h"
 #include "storage/tablet/tablet_meta_manager.h"
 #include "storage/tablet_info.h"
+#include "storage/task/engine_publish_version_task.h"
 #include "testutil/creators.h"
 
 namespace doris {
@@ -305,6 +306,30 @@ TEST_F(GroupRowsetBuilderTest, recoverMultipleRowBinlogPairsInOneTxn) {
         EXPECT_EQ(txn_info->second->attach_row_binlog.tablet->tablet_id(), row_binlog_tablet_id);
         EXPECT_EQ(txn_info->second->attach_row_binlog.rowset->rowset_meta()->tablet_id(),
                   row_binlog_tablet_id);
+
+        // Local recovery must still hydrate the common publish snapshot from committed metadata.
+        ASSERT_TRUE(txn_info->second->unique_key_merge_on_write);
+        EXPECT_TRUE(txn_info->second->attach_row_binlog.column_mappings.empty());
+        auto binlog_tablet =
+                std::static_pointer_cast<Tablet>(txn_info->second->attach_row_binlog.tablet);
+        std::lock_guard binlog_lock(binlog_tablet->get_rowset_update_lock());
+        std::lock_guard base_lock(base_tablet->get_rowset_update_lock());
+        TabletPublishStatistics stats;
+        std::shared_ptr<TabletTxnInfo> published_txn;
+        auto st = engine_ref->txn_manager()->publish_txn(partition_id, base_tablet, txn_id,
+                                                         Version(2, 2), &stats, published_txn);
+        ASSERT_TRUE(st.ok()) << st;
+        ASSERT_NE(published_txn, nullptr);
+        const auto& snapshot = published_txn->attach_row_binlog;
+        EXPECT_FALSE(snapshot.need_historical_value);
+        ASSERT_EQ(snapshot.column_mappings.size(), 2U);
+        EXPECT_EQ(snapshot.column_mappings[0].source_uid, 0);
+        EXPECT_EQ(snapshot.column_mappings[0].current_uid, 0);
+        EXPECT_FALSE(snapshot.column_mappings[0].before_uid.has_value());
+        EXPECT_EQ(snapshot.column_mappings[1].source_uid, 1);
+        EXPECT_EQ(snapshot.column_mappings[1].current_uid, 1);
+        EXPECT_FALSE(snapshot.column_mappings[1].before_uid.has_value());
+        EXPECT_FALSE(published_txn->rowset->rowset_meta()->has_row_binlog_column_mappings());
     }
 }
 

--- a/be/test/olap/rowset/group_rowset_builder_test.cpp
+++ b/be/test/olap/rowset/group_rowset_builder_test.cpp
@@ -46,6 +46,8 @@
 #include "storage/tablet_info.h"
 #include "storage/task/engine_publish_version_task.h"
 #include "testutil/creators.h"
+#include "util/defer_op.h"
+#include "util/threadpool.h"
 
 namespace doris {
 
@@ -61,6 +63,11 @@ static void open_engine() {
     auto engine = std::make_unique<StorageEngine>(options);
     engine_ref = engine.get();
     Status s = engine->open();
+    ASSERT_TRUE(s.ok()) << s;
+    s = ThreadPoolBuilder("TabletPublishTxnThreadPool")
+                .set_min_threads(1)
+                .set_max_threads(2)
+                .build(&engine->_tablet_publish_txn_thread_pool);
     ASSERT_TRUE(s.ok()) << s;
     ExecEnv::GetInstance()->set_storage_engine(std::move(engine));
 }
@@ -96,8 +103,8 @@ static void tear_down() {
 
 class GroupRowsetBuilderTest : public ::testing::Test {
 public:
-    static void SetUpTestSuite() { set_up(); }
-    static void TearDownTestSuite() { tear_down(); }
+    void SetUp() override { set_up(); }
+    void TearDown() override { tear_down(); }
 };
 
 TEST_F(GroupRowsetBuilderTest, buildWithRowBinlogMeta) {
@@ -168,24 +175,6 @@ TEST_F(GroupRowsetBuilderTest, buildWithRowBinlogMeta) {
     ASSERT_EQ(mappings.size(), 2U);
     EXPECT_EQ(mappings[0], (segment_v2::RowBinlogColumnCidMapping {0, 0, std::nullopt}));
     EXPECT_EQ(mappings[1], (segment_v2::RowBinlogColumnCidMapping {1, 1, std::nullopt}));
-    const auto& data_writer_meta = builder.txn_rowset_builder()->rowset_writer()->rowset_meta();
-    ASSERT_TRUE(data_writer_meta->has_row_binlog_column_mappings());
-    const auto& persisted_mappings = data_writer_meta->row_binlog_column_mappings();
-    ASSERT_TRUE(persisted_mappings.has_need_historical_value());
-    EXPECT_FALSE(persisted_mappings.need_historical_value());
-    ASSERT_EQ(persisted_mappings.entries_size(), 2);
-    const auto& requested_mappings = param->indexes()[0]->row_binlog_column_mappings;
-    for (int i = 0; i < persisted_mappings.entries_size(); ++i) {
-        EXPECT_EQ(persisted_mappings.entries(i).source_column_unique_id(),
-                  requested_mappings[i].source_uid);
-        EXPECT_EQ(persisted_mappings.entries(i).current_column_unique_id(),
-                  requested_mappings[i].current_uid);
-        EXPECT_FALSE(persisted_mappings.entries(i).has_before_column_unique_id());
-    }
-    EXPECT_FALSE(builder.row_binlog_builder()
-                         ->rowset_writer()
-                         ->rowset_meta()
-                         ->has_row_binlog_column_mappings());
     ASSERT_TRUE(builder.rowset_writer()->flush().ok());
     ASSERT_TRUE(builder.build_rowset().ok());
 
@@ -208,7 +197,10 @@ TEST_F(GroupRowsetBuilderTest, buildWithRowBinlogMeta) {
     ASSERT_TRUE(res.ok());
 }
 
-TEST_F(GroupRowsetBuilderTest, recoverMultipleRowBinlogPairsInOneTxn) {
+// Keep the real-engine commit/restart/publish sequence together across the mapping variants.
+// NOLINTNEXTLINE(readability-function-cognitive-complexity, readability-function-size)
+static void recover_multiple_row_binlog_pairs(bool historical, bool key_only,
+                                              std::optional<int32_t> max_gap = std::nullopt) {
     constexpr int64_t partition_id = 10100;
     constexpr int64_t txn_id = 20100;
     constexpr int64_t index_id = 30100;
@@ -221,10 +213,18 @@ TEST_F(GroupRowsetBuilderTest, recoverMultipleRowBinlogPairsInOneTxn) {
     auto base_request = testutil::create_tablet_request(
             0, schema_hash, partition_id, 1, TKeysType::UNIQUE_KEYS,
             {{"k1", TPrimitiveType::INT, true}, {"v1", TPrimitiveType::INT, false}});
+    if (key_only) {
+        base_request.tablet_schema.columns.resize(1);
+    }
     base_request.__set_enable_unique_key_merge_on_write(true);
     testutil::enable_row_binlog(&base_request);
     auto row_binlog_schema = testutil::create_row_binlog_tablet_schema(base_request.tablet_schema,
                                                                        row_binlog_schema_hash);
+    if (historical && !key_only) {
+        auto before = row_binlog_schema.columns[1];
+        before.column_name = binlog::build_before_column_name("v1");
+        row_binlog_schema.columns.push_back(before);
+    }
 
     RuntimeProfile profile("CreateTablet");
     for (const auto& [base_tablet_id, row_binlog_tablet_id] : tablet_pairs) {
@@ -254,43 +254,153 @@ TEST_F(GroupRowsetBuilderTest, recoverMultipleRowBinlogPairsInOneTxn) {
     }
 
     TDescriptorTable tdesc_tbl =
-            testutil::create_descriptor_table({{TYPE_INT, "k1", false}, {TYPE_INT, "v1", false}});
+            key_only ? testutil::create_descriptor_table({{TYPE_INT, "k1", false}})
+                     : testutil::create_descriptor_table(
+                               {{TYPE_INT, "k1", false}, {TYPE_INT, "v1", false}});
     auto schema_param = testutil::create_table_schema_param(
             tdesc_tbl, index_id, schema_hash, base_request.tablet_schema.columns,
             row_binlog_index_id, row_binlog_schema_hash, &row_binlog_schema.columns);
     ASSERT_NE(schema_param, nullptr);
+    auto* source_index = schema_param->indexes()[0];
+    source_index->row_binlog_need_historical_value = historical;
+    if (historical && !key_only) {
+        source_index->row_binlog_column_mappings[1].before_uid = 5;
+    }
+
+    TRowBinlogWriteColumnMappings thrift_snapshot;
+    thrift_snapshot.__set_need_historical_value(historical);
+    std::vector<TRowBinlogWriteColumnMapping> entries;
+    for (const auto& mapping : source_index->row_binlog_column_mappings) {
+        TRowBinlogWriteColumnMapping entry;
+        entry.__set_source_column_unique_id(mapping.source_uid);
+        entry.__set_current_column_unique_id(mapping.current_uid);
+        if (mapping.before_uid.has_value()) {
+            entry.__set_before_column_unique_id(*mapping.before_uid);
+        }
+        entries.push_back(entry);
+    }
+    thrift_snapshot.__set_entries(entries);
 
     PUniqueId load_id;
     load_id.set_hi(0);
     load_id.set_lo(1);
-    for (const auto& [base_tablet_id, row_binlog_tablet_id] : tablet_pairs) {
-        WriteRequest data_req;
-        data_req.tablet_id = base_tablet_id;
-        data_req.schema_hash = schema_hash;
-        data_req.txn_id = txn_id;
-        data_req.partition_id = partition_id;
-        data_req.index_id = index_id;
-        data_req.load_id = load_id;
-        data_req.table_schema_param = schema_param;
-        data_req.write_req_type = WriteRequestType::DATA;
+    for (int64_t committed_txn = txn_id; committed_txn <= txn_id + max_gap.has_value();
+         ++committed_txn) {
+        for (const auto& [base_tablet_id, row_binlog_tablet_id] : tablet_pairs) {
+            WriteRequest data_req;
+            data_req.tablet_id = base_tablet_id;
+            data_req.schema_hash = schema_hash;
+            data_req.txn_id = committed_txn;
+            data_req.partition_id = partition_id;
+            data_req.index_id = index_id;
+            data_req.load_id = load_id;
+            data_req.table_schema_param = schema_param;
+            data_req.write_req_type = WriteRequestType::DATA;
 
-        WriteRequest row_binlog_req = data_req;
-        row_binlog_req.tablet_id = row_binlog_tablet_id;
-        row_binlog_req.index_id = row_binlog_index_id;
-        row_binlog_req.schema_hash = row_binlog_schema_hash;
-        row_binlog_req.write_req_type = WriteRequestType::ROW_BINLOG;
+            WriteRequest row_binlog_req = data_req;
+            row_binlog_req.tablet_id = row_binlog_tablet_id;
+            row_binlog_req.index_id = row_binlog_index_id;
+            row_binlog_req.schema_hash = row_binlog_schema_hash;
+            row_binlog_req.write_req_type = WriteRequestType::ROW_BINLOG;
 
-        WriteRequest group_req = data_req;
-        group_req.write_req_type = WriteRequestType::GROUP;
+            WriteRequest group_req = data_req;
+            group_req.write_req_type = WriteRequestType::GROUP;
 
-        GroupRowsetBuilder builder(*engine_ref, group_req, data_req, row_binlog_req, &profile);
-        ASSERT_TRUE(builder.init().ok());
-        ASSERT_TRUE(builder.rowset_writer()->flush().ok());
-        ASSERT_TRUE(builder.build_rowset().ok());
-        ASSERT_TRUE(builder.commit_txn().ok());
+            RuntimeProfile write_profile("GroupWrite");
+            GroupRowsetBuilder builder(*engine_ref, group_req, data_req, row_binlog_req,
+                                       &write_profile);
+            ASSERT_TRUE(builder.init().ok());
+            ASSERT_TRUE(builder.rowset_writer()->flush().ok());
+            ASSERT_TRUE(builder.build_rowset().ok());
+            ASSERT_TRUE(builder.commit_txn().ok());
+        }
     }
 
     restart_engine();
+
+    TPublishVersionRequest publish_request;
+    publish_request.__set_transaction_id(txn_id);
+    TPartitionVersionInfo version_info;
+    version_info.__set_partition_id(partition_id);
+    version_info.__set_version(2);
+    version_info.__set_commit_tso(12345);
+    publish_request.__set_partition_version_infos({version_info});
+    std::set<TTabletId> errors;
+    std::map<TTabletId, TVersion> successes;
+    std::vector<DiscontinuousVersionTablet> discontinuous;
+    std::map<TTableId, std::map<TTabletId, int64_t>> delta_rows;
+    auto publish = [&] {
+        errors.clear();
+        discontinuous.clear();
+        EnginePublishVersionTask task(*engine_ref, publish_request, &errors, &successes,
+                                      &discontinuous, &delta_rows);
+        return task.execute();
+    };
+
+    // Missing, wrong-index, malformed, and invalid-UID snapshots must fail before visibility.
+    auto assert_committed = [&] {
+        std::map<TabletInfo, RowsetSharedPtr> committed;
+        std::map<TabletInfo, std::shared_ptr<TabletTxnInfo>> infos;
+        engine_ref->txn_manager()->get_txn_related_tablets(txn_id, partition_id, &committed,
+                                                           &infos);
+        ASSERT_EQ(committed.size(), tablet_pairs.size());
+        for (const auto& [tablet_info, info] : infos) {
+            EXPECT_EQ(info->rowset->rowset_meta()->rowset_state(), RowsetStatePB::COMMITTED);
+            EXPECT_EQ(info->attach_row_binlog.rowset->rowset_meta()->rowset_state(),
+                      RowsetStatePB::COMMITTED);
+        }
+    };
+    EXPECT_FALSE(publish().ok());
+    assert_committed();
+    publish_request.__set_row_binlog_column_mappings({{row_binlog_index_id, thrift_snapshot}});
+    EXPECT_FALSE(publish().ok());
+    assert_committed();
+    auto malformed_snapshot = thrift_snapshot;
+    malformed_snapshot.__isset.need_historical_value = false;
+    publish_request.__set_row_binlog_column_mappings({{index_id, malformed_snapshot}});
+    EXPECT_FALSE(publish().ok());
+    assert_committed();
+    auto invalid_snapshot = thrift_snapshot;
+    invalid_snapshot.entries[0].source_column_unique_id = 9999;
+    publish_request.__set_row_binlog_column_mappings({{index_id, invalid_snapshot}});
+    EXPECT_FALSE(publish().ok());
+    assert_committed();
+    // Local tablet metadata does not carry an index ID. Select the committed writer's source
+    // index, not the default tablet index or the attached binlog index.
+    publish_request.__set_row_binlog_column_mappings(
+            {{index_id, thrift_snapshot}, {0, invalid_snapshot}});
+
+    if (max_gap.has_value()) {
+        const auto old_gap = config::mow_publish_max_discontinuous_version_num;
+        config::mow_publish_max_discontinuous_version_num = *max_gap;
+        Defer restore_gap([&] { config::mow_publish_max_discontinuous_version_num = old_gap; });
+        publish_request.partition_version_infos[0].version = 3;
+        EXPECT_TRUE(publish().is<ErrorCode::PUBLISH_VERSION_NOT_CONTINUOUS>());
+        if (*max_gap == 0) {
+            EXPECT_TRUE(discontinuous.empty());
+        } else {
+            ASSERT_EQ(discontinuous.size(), tablet_pairs.size());
+            for (const auto& item : discontinuous) {
+                engine_ref->add_async_publish_task(
+                        item.partition_id, item.tablet_id, item.publish_version, txn_id, false,
+                        item.commit_tso, item.row_binlog_column_mappings);
+            }
+        }
+        // Both discontinuity paths persist the snapshot; subsequent execution needs no FE map.
+        restart_engine();
+        for (const auto& [base_tablet_id, binlog_tablet_id] : tablet_pairs) {
+            const auto& queued = engine_ref->_async_publish_tasks.at(base_tablet_id).at(3);
+            ASSERT_NE(std::get<3>(queued), nullptr);
+            EXPECT_EQ(std::get<3>(queued)->need_historical_value(), historical);
+            EXPECT_EQ(std::get<3>(queued)->entries_size(), key_only ? 1 : 2);
+            EXPECT_EQ(std::get<2>(queued), 12345);
+        }
+        publish_request.transaction_id = txn_id + 1;
+        publish_request.partition_version_infos[0].version = 2;
+        auto st = publish();
+        ASSERT_TRUE(st.ok()) << st;
+        publish_request.row_binlog_column_mappings.clear();
+    }
 
     std::map<TabletInfo, RowsetSharedPtr> rowsets;
     std::map<TabletInfo, std::shared_ptr<TabletTxnInfo>> txn_infos;
@@ -307,30 +417,75 @@ TEST_F(GroupRowsetBuilderTest, recoverMultipleRowBinlogPairsInOneTxn) {
         EXPECT_EQ(txn_info->second->attach_row_binlog.rowset->rowset_meta()->tablet_id(),
                   row_binlog_tablet_id);
 
-        // Local recovery must still hydrate the common publish snapshot from committed metadata.
+        // Committed-rowset recovery deliberately does not reconstruct a mapping snapshot.
         ASSERT_TRUE(txn_info->second->unique_key_merge_on_write);
         EXPECT_TRUE(txn_info->second->attach_row_binlog.column_mappings.empty());
-        auto binlog_tablet =
-                std::static_pointer_cast<Tablet>(txn_info->second->attach_row_binlog.tablet);
-        std::lock_guard binlog_lock(binlog_tablet->get_rowset_update_lock());
-        std::lock_guard base_lock(base_tablet->get_rowset_update_lock());
-        TabletPublishStatistics stats;
-        std::shared_ptr<TabletTxnInfo> published_txn;
-        auto st = engine_ref->txn_manager()->publish_txn(partition_id, base_tablet, txn_id,
-                                                         Version(2, 2), &stats, published_txn);
+
+        // Model ADD COLUMN after commit: publish must resolve the old snapshot against the
+        // transaction rowsets, not this newer tablet schema requiring an additional mapping.
+        TabletSchemaPB latest_schema_pb;
+        base_tablet->tablet_schema()->to_schema_pb(&latest_schema_pb);
+        latest_schema_pb.set_schema_version(latest_schema_pb.schema_version() + 1);
+        auto* added_column = latest_schema_pb.add_column();
+        added_column->CopyFrom(latest_schema_pb.column(0));
+        added_column->set_name("added_after_commit");
+        added_column->set_unique_id(1000);
+        added_column->set_is_key(false);
+        added_column->set_is_nullable(true);
+        added_column->set_aggregation("REPLACE");
+        auto latest_schema = std::make_shared<TabletSchema>();
+        latest_schema->init_from_pb(latest_schema_pb);
+        base_tablet->update_max_version_schema(latest_schema);
+        ASSERT_GE(base_tablet->tablet_schema()->field_index(1000), 0);
+        ASSERT_EQ(txn_info->second->rowset->tablet_schema()->field_index(1000), -1);
+    }
+    if (max_gap.has_value()) {
+        engine_ref->_process_async_publish();
+        engine_ref->_tablet_publish_txn_thread_pool->wait();
+    } else {
+        auto st = publish();
         ASSERT_TRUE(st.ok()) << st;
-        ASSERT_NE(published_txn, nullptr);
-        const auto& snapshot = published_txn->attach_row_binlog;
-        EXPECT_FALSE(snapshot.need_historical_value);
-        ASSERT_EQ(snapshot.column_mappings.size(), 2U);
+    }
+    for (const auto& [base_tablet_id, row_binlog_tablet_id] : tablet_pairs) {
+        auto base_tablet = engine_ref->tablet_manager()->get_tablet(base_tablet_id);
+        auto binlog_tablet = engine_ref->tablet_manager()->get_tablet(row_binlog_tablet_id);
+        EXPECT_EQ(base_tablet->max_version().second, max_gap.has_value() ? 3 : 2);
+        EXPECT_EQ(binlog_tablet->max_version().second, max_gap.has_value() ? 3 : 2);
+        const auto& info = txn_infos.at(base_tablet->get_tablet_info());
+        EXPECT_EQ(info->rowset->rowset_meta()->rowset_state(), RowsetStatePB::VISIBLE);
+        const auto& snapshot = info->attach_row_binlog;
+        EXPECT_EQ(snapshot.need_historical_value, historical);
+        ASSERT_EQ(snapshot.column_mappings.size(), key_only ? 1U : 2U);
         EXPECT_EQ(snapshot.column_mappings[0].source_uid, 0);
         EXPECT_EQ(snapshot.column_mappings[0].current_uid, 0);
         EXPECT_FALSE(snapshot.column_mappings[0].before_uid.has_value());
-        EXPECT_EQ(snapshot.column_mappings[1].source_uid, 1);
-        EXPECT_EQ(snapshot.column_mappings[1].current_uid, 1);
-        EXPECT_FALSE(snapshot.column_mappings[1].before_uid.has_value());
-        EXPECT_FALSE(published_txn->rowset->rowset_meta()->has_row_binlog_column_mappings());
+        if (!key_only) {
+            EXPECT_EQ(snapshot.column_mappings[1].source_uid, 1);
+            EXPECT_EQ(snapshot.column_mappings[1].current_uid, 1);
+            EXPECT_EQ(snapshot.column_mappings[1].before_uid,
+                      historical ? std::optional<int32_t>(5) : std::nullopt);
+        }
     }
+}
+
+TEST_F(GroupRowsetBuilderTest, recoverMultipleRowBinlogPairsInOneTxn) {
+    recover_multiple_row_binlog_pairs(false, false);
+}
+
+TEST_F(GroupRowsetBuilderTest, recoverHistoricalRowBinlogPublishSnapshot) {
+    recover_multiple_row_binlog_pairs(true, false);
+}
+
+TEST_F(GroupRowsetBuilderTest, recoverKeyOnlyHistoricalRowBinlogPublishSnapshot) {
+    recover_multiple_row_binlog_pairs(true, true);
+}
+
+TEST_F(GroupRowsetBuilderTest, recoverDirectPendingRowBinlogSnapshot) {
+    recover_multiple_row_binlog_pairs(true, false, 0);
+}
+
+TEST_F(GroupRowsetBuilderTest, recoverRetryPendingRowBinlogSnapshot) {
+    recover_multiple_row_binlog_pairs(true, true, 100);
 }
 
 } // namespace doris

--- a/be/test/olap/rowset/group_rowset_builder_test.cpp
+++ b/be/test/olap/rowset/group_rowset_builder_test.cpp
@@ -25,6 +25,7 @@
 #include <array>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -157,6 +158,33 @@ TEST_F(GroupRowsetBuilderTest, buildWithRowBinlogMeta) {
 
     GroupRowsetBuilder builder(*engine_ref, group_req, data_req, row_binlog_req, profile.get());
     ASSERT_TRUE(builder.init().ok());
+    const auto& mappings = builder.row_binlog_builder()
+                                   ->rowset_writer()
+                                   ->context()
+                                   .write_binlog_opt()
+                                   .write_binlog_config()
+                                   .column_mappings;
+    ASSERT_EQ(mappings.size(), 2U);
+    EXPECT_EQ(mappings[0], (segment_v2::RowBinlogColumnCidMapping {0, 0, std::nullopt}));
+    EXPECT_EQ(mappings[1], (segment_v2::RowBinlogColumnCidMapping {1, 1, std::nullopt}));
+    const auto& data_writer_meta = builder.txn_rowset_builder()->rowset_writer()->rowset_meta();
+    ASSERT_TRUE(data_writer_meta->has_row_binlog_column_mappings());
+    const auto& persisted_mappings = data_writer_meta->row_binlog_column_mappings();
+    ASSERT_TRUE(persisted_mappings.has_need_historical_value());
+    EXPECT_FALSE(persisted_mappings.need_historical_value());
+    ASSERT_EQ(persisted_mappings.entries_size(), 2);
+    const auto& requested_mappings = param->indexes()[0]->row_binlog_column_mappings;
+    for (int i = 0; i < persisted_mappings.entries_size(); ++i) {
+        EXPECT_EQ(persisted_mappings.entries(i).source_column_unique_id(),
+                  requested_mappings[i].source_uid);
+        EXPECT_EQ(persisted_mappings.entries(i).current_column_unique_id(),
+                  requested_mappings[i].current_uid);
+        EXPECT_FALSE(persisted_mappings.entries(i).has_before_column_unique_id());
+    }
+    EXPECT_FALSE(builder.row_binlog_builder()
+                         ->rowset_writer()
+                         ->rowset_meta()
+                         ->has_row_binlog_column_mappings());
     ASSERT_TRUE(builder.rowset_writer()->flush().ok());
     ASSERT_TRUE(builder.build_rowset().ok());
 

--- a/be/test/olap/rowset/group_rowset_writer_test.cpp
+++ b/be/test/olap/rowset/group_rowset_writer_test.cpp
@@ -24,6 +24,7 @@
 #include <array>
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <thread>
@@ -46,6 +47,8 @@
 #include "storage/storage_engine.h"
 #include "storage/tablet/tablet.h"
 #include "storage/tablet/tablet_manager.h"
+#include "storage/tablet_info.h"
+#include "storage/transform/row_binlog_derive.h"
 #include "testutil/creators.h"
 #include "util/debug_points.h"
 
@@ -164,6 +167,30 @@ protected:
                                             std::vector<RowsetSharedPtr> {}, nullptr);
     }
 
+    Status set_row_binlog_column_mappings(RowsetWriterContext* context) const {
+        auto& cfg = context->write_binlog_opt().write_binlog_config();
+        std::vector<RowBinlogColumnUidMapping> uid_mappings;
+        for (ColumnId source_cid = 0; source_cid < cfg.source.tablet_schema->num_columns();
+             ++source_cid) {
+            const auto& source_column = cfg.source.tablet_schema->column(source_cid);
+            if (!source_column.visible() && !source_column.is_key()) {
+                continue;
+            }
+            const int32_t current_cid = context->tablet_schema->field_index(source_column.name());
+            DORIS_CHECK_GE(current_cid, 0);
+            uid_mappings.push_back({source_column.unique_id(),
+                                    context->tablet_schema->column(current_cid).unique_id(),
+                                    std::nullopt});
+        }
+        auto mappings = segment_v2::resolve_row_binlog_column_mappings(
+                *cfg.source.tablet_schema, *context->tablet_schema, uid_mappings);
+        if (!mappings.has_value()) {
+            return mappings.error();
+        }
+        cfg.column_mappings = std::move(*mappings);
+        return Status::OK();
+    }
+
     Result<std::unique_ptr<RowsetWriter>> create_partial_update_row_binlog_writer(
             const std::shared_ptr<PartialUpdateInfo>& partial_update_info, size_t num_rows,
             const std::shared_ptr<MowContext>& mow_context) {
@@ -183,6 +210,7 @@ protected:
         binlog_options.source.partial_update_info = partial_update_info;
         binlog_options.source.mow_context = mow_context;
         binlog_options.source.source_write_type = DataWriteType::TYPE_DIRECT;
+        RETURN_IF_ERROR_RESULT(set_row_binlog_column_mappings(&row_binlog_context));
 
         auto lsn_buffer = AutoIncIDBuffer::create_shared(1, 1, kBinlogLsnAutoIncId);
         lsn_buffer->append_range_for_test(1000, num_rows);
@@ -261,6 +289,7 @@ protected:
         cfg.source.base_tablet = _tablet;
         cfg.source.is_transient_rowset_writer = true;
         cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
+        RETURN_IF_ERROR(set_row_binlog_column_mappings(&row_binlog_context));
         auto lsn_buffer = AutoIncIDBuffer::create_shared(1, 1, kBinlogLsnAutoIncId);
         lsn_buffer->append_range_for_test(1000, num_rows);
         std::vector<int64_t> allocated_lsns;

--- a/be/test/storage/iterator/block_reader_binlog_vcollect_merge_test.cpp
+++ b/be/test/storage/iterator/block_reader_binlog_vcollect_merge_test.cpp
@@ -75,7 +75,7 @@ namespace {
 // merge-heap key comparison and for MIN_DELTA group boundaries:
 //   0: key                  (Int64, the only key column)
 //   1: val                  (Int64, "after" value)
-//   2: __BEFORE__val__       (Int64, "before" value mirror)
+//   2: __DORIS_BEFORE__val__ (Int64, "before" value mirror)
 //   3: __DORIS_BINLOG_TSO__  (Int64, the merge sequence / order column)
 //   4: __DORIS_BINLOG_LSN__  (Int64)
 //   5: __DORIS_BINLOG_OP__   (Int64, ROW_BINLOG_APPEND/UPDATE/DELETE)
@@ -96,7 +96,7 @@ struct Row {
     int64_t op;
 };
 
-// Row-binlog read schema: single leading key column, a value column plus its __BEFORE__
+// Row-binlog read schema: single leading key column, a value column plus its __DORIS_BEFORE__
 // mirror, and the three binlog meta columns. Marking BINLOG_TSO_COL by name makes
 // TabletSchema::binlog_tso_col_idx() return its position, which Level1Iterator::init()
 // uses to pick the TSO as the merge sequence column.
@@ -174,6 +174,10 @@ public:
         meta->set_rowset_type(BETA_ROWSET);
         _rowset = std::make_shared<FakeRowset>(nullptr, meta);
         _read_schema = std::make_shared<ReadSchema>(make_binlog_schema()->columns());
+        DORIS_CHECK(_read_schema
+                            ->init_row_binlog_column_mappings({{VAL_IDX, BEFORE_VAL_IDX}}, TSO_IDX,
+                                                              LSN_IDX, OP_IDX)
+                            .ok());
     }
 
     Status init(RowsetReaderContext*, const RowSetSplits&) override { return Status::OK(); }
@@ -248,11 +252,13 @@ void configure_two_rowset_merge(BlockReader& reader, std::vector<Row> rowset0_ro
     reader._reader_type = ReaderType::READER_BASE_COMPACTION;
 
     reader._tablet_schema = make_binlog_schema();
-    // Identity read schema over the full row-binlog layout. ReadSchema derives num_key_columns()
-    // from is_key() and tso_ordinal() from the BINLOG_TSO_COL name, which Level1Iterator::init()
-    // uses to pick the TSO as the merge sequence column, and which
-    // _validate_merge_compare_contract() checks for the leading key prefix.
+    // Identity read schema over the full row-binlog layout. The explicit TSO ordinal is the merge
+    // sequence column; _validate_merge_compare_contract() also checks the leading key prefix.
     reader._read_schema = std::make_shared<ReadSchema>(reader._tablet_schema->columns());
+    DORIS_CHECK(reader._read_schema
+                        ->init_row_binlog_column_mappings({{VAL_IDX, BEFORE_VAL_IDX}}, TSO_IDX,
+                                                          LSN_IDX, OP_IDX)
+                        .ok());
 
     // Mirror BlockReader::_init_collect_iter: init the collect iterator (force_merge=true,
     // as a MIN_DELTA stream does), add one child per rowset, then build the heap.
@@ -377,7 +383,7 @@ TEST_F(BlockReaderBinlogVCollectMergeTest, MinDeltaInterleavedKeysAcrossRowsets)
     EXPECT_EQ(out[0].val, 15); // most recent value for key 1
     EXPECT_EQ(out[1].key, 2);
     EXPECT_EQ(out[1].op, binlog::STREAM_CHANGE_DELETE);
-    EXPECT_EQ(out[1].val, 18); // delete uses the first op's __BEFORE__ value
+    EXPECT_EQ(out[1].val, 18); // delete uses the first op's __DORIS_BEFORE__ value
 }
 
 // DETAIL scan over the same two-rowset / same-key / different-TSO input emits every event

--- a/be/test/storage/iterator/block_reader_binlog_vcollect_merge_test.cpp
+++ b/be/test/storage/iterator/block_reader_binlog_vcollect_merge_test.cpp
@@ -75,7 +75,7 @@ namespace {
 // merge-heap key comparison and for MIN_DELTA group boundaries:
 //   0: key                  (Int64, the only key column)
 //   1: val                  (Int64, "after" value)
-//   2: __DORIS_BEFORE__val__ (Int64, "before" value mirror)
+//   2: __BEFORE__val__ (Int64, "before" value mirror)
 //   3: __DORIS_BINLOG_TSO__  (Int64, the merge sequence / order column)
 //   4: __DORIS_BINLOG_LSN__  (Int64)
 //   5: __DORIS_BINLOG_OP__   (Int64, ROW_BINLOG_APPEND/UPDATE/DELETE)
@@ -96,7 +96,7 @@ struct Row {
     int64_t op;
 };
 
-// Row-binlog read schema: single leading key column, a value column plus its __DORIS_BEFORE__
+// Row-binlog read schema: single leading key column, a value column plus its __BEFORE__
 // mirror, and the three binlog meta columns. Marking BINLOG_TSO_COL by name makes
 // TabletSchema::binlog_tso_col_idx() return its position, which Level1Iterator::init()
 // uses to pick the TSO as the merge sequence column.
@@ -383,7 +383,7 @@ TEST_F(BlockReaderBinlogVCollectMergeTest, MinDeltaInterleavedKeysAcrossRowsets)
     EXPECT_EQ(out[0].val, 15); // most recent value for key 1
     EXPECT_EQ(out[1].key, 2);
     EXPECT_EQ(out[1].op, binlog::STREAM_CHANGE_DELETE);
-    EXPECT_EQ(out[1].val, 18); // delete uses the first op's __DORIS_BEFORE__ value
+    EXPECT_EQ(out[1].val, 18); // delete uses the first op's __BEFORE__ value
 }
 
 // DETAIL scan over the same two-rowset / same-key / different-TSO input emits every event

--- a/be/test/storage/iterator/block_reader_change_next_block_test.cpp
+++ b/be/test/storage/iterator/block_reader_change_next_block_test.cpp
@@ -67,7 +67,7 @@ namespace {
 // row-binlog scan produces after merge:
 //   0: key         (Int64, the primary key used to group same-key rows)
 //   1: val         (Int64, the "after" value of a data column)
-//   2: __BEFORE__val__ (Int64, the "before" value mirror of `val`)
+//   2: __DORIS_BEFORE__val__ (Int64, the "before" value mirror of `val`)
 //   3: __DORIS_BINLOG_TSO__ (Int64)
 //   4: __DORIS_BINLOG_LSN__ (Int64)
 //   5: __DORIS_BINLOG_OP__  (Int64, one of ROW_BINLOG_APPEND/UPDATE/DELETE)
@@ -214,9 +214,9 @@ std::shared_ptr<Block> make_colliding_name_source_block(int64_t after_v, int64_t
     const std::vector<std::pair<std::string, int64_t>> values = {
             {"key", 1},
             {"v", after_v},
-            {"__BEFORE__v__", after_collision},
+            {"__DORIS_BEFORE__v__", after_collision},
             {binlog::build_before_column_name("v"), before_v},
-            {binlog::build_before_column_name("__BEFORE__v__"), before_collision},
+            {binlog::build_before_column_name("__DORIS_BEFORE__v__"), before_collision},
             {BINLOG_TSO_COL, 1},
             {BINLOG_LSN_COL, 1},
             {BINLOG_OP_COL, ROW_BINLOG_UPDATE},
@@ -337,9 +337,9 @@ private:
 };
 
 // Read schema mirroring the merged binlog block layout above.
-ReadSchemaSPtr make_read_schema(const std::vector<std::string>& names = {
-                                        "key", "val", binlog::build_before_column_name("val"),
-                                        BINLOG_TSO_COL, BINLOG_LSN_COL, BINLOG_OP_COL}) {
+ReadSchemaSPtr make_read_schema(const std::vector<std::string>& names,
+                                ReadSchema::RowBinlogValueColumnPairs value_pairs,
+                                int32_t tso_ordinal, int32_t lsn_ordinal, int32_t op_ordinal) {
     std::vector<TabletColumnPtr> cols;
     auto add_bigint = [&](const std::string& name) {
         auto col = std::make_shared<TabletColumn>();
@@ -350,7 +350,12 @@ ReadSchemaSPtr make_read_schema(const std::vector<std::string>& names = {
     for (const auto& name : names) {
         add_bigint(name);
     }
-    return std::make_shared<ReadSchema>(std::move(cols));
+    auto read_schema = std::make_shared<ReadSchema>(std::move(cols));
+    DORIS_CHECK(read_schema
+                        ->init_row_binlog_column_mappings(std::move(value_pairs), tso_ordinal,
+                                                          lsn_ordinal, op_ordinal)
+                        .ok());
+    return read_schema;
 }
 
 // Wire a BlockReader as if init() had already completed for a row-binlog change
@@ -360,8 +365,8 @@ void configure_reader(BlockReader& reader, std::shared_ptr<Block> source, size_t
     config::enable_adaptive_batch_size = false;
     reader._reader_context.batch_size = batch_size;
 
-    // The physical tablet schema supplies stable unique ids for AFTER/BEFORE pairing. The fake
-    // source block supplies the materialized types used by this read schema.
+    // The fake fixture layout is [key][current values][before values][TSO][LSN][OP]. Supply its
+    // relationships explicitly, as OlapScanner does before constructing BlockReader.
     reader._tablet_schema = std::move(schema);
     ASSERT_EQ(reader._tablet_schema->num_columns(), source->columns());
     std::vector<DataTypePtr> read_types;
@@ -371,7 +376,16 @@ void configure_reader(BlockReader& reader, std::shared_ptr<Block> source, size_t
     }
     auto read_schema =
             std::make_shared<ReadSchema>(reader._tablet_schema->columns(), std::move(read_types));
-    read_schema->init_row_binlog_column_mappings(*reader._tablet_schema);
+    const ColumnId value_count = cast_set<ColumnId>((source->columns() - 4) / 2);
+    ReadSchema::RowBinlogValueColumnPairs value_pairs;
+    for (ColumnId i = 0; i < value_count; ++i) {
+        value_pairs.emplace_back(1 + i, 1 + value_count + i);
+    }
+    DORIS_CHECK(read_schema
+                        ->init_row_binlog_column_mappings(std::move(value_pairs),
+                                                          1 + 2 * value_count, 2 + 2 * value_count,
+                                                          3 + 2 * value_count)
+                        .ok());
     reader._read_schema = std::move(read_schema);
 
     reader._next_row.block = source;
@@ -453,14 +467,16 @@ protected:
 };
 
 TEST_F(BlockReaderChangeNextBlockTest, BinlogSchemaWithoutBeforeUsesCurrentColumn) {
-    auto read_schema = make_read_schema({"key", "val", BINLOG_TSO_COL, BINLOG_OP_COL});
+    auto read_schema =
+            make_read_schema({"key", "val", BINLOG_TSO_COL, BINLOG_OP_COL}, {}, 2, -1, 3);
 
     EXPECT_EQ(VAL_IDX, read_schema->before_column_ordinal(VAL_IDX));
 }
 
 TEST_F(BlockReaderChangeNextBlockTest, BinlogSchemaDoesNotRequireLsn) {
     auto read_schema = make_read_schema(
-            {"key", "val", binlog::build_before_column_name("val"), BINLOG_TSO_COL, BINLOG_OP_COL});
+            {"key", "val", binlog::build_before_column_name("val"), BINLOG_TSO_COL, BINLOG_OP_COL},
+            {{1, 2}}, 3, -1, 4);
 
     EXPECT_EQ(-1, read_schema->lsn_ordinal());
     EXPECT_EQ(2, read_schema->before_column_ordinal(VAL_IDX));
@@ -512,7 +528,7 @@ TEST_F(BlockReaderChangeNextBlockTest, MinDeltaDelete) {
     ASSERT_EQ(out.size(), 1);
     EXPECT_EQ(out[0].op, binlog::STREAM_CHANGE_DELETE);
     EXPECT_EQ(out[0].key, 1);
-    // delete uses the first op's before value (val's __BEFORE__ mirror of row 0).
+    // delete uses the first op's before value (val's __DORIS_BEFORE__ mirror of row 0).
     EXPECT_EQ(out[0].val, 10);
 }
 
@@ -570,8 +586,9 @@ TEST_F(BlockReaderChangeNextBlockTest, MinDeltaAllNullBeforeImageIsRetained) {
 TEST_F(BlockReaderChangeNextBlockTest, MinDeltaNoOpWithCollidingBeforeNameIsSkipped) {
     auto source = make_colliding_name_source_block(/*after_v=*/10, /*after_collision=*/20,
                                                    /*before_v=*/10, /*before_collision=*/20);
-    auto schema = make_test_tablet_schema({{"v", FieldType::OLAP_FIELD_TYPE_BIGINT},
-                                           {"__BEFORE__v__", FieldType::OLAP_FIELD_TYPE_BIGINT}});
+    auto schema =
+            make_test_tablet_schema({{"v", FieldType::OLAP_FIELD_TYPE_BIGINT},
+                                     {"__DORIS_BEFORE__v__", FieldType::OLAP_FIELD_TYPE_BIGINT}});
     BlockReader reader;
     configure_reader(reader, source, 16, std::move(schema));
 
@@ -953,7 +970,7 @@ TEST_F(BlockReaderChangeNextBlockTest, DetailDelete) {
     ASSERT_EQ(out.size(), 1);
     EXPECT_EQ(out[0].op, binlog::STREAM_CHANGE_DELETE);
     EXPECT_EQ(out[0].key, 1);
-    EXPECT_EQ(out[0].val, 99); // delete uses __BEFORE__ mirror
+    EXPECT_EQ(out[0].val, 99); // delete uses __DORIS_BEFORE__ mirror
 }
 
 // UPDATE -> a BEFORE (before value) + AFTER (after value) pair.
@@ -975,8 +992,9 @@ TEST_F(BlockReaderChangeNextBlockTest, DetailUpdatePair) {
 TEST_F(BlockReaderChangeNextBlockTest, DetailUsesOrdinalBeforePairWhenNamesCollide) {
     auto source = make_colliding_name_source_block(/*after_v=*/11, /*after_collision=*/20,
                                                    /*before_v=*/10, /*before_collision=*/20);
-    auto schema = make_test_tablet_schema({{"v", FieldType::OLAP_FIELD_TYPE_BIGINT},
-                                           {"__BEFORE__v__", FieldType::OLAP_FIELD_TYPE_BIGINT}});
+    auto schema =
+            make_test_tablet_schema({{"v", FieldType::OLAP_FIELD_TYPE_BIGINT},
+                                     {"__DORIS_BEFORE__v__", FieldType::OLAP_FIELD_TYPE_BIGINT}});
     BlockReader reader;
     configure_reader(reader, source, 16, std::move(schema));
 

--- a/be/test/storage/iterator/block_reader_change_next_block_test.cpp
+++ b/be/test/storage/iterator/block_reader_change_next_block_test.cpp
@@ -67,7 +67,7 @@ namespace {
 // row-binlog scan produces after merge:
 //   0: key         (Int64, the primary key used to group same-key rows)
 //   1: val         (Int64, the "after" value of a data column)
-//   2: __DORIS_BEFORE__val__ (Int64, the "before" value mirror of `val`)
+//   2: __BEFORE__val__ (Int64, the "before" value mirror of `val`)
 //   3: __DORIS_BINLOG_TSO__ (Int64)
 //   4: __DORIS_BINLOG_LSN__ (Int64)
 //   5: __DORIS_BINLOG_OP__  (Int64, one of ROW_BINLOG_APPEND/UPDATE/DELETE)
@@ -214,9 +214,9 @@ std::shared_ptr<Block> make_colliding_name_source_block(int64_t after_v, int64_t
     const std::vector<std::pair<std::string, int64_t>> values = {
             {"key", 1},
             {"v", after_v},
-            {"__DORIS_BEFORE__v__", after_collision},
+            {"__BEFORE__v__", after_collision},
             {binlog::build_before_column_name("v"), before_v},
-            {binlog::build_before_column_name("__DORIS_BEFORE__v__"), before_collision},
+            {binlog::build_before_column_name("__BEFORE__v__"), before_collision},
             {BINLOG_TSO_COL, 1},
             {BINLOG_LSN_COL, 1},
             {BINLOG_OP_COL, ROW_BINLOG_UPDATE},
@@ -528,7 +528,7 @@ TEST_F(BlockReaderChangeNextBlockTest, MinDeltaDelete) {
     ASSERT_EQ(out.size(), 1);
     EXPECT_EQ(out[0].op, binlog::STREAM_CHANGE_DELETE);
     EXPECT_EQ(out[0].key, 1);
-    // delete uses the first op's before value (val's __DORIS_BEFORE__ mirror of row 0).
+    // delete uses the first op's before value (val's __BEFORE__ mirror of row 0).
     EXPECT_EQ(out[0].val, 10);
 }
 
@@ -586,9 +586,8 @@ TEST_F(BlockReaderChangeNextBlockTest, MinDeltaAllNullBeforeImageIsRetained) {
 TEST_F(BlockReaderChangeNextBlockTest, MinDeltaNoOpWithCollidingBeforeNameIsSkipped) {
     auto source = make_colliding_name_source_block(/*after_v=*/10, /*after_collision=*/20,
                                                    /*before_v=*/10, /*before_collision=*/20);
-    auto schema =
-            make_test_tablet_schema({{"v", FieldType::OLAP_FIELD_TYPE_BIGINT},
-                                     {"__DORIS_BEFORE__v__", FieldType::OLAP_FIELD_TYPE_BIGINT}});
+    auto schema = make_test_tablet_schema({{"v", FieldType::OLAP_FIELD_TYPE_BIGINT},
+                                           {"__BEFORE__v__", FieldType::OLAP_FIELD_TYPE_BIGINT}});
     BlockReader reader;
     configure_reader(reader, source, 16, std::move(schema));
 
@@ -970,7 +969,7 @@ TEST_F(BlockReaderChangeNextBlockTest, DetailDelete) {
     ASSERT_EQ(out.size(), 1);
     EXPECT_EQ(out[0].op, binlog::STREAM_CHANGE_DELETE);
     EXPECT_EQ(out[0].key, 1);
-    EXPECT_EQ(out[0].val, 99); // delete uses __DORIS_BEFORE__ mirror
+    EXPECT_EQ(out[0].val, 99); // delete uses __BEFORE__ mirror
 }
 
 // UPDATE -> a BEFORE (before value) + AFTER (after value) pair.
@@ -992,9 +991,8 @@ TEST_F(BlockReaderChangeNextBlockTest, DetailUpdatePair) {
 TEST_F(BlockReaderChangeNextBlockTest, DetailUsesOrdinalBeforePairWhenNamesCollide) {
     auto source = make_colliding_name_source_block(/*after_v=*/11, /*after_collision=*/20,
                                                    /*before_v=*/10, /*before_collision=*/20);
-    auto schema =
-            make_test_tablet_schema({{"v", FieldType::OLAP_FIELD_TYPE_BIGINT},
-                                     {"__DORIS_BEFORE__v__", FieldType::OLAP_FIELD_TYPE_BIGINT}});
+    auto schema = make_test_tablet_schema({{"v", FieldType::OLAP_FIELD_TYPE_BIGINT},
+                                           {"__BEFORE__v__", FieldType::OLAP_FIELD_TYPE_BIGINT}});
     BlockReader reader;
     configure_reader(reader, source, 16, std::move(schema));
 

--- a/be/test/storage/mow/key_probe_test.cpp
+++ b/be/test/storage/mow/key_probe_test.cpp
@@ -311,7 +311,7 @@ TEST_F(KeyProbeTest, DeleteSignTakesDefaultsOnlyWithoutSequenceColumn) {
 }
 
 // The row binlog retriever keeps the old values of a delete-signed row so it can emit the
-// __BEFORE__ image: use_defaults_for_delete_signed off flips that same case.
+// __DORIS_BEFORE__ image: use_defaults_for_delete_signed off flips that same case.
 TEST_F(KeyProbeTest, DeleteSignReadsHistoryWhenDefaultsForDeleteSignedIsOff) {
     auto schema = create_mow_schema(/*has_seq=*/false);
     TabletSharedPtr tablet;
@@ -348,7 +348,7 @@ TEST_F(KeyProbeTest, MarkNoneLeavesTheDeleteBitmapAlone) {
     PartialUpdateStats stats;
     // through the factory the row binlog retriever calls, so its MarkDeleted::NONE is pinned here
     auto probe = MowKeyProbe::for_row_binlog(tablet.get(), schema.get(), schema->has_sequence_col(),
-                                             mow, /*write_before=*/true);
+                                             mow, /*need_historical_value=*/true);
 
     // a replaced row ...
     auto found = probe.probe(encode_key_with_seq(schema, encoder, 1, 20), /*segment_pos=*/0,

--- a/be/test/storage/mow/key_probe_test.cpp
+++ b/be/test/storage/mow/key_probe_test.cpp
@@ -311,7 +311,7 @@ TEST_F(KeyProbeTest, DeleteSignTakesDefaultsOnlyWithoutSequenceColumn) {
 }
 
 // The row binlog retriever keeps the old values of a delete-signed row so it can emit the
-// __DORIS_BEFORE__ image: use_defaults_for_delete_signed off flips that same case.
+// __BEFORE__ image: use_defaults_for_delete_signed off flips that same case.
 TEST_F(KeyProbeTest, DeleteSignReadsHistoryWhenDefaultsForDeleteSignedIsOff) {
     auto schema = create_mow_schema(/*has_seq=*/false);
     TabletSharedPtr tablet;

--- a/be/test/storage/mow/mow_transform_test_base.h
+++ b/be/test/storage/mow/mow_transform_test_base.h
@@ -504,6 +504,8 @@ protected:
             c->set_is_key(is_key);
             c->set_length(type == "TINYINT" ? 1 : 4);
             c->set_index_length(type == "TINYINT" ? 1 : 4);
+            c->set_precision(0);
+            c->set_frac(0);
             c->set_is_nullable(nullable);
             c->set_aggregation("NONE");
             c->set_visible(visible);

--- a/be/test/storage/pb_convert_test.cpp
+++ b/be/test/storage/pb_convert_test.cpp
@@ -201,17 +201,26 @@ TEST(PbConvert, ensure_all_fields_converted_correctly) {
     // rowset meta
     RowsetMetaPB rs;
     set_all_fields_to_default(&rs);
+    auto* rs_mapping = rs.mutable_row_binlog_column_mappings()->mutable_entries(0);
+    rs_mapping->set_source_column_unique_id(1);
+    rs_mapping->set_current_column_unique_id(10);
+    rs_mapping->set_before_column_unique_id(11);
     auto rowset_meta_set_fields = get_set_fields(rs);
     EXPECT_EQ(rowset_meta_set_fields.size(), RowsetMetaPB::GetDescriptor()->field_count()) << print(rowset_meta_set_fields);
 
     RowsetMetaCloudPB rs_cloud;
     set_all_fields_to_default(&rs_cloud);
+    auto* rs_cloud_mapping = rs_cloud.mutable_row_binlog_column_mappings()->mutable_entries(0);
+    rs_cloud_mapping->set_source_column_unique_id(2);
+    rs_cloud_mapping->set_current_column_unique_id(20);
     auto rowset_meta_cloud_set_fields = get_set_fields(rs_cloud);
     EXPECT_EQ(rowset_meta_cloud_set_fields.size(), RowsetMetaCloudPB::GetDescriptor()->field_count()) << print(rowset_meta_cloud_set_fields);
     EXPECT_EQ(rowset_meta_set_fields.size(), rowset_meta_cloud_set_fields.size());
 
     RowsetMetaCloudPB rowset_meta_cloud_out;
     doris_rowset_meta_to_cloud(&rowset_meta_cloud_out, rs);
+    EXPECT_EQ(rowset_meta_cloud_out.row_binlog_column_mappings().SerializeAsString(),
+              rs.row_binlog_column_mappings().SerializeAsString());
     auto rowset_meta_cloud_out_set_fields = get_set_fields(rowset_meta_cloud_out);
     EXPECT_EQ(rowset_meta_set_fields.size(), rowset_meta_cloud_out_set_fields.size())
         << "doris_rowset_meta_to_cloud() missing output fields,"
@@ -221,6 +230,8 @@ TEST(PbConvert, ensure_all_fields_converted_correctly) {
 
     RowsetMetaPB rowset_meta_out;
     cloud_rowset_meta_to_doris(&rowset_meta_out, rs_cloud);
+    EXPECT_EQ(rowset_meta_out.row_binlog_column_mappings().SerializeAsString(),
+              rs_cloud.row_binlog_column_mappings().SerializeAsString());
     auto rowset_meta_out_set_fields = get_set_fields(rowset_meta_out);
     EXPECT_EQ(rowset_meta_cloud_set_fields.size(), rowset_meta_out_set_fields.size())
         << "cloud_rowset_meta_to_doris() missing output fields,"

--- a/be/test/storage/pb_convert_test.cpp
+++ b/be/test/storage/pb_convert_test.cpp
@@ -188,6 +188,8 @@ auto set_diff = [](auto a, auto b) {
 // ensure that PBs need to be converted have identical fields, so that they can
 // be inter-converted
 TEST(PbConvert, ensure_identical_fields) {
+    EXPECT_EQ(RowsetMetaPB::GetDescriptor()->FindFieldByName("row_binlog_column_mappings"), nullptr);
+    EXPECT_EQ(RowsetMetaCloudPB::GetDescriptor()->FindFieldByName("row_binlog_column_mappings"), nullptr);
     EXPECT_EQ(RowsetMetaPB::GetDescriptor()->field_count(), RowsetMetaCloudPB::GetDescriptor()->field_count());
     EXPECT_EQ(TabletSchemaPB::GetDescriptor()->field_count(), TabletSchemaCloudPB::GetDescriptor()->field_count());
     EXPECT_EQ(TabletMetaPB::GetDescriptor()->field_count(), TabletMetaCloudPB::GetDescriptor()->field_count());
@@ -201,26 +203,17 @@ TEST(PbConvert, ensure_all_fields_converted_correctly) {
     // rowset meta
     RowsetMetaPB rs;
     set_all_fields_to_default(&rs);
-    auto* rs_mapping = rs.mutable_row_binlog_column_mappings()->mutable_entries(0);
-    rs_mapping->set_source_column_unique_id(1);
-    rs_mapping->set_current_column_unique_id(10);
-    rs_mapping->set_before_column_unique_id(11);
     auto rowset_meta_set_fields = get_set_fields(rs);
     EXPECT_EQ(rowset_meta_set_fields.size(), RowsetMetaPB::GetDescriptor()->field_count()) << print(rowset_meta_set_fields);
 
     RowsetMetaCloudPB rs_cloud;
     set_all_fields_to_default(&rs_cloud);
-    auto* rs_cloud_mapping = rs_cloud.mutable_row_binlog_column_mappings()->mutable_entries(0);
-    rs_cloud_mapping->set_source_column_unique_id(2);
-    rs_cloud_mapping->set_current_column_unique_id(20);
     auto rowset_meta_cloud_set_fields = get_set_fields(rs_cloud);
     EXPECT_EQ(rowset_meta_cloud_set_fields.size(), RowsetMetaCloudPB::GetDescriptor()->field_count()) << print(rowset_meta_cloud_set_fields);
     EXPECT_EQ(rowset_meta_set_fields.size(), rowset_meta_cloud_set_fields.size());
 
     RowsetMetaCloudPB rowset_meta_cloud_out;
     doris_rowset_meta_to_cloud(&rowset_meta_cloud_out, rs);
-    EXPECT_EQ(rowset_meta_cloud_out.row_binlog_column_mappings().SerializeAsString(),
-              rs.row_binlog_column_mappings().SerializeAsString());
     auto rowset_meta_cloud_out_set_fields = get_set_fields(rowset_meta_cloud_out);
     EXPECT_EQ(rowset_meta_set_fields.size(), rowset_meta_cloud_out_set_fields.size())
         << "doris_rowset_meta_to_cloud() missing output fields,"
@@ -230,8 +223,6 @@ TEST(PbConvert, ensure_all_fields_converted_correctly) {
 
     RowsetMetaPB rowset_meta_out;
     cloud_rowset_meta_to_doris(&rowset_meta_out, rs_cloud);
-    EXPECT_EQ(rowset_meta_out.row_binlog_column_mappings().SerializeAsString(),
-              rs_cloud.row_binlog_column_mappings().SerializeAsString());
     auto rowset_meta_out_set_fields = get_set_fields(rowset_meta_out);
     EXPECT_EQ(rowset_meta_cloud_set_fields.size(), rowset_meta_out_set_fields.size())
         << "cloud_rowset_meta_to_doris() missing output fields,"

--- a/be/test/storage/read_schema_test.cpp
+++ b/be/test/storage/read_schema_test.cpp
@@ -26,7 +26,6 @@
 #include "core/block/block.h"
 #include "core/data_type/data_type_number.h"
 #include "core/data_type/data_type_struct.h"
-#include "storage/binlog.h"
 #include "storage/schema.h"
 
 namespace doris {
@@ -53,20 +52,6 @@ TabletColumnPtr create_struct_column(int32_t unique_id) {
     column->add_sub_column(*first_child);
     column->add_sub_column(*second_child);
     return column;
-}
-
-TabletSchemaSPtr create_row_binlog_schema_with_colliding_names() {
-    auto schema = std::make_shared<TabletSchema>();
-    schema->append_column(*create_int_column(10, "key", true));
-    schema->append_column(*create_int_column(11, "v"));
-    schema->append_column(*create_int_column(12, "__BEFORE__v__"));
-    schema->append_column(*create_int_column(13, binlog::build_before_column_name("v")));
-    schema->append_column(
-            *create_int_column(14, binlog::build_before_column_name("__BEFORE__v__")));
-    schema->append_column(*create_int_column(15, BINLOG_TSO_COL));
-    schema->append_column(*create_int_column(16, BINLOG_LSN_COL));
-    schema->append_column(*create_int_column(17, BINLOG_OP_COL));
-    return schema;
 }
 
 TEST(ReadSchemaTest, DefaultColumnsAreVisible) {
@@ -140,41 +125,68 @@ TEST(ReadSchemaTest, AppendedDroppedColumnDoesNotExtendReadBlock) {
     EXPECT_EQ(2, read_schema.create_read_block().columns());
 }
 
-TEST(ReadSchemaTest, RowBinlogMappingsUsePhysicalSchemaOrdinals) {
-    auto tablet_schema = create_row_binlog_schema_with_colliding_names();
-    // Reorder the two AFTER values and their BEFORE companions to verify that ReadSchema stores
-    // dense read ordinals resolved by unique id, rather than physical tablet column ids or names.
-    ReadSchema read_schema(project_columns_by_ordinal(
-            tablet_schema->columns(), std::vector<ColumnId> {0, 2, 1, 4, 3, 5, 6, 7}));
+TEST(ReadSchemaTest, RowBinlogMappingsUseExplicitReadOrdinals) {
+    // Names and layout deliberately carry no row-binlog meaning. The supplied read ordinals are
+    // the only source of truth for current/before and special-column relationships.
+    ReadSchema read_schema({create_int_column(10, "key", true), create_int_column(11, "first"),
+                            create_int_column(12, "second"), create_int_column(13, "third"),
+                            create_int_column(14, "fourth"), create_int_column(15, "fifth"),
+                            create_int_column(16, "sixth")});
 
-    read_schema.init_row_binlog_column_mappings(*tablet_schema);
+    ASSERT_TRUE(read_schema.init_row_binlog_column_mappings({{4, 1}, {5, 6}}, 3, -1, 2).ok());
 
     EXPECT_TRUE(read_schema.row_binlog_value_pairs_complete());
     EXPECT_EQ(read_schema.row_binlog_value_column_pairs(),
-              (ReadSchema::RowBinlogValueColumnPairs {{2, 4}, {1, 3}}));
-    EXPECT_EQ(4, read_schema.before_column_ordinal(2));
-    EXPECT_EQ(3, read_schema.before_column_ordinal(1));
-    for (ColumnId ordinal : {0, 3, 4, 5, 6, 7}) {
+              (ReadSchema::RowBinlogValueColumnPairs {{4, 1}, {5, 6}}));
+    EXPECT_EQ(1, read_schema.before_column_ordinal(4));
+    EXPECT_EQ(6, read_schema.before_column_ordinal(5));
+    for (ColumnId ordinal : {0, 1, 2, 3, 6}) {
         EXPECT_EQ(ordinal, read_schema.before_column_ordinal(ordinal));
     }
+    EXPECT_EQ(3, read_schema.tso_ordinal());
+    EXPECT_EQ(-1, read_schema.lsn_ordinal());
+    EXPECT_EQ(2, read_schema.op_ordinal());
 }
 
-TEST(ReadSchemaTest, MalformedRowBinlogLayoutKeepsConservativeNameMapping) {
-    TabletSchema tablet_schema;
-    tablet_schema.append_column(*create_int_column(10, "key", true));
-    tablet_schema.append_column(*create_int_column(11, "v"));
-    tablet_schema.append_column(*create_int_column(12, binlog::build_before_column_name("v")));
-    tablet_schema.append_column(*create_int_column(13, "orphan"));
-    tablet_schema.append_column(*create_int_column(14, BINLOG_TSO_COL));
-    tablet_schema.append_column(*create_int_column(15, BINLOG_LSN_COL));
-    tablet_schema.append_column(*create_int_column(16, BINLOG_OP_COL));
-    ReadSchema read_schema(tablet_schema.columns());
+TEST(ReadSchemaTest, RowBinlogMappingReportsIncompleteProjection) {
+    ReadSchema read_schema({create_int_column(10, "key", true), create_int_column(11, "current"),
+                            create_int_column(12, "unpaired"), create_int_column(13, "tso"),
+                            create_int_column(14, "op")});
 
-    read_schema.init_row_binlog_column_mappings(tablet_schema);
+    ASSERT_TRUE(read_schema.init_row_binlog_column_mappings({}, 3, -1, 4).ok());
 
     EXPECT_FALSE(read_schema.row_binlog_value_pairs_complete());
     EXPECT_TRUE(read_schema.row_binlog_value_column_pairs().empty());
-    EXPECT_EQ(2, read_schema.before_column_ordinal(1));
+    EXPECT_EQ(1, read_schema.before_column_ordinal(1));
+}
+
+TEST(ReadSchemaTest, RowBinlogMappingRejectsInvalidOrdinals) {
+    const std::vector<TabletColumnPtr> columns {
+            create_int_column(10, "key", true), create_int_column(11, "before"),
+            create_int_column(12, "op"),        create_int_column(13, "tso"),
+            create_int_column(14, "current"),   create_int_column(15, "other")};
+    const std::vector<ReadSchema::RowBinlogValueColumnPairs> invalid_pairs {
+            {{6, 1}}, {{4, 4}}, {{4, 1}, {4, 5}}, {{4, 1}, {5, 1}}, {{4, 2}}, {{0, 1}}};
+
+    for (const auto& pairs : invalid_pairs) {
+        ReadSchema read_schema(columns);
+        EXPECT_TRUE(read_schema.init_row_binlog_column_mappings(pairs, 3, -1, 2)
+                            .is<ErrorCode::INVALID_ARGUMENT>());
+    }
+
+    ReadSchema read_schema(columns);
+    EXPECT_TRUE(read_schema.init_row_binlog_column_mappings({{4, 1}}, 3, -1, 3)
+                        .is<ErrorCode::INVALID_ARGUMENT>());
+    EXPECT_TRUE(read_schema.init_row_binlog_column_mappings({{4, 1}}, 0, -1, 2)
+                        .is<ErrorCode::INVALID_ARGUMENT>());
+    EXPECT_TRUE(read_schema.init_row_binlog_column_mappings({{4, 1}}, 6, -1, 2)
+                        .is<ErrorCode::INVALID_ARGUMENT>());
+
+    auto mismatched_columns = columns;
+    mismatched_columns[1] = create_struct_column(11);
+    ReadSchema mismatched_read_schema(std::move(mismatched_columns));
+    EXPECT_TRUE(mismatched_read_schema.init_row_binlog_column_mappings({{4, 1}}, 3, -1, 2)
+                        .is<ErrorCode::INVALID_ARGUMENT>());
 }
 
 } // namespace

--- a/be/test/storage/read_schema_test.cpp
+++ b/be/test/storage/read_schema_test.cpp
@@ -148,6 +148,22 @@ TEST(ReadSchemaTest, RowBinlogMappingsUseExplicitReadOrdinals) {
     EXPECT_EQ(2, read_schema.op_ordinal());
 }
 
+TEST(ReadSchemaTest, RowBinlogSpecialOrdinalsUseTabletColumnUids) {
+    TabletSchema tablet_schema;
+    tablet_schema.append_column(*create_int_column(10, "key", true));
+    tablet_schema.append_column(*create_int_column(11, BINLOG_TSO_COL));
+    tablet_schema.append_column(*create_int_column(12, BINLOG_LSN_COL));
+    tablet_schema.append_column(*create_int_column(13, BINLOG_OP_COL));
+
+    ReadSchema read_schema(
+            project_columns_by_ordinal(tablet_schema.columns(), std::vector<ColumnId> {3, 0, 1}));
+
+    ASSERT_TRUE(read_schema.init_row_binlog_column_mappings({}, tablet_schema).ok());
+    EXPECT_EQ(2, read_schema.tso_ordinal());
+    EXPECT_EQ(-1, read_schema.lsn_ordinal());
+    EXPECT_EQ(0, read_schema.op_ordinal());
+}
+
 TEST(ReadSchemaTest, RowBinlogMappingReportsIncompleteProjection) {
     ReadSchema read_schema({create_int_column(10, "key", true), create_int_column(11, "current"),
                             create_int_column(12, "unpaired"), create_int_column(13, "tso"),

--- a/be/test/storage/rowset/rowset_meta_test.cpp
+++ b/be/test/storage/rowset/rowset_meta_test.cpp
@@ -190,6 +190,41 @@ TEST_F(RowsetMetaTest, LegacyEmbeddedSchemaInvertedIndexFormatIsFallback) {
               rowset_meta.tablet_schema()->get_inverted_index_storage_format());
 }
 
+TEST_F(RowsetMetaTest, RowBinlogColumnMappings) {
+    RowsetMeta rowset_meta;
+    EXPECT_TRUE(rowset_meta.init_from_json(_json_rowset_meta));
+    EXPECT_FALSE(rowset_meta.has_row_binlog_column_mappings());
+
+    rowset_meta.mutable_row_binlog_column_mappings();
+    EXPECT_TRUE(rowset_meta.has_row_binlog_column_mappings());
+    EXPECT_EQ(rowset_meta.row_binlog_column_mappings().entries_size(), 0);
+
+    std::string serialized;
+    ASSERT_TRUE(rowset_meta.serialize(&serialized));
+    RowsetMeta restored;
+    ASSERT_TRUE(restored.init(serialized));
+    EXPECT_TRUE(restored.has_row_binlog_column_mappings());
+    EXPECT_EQ(restored.row_binlog_column_mappings().entries_size(), 0);
+
+    auto* mapping = restored.mutable_row_binlog_column_mappings()->add_entries();
+    mapping->set_source_column_unique_id(1);
+    mapping->set_current_column_unique_id(10);
+    mapping->set_before_column_unique_id(11);
+
+    ASSERT_TRUE(restored.serialize(&serialized));
+    RowsetMeta restored_with_mapping;
+    ASSERT_TRUE(restored_with_mapping.init(serialized));
+    ASSERT_TRUE(restored_with_mapping.has_row_binlog_column_mappings());
+    ASSERT_EQ(restored_with_mapping.row_binlog_column_mappings().entries_size(), 1);
+    const auto& restored_mapping = restored_with_mapping.row_binlog_column_mappings().entries(0);
+    EXPECT_EQ(restored_mapping.source_column_unique_id(), 1);
+    EXPECT_EQ(restored_mapping.current_column_unique_id(), 10);
+    EXPECT_EQ(restored_mapping.before_column_unique_id(), 11);
+
+    restored_with_mapping.clear_row_binlog_column_mappings();
+    EXPECT_FALSE(restored_with_mapping.has_row_binlog_column_mappings());
+}
+
 TEST_F(RowsetMetaTest, TestInitWithInvalidData) {
     RowsetMeta rowset_meta;
     EXPECT_FALSE(rowset_meta.init_from_json("invalid json meta data"));

--- a/be/test/storage/rowset/rowset_meta_test.cpp
+++ b/be/test/storage/rowset/rowset_meta_test.cpp
@@ -190,41 +190,6 @@ TEST_F(RowsetMetaTest, LegacyEmbeddedSchemaInvertedIndexFormatIsFallback) {
               rowset_meta.tablet_schema()->get_inverted_index_storage_format());
 }
 
-TEST_F(RowsetMetaTest, RowBinlogColumnMappings) {
-    RowsetMeta rowset_meta;
-    EXPECT_TRUE(rowset_meta.init_from_json(_json_rowset_meta));
-    EXPECT_FALSE(rowset_meta.has_row_binlog_column_mappings());
-
-    rowset_meta.mutable_row_binlog_column_mappings();
-    EXPECT_TRUE(rowset_meta.has_row_binlog_column_mappings());
-    EXPECT_EQ(rowset_meta.row_binlog_column_mappings().entries_size(), 0);
-
-    std::string serialized;
-    ASSERT_TRUE(rowset_meta.serialize(&serialized));
-    RowsetMeta restored;
-    ASSERT_TRUE(restored.init(serialized));
-    EXPECT_TRUE(restored.has_row_binlog_column_mappings());
-    EXPECT_EQ(restored.row_binlog_column_mappings().entries_size(), 0);
-
-    auto* mapping = restored.mutable_row_binlog_column_mappings()->add_entries();
-    mapping->set_source_column_unique_id(1);
-    mapping->set_current_column_unique_id(10);
-    mapping->set_before_column_unique_id(11);
-
-    ASSERT_TRUE(restored.serialize(&serialized));
-    RowsetMeta restored_with_mapping;
-    ASSERT_TRUE(restored_with_mapping.init(serialized));
-    ASSERT_TRUE(restored_with_mapping.has_row_binlog_column_mappings());
-    ASSERT_EQ(restored_with_mapping.row_binlog_column_mappings().entries_size(), 1);
-    const auto& restored_mapping = restored_with_mapping.row_binlog_column_mappings().entries(0);
-    EXPECT_EQ(restored_mapping.source_column_unique_id(), 1);
-    EXPECT_EQ(restored_mapping.current_column_unique_id(), 10);
-    EXPECT_EQ(restored_mapping.before_column_unique_id(), 11);
-
-    restored_with_mapping.clear_row_binlog_column_mappings();
-    EXPECT_FALSE(restored_with_mapping.has_row_binlog_column_mappings());
-}
-
 TEST_F(RowsetMetaTest, TestInitWithInvalidData) {
     RowsetMeta rowset_meta;
     EXPECT_FALSE(rowset_meta.init_from_json("invalid json meta data"));

--- a/be/test/storage/rowset/segment_flusher_format_test.cpp
+++ b/be/test/storage/rowset/segment_flusher_format_test.cpp
@@ -37,6 +37,7 @@
 #include <map>
 #include <memory>
 #include <numeric>
+#include <optional>
 #include <roaring/roaring.hh>
 #include <set>
 #include <string>
@@ -91,6 +92,8 @@
 #include "storage/tablet/tablet_manager.h"
 #include "storage/tablet/tablet_meta.h"
 #include "storage/tablet/tablet_schema.h"
+#include "storage/tablet_info.h"
+#include "storage/transform/row_binlog_derive.h"
 #include "storage/utils.h"
 #include "testutil/creators.h"
 #include "testutil/variant_util.h"
@@ -2487,14 +2490,14 @@ Status verify_row_binlog_before_segment(const TabletSharedPtr& tablet, uint32_t 
                 Field::create_field<TYPE_BIGINT>(static_cast<Int64>(operation))));
         if (row_id < 2) {
             RETURN_IF_ERROR(verify_segment_field(
-                    block, "__BEFORE__v1__", row_id,
+                    block, "__DORIS_BEFORE__v1__", row_id,
                     Field::create_field<TYPE_INT>(static_cast<Int32>(3000 + key))));
             RETURN_IF_ERROR(verify_segment_field(
-                    block, "__BEFORE__v2__", row_id,
+                    block, "__DORIS_BEFORE__v2__", row_id,
                     Field::create_field<TYPE_BIGINT>(static_cast<Int64>(4000 + key))));
         } else {
-            RETURN_IF_ERROR(verify_segment_field(block, "__BEFORE__v1__", row_id, Field {}));
-            RETURN_IF_ERROR(verify_segment_field(block, "__BEFORE__v2__", row_id, Field {}));
+            RETURN_IF_ERROR(verify_segment_field(block, "__DORIS_BEFORE__v1__", row_id, Field {}));
+            RETURN_IF_ERROR(verify_segment_field(block, "__DORIS_BEFORE__v2__", row_id, Field {}));
         }
     }
     return Status::OK();
@@ -3173,11 +3176,11 @@ protected:
                                  kRowBinlogSystemColumnCount;
         if (include_before_columns) {
             auto before_v1 = find_binlog_column("v1");
-            before_v1.__set_column_name("__BEFORE__v1__");
+            before_v1.__set_column_name("__DORIS_BEFORE__v1__");
             before_v1.__set_is_key(false);
             before_v1.__set_is_allow_null(true);
             auto before_v2 = find_binlog_column("v2");
-            before_v2.__set_column_name("__BEFORE__v2__");
+            before_v2.__set_column_name("__DORIS_BEFORE__v2__");
             before_v2.__set_is_key(false);
             before_v2.__set_is_allow_null(true);
             binlog_request.tablet_schema.columns.insert(
@@ -3349,7 +3352,6 @@ protected:
         }
         context.write_binlog_opt().enable = true;
         context.allocated_lsn_map = std::make_shared<segment_v2::SegmentAllocatedLsnMap>();
-        context.write_binlog_opt().set_need_before(need_before);
         auto& options = context.write_binlog_opt().write_binlog_config();
         options.source.tablet_schema = source_tablet->tablet_schema();
         options.source.base_tablet = source_tablet;
@@ -3357,6 +3359,31 @@ protected:
         options.source.mow_context = std::move(source_mow_context);
         options.source.is_transient_rowset_writer = source_is_transient;
         options.source.source_write_type = DataWriteType::TYPE_DIRECT;
+        std::vector<RowBinlogColumnUidMapping> uid_mappings;
+        for (ColumnId source_cid = 0; source_cid < options.source.tablet_schema->num_columns();
+             ++source_cid) {
+            const auto& source_column = options.source.tablet_schema->column(source_cid);
+            if (!source_column.visible() && !source_column.is_key()) {
+                continue;
+            }
+            const int32_t current_cid = context.tablet_schema->field_index(source_column.name());
+            ASSERT_GE(current_cid, 0);
+            std::optional<int32_t> before_uid;
+            if (need_before && source_column.visible() && !source_column.is_key()) {
+                const int32_t before_cid = context.tablet_schema->field_index(
+                        binlog::build_before_column_name(source_column.name()));
+                ASSERT_GE(before_cid, 0);
+                before_uid = context.tablet_schema->column(before_cid).unique_id();
+            }
+            uid_mappings.push_back({source_column.unique_id(),
+                                    context.tablet_schema->column(current_cid).unique_id(),
+                                    before_uid});
+        }
+        auto mappings = segment_v2::resolve_row_binlog_column_mappings(
+                *options.source.tablet_schema, *context.tablet_schema, uid_mappings);
+        ASSERT_TRUE(mappings.has_value()) << mappings.error();
+        options.need_historical_value = need_before;
+        options.column_mappings = std::move(*mappings);
         for (int64_t segment_id = 0; segment_id < 2; ++segment_id) {
             auto lsn_ids = std::make_shared<std::vector<int64_t>>();
             for (int64_t row = 0; row < rows_per_segment; ++row) {

--- a/be/test/storage/rowset/segment_flusher_format_test.cpp
+++ b/be/test/storage/rowset/segment_flusher_format_test.cpp
@@ -2490,14 +2490,14 @@ Status verify_row_binlog_before_segment(const TabletSharedPtr& tablet, uint32_t 
                 Field::create_field<TYPE_BIGINT>(static_cast<Int64>(operation))));
         if (row_id < 2) {
             RETURN_IF_ERROR(verify_segment_field(
-                    block, "__DORIS_BEFORE__v1__", row_id,
+                    block, "__BEFORE__v1__", row_id,
                     Field::create_field<TYPE_INT>(static_cast<Int32>(3000 + key))));
             RETURN_IF_ERROR(verify_segment_field(
-                    block, "__DORIS_BEFORE__v2__", row_id,
+                    block, "__BEFORE__v2__", row_id,
                     Field::create_field<TYPE_BIGINT>(static_cast<Int64>(4000 + key))));
         } else {
-            RETURN_IF_ERROR(verify_segment_field(block, "__DORIS_BEFORE__v1__", row_id, Field {}));
-            RETURN_IF_ERROR(verify_segment_field(block, "__DORIS_BEFORE__v2__", row_id, Field {}));
+            RETURN_IF_ERROR(verify_segment_field(block, "__BEFORE__v1__", row_id, Field {}));
+            RETURN_IF_ERROR(verify_segment_field(block, "__BEFORE__v2__", row_id, Field {}));
         }
     }
     return Status::OK();
@@ -3176,11 +3176,11 @@ protected:
                                  kRowBinlogSystemColumnCount;
         if (include_before_columns) {
             auto before_v1 = find_binlog_column("v1");
-            before_v1.__set_column_name("__DORIS_BEFORE__v1__");
+            before_v1.__set_column_name("__BEFORE__v1__");
             before_v1.__set_is_key(false);
             before_v1.__set_is_allow_null(true);
             auto before_v2 = find_binlog_column("v2");
-            before_v2.__set_column_name("__DORIS_BEFORE__v2__");
+            before_v2.__set_column_name("__BEFORE__v2__");
             before_v2.__set_is_key(false);
             before_v2.__set_is_allow_null(true);
             binlog_request.tablet_schema.columns.insert(

--- a/be/test/storage/segment/historical_row_retriever_test.cpp
+++ b/be/test/storage/segment/historical_row_retriever_test.cpp
@@ -90,7 +90,10 @@ protected:
         ctx->partial_update_info = info;
         ctx->write_type = DataWriteType::TYPE_DIRECT;
         ctx->write_binlog_opt().enable = true;
-        ctx->write_binlog_opt().set_need_before(need_before);
+        ctx->write_binlog_opt().write_binlog_config().need_historical_value = need_before;
+        if (need_before) {
+            ctx->write_binlog_opt().write_binlog_config().column_mappings = {{0, 0, 1}};
+        }
     }
 
     // A block holding the key column and the sequence column, in that order.
@@ -151,7 +154,7 @@ TEST_F(HistoricalRowRetrieverTest, UpdateReadsHistoryAndAppendTakesDefault) {
 }
 
 // A delete-signed row: without the BEFORE image there is nothing to read back, with it the old row
-// must still be fetched so __BEFORE__* can be filled.
+// must still be fetched so __DORIS_BEFORE__* can be filled.
 TEST_F(HistoricalRowRetrieverTest, DeleteReadsHistoryOnlyWhenBeforeImageIsWanted) {
     for (bool need_before : {false, true}) {
         auto schema = create_mow_schema(/*has_seq=*/false);

--- a/be/test/storage/segment/historical_row_retriever_test.cpp
+++ b/be/test/storage/segment/historical_row_retriever_test.cpp
@@ -154,7 +154,7 @@ TEST_F(HistoricalRowRetrieverTest, UpdateReadsHistoryAndAppendTakesDefault) {
 }
 
 // A delete-signed row: without the BEFORE image there is nothing to read back, with it the old row
-// must still be fetched so __DORIS_BEFORE__* can be filled.
+// must still be fetched so __BEFORE__* can be filled.
 TEST_F(HistoricalRowRetrieverTest, DeleteReadsHistoryOnlyWhenBeforeImageIsWanted) {
     for (bool need_before : {false, true}) {
         auto schema = create_mow_schema(/*has_seq=*/false);

--- a/be/test/storage/tablet/tablet_schema_cache_test.cpp
+++ b/be/test/storage/tablet/tablet_schema_cache_test.cpp
@@ -122,4 +122,77 @@ TEST(TabletSchemaCacheTest, InsertAndLookupLoadSchema) {
     TabletSchemaCache::instance()->release(cached.first);
 }
 
+TEST(TabletSchemaCacheTest, RowBinlogColumnMappingsRoundTrip) {
+    POlapTableSchemaParam pschema;
+    pschema.set_db_id(10);
+    pschema.set_table_id(20);
+    pschema.set_version(3);
+    auto* pindex = pschema.add_indexes();
+    pindex->set_id(100);
+    pindex->set_schema_hash(200);
+    pindex->set_row_binlog_id(101);
+    auto* mappings = pindex->mutable_row_binlog_column_mappings();
+    mappings->set_need_historical_value(true);
+    auto* mapping = mappings->add_entries();
+    mapping->set_source_column_unique_id(1);
+    mapping->set_current_column_unique_id(11);
+    mapping->set_before_column_unique_id(12);
+
+    OlapTableSchemaParam param;
+    ASSERT_TRUE(param.init(pschema).ok());
+    ASSERT_EQ(1, param.indexes().size());
+    EXPECT_TRUE(param.indexes()[0]->row_binlog_need_historical_value);
+    ASSERT_EQ(1, param.indexes()[0]->row_binlog_column_mappings.size());
+    const auto& internal_mapping = param.indexes()[0]->row_binlog_column_mappings[0];
+    EXPECT_EQ(1, internal_mapping.source_uid);
+    EXPECT_EQ(11, internal_mapping.current_uid);
+    ASSERT_TRUE(internal_mapping.before_uid.has_value());
+    EXPECT_EQ(12, *internal_mapping.before_uid);
+
+    POlapTableSchemaParam round_trip;
+    param.to_protobuf(&round_trip);
+    ASSERT_EQ(1, round_trip.indexes_size());
+    ASSERT_TRUE(round_trip.indexes(0).has_row_binlog_column_mappings());
+    const auto& round_trip_mappings = round_trip.indexes(0).row_binlog_column_mappings();
+    ASSERT_TRUE(round_trip_mappings.has_need_historical_value());
+    EXPECT_TRUE(round_trip_mappings.need_historical_value());
+    ASSERT_EQ(1, round_trip_mappings.entries_size());
+    const auto& round_trip_mapping = round_trip_mappings.entries(0);
+    EXPECT_EQ(1, round_trip_mapping.source_column_unique_id());
+    EXPECT_EQ(11, round_trip_mapping.current_column_unique_id());
+    ASSERT_TRUE(round_trip_mapping.has_before_column_unique_id());
+    EXPECT_EQ(12, round_trip_mapping.before_column_unique_id());
+}
+
+TEST(TabletSchemaCacheTest, RejectsMissingRowBinlogHistoricalValueFlag) {
+    POlapTableSchemaParam pschema;
+    pschema.set_db_id(10);
+    pschema.set_table_id(20);
+    pschema.set_version(3);
+    auto* pindex = pschema.add_indexes();
+    pindex->set_id(100);
+    pindex->set_schema_hash(200);
+    pindex->set_row_binlog_id(101);
+    auto* mapping = pindex->mutable_row_binlog_column_mappings()->add_entries();
+    mapping->set_source_column_unique_id(1);
+    mapping->set_current_column_unique_id(11);
+
+    OlapTableSchemaParam param;
+    EXPECT_FALSE(param.init(pschema).ok());
+}
+
+TEST(TabletSchemaCacheTest, RejectsMissingRowBinlogColumnMappings) {
+    POlapTableSchemaParam pschema;
+    pschema.set_db_id(10);
+    pschema.set_table_id(20);
+    pschema.set_version(3);
+    auto* pindex = pschema.add_indexes();
+    pindex->set_id(100);
+    pindex->set_schema_hash(200);
+    pindex->set_row_binlog_id(101);
+
+    OlapTableSchemaParam param;
+    EXPECT_FALSE(param.init(pschema).ok());
+}
+
 } // namespace doris

--- a/be/test/storage/transform/row_binlog_derive_test.cpp
+++ b/be/test/storage/transform/row_binlog_derive_test.cpp
@@ -34,6 +34,8 @@
 //
 // Oracle values are ported from the deleted RowBinlogSegmentWriter.
 
+#include "storage/transform/row_binlog_derive.h"
+
 #include <gtest/gtest.h>
 
 #include <string>
@@ -47,6 +49,7 @@
 #include "storage/binlog.h"
 #include "storage/mow/mow_transform_test_base.h"
 #include "storage/partial_update_info.h"
+#include "storage/tablet_info.h"
 #include "storage/transform/block_transform.h"
 
 namespace doris {
@@ -56,6 +59,46 @@ using segment_v2::TransformExecContext;
 
 class RowBinlogDeriveTest : public MowTransformTestBase {
 protected:
+    struct TestColumn {
+        int32_t uid;
+        std::string name;
+        std::string type;
+        bool is_key = false;
+        bool visible = true;
+        bool nullable = false;
+    };
+
+    static TabletSchemaSPtr create_test_schema(const std::vector<TestColumn>& columns,
+                                               int32_t tso_cid = -1, int32_t lsn_cid = -1,
+                                               int32_t op_cid = -1) {
+        TabletSchemaPB pb;
+        pb.set_keys_type(DUP_KEYS);
+        pb.set_num_short_key_columns(1);
+        pb.set_num_rows_per_row_block(1024);
+        pb.set_compress_kind(COMPRESS_LZ4);
+        pb.set_next_column_unique_id(1000);
+        for (const auto& column : columns) {
+            auto* pb_column = pb.add_column();
+            pb_column->set_unique_id(column.uid);
+            pb_column->set_name(column.name);
+            pb_column->set_type(column.type);
+            pb_column->set_is_key(column.is_key);
+            const int32_t length = column.type == "BIGINT" ? 8 : 4;
+            pb_column->set_length(length);
+            pb_column->set_index_length(length);
+            pb_column->set_is_nullable(column.nullable);
+            pb_column->set_aggregation("NONE");
+            pb_column->set_visible(column.visible);
+        }
+        pb.set_binlog_tso_col_idx(tso_cid);
+        pb.set_binlog_lsn_col_idx(lsn_cid);
+        pb.set_binlog_op_col_idx(op_cid);
+
+        auto schema = std::make_shared<TabletSchema>();
+        schema->init_from_pb(pb);
+        return schema;
+    }
+
     // Reads a (nullable) BIGINT op cell from the binlog block.
     static int64_t read_op(const Block& block, int col_pos, size_t row) {
         const IColumn* col = block.get_by_position(col_pos).column.get();
@@ -74,15 +117,14 @@ protected:
         return assert_cast<const ColumnInt64&>(*col).get_data()[row];
     }
 
-    // A row-binlog DUP schema WITH __BEFORE__* mirror columns for the binlog
+    // A row-binlog DUP schema WITH __DORIS_BEFORE__* mirror columns for the binlog
     // source `create_binlog_pu_source_schema()` (k1 key, v1, v2, hidden
-    // delete_sign). Layout matches resolve_binlog_context's before_col_start =
-    // normal_col_start + normal_col_num: the visible source columns first, then
-    // one BEFORE column per visible value column, then TSO/LSN/OP.
-    //   [k1(0), v1(1), v2(2), __BEFORE__v1__(3), __BEFORE__v2__(4),
+    // delete_sign). The visible source columns come first, followed by one BEFORE
+    // column per visible value column, then TSO/LSN/OP.
+    //   [k1(0), v1(1), v2(2), __DORIS_BEFORE__v1__(3), __DORIS_BEFORE__v2__(4),
     //    __DORIS_BINLOG_TSO__(5), __DORIS_BINLOG_LSN__(6), __DORIS_BINLOG_OP__(7)]
     // The fixture's create_binlog_tablet builds a binlog schema with no BEFORE
-    // columns, so this variant is defined locally for the write_before=true path.
+    // columns, so this variant is defined locally for explicit BEFORE mappings.
     TabletSchemaSPtr create_binlog_before_schema() {
         TabletSchemaPB pb;
         pb.set_keys_type(DUP_KEYS); // row binlog is written as a DUP block
@@ -108,6 +150,8 @@ protected:
             }
             c->set_length(len);
             c->set_index_length(len);
+            c->set_precision(0);
+            c->set_frac(0);
             c->set_is_nullable(nullable);
             c->set_aggregation("NONE");
         };
@@ -115,13 +159,13 @@ protected:
         add_col(1, "v1", "INT", false, true);
         add_col(2, "v2", "INT", false, true);
         // BEFORE mirror columns -- always nullable (NULL when no historical row).
-        add_col(3, "__BEFORE__v1__", "INT", false, true);
-        add_col(4, "__BEFORE__v2__", "INT", false, true);
+        add_col(3, "__DORIS_BEFORE__v1__", "INT", false, true);
+        add_col(4, "__DORIS_BEFORE__v2__", "INT", false, true);
         add_col(5, BINLOG_TSO_COL, "BIGINT", false, true);
         add_col(6, BINLOG_LSN_COL, "BIGINT", false, false);
         add_col(7, BINLOG_OP_COL, "BIGINT", false, false);
         // init_from_pb reads this straight from the PB (it is not inferred from
-        // the column name). [k1,v1,v2,__BEFORE__v1__,__BEFORE__v2__,TSO,LSN,OP]
+        // the column name). [k1,v1,v2,__DORIS_BEFORE__v1__,__DORIS_BEFORE__v2__,TSO,LSN,OP]
         pb.set_binlog_tso_col_idx(5);
         pb.set_binlog_lsn_col_idx(6);
         pb.set_binlog_op_col_idx(7);
@@ -131,7 +175,7 @@ protected:
         return schema;
     }
 
-    // A row-binlog DUP schema with __BEFORE__* columns for a key-only source
+    // A row-binlog DUP schema with __DORIS_BEFORE__* columns for a key-only source
     // (k1 key, hidden delete_sign, 0 visible value columns) -- the BEFORE no-op
     // case. Layout: [k1(0), TSO(1), LSN(2), OP(3)]; no BEFORE column is emitted
     // because num_visible_value_columns()==0.
@@ -316,7 +360,181 @@ protected:
         rwc.allocated_lsn_map = std::make_shared<segment_v2::SegmentAllocatedLsnMap>();
         rwc.insert_segment_allocated_lsns(0, make_seg_lsn(num_rows));
     }
+
+    void set_test_column_mappings(RowsetWriterContext& rwc, bool need_historical_value) {
+        auto& cfg = rwc.write_binlog_opt().write_binlog_config();
+        cfg.need_historical_value = need_historical_value;
+        std::vector<RowBinlogColumnUidMapping> uid_mappings;
+        for (ColumnId source_cid = 0; source_cid < cfg.source.tablet_schema->num_columns();
+             ++source_cid) {
+            const auto& source_column = cfg.source.tablet_schema->column(source_cid);
+            if (!source_column.visible() && !source_column.is_key()) {
+                continue;
+            }
+            const int32_t current_cid = rwc.tablet_schema->field_index(source_column.name());
+            ASSERT_GE(current_cid, 0);
+            std::optional<int32_t> before_uid;
+            if (need_historical_value && source_column.visible() && !source_column.is_key()) {
+                const int32_t before_cid = rwc.tablet_schema->field_index(
+                        binlog::build_before_column_name(source_column.name()));
+                ASSERT_GE(before_cid, 0);
+                before_uid = rwc.tablet_schema->column(before_cid).unique_id();
+            }
+            uid_mappings.push_back({source_column.unique_id(),
+                                    rwc.tablet_schema->column(current_cid).unique_id(),
+                                    before_uid});
+        }
+        auto result = segment_v2::resolve_row_binlog_column_mappings(
+                *cfg.source.tablet_schema, *rwc.tablet_schema, uid_mappings);
+        ASSERT_TRUE(result.has_value()) << result.error();
+        cfg.column_mappings = std::move(*result);
+    }
 };
+
+TEST_F(RowBinlogDeriveTest, ResolvesExplicitUidMappings) {
+    auto source_schema = create_test_schema({
+            {10, "key", "INT", true},
+            {11, "value_1", "INT", false, true, false},
+            {12, "hidden", "INT", false, false, true},
+            {13, "value_2", "INT", false, true, true},
+    });
+    auto target_schema = create_test_schema(
+            {
+                    {103, "before_1", "INT", false, true, true},
+                    {100, "current_key", "INT", true},
+                    {200, "tso", "BIGINT", false, true, true},
+                    {101, "current_1", "INT", false, true, true},
+                    {201, "lsn", "BIGINT"},
+                    {102, "current_2", "INT", false, true, true},
+                    {202, "op", "BIGINT"},
+            },
+            2, 4, 6);
+    const std::vector<RowBinlogColumnUidMapping> uid_mappings {
+            {10, 100, std::nullopt}, {11, 101, 103}, {13, 102, std::nullopt}};
+
+    auto result = segment_v2::resolve_row_binlog_column_mappings(*source_schema, *target_schema,
+                                                                 uid_mappings);
+    ASSERT_TRUE(result.has_value()) << result.error();
+    EXPECT_EQ(*result, (std::vector<segment_v2::RowBinlogColumnCidMapping> {
+                               {0, 1, std::nullopt}, {1, 3, 0}, {3, 5, std::nullopt}}));
+}
+
+TEST_F(RowBinlogDeriveTest, RejectsInvalidUidMappings) {
+    auto source_schema = create_test_schema({
+            {10, "key", "INT", true},
+            {11, "value_1", "INT", false, true, false},
+            {12, "hidden", "INT", false, false, true},
+            {13, "value_2", "INT", false, true, true},
+    });
+    auto target_schema = create_test_schema(
+            {
+                    {103, "before_1", "INT", false, true, true},
+                    {100, "current_key", "INT", true},
+                    {200, "tso", "BIGINT", false, true, true},
+                    {101, "current_1", "INT", false, true, true},
+                    {201, "lsn", "BIGINT"},
+                    {102, "current_2", "INT", false, true, true},
+                    {202, "op", "BIGINT"},
+            },
+            2, 4, 6);
+    const std::vector<std::vector<RowBinlogColumnUidMapping>> invalid_mappings {
+            {{999, 100, std::nullopt}, {11, 101, 103}, {13, 102, std::nullopt}},
+            {{10, 999, std::nullopt}, {11, 101, 103}, {13, 102, std::nullopt}},
+            {{10, 100, std::nullopt}, {11, 101, 999}, {13, 102, std::nullopt}},
+            {{10, 100, std::nullopt}, {10, 101, 103}, {13, 102, std::nullopt}},
+            {{10, 100, std::nullopt}, {11, 100, 103}, {13, 102, std::nullopt}},
+            {{10, 100, std::nullopt}, {11, 101, 103}, {13, 102, 103}},
+            {{10, 100, std::nullopt}, {11, 101, 103}},
+            {{10, 200, std::nullopt}, {11, 101, 103}, {13, 102, std::nullopt}},
+            {{10, 100, std::nullopt}, {11, 101, 100}, {13, 102, std::nullopt}},
+            {{10, 101, std::nullopt}, {11, 100, 103}, {13, 102, std::nullopt}},
+    };
+
+    for (const auto& mappings : invalid_mappings) {
+        auto result = segment_v2::resolve_row_binlog_column_mappings(*source_schema, *target_schema,
+                                                                     mappings);
+        EXPECT_FALSE(result.has_value());
+    }
+
+    auto target_with_extra = create_test_schema(
+            {
+                    {103, "before_1", "INT", false, true, true},
+                    {100, "current_key", "INT", true},
+                    {200, "tso", "BIGINT", false, true, true},
+                    {101, "current_1", "INT", false, true, true},
+                    {201, "lsn", "BIGINT"},
+                    {102, "current_2", "INT", false, true, true},
+                    {104, "unmapped", "INT", false, true, true},
+                    {202, "op", "BIGINT"},
+            },
+            2, 4, 7);
+    EXPECT_FALSE(segment_v2::resolve_row_binlog_column_mappings(
+                         *source_schema, *target_with_extra,
+                         {{10, 100, std::nullopt}, {11, 101, 103}, {13, 102, std::nullopt}})
+                         .has_value());
+
+    auto target_with_bad_type = create_test_schema(
+            {
+                    {103, "before_1", "INT", false, true, true},
+                    {100, "current_key", "INT", true},
+                    {200, "tso", "BIGINT", false, true, true},
+                    {101, "current_1", "BIGINT", false, true, true},
+                    {201, "lsn", "BIGINT"},
+                    {102, "current_2", "INT", false, true, true},
+                    {202, "op", "BIGINT"},
+            },
+            2, 4, 6);
+    EXPECT_FALSE(segment_v2::resolve_row_binlog_column_mappings(
+                         *source_schema, *target_with_bad_type,
+                         {{10, 100, std::nullopt}, {11, 101, 103}, {13, 102, std::nullopt}})
+                         .has_value());
+}
+
+TEST_F(RowBinlogDeriveTest, PlainUsesExplicitInterleavedTargetCids) {
+    auto source_schema = create_test_schema(
+            {{10, "key", "INT", true}, {11, "value_1", "INT"}, {12, "value_2", "INT"}});
+    auto target_schema = create_test_schema(
+            {
+                    {200, "tso", "BIGINT", false, true, true},
+                    {102, "current_2", "INT", false, true, true},
+                    {201, "lsn", "BIGINT"},
+                    {100, "current_key", "INT", true},
+                    {202, "op", "BIGINT"},
+                    {101, "current_1", "INT", false, true, true},
+            },
+            0, 2, 4);
+
+    RowsetWriterContext rwc;
+    rwc.tablet_schema = target_schema;
+    rwc.write_type = DataWriteType::TYPE_DIRECT;
+    rwc.write_binlog_opt().enable = true;
+    auto& cfg = rwc.write_binlog_opt().write_binlog_config();
+    cfg.source.tablet_schema = source_schema;
+    cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
+    cfg.column_mappings = *segment_v2::resolve_row_binlog_column_mappings(
+            *source_schema, *target_schema,
+            {{10, 100, std::nullopt}, {11, 101, std::nullopt}, {12, 102, std::nullopt}});
+    register_segment_lsns(rwc, 1);
+
+    Block block = source_schema->create_storage_block();
+    {
+        auto guard = block.mutate_columns_scoped();
+        auto& columns = guard.mutable_columns();
+        int32_t values[] = {7, 70, 700};
+        for (size_t cid = 0; cid < 3; ++cid) {
+            columns[cid]->insert_data(reinterpret_cast<const char*>(&values[cid]), sizeof(int32_t));
+        }
+    }
+
+    auto chain = build_transform_chain(rwc);
+    TransformExecContext ctx = exec_ctx(target_schema, &rwc);
+    ASSERT_TRUE(chain.apply(ctx, &block).ok());
+    EXPECT_EQ(read_int(block, 3, 0), 7);
+    EXPECT_EQ(read_int(block, 5, 0), 70);
+    EXPECT_EQ(read_int(block, 1, 0), 700);
+    EXPECT_EQ(read_lsn(block, 2, 0), 1000);
+    EXPECT_EQ(read_op(block, 4, 0), ROW_BINLOG_APPEND);
+}
 
 // ===========================================================================
 // §5.2 Plain derive (no probe): op comes only from the row's own delete sign.
@@ -341,7 +559,7 @@ TEST_F(RowBinlogDeriveTest, PlainAppendAndDeleteWithAfterAndLsn) {
     cfg.source.tablet_schema = source_schema;
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
-    cfg.write_before = false; // no PU, no BEFORE -> plain derive
+    set_test_column_mappings(rwc, false);
     register_segment_lsns(rwc, 2);
 
     auto chain = build_transform_chain(rwc);
@@ -407,7 +625,7 @@ TEST_F(RowBinlogDeriveTest, PlainNoDeleteSignColumnAllAppend) {
     cfg.source.tablet_schema = source_schema;
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
-    cfg.write_before = false;
+    set_test_column_mappings(rwc, false);
     register_segment_lsns(rwc, 2);
 
     auto chain = build_transform_chain(rwc);
@@ -499,6 +717,7 @@ TEST_F(RowBinlogDeriveTest, PlainMapsHiddenKeysAndSkipsHiddenNonKeys) {
     cfg.source.tablet_schema = source_schema;
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
+    set_test_column_mappings(rwc, false);
     register_segment_lsns(rwc, 2);
 
     Block block = source_schema->create_storage_block();
@@ -585,7 +804,7 @@ TEST_F(RowBinlogDeriveTest, MowUpdateAndAppendTakesHistoryV2) {
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
     cfg.source.mow_context = mow;
-    cfg.write_before = false;
+    set_test_column_mappings(rwc, false);
     register_segment_lsns(rwc, 2);
 
     auto chain = build_transform_chain(rwc);
@@ -729,7 +948,7 @@ TEST_F(RowBinlogDeriveTest, MowHiddenKeyColumnIsPartOfTheProbeKey) {
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
     cfg.source.mow_context = mow;
-    cfg.write_before = false;
+    set_test_column_mappings(rwc, false);
     register_segment_lsns(rwc, 1);
 
     auto chain = build_transform_chain(rwc);
@@ -771,7 +990,7 @@ TEST_F(RowBinlogDeriveTest, MowHiddenKeyColumnIsPartOfTheProbeKey) {
 // BEFORE is read first, then the op is revised from the old delete signs.
 TEST_F(RowBinlogDeriveTest, MowPartialUpdateWithBeforeImage) {
     auto source_schema = create_binlog_pu_source_schema(); // k1,v1,v2,delete_sign(hidden)
-    auto binlog_schema = create_binlog_before_schema();    // + __BEFORE__v1__/v2__ + TSO/LSN/OP
+    auto binlog_schema = create_binlog_before_schema(); // + __DORIS_BEFORE__v1__/v2__ + TSO/LSN/OP
 
     // history: key 1 -> (v1=100, v2=777); key 99 does not exist
     TabletSharedPtr probe_tablet;
@@ -807,7 +1026,7 @@ TEST_F(RowBinlogDeriveTest, MowPartialUpdateWithBeforeImage) {
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
     cfg.source.mow_context = mow;
-    cfg.write_before = true;
+    set_test_column_mappings(rwc, true);
     register_segment_lsns(rwc, 2);
 
     auto chain = build_transform_chain(rwc);
@@ -900,7 +1119,7 @@ TEST_F(RowBinlogDeriveTest, MowInsertAfterDeletedHistoryRowIsAppend) {
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
     cfg.source.mow_context = mow;
-    cfg.write_before = false;
+    set_test_column_mappings(rwc, false);
     register_segment_lsns(rwc, 2);
 
     auto chain = build_transform_chain(rwc);
@@ -986,7 +1205,7 @@ TEST_F(RowBinlogDeriveTest, MowLooksUpHistoryInBaseTabletNotBinlogTablet) {
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
     cfg.source.mow_context = mow;
-    cfg.write_before = false;
+    set_test_column_mappings(rwc, false);
     register_segment_lsns(rwc, 1);
 
     auto chain = build_transform_chain(rwc);
@@ -1060,7 +1279,7 @@ TEST_F(RowBinlogDeriveTest, MowDeleteExistingAndNewKey) {
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
     cfg.source.mow_context = mow;
-    cfg.write_before = false;
+    set_test_column_mappings(rwc, false);
     register_segment_lsns(rwc, 2);
 
     auto chain = build_transform_chain(rwc);
@@ -1097,15 +1316,15 @@ TEST_F(RowBinlogDeriveTest, MowDeleteExistingAndNewKey) {
 }
 
 // ===========================================================================
-// §5.3.3 / §5.3.4 BEFORE image (write_before=true). Previously 0 coverage.
+// §5.3.3 / §5.3.4 BEFORE image. Previously 0 coverage.
 // ===========================================================================
 
 // B19/B21: UPDATE & DELETE rows mirror the historical value columns into the
-// __BEFORE__* columns; the APPEND row (no history) has BEFORE == NULL. BEFORE
+// __DORIS_BEFORE__* columns; the APPEND row (no history) has BEFORE == NULL. BEFORE
 // covers value columns only (not the key, not delete_sign).
 TEST_F(RowBinlogDeriveTest, MowBeforeImageMirrorsHistory) {
     auto source_schema = create_binlog_pu_source_schema(); // k1,v1,v2,delete_sign(3 hidden)
-    auto binlog_schema = create_binlog_before_schema();    // + __BEFORE__v1__/v2__ + TSO/LSN/OP
+    auto binlog_schema = create_binlog_before_schema(); // + __DORIS_BEFORE__v1__/v2__ + TSO/LSN/OP
     ASSERT_EQ(binlog_schema->binlog_lsn_col_idx(), 6);
     ASSERT_EQ(binlog_schema->num_columns(), 8U);
 
@@ -1138,12 +1357,12 @@ TEST_F(RowBinlogDeriveTest, MowBeforeImageMirrorsHistory) {
     auto& cfg = rwc.write_binlog_opt().write_binlog_config();
     cfg.source.tablet_schema = source_schema;
     cfg.source.base_tablet = probe_tablet;
-    // write_before=true alone (no PU) routes to the MoW derive; the source block
+    // Explicit BEFORE mappings alone (no PU) route to the MoW derive; the source block
     // is a full-width upsert, no partial_update_info.
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
     cfg.source.mow_context = mow;
-    cfg.write_before = true;
+    set_test_column_mappings(rwc, true);
     register_segment_lsns(rwc, 3);
 
     // setup_retriever_and_lookup requires partial_update_info on the retriever
@@ -1156,7 +1375,7 @@ TEST_F(RowBinlogDeriveTest, MowBeforeImageMirrorsHistory) {
                         .ok());
     cfg.source.partial_update_info = pui;
 
-    auto chain = build_transform_chain(rwc); // write_before -> MoW derive
+    auto chain = build_transform_chain(rwc); // BEFORE mappings -> MoW derive
     EXPECT_EQ(chain.stage_names(), (std::vector<std::string_view> {"MowRowBinlogDerive"}));
 
     TransformExecContext ctx = exec_ctx(binlog_schema, &rwc);
@@ -1209,7 +1428,7 @@ TEST_F(RowBinlogDeriveTest, MowBeforeImageMirrorsHistory) {
     EXPECT_EQ(read_int(block, before_v1, 0), 100);
     EXPECT_EQ(read_int(block, before_v2, 0), 0);
     // BEFORE of DELETE row 1 == history (v1=300, v2=400) -- delete rows still
-    // read history when write_before=true (skip_delete_sign is off)
+    // read history when BEFORE mappings are present (skip_delete_sign is off)
     EXPECT_FALSE(read_is_null(block, before_v1, 1));
     EXPECT_FALSE(read_is_null(block, before_v2, 1));
     EXPECT_EQ(read_int(block, before_v1, 1), 300);
@@ -1225,7 +1444,7 @@ TEST_F(RowBinlogDeriveTest, MowBeforeImageMirrorsHistory) {
 }
 
 // B20: BEFORE no-op -- a key-only source (0 visible value columns) emits no
-// BEFORE column even with write_before=true; fill_before_columns returns early.
+// BEFORE column even when historical values are requested; fill_before_columns returns early.
 TEST_F(RowBinlogDeriveTest, MowBeforeNoopZeroValueColumns) {
     auto source_schema = create_binlog_keyonly_source_schema(); // k1, delete_sign(hidden)
     auto binlog_schema = create_binlog_keyonly_before_schema(); // [k1, TSO, LSN, OP]
@@ -1265,7 +1484,7 @@ TEST_F(RowBinlogDeriveTest, MowBeforeNoopZeroValueColumns) {
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
     cfg.source.mow_context = mow;
-    cfg.write_before = true;
+    set_test_column_mappings(rwc, true);
     register_segment_lsns(rwc, 2);
 
     auto chain = build_transform_chain(rwc);
@@ -1353,7 +1572,7 @@ TEST_F(RowBinlogDeriveTest, MowSeqSourceSeqLosesStillReadsHistory) {
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
     cfg.source.mow_context = mow;
-    cfg.write_before = false;
+    set_test_column_mappings(rwc, false);
     register_segment_lsns(rwc, 2);
 
     auto chain = build_transform_chain(rwc);
@@ -1436,7 +1655,7 @@ TEST_F(RowBinlogDeriveTest, MowMaterializesFlexiblePartialUpdate) {
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
     cfg.source.mow_context = mow;
-    cfg.write_before = false;
+    set_test_column_mappings(rwc, false);
     register_segment_lsns(rwc, 1);
 
     auto chain = build_transform_chain(rwc);
@@ -1498,7 +1717,7 @@ TEST_F(RowBinlogDeriveTest, MowFixedPartialUpdateRejectsBadWidth) {
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
     cfg.source.mow_context = mow;
-    cfg.write_before = false;
+    set_test_column_mappings(rwc, false);
 
     auto chain = build_transform_chain(rwc);
     EXPECT_EQ(chain.stage_names(), (std::vector<std::string_view> {"MowRowBinlogDerive"}));
@@ -1553,7 +1772,6 @@ TEST_F(RowBinlogDeriveTest, RejectsMissingSourceSchema) {
     cfg.source.tablet_schema = nullptr; // missing source schema
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
-    cfg.write_before = false;
     register_segment_lsns(rwc, 1);
 
     auto chain = build_transform_chain(rwc); // no PU, no BEFORE -> plain derive
@@ -1590,7 +1808,7 @@ TEST_F(RowBinlogDeriveTest, RejectsNegativeSegmentId) {
     cfg.source.tablet_schema = source_schema;
     cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
     cfg.source.is_transient_rowset_writer = false;
-    cfg.write_before = false;
+    set_test_column_mappings(rwc, false);
     register_segment_lsns(rwc, 1);
 
     auto chain = build_transform_chain(rwc);
@@ -1607,43 +1825,6 @@ TEST_F(RowBinlogDeriveTest, RejectsNegativeSegmentId) {
     auto st = chain.apply(ctx, &block);
     EXPECT_FALSE(st.ok());
     EXPECT_NE(st.to_string().find("flush_single_block"), std::string::npos) << st;
-}
-
-// The schema and write_before have to agree about the BEFORE columns. Both
-// directions are rejected: a schema without BEFORE columns while write_before is
-// on would fill over the TSO/LSN columns, and one with them while write_before is
-// off would leave those columns empty in an otherwise full block.
-TEST_F(RowBinlogDeriveTest, RejectsSchemaAndWriteBeforeDisagreement) {
-    auto tablets = create_binlog_tablets(/*tablet_id=*/8901, TKeysType::DUP_KEYS, /*mow=*/false);
-    auto binlog_schema = tablets.binlog->tablet_schema(); // no BEFORE columns
-    auto source_schema = create_binlog_pu_source_schema();
-
-    RowsetWriterContext rwc;
-    rwc.tablet = tablets.binlog;
-    rwc.tablet_schema = binlog_schema;
-    rwc.write_type = DataWriteType::TYPE_DIRECT;
-    rwc.write_binlog_opt().enable = true;
-    auto& cfg = rwc.write_binlog_opt().write_binlog_config();
-    cfg.source.tablet_schema = source_schema;
-    cfg.source.base_tablet = tablets.source;
-    cfg.source.source_write_type = DataWriteType::TYPE_DIRECT;
-    cfg.source.is_transient_rowset_writer = false;
-    cfg.source.mow_context = make_mow_context(100, {});
-    cfg.write_before = true; // the schema has no BEFORE columns
-    register_segment_lsns(rwc, 1);
-
-    auto chain = build_transform_chain(rwc);
-    TransformExecContext ctx = exec_ctx(binlog_schema, &rwc);
-    ctx.tablet = tablets.binlog;
-    ctx.mow_context = cfg.source.mow_context;
-
-    Block block = source_schema->create_storage_block();
-    for (size_t cid = 0; cid < source_schema->num_columns(); ++cid) {
-        block.get_by_position(cid).column->assert_mutable()->insert_default();
-    }
-    auto st = chain.apply(ctx, &block);
-    EXPECT_FALSE(st.ok());
-    EXPECT_NE(st.to_string().find("does not match the derived block"), std::string::npos) << st;
 }
 
 } // namespace doris

--- a/be/test/storage/transform/row_binlog_derive_test.cpp
+++ b/be/test/storage/transform/row_binlog_derive_test.cpp
@@ -117,11 +117,11 @@ protected:
         return assert_cast<const ColumnInt64&>(*col).get_data()[row];
     }
 
-    // A row-binlog DUP schema WITH __DORIS_BEFORE__* mirror columns for the binlog
+    // A row-binlog DUP schema WITH __BEFORE__* mirror columns for the binlog
     // source `create_binlog_pu_source_schema()` (k1 key, v1, v2, hidden
     // delete_sign). The visible source columns come first, followed by one BEFORE
     // column per visible value column, then TSO/LSN/OP.
-    //   [k1(0), v1(1), v2(2), __DORIS_BEFORE__v1__(3), __DORIS_BEFORE__v2__(4),
+    //   [k1(0), v1(1), v2(2), __BEFORE__v1__(3), __BEFORE__v2__(4),
     //    __DORIS_BINLOG_TSO__(5), __DORIS_BINLOG_LSN__(6), __DORIS_BINLOG_OP__(7)]
     // The fixture's create_binlog_tablet builds a binlog schema with no BEFORE
     // columns, so this variant is defined locally for explicit BEFORE mappings.
@@ -159,13 +159,13 @@ protected:
         add_col(1, "v1", "INT", false, true);
         add_col(2, "v2", "INT", false, true);
         // BEFORE mirror columns -- always nullable (NULL when no historical row).
-        add_col(3, "__DORIS_BEFORE__v1__", "INT", false, true);
-        add_col(4, "__DORIS_BEFORE__v2__", "INT", false, true);
+        add_col(3, "__BEFORE__v1__", "INT", false, true);
+        add_col(4, "__BEFORE__v2__", "INT", false, true);
         add_col(5, BINLOG_TSO_COL, "BIGINT", false, true);
         add_col(6, BINLOG_LSN_COL, "BIGINT", false, false);
         add_col(7, BINLOG_OP_COL, "BIGINT", false, false);
         // init_from_pb reads this straight from the PB (it is not inferred from
-        // the column name). [k1,v1,v2,__DORIS_BEFORE__v1__,__DORIS_BEFORE__v2__,TSO,LSN,OP]
+        // the column name). [k1,v1,v2,__BEFORE__v1__,__BEFORE__v2__,TSO,LSN,OP]
         pb.set_binlog_tso_col_idx(5);
         pb.set_binlog_lsn_col_idx(6);
         pb.set_binlog_op_col_idx(7);
@@ -175,7 +175,7 @@ protected:
         return schema;
     }
 
-    // A row-binlog DUP schema with __DORIS_BEFORE__* columns for a key-only source
+    // A row-binlog DUP schema with __BEFORE__* columns for a key-only source
     // (k1 key, hidden delete_sign, 0 visible value columns) -- the BEFORE no-op
     // case. Layout: [k1(0), TSO(1), LSN(2), OP(3)]; no BEFORE column is emitted
     // because num_visible_value_columns()==0.
@@ -990,7 +990,7 @@ TEST_F(RowBinlogDeriveTest, MowHiddenKeyColumnIsPartOfTheProbeKey) {
 // BEFORE is read first, then the op is revised from the old delete signs.
 TEST_F(RowBinlogDeriveTest, MowPartialUpdateWithBeforeImage) {
     auto source_schema = create_binlog_pu_source_schema(); // k1,v1,v2,delete_sign(hidden)
-    auto binlog_schema = create_binlog_before_schema(); // + __DORIS_BEFORE__v1__/v2__ + TSO/LSN/OP
+    auto binlog_schema = create_binlog_before_schema();    // + __BEFORE__v1__/v2__ + TSO/LSN/OP
 
     // history: key 1 -> (v1=100, v2=777); key 99 does not exist
     TabletSharedPtr probe_tablet;
@@ -1320,11 +1320,11 @@ TEST_F(RowBinlogDeriveTest, MowDeleteExistingAndNewKey) {
 // ===========================================================================
 
 // B19/B21: UPDATE & DELETE rows mirror the historical value columns into the
-// __DORIS_BEFORE__* columns; the APPEND row (no history) has BEFORE == NULL. BEFORE
+// __BEFORE__* columns; the APPEND row (no history) has BEFORE == NULL. BEFORE
 // covers value columns only (not the key, not delete_sign).
 TEST_F(RowBinlogDeriveTest, MowBeforeImageMirrorsHistory) {
     auto source_schema = create_binlog_pu_source_schema(); // k1,v1,v2,delete_sign(3 hidden)
-    auto binlog_schema = create_binlog_before_schema(); // + __DORIS_BEFORE__v1__/v2__ + TSO/LSN/OP
+    auto binlog_schema = create_binlog_before_schema();    // + __BEFORE__v1__/v2__ + TSO/LSN/OP
     ASSERT_EQ(binlog_schema->binlog_lsn_col_idx(), 6);
     ASSERT_EQ(binlog_schema->num_columns(), 8U);
 

--- a/be/test/storage/transform/validate_stage_test.cpp
+++ b/be/test/storage/transform/validate_stage_test.cpp
@@ -193,12 +193,14 @@ TEST_F(ValidateStageTest, CompositionBinlogTransientPartialUpdateStaysPlain) {
     EXPECT_EQ(build_transform_chain(rwc).stage_names(), (V {"PlainRowBinlogDerive"}));
 
     // the same write with a BEFORE image still needs the probe
-    rwc.write_binlog_opt().write_binlog_config().write_before = true;
+    cfg.need_historical_value = true;
+    cfg.column_mappings = {{0, 0, 1}};
     EXPECT_EQ(build_transform_chain(rwc).stage_names(), (V {"MowRowBinlogDerive"}));
 
     // and a non-transient write of the same partial update does probe
-    rwc.write_binlog_opt().write_binlog_config().write_before = false;
-    rwc.write_binlog_opt().write_binlog_config().source.is_transient_rowset_writer = false;
+    cfg.need_historical_value = false;
+    cfg.column_mappings.clear();
+    cfg.source.is_transient_rowset_writer = false;
     EXPECT_EQ(build_transform_chain(rwc).stage_names(), (V {"MowRowBinlogDerive"}));
 }
 
@@ -209,7 +211,9 @@ TEST_F(ValidateStageTest, CompositionBinlogBeforeImagePicksMowDerive) {
     auto schema = create_mow_schema(/*has_seq=*/false);
     RowsetWriterContext rwc = direct_rwc(schema);
     rwc.write_binlog_opt().enable = true;
-    rwc.write_binlog_opt().write_binlog_config().write_before = true;
+    auto& cfg = rwc.write_binlog_opt().write_binlog_config();
+    cfg.need_historical_value = true;
+    cfg.column_mappings = {{0, 0, 1}};
 
     EXPECT_EQ(build_transform_chain(rwc).stage_names(), (V {"MowRowBinlogDerive"}));
 }

--- a/be/test/storage/txn/txn_manager_test.cpp
+++ b/be/test/storage/txn/txn_manager_test.cpp
@@ -420,6 +420,12 @@ TEST_F(TxnManagerTest, PublishVersionWithCommitTSO) {
 
 TEST_F(TxnManagerTest, TxnWithRowBinlog) {
     auto binlog_rowset = create_binlog_rowset(30000, _rowset->version());
+    auto* mappings = _rowset->rowset_meta()->mutable_row_binlog_column_mappings();
+    mappings->set_need_historical_value(true);
+    auto* mapping = mappings->add_entries();
+    mapping->set_source_column_unique_id(1);
+    mapping->set_current_column_unique_id(10);
+    mapping->set_before_column_unique_id(11);
     RowBinlogTxnInfo attach_row_binlog;
     attach_row_binlog.rowset = binlog_rowset;
     attach_row_binlog.tablet = k_engine->tablet_manager()->get_tablet(tablet_id, _tablet_uid);
@@ -431,12 +437,20 @@ TEST_F(TxnManagerTest, TxnWithRowBinlog) {
             std::move(guard), false, nullptr, attach_row_binlog);
     ASSERT_TRUE(st.ok()) << st;
 
+    RowsetMetaSharedPtr committed_meta(new RowsetMeta());
+    st = RowsetMetaManager::get_rowset_meta(_meta.get(), _tablet_uid, _rowset->rowset_id(),
+                                            committed_meta);
+    ASSERT_TRUE(st.ok()) << st;
+    EXPECT_TRUE(committed_meta->has_row_binlog_column_mappings());
+    EXPECT_TRUE(committed_meta->row_binlog_column_mappings().need_historical_value());
+
     RowsetMetaSharedPtr committed_binlog_meta(new RowsetMeta());
     st = RowsetMetaManager::get_rowset_meta(_meta.get(), _tablet_uid, binlog_rowset->rowset_id(),
                                             committed_binlog_meta);
     ASSERT_TRUE(st.ok()) << st;
     EXPECT_EQ(committed_binlog_meta->rowset_state(), RowsetStatePB::COMMITTED);
     EXPECT_TRUE(committed_binlog_meta->is_row_binlog());
+    EXPECT_FALSE(committed_binlog_meta->has_row_binlog_column_mappings());
 
     Version new_version(10, 10);
     TabletPublishStatistics stats;
@@ -451,6 +465,7 @@ TEST_F(TxnManagerTest, TxnWithRowBinlog) {
     ASSERT_TRUE(st.ok()) << st;
     EXPECT_EQ(rowset_meta->start_version(), 10);
     EXPECT_EQ(rowset_meta->end_version(), 10);
+    EXPECT_FALSE(rowset_meta->has_row_binlog_column_mappings());
 
     RowsetMetaSharedPtr binlog_rowset_meta(new RowsetMeta());
     st = RowsetMetaManager::get_rowset_meta(_meta.get(), _tablet_uid, binlog_rowset->rowset_id(),

--- a/be/test/storage/txn/txn_manager_test.cpp
+++ b/be/test/storage/txn/txn_manager_test.cpp
@@ -420,12 +420,6 @@ TEST_F(TxnManagerTest, PublishVersionWithCommitTSO) {
 
 TEST_F(TxnManagerTest, TxnWithRowBinlog) {
     auto binlog_rowset = create_binlog_rowset(30000, _rowset->version());
-    auto* mappings = _rowset->rowset_meta()->mutable_row_binlog_column_mappings();
-    mappings->set_need_historical_value(true);
-    auto* mapping = mappings->add_entries();
-    mapping->set_source_column_unique_id(1);
-    mapping->set_current_column_unique_id(10);
-    mapping->set_before_column_unique_id(11);
     RowBinlogTxnInfo attach_row_binlog;
     attach_row_binlog.rowset = binlog_rowset;
     attach_row_binlog.tablet = k_engine->tablet_manager()->get_tablet(tablet_id, _tablet_uid);
@@ -441,8 +435,6 @@ TEST_F(TxnManagerTest, TxnWithRowBinlog) {
     st = RowsetMetaManager::get_rowset_meta(_meta.get(), _tablet_uid, _rowset->rowset_id(),
                                             committed_meta);
     ASSERT_TRUE(st.ok()) << st;
-    EXPECT_TRUE(committed_meta->has_row_binlog_column_mappings());
-    EXPECT_TRUE(committed_meta->row_binlog_column_mappings().need_historical_value());
 
     RowsetMetaSharedPtr committed_binlog_meta(new RowsetMeta());
     st = RowsetMetaManager::get_rowset_meta(_meta.get(), _tablet_uid, binlog_rowset->rowset_id(),
@@ -450,7 +442,6 @@ TEST_F(TxnManagerTest, TxnWithRowBinlog) {
     ASSERT_TRUE(st.ok()) << st;
     EXPECT_EQ(committed_binlog_meta->rowset_state(), RowsetStatePB::COMMITTED);
     EXPECT_TRUE(committed_binlog_meta->is_row_binlog());
-    EXPECT_FALSE(committed_binlog_meta->has_row_binlog_column_mappings());
 
     Version new_version(10, 10);
     TabletPublishStatistics stats;
@@ -465,7 +456,6 @@ TEST_F(TxnManagerTest, TxnWithRowBinlog) {
     ASSERT_TRUE(st.ok()) << st;
     EXPECT_EQ(rowset_meta->start_version(), 10);
     EXPECT_EQ(rowset_meta->end_version(), 10);
-    EXPECT_FALSE(rowset_meta->has_row_binlog_column_mappings());
 
     RowsetMetaSharedPtr binlog_rowset_meta(new RowsetMeta());
     st = RowsetMetaManager::get_rowset_meta(_meta.get(), _tablet_uid, binlog_rowset->rowset_id(),

--- a/be/test/testutil/creators.h
+++ b/be/test/testutil/creators.h
@@ -272,6 +272,21 @@ inline std::shared_ptr<OlapTableSchemaParam> create_table_schema_param(
     }
     if (row_binlog_index_id > 0) {
         tschema.indexes[0].__set_row_binlog_id(row_binlog_index_id);
+        tschema.indexes[0].__set_row_binlog_need_historical_value(false);
+        std::vector<TRowBinlogWriteColumnMapping> mappings;
+        for (size_t source_cid = 0; source_cid < columns.size(); ++source_cid) {
+            const auto& column = columns[source_cid];
+            if (column.__isset.visible && !column.visible && !column.is_key) {
+                continue;
+            }
+            TRowBinlogWriteColumnMapping mapping;
+            mapping.source_column_unique_id = column.col_unique_id >= 0
+                                                      ? column.col_unique_id
+                                                      : static_cast<int32_t>(source_cid);
+            mapping.current_column_unique_id = mapping.source_column_unique_id;
+            mappings.push_back(mapping);
+        }
+        tschema.indexes[0].__set_row_binlog_column_mappings(std::move(mappings));
         TOlapTableIndexSchema row_binlog_index_schema;
         row_binlog_index_schema.id = row_binlog_index_id;
         row_binlog_index_schema.schema_hash = row_binlog_schema_hash;

--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -2068,6 +2068,7 @@ void MetaServiceImpl::commit_txn_immediately(
             commit_txn_log.mutable_tablet_to_partition_map()->insert({tablet_id, partition_id});
             commit_txn_log.mutable_partition_version_map()->insert({partition_id, new_version});
 
+            i.clear_row_binlog_column_mappings();
             rowsets.emplace_back(std::make_tuple(tablet_id, i.end_version()), i);
         } // for tmp_rowsets_meta
 
@@ -3283,6 +3284,7 @@ void MetaServiceImpl::commit_txn_with_sub_txn(const CommitTxnRequest* request,
                 stats.index_size += i.index_disk_size();
                 stats.segment_size += i.data_disk_size();
 
+                i.clear_row_binlog_column_mappings();
                 rowsets.emplace_back(std::make_tuple(tablet_id, i.end_version()), std::move(i));
                 commit_txn_log.mutable_tablet_to_partition_map()->insert({tablet_id, partition_id});
             } // for tmp_rowsets_meta

--- a/cloud/src/meta-service/meta_service_txn.cpp
+++ b/cloud/src/meta-service/meta_service_txn.cpp
@@ -2068,7 +2068,6 @@ void MetaServiceImpl::commit_txn_immediately(
             commit_txn_log.mutable_tablet_to_partition_map()->insert({tablet_id, partition_id});
             commit_txn_log.mutable_partition_version_map()->insert({partition_id, new_version});
 
-            i.clear_row_binlog_column_mappings();
             rowsets.emplace_back(std::make_tuple(tablet_id, i.end_version()), i);
         } // for tmp_rowsets_meta
 
@@ -3284,7 +3283,6 @@ void MetaServiceImpl::commit_txn_with_sub_txn(const CommitTxnRequest* request,
                 stats.index_size += i.index_disk_size();
                 stats.segment_size += i.data_disk_size();
 
-                i.clear_row_binlog_column_mappings();
                 rowsets.emplace_back(std::make_tuple(tablet_id, i.end_version()), std::move(i));
                 commit_txn_log.mutable_tablet_to_partition_map()->insert({tablet_id, partition_id});
             } // for tmp_rowsets_meta

--- a/cloud/src/meta-service/txn_lazy_committer.cpp
+++ b/cloud/src/meta-service/txn_lazy_committer.cpp
@@ -392,6 +392,7 @@ void convert_tmp_rowsets(
         tmp_rowset_pb.set_visible_ts_ms(rowsets_visible_ts_ms);
         tmp_rowset_pb.mutable_commit_tso()->set_start_tso(commit_tso);
         tmp_rowset_pb.mutable_commit_tso()->set_end_tso(commit_tso);
+        tmp_rowset_pb.clear_row_binlog_column_mappings();
 
         rowset_val.clear();
         if (!tmp_rowset_pb.SerializeToString(&rowset_val)) {

--- a/cloud/src/meta-service/txn_lazy_committer.cpp
+++ b/cloud/src/meta-service/txn_lazy_committer.cpp
@@ -392,7 +392,6 @@ void convert_tmp_rowsets(
         tmp_rowset_pb.set_visible_ts_ms(rowsets_visible_ts_ms);
         tmp_rowset_pb.mutable_commit_tso()->set_start_tso(commit_tso);
         tmp_rowset_pb.mutable_commit_tso()->set_end_tso(commit_tso);
-        tmp_rowset_pb.clear_row_binlog_column_mappings();
 
         rowset_val.clear();
         if (!tmp_rowset_pb.SerializeToString(&rowset_val)) {

--- a/cloud/test/meta_service_table_stream_test.cpp
+++ b/cloud/test/meta_service_table_stream_test.cpp
@@ -291,9 +291,15 @@ protected:
         ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
     }
 
-    void stage_target_rowset(int64_t txn_id, int64_t partition_id, int64_t tablet_id) {
-        const doris::RowsetMetaCloudPB rowset =
-                create_rowset(txn_id, tablet_id, partition_id, -1, 100);
+    void stage_target_rowset(int64_t txn_id, int64_t partition_id, int64_t tablet_id,
+                             bool include_row_binlog_mapping = false) {
+        doris::RowsetMetaCloudPB rowset = create_rowset(txn_id, tablet_id, partition_id, -1, 100);
+        if (include_row_binlog_mapping) {
+            auto* mapping = rowset.mutable_row_binlog_column_mappings()->add_entries();
+            mapping->set_source_column_unique_id(1);
+            mapping->set_current_column_unique_id(10);
+            mapping->set_before_column_unique_id(11);
+        }
         auto call = [&](bool prepare) {
             CreateRowsetRequest request;
             request.set_cloud_unique_id(cloud_unique_id_);
@@ -1142,7 +1148,14 @@ TEST_F(MetaServiceTableStreamTest, CommitTargetRowsetAndOffsetAtomically) {
     EXPECT_EQ(target_version.version(), 1);
 
     int64_t committed_txn_id = begin_target_transaction("consume-target-rowset");
-    stage_target_rowset(committed_txn_id, kTargetPartitionId, kTargetTabletId);
+    stage_target_rowset(committed_txn_id, kTargetPartitionId, kTargetTabletId, true);
+    ASSERT_EQ(service_->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
+    ASSERT_EQ(txn->get(meta_rowset_tmp_key({instance_id_, committed_txn_id, kTargetTabletId}),
+                       &value),
+              TxnErrorCode::TXN_OK);
+    doris::RowsetMetaCloudPB staged_rowset;
+    ASSERT_TRUE(staged_rowset.ParseFromString(value));
+    EXPECT_TRUE(staged_rowset.has_row_binlog_column_mappings());
     CommitTxnRequest commit_request = make_consume_request(committed_txn_id, kSourcePartitionId,
                                                            TABLE_STREAM_OFFSET_CONSUMED, 100, 120);
     commit_request.set_commit_tso(999);
@@ -1159,6 +1172,7 @@ TEST_F(MetaServiceTableStreamTest, CommitTargetRowsetAndOffsetAtomically) {
     doris::RowsetMetaCloudPB committed_rowset;
     ASSERT_TRUE(committed_rowset.ParseFromString(value));
     EXPECT_EQ(committed_rowset.txn_id(), committed_txn_id);
+    EXPECT_FALSE(committed_rowset.has_row_binlog_column_mappings());
     ASSERT_EQ(txn->get(partition_version_key(
                                {instance_id_, kTargetDbId, kTargetTableId, kTargetPartitionId}),
                        &value),

--- a/cloud/test/meta_service_table_stream_test.cpp
+++ b/cloud/test/meta_service_table_stream_test.cpp
@@ -1148,7 +1148,6 @@ TEST_F(MetaServiceTableStreamTest, CommitTargetRowsetAndOffsetAtomically) {
               TxnErrorCode::TXN_OK);
     doris::RowsetMetaCloudPB staged_rowset;
     ASSERT_TRUE(staged_rowset.ParseFromString(value));
-    EXPECT_FALSE(staged_rowset.has_row_binlog_column_mappings());
     CommitTxnRequest commit_request = make_consume_request(committed_txn_id, kSourcePartitionId,
                                                            TABLE_STREAM_OFFSET_CONSUMED, 100, 120);
     commit_request.set_commit_tso(999);
@@ -1165,7 +1164,6 @@ TEST_F(MetaServiceTableStreamTest, CommitTargetRowsetAndOffsetAtomically) {
     doris::RowsetMetaCloudPB committed_rowset;
     ASSERT_TRUE(committed_rowset.ParseFromString(value));
     EXPECT_EQ(committed_rowset.txn_id(), committed_txn_id);
-    EXPECT_FALSE(committed_rowset.has_row_binlog_column_mappings());
     ASSERT_EQ(txn->get(partition_version_key(
                                {instance_id_, kTargetDbId, kTargetTableId, kTargetPartitionId}),
                        &value),

--- a/cloud/test/meta_service_table_stream_test.cpp
+++ b/cloud/test/meta_service_table_stream_test.cpp
@@ -291,15 +291,8 @@ protected:
         ASSERT_EQ(txn->commit(), TxnErrorCode::TXN_OK);
     }
 
-    void stage_target_rowset(int64_t txn_id, int64_t partition_id, int64_t tablet_id,
-                             bool include_row_binlog_mapping = false) {
+    void stage_target_rowset(int64_t txn_id, int64_t partition_id, int64_t tablet_id) {
         doris::RowsetMetaCloudPB rowset = create_rowset(txn_id, tablet_id, partition_id, -1, 100);
-        if (include_row_binlog_mapping) {
-            auto* mapping = rowset.mutable_row_binlog_column_mappings()->add_entries();
-            mapping->set_source_column_unique_id(1);
-            mapping->set_current_column_unique_id(10);
-            mapping->set_before_column_unique_id(11);
-        }
         auto call = [&](bool prepare) {
             CreateRowsetRequest request;
             request.set_cloud_unique_id(cloud_unique_id_);
@@ -1148,14 +1141,14 @@ TEST_F(MetaServiceTableStreamTest, CommitTargetRowsetAndOffsetAtomically) {
     EXPECT_EQ(target_version.version(), 1);
 
     int64_t committed_txn_id = begin_target_transaction("consume-target-rowset");
-    stage_target_rowset(committed_txn_id, kTargetPartitionId, kTargetTabletId, true);
+    stage_target_rowset(committed_txn_id, kTargetPartitionId, kTargetTabletId);
     ASSERT_EQ(service_->txn_kv()->create_txn(&txn), TxnErrorCode::TXN_OK);
     ASSERT_EQ(txn->get(meta_rowset_tmp_key({instance_id_, committed_txn_id, kTargetTabletId}),
                        &value),
               TxnErrorCode::TXN_OK);
     doris::RowsetMetaCloudPB staged_rowset;
     ASSERT_TRUE(staged_rowset.ParseFromString(value));
-    EXPECT_TRUE(staged_rowset.has_row_binlog_column_mappings());
+    EXPECT_FALSE(staged_rowset.has_row_binlog_column_mappings());
     CommitTxnRequest commit_request = make_consume_request(committed_txn_id, kSourcePartitionId,
                                                            TABLE_STREAM_OFFSET_CONSUMED, 100, 120);
     commit_request.set_commit_tso(999);

--- a/cloud/test/txn_lazy_commit_test.cpp
+++ b/cloud/test/txn_lazy_commit_test.cpp
@@ -926,6 +926,12 @@ TEST(TxnLazyCommitVersionedReadTest, CommitTxnEventually) {
         create_tablet_with_db_id(meta_service.get(), db_id, table_id, index_id, partition_id,
                                  tablet_id_base + i);
         auto tmp_rowset = create_rowset(txn_id, tablet_id_base + i, index_id, partition_id);
+        auto* mappings = tmp_rowset.mutable_row_binlog_column_mappings();
+        mappings->set_need_historical_value(true);
+        auto* mapping = mappings->add_entries();
+        mapping->set_source_column_unique_id(1);
+        mapping->set_current_column_unique_id(10);
+        mapping->set_before_column_unique_id(11);
         CreateRowsetResponse res;
         prepare_rowset(meta_service.get(), tmp_rowset, res);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);
@@ -963,7 +969,12 @@ TEST(TxnLazyCommitVersionedReadTest, CommitTxnEventually) {
             int64_t tablet_id = tablet_id_base + i;
             check_tablet_idx_db_id(txn, db_id, tablet_id);
             check_tmp_rowset_not_exist(txn, tablet_id, txn_id);
-            check_rowset_meta_exist(txn, tablet_id, 2);
+            std::string legacy_rowset_val;
+            ASSERT_EQ(txn->get(meta_rowset_key({mock_instance, tablet_id, 2}), &legacy_rowset_val),
+                      TxnErrorCode::TXN_OK);
+            RowsetMetaCloudPB legacy_rowset_meta;
+            ASSERT_TRUE(legacy_rowset_meta.ParseFromString(legacy_rowset_val));
+            ASSERT_FALSE(legacy_rowset_meta.has_row_binlog_column_mappings());
 
             // Check versioned rowset meta exists.
             std::string rowset_key = versioned::meta_rowset_load_key({mock_instance, tablet_id, 2});
@@ -971,6 +982,7 @@ TEST(TxnLazyCommitVersionedReadTest, CommitTxnEventually) {
             Versionstamp versionstamp;
             ASSERT_EQ(versioned::document_get(txn.get(), rowset_key, &rowset_val, &versionstamp),
                       TxnErrorCode::TXN_OK);
+            ASSERT_FALSE(rowset_val.has_row_binlog_column_mappings());
         }
     }
 

--- a/cloud/test/txn_lazy_commit_test.cpp
+++ b/cloud/test/txn_lazy_commit_test.cpp
@@ -926,12 +926,6 @@ TEST(TxnLazyCommitVersionedReadTest, CommitTxnEventually) {
         create_tablet_with_db_id(meta_service.get(), db_id, table_id, index_id, partition_id,
                                  tablet_id_base + i);
         auto tmp_rowset = create_rowset(txn_id, tablet_id_base + i, index_id, partition_id);
-        auto* mappings = tmp_rowset.mutable_row_binlog_column_mappings();
-        mappings->set_need_historical_value(true);
-        auto* mapping = mappings->add_entries();
-        mapping->set_source_column_unique_id(1);
-        mapping->set_current_column_unique_id(10);
-        mapping->set_before_column_unique_id(11);
         CreateRowsetResponse res;
         prepare_rowset(meta_service.get(), tmp_rowset, res);
         ASSERT_EQ(res.status().code(), MetaServiceCode::OK);

--- a/cloud/test/txn_lazy_commit_test.cpp
+++ b/cloud/test/txn_lazy_commit_test.cpp
@@ -968,7 +968,6 @@ TEST(TxnLazyCommitVersionedReadTest, CommitTxnEventually) {
                       TxnErrorCode::TXN_OK);
             RowsetMetaCloudPB legacy_rowset_meta;
             ASSERT_TRUE(legacy_rowset_meta.ParseFromString(legacy_rowset_val));
-            ASSERT_FALSE(legacy_rowset_meta.has_row_binlog_column_mappings());
 
             // Check versioned rowset meta exists.
             std::string rowset_key = versioned::meta_rowset_load_key({mock_instance, tablet_id, 2});
@@ -976,7 +975,6 @@ TEST(TxnLazyCommitVersionedReadTest, CommitTxnEventually) {
             Versionstamp versionstamp;
             ASSERT_EQ(versioned::document_get(txn.get(), rowset_key, &rowset_val, &versionstamp),
                       TxnErrorCode::TXN_OK);
-            ASSERT_FALSE(rowset_val.has_row_binlog_column_mappings());
         }
     }
 

--- a/fe/fe-catalog/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/catalog/Column.java
@@ -103,7 +103,7 @@ public class Column implements GsonPostProcessable {
     public static final String BINLOG_LSN_COL = "__DORIS_BINLOG_LSN__";
     // implicit columns
     public static final String BINLOG_OPERATION_COL = "__DORIS_BINLOG_OP__";
-    public static final String BINLOG_BEFORE_PREFIX = "__DORIS_BEFORE__";
+    public static final String BINLOG_BEFORE_PREFIX = "__BEFORE__";
 
     public static String generateBeforeColName(String colName) {
         return BINLOG_BEFORE_PREFIX + colName + "__";

--- a/fe/fe-catalog/src/main/java/org/apache/doris/catalog/Column.java
+++ b/fe/fe-catalog/src/main/java/org/apache/doris/catalog/Column.java
@@ -103,7 +103,7 @@ public class Column implements GsonPostProcessable {
     public static final String BINLOG_LSN_COL = "__DORIS_BINLOG_LSN__";
     // implicit columns
     public static final String BINLOG_OPERATION_COL = "__DORIS_BINLOG_OP__";
-    public static final String BINLOG_BEFORE_PREFIX = "__BEFORE__";
+    public static final String BINLOG_BEFORE_PREFIX = "__DORIS_BEFORE__";
 
     public static String generateBeforeColName(String colName) {
         return BINLOG_BEFORE_PREFIX + colName + "__";

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/LocalTabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/LocalTabletInvertedIndex.java
@@ -39,7 +39,6 @@ import org.apache.doris.transaction.TransactionStatus;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -103,7 +102,7 @@ public class LocalTabletInvertedIndex extends TabletInvertedIndex {
                              Set<Long> tabletFoundInMeta,
                              ListMultimap<TStorageMedium, Long> tabletMigrationMap,
                              Map<Long, Long> partitionVersionSyncMap,
-                             Map<Long, SetMultimap<Long, TPartitionVersionInfo>> transactionsToPublish,
+                             Map<Long, Pair<TransactionState, Set<TPartitionVersionInfo>>> transactionsToPublish,
                              SetMultimap<Long, Long> transactionsToClear,
                              ListMultimap<Long, Long> tabletRecoveryMap,
                              List<TTabletMetaInfo> tabletToUpdate,
@@ -153,7 +152,8 @@ public class LocalTabletInvertedIndex extends TabletInvertedIndex {
                                           Set<Long> tabletFoundInMeta,
                                           ListMultimap<TStorageMedium, Long> tabletMigrationMap,
                                           Map<Long, Long> partitionVersionSyncMap,
-                                          Map<Long, SetMultimap<Long, TPartitionVersionInfo>> transactionsToPublish,
+                                          Map<Long, Pair<TransactionState, Set<TPartitionVersionInfo>>>
+                                                  transactionsToPublish,
                                           SetMultimap<Long, Long> transactionsToClear,
                                           ListMultimap<Long, Long> tabletRecoveryMap,
                                           List<TTabletMetaInfo> tabletToUpdate,
@@ -215,7 +215,8 @@ public class LocalTabletInvertedIndex extends TabletInvertedIndex {
                                      ListMultimap<Long, Long> tabletDeleteFromMeta,
                                      Set<Long> tabletFoundInMeta,
                                      ListMultimap<TStorageMedium, Long> tabletMigrationMap,
-                                     Map<Long, SetMultimap<Long, TPartitionVersionInfo>> transactionsToPublish,
+                                     Map<Long, Pair<TransactionState, Set<TPartitionVersionInfo>>>
+                                             transactionsToPublish,
                                      SetMultimap<Long, Long> transactionsToClear,
                                      ListMultimap<Long, Long> tabletRecoveryMap,
                                      List<TTabletMetaInfo> tabletToUpdate,
@@ -252,7 +253,8 @@ public class LocalTabletInvertedIndex extends TabletInvertedIndex {
                                         HashMap<Long, TStorageMedium> storageMediumMap,
                                         ListMultimap<Long, Long> tabletSyncMap,
                                         ListMultimap<TStorageMedium, Long> tabletMigrationMap,
-                                        Map<Long, SetMultimap<Long, TPartitionVersionInfo>> transactionsToPublish,
+                                        Map<Long, Pair<TransactionState, Set<TPartitionVersionInfo>>>
+                                                transactionsToPublish,
                                         SetMultimap<Long, Long> transactionsToClear,
                                         ListMultimap<Long, Long> tabletRecoveryMap,
                                         List<TTabletMetaInfo> tabletToUpdate,
@@ -465,7 +467,8 @@ public class LocalTabletInvertedIndex extends TabletInvertedIndex {
                                          Set<Long> tabletFoundInMeta,
                                          ListMultimap<TStorageMedium, Long> tabletMigrationMap,
                                          Map<Long, Long> partitionVersionSyncMap,
-                                         Map<Long, SetMultimap<Long, TPartitionVersionInfo>> transactionsToPublish,
+                                         Map<Long, Pair<TransactionState, Set<TPartitionVersionInfo>>>
+                                                 transactionsToPublish,
                                          SetMultimap<Long, Long> transactionsToClear,
                                          List<TTabletMetaInfo> tabletToUpdate,
                                          ListMultimap<Long, Long> tabletRecoveryMap,
@@ -473,10 +476,9 @@ public class LocalTabletInvertedIndex extends TabletInvertedIndex {
         long endTime = System.currentTimeMillis();
         long toClearTransactionsNum = transactionsToClear.keySet().size();
         long toClearTransactionsPartitions = transactionsToClear.values().size();
-        long toPublishTransactionsNum = transactionsToPublish.values().stream()
-                .mapToLong(m -> m.keySet().size()).sum();
+        long toPublishTransactionsNum = transactionsToPublish.size();
         long toPublishTransactionsPartitions = transactionsToPublish.values().stream()
-                .mapToLong(m -> m.values().size()).sum();
+                .mapToLong(p -> p.second.size()).sum();
 
         LOG.info("finished to do tablet diff with backend[{}]. fe tablet num: {}, backend tablet num: {}. "
                         + "sync: {}, metaDel: {}, foundInMeta: {}, migration: {}, "
@@ -493,7 +495,7 @@ public class LocalTabletInvertedIndex extends TabletInvertedIndex {
     }
 
     private void handleBackendTransactions(long backendId, List<Long> transactionIds, long tabletId,
-            TabletMeta tabletMeta, Map<Long, SetMultimap<Long, TPartitionVersionInfo>> transactionsToPublish,
+            TabletMeta tabletMeta, Map<Long, Pair<TransactionState, Set<TPartitionVersionInfo>>> transactionsToPublish,
             SetMultimap<Long, Long> transactionsToClear) {
         GlobalTransactionMgrIface transactionMgr = Env.getCurrentGlobalTransactionMgr();
         long partitionId = tabletMeta.getPartitionId();
@@ -557,18 +559,14 @@ public class LocalTabletInvertedIndex extends TabletInvertedIndex {
     }
 
     private void publishPartition(TransactionState transactionState, long transactionId, TabletMeta tabletMeta,
-            long partitionId, Map<Long, SetMultimap<Long, TPartitionVersionInfo>> transactionsToPublish) {
+            long partitionId, Map<Long, Pair<TransactionState, Set<TPartitionVersionInfo>>> transactionsToPublish) {
         TPartitionVersionInfo versionInfo = generatePartitionVersionInfoWhenReport(transactionState,
                 transactionId, tabletMeta, partitionId);
         if (versionInfo != null) {
             synchronized (transactionsToPublish) {
-                SetMultimap<Long, TPartitionVersionInfo> map = transactionsToPublish.get(
-                        transactionState.getDbId());
-                if (map == null) {
-                    map = LinkedHashMultimap.create();
-                    transactionsToPublish.put(transactionState.getDbId(), map);
-                }
-                map.put(transactionId, versionInfo);
+                // Retain the state: becoming VISIBLE removes child-to-parent transaction aliases.
+                transactionsToPublish.computeIfAbsent(transactionId,
+                        id -> Pair.of(transactionState, Sets.newLinkedHashSet())).second.add(versionInfo);
             }
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/RowBinlogTableWrapper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/RowBinlogTableWrapper.java
@@ -60,6 +60,14 @@ public class RowBinlogTableWrapper extends OlapTableWrapper {
                 || column.getName().equals(Column.BINLOG_LSN_COL);
     }
 
+    public static boolean isRowBinlogInternalColumn(Column column) {
+        String columnName = column.getName();
+        return columnName.startsWith(Column.BINLOG_BEFORE_PREFIX)
+                || columnName.equals(Column.BINLOG_LSN_COL)
+                || columnName.equals(Column.BINLOG_OPERATION_COL)
+                || columnName.equals(Column.BINLOG_TSO_COL);
+    }
+
     @Override
     public MaterializedIndex getPartitionIndex(Partition partition, long indexId) {
         MaterializedIndex index = partition.getIndex(indexId);

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletInvertedIndex.java
@@ -25,6 +25,7 @@ import org.apache.doris.thrift.TPartitionVersionInfo;
 import org.apache.doris.thrift.TStorageMedium;
 import org.apache.doris.thrift.TTablet;
 import org.apache.doris.thrift.TTabletMetaInfo;
+import org.apache.doris.transaction.TransactionState;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ListMultimap;
@@ -89,7 +90,7 @@ public abstract class TabletInvertedIndex {
                              Set<Long> tabletFoundInMeta,
                              ListMultimap<TStorageMedium, Long> tabletMigrationMap,
                              Map<Long, Long> partitionVersionSyncMap,
-                             Map<Long, SetMultimap<Long, TPartitionVersionInfo>> transactionsToPublish,
+                             Map<Long, Pair<TransactionState, Set<TPartitionVersionInfo>>> transactionsToPublish,
                              SetMultimap<Long, Long> transactionsToClear,
                              ListMultimap<Long, Long> tabletRecoveryMap,
                              List<TTabletMetaInfo> tabletToUpdate,

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -2044,7 +2044,7 @@ public abstract class RoutineLoadJob
 
     public abstract void replayModifyProperties(AlterRoutineLoadJobOperationLog log);
 
-    public abstract NereidsRoutineLoadTaskInfo toNereidsRoutineLoadTaskInfo() throws UserException;
+    public abstract NereidsRoutineLoadTaskInfo toNereidsRoutineLoadTaskInfo(long txnId) throws UserException;
 
     // for ALTER ROUTINE LOAD
     protected void modifyCommonJobProperties(Map<String, String> jobProperties) throws UserException {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kafka/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kafka/KafkaRoutineLoadJob.java
@@ -1091,7 +1091,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     }
 
     @Override
-    public NereidsRoutineLoadTaskInfo toNereidsRoutineLoadTaskInfo() throws UserException {
+    public NereidsRoutineLoadTaskInfo toNereidsRoutineLoadTaskInfo(long txnId) throws UserException {
         Expression deleteCondition = getDeleteCondition() != null
                 ? NereidsLoadUtils.parseExpressionSeq(
                         getDeleteCondition().accept(ExprToSqlVisitor.INSTANCE,
@@ -1117,7 +1117,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
                 importColumnDescs.descs.add(new NereidsImportColumnDesc(desc.getColumnName(), expression));
             }
         }
-        return new NereidsRoutineLoadTaskInfo(execMemLimit, new HashMap<>(jobProperties), maxBatchIntervalS,
+        return new NereidsRoutineLoadTaskInfo(txnId, execMemLimit, new HashMap<>(jobProperties), maxBatchIntervalS,
                 partitionNamesInfo, mergeType, deleteCondition, sequenceCol, maxFilterRatio, importColumnDescs,
                 precedingFilter, whereExpr, columnSeparator, lineDelimiter, enclose, escape, sendBatchParallelism,
                 loadToSingleTablet, uniqueKeyUpdateMode, partialUpdateNewKeyPolicy, memtableOnSinkNode);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kafka/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kafka/KafkaTaskInfo.java
@@ -37,7 +37,6 @@ import org.apache.doris.thrift.TKafkaLoadInfo;
 import org.apache.doris.thrift.TLoadSourceType;
 import org.apache.doris.thrift.TPipelineFragmentParams;
 import org.apache.doris.thrift.TPipelineWorkloadGroup;
-import org.apache.doris.thrift.TPlanFragment;
 import org.apache.doris.thrift.TRoutineLoadTask;
 import org.apache.doris.thrift.TUniqueId;
 
@@ -181,14 +180,12 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         TUniqueId loadId = new TUniqueId(id.getMostSignificantBits(), id.getLeastSignificantBits());
         // plan for each task, in case table has change(rollup or schema change)
         Database db = Env.getCurrentInternalCatalog().getDbOrMetaException(routineLoadJob.getDbId());
-        NereidsLoadTaskInfo taskInfo = routineLoadJob.toNereidsRoutineLoadTaskInfo();
+        NereidsLoadTaskInfo taskInfo = routineLoadJob.toNereidsRoutineLoadTaskInfo(txnId);
         taskInfo.setTimeout((int) (this.timeoutMs / 1000));
         NereidsStreamLoadPlanner planner = new NereidsStreamLoadPlanner(db,
                 (OlapTable) db.getTableOrMetaException(routineLoadJob.getTableId(),
                 Table.TableType.OLAP), taskInfo);
         TPipelineFragmentParams tExecPlanFragmentParams = routineLoadJob.plan(planner, loadId, txnId);
-        TPlanFragment tPlanFragment = tExecPlanFragmentParams.getFragment();
-        tPlanFragment.getOutputSink().getOlapTableSink().setTxnId(txnId);
 
         if (Config.enable_workload_group) {
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kinesis/KinesisRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kinesis/KinesisRoutineLoadJob.java
@@ -847,7 +847,7 @@ public class KinesisRoutineLoadJob extends RoutineLoadJob {
     }
 
     @Override
-    public NereidsRoutineLoadTaskInfo toNereidsRoutineLoadTaskInfo() throws UserException {
+    public NereidsRoutineLoadTaskInfo toNereidsRoutineLoadTaskInfo(long txnId) throws UserException {
         Expression deleteCondition = getDeleteCondition() != null
                 ? NereidsLoadUtils.parseExpressionSeq(
                         getDeleteCondition().accept(ExprToSqlVisitor.INSTANCE,
@@ -873,7 +873,7 @@ public class KinesisRoutineLoadJob extends RoutineLoadJob {
                 importColumnDescs.descs.add(new NereidsImportColumnDesc(desc.getColumnName(), expression));
             }
         }
-        return new NereidsRoutineLoadTaskInfo(execMemLimit, new HashMap<>(jobProperties), maxBatchIntervalS,
+        return new NereidsRoutineLoadTaskInfo(txnId, execMemLimit, new HashMap<>(jobProperties), maxBatchIntervalS,
                 partitionNamesInfo, mergeType, deleteCondition, sequenceCol, maxFilterRatio, importColumnDescs,
                 precedingFilter, whereExpr, columnSeparator, lineDelimiter, enclose, escape, sendBatchParallelism,
                 loadToSingleTablet, uniqueKeyUpdateMode, partialUpdateNewKeyPolicy, memtableOnSinkNode);

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kinesis/KinesisTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kinesis/KinesisTaskInfo.java
@@ -35,7 +35,6 @@ import org.apache.doris.thrift.TKinesisLoadInfo;
 import org.apache.doris.thrift.TLoadSourceType;
 import org.apache.doris.thrift.TPipelineFragmentParams;
 import org.apache.doris.thrift.TPipelineWorkloadGroup;
-import org.apache.doris.thrift.TPlanFragment;
 import org.apache.doris.thrift.TRoutineLoadTask;
 import org.apache.doris.thrift.TUniqueId;
 
@@ -195,14 +194,12 @@ public class KinesisTaskInfo extends RoutineLoadTaskInfo {
         TUniqueId loadId = new TUniqueId(id.getMostSignificantBits(), id.getLeastSignificantBits());
         // plan for each task, in case table has change(rollup or schema change)
         Database db = Env.getCurrentInternalCatalog().getDbOrMetaException(routineLoadJob.getDbId());
-        NereidsLoadTaskInfo taskInfo = routineLoadJob.toNereidsRoutineLoadTaskInfo();
+        NereidsLoadTaskInfo taskInfo = routineLoadJob.toNereidsRoutineLoadTaskInfo(txnId);
         taskInfo.setTimeout((int) (this.timeoutMs / 1000));
         NereidsStreamLoadPlanner planner = new NereidsStreamLoadPlanner(db,
                 (OlapTable) db.getTableOrMetaException(routineLoadJob.getTableId(),
                 Table.TableType.OLAP), taskInfo);
         TPipelineFragmentParams tExecPlanFragmentParams = routineLoadJob.plan(planner, loadId, txnId);
-        TPlanFragment tPlanFragment = tExecPlanFragmentParams.getFragment();
-        tPlanFragment.getOutputSink().getOlapTableSink().setTxnId(txnId);
 
         if (Config.enable_workload_group) {
             try {

--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -93,6 +93,7 @@ import org.apache.doris.thrift.TTabletInfo;
 import org.apache.doris.thrift.TTabletMetaInfo;
 import org.apache.doris.thrift.TTabletRole;
 import org.apache.doris.thrift.TTaskType;
+import org.apache.doris.transaction.TransactionState;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.LinkedHashMultimap;
@@ -605,8 +606,8 @@ public class ReportHandler extends Daemon {
         // partition id -> visible version
         Map<Long, Long> partitionVersionSyncMap = Maps.newConcurrentMap();
 
-        // dbid -> txn id -> [partition info]
-        Map<Long, SetMultimap<Long, TPartitionVersionInfo>> transactionsToPublish = Maps.newHashMap();
+        // actual txn id -> (retained transaction state, partition infos)
+        Map<Long, Pair<TransactionState, Set<TPartitionVersionInfo>>> transactionsToPublish = Maps.newHashMap();
         SetMultimap<Long, Long> transactionsToClear = LinkedHashMultimap.create();
 
         // db id -> tablet id
@@ -1310,18 +1311,19 @@ public class ReportHandler extends Daemon {
     }
 
     private static void handleRepublishVersionInfo(
-            Map<Long, SetMultimap<Long, TPartitionVersionInfo>> transactionsToPublish, long backendId) {
+            Map<Long, Pair<TransactionState, Set<TPartitionVersionInfo>>> transactionsToPublish, long backendId) {
         AgentBatchTask batchTask = new AgentBatchTask();
         long createPublishVersionTaskTime = System.currentTimeMillis();
-        for (Long dbId : transactionsToPublish.keySet()) {
-            SetMultimap<Long, TPartitionVersionInfo> map = transactionsToPublish.get(dbId);
-            for (long txnId : map.keySet()) {
-                PublishVersionTask task = new PublishVersionTask(backendId, txnId, dbId,
-                        Lists.newArrayList(map.get(txnId)), createPublishVersionTaskTime);
-                batchTask.addTask(task);
-                // add to AgentTaskQueue for handling finish report.
-                AgentTaskQueue.addTask(task);
-            }
+        for (Map.Entry<Long, Pair<TransactionState, Set<TPartitionVersionInfo>>> entry
+                : transactionsToPublish.entrySet()) {
+            long txnId = entry.getKey();
+            TransactionState state = entry.getValue().first;
+            PublishVersionTask task = new PublishVersionTask(backendId, txnId, state.getDbId(),
+                    Lists.newArrayList(entry.getValue().second), createPublishVersionTaskTime);
+            task.setRowBinlogColumnMappings(state.getRowBinlogColumnMappings(txnId));
+            batchTask.addTask(task);
+            // add to AgentTaskQueue for handling finish report.
+            AgentTaskQueue.addTask(task);
         }
         AgentTaskExecutor.submit(batchTask);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslator.java
@@ -3127,7 +3127,8 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
         boolean preserveCompleteRow = scanType == TBinlogScanType.MIN_DELTA;
         for (SlotDescriptor slot : scanSlots) {
             Column column = slot.getColumn();
-            if (column == null || column.isKey() || isRowBinlogInternalColumn(column)
+            if (column == null || column.isKey()
+                    || RowBinlogTableWrapper.isRowBinlogInternalColumn(column)
                     || (!preserveCompleteRow && !requiredSlotIds.contains(slot.getId()))) {
                 continue;
             }
@@ -3135,14 +3136,6 @@ public class PhysicalPlanTranslator extends DefaultPlanVisitor<PlanFragment, Pla
             preserveStorageSlot(slotByName.get(Column.generateBeforeColName(column.getName())),
                     requiredSlotIds);
         }
-    }
-
-    private boolean isRowBinlogInternalColumn(Column column) {
-        String columnName = column.getName();
-        return columnName.startsWith(Column.BINLOG_BEFORE_PREFIX)
-                || columnName.equals(Column.BINLOG_LSN_COL)
-                || columnName.equals(Column.BINLOG_OPERATION_COL)
-                || columnName.equals(Column.BINLOG_TSO_COL);
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsRoutineLoadTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsRoutineLoadTaskInfo.java
@@ -70,17 +70,20 @@ public class NereidsRoutineLoadTaskInfo implements NereidsLoadTaskInfo {
     protected TPartialUpdateNewRowPolicy partialUpdateNewKeyPolicy = TPartialUpdateNewRowPolicy.APPEND;
     protected boolean memtableOnSinkNode;
     protected int timeoutSec;
+    private final long txnId;
 
     /**
      * NereidsRoutineLoadTaskInfo
      */
-    public NereidsRoutineLoadTaskInfo(long execMemLimit, Map<String, String> jobProperties, long maxBatchIntervalS,
+    public NereidsRoutineLoadTaskInfo(long txnId, long execMemLimit,
+            Map<String, String> jobProperties, long maxBatchIntervalS,
             PartitionNamesInfo partitions, LoadTask.MergeType mergeType, Expression deleteCondition,
             String sequenceCol, double maxFilterRatio, NereidsImportColumnDescs columnDescs,
             Expression precedingFilter, Expression whereExpr, Separator columnSeparator,
             Separator lineDelimiter, byte enclose, byte escape, int sendBatchParallelism,
             boolean loadToSingleTablet, TUniqueKeyUpdateMode uniqueKeyUpdateMode,
             TPartialUpdateNewRowPolicy partialUpdateNewKeyPolicy, boolean memtableOnSinkNode) {
+        this.txnId = txnId;
         this.execMemLimit = execMemLimit;
         this.jobProperties = jobProperties;
         this.maxBatchIntervalS = maxBatchIntervalS;
@@ -111,7 +114,7 @@ public class NereidsRoutineLoadTaskInfo implements NereidsLoadTaskInfo {
 
     @Override
     public long getTxnId() {
-        return -1L;
+        return txnId;
     }
 
     public int calTimeoutSec() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/RemoteOlapInsertExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/insert/RemoteOlapInsertExecutor.java
@@ -48,13 +48,18 @@ import org.apache.doris.thrift.TBeginRemoteTxnResult;
 import org.apache.doris.thrift.TCommitRemoteTxnRequest;
 import org.apache.doris.thrift.TCommitRemoteTxnResult;
 import org.apache.doris.thrift.TPartitionType;
+import org.apache.doris.thrift.TRowBinlogWriteColumnMappings;
 import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.transaction.BeginTransactionException;
+import org.apache.doris.transaction.TransactionState;
 import org.apache.doris.transaction.TransactionStatus;
 
 import com.google.common.base.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * Remote executor for Doris Catalog remote insert.
@@ -67,6 +72,7 @@ import org.apache.logging.log4j.Logger;
 public class RemoteOlapInsertExecutor extends OlapInsertExecutor {
 
     private static final Logger LOG = LogManager.getLogger(RemoteOlapInsertExecutor.class);
+    private Map<Long, TRowBinlogWriteColumnMappings> rowBinlogColumnMappings = Collections.emptyMap();
 
     public RemoteOlapInsertExecutor(ConnectContext ctx, RemoteOlapTable table,
             String labelName, org.apache.doris.nereids.NereidsPlanner planner,
@@ -141,6 +147,9 @@ public class RemoteOlapInsertExecutor extends OlapInsertExecutor {
                     false,
                     isStrictMode,
                     timeout, olapInsertCtx);
+            rowBinlogColumnMappings = TransactionState.collectRowBinlogColumnMappings(
+                    remoteOlapTableSink.getOlapTableSchemaParam());
+            rowBinlogColumnMappings.replaceAll((indexId, mapping) -> mapping.deepCopy());
 
             if (fragment.getPlanRoot() instanceof ExchangeNode
                     && fragment.getDataPartition().getType() == TPartitionType.OLAP_TABLE_SINK_HASH_PARTITIONED) {
@@ -200,6 +209,7 @@ public class RemoteOlapInsertExecutor extends OlapInsertExecutor {
         request.setTbl(table.getName());
         request.setCommitInfos(coordinator.getCommitInfos());
         request.setInsertVisibleTimeoutMs(ctx.getSessionVariable().getInsertVisibleTimeoutMs());
+        request.setRowBinlogColumnMappings(rowBinlogColumnMappings);
         try {
             TCommitRemoteTxnResult result = client.commitRemoteTxn(request);
             if (result.getStatus().getStatusCode() == TStatusCode.OK) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -983,7 +983,7 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan,
     }
 
     /**
-     * BE needs the {@code __DORIS_BEFORE__} columns to build before-images on an {@code @incr} read, but
+     * BE needs the {@code __BEFORE__} columns to build before-images on an {@code @incr} read, but
      * they are storage bookkeeping: {@code SELECT * FROM t@incr(...)} should return t's own columns,
      * not the mirrors behind them. The flag is set on a copy because these Column instances belong
      * to the table's persisted metadata and are shared across statements.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -982,7 +982,7 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan,
     }
 
     /**
-     * BE needs the {@code __BEFORE__} columns to build before-images on an {@code @incr} read, but
+     * BE needs the {@code __DORIS_BEFORE__} columns to build before-images on an {@code @incr} read, but
      * they are storage bookkeeping: {@code SELECT * FROM t@incr(...)} should return t's own columns,
      * not the mirrors behind them. The flag is set on a copy because these Column instances belong
      * to the table's persisted metadata and are shared across statements.

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/logical/LogicalOlapScan.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.MTMV;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.RowBinlogTableWrapper;
 import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.stream.OlapTableStream;
 import org.apache.doris.catalog.stream.OlapTableStreamWrapper;
@@ -1334,7 +1335,8 @@ public class LogicalOlapScan extends LogicalCatalogRelation implements OlapScan,
 
     @Override
     public boolean supportPruneNestedColumn() {
-        return true;
+        // Row-binlog pairs need matching full values, including unprojected fields for MIN_DELTA comparisons.
+        return !(getTable() instanceof RowBinlogTableWrapper);
     }
 
     public Optional<TableScanParams> getScanParams() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -1433,6 +1433,7 @@ public class OlapScanNode extends ScanNode {
         msg.olap_scan_node.setIndexesDesc(indexDesc);
         if (olapTable instanceof RowBinlogTableWrapper) {
             msg.olap_scan_node.setReadRowBinlog(true);
+            setRowBinlogColumnMappings(msg.olap_scan_node);
         }
         if (selectedIndexId != -1) {
             msg.olap_scan_node.setSchemaVersion(olapTable.getIndexSchemaVersion(selectedIndexId));
@@ -1529,6 +1530,38 @@ public class OlapScanNode extends ScanNode {
             setRuntimeFilterBucketPruneParameters();
         }
         super.toThrift(msg);
+    }
+
+    private void setRowBinlogColumnMappings(TOlapScanNode olapScanNode) {
+        RowBinlogTableWrapper wrapper = (RowBinlogTableWrapper) olapTable;
+        TBinlogScanType scanType = parseBinlogScanType(scanParams, wrapper.getOriginTable());
+        if (scanType != TBinlogScanType.DETAIL && scanType != TBinlogScanType.MIN_DELTA) {
+            return;
+        }
+
+        Map<String, SlotDescriptor> slotByName = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+        for (SlotDescriptor slot : desc.getSlots()) {
+            if (slot.getColumn() != null) {
+                slotByName.put(slot.getColumn().getName(), slot);
+            }
+        }
+
+        List<Integer> currentSlotIds = new ArrayList<>();
+        List<Integer> beforeSlotIds = new ArrayList<>();
+        for (SlotDescriptor slot : desc.getSlots()) {
+            Column column = slot.getColumn();
+            if (column == null || column.isKey()
+                    || RowBinlogTableWrapper.isRowBinlogInternalColumn(column)) {
+                continue;
+            }
+            SlotDescriptor beforeSlot = slotByName.get(Column.generateBeforeColName(column.getName()));
+            if (beforeSlot != null) {
+                currentSlotIds.add(slot.getId().asInt());
+                beforeSlotIds.add(beforeSlot.getId().asInt());
+            }
+        }
+        olapScanNode.setRowBinlogCurrentSlotIds(currentSlotIds);
+        olapScanNode.setRowBinlogBeforeSlotIds(beforeSlotIds);
     }
 
     private boolean hasRfDrivingPartitionPruning() {

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -84,6 +84,7 @@ import org.apache.doris.thrift.TOlapTableSchemaParam;
 import org.apache.doris.thrift.TOlapTableSink;
 import org.apache.doris.thrift.TPaloNodesInfo;
 import org.apache.doris.thrift.TPartialUpdateNewRowPolicy;
+import org.apache.doris.thrift.TRowBinlogWriteColumnMapping;
 import org.apache.doris.thrift.TTabletLocation;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.thrift.TUniqueKeyUpdateMode;
@@ -407,6 +408,7 @@ public class OlapTableSink extends DataSink {
             schemaParam.addToSlotDescs(DescriptorToThriftConverter.toThrift(slotDesc));
         }
 
+        MaterializedIndexMeta rowBinlogMeta = table.needRowBinlog() ? table.getRowBinlogMeta() : null;
         for (Map.Entry<Long, MaterializedIndexMeta> pair : table.getIndexIdToMeta().entrySet()) {
             MaterializedIndexMeta indexMeta = pair.getValue();
             List<String> columns = Lists.newArrayList();
@@ -437,6 +439,13 @@ public class OlapTableSink extends DataSink {
             TOlapTableIndexSchema indexSchema = new TOlapTableIndexSchema(pair.getKey(), columns,
                     indexMeta.getSchemaHash());
             indexSchema.setRowBinlogId(indexMeta.getRowBinlogIndexId());
+            if (indexMeta.getRowBinlogIndexId() > 0) {
+                Preconditions.checkState(rowBinlogMeta != null);
+                boolean needHistoricalValue = table.getBinlogConfig().getNeedHistoricalValue();
+                indexSchema.setRowBinlogNeedHistoricalValue(needHistoricalValue);
+                indexSchema.setRowBinlogColumnMappings(createRowBinlogColumnMappings(
+                        indexMeta, rowBinlogMeta, needHistoricalValue));
+            }
             Expr whereClause = indexMeta.getWhereClause();
             if (whereClause != null) {
                 Expr expr = syncMvWhereClauses.getOrDefault(pair.getKey(), null);
@@ -452,7 +461,6 @@ public class OlapTableSink extends DataSink {
         }
 
         if (table.needRowBinlog()) {
-            MaterializedIndexMeta rowBinlogMeta = table.getRowBinlogMeta();
             List<String> binlogColumns = Lists.newArrayList();
             List<TColumn> binlogColumnsDesc = Lists.newArrayList();
             for (Column column : rowBinlogMeta.getSchema(true)) {
@@ -469,6 +477,34 @@ public class OlapTableSink extends DataSink {
         setPartialUpdateInfoForParam(schemaParam, table, uniqueKeyUpdateMode);
         schemaParam.setInvertedIndexFileStorageFormat(table.getInvertedIndexFileStorageFormat());
         return schemaParam;
+    }
+
+    static List<TRowBinlogWriteColumnMapping> createRowBinlogColumnMappings(
+            MaterializedIndexMeta sourceMeta, MaterializedIndexMeta rowBinlogMeta,
+            boolean needHistoricalValue) throws AnalysisException {
+        List<TRowBinlogWriteColumnMapping> mappings = new ArrayList<>();
+        for (Column sourceColumn : sourceMeta.getSchema(true)) {
+            if (!sourceColumn.isVisible() && !sourceColumn.isKey()) {
+                continue;
+            }
+            String currentName = sourceColumn.getNonShadowName();
+            Column currentColumn = rowBinlogMeta.getColumnByName(currentName);
+            if (currentColumn == null) {
+                throw new AnalysisException("Missing row-binlog current column: " + currentName);
+            }
+            TRowBinlogWriteColumnMapping mapping = new TRowBinlogWriteColumnMapping(
+                    sourceColumn.getUniqueId(), currentColumn.getUniqueId());
+            if (needHistoricalValue && sourceColumn.isVisible() && !sourceColumn.isKey()) {
+                String beforeName = Column.generateBeforeColName(currentName);
+                Column beforeColumn = rowBinlogMeta.getColumnByName(beforeName);
+                if (beforeColumn == null) {
+                    throw new AnalysisException("Missing row-binlog before column: " + beforeName);
+                }
+                mapping.setBeforeColumnUniqueId(beforeColumn.getUniqueId());
+            }
+            mappings.add(mapping);
+        }
+        return mappings;
     }
 
     private void setPartialUpdateInfoForParam(TOlapTableSchemaParam schemaParam, OlapTable table,

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -478,8 +478,10 @@ public class OlapTableSink extends DataSink {
         setPartialUpdateInfoForParam(schemaParam, table, uniqueKeyUpdateMode);
         schemaParam.setInvertedIndexFileStorageFormat(table.getInvertedIndexFileStorageFormat());
         // GroupCommitBlockSink only queues input. Its actual batch writer plans a regular sink
-        // with the batch transaction ID. Cloud owns the snapshot in the BE transaction cache.
-        if (table.needRowBinlog() && !Config.isCloudMode() && getDataSinkType() == TDataSinkType.OLAP_TABLE_SINK) {
+        // with the batch transaction ID. Cloud owns the snapshot in the BE transaction cache;
+        // RemoteOlapTableSink sends it to the transaction-owning FE with commitRemoteTxn.
+        if (table.needRowBinlog() && !Config.isCloudMode() && !(this instanceof RemoteOlapTableSink)
+                && getDataSinkType() == TDataSinkType.OLAP_TABLE_SINK) {
             TransactionState state = Env.getCurrentGlobalTransactionMgr().getTransactionState(dbId, txnId);
             if (state == null) {
                 throw new AnalysisException("txn does not exist: " + txnId);

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapTableSink.java
@@ -88,6 +88,7 @@ import org.apache.doris.thrift.TRowBinlogWriteColumnMapping;
 import org.apache.doris.thrift.TTabletLocation;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.thrift.TUniqueKeyUpdateMode;
+import org.apache.doris.transaction.TransactionState;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
@@ -476,6 +477,15 @@ public class OlapTableSink extends DataSink {
 
         setPartialUpdateInfoForParam(schemaParam, table, uniqueKeyUpdateMode);
         schemaParam.setInvertedIndexFileStorageFormat(table.getInvertedIndexFileStorageFormat());
+        // GroupCommitBlockSink only queues input. Its actual batch writer plans a regular sink
+        // with the batch transaction ID. Cloud owns the snapshot in the BE transaction cache.
+        if (table.needRowBinlog() && !Config.isCloudMode() && getDataSinkType() == TDataSinkType.OLAP_TABLE_SINK) {
+            TransactionState state = Env.getCurrentGlobalTransactionMgr().getTransactionState(dbId, txnId);
+            if (state == null) {
+                throw new AnalysisException("txn does not exist: " + txnId);
+            }
+            state.captureRowBinlogColumnMappings(txnId, schemaParam);
+        }
         return schemaParam;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -2419,6 +2419,20 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
         TableIf tableIf = db.getTableOrMetaException(request.getTbl(), TableType.OLAP);
         OlapTable table = (OlapTable) tableIf;
+        // Cloud retains the writer snapshot in the BE transaction cache. Local publish needs it
+        // journaled by the owning FE, even if its current catalog differs from the writer's schema.
+        if (!Config.isCloudMode()) {
+            if (!request.isSetRowBinlogColumnMappings()) {
+                throw new AnalysisException("Missing row-binlog column mapping for remote transaction "
+                        + request.getTxnId());
+            }
+            TransactionState state = Env.getCurrentGlobalTransactionMgr().getTransactionState(db.getId(),
+                    request.getTxnId());
+            if (state == null) {
+                throw new AnalysisException("txn does not exist: " + request.getTxnId());
+            }
+            state.captureRemoteRowBinlogColumnMappings(request.getRowBinlogColumnMappings());
+        }
         return Env.getCurrentGlobalTransactionMgr().commitAndPublishTransaction(
                 db, Lists.newArrayList(table),
                 request.getTxnId(),

--- a/fe/fe-core/src/main/java/org/apache/doris/task/PublishVersionTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/task/PublishVersionTask.java
@@ -19,11 +19,13 @@ package org.apache.doris.task;
 
 import org.apache.doris.thrift.TPartitionVersionInfo;
 import org.apache.doris.thrift.TPublishVersionRequest;
+import org.apache.doris.thrift.TRowBinlogWriteColumnMappings;
 import org.apache.doris.thrift.TTaskType;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import lombok.Getter;
+import lombok.Setter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -45,6 +47,9 @@ public class PublishVersionTask extends AgentTask {
     private Set<Long> baseTabletsIds = Sets.newHashSet();
 
     private List<Long> errorTablets;
+
+    @Setter
+    private Map<Long, TRowBinlogWriteColumnMappings> rowBinlogColumnMappings = Maps.newHashMap();
 
     // tabletId => version, current version = 0
     // Initialized to an empty map (not null) so that getSuccTablets() never returns null
@@ -69,6 +74,9 @@ public class PublishVersionTask extends AgentTask {
         TPublishVersionRequest publishVersionRequest = new TPublishVersionRequest(transactionId,
                 partitionVersionInfos);
         publishVersionRequest.setBaseTabletIds(baseTabletsIds);
+        if (!rowBinlogColumnMappings.isEmpty()) {
+            publishVersionRequest.setRowBinlogColumnMappings(rowBinlogColumnMappings);
+        }
         return publishVersionRequest;
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/PublishVersionDaemon.java
@@ -37,6 +37,7 @@ import org.apache.doris.task.AgentTaskQueue;
 import org.apache.doris.task.PublishVersionTask;
 import org.apache.doris.task.UpdateVisibleVersionTask;
 import org.apache.doris.thrift.TPartitionVersionInfo;
+import org.apache.doris.thrift.TRowBinlogWriteColumnMappings;
 import org.apache.doris.thrift.TTaskType;
 
 import com.google.common.collect.Maps;
@@ -431,6 +432,8 @@ public class PublishVersionDaemon extends MasterDaemon {
             List<TPartitionVersionInfo> partitionVersionInfos, Map<Long, Set<Long>> beIdToBaseTabletIds,
             long createPublishVersionTaskTime,
             AgentBatchTask batchTask) {
+        Map<Long, TRowBinlogWriteColumnMappings> mappings =
+                transactionState.getRowBinlogColumnMappings(transactionId);
         for (Long backendId : publishBackends) {
             PublishVersionTask task = new PublishVersionTask(backendId,
                     transactionId,
@@ -438,6 +441,7 @@ public class PublishVersionDaemon extends MasterDaemon {
                     partitionVersionInfos,
                     createPublishVersionTaskTime);
             task.setBaseTabletsIds(beIdToBaseTabletIds.getOrDefault(backendId, Collections.emptySet()));
+            task.setRowBinlogColumnMappings(mappings);
             // add to AgentTaskQueue for handling finish report.
             // not check return value, because the add will success
             AgentTaskQueue.addTask(task);

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -22,6 +22,7 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.stream.TableStreamUpdateInfo;
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
@@ -29,15 +30,21 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.task.PublishVersionTask;
+import org.apache.doris.thrift.TOlapTableIndexSchema;
+import org.apache.doris.thrift.TOlapTableSchemaParam;
+import org.apache.doris.thrift.TRowBinlogWriteColumnMapping;
+import org.apache.doris.thrift.TRowBinlogWriteColumnMappings;
 import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -48,6 +55,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -282,6 +290,88 @@ public class TransactionState implements Writable {
     // tbl id -> (index ids)
     @SerializedName(value = "loadedTblIndexes")
     private Map<Long, Set<Long>> loadedTblIndexes = Maps.newHashMap();
+
+    // Actual write txn (possibly a subtxn) -> source index -> immutable write-time snapshot.
+    // Copy-on-write keeps checkpoint serialization safe while concurrent load planning adds indexes.
+    @SerializedName("rowBinlogMappings")
+    private volatile Map<Long, Map<Long, RowBinlogWriteMapping>> rowBinlogColumnMappings = ImmutableMap.of();
+
+    @EqualsAndHashCode
+    private static class RowBinlogColumnMapping {
+        @SerializedName("source")
+        private final int source;
+        @SerializedName("current")
+        private final int current;
+        @SerializedName("before")
+        private final Integer before;
+
+        RowBinlogColumnMapping(TRowBinlogWriteColumnMapping mapping) {
+            source = mapping.getSourceColumnUniqueId();
+            current = mapping.getCurrentColumnUniqueId();
+            before = mapping.isSetBeforeColumnUniqueId() ? mapping.getBeforeColumnUniqueId() : null;
+        }
+
+        TRowBinlogWriteColumnMapping toThrift() {
+            TRowBinlogWriteColumnMapping mapping = new TRowBinlogWriteColumnMapping(source, current);
+            if (before != null) {
+                mapping.setBeforeColumnUniqueId(before);
+            }
+            return mapping;
+        }
+    }
+
+    @EqualsAndHashCode
+    private static class RowBinlogWriteMapping {
+        @SerializedName("historical")
+        private final boolean historical;
+        @SerializedName("columns")
+        private final List<RowBinlogColumnMapping> columns;
+
+        RowBinlogWriteMapping(TOlapTableIndexSchema index) {
+            Preconditions.checkState(index.isSetRowBinlogNeedHistoricalValue());
+            Preconditions.checkState(index.isSetRowBinlogColumnMappings());
+            historical = index.isRowBinlogNeedHistoricalValue();
+            columns = new ArrayList<>(index.getRowBinlogColumnMappingsSize());
+            for (TRowBinlogWriteColumnMapping mapping : index.getRowBinlogColumnMappings()) {
+                columns.add(new RowBinlogColumnMapping(mapping));
+            }
+        }
+
+        TRowBinlogWriteColumnMappings toThrift() {
+            List<TRowBinlogWriteColumnMapping> entries = new ArrayList<>(columns.size());
+            for (RowBinlogColumnMapping column : columns) {
+                entries.add(column.toThrift());
+            }
+            return new TRowBinlogWriteColumnMappings().setEntries(entries).setNeedHistoricalValue(historical);
+        }
+    }
+
+    public synchronized void captureRowBinlogColumnMappings(long writeTxnId, TOlapTableSchemaParam schema)
+            throws AnalysisException {
+        Map<Long, RowBinlogWriteMapping> indexes = new HashMap<>(
+                rowBinlogColumnMappings.getOrDefault(writeTxnId, Collections.emptyMap()));
+        for (TOlapTableIndexSchema index : schema.getIndexes()) {
+            if (index.getRowBinlogId() <= 0) {
+                continue;
+            }
+            RowBinlogWriteMapping snapshot = new RowBinlogWriteMapping(index);
+            RowBinlogWriteMapping previous = indexes.putIfAbsent(index.getId(), snapshot);
+            if (previous != null && !previous.equals(snapshot)) {
+                throw new AnalysisException("Row-binlog write schema changed within transaction "
+                        + writeTxnId + ", source index " + index.getId());
+            }
+        }
+        Map<Long, Map<Long, RowBinlogWriteMapping>> snapshots = new HashMap<>(rowBinlogColumnMappings);
+        snapshots.put(writeTxnId, ImmutableMap.copyOf(indexes));
+        rowBinlogColumnMappings = ImmutableMap.copyOf(snapshots);
+    }
+
+    public Map<Long, TRowBinlogWriteColumnMappings> getRowBinlogColumnMappings(long writeTxnId) {
+        Map<Long, TRowBinlogWriteColumnMappings> mappings = new HashMap<>();
+        rowBinlogColumnMappings.getOrDefault(writeTxnId, Collections.emptyMap())
+                .forEach((indexId, snapshot) -> mappings.put(indexId, snapshot.toThrift()));
+        return mappings;
+    }
 
     /**
      * the value is the num delta rows of all replicas in each tablet

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
@@ -327,12 +327,16 @@ public class TransactionState implements Writable {
         @SerializedName("columns")
         private final List<RowBinlogColumnMapping> columns;
 
-        RowBinlogWriteMapping(TOlapTableIndexSchema index) {
-            Preconditions.checkState(index.isSetRowBinlogNeedHistoricalValue());
-            Preconditions.checkState(index.isSetRowBinlogColumnMappings());
-            historical = index.isRowBinlogNeedHistoricalValue();
-            columns = new ArrayList<>(index.getRowBinlogColumnMappingsSize());
-            for (TRowBinlogWriteColumnMapping mapping : index.getRowBinlogColumnMappings()) {
+        RowBinlogWriteMapping(TRowBinlogWriteColumnMappings mappings) throws AnalysisException {
+            if (!mappings.isSetNeedHistoricalValue() || !mappings.isSetEntries()) {
+                throw new AnalysisException("Incomplete row-binlog column mapping");
+            }
+            historical = mappings.isNeedHistoricalValue();
+            columns = new ArrayList<>(mappings.getEntriesSize());
+            for (TRowBinlogWriteColumnMapping mapping : mappings.getEntries()) {
+                if (!mapping.isSetSourceColumnUniqueId() || !mapping.isSetCurrentColumnUniqueId()) {
+                    throw new AnalysisException("Missing column unique ID in row-binlog column mapping");
+                }
                 columns.add(new RowBinlogColumnMapping(mapping));
             }
         }
@@ -346,23 +350,59 @@ public class TransactionState implements Writable {
         }
     }
 
+    public static Map<Long, TRowBinlogWriteColumnMappings> collectRowBinlogColumnMappings(
+            TOlapTableSchemaParam schema) {
+        Map<Long, TRowBinlogWriteColumnMappings> mappings = new HashMap<>();
+        for (TOlapTableIndexSchema index : schema.getIndexes()) {
+            if (index.getRowBinlogId() > 0) {
+                Preconditions.checkState(index.isSetRowBinlogNeedHistoricalValue());
+                Preconditions.checkState(index.isSetRowBinlogColumnMappings());
+                mappings.put(index.getId(), new TRowBinlogWriteColumnMappings()
+                        .setNeedHistoricalValue(index.isRowBinlogNeedHistoricalValue())
+                        .setEntries(index.getRowBinlogColumnMappings()));
+            }
+        }
+        return mappings;
+    }
+
     public synchronized void captureRowBinlogColumnMappings(long writeTxnId, TOlapTableSchemaParam schema)
             throws AnalysisException {
         Map<Long, RowBinlogWriteMapping> indexes = new HashMap<>(
                 rowBinlogColumnMappings.getOrDefault(writeTxnId, Collections.emptyMap()));
-        for (TOlapTableIndexSchema index : schema.getIndexes()) {
-            if (index.getRowBinlogId() <= 0) {
-                continue;
-            }
-            RowBinlogWriteMapping snapshot = new RowBinlogWriteMapping(index);
-            RowBinlogWriteMapping previous = indexes.putIfAbsent(index.getId(), snapshot);
+        for (Map.Entry<Long, TRowBinlogWriteColumnMappings> entry : collectRowBinlogColumnMappings(schema).entrySet()) {
+            RowBinlogWriteMapping snapshot = new RowBinlogWriteMapping(entry.getValue());
+            RowBinlogWriteMapping previous = indexes.putIfAbsent(entry.getKey(), snapshot);
             if (previous != null && !previous.equals(snapshot)) {
                 throw new AnalysisException("Row-binlog write schema changed within transaction "
-                        + writeTxnId + ", source index " + index.getId());
+                        + writeTxnId + ", source index " + entry.getKey());
             }
         }
         Map<Long, Map<Long, RowBinlogWriteMapping>> snapshots = new HashMap<>(rowBinlogColumnMappings);
         snapshots.put(writeTxnId, ImmutableMap.copyOf(indexes));
+        rowBinlogColumnMappings = ImmutableMap.copyOf(snapshots);
+    }
+
+    public synchronized void captureRemoteRowBinlogColumnMappings(Map<Long, TRowBinlogWriteColumnMappings> mappings)
+            throws AnalysisException {
+        Map<Long, RowBinlogWriteMapping> indexes = new HashMap<>();
+        for (Map.Entry<Long, TRowBinlogWriteColumnMappings> entry : mappings.entrySet()) {
+            indexes.put(entry.getKey(), new RowBinlogWriteMapping(entry.getValue()));
+        }
+        // A remote commit supplies the complete writer snapshot, not incremental sink planning.
+        Map<Long, RowBinlogWriteMapping> previous = rowBinlogColumnMappings.get(transactionId);
+        if (previous != null) {
+            if (!previous.equals(indexes)) {
+                throw new AnalysisException("Row-binlog column mapping changed within transaction " + transactionId);
+            }
+            return;
+        }
+        // Commit journals under this same monitor. A late retry must never amend journaled state.
+        if (transactionStatus != TransactionStatus.PREPARE) {
+            throw new AnalysisException("Cannot capture row-binlog column mapping for transaction "
+                    + transactionId + " in state " + transactionStatus);
+        }
+        Map<Long, Map<Long, RowBinlogWriteMapping>> snapshots = new HashMap<>(rowBinlogColumnMappings);
+        snapshots.put(transactionId, ImmutableMap.copyOf(indexes));
         rowBinlogColumnMappings = ImmutableMap.copyOf(snapshots);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableRowBinlogSchemaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableRowBinlogSchemaTest.java
@@ -63,6 +63,8 @@ public class OlapTableRowBinlogSchemaTest {
 
     @Test
     public void testRowBinlogSchemaOnEnable() {
+        Assertions.assertEquals("__DORIS_BEFORE__v1__", Column.generateBeforeColName("v1"));
+
         OlapTable tableWithoutBefore = newTestTable(BinlogTestUtils.newTestRowBinlogConfig(true, false));
         Assertions.assertTrue(tableWithoutBefore.needRowBinlog());
         Assertions.assertFalse(tableWithoutBefore.getBaseSchema(true).get(1).isAllowNull());

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableRowBinlogSchemaTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/OlapTableRowBinlogSchemaTest.java
@@ -63,7 +63,7 @@ public class OlapTableRowBinlogSchemaTest {
 
     @Test
     public void testRowBinlogSchemaOnEnable() {
-        Assertions.assertEquals("__DORIS_BEFORE__v1__", Column.generateBeforeColName("v1"));
+        Assertions.assertEquals("__BEFORE__v1__", Column.generateBeforeColName("v1"));
 
         OlapTable tableWithoutBefore = newTestTable(BinlogTestUtils.newTestRowBinlogConfig(true, false));
         Assertions.assertTrue(tableWithoutBefore.needRowBinlog());

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslatorTest.java
@@ -129,6 +129,14 @@ public class PhysicalPlanTranslatorTest extends TestWithFeService {
                 + "'enable_unique_key_merge_on_write' = 'true',"
                 + "'binlog.enable' = 'true','binlog.format' = 'ROW',"
                 + "'binlog.need_historical_value' = 'true');");
+        createTable("create table test_db.binlog_scan_schema_no_history_t(\n"
+                + "k1 int, k2 int, v1 int, v2 int)\n"
+                + "unique key(k1, k2)\n"
+                + "distributed by hash(k1) buckets 1\n"
+                + "properties('replication_num' = '1',"
+                + "'enable_unique_key_merge_on_write' = 'true',"
+                + "'binlog.enable' = 'true','binlog.format' = 'ROW',"
+                + "'binlog.need_historical_value' = 'false');");
         createTable("create table test_db.sequence_scan_schema_t(\n"
                 + "k1 int, k2 int, v1 int, v2 int)\n"
                 + "unique key(k1, k2)\n"
@@ -158,6 +166,9 @@ public class PhysicalPlanTranslatorTest extends TestWithFeService {
         // beyond the recorded consumption offset, driving the snapshot scan down the rebuild path
         // (base scan wrapped in OlapTableWrapper unioned with the binlog before-image).
         bumpPartitionsAndReplicas(binlogScanSchemaTable, 3L, 200L);
+        bumpPartitionsAndReplicas(
+                (OlapTable) database.getTableOrMetaException("binlog_scan_schema_no_history_t"),
+                2L, 100L);
         createTable("create table test_db.t_topn_lazy(c1 int, c2 int, c3 int) "
                 + "duplicate key(c1) distributed by hash(c1) buckets 1 "
                 + "properties('replication_num' = '1', 'light_schema_change' = 'true');");
@@ -269,6 +280,38 @@ public class PhysicalPlanTranslatorTest extends TestWithFeService {
                 .collect(Collectors.toSet());
         Assertions.assertTrue(dependencyUniqueIds.stream()
                 .noneMatch(thriftScanNode.olap_scan_node.getOutputColumnUniqueIds()::contains));
+        Assertions.assertEquals(ImmutableList.of(slotId(scanNode, "v1"), slotId(scanNode, "v2")),
+                thriftScanNode.olap_scan_node.getRowBinlogCurrentSlotIds());
+        Assertions.assertEquals(ImmutableList.of(
+                        slotId(scanNode, Column.generateBeforeColName("v1")),
+                        slotId(scanNode, Column.generateBeforeColName("v2"))),
+                thriftScanNode.olap_scan_node.getRowBinlogBeforeSlotIds());
+    }
+
+    @Test
+    public void testDetailBinlogPhysicalScanColumnMappings() throws Exception {
+        OlapScanNode scanNode = getFirstOlapScanNode(
+                "select v1 from test_db.binlog_scan_schema_t"
+                        + "@incr(\"incrementType\" = \"DETAIL\")");
+
+        TPlanNode thriftScanNode = scanNode.treeToThrift().getNodes().get(0);
+        Assertions.assertEquals(ImmutableList.of(slotId(scanNode, "v1")),
+                thriftScanNode.olap_scan_node.getRowBinlogCurrentSlotIds());
+        Assertions.assertEquals(ImmutableList.of(slotId(scanNode, Column.generateBeforeColName("v1"))),
+                thriftScanNode.olap_scan_node.getRowBinlogBeforeSlotIds());
+    }
+
+    @Test
+    public void testDetailBinlogPhysicalScanWithoutHistorySendsEmptyMappings() throws Exception {
+        OlapScanNode scanNode = getFirstOlapScanNode(
+                "select v1 from test_db.binlog_scan_schema_no_history_t"
+                        + "@incr(\"incrementType\" = \"DETAIL\")");
+
+        TPlanNode thriftScanNode = scanNode.treeToThrift().getNodes().get(0);
+        Assertions.assertTrue(thriftScanNode.olap_scan_node.isSetRowBinlogCurrentSlotIds());
+        Assertions.assertTrue(thriftScanNode.olap_scan_node.getRowBinlogCurrentSlotIds().isEmpty());
+        Assertions.assertTrue(thriftScanNode.olap_scan_node.isSetRowBinlogBeforeSlotIds());
+        Assertions.assertTrue(thriftScanNode.olap_scan_node.getRowBinlogBeforeSlotIds().isEmpty());
     }
 
     @Test
@@ -283,6 +326,9 @@ public class PhysicalPlanTranslatorTest extends TestWithFeService {
                 "v1", Column.BINLOG_OPERATION_COL, Column.BINLOG_TSO_COL), scanColumns);
 
         Assertions.assertTrue(scanNode.getExtraKeyColumnSlotIds().isEmpty());
+        TPlanNode thriftScanNode = scanNode.treeToThrift().getNodes().get(0);
+        Assertions.assertFalse(thriftScanNode.olap_scan_node.isSetRowBinlogCurrentSlotIds());
+        Assertions.assertFalse(thriftScanNode.olap_scan_node.isSetRowBinlogBeforeSlotIds());
     }
 
     @Test
@@ -537,6 +583,14 @@ public class PhysicalPlanTranslatorTest extends TestWithFeService {
 
     private OlapScanNode getFirstOlapScanNode(String sql) throws Exception {
         return getOlapScanNodes(sql).get(0);
+    }
+
+    private static int slotId(OlapScanNode scanNode, String columnName) {
+        return scanNode.getTupleDesc().getSlots().stream()
+                .filter(slot -> slot.getColumn().getName().equalsIgnoreCase(columnName))
+                .findFirst()
+                .orElseThrow()
+                .getId().asInt();
     }
 
     private List<OlapScanNode> getOlapScanNodes(String sql) throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslatorTest.java
@@ -26,6 +26,7 @@ import org.apache.doris.analysis.SlotRef;
 import org.apache.doris.analysis.SortInfo;
 import org.apache.doris.analysis.TupleDescriptor;
 import org.apache.doris.analysis.TupleId;
+import org.apache.doris.analysis.UserIdentity;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
@@ -37,10 +38,16 @@ import org.apache.doris.catalog.OlapTableWrapper;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.RowBinlogTableWrapper;
+import org.apache.doris.catalog.StructType;
 import org.apache.doris.catalog.Tablet;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
+import org.apache.doris.load.routineload.RoutineLoadJob;
+import org.apache.doris.load.routineload.kafka.KafkaRoutineLoadJob;
+import org.apache.doris.load.routineload.kinesis.KinesisRoutineLoadJob;
 import org.apache.doris.nereids.NereidsPlanner;
+import org.apache.doris.nereids.load.NereidsRoutineLoadTaskInfo;
+import org.apache.doris.nereids.load.NereidsStreamLoadPlanner;
 import org.apache.doris.nereids.processor.post.PlanPostProcessors;
 import org.apache.doris.nereids.properties.DataTrait;
 import org.apache.doris.nereids.properties.LogicalProperties;
@@ -62,6 +69,7 @@ import org.apache.doris.nereids.trees.plans.physical.PhysicalProject;
 import org.apache.doris.nereids.types.IntegerType;
 import org.apache.doris.nereids.util.PlanChecker;
 import org.apache.doris.nereids.util.PlanConstructor;
+import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.planner.AggregationNode;
 import org.apache.doris.planner.MaterializationNode;
 import org.apache.doris.planner.OlapScanNode;
@@ -74,14 +82,21 @@ import org.apache.doris.planner.RepeatNode;
 import org.apache.doris.planner.ScanContext;
 import org.apache.doris.planner.ScanNode;
 import org.apache.doris.thrift.TExplainLevel;
+import org.apache.doris.thrift.TPipelineFragmentParams;
 import org.apache.doris.thrift.TPlanNode;
 import org.apache.doris.thrift.TRuntimeFilterType;
 import org.apache.doris.thrift.TScanRangeLocations;
+import org.apache.doris.thrift.TUniqueId;
+import org.apache.doris.transaction.TransactionState;
+import org.apache.doris.transaction.TransactionState.LoadJobSourceType;
+import org.apache.doris.transaction.TransactionState.TxnCoordinator;
+import org.apache.doris.transaction.TransactionState.TxnSourceType;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
+import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -121,6 +136,10 @@ public class PhysicalPlanTranslatorTest extends TestWithFeService {
                 + "properties('replication_num' = '1');");
         Config.enable_feature_binlog = true;
         Config.enable_table_stream = true;
+        createTable("create table test_db.binlog_nested_scan_t(k1 int, v struct<a:int,b:int>, s string)\n"
+                + "unique key(k1) distributed by hash(k1) buckets 1\n"
+                + "properties('replication_num' = '1','enable_unique_key_merge_on_write' = 'true',"
+                + "'binlog.enable' = 'true','binlog.format' = 'ROW','binlog.need_historical_value' = 'true');");
         createTable("create table test_db.binlog_scan_schema_t(\n"
                 + "k1 int, k2 int, v1 int, v2 int)\n"
                 + "unique key(k1, k2)\n"
@@ -157,6 +176,7 @@ public class PhysicalPlanTranslatorTest extends TestWithFeService {
         // treats a positive offset as a real baseline, otherwise every partition would be pruned out
         // of the snapshot scan.
         Database database = (Database) Env.getCurrentInternalCatalog().getDbOrMetaException("test_db");
+        bumpPartitionsAndReplicas((OlapTable) database.getTableOrMetaException("binlog_nested_scan_t"), 2L, 100L);
         OlapTable binlogScanSchemaTable =
                 (OlapTable) database.getTableOrMetaException("binlog_scan_schema_t");
         bumpPartitionsAndReplicas(binlogScanSchemaTable, 2L, 100L);
@@ -299,6 +319,59 @@ public class PhysicalPlanTranslatorTest extends TestWithFeService {
                 thriftScanNode.olap_scan_node.getRowBinlogCurrentSlotIds());
         Assertions.assertEquals(ImmutableList.of(slotId(scanNode, Column.generateBeforeColName("v1"))),
                 thriftScanNode.olap_scan_node.getRowBinlogBeforeSlotIds());
+    }
+
+    @Test
+    public void testRoutineLoadPlannerCapturesActualTransactionSnapshot() throws Exception {
+        Database db = Env.getCurrentInternalCatalog().getDbOrMetaException("test_db");
+        OlapTable table = (OlapTable) db.getTableOrMetaException("binlog_scan_schema_t");
+        for (RoutineLoadJob job : ImmutableList.of(
+                new KafkaRoutineLoadJob(100L, "binlog_kafka", db.getId(), table.getId(),
+                        "localhost:9092", "topic", UserIdentity.ROOT),
+                new KinesisRoutineLoadJob(101L, "binlog_kinesis", db.getId(), table.getId(),
+                        "us-east-1", "stream", UserIdentity.ROOT))) {
+            long txnId = Env.getCurrentGlobalTransactionMgr().beginTransaction(db.getId(),
+                    ImmutableList.of(table.getId()), job.getName(), null,
+                    new TxnCoordinator(TxnSourceType.BE, 0L, "127.0.0.1", 0L),
+                    LoadJobSourceType.ROUTINE_LOAD_TASK, job.getId(), 60L);
+            NereidsRoutineLoadTaskInfo taskInfo = job.toNereidsRoutineLoadTaskInfo(txnId);
+            TPipelineFragmentParams plan = job.plan(new NereidsStreamLoadPlanner(db, table, taskInfo),
+                    new TUniqueId(0L, txnId), txnId);
+            Assertions.assertEquals(txnId, plan.getFragment().getOutputSink().getOlapTableSink().getTxnId());
+            TransactionState state = Env.getCurrentGlobalTransactionMgr().getTransactionState(db.getId(), txnId);
+            String expected = "{\"" + txnId + "\":{\"" + table.getBaseIndexId()
+                    + "\":{\"historical\":true,\"columns\":["
+                    + "{\"source\":0,\"current\":0},{\"source\":1,\"current\":1},"
+                    + "{\"source\":2,\"current\":2,\"before\":4},{\"source\":3,\"current\":3,\"before\":5}]}}}";
+            Assertions.assertEquals(JsonParser.parseString(expected),
+                    JsonParser.parseString(GsonUtils.GSON.toJson(state)).getAsJsonObject().get("rowBinlogMappings"));
+        }
+    }
+
+    @Test
+    public void testBinlogNestedValuesRetainCompleteCurrentAndBeforeImages() throws Exception {
+        for (String mode : ImmutableList.of("DETAIL", "MIN_DELTA")) {
+            OlapScanNode scan = getFirstOlapScanNode("select struct_element(v, 'a') from "
+                    + "test_db.binlog_nested_scan_t@incr(\"incrementType\"=\"" + mode + "\")");
+            for (String name : ImmutableList.of("v", Column.generateBeforeColName("v"))) {
+                SlotDescriptor slot = scan.getTupleDesc().getSlots().stream()
+                        .filter(s -> s.getColumn().getName().equalsIgnoreCase(name)).findFirst().orElseThrow();
+                Assertions.assertEquals(slot.getColumn().getType(), slot.getType(), mode + ": " + name);
+                Assertions.assertEquals(2, ((StructType) slot.getType()).getFields().size(), mode + ": " + name);
+                Assertions.assertTrue(slot.getAllAccessPaths().isEmpty(), mode + ": " + name);
+            }
+            TPlanNode thriftScan = scan.treeToThrift().getNodes().get(0);
+            List<String> pairedColumns = mode.equals("DETAIL") ? ImmutableList.of("v") : ImmutableList.of("v", "s");
+            Assertions.assertEquals(pairedColumns.stream().map(name -> slotId(scan, name)).collect(Collectors.toList()),
+                    thriftScan.olap_scan_node.getRowBinlogCurrentSlotIds());
+            Assertions.assertEquals(pairedColumns.stream().map(name -> slotId(scan, Column.generateBeforeColName(name)))
+                            .collect(Collectors.toList()), thriftScan.olap_scan_node.getRowBinlogBeforeSlotIds());
+        }
+        OlapScanNode scan = getFirstOlapScanNode("select length(s), v is null from "
+                + "test_db.binlog_nested_scan_t@incr(\"incrementType\"=\"MIN_DELTA\")");
+        for (SlotDescriptor slot : scan.getTupleDesc().getSlots()) {
+            Assertions.assertTrue(slot.getAllAccessPaths().isEmpty(), slot.getColumn().getName());
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/load/VariantLoadParseInjectionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/load/VariantLoadParseInjectionTest.java
@@ -157,7 +157,7 @@ public class VariantLoadParseInjectionTest extends TestWithFeService {
     }
 
     private LoadFixture createRoutineFixture(InputShape shape) throws Exception {
-        NereidsRoutineLoadTaskInfo task = new NereidsRoutineLoadTaskInfo(1024L, new HashMap<>(), 10L,
+        NereidsRoutineLoadTaskInfo task = new NereidsRoutineLoadTaskInfo(6L, 1024L, new HashMap<>(), 10L,
                 null, LoadTask.MergeType.APPEND, null, null, 0.0, columnDescs(shape), null, null,
                 null, null, (byte) 0, (byte) 0, 1, false, TUniqueKeyUpdateMode.UPSERT,
                 TPartialUpdateNewRowPolicy.APPEND, false);

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/RemoteOlapInsertExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/insert/RemoteOlapInsertExecutorTest.java
@@ -1,0 +1,308 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.trees.plans.commands.insert;
+
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.EnvFactory;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.TableIf.TableType;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.FeMetaVersion;
+import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.datasource.doris.FeServiceClient;
+import org.apache.doris.datasource.doris.RemoteDorisExternalCatalog;
+import org.apache.doris.datasource.doris.RemoteDorisExternalDatabase;
+import org.apache.doris.datasource.doris.RemoteOlapTable;
+import org.apache.doris.master.MasterImpl;
+import org.apache.doris.meta.MetaContext;
+import org.apache.doris.nereids.NereidsPlanner;
+import org.apache.doris.nereids.trees.plans.physical.PhysicalOlapTableSink;
+import org.apache.doris.planner.PlanFragment;
+import org.apache.doris.planner.RemoteOlapTableSink;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.Coordinator;
+import org.apache.doris.service.FrontendServiceImpl;
+import org.apache.doris.task.PublishVersionTask;
+import org.apache.doris.thrift.TCommitRemoteTxnRequest;
+import org.apache.doris.thrift.TCommitRemoteTxnResult;
+import org.apache.doris.thrift.TOlapTableIndexSchema;
+import org.apache.doris.thrift.TOlapTableSchemaParam;
+import org.apache.doris.thrift.TRowBinlogWriteColumnMapping;
+import org.apache.doris.thrift.TRowBinlogWriteColumnMappings;
+import org.apache.doris.thrift.TStatusCode;
+import org.apache.doris.transaction.GlobalTransactionMgrIface;
+import org.apache.doris.transaction.TransactionState;
+import org.apache.doris.transaction.TransactionState.LoadJobSourceType;
+import org.apache.doris.transaction.TransactionState.TxnCoordinator;
+import org.apache.doris.transaction.TransactionState.TxnSourceType;
+import org.apache.doris.transaction.TransactionStatus;
+
+import org.apache.thrift.TDeserializer;
+import org.apache.thrift.TSerializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+class RemoteOlapInsertExecutorTest {
+    private final TransactionState owner = new TransactionState(1L, Collections.singletonList(2L), 100L,
+            "remote", null, LoadJobSourceType.BACKEND_STREAMING,
+            new TxnCoordinator(TxnSourceType.FE, 0, "127.0.0.1", 0), -1, 60000);
+    private final GlobalTransactionMgrIface manager = Mockito.mock(GlobalTransactionMgrIface.class);
+    private final FeServiceClient client = Mockito.mock(FeServiceClient.class);
+    private final RemoteOlapTable table = Mockito.mock(RemoteOlapTable.class);
+    private MockedStatic<Env> envMock;
+    private MockedStatic<EnvFactory> factoryMock;
+    private FrontendServiceImpl service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Env env = Mockito.mock(Env.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(env.isMaster()).thenReturn(true);
+        Mockito.when(env.getTokenManager().checkAuthToken("test-token")).thenReturn(true);
+        InternalCatalog internalCatalog = Mockito.mock(InternalCatalog.class);
+        Database db = Mockito.mock(Database.class);
+        Mockito.when(db.getId()).thenReturn(1L);
+        Mockito.when(db.getTableOrMetaException("target", TableType.OLAP)).thenReturn(Mockito.mock(OlapTable.class));
+        Mockito.when(internalCatalog.getDbNullable("remote_db")).thenReturn(db);
+        Mockito.when(manager.getTransactionState(1L, 100L)).thenReturn(owner);
+        Mockito.when(manager.commitAndPublishTransaction(Mockito.eq(db), Mockito.anyList(), Mockito.eq(100L),
+                Mockito.anyList(), Mockito.anyLong(), Mockito.isNull())).thenReturn(false);
+        envMock = Mockito.mockStatic(Env.class);
+        envMock.when(Env::getCurrentEnv).thenReturn(env);
+        envMock.when(Env::getCurrentInternalCatalog).thenReturn(internalCatalog);
+        envMock.when(Env::getCurrentGlobalTransactionMgr).thenReturn(manager);
+
+        RemoteDorisExternalCatalog catalog = Mockito.mock(RemoteDorisExternalCatalog.class);
+        RemoteDorisExternalDatabase externalDb = Mockito.mock(RemoteDorisExternalDatabase.class);
+        Mockito.when(table.getDatabase()).thenReturn(externalDb);
+        Mockito.when(table.getCatalog()).thenReturn(catalog);
+        Mockito.when(table.getName()).thenReturn("target");
+        Mockito.when(externalDb.getId()).thenReturn(99L);
+        Mockito.when(externalDb.getFullName()).thenReturn("remote_db");
+        Mockito.when(externalDb.getCatalog()).thenReturn(catalog);
+        Mockito.when(catalog.getName()).thenReturn("remote_catalog");
+        Mockito.when(catalog.getFeServiceClient()).thenReturn(client);
+        EnvFactory factory = Mockito.mock(EnvFactory.class);
+        Mockito.when(factory.createCoordinator(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyLong()))
+                .thenReturn(Mockito.mock(Coordinator.class));
+        factoryMock = Mockito.mockStatic(EnvFactory.class);
+        factoryMock.when(EnvFactory::getInstance).thenReturn(factory);
+        try (MockedConstruction<MasterImpl> master = Mockito.mockConstruction(MasterImpl.class)) {
+            service = new FrontendServiceImpl(null);
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        factoryMock.close();
+        envMock.close();
+        ConnectContext.remove();
+    }
+
+    @Test
+    void testSenderSnapshotReachesOwnerBeforeCommitAndSurvivesReplay() throws Exception {
+        TOlapTableIndexSchema index = new TOlapTableIndexSchema(10L, Collections.emptyList(), 1)
+                .setRowBinlogId(20L).setRowBinlogNeedHistoricalValue(true)
+                .setRowBinlogColumnMappings(Arrays.asList(new TRowBinlogWriteColumnMapping(1, 11),
+                        new TRowBinlogWriteColumnMapping(2, 12).setBeforeColumnUniqueId(22)));
+        RemoteOlapInsertExecutor executor = prepareExecutor(index);
+        // The writer's schema is mutable; commit must retain the snapshot made during finalizeSink.
+        index.getRowBinlogColumnMappings().get(1).setCurrentColumnUniqueId(99);
+        TRowBinlogWriteColumnMappings expected = historicalMapping();
+        Mockito.when(manager.commitAndPublishTransaction(Mockito.any(), Mockito.anyList(), Mockito.eq(100L),
+                Mockito.anyList(), Mockito.anyLong(), Mockito.isNull())).thenAnswer(invocation -> {
+                    Assertions.assertEquals(Collections.singletonMap(10L, expected),
+                            owner.getRowBinlogColumnMappings(100L));
+                    owner.setTransactionStatus(TransactionStatus.COMMITTED);
+                    return false;
+                });
+        Mockito.when(client.commitRemoteTxn(Mockito.any())).thenAnswer(invocation -> {
+            TCommitRemoteTxnRequest sent = invocation.getArgument(0);
+            Assertions.assertTrue(sent.isSetRowBinlogColumnMappings());
+            Assertions.assertEquals(Collections.singletonMap(10L, expected), sent.getRowBinlogColumnMappings());
+            TCommitRemoteTxnRequest received = new TCommitRemoteTxnRequest();
+            new TDeserializer().deserialize(received, new TSerializer().serialize(sent));
+            return service.commitRemoteTxn(received.setToken("test-token"));
+        });
+        executor.onComplete();
+        executor.onComplete(); // The existing RPC retry is idempotent even after COMMITTED.
+        Assertions.assertEquals(TransactionStatus.COMMITTED, executor.txnStatus);
+
+        MetaContext context = new MetaContext();
+        context.setMetaVersion(FeMetaVersion.VERSION_CURRENT);
+        context.setThreadLocalInfo();
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        owner.write(new DataOutputStream(bytes));
+        TransactionState replayed = TransactionState.read(new DataInputStream(
+                new ByteArrayInputStream(bytes.toByteArray())));
+        PublishVersionTask publish = new PublishVersionTask(1L, 100L, 1L, Collections.emptyList(), 0);
+        publish.setRowBinlogColumnMappings(replayed.getRowBinlogColumnMappings(100L));
+        Assertions.assertEquals(Collections.singletonMap(10L, expected),
+                publish.toThrift().getRowBinlogColumnMappings());
+        Mockito.verify(manager, Mockito.never()).getTransactionState(99L, 100L);
+    }
+
+    @Test
+    void testSenderExplicitlySendsEmptySnapshot() throws Exception {
+        RemoteOlapInsertExecutor executor = prepareExecutor(
+                new TOlapTableIndexSchema(10L, Collections.emptyList(), 1));
+        Mockito.when(client.commitRemoteTxn(Mockito.any())).thenAnswer(invocation -> {
+            TCommitRemoteTxnRequest request = invocation.getArgument(0);
+            Assertions.assertTrue(request.isSetRowBinlogColumnMappings());
+            Assertions.assertTrue(request.getRowBinlogColumnMappings().isEmpty());
+            return service.commitRemoteTxn(request.setToken("test-token"));
+        });
+        executor.onComplete();
+        Assertions.assertEquals(TransactionStatus.COMMITTED, executor.txnStatus);
+    }
+
+    @Test
+    void testCloudSenderStillSendsSnapshotToLocalOwner() throws Exception {
+        RemoteOlapInsertExecutor executor;
+        try (MockedStatic<Config> config = Mockito.mockStatic(Config.class, Mockito.CALLS_REAL_METHODS)) {
+            config.when(Config::isCloudMode).thenReturn(true);
+            executor = prepareExecutor(new TOlapTableIndexSchema(10L, Collections.emptyList(), 1)
+                    .setRowBinlogId(20L).setRowBinlogNeedHistoricalValue(true)
+                    .setRowBinlogColumnMappings(historicalMapping().getEntries()));
+        }
+        Mockito.when(client.commitRemoteTxn(Mockito.any())).thenAnswer(invocation -> {
+            TCommitRemoteTxnRequest request = invocation.getArgument(0);
+            return service.commitRemoteTxn(request.setToken("test-token"));
+        });
+        executor.onComplete();
+        Assertions.assertEquals(Collections.singletonMap(10L, historicalMapping()),
+                owner.getRowBinlogColumnMappings(100L));
+    }
+
+    @Test
+    void testOwnerRejectsMissingOrIncompleteSnapshotBeforeCommit() throws Exception {
+        assertRejected(request(), "mapping");
+        assertRejected(request().setRowBinlogColumnMappings(Collections.singletonMap(10L,
+                new TRowBinlogWriteColumnMappings().setEntries(Collections.emptyList()))), "mapping");
+        assertRejected(request().setRowBinlogColumnMappings(Collections.singletonMap(10L,
+                new TRowBinlogWriteColumnMappings().setNeedHistoricalValue(true))), "mapping");
+        assertRejected(request().setRowBinlogColumnMappings(Collections.singletonMap(10L,
+                new TRowBinlogWriteColumnMappings().setNeedHistoricalValue(true)
+                        .setEntries(Collections.singletonList(new TRowBinlogWriteColumnMapping())))), "mapping");
+        Assertions.assertTrue(owner.getRowBinlogColumnMappings(100L).isEmpty());
+        Mockito.verify(manager, Mockito.never()).commitAndPublishTransaction(Mockito.any(), Mockito.anyList(),
+                Mockito.anyLong(), Mockito.anyList(), Mockito.anyLong(), Mockito.isNull());
+    }
+
+    @Test
+    void testOwnerRejectsChangedRetriesIncludingAfterCommit() throws Exception {
+        TCommitRemoteTxnRequest original = request().setRowBinlogColumnMappings(
+                Collections.singletonMap(10L, historicalMapping()));
+        Assertions.assertEquals(TStatusCode.OK, service.commitRemoteTxn(original).getStatus().getStatusCode());
+        for (TransactionStatus status : Arrays.asList(TransactionStatus.PREPARE, TransactionStatus.COMMITTED,
+                TransactionStatus.VISIBLE)) {
+            owner.setTransactionStatus(status);
+            Assertions.assertEquals(TStatusCode.OK, service.commitRemoteTxn(original).getStatus().getStatusCode());
+            TCommitRemoteTxnRequest changed = original.deepCopy();
+            changed.getRowBinlogColumnMappings().get(10L).setNeedHistoricalValue(false);
+            assertRejected(changed, "changed");
+            assertRejected(request().setRowBinlogColumnMappings(Collections.emptyMap()), "changed");
+            Assertions.assertEquals(original.getRowBinlogColumnMappings(), owner.getRowBinlogColumnMappings(100L));
+        }
+    }
+
+    @Test
+    void testOwnerPreservesKeyOnlyHistoricalAndExplicitFalse() throws Exception {
+        TRowBinlogWriteColumnMappings keyOnly = new TRowBinlogWriteColumnMappings()
+                .setNeedHistoricalValue(true).setEntries(Collections.singletonList(
+                        new TRowBinlogWriteColumnMapping(1, 11)));
+        Map<Long, TRowBinlogWriteColumnMappings> mappings = new HashMap<>();
+        mappings.put(10L, keyOnly);
+        mappings.put(30L, keyOnly.deepCopy().setNeedHistoricalValue(false));
+        Assertions.assertEquals(TStatusCode.OK,
+                service.commitRemoteTxn(request().setRowBinlogColumnMappings(mappings)).getStatus().getStatusCode());
+        keyOnly.setNeedHistoricalValue(false);
+        Assertions.assertTrue(owner.getRowBinlogColumnMappings(100L).get(10L).isNeedHistoricalValue());
+        Assertions.assertTrue(owner.getRowBinlogColumnMappings(100L).get(30L).isSetNeedHistoricalValue());
+        Assertions.assertFalse(owner.getRowBinlogColumnMappings(100L).get(30L).isNeedHistoricalValue());
+        Assertions.assertFalse(owner.getRowBinlogColumnMappings(100L).get(10L).getEntries().get(0)
+                .isSetBeforeColumnUniqueId());
+    }
+
+    @Test
+    void testOwnerRejectsLateFirstSnapshotAndMissingTransaction() throws Exception {
+        owner.setTransactionStatus(TransactionStatus.COMMITTED);
+        TCommitRemoteTxnRequest request = request().setRowBinlogColumnMappings(
+                Collections.singletonMap(10L, historicalMapping()));
+        assertRejected(request, "COMMITTED");
+        Assertions.assertTrue(owner.getRowBinlogColumnMappings(100L).isEmpty());
+        Mockito.when(manager.getTransactionState(1L, 100L)).thenReturn(null);
+        assertRejected(request, "100");
+        Mockito.verify(manager, Mockito.never()).commitAndPublishTransaction(Mockito.any(), Mockito.anyList(),
+                Mockito.anyLong(), Mockito.anyList(), Mockito.anyLong(), Mockito.isNull());
+    }
+
+    @Test
+    void testCloudOwnerDoesNotPersistFeSnapshot() throws Exception {
+        try (MockedStatic<Config> config = Mockito.mockStatic(Config.class, Mockito.CALLS_REAL_METHODS)) {
+            config.when(Config::isCloudMode).thenReturn(true);
+            Assertions.assertEquals(TStatusCode.OK, service.commitRemoteTxn(request().setRowBinlogColumnMappings(
+                    Collections.singletonMap(10L, historicalMapping()))).getStatus().getStatusCode());
+            Assertions.assertTrue(owner.getRowBinlogColumnMappings(100L).isEmpty());
+            Mockito.verify(manager, Mockito.never()).getTransactionState(Mockito.anyLong(), Mockito.anyLong());
+        }
+    }
+
+    private RemoteOlapInsertExecutor prepareExecutor(TOlapTableIndexSchema index) {
+        RemoteOlapInsertExecutor executor = new RemoteOlapInsertExecutor(new ConnectContext(), table, "remote",
+                Mockito.mock(NereidsPlanner.class), Optional.empty(), false, 123L);
+        executor.txnId = 100L;
+        RemoteOlapTableSink sink = Mockito.mock(RemoteOlapTableSink.class);
+        Mockito.when(sink.getOlapTableSchemaParam()).thenReturn(new TOlapTableSchemaParam()
+                .setIndexes(Collections.singletonList(index)));
+        executor.finalizeSink(Mockito.mock(PlanFragment.class), sink, Mockito.mock(PhysicalOlapTableSink.class));
+        return executor;
+    }
+
+    private TCommitRemoteTxnRequest request() {
+        return new TCommitRemoteTxnRequest().setDb("remote_db").setTbl("target").setTxnId(100L)
+                .setToken("test-token").setCommitInfos(Collections.emptyList()).setInsertVisibleTimeoutMs(1000L);
+    }
+
+    private TRowBinlogWriteColumnMappings historicalMapping() {
+        return new TRowBinlogWriteColumnMappings().setNeedHistoricalValue(true).setEntries(Arrays.asList(
+                new TRowBinlogWriteColumnMapping(1, 11),
+                new TRowBinlogWriteColumnMapping(2, 12).setBeforeColumnUniqueId(22)));
+    }
+
+    private void assertRejected(TCommitRemoteTxnRequest request, String message) throws Exception {
+        TCommitRemoteTxnResult result = service.commitRemoteTxn(request);
+        Assertions.assertEquals(TStatusCode.ANALYSIS_ERROR, result.getStatus().getStatusCode());
+        Assertions.assertTrue(result.getStatus().getErrorMsgs().get(0).contains(message), result.toString());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
@@ -17,8 +17,12 @@
 
 package org.apache.doris.planner;
 
+import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.KeysType;
+import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.planner.OlapTableSink.AdaptiveBucketAssignment;
 import org.apache.doris.planner.OlapTableSink.AdaptiveIndexBucketAssignment;
 import org.apache.doris.system.Backend;
@@ -26,6 +30,8 @@ import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TOlapTableIndexTablets;
 import org.apache.doris.thrift.TOlapTableLocationParam;
 import org.apache.doris.thrift.TOlapTablePartition;
+import org.apache.doris.thrift.TRowBinlogWriteColumnMapping;
+import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TTabletLocation;
 
 import com.google.common.collect.ImmutableMap;
@@ -40,6 +46,43 @@ import java.util.List;
 import java.util.Map;
 
 public class OlapTableSinkTest {
+    @Test
+    public void testCreateHistoricalRowBinlogColumnMappings() throws Exception {
+        MaterializedIndexMeta sourceMeta = indexMeta(1L, Arrays.asList(
+                column("K1", 1, true, true),
+                column("hidden_value", 2, false, false),
+                column(Column.SHADOW_NAME_PREFIX + "v1", 3, false, true),
+                column("HIDDEN_KEY", 4, true, false)));
+        MaterializedIndexMeta rowBinlogMeta = indexMeta(2L, Arrays.asList(
+                column("k1", 11, true, true),
+                column("V1", 13, false, true),
+                column("hidden_key", 14, true, false),
+                column(Column.generateBeforeColName("v1"), 23, false, true)));
+
+        List<TRowBinlogWriteColumnMapping> mappings = OlapTableSink.createRowBinlogColumnMappings(
+                sourceMeta, rowBinlogMeta, true);
+
+        Assertions.assertEquals(3, mappings.size());
+        assertMapping(mappings.get(0), 1, 11, null);
+        assertMapping(mappings.get(1), 3, 13, 23);
+        assertMapping(mappings.get(2), 4, 14, null);
+    }
+
+    @Test
+    public void testCreateNonHistoricalRowBinlogColumnMappings() throws Exception {
+        MaterializedIndexMeta sourceMeta = indexMeta(1L, Arrays.asList(
+                column("k1", 1, true, true), column("v1", 2, false, true)));
+        MaterializedIndexMeta rowBinlogMeta = indexMeta(2L, Arrays.asList(
+                column("k1", 11, true, true), column("v1", 12, false, true)));
+
+        List<TRowBinlogWriteColumnMapping> mappings = OlapTableSink.createRowBinlogColumnMappings(
+                sourceMeta, rowBinlogMeta, false);
+
+        Assertions.assertEquals(2, mappings.size());
+        assertMapping(mappings.get(0), 1, 11, null);
+        assertMapping(mappings.get(1), 2, 12, null);
+    }
+
     @Test
     public void testCreateDummyLocationUsesLoadAvailableBackendInCurrentComputeGroup() throws Exception {
         SystemInfoService systemInfoService = Mockito.mock(SystemInfoService.class);
@@ -194,5 +237,28 @@ public class OlapTableSinkTest {
         Assertions.assertEquals(indexId, indexAssignment.getIndexId());
         Assertions.assertEquals(bucketBeId, indexAssignment.getBucketBeId());
         Assertions.assertEquals(localBucketSeqs, indexAssignment.getLocalBucketSeqs());
+    }
+
+    private static Column column(String name, int uniqueId, boolean isKey, boolean isVisible) {
+        Column column = new Column(name, PrimitiveType.INT);
+        column.setUniqueId(uniqueId);
+        column.setIsKey(isKey);
+        column.setIsVisible(isVisible);
+        return column;
+    }
+
+    private static MaterializedIndexMeta indexMeta(long indexId, List<Column> columns) {
+        return new MaterializedIndexMeta(indexId, columns, 1, 1, (short) 1, TStorageType.COLUMN,
+                KeysType.PRIMARY_KEYS, null);
+    }
+
+    private static void assertMapping(TRowBinlogWriteColumnMapping mapping, int sourceUniqueId,
+            int currentUniqueId, Integer beforeUniqueId) {
+        Assertions.assertEquals(sourceUniqueId, mapping.getSourceColumnUniqueId());
+        Assertions.assertEquals(currentUniqueId, mapping.getCurrentColumnUniqueId());
+        Assertions.assertEquals(beforeUniqueId != null, mapping.isSetBeforeColumnUniqueId());
+        if (beforeUniqueId != null) {
+            Assertions.assertEquals(beforeUniqueId.intValue(), mapping.getBeforeColumnUniqueId());
+        }
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
@@ -17,12 +17,20 @@
 
 package org.apache.doris.planner;
 
+import org.apache.doris.analysis.TupleDescriptor;
+import org.apache.doris.analysis.TupleId;
+import org.apache.doris.catalog.BinlogConfig;
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.KeysType;
 import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.load.routineload.RoutineLoadJob;
+import org.apache.doris.load.routineload.kafka.KafkaRoutineLoadJob;
+import org.apache.doris.load.routineload.kinesis.KinesisRoutineLoadJob;
+import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.planner.OlapTableSink.AdaptiveBucketAssignment;
 import org.apache.doris.planner.OlapTableSink.AdaptiveIndexBucketAssignment;
 import org.apache.doris.system.Backend;
@@ -33,8 +41,11 @@ import org.apache.doris.thrift.TOlapTablePartition;
 import org.apache.doris.thrift.TRowBinlogWriteColumnMapping;
 import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TTabletLocation;
+import org.apache.doris.transaction.GlobalTransactionMgrIface;
+import org.apache.doris.transaction.TransactionState;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -46,6 +57,51 @@ import java.util.List;
 import java.util.Map;
 
 public class OlapTableSinkTest {
+    @Test
+    public void testWriteSchemaCapturesTransactionSnapshot() throws Exception {
+        checkWriteSchemaSnapshot(100L);
+    }
+
+    @Test
+    public void testRoutineLoadPlansWithActualTransactionBeforeCapturingSnapshot() throws Exception {
+        for (RoutineLoadJob job : Arrays.asList(new KafkaRoutineLoadJob(), new KinesisRoutineLoadJob())) {
+            long planningTxnId = job.toNereidsRoutineLoadTaskInfo(100L).getTxnId();
+            Assertions.assertDoesNotThrow(() -> checkWriteSchemaSnapshot(planningTxnId));
+        }
+    }
+
+    private void checkWriteSchemaSnapshot(long planningTxnId) throws Exception {
+        MaterializedIndexMeta source = indexMeta(10L, Arrays.asList(
+                column("k1", 1, true, true), column("v1", 2, false, true)));
+        source.setRowBinlogIndexId(20L);
+        MaterializedIndexMeta binlog = indexMeta(20L, Arrays.asList(
+                column("k1", 11, true, true), column("v1", 12, false, true),
+                column(Column.generateBeforeColName("v1"), 22, false, true)));
+        OlapTable table = Mockito.mock(OlapTable.class);
+        Mockito.when(table.needRowBinlog()).thenReturn(true);
+        Mockito.when(table.getBaseIndexId()).thenReturn(10L);
+        Mockito.when(table.getIndexMetaByIndexId(10L)).thenReturn(source);
+        Mockito.when(table.getIndexIdToMeta()).thenReturn(ImmutableMap.of(10L, source));
+        Mockito.when(table.getRowBinlogMeta()).thenReturn(binlog);
+        BinlogConfig config = Mockito.mock(BinlogConfig.class);
+        Mockito.when(config.getNeedHistoricalValue()).thenReturn(true);
+        Mockito.when(table.getBinlogConfig()).thenReturn(config);
+        TransactionState state = new TransactionState();
+        GlobalTransactionMgrIface manager = Mockito.mock(GlobalTransactionMgrIface.class);
+        Mockito.when(manager.getTransactionState(1L, 100L)).thenReturn(state);
+        try (MockedStatic<Env> env = Mockito.mockStatic(Env.class)) {
+            env.when(Env::getCurrentGlobalTransactionMgr).thenReturn(manager);
+            OlapTableSink sink = new OlapTableSink(table, new TupleDescriptor(new TupleId(0)),
+                    Collections.emptyList());
+            Deencapsulation.setField(sink, "txnId", planningTxnId);
+            Deencapsulation.invoke(sink, "createSchema", 1L, table);
+        }
+        String expected = "{\"100\":{\"10\":{\"historical\":true,\"columns\":["
+                + "{\"source\":1,\"current\":11},{\"source\":2,\"current\":12,\"before\":22}]}}}";
+        Assertions.assertEquals(JsonParser.parseString(expected),
+                JsonParser.parseString(GsonUtils.GSON.toJson(state)).getAsJsonObject().get("rowBinlogMappings"));
+    }
+
     @Test
     public void testCreateHistoricalRowBinlogColumnMappings() throws Exception {
         MaterializedIndexMeta sourceMeta = indexMeta(1L, Arrays.asList(

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/OlapTableSinkTest.java
@@ -27,6 +27,8 @@ import org.apache.doris.catalog.MaterializedIndexMeta;
 import org.apache.doris.catalog.OlapTable;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.doris.RemoteDorisExternalCatalog;
+import org.apache.doris.datasource.doris.RemoteOlapTable;
 import org.apache.doris.load.routineload.RoutineLoadJob;
 import org.apache.doris.load.routineload.kafka.KafkaRoutineLoadJob;
 import org.apache.doris.load.routineload.kinesis.KinesisRoutineLoadJob;
@@ -38,6 +40,7 @@ import org.apache.doris.system.SystemInfoService;
 import org.apache.doris.thrift.TOlapTableIndexTablets;
 import org.apache.doris.thrift.TOlapTableLocationParam;
 import org.apache.doris.thrift.TOlapTablePartition;
+import org.apache.doris.thrift.TOlapTableSchemaParam;
 import org.apache.doris.thrift.TRowBinlogWriteColumnMapping;
 import org.apache.doris.thrift.TStorageType;
 import org.apache.doris.thrift.TTabletLocation;
@@ -71,13 +74,22 @@ public class OlapTableSinkTest {
     }
 
     private void checkWriteSchemaSnapshot(long planningTxnId) throws Exception {
+        checkWriteSchemaSnapshot(planningTxnId, false);
+    }
+
+    @Test
+    public void testRemoteWriteSchemaDoesNotCaptureInLocalTransaction() throws Exception {
+        checkWriteSchemaSnapshot(100L, true);
+    }
+
+    private void checkWriteSchemaSnapshot(long planningTxnId, boolean remote) throws Exception {
         MaterializedIndexMeta source = indexMeta(10L, Arrays.asList(
                 column("k1", 1, true, true), column("v1", 2, false, true)));
         source.setRowBinlogIndexId(20L);
         MaterializedIndexMeta binlog = indexMeta(20L, Arrays.asList(
                 column("k1", 11, true, true), column("v1", 12, false, true),
                 column(Column.generateBeforeColName("v1"), 22, false, true)));
-        OlapTable table = Mockito.mock(OlapTable.class);
+        OlapTable table = remote ? Mockito.mock(RemoteOlapTable.class) : Mockito.mock(OlapTable.class);
         Mockito.when(table.needRowBinlog()).thenReturn(true);
         Mockito.when(table.getBaseIndexId()).thenReturn(10L);
         Mockito.when(table.getIndexMetaByIndexId(10L)).thenReturn(source);
@@ -91,10 +103,24 @@ public class OlapTableSinkTest {
         Mockito.when(manager.getTransactionState(1L, 100L)).thenReturn(state);
         try (MockedStatic<Env> env = Mockito.mockStatic(Env.class)) {
             env.when(Env::getCurrentGlobalTransactionMgr).thenReturn(manager);
-            OlapTableSink sink = new OlapTableSink(table, new TupleDescriptor(new TupleId(0)),
-                    Collections.emptyList());
+            OlapTableSink sink;
+            if (remote) {
+                RemoteDorisExternalCatalog catalog = Mockito.mock(RemoteDorisExternalCatalog.class,
+                        Mockito.RETURNS_DEEP_STUBS);
+                Mockito.when(((RemoteOlapTable) table).getCatalog()).thenReturn(catalog);
+                sink = new RemoteOlapTableSink((RemoteOlapTable) table, new TupleDescriptor(new TupleId(0)),
+                        Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
+            } else {
+                sink = new OlapTableSink(table, new TupleDescriptor(new TupleId(0)), Collections.emptyList());
+            }
             Deencapsulation.setField(sink, "txnId", planningTxnId);
-            Deencapsulation.invoke(sink, "createSchema", 1L, table);
+            TOlapTableSchemaParam schema = Deencapsulation.invoke(sink, "createSchema", 1L, table);
+            if (remote) {
+                Assertions.assertEquals(2, schema.getIndexes().get(0).getRowBinlogColumnMappingsSize());
+                Mockito.verifyNoInteractions(manager);
+                Assertions.assertTrue(state.getRowBinlogColumnMappings(100L).isEmpty());
+                return;
+            }
         }
         String expected = "{\"100\":{\"10\":{\"historical\":true,\"columns\":["
                 + "{\"source\":1,\"current\":11},{\"source\":2,\"current\":12,\"before\":22}]}}}";

--- a/fe/fe-core/src/test/java/org/apache/doris/task/PublishVersionTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/task/PublishVersionTaskTest.java
@@ -17,12 +17,37 @@
 
 package org.apache.doris.task;
 
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.LocalTabletInvertedIndex;
+import org.apache.doris.catalog.TabletMeta;
+import org.apache.doris.common.Pair;
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.master.ReportHandler;
+import org.apache.doris.persist.gson.GsonUtils;
+import org.apache.doris.thrift.TPartitionVersionInfo;
+import org.apache.doris.thrift.TPublishVersionRequest;
+import org.apache.doris.thrift.TRowBinlogWriteColumnMappings;
+import org.apache.doris.thrift.TStorageMedium;
+import org.apache.doris.thrift.TTaskType;
+import org.apache.doris.transaction.GlobalTransactionMgrIface;
+import org.apache.doris.transaction.PartitionCommitInfo;
+import org.apache.doris.transaction.PublishVersionDaemon;
+import org.apache.doris.transaction.TableCommitInfo;
+import org.apache.doris.transaction.TransactionState;
+
 import com.google.common.collect.ImmutableMap;
+import org.apache.thrift.TDeserializer;
+import org.apache.thrift.TSerializer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Regression tests for the invariant: PublishVersionTask.getSuccTablets() must never return null,
@@ -31,6 +56,86 @@ import java.util.Map;
  * non-OK BE callback (MasterImpl.finishPublishVersion path).
  */
 public class PublishVersionTaskTest {
+
+    @Test
+    public void testReportRetainsSnapshotAfterSubtransactionAliasRemoved() throws Exception {
+        TransactionState state = GsonUtils.GSON.fromJson("{\"dbId\":1,\"txnId\":100,\"rowBinlogMappings\":{"
+                + "\"101\":{\"10\":{\"historical\":false,\"columns\":[{\"source\":1,\"current\":31}]}}}}",
+                TransactionState.class);
+        Deencapsulation.setField(state, "subTxnIds", Arrays.asList(100L, 101L));
+        TableCommitInfo table = new TableCommitInfo(123L);
+        PartitionCommitInfo partition = new PartitionCommitInfo();
+        Deencapsulation.setField(partition, "partitionId", 2L);
+        partition.setVersion(3L);
+        table.addPartitionCommitInfo(partition);
+        state.getSubTxnIdToTableCommitInfo().put(101L, table);
+        Map<Long, Pair<TransactionState, Set<TPartitionVersionInfo>>> classified = new HashMap<>();
+        TabletMeta tablet = new TabletMeta(1L, 123L, 2L, 10L, 1, TStorageMedium.HDD, false);
+        LocalTabletInvertedIndex index = new LocalTabletInvertedIndex();
+        Deencapsulation.invoke(index, "publishPartition", state, 101L, tablet, 2L, classified);
+        Deencapsulation.invoke(index, "publishPartition", state, 101L, tablet, 2L, classified);
+        Assertions.assertEquals(1, classified.size());
+        Assertions.assertEquals(1, classified.get(101L).second.size());
+        long backendId = 10002L;
+        // Becoming VISIBLE removes the subtransaction alias, not the parent state's snapshot.
+        GlobalTransactionMgrIface manager = Mockito.mock(GlobalTransactionMgrIface.class);
+        try (MockedStatic<Env> env = Mockito.mockStatic(Env.class);
+                MockedStatic<AgentTaskExecutor> executor = Mockito.mockStatic(AgentTaskExecutor.class)) {
+            env.when(Env::getCurrentGlobalTransactionMgr).thenReturn(manager);
+            Deencapsulation.invoke(ReportHandler.class, "handleRepublishVersionInfo", classified, backendId);
+            PublishVersionTask task = (PublishVersionTask) AgentTaskQueue.getTask(
+                    backendId, TTaskType.PUBLISH_VERSION, 101L);
+            Assertions.assertNotNull(task);
+            assertWireMapping(task, 101L, 31, false);
+        } finally {
+            AgentTaskQueue.removeTask(backendId, TTaskType.PUBLISH_VERSION, 101L);
+        }
+    }
+
+    @Test
+    public void testNormalAndReportPublishUseReplayedSubtransactionSnapshots() throws Exception {
+        TransactionState state = GsonUtils.GSON.fromJson("{\"dbId\":1,\"txnId\":100,\"rowBinlogMappings\":{"
+                + "\"100\":{\"10\":{\"historical\":true,\"columns\":[{\"source\":1,\"current\":11}]}},"
+                + "\"101\":{\"10\":{\"historical\":false,\"columns\":[{\"source\":1,\"current\":31}]}}}}",
+                TransactionState.class);
+        long backendId = 10001L;
+        TPartitionVersionInfo version = new TPartitionVersionInfo(2L, 3L, 0L);
+        try {
+            AgentBatchTask batch = new AgentBatchTask();
+            Deencapsulation.invoke(new PublishVersionDaemon(), "addPublishVersionTask",
+                    Collections.singleton(backendId), 100L, state, Collections.singletonList(version),
+                    Collections.emptyMap(), 0L, batch);
+            Assertions.assertEquals(1, batch.getAllTasks().size());
+            assertWireMapping((PublishVersionTask) batch.getAllTasks().get(0), 100L, 11, true);
+
+            try (MockedStatic<AgentTaskExecutor> executor = Mockito.mockStatic(AgentTaskExecutor.class)) {
+                Deencapsulation.invoke(ReportHandler.class, "handleRepublishVersionInfo",
+                        ImmutableMap.of(101L, Pair.of(state, Collections.singleton(version))), backendId);
+                PublishVersionTask republish = (PublishVersionTask) AgentTaskQueue.getTask(
+                        backendId, TTaskType.PUBLISH_VERSION, 101L);
+                Assertions.assertNotNull(republish);
+                assertWireMapping(republish, 101L, 31, false);
+            }
+        } finally {
+            AgentTaskQueue.removeTask(backendId, TTaskType.PUBLISH_VERSION, 100L);
+            AgentTaskQueue.removeTask(backendId, TTaskType.PUBLISH_VERSION, 101L);
+        }
+    }
+
+    private static void assertWireMapping(PublishVersionTask task, long txnId, int current, boolean historical)
+            throws Exception {
+        TPublishVersionRequest request = new TPublishVersionRequest();
+        new TDeserializer().deserialize(request, new TSerializer().serialize(task.toThrift()));
+        Assertions.assertEquals(txnId, request.getTransactionId());
+        Assertions.assertEquals(1, request.getRowBinlogColumnMappingsSize());
+        TRowBinlogWriteColumnMappings mapping = request.getRowBinlogColumnMappings().get(10L);
+        Assertions.assertTrue(mapping.isSetNeedHistoricalValue());
+        Assertions.assertEquals(historical, mapping.isNeedHistoricalValue());
+        Assertions.assertEquals(1, mapping.getEntriesSize());
+        Assertions.assertEquals(1, mapping.getEntries().get(0).getSourceColumnUniqueId());
+        Assertions.assertEquals(current, mapping.getEntries().get(0).getCurrentColumnUniqueId());
+        Assertions.assertFalse(mapping.getEntries().get(0).isSetBeforeColumnUniqueId());
+    }
 
     private PublishVersionTask newTask() {
         return new PublishVersionTask(

--- a/fe/fe-core/src/test/java/org/apache/doris/transaction/TransactionStateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/transaction/TransactionStateTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.transaction;
 
+import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.load.EtlStatus;
@@ -27,8 +28,13 @@ import org.apache.doris.load.loadv2.LoadJobFinalOperation;
 import org.apache.doris.load.routineload.RLTaskTxnCommitAttachment;
 import org.apache.doris.load.routineload.kafka.KafkaProgress;
 import org.apache.doris.meta.MetaContext;
+import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.thrift.TEtlState;
 import org.apache.doris.thrift.TKafkaRLTaskProgress;
+import org.apache.doris.thrift.TOlapTableIndexSchema;
+import org.apache.doris.thrift.TOlapTableSchemaParam;
+import org.apache.doris.thrift.TRowBinlogWriteColumnMapping;
+import org.apache.doris.thrift.TRowBinlogWriteColumnMappings;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.TransactionState.LoadJobSourceType;
 import org.apache.doris.transaction.TransactionState.TxnCoordinator;
@@ -36,6 +42,7 @@ import org.apache.doris.transaction.TransactionState.TxnSourceType;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.gson.JsonParser;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -46,6 +53,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
 
@@ -54,6 +64,53 @@ public class TransactionStateTest {
     private static String fileName = "./TransactionStateTest";
     private static String fileName2 = "./TransactionStateTest2";
     private static String fileName3 = "./TransactionStateTest3";
+
+    @Test
+    public void testRowBinlogSnapshotsAreIndependentOfWriterAndPublishRequests() throws Exception {
+        TransactionState state = new TransactionState();
+        TRowBinlogWriteColumnMapping key = new TRowBinlogWriteColumnMapping(1, 11);
+        TRowBinlogWriteColumnMapping value = new TRowBinlogWriteColumnMapping(2, 12)
+                .setBeforeColumnUniqueId(22);
+        TOlapTableIndexSchema index = new TOlapTableIndexSchema(10L, Collections.emptyList(), 1)
+                .setRowBinlogId(20L).setRowBinlogNeedHistoricalValue(true)
+                .setRowBinlogColumnMappings(Arrays.asList(key, value));
+        TOlapTableSchemaParam schema = new TOlapTableSchemaParam().setIndexes(Collections.singletonList(index));
+        state.captureRowBinlogColumnMappings(100L, schema);
+        state.captureRowBinlogColumnMappings(100L, schema); // Identical retries are allowed.
+        value.setCurrentColumnUniqueId(99);
+        Assertions.assertThrows(AnalysisException.class, () -> state.captureRowBinlogColumnMappings(100L, schema));
+        state.captureRowBinlogColumnMappings(101L, schema); // Separate subtransaction, separate schema snapshot.
+
+        testSerDe(fileName, state, restored -> {
+            Map<Long, TRowBinlogWriteColumnMappings> published = restored.getRowBinlogColumnMappings(100L);
+            TRowBinlogWriteColumnMappings mapping = published.get(10L);
+            Assertions.assertTrue(mapping.isSetNeedHistoricalValue());
+            Assertions.assertTrue(mapping.isNeedHistoricalValue());
+            Assertions.assertEquals(2, mapping.getEntriesSize());
+            Assertions.assertFalse(mapping.getEntries().get(0).isSetBeforeColumnUniqueId());
+            Assertions.assertEquals(12, mapping.getEntries().get(1).getCurrentColumnUniqueId());
+            Assertions.assertEquals(22, mapping.getEntries().get(1).getBeforeColumnUniqueId());
+            mapping.getEntries().clear();
+            published.clear();
+            Assertions.assertEquals(2, restored.getRowBinlogColumnMappings(100L).get(10L).getEntriesSize());
+            Assertions.assertEquals(99, restored.getRowBinlogColumnMappings(101L).get(10L)
+                    .getEntries().get(1).getCurrentColumnUniqueId());
+            Assertions.assertTrue(restored.getRowBinlogColumnMappings(102L).isEmpty());
+        });
+    }
+
+    @Test
+    public void testRowBinlogSnapshotSurvivesTransactionReplay() throws IOException {
+        // Key-only historical and a later subtransaction must retain distinct write-time snapshots.
+        String snapshots = "{\"100\":{\"10\":{\"historical\":true,\"columns\":["
+                + "{\"source\":1,\"current\":11}]}},"
+                + "\"101\":{\"10\":{\"historical\":false,\"columns\":["
+                + "{\"source\":1,\"current\":11},{\"source\":2,\"current\":12}]}}}";
+        TransactionState state = GsonUtils.GSON.fromJson(
+                "{\"txnId\":100,\"rowBinlogMappings\":" + snapshots + "}", TransactionState.class);
+        testSerDe(fileName, state, restored -> Assertions.assertEquals(JsonParser.parseString(snapshots),
+                JsonParser.parseString(restored.toJson()).getAsJsonObject().get("rowBinlogMappings")));
+    }
 
     @AfterEach
     public void tearDown() {

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -454,8 +454,8 @@ under the License.
         <flatbuffers.version>1.12.0</flatbuffers.version>
         <jacoco.version>0.8.10</jacoco.version>
         <!-- Maven Shade 3.4.1 cannot parse the Java 21 multi-release classes shipped by
-             Jackson 2.21.x. Version 3.5.1 uses ASM 9.5, which supports Java 21. -->
-        <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
+             Jackson 2.21.x. Version 3.6.2 uses a current ASM release that supports them. -->
+        <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
         <argLine></argLine>
         <trino.version>435</trino.version>
         <nimbusds.version>10.0.1</nimbusds.version>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -454,8 +454,8 @@ under the License.
         <flatbuffers.version>1.12.0</flatbuffers.version>
         <jacoco.version>0.8.10</jacoco.version>
         <!-- Maven Shade 3.4.1 cannot parse the Java 21 multi-release classes shipped by
-             Jackson 2.21.x. Version 3.6.2 uses a current ASM release that supports them. -->
-        <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
+             Jackson 2.21.x. Version 3.5.1 uses ASM 9.5, which supports Java 21. -->
+        <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
         <argLine></argLine>
         <trino.version>435</trino.version>
         <nimbusds.version>10.0.1</nimbusds.version>

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -104,6 +104,7 @@ message POlapTableIndexSchema {
     repeated ColumnPB columns_desc = 4;
     repeated TabletIndexPB indexes_desc = 5;
     optional int64 row_binlog_id = 6;
+    optional PRowBinlogWriteColumnMappings row_binlog_column_mappings = 7;
 };
 
 message POlapTableSchemaParam {
@@ -128,4 +129,3 @@ message POlapTableSchemaParam {
     optional PartialUpdateNewRowPolicyPB partial_update_new_key_policy = 17 [default = APPEND];
     repeated POlapTableIndexSchema row_binlog_index_schemas = 18;
 };
-

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -80,6 +80,17 @@ message TsoRangePB {
     optional int64 end_tso = 2 [default = -1];
 }
 
+message PRowBinlogWriteColumnMapping {
+    required int32 source_column_unique_id = 1;
+    required int32 current_column_unique_id = 2;
+    optional int32 before_column_unique_id = 3;
+}
+
+message PRowBinlogWriteColumnMappings {
+    repeated PRowBinlogWriteColumnMapping entries = 1;
+    optional bool need_historical_value = 2;
+}
+
 // ATTN: When adding or deleting fields, please update `message RowsetMetaCloudPB`
 // simultaneously and modify the conversion function in the be/src/cloud/pb_convert.{h,cpp}.
 message RowsetMetaPB {
@@ -155,6 +166,7 @@ message RowsetMetaPB {
     optional bool segments_key_bounds_aggregated = 57;
 
     optional bool is_row_binlog = 58 [default = false];
+    optional PRowBinlogWriteColumnMappings row_binlog_column_mappings = 60;
 
     // Valid only when segments_overlap_pb is NONOVERLAPPING_WITHIN_GROUP.
     // Each value is the number of consecutive output segments in one non-overlapping group.
@@ -285,6 +297,7 @@ message RowsetMetaCloudPB {
     optional bool segments_key_bounds_aggregated = 57;
 
     optional bool is_row_binlog = 58 [default = false];
+    optional PRowBinlogWriteColumnMappings row_binlog_column_mappings = 60;
 
     // Valid only when segments_overlap_pb is NONOVERLAPPING_WITHIN_GROUP.
     // Each value is the number of consecutive output segments in one non-overlapping group.

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -166,7 +166,6 @@ message RowsetMetaPB {
     optional bool segments_key_bounds_aggregated = 57;
 
     optional bool is_row_binlog = 58 [default = false];
-    optional PRowBinlogWriteColumnMappings row_binlog_column_mappings = 60;
 
     // Valid only when segments_overlap_pb is NONOVERLAPPING_WITHIN_GROUP.
     // Each value is the number of consecutive output segments in one non-overlapping group.
@@ -297,7 +296,6 @@ message RowsetMetaCloudPB {
     optional bool segments_key_bounds_aggregated = 57;
 
     optional bool is_row_binlog = 58 [default = false];
-    optional PRowBinlogWriteColumnMappings row_binlog_column_mappings = 60;
 
     // Valid only when segments_overlap_pb is NONOVERLAPPING_WITHIN_GROUP.
     // Each value is the number of consecutive output segments in one non-overlapping group.
@@ -875,6 +873,7 @@ message PendingPublishInfoPB {
     optional int64 partition_id = 1;
     optional int64 transaction_id = 2;
     optional int64 commit_tso = 3;
+    optional PRowBinlogWriteColumnMappings row_binlog_column_mappings = 4;
 }
 
 message RowsetBinlogMetasPB {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -504,6 +504,8 @@ struct TPublishVersionRequest {
     3: optional bool strict_mode = false
     // for delta rows statistics to exclude rollup tablets
     4: optional set<Types.TTabletId> base_tablet_ids
+    // Write-time snapshots keyed by source index, scoped to transaction_id (including subtransactions).
+    5: optional map<i64, Descriptors.TRowBinlogWriteColumnMappings> row_binlog_column_mappings
 }
 
 struct TVisibleVersionReq {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -354,6 +354,11 @@ struct TRowBinlogWriteColumnMapping {
     3: optional i32 before_column_unique_id
 }
 
+struct TRowBinlogWriteColumnMappings {
+    1: optional list<TRowBinlogWriteColumnMapping> entries
+    2: optional bool need_historical_value
+}
+
 struct TOlapTableIndexSchema {
     1: required i64 id
     2: required list<string> columns

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -348,6 +348,12 @@ struct TOlapTableIndex {
   7: optional list<i32> column_unique_ids
 }
 
+struct TRowBinlogWriteColumnMapping {
+    1: required i32 source_column_unique_id
+    2: required i32 current_column_unique_id
+    3: optional i32 before_column_unique_id
+}
+
 struct TOlapTableIndexSchema {
     1: required i64 id
     2: required list<string> columns
@@ -356,6 +362,8 @@ struct TOlapTableIndexSchema {
     5: optional list<TOlapTableIndex> indexes_desc
     6: optional Exprs.TExpr where_clause
     7: optional i64 row_binlog_id
+    8: optional list<TRowBinlogWriteColumnMapping> row_binlog_column_mappings
+    9: optional bool row_binlog_need_historical_value
 }
 
 struct TOlapTableSchemaParam {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1839,6 +1839,8 @@ struct TCommitRemoteTxnRequest {
     7: optional i64 txn_id
     8: optional list<Types.TTabletCommitInfo> commit_infos
     9: optional i64 insert_visible_timeout_ms
+    // Write-time snapshots keyed by source index ID; empty when the writer has no row binlog.
+    10: optional map<i64, Descriptors.TRowBinlogWriteColumnMappings> row_binlog_column_mappings
 }
 
 struct TCommitRemoteTxnResult {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1070,6 +1070,8 @@ struct TOlapScanNode {
   27: optional list<TPartitionBoundary> partition_boundaries
   // Slot ids of extra storage key columns used only to align the scan tuple with storage schema.
   28: optional set<i32> extra_key_column_slot_ids
+  29: optional list<Types.TSlotId> row_binlog_current_slot_ids
+  30: optional list<Types.TSlotId> row_binlog_before_slot_ids
 }
 
 struct TEqJoinCondition {

--- a/regression-test/suites/row_binlog_p0/test_binlog_changes_syntax.groovy
+++ b/regression-test/suites/row_binlog_p0/test_binlog_changes_syntax.groovy
@@ -580,7 +580,7 @@ suite("test_binlog_changes_syntax", "nonConcurrent") {
         // 5. MoW table with BITMAP NOT NULL.
         //    This specifically exercises MIN_DELTA UPDATE_BEFORE/AFTER on a
         //    complex-type value column. Before the Column.java fix, the
-        //    UPDATE_BEFORE row read from nullable __DORIS_BEFORE__b__ would be
+        //    UPDATE_BEFORE row read from nullable __BEFORE__b__ would be
         //    copied into the non-nullable after-slot and BE would crash with
         //    "Bad cast from type ColumnNullable to ColumnComplexType<BITMAP>".
         // ============================================================

--- a/regression-test/suites/row_binlog_p0/test_binlog_changes_syntax.groovy
+++ b/regression-test/suites/row_binlog_p0/test_binlog_changes_syntax.groovy
@@ -580,7 +580,7 @@ suite("test_binlog_changes_syntax", "nonConcurrent") {
         // 5. MoW table with BITMAP NOT NULL.
         //    This specifically exercises MIN_DELTA UPDATE_BEFORE/AFTER on a
         //    complex-type value column. Before the Column.java fix, the
-        //    UPDATE_BEFORE row read from nullable __BEFORE__b__ would be
+        //    UPDATE_BEFORE row read from nullable __DORIS_BEFORE__b__ would be
         //    copied into the non-nullable after-slot and BE would crash with
         //    "Bad cast from type ColumnNullable to ColumnComplexType<BITMAP>".
         // ============================================================

--- a/regression-test/suites/row_binlog_p0/test_binlog_compaction.groovy
+++ b/regression-test/suites/row_binlog_p0/test_binlog_compaction.groovy
@@ -143,8 +143,8 @@ suite("test_binlog_compaction", "nonConcurrent") {
                    k1,
                    v1,
                    v2,
-                   __BEFORE__v1__,
-                   __BEFORE__v2__
+                   __DORIS_BEFORE__v1__,
+                   __DORIS_BEFORE__v2__
             FROM binlog("table" = "test_binlog_compaction_mow_historical")
         """
 
@@ -203,8 +203,8 @@ suite("test_binlog_compaction", "nonConcurrent") {
                    k1,
                    v1,
                    v2,
-                   __BEFORE__v1__,
-                   __BEFORE__v2__
+                   __DORIS_BEFORE__v1__,
+                   __DORIS_BEFORE__v2__
             FROM binlog("table" = "test_binlog_compaction_mow_seq_historical")
         """
 
@@ -264,8 +264,8 @@ suite("test_binlog_compaction", "nonConcurrent") {
                    k1,
                    v1,
                    v2,
-                   __BEFORE__v1__,
-                   __BEFORE__v2__
+                   __DORIS_BEFORE__v1__,
+                   __DORIS_BEFORE__v2__
             FROM binlog("table" = "test_binlog_compaction_mow_historical_long_chain")
         """
     }

--- a/regression-test/suites/row_binlog_p0/test_binlog_compaction.groovy
+++ b/regression-test/suites/row_binlog_p0/test_binlog_compaction.groovy
@@ -143,8 +143,8 @@ suite("test_binlog_compaction", "nonConcurrent") {
                    k1,
                    v1,
                    v2,
-                   __DORIS_BEFORE__v1__,
-                   __DORIS_BEFORE__v2__
+                   __BEFORE__v1__,
+                   __BEFORE__v2__
             FROM binlog("table" = "test_binlog_compaction_mow_historical")
         """
 
@@ -203,8 +203,8 @@ suite("test_binlog_compaction", "nonConcurrent") {
                    k1,
                    v1,
                    v2,
-                   __DORIS_BEFORE__v1__,
-                   __DORIS_BEFORE__v2__
+                   __BEFORE__v1__,
+                   __BEFORE__v2__
             FROM binlog("table" = "test_binlog_compaction_mow_seq_historical")
         """
 
@@ -264,8 +264,8 @@ suite("test_binlog_compaction", "nonConcurrent") {
                    k1,
                    v1,
                    v2,
-                   __DORIS_BEFORE__v1__,
-                   __DORIS_BEFORE__v2__
+                   __BEFORE__v1__,
+                   __BEFORE__v2__
             FROM binlog("table" = "test_binlog_compaction_mow_historical_long_chain")
         """
     }

--- a/regression-test/suites/row_binlog_p0/test_cloud_row_binlog_compaction.groovy
+++ b/regression-test/suites/row_binlog_p0/test_cloud_row_binlog_compaction.groovy
@@ -138,8 +138,8 @@ suite("test_cloud_row_binlog_compaction", "nonConcurrent") {
                    k1,
                    v1,
                    v2,
-                   __BEFORE__v1__,
-                   __BEFORE__v2__
+                   __DORIS_BEFORE__v1__,
+                   __DORIS_BEFORE__v2__
             FROM binlog("table" = "test_cloud_binlog_compaction_mow_historical")
         """
 
@@ -202,8 +202,8 @@ suite("test_cloud_row_binlog_compaction", "nonConcurrent") {
                    k1,
                    v1,
                    v2,
-                   __BEFORE__v1__,
-                   __BEFORE__v2__
+                   __DORIS_BEFORE__v1__,
+                   __DORIS_BEFORE__v2__
             FROM binlog("table" = "test_cloud_binlog_compaction_mow_seq_historical")
         """
 
@@ -213,8 +213,8 @@ suite("test_cloud_row_binlog_compaction", "nonConcurrent") {
                    k1,
                    v1,
                    v2,
-                   __BEFORE__v1__,
-                   __BEFORE__v2__
+                   __DORIS_BEFORE__v1__,
+                   __DORIS_BEFORE__v2__
             FROM binlog("table" = "test_cloud_binlog_compaction_mow_seq_historical")
         """
         sql "SET skip_delete_bitmap = false"
@@ -278,8 +278,8 @@ suite("test_cloud_row_binlog_compaction", "nonConcurrent") {
                    k1,
                    v1,
                    v2,
-                   __BEFORE__v1__,
-                   __BEFORE__v2__
+                   __DORIS_BEFORE__v1__,
+                   __DORIS_BEFORE__v2__
             FROM binlog("table" = "test_cloud_binlog_compaction_mow_historical_long_chain")
         """
     }

--- a/regression-test/suites/row_binlog_p0/test_cloud_row_binlog_compaction.groovy
+++ b/regression-test/suites/row_binlog_p0/test_cloud_row_binlog_compaction.groovy
@@ -138,8 +138,8 @@ suite("test_cloud_row_binlog_compaction", "nonConcurrent") {
                    k1,
                    v1,
                    v2,
-                   __DORIS_BEFORE__v1__,
-                   __DORIS_BEFORE__v2__
+                   __BEFORE__v1__,
+                   __BEFORE__v2__
             FROM binlog("table" = "test_cloud_binlog_compaction_mow_historical")
         """
 
@@ -202,8 +202,8 @@ suite("test_cloud_row_binlog_compaction", "nonConcurrent") {
                    k1,
                    v1,
                    v2,
-                   __DORIS_BEFORE__v1__,
-                   __DORIS_BEFORE__v2__
+                   __BEFORE__v1__,
+                   __BEFORE__v2__
             FROM binlog("table" = "test_cloud_binlog_compaction_mow_seq_historical")
         """
 
@@ -213,8 +213,8 @@ suite("test_cloud_row_binlog_compaction", "nonConcurrent") {
                    k1,
                    v1,
                    v2,
-                   __DORIS_BEFORE__v1__,
-                   __DORIS_BEFORE__v2__
+                   __BEFORE__v1__,
+                   __BEFORE__v2__
             FROM binlog("table" = "test_cloud_binlog_compaction_mow_seq_historical")
         """
         sql "SET skip_delete_bitmap = false"
@@ -278,8 +278,8 @@ suite("test_cloud_row_binlog_compaction", "nonConcurrent") {
                    k1,
                    v1,
                    v2,
-                   __DORIS_BEFORE__v1__,
-                   __DORIS_BEFORE__v2__
+                   __BEFORE__v1__,
+                   __BEFORE__v2__
             FROM binlog("table" = "test_cloud_binlog_compaction_mow_historical_long_chain")
         """
     }

--- a/regression-test/suites/row_binlog_p0/test_cloud_row_binlog_publish_conflict.groovy
+++ b/regression-test/suites/row_binlog_p0/test_cloud_row_binlog_publish_conflict.groovy
@@ -115,8 +115,8 @@ suite("test_cloud_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __BEFORE__v1__,
-                   __BEFORE__v2__
+                   __DORIS_BEFORE__v1__,
+                   __DORIS_BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (1, 2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -130,8 +130,8 @@ suite("test_cloud_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __BEFORE__v1__,
-                   __BEFORE__v2__
+                   __DORIS_BEFORE__v1__,
+                   __DORIS_BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (1, 2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -178,8 +178,8 @@ suite("test_cloud_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __BEFORE__v1__,
-                   __BEFORE__v2__
+                   __DORIS_BEFORE__v1__,
+                   __DORIS_BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -193,8 +193,8 @@ suite("test_cloud_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __BEFORE__v1__,
-                   __BEFORE__v2__
+                   __DORIS_BEFORE__v1__,
+                   __DORIS_BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__

--- a/regression-test/suites/row_binlog_p0/test_cloud_row_binlog_publish_conflict.groovy
+++ b/regression-test/suites/row_binlog_p0/test_cloud_row_binlog_publish_conflict.groovy
@@ -115,8 +115,8 @@ suite("test_cloud_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __DORIS_BEFORE__v1__,
-                   __DORIS_BEFORE__v2__
+                   __BEFORE__v1__,
+                   __BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (1, 2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -130,8 +130,8 @@ suite("test_cloud_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __DORIS_BEFORE__v1__,
-                   __DORIS_BEFORE__v2__
+                   __BEFORE__v1__,
+                   __BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (1, 2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -178,8 +178,8 @@ suite("test_cloud_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __DORIS_BEFORE__v1__,
-                   __DORIS_BEFORE__v2__
+                   __BEFORE__v1__,
+                   __BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -193,8 +193,8 @@ suite("test_cloud_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __DORIS_BEFORE__v1__,
-                   __DORIS_BEFORE__v2__
+                   __BEFORE__v1__,
+                   __BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__

--- a/regression-test/suites/row_binlog_p0/test_row_binlog_basic.groovy
+++ b/regression-test/suites/row_binlog_p0/test_row_binlog_basic.groovy
@@ -279,8 +279,8 @@ suite("test_row_binlog_basic", "nonConcurrent") {
                k3,
                v1,
                v2,
-               __BEFORE__v1__,
-               __BEFORE__v2__
+               __DORIS_BEFORE__v1__,
+               __DORIS_BEFORE__v2__
         FROM binlog("table" = "test_mow_with_before_binlog")
         ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
     """
@@ -293,7 +293,7 @@ suite("test_row_binlog_basic", "nonConcurrent") {
         SELECT __DORIS_BINLOG_OP__ AS op,
                k1,
                v1,
-               __BEFORE__v1__
+               __DORIS_BEFORE__v1__
         FROM binlog("table" = "test_mow_reinsert_with_before_binlog")
         ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
     """
@@ -358,8 +358,8 @@ suite("test_row_binlog_basic", "nonConcurrent") {
                k3,
                v1,
                v2,
-               __BEFORE__v1__,
-               __BEFORE__v2__
+               __DORIS_BEFORE__v1__,
+               __DORIS_BEFORE__v2__
         FROM binlog("table" = "test_mow_seq_with_binlog")
         ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
     """
@@ -373,8 +373,8 @@ suite("test_row_binlog_basic", "nonConcurrent") {
                k3,
                v1,
                v2,
-               __BEFORE__v1__,
-               __BEFORE__v2__
+               __DORIS_BEFORE__v1__,
+               __DORIS_BEFORE__v2__
         FROM binlog("table" = "test_mow_seq_with_binlog")
         ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
     """

--- a/regression-test/suites/row_binlog_p0/test_row_binlog_basic.groovy
+++ b/regression-test/suites/row_binlog_p0/test_row_binlog_basic.groovy
@@ -279,8 +279,8 @@ suite("test_row_binlog_basic", "nonConcurrent") {
                k3,
                v1,
                v2,
-               __DORIS_BEFORE__v1__,
-               __DORIS_BEFORE__v2__
+               __BEFORE__v1__,
+               __BEFORE__v2__
         FROM binlog("table" = "test_mow_with_before_binlog")
         ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
     """
@@ -293,7 +293,7 @@ suite("test_row_binlog_basic", "nonConcurrent") {
         SELECT __DORIS_BINLOG_OP__ AS op,
                k1,
                v1,
-               __DORIS_BEFORE__v1__
+               __BEFORE__v1__
         FROM binlog("table" = "test_mow_reinsert_with_before_binlog")
         ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
     """
@@ -358,8 +358,8 @@ suite("test_row_binlog_basic", "nonConcurrent") {
                k3,
                v1,
                v2,
-               __DORIS_BEFORE__v1__,
-               __DORIS_BEFORE__v2__
+               __BEFORE__v1__,
+               __BEFORE__v2__
         FROM binlog("table" = "test_mow_seq_with_binlog")
         ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
     """
@@ -373,8 +373,8 @@ suite("test_row_binlog_basic", "nonConcurrent") {
                k3,
                v1,
                v2,
-               __DORIS_BEFORE__v1__,
-               __DORIS_BEFORE__v2__
+               __BEFORE__v1__,
+               __BEFORE__v2__
         FROM binlog("table" = "test_mow_seq_with_binlog")
         ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
     """

--- a/regression-test/suites/row_binlog_p0/test_row_binlog_multi_segment.groovy
+++ b/regression-test/suites/row_binlog_p0/test_row_binlog_multi_segment.groovy
@@ -97,8 +97,8 @@ suite("test_row_binlog_multi_segment", "nonConcurrent") {
                        k3,
                        v1,
                        v2,
-                       __BEFORE__v1__,
-                       __BEFORE__v2__
+                       __DORIS_BEFORE__v1__,
+                       __DORIS_BEFORE__v2__
                 FROM binlog("table" = "test_mow_multi_segment_with_binlog")
                 WHERE k1 IN (1, 3000, 5000)
                 ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -144,8 +144,8 @@ suite("test_row_binlog_multi_segment", "nonConcurrent") {
                        k3,
                        v1,
                        v2,
-                       __BEFORE__v1__,
-                       __BEFORE__v2__
+                       __DORIS_BEFORE__v1__,
+                       __DORIS_BEFORE__v2__
                 FROM binlog("table" = "test_mow_multi_segment_with_binlog")
                 WHERE k1 IN (1, 3000, 5000)
                 ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -200,8 +200,8 @@ suite("test_row_binlog_multi_segment", "nonConcurrent") {
                        k3,
                        v1,
                        v2,
-                       __BEFORE__v1__,
-                       __BEFORE__v2__
+                       __DORIS_BEFORE__v1__,
+                       __DORIS_BEFORE__v2__
                 FROM binlog("table" = "test_mow_multi_segment_with_binlog")
                 WHERE k1 IN (1, 3000, 5000)
                 ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -217,8 +217,8 @@ suite("test_row_binlog_multi_segment", "nonConcurrent") {
                        k3,
                        v1,
                        v2,
-                       __BEFORE__v1__,
-                       __BEFORE__v2__
+                       __DORIS_BEFORE__v1__,
+                       __DORIS_BEFORE__v2__
                 FROM binlog("table" = "test_mow_multi_segment_with_binlog")
                 WHERE k1 IN (1, 3000, 5000)
                 ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__

--- a/regression-test/suites/row_binlog_p0/test_row_binlog_multi_segment.groovy
+++ b/regression-test/suites/row_binlog_p0/test_row_binlog_multi_segment.groovy
@@ -97,8 +97,8 @@ suite("test_row_binlog_multi_segment", "nonConcurrent") {
                        k3,
                        v1,
                        v2,
-                       __DORIS_BEFORE__v1__,
-                       __DORIS_BEFORE__v2__
+                       __BEFORE__v1__,
+                       __BEFORE__v2__
                 FROM binlog("table" = "test_mow_multi_segment_with_binlog")
                 WHERE k1 IN (1, 3000, 5000)
                 ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -144,8 +144,8 @@ suite("test_row_binlog_multi_segment", "nonConcurrent") {
                        k3,
                        v1,
                        v2,
-                       __DORIS_BEFORE__v1__,
-                       __DORIS_BEFORE__v2__
+                       __BEFORE__v1__,
+                       __BEFORE__v2__
                 FROM binlog("table" = "test_mow_multi_segment_with_binlog")
                 WHERE k1 IN (1, 3000, 5000)
                 ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -200,8 +200,8 @@ suite("test_row_binlog_multi_segment", "nonConcurrent") {
                        k3,
                        v1,
                        v2,
-                       __DORIS_BEFORE__v1__,
-                       __DORIS_BEFORE__v2__
+                       __BEFORE__v1__,
+                       __BEFORE__v2__
                 FROM binlog("table" = "test_mow_multi_segment_with_binlog")
                 WHERE k1 IN (1, 3000, 5000)
                 ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -217,8 +217,8 @@ suite("test_row_binlog_multi_segment", "nonConcurrent") {
                        k3,
                        v1,
                        v2,
-                       __DORIS_BEFORE__v1__,
-                       __DORIS_BEFORE__v2__
+                       __BEFORE__v1__,
+                       __BEFORE__v2__
                 FROM binlog("table" = "test_mow_multi_segment_with_binlog")
                 WHERE k1 IN (1, 3000, 5000)
                 ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__

--- a/regression-test/suites/row_binlog_p0/test_row_binlog_partial_update_only_keys.groovy
+++ b/regression-test/suites/row_binlog_p0/test_row_binlog_partial_update_only_keys.groovy
@@ -64,8 +64,8 @@ suite("test_row_binlog_partial_update_only_keys", "nonConcurrent") {
                    k2,
                    v_default,
                    v_nullable,
-                   __BEFORE__v_default__,
-                   __BEFORE__v_nullable__
+                   __DORIS_BEFORE__v_default__,
+                   __DORIS_BEFORE__v_nullable__
             FROM binlog("table" = "test_row_binlog_partial_update_only_keys")
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
         """

--- a/regression-test/suites/row_binlog_p0/test_row_binlog_partial_update_only_keys.groovy
+++ b/regression-test/suites/row_binlog_p0/test_row_binlog_partial_update_only_keys.groovy
@@ -64,8 +64,8 @@ suite("test_row_binlog_partial_update_only_keys", "nonConcurrent") {
                    k2,
                    v_default,
                    v_nullable,
-                   __DORIS_BEFORE__v_default__,
-                   __DORIS_BEFORE__v_nullable__
+                   __BEFORE__v_default__,
+                   __BEFORE__v_nullable__
             FROM binlog("table" = "test_row_binlog_partial_update_only_keys")
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
         """

--- a/regression-test/suites/row_binlog_p0/test_row_binlog_publish_conflict.groovy
+++ b/regression-test/suites/row_binlog_p0/test_row_binlog_publish_conflict.groovy
@@ -173,8 +173,8 @@ suite("test_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __BEFORE__v1__,
-                   __BEFORE__v2__
+                   __DORIS_BEFORE__v1__,
+                   __DORIS_BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (1, 2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -188,8 +188,8 @@ suite("test_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __BEFORE__v1__,
-                   __BEFORE__v2__
+                   __DORIS_BEFORE__v1__,
+                   __DORIS_BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (1, 2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -274,8 +274,8 @@ suite("test_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __BEFORE__v1__,
-                   __BEFORE__v2__
+                   __DORIS_BEFORE__v1__,
+                   __DORIS_BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -289,8 +289,8 @@ suite("test_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __BEFORE__v1__,
-                   __BEFORE__v2__
+                   __DORIS_BEFORE__v1__,
+                   __DORIS_BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__

--- a/regression-test/suites/row_binlog_p0/test_row_binlog_publish_conflict.groovy
+++ b/regression-test/suites/row_binlog_p0/test_row_binlog_publish_conflict.groovy
@@ -173,8 +173,8 @@ suite("test_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __DORIS_BEFORE__v1__,
-                   __DORIS_BEFORE__v2__
+                   __BEFORE__v1__,
+                   __BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (1, 2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -188,8 +188,8 @@ suite("test_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __DORIS_BEFORE__v1__,
-                   __DORIS_BEFORE__v2__
+                   __BEFORE__v1__,
+                   __BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (1, 2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -274,8 +274,8 @@ suite("test_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __DORIS_BEFORE__v1__,
-                   __DORIS_BEFORE__v2__
+                   __BEFORE__v1__,
+                   __BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
@@ -289,8 +289,8 @@ suite("test_row_binlog_publish_conflict", "nonConcurrent") {
                    k3,
                    v1,
                    v2,
-                   __DORIS_BEFORE__v1__,
-                   __DORIS_BEFORE__v2__
+                   __BEFORE__v1__,
+                   __BEFORE__v2__
             FROM binlog("table" = "test_mow_publish_conflict_with_binlog")
             WHERE k1 IN (2, 3)
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__

--- a/regression-test/suites/row_binlog_p0/test_row_binlog_schema_change.groovy
+++ b/regression-test/suites/row_binlog_p0/test_row_binlog_schema_change.groovy
@@ -56,9 +56,9 @@ suite("test_row_binlog_schema_change", "nonConcurrent") {
                v1,
                v2,
                v3,
-               __BEFORE__v1__,
-               __BEFORE__v2__,
-               __BEFORE__v3__
+               __DORIS_BEFORE__v1__,
+               __DORIS_BEFORE__v2__,
+               __DORIS_BEFORE__v3__
         FROM binlog("table" = "test_mow_schema_change_with_binlog")
         ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
     """
@@ -73,8 +73,8 @@ suite("test_row_binlog_schema_change", "nonConcurrent") {
                k3,
                v2,
                v3,
-               __BEFORE__v2__,
-               __BEFORE__v3__
+               __DORIS_BEFORE__v2__,
+               __DORIS_BEFORE__v3__
         FROM binlog("table" = "test_mow_schema_change_with_binlog")
         ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
     """
@@ -91,9 +91,9 @@ suite("test_row_binlog_schema_change", "nonConcurrent") {
                v1,
                v2,
                v3,
-               __BEFORE__v1__,
-               __BEFORE__v2__,
-               __BEFORE__v3__
+               __DORIS_BEFORE__v1__,
+               __DORIS_BEFORE__v2__,
+               __DORIS_BEFORE__v3__
         FROM binlog("table" = "test_mow_schema_change_with_binlog")
         ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
     """

--- a/regression-test/suites/row_binlog_p0/test_row_binlog_schema_change.groovy
+++ b/regression-test/suites/row_binlog_p0/test_row_binlog_schema_change.groovy
@@ -56,9 +56,9 @@ suite("test_row_binlog_schema_change", "nonConcurrent") {
                v1,
                v2,
                v3,
-               __DORIS_BEFORE__v1__,
-               __DORIS_BEFORE__v2__,
-               __DORIS_BEFORE__v3__
+               __BEFORE__v1__,
+               __BEFORE__v2__,
+               __BEFORE__v3__
         FROM binlog("table" = "test_mow_schema_change_with_binlog")
         ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
     """
@@ -73,8 +73,8 @@ suite("test_row_binlog_schema_change", "nonConcurrent") {
                k3,
                v2,
                v3,
-               __DORIS_BEFORE__v2__,
-               __DORIS_BEFORE__v3__
+               __BEFORE__v2__,
+               __BEFORE__v3__
         FROM binlog("table" = "test_mow_schema_change_with_binlog")
         ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
     """
@@ -91,9 +91,9 @@ suite("test_row_binlog_schema_change", "nonConcurrent") {
                v1,
                v2,
                v3,
-               __DORIS_BEFORE__v1__,
-               __DORIS_BEFORE__v2__,
-               __DORIS_BEFORE__v3__
+               __BEFORE__v1__,
+               __BEFORE__v2__,
+               __BEFORE__v3__
         FROM binlog("table" = "test_mow_schema_change_with_binlog")
         ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
     """

--- a/regression-test/suites/table_stream_p0/test_min_delta_stream.groovy
+++ b/regression-test/suites/table_stream_p0/test_min_delta_stream.groovy
@@ -131,7 +131,7 @@ suite("test_min_delta_stream", "nonConcurrent") {
 
         // 1.1) Stream hidden columns:
         // - __DORIS_STREAM_CHANGE_TYPE_COL__/__DORIS_STREAM_SEQUENCE_COL__ must be queryable;
-        // - SELECT * should not expose hidden columns or __BEFORE__ columns by default.
+        // - SELECT * should not expose hidden columns or __DORIS_BEFORE__ columns by default.
         def ukMetaRows = sql """
             SELECT id, v1, __DORIS_STREAM_CHANGE_TYPE_COL__, __DORIS_STREAM_SEQUENCE_COL__
             FROM ${ukStream}
@@ -147,13 +147,13 @@ suite("test_min_delta_stream", "nonConcurrent") {
             ORDER BY id, v1
         """
         assertEquals(2, ukAllRows.size())
-        // Base table has 2 visible columns; hidden columns and __BEFORE__v1__ must not be included by default.
+        // Base table has 2 visible columns; hidden columns and __DORIS_BEFORE__v1__ must not be included by default.
         assertEquals(2, ukAllRows[0].size())
         assertEquals(2, ukAllRows[1].size())
 
         sql "SET show_hidden_columns=true"
         def ukDescRows = sql "DESC ${ukStream}"
-        def hasBeforeCol = ukDescRows.any { it[0].toString().startsWith("__BEFORE__") }
+        def hasBeforeCol = ukDescRows.any { it[0].toString().startsWith("__DORIS_BEFORE__") }
         def hasChangeTypeCol = ukDescRows.any { it[0].toString().equalsIgnoreCase("__DORIS_STREAM_CHANGE_TYPE_COL__") }
         def hasSequenceCol = ukDescRows.any { it[0].toString().equalsIgnoreCase("__DORIS_STREAM_SEQUENCE_COL__") }
         assertEquals(false, hasBeforeCol)
@@ -494,7 +494,7 @@ suite("test_min_delta_stream", "nonConcurrent") {
         assertEquals("91", ukPendingRows[3][1].toString())
         assertEquals("UPDATE_AFTER", ukPendingRows[3][2].toString())
 
-        // 8) UPDATE then DELETE: min_delta result is DELETE, and value columns should use __BEFORE__ (pre-delete snapshot).
+        // 8) UPDATE then DELETE: min_delta result is DELETE, and value columns should use __DORIS_BEFORE__ (pre-delete snapshot).
         sql """
             CREATE TABLE ${ukDeleteBeforeBase} (
                 id BIGINT,

--- a/regression-test/suites/table_stream_p0/test_min_delta_stream.groovy
+++ b/regression-test/suites/table_stream_p0/test_min_delta_stream.groovy
@@ -131,7 +131,7 @@ suite("test_min_delta_stream", "nonConcurrent") {
 
         // 1.1) Stream hidden columns:
         // - __DORIS_STREAM_CHANGE_TYPE_COL__/__DORIS_STREAM_SEQUENCE_COL__ must be queryable;
-        // - SELECT * should not expose hidden columns or __DORIS_BEFORE__ columns by default.
+        // - SELECT * should not expose hidden columns or __BEFORE__ columns by default.
         def ukMetaRows = sql """
             SELECT id, v1, __DORIS_STREAM_CHANGE_TYPE_COL__, __DORIS_STREAM_SEQUENCE_COL__
             FROM ${ukStream}
@@ -147,13 +147,13 @@ suite("test_min_delta_stream", "nonConcurrent") {
             ORDER BY id, v1
         """
         assertEquals(2, ukAllRows.size())
-        // Base table has 2 visible columns; hidden columns and __DORIS_BEFORE__v1__ must not be included by default.
+        // Base table has 2 visible columns; hidden columns and __BEFORE__v1__ must not be included by default.
         assertEquals(2, ukAllRows[0].size())
         assertEquals(2, ukAllRows[1].size())
 
         sql "SET show_hidden_columns=true"
         def ukDescRows = sql "DESC ${ukStream}"
-        def hasBeforeCol = ukDescRows.any { it[0].toString().startsWith("__DORIS_BEFORE__") }
+        def hasBeforeCol = ukDescRows.any { it[0].toString().startsWith("__BEFORE__") }
         def hasChangeTypeCol = ukDescRows.any { it[0].toString().equalsIgnoreCase("__DORIS_STREAM_CHANGE_TYPE_COL__") }
         def hasSequenceCol = ukDescRows.any { it[0].toString().equalsIgnoreCase("__DORIS_STREAM_SEQUENCE_COL__") }
         assertEquals(false, hasBeforeCol)
@@ -494,7 +494,7 @@ suite("test_min_delta_stream", "nonConcurrent") {
         assertEquals("91", ukPendingRows[3][1].toString())
         assertEquals("UPDATE_AFTER", ukPendingRows[3][2].toString())
 
-        // 8) UPDATE then DELETE: min_delta result is DELETE, and value columns should use __DORIS_BEFORE__ (pre-delete snapshot).
+        // 8) UPDATE then DELETE: min_delta result is DELETE, and value columns should use __BEFORE__ (pre-delete snapshot).
         sql """
             CREATE TABLE ${ukDeleteBeforeBase} (
                 id BIGINT,

--- a/regression-test/suites/table_stream_p0/test_table_stream_multi_segment_mow.groovy
+++ b/regression-test/suites/table_stream_p0/test_table_stream_multi_segment_mow.groovy
@@ -515,7 +515,7 @@ suite("test_table_stream_multi_segment_mow", "nonConcurrent") {
                 SELECT __DORIS_BINLOG_OP__ AS op,
                        id,
                        v,
-                       __BEFORE__v__
+                       __DORIS_BEFORE__v__
                 FROM binlog("table" = "ts_ms_mow_qm_base")
                 ORDER BY id, v, op
             """

--- a/regression-test/suites/table_stream_p0/test_table_stream_multi_segment_mow.groovy
+++ b/regression-test/suites/table_stream_p0/test_table_stream_multi_segment_mow.groovy
@@ -515,7 +515,7 @@ suite("test_table_stream_multi_segment_mow", "nonConcurrent") {
                 SELECT __DORIS_BINLOG_OP__ AS op,
                        id,
                        v,
-                       __DORIS_BEFORE__v__
+                       __BEFORE__v__
                 FROM binlog("table" = "ts_ms_mow_qm_base")
                 ORDER BY id, v, op
             """


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:
Row-binlog and table-stream paths derived current, before-image, and system-column positions independently in BE from column names and physical layout. This coupled reads and writes to layout details and caused key-only tables requesting historical values to select plain derivation. Compute stable mapping identifiers in FE, downlink them through Thrift and protobuf, resolve ordinals once in BE, and consume explicit CID mappings in write derivation. Preserve mappings only while pending transactions may recover, then clear them before local or Cloud rowsets become visible. 

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

