### PR TITLE
[fix](be) remove duplicate default argument on clear_blocks forward declaration

### DIFF
--- a/be/src/exec/sink/writer/async_result_writer.cpp
+++ b/be/src/exec/sink/writer/async_result_writer.cpp
@@ -315,7 +315,7 @@ std::unique_ptr<Block> AsyncResultWriter::_get_free_block(doris::Block* block, s
 
 template <typename T>
 void clear_blocks(moodycamel::ConcurrentQueue<T>& blocks,
-                  RuntimeProfile::Counter* memory_used_counter = nullptr);
+                  RuntimeProfile::Counter* memory_used_counter);
 void AsyncResultWriter::set_low_memory_mode() {
     _low_memory_mode = true;
     clear_blocks(_free_blocks, _memory_used_counter);


### PR DESCRIPTION
### What problem does this PR solve?

Under Unity Build, `be/src/exec/sink/writer/async_result_writer.cpp` fails to compile:

```
error: redeclaration of `clear_blocks` may not have default arguments
```

`clear_blocks<T>()` is declared twice with the same default argument for `memory_used_counter`:

- `be/src/exec/exchange/local_exchanger.h:27-28` — the original declaration, `= nullptr`
- `be/src/exec/sink/writer/async_result_writer.cpp:316-317` — a forward declaration added by #66400 ([opt](build) 1/4: Speed up BE full build ~22% by cutting hot-header include edges) to avoid pulling in `local_exchanger.h`, also `= nullptr`

C++ forbids repeating a default argument across declarations of the same function template ([dcl.fct.default]/4). Separate translation units never see both, so a normal build is fine — but Unity Build concatenates sources into one TU, both declarations land together, and `-Werror` turns it into a hard error.

### Fix

Drop the default from the forward declaration in `async_result_writer.cpp`. The one in `local_exchanger.h` still applies at every call site that sees that header, so no call site changes.

### Release note

None

### Check List

- [x] Test <!-- At least one of them must be included. -->
    - [x] No need to test or manual test. Explain why:
        - Compile-only fix; no behavior change. The removed token is a default argument on a *declaration*, and every existing call site passes the argument explicitly or sees the header-declared default.

- [x] Behavior changed:
    - [x] No.

- [x] Does this need documentation?
    - [x] No.