### PR TITLE
[fix](build) write the hms-hive-shade artifact via explicit outputFile

### DIFF
--- a/fe/fe-connector/fe-connector-hms-hive-shade/pom.xml
+++ b/fe/fe-connector/fe-connector-hms-hive-shade/pom.xml
@@ -314,6 +314,15 @@ under the License.
                         </goals>
                         <phase>process-classes</phase>
                         <configuration>
+                            <!-- Write the shaded jar straight to the module's artifact path instead of
+                                 going through shade's replace-the-main-artifact step. That step reads
+                                 project.getArtifact().getFile(), which Maven only populates in the
+                                 package phase — but this shade runs in process-classes (see the
+                                 maven-jar-plugin comment above for why it must). Without this the build
+                                 fails with "Failed to create shaded artifact, project main artifact does
+                                 not exist" even though maven-jar-plugin did create the jar. The path is
+                                 the default artifact path, so downstream consumers are unaffected. -->
+                            <outputFile>${project.build.directory}/${project.artifactId}-${project.version}.jar</outputFile>
                             <!-- WHITELIST, not blacklist. The fat hive-catalog-shade used a short
                                  exclude list and tolerated a huge tail of transitive junk (hadoop-yarn,
                                  curator, jersey, jetty, kerby, ehcache, nimbus-jose, mssql-jdbc, guice,


### PR DESCRIPTION
### What problem does this PR solve?

A clean build of `fe-connector-hms-hive-shade` fails:

```
Failed to create shaded artifact, project main artifact does not exist
```

`maven-shade-plugin` is bound to the `process-classes` phase in this module (it must run there — see the `maven-jar-plugin` comment directly above it in the pom). By default shade performs a *replace-the-main-artifact* step, which reads `project.getArtifact().getFile()`. Maven only populates that field during the `package` phase, so at `process-classes` it is still null and shade aborts — even though `maven-jar-plugin` did produce the jar.

### Fix

Point shade at an explicit `<outputFile>` so it writes the shaded jar directly instead of going through the main-artifact replacement:

```xml
<outputFile>${project.build.directory}/${project.artifactId}-${project.version}.jar</outputFile>
```

The path is the default artifact path, so downstream consumers resolve exactly the same file as before.

### Release note

None

### Check List

- [x] Test <!-- At least one of them must be included. -->
    - [x] No need to test or manual test. Explain why:
        - Build-configuration fix, verified by the build itself: `mvn clean` + module build fails before this change and succeeds after. The output path is unchanged, so no consumer-visible difference.

- [x] Behavior changed:
    - [x] No.

- [x] Does this need documentation?
    - [x] No.