### PR TITLE
[fix](parser) Remove stale post-processor usage from limit test

### DIFF
--- a/fe/fe-sql-parser/src/test/java/org/apache/doris/sqlparser/LimitClausePrefixTest.java
+++ b/fe/fe-sql-parser/src/test/java/org/apache/doris/sqlparser/LimitClausePrefixTest.java
@@ -20,7 +20,6 @@ package org.apache.doris.sqlparser;
 import org.apache.doris.nereids.DorisParser;
 import org.apache.doris.nereids.DorisParser.LimitClauseContext;
 import org.apache.doris.nereids.parser.ParseErrorListener;
-import org.apache.doris.nereids.parser.PostProcessor;
 
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.Token;
@@ -39,7 +38,6 @@ class LimitClausePrefixTest {
     @MethodSource("limitClauses")
     void preservesLimitAndOffsetLabels(String sql, String expectedLimit, String expectedOffset) {
         DorisParser parser = new DorisParser(new CommonTokenStream(facade.newLexer(sql)));
-        parser.addParseListener(new PostProcessor());
         parser.removeErrorListeners();
         parser.addErrorListener(new ParseErrorListener());
         parser.getInterpreter().setPredictionMode(PredictionMode.SLL);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #67455, #67457

Problem Summary:

`LimitClausePrefixTest` registered `PostProcessor` directly. After #67457 moved identifier post-processing into grammar actions and deleted `PostProcessor`, combining it with the LIMIT-prefix test from #67455 caused `fe-sql-parser` test compilation to fail.

Remove the obsolete import and listener registration. Identifier post-processing is now performed by the grammar, and the LIMIT test does not require a global parse listener.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test
    - [ ] No need to test or manual test
    - All seven `fe-sql-parser` test classes: 199 tests passed
    - `mvn checkstyle:check -pl fe-sql-parser`: 0 violations

- Behavior changed:
    - [x] No.
    - [ ] Yes.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
