### PR TITLE
[fix](iceberg) Avoid unsafe historical predicate pushdown

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/iceberg/source/IcebergScanNode.java
@@ -1742,9 +1742,7 @@ public class IcebergScanNode extends FileQueryScanNode {
         // set filter
         List<Expression> expressions = new ArrayList<>();
         for (Expr conjunct : conjuncts) {
-            // Ref/snapshot selection can change field IDs and names, so every pruning expression
-            // must be bound against the schema selected by this scan rather than the current table.
-            Expression expression = IcebergUtils.convertToIcebergExpr(conjunct, scanSchema);
+            Expression expression = convertToIcebergPruningExpression(conjunct, scanSchema);
             if (expression != null) {
                 expressions.add(expression);
             }
@@ -1757,6 +1755,27 @@ public class IcebergScanNode extends FileQueryScanNode {
         icebergTableScan = scan.planWith(source.getCatalog().getThreadPoolWithPreAuth());
 
         return icebergTableScan;
+    }
+
+    @VisibleForTesting
+    protected Expression convertToIcebergPruningExpression(Expr conjunct, Schema scanSchema) {
+        Expression scanExpression = IcebergUtils.convertToIcebergExpr(conjunct, scanSchema);
+        Schema currentSchema = icebergTable.schema();
+        if (scanExpression == null || scanSchema.sameSchema(currentSchema)) {
+            return scanExpression;
+        }
+
+        Expression currentExpression = IcebergUtils.convertToIcebergExpr(conjunct, currentSchema);
+        if (currentExpression == null) {
+            return null;
+        }
+        Set<Integer> scanFieldIds = Binder.boundReferences(
+                scanSchema.asStruct(), Collections.singletonList(scanExpression), true);
+        Set<Integer> currentFieldIds = Binder.boundReferences(
+                currentSchema.asStruct(), Collections.singletonList(currentExpression), true);
+        // Iceberg 1.10 plans manifests with current partition specs, so only push an
+        // historical predicate when its names still resolve to the same field IDs.
+        return scanFieldIds.equals(currentFieldIds) ? scanExpression : null;
     }
 
     private Table useFrozenTableGeneration(Table currentTable) {
@@ -2208,7 +2227,7 @@ public class IcebergScanNode extends FileQueryScanNode {
         // Convert query conjuncts to Iceberg filter expression
         // This combines all predicates with AND logic for partition/file pruning
         Expression filterExpr = conjuncts.stream()
-                .map(conjunct -> IcebergUtils.convertToIcebergExpr(conjunct, scanSchema))
+                .map(conjunct -> convertToIcebergPruningExpression(conjunct, scanSchema))
                 .filter(Objects::nonNull)
                 .reduce(Expressions.alwaysTrue(), Expressions::and);
 
@@ -2690,7 +2709,7 @@ public class IcebergScanNode extends FileQueryScanNode {
 
         List<Expression> expressions = new ArrayList<>();
         for (Expr conjunct : conjuncts) {
-            Expression expression = IcebergUtils.convertToIcebergExpr(conjunct, scanSchema);
+            Expression expression = convertToIcebergPruningExpression(conjunct, scanSchema);
             if (expression != null) {
                 expressions.add(expression);
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/iceberg/source/IcebergScanNodeTest.java
@@ -2903,11 +2903,14 @@ public class IcebergScanNodeTest {
     }
 
     @Test
-    public void testHistoricalPredicateUsesSelectedScanSchema() throws Exception {
+    public void testHistoricalPredicateSkipsPushdownAfterColumnChange() throws Exception {
         Schema historicalSchema = new Schema(
-                Types.NestedField.optional(7, "old_name", Types.IntegerType.get()));
+                Types.NestedField.optional(7, "old_name", Types.IntegerType.get()),
+                Types.NestedField.optional(9, "stable_name", Types.IntegerType.get()));
         Schema currentSchema = new Schema(
-                Types.NestedField.optional(8, "new_name", Types.IntegerType.get()));
+                Types.NestedField.optional(7, "new_name", Types.IntegerType.get()),
+                Types.NestedField.optional(8, "old_name", Types.IntegerType.get()),
+                Types.NestedField.optional(9, "stable_name", Types.IntegerType.get()));
         Table table = Mockito.mock(Table.class);
         Mockito.when(table.schema()).thenReturn(currentSchema);
         Mockito.when(table.schemas()).thenReturn(Collections.singletonMap(
@@ -2932,10 +2935,77 @@ public class IcebergScanNodeTest {
                 .when(node).getSpecifiedSnapshot();
         node.addConjunct(new BinaryPredicate(BinaryPredicate.Operator.EQ,
                 new SlotRef(new TableName(), "old_name"), new IntLiteral(1, Type.INT)));
+        node.addConjunct(new BinaryPredicate(BinaryPredicate.Operator.EQ,
+                new SlotRef(new TableName(), "stable_name"), new IntLiteral(2, Type.INT)));
 
         node.createRealTableScan();
 
-        Mockito.verify(scan).filter(Mockito.argThat(expression -> expression.toString().contains("old_name")));
+        Mockito.verify(scan).filter(Mockito.argThat(expression -> expression.toString().contains("stable_name")));
+        Mockito.verify(scan, Mockito.never())
+                .filter(Mockito.argThat(expression -> expression.toString().contains("old_name")));
+    }
+
+    @Test
+    public void testHistoricalPredicatePlansAfterColumnRename() throws Exception {
+        assertHistoricalPredicatePlansAfterSchemaEvolution(false);
+    }
+
+    @Test
+    public void testHistoricalPredicatePlansAfterColumnDrop() throws Exception {
+        assertHistoricalPredicatePlansAfterSchemaEvolution(true);
+    }
+
+    private void assertHistoricalPredicatePlansAfterSchemaEvolution(boolean dropColumn) throws Exception {
+        Schema historicalSchema = new Schema(
+                Types.NestedField.optional(1, "x", Types.IntegerType.get()),
+                Types.NestedField.optional(2, "y", Types.IntegerType.get()),
+                Types.NestedField.optional(3, "part", Types.IntegerType.get()));
+        HadoopTables tables = new HadoopTables(new Configuration());
+        String tableLocation = temporaryFolder.getRoot().toPath()
+                .resolve("historical_predicate_after_" + (dropColumn ? "drop" : "rename")).toUri().toString();
+        Table table = tables.create(
+                historicalSchema, PartitionSpec.unpartitioned(), SortOrder.unsorted(),
+                ImmutableMap.of(TableProperties.FORMAT_VERSION, "2"), tableLocation);
+        DataFile dataFile = DataFiles.builder(table.spec())
+                .withPath(tableLocation + "/data/data.parquet")
+                .withFormat(FileFormat.PARQUET)
+                .withFileSizeInBytes(10)
+                .withRecordCount(2)
+                .build();
+        table.newFastAppend().appendFile(dataFile).commit();
+        long historicalSnapshotId = table.currentSnapshot().snapshotId();
+        int historicalSchemaId = table.currentSnapshot().schemaId();
+        if (dropColumn) {
+            table.updateSchema().deleteColumn("x").commit();
+        } else {
+            table.updateSchema().renameColumn("x", "renamed_x").commit();
+        }
+        DataFile currentDataFile = DataFiles.builder(table.spec())
+                .withPath(tableLocation + "/data/current.parquet")
+                .withFormat(FileFormat.PARQUET)
+                .withFileSizeInBytes(10)
+                .withRecordCount(1)
+                .build();
+        // A newer snapshot makes Iceberg resolve historical partition specs during time travel.
+        table.newFastAppend().appendFile(currentDataFile).commit();
+
+        TableScan scan = table.newScan()
+                .useSnapshot(historicalSnapshotId)
+                .project(table.schemas().get(historicalSchemaId));
+        BinaryPredicate conjunct = new BinaryPredicate(BinaryPredicate.Operator.EQ,
+                new SlotRef(new TableName(), "x"), new IntLiteral(1, Type.INT));
+        TestIcebergScanNode node = new TestIcebergScanNode(new SessionVariable());
+        setIcebergTable(node, table);
+        org.apache.iceberg.expressions.Expression predicate =
+                node.convertToIcebergPruningExpression(conjunct, scan.schema());
+        Assert.assertNull(predicate);
+
+        try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+            Iterator<FileScanTask> iterator = tasks.iterator();
+            Assert.assertTrue(iterator.hasNext());
+            iterator.next();
+            Assert.assertFalse(iterator.hasNext());
+        }
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: apache/iceberg#13301

Problem Summary:

Iceberg 1.10 plans manifest filters against current partition specs. A time-travel predicate using a column that was later renamed, dropped, or replaced by a same-named field can therefore fail to bind or bind to the wrong field ID.

This change validates pruning predicates against both the selected scan schema and the current table schema. It skips only predicates whose names no longer resolve to the same field IDs, leaving the original Doris conjunct for execution filtering while preserving safe Iceberg metadata pruning.

### Release note

Fix Iceberg time-travel queries that filter on columns renamed or dropped after the selected snapshot.

### Check List (For Author)

- Test
    - [x] Unit Test

- Behavior changed:
    - [x] Yes. Unsafe metadata predicate pushdown is skipped for evolved historical columns so the query can be evaluated correctly by Doris.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
