### PR TITLE
[fix](nereids) gate IcebergRowLevelDmlTransform on catalog identity, not capability alone

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/IcebergRowLevelDmlTransform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/IcebergRowLevelDmlTransform.java
@@ -83,7 +83,13 @@ public class IcebergRowLevelDmlTransform implements RowLevelDmlTransform {
 
     @Override
     public boolean handles(TableIf table) {
+        // Identity FIRST, capability second: several connectors now declare row-level write
+        // capabilities, so the capability probe alone would let registry order decide which
+        // transform claims a table. The synthesized plan shape is connector-specific (iceberg's
+        // position-delete stream vs paimon's full-row keyed delete), so the claim must be too.
         return table instanceof PluginDrivenExternalTable
+                && "iceberg".equalsIgnoreCase(
+                        ((PluginDrivenExternalTable) table).getCatalog().getType())
                 && pluginConnectorSupportsRowLevelDml((PluginDrivenExternalTable) table);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/IcebergRowLevelDmlTransformTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/commands/IcebergRowLevelDmlTransformTest.java
@@ -96,8 +96,14 @@ public class IcebergRowLevelDmlTransformTest {
      * {@code getConnector().getWritePlanProvider(handle).supportedOperations()} probe.
      */
     private static PluginDrivenExternalTable pluginTable(boolean supportsDelete, boolean supportsMerge) {
+        return pluginTable("iceberg", supportsDelete, supportsMerge);
+    }
+
+    private static PluginDrivenExternalTable pluginTable(
+            String catalogType, boolean supportsDelete, boolean supportsMerge) {
         PluginDrivenExternalTable table = Mockito.mock(PluginDrivenExternalTable.class);
         PluginDrivenExternalCatalog catalog = Mockito.mock(PluginDrivenExternalCatalog.class);
+        Mockito.when(catalog.getType()).thenReturn(catalogType);
         Connector connector = Mockito.mock(Connector.class);
         Set<WriteOperation> ops = EnumSet.noneOf(WriteOperation.class);
         if (supportsDelete) {
@@ -121,9 +127,13 @@ public class IcebergRowLevelDmlTransformTest {
         Assertions.assertTrue(transform.handles(pluginTable(true, false)));
         Assertions.assertTrue(transform.handles(pluginTable(false, true)));
         Assertions.assertTrue(transform.handles(pluginTable(true, true)));
-        // A plugin connector with neither capability (e.g. jdbc/es/paimon today) must NOT be admitted,
+        // A plugin connector with neither capability must NOT be admitted,
         // else its row-level DML would route through the iceberg synthesis path.
         Assertions.assertFalse(transform.handles(pluginTable(false, false)));
+        // Identity gate: a NON-iceberg connector that DOES declare row-level capabilities must not be
+        // claimed either — with several connectors declaring capabilities, registry order must not
+        // decide whose connector-specific plan shape a table gets.
+        Assertions.assertFalse(transform.handles(pluginTable("paimon", true, true)));
         // Non-plugin table types and null are never admitted.
         Assertions.assertFalse(transform.handles(Mockito.mock(TableIf.class)));
         Assertions.assertFalse(transform.handles(null));


### PR DESCRIPTION
### What problem does this PR solve?

`RowLevelDmlRegistry` dispatches a row-level `DELETE`/`UPDATE`/`MERGE` to the first registered `RowLevelDmlTransform` whose `handles()` claims the table. The single entry today, `IcebergRowLevelDmlTransform`, claims a table on a **pure capability probe** with no identity check:

```java
public boolean handles(TableIf table) {
    return table instanceof PluginDrivenExternalTable
            && pluginConnectorSupportsRowLevelDml((PluginDrivenExternalTable) table);
}
```

`pluginConnectorSupportsRowLevelDml` only asks whether the connector declares `DELETE` or `MERGE`. That is safe **only while iceberg is the sole connector declaring those capabilities** — which is the case on master right now, so this is not currently a live bug.

It stops being safe the moment a second connector declares them. The capability probe alone then lets **registry order** decide which transform claims the table, and the iceberg transform would synthesize its own connector-specific plan shape (a position-delete stream over `ICEBERG_ROWID_COL`) for a table whose connector expects a different one. The failure mode is not a clean error: the plan is built, bound, and executed against the wrong write protocol.

The registry javadoc already acknowledges the hazard — "order only matters if two transforms could claim the same table" — but nothing enforces it.

### Fix

Check catalog identity first, capability second, so a transform only ever claims tables it can actually synthesize for:

```java
return table instanceof PluginDrivenExternalTable
        && "iceberg".equalsIgnoreCase(
                ((PluginDrivenExternalTable) table).getCatalog().getType())
        && pluginConnectorSupportsRowLevelDml((PluginDrivenExternalTable) table);
```

This is a defensive fix that makes the registry safe to extend. It changes nothing for iceberg tables, which continue to be claimed exactly as before.

### Release note

None

### Check List

- [x] Test <!-- At least one of them must be included. -->
    - [x] Unit Test
        - `IcebergRowLevelDmlTransformTest` now stubs the catalog type its `handles()` reads, and asserts that a capability-declaring **non-iceberg** table is not claimed. Existing assertions (iceberg tables with each capability combination are still claimed; no-capability, non-plugin and null tables are still rejected) are unchanged and still pass.

- [x] Behavior changed:
    - [x] No — iceberg tables are claimed exactly as before. Only a hypothetical non-iceberg plugin table declaring row-level capabilities is newly rejected, and no such connector exists on master today.

- [x] Does this need documentation?
    - [x] No.