### PR TITLE
[fix](filesystem) accept the dotted s3.path.style.access alias

### DIFF
--- a/fe/fe-filesystem/fe-filesystem-minio/src/main/java/org/apache/doris/filesystem/minio/MinioFileSystemProperties.java
+++ b/fe/fe-filesystem/fe-filesystem-minio/src/main/java/org/apache/doris/filesystem/minio/MinioFileSystemProperties.java
@@ -94,7 +94,8 @@ public final class MinioFileSystemProperties extends AbstractDelegatingS3Propert
             description = "Connection timeout in milliseconds.")
     private String connectionTimeoutMs = "10000";
 
-    @ConnectorProperty(names = {USE_PATH_STYLE, "use_path_style", "s3.path-style-access"},
+    @ConnectorProperty(names = {USE_PATH_STYLE, "use_path_style", "s3.path-style-access",
+            "s3.path.style.access"},
             required = false,
             description = "Whether to use path style URL for the storage.")
     private String usePathStyle = "false";

--- a/fe/fe-filesystem/fe-filesystem-s3-base/src/main/java/org/apache/doris/filesystem/s3/S3FileSystemProperties.java
+++ b/fe/fe-filesystem/fe-filesystem-s3-base/src/main/java/org/apache/doris/filesystem/s3/S3FileSystemProperties.java
@@ -170,7 +170,7 @@ public final class S3FileSystemProperties
     private String connectionTimeoutMs = DEFAULT_CONNECTION_TIMEOUT_MS;
 
     @Getter
-    @ConnectorProperty(names = {USE_PATH_STYLE, "s3.path-style-access"},
+    @ConnectorProperty(names = {USE_PATH_STYLE, "s3.path-style-access", "s3.path.style.access"},
             required = false,
             description = "Whether to use path-style bucket addressing.")
     private String usePathStyle = "false";


### PR DESCRIPTION
### What problem does this PR solve?

The path-style-addressing flag is spelled `s3.path.style.access` (all dots) in every existing Paimon/Iceberg regression catalog — 42 occurrences under `regression-test/suites/` — but the typed storage property models only recognize:

- `S3FileSystemProperties`: `USE_PATH_STYLE`, `s3.path-style-access`
- `MinioFileSystemProperties`: `USE_PATH_STYLE`, `use_path_style`, `s3.path-style-access`

An unrecognized property is silently ignored, so `usePathStyle` keeps its `"false"` default. The AWS SDK then addresses the bucket virtual-hosted (`bucket.host`), which fails DNS resolution against an S3-compatible endpoint addressed by hostname (MinIO, Ceph RGW, COS-compatible gateways).

CI never caught this because its MinIO endpoint is an **IP address**, and the AWS SDK force-switches to path-style addressing for IP endpoints regardless of the flag.

Note the dotted spelling is not arbitrary — it matches the Hadoop key this same class already emits at `S3FileSystemProperties.java:341`:

```java
cfg.put("fs.s3a.path.style.access", usePathStyle);
```

### Fix

Recognize `s3.path.style.access` as an additional alias in both property models. Existing spellings are unchanged, so this is purely additive.

### Release note

Accept the dotted `s3.path.style.access` spelling as an alias for the S3/MinIO path-style-addressing property.

### Check List

- [x] Test <!-- At least one of them must be included. -->
    - [x] Regression test
        - Covered implicitly by the existing external-table suites that already spell the property this way; they previously ran with the flag silently defaulting to false.
    - [x] Manual test:
        - Verified against a hostname-addressed S3-compatible endpoint: before this change the request goes virtual-hosted and fails DNS; after, it goes path-style and succeeds.

- [x] Behavior changed:
    - [x] Yes — a catalog that already spells the property `s3.path.style.access` now takes effect instead of being silently ignored. That is the intended fix; catalogs using the previously-recognized spellings are unaffected.

- [x] Does this need documentation?
    - [x] No.