### PR TITLE
[fix](build) Allow Doris hidden columns in Gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -25,6 +25,12 @@ regexTarget = "match"
 regexes = ['''token:\s*iceberg/paimon''']
 
 [[rules.allowlists]]
+description = "Ignore Doris internal hidden-column names; these deterministic identifiers are not credentials"
+condition = "AND"
+regexTarget = "match"
+regexes = ['''__DORIS_[A-Z0-9_]+_COL__''']
+
+[[rules.allowlists]]
 description = "Ignore the fake OIDC token fixture in AuthenticatorManagerTest"
 condition = "AND"
 regexTarget = "line"


### PR DESCRIPTION
## Problem

Doris internal hidden column identifiers such as `__DORIS_IVM_UNION_KEY_0_0_COL__` can match the `generic-api-key` heuristic even though they are deterministic schema names, not credentials.

## Solution

Add a rule-scoped allowlist for the exact hidden-column pattern `__DORIS_[A-Z0-9_]+_COL__`.

## Validation

- `git diff --check`
- Gitleaks 8.30.0 config parse and hidden-column sample scan: 0 findings
- PR #62606 reproduction: `generic-api-key` false positive in the IvmNormalizeMTMVTest hidden-column assertion