### PR TITLE
[fix](paimon) tolerate removed paimon-cpp session variable

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -154,6 +154,7 @@ public class VariableMgr {
             "enable_common_expr_pushdown_for_inverted_index",
             "enable_phrase_query_sequential_opt",
             "enable_rust_lance_reader",
+            "enable_paimon_cpp_reader",
             "shuffled_agg_node_ids",
             "plan_nereids_dump");
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #67385

After removing `enable_paimon_cpp_reader`, older clients and replayed state may still reference it. Add the name to `REMOVED_SESSION_VAR_NAMES` so existing compatibility handling silently ignores SET and tolerates reads instead of reporting an unknown system variable.

### Release note

None

### Check List (For Author)

- Test:
    - [x] No local test needed; this is a one-entry compatibility allowlist update.
    - [x] `git diff --check`
- Behavior changed:
    - [x] Yes. References to the removed variable are tolerated.
- Does this need documentation:
    - [x] No