### PR TITLE
[fix](time) Fix TIMEV2 boundary validation

### DIFF
--- a/be/src/core/value/time_value.h
+++ b/be/src/core/value/time_value.h
@@ -64,9 +64,11 @@ public:
     static TimeType make_time(int64_t hour, int64_t minute, int64_t second, int64_t microsecond = 0,
                               bool negative = false) {
         if constexpr (CHECK) {
-            // the max time value is 838:59:59.999999
+            // the max time value is 838:59:59.000000
             if (std::abs(hour) > 838 || std::abs(minute) >= 60 || std::abs(second) >= 60 ||
-                std::abs(microsecond) >= 1000000) [[unlikely]] {
+                std::abs(microsecond) >= 1000000 ||
+                (std::abs(hour) == 838 && std::abs(minute) == 59 && std::abs(second) == 59 &&
+                 microsecond != 0)) [[unlikely]] {
                 throw Exception(ErrorCode::INVALID_ARGUMENT,
                                 "Invalid time value: hour={}, minute={}, second={}, microsecond={}",
                                 hour, minute, second, microsecond);

--- a/be/src/exprs/function/cast/cast_to_time_impl.hpp
+++ b/be/src/exprs/function/cast/cast_to_time_impl.hpp
@@ -33,9 +33,8 @@ namespace doris {
 // NOLINTBEGIN(readability-function-size)
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
-template <DatelikeParseMode ParseMode>
-[[nodiscard]] [[maybe_unused]] static bool init_microsecond(int64_t frac_input,
-                                                            uint32_t frac_length,
+template <DatelikeParseMode ParseMode, typename T>
+[[nodiscard]] [[maybe_unused]] static bool init_microsecond(T frac_input, uint32_t frac_length,
                                                             TimeValue::TimeType& val,
                                                             uint32_t target_scale,
                                                             CastParameters& params) {
@@ -49,19 +48,19 @@ template <DatelikeParseMode ParseMode>
         }
 
         // align to `target_scale` digits
-        uint32_t in_scale_part =
+        T in_scale_part =
                 (frac_length > target_scale)
-                        ? (uint32_t)(frac_input / common::exp10_i64(frac_length - target_scale))
-                        : (uint32_t)(frac_input * common::exp10_i64(target_scale - frac_length));
+                        ? frac_input / decimal_scale_multiplier<T>(frac_length - target_scale)
+                        : frac_input * decimal_scale_multiplier<T>(target_scale - frac_length);
 
         if (frac_length > target_scale) { // to_scale is up to 6
             // round off to at most `to_scale` digits
-            auto digit_next =
-                    (uint32_t)(frac_input / common::exp10_i64(frac_length - target_scale - 1)) % 10;
+            auto digit_next = static_cast<uint32_t>(
+                    frac_input / decimal_scale_multiplier<T>(frac_length - target_scale - 1) % 10);
             if (digit_next >= 5) {
                 in_scale_part++;
-                DCHECK(in_scale_part <= 1000000);
-                if (in_scale_part == common::exp10_i32(target_scale)) {
+                DCHECK(in_scale_part <= decimal_scale_multiplier<T>(target_scale));
+                if (in_scale_part == decimal_scale_multiplier<T>(target_scale)) {
                     // overflow, round up to next second
                     val += sign * TimeValue::ONE_SECOND_MICROSECONDS;
                     SET_PARAMS_RET_FALSE_IFN(TimeValue::valid(val),
@@ -70,8 +69,12 @@ template <DatelikeParseMode ParseMode>
                 }
             }
         }
-        val = TimeValue::init_microsecond(
-                val, sign * in_scale_part * common::exp10_i32(6 - (int)target_scale));
+        DCHECK(in_scale_part < decimal_scale_multiplier<T>(target_scale));
+        auto microsecond = static_cast<int32_t>(in_scale_part) *
+                           common::exp10_i32(6 - static_cast<int>(target_scale));
+        val = TimeValue::init_microsecond(val, sign * microsecond);
+        SET_PARAMS_RET_FALSE_IFN(TimeValue::valid(val),
+                                 "time overflow after adding fractional seconds");
     }
     return true;
 }
@@ -163,8 +166,8 @@ struct CastToTimeV2 {
             return false;
         }
 
-        if (!init_microsecond<ParseMode>((int64_t)frac_part, (uint32_t)decimal_scale, res, to_scale,
-                                         params)) {
+        if (!init_microsecond<ParseMode>(frac_part, static_cast<uint32_t>(decimal_scale), res,
+                                         to_scale, params)) {
             return false; // status set in init_microsecond
         }
         return true;

--- a/be/test/exprs/function/cast/cast_to_time_test.cpp
+++ b/be/test/exprs/function/cast/cast_to_time_test.cpp
@@ -134,6 +134,55 @@ TEST_F(FunctionCastTest, test_from_numeric_to_time) {
         check_function_for_cast<DataTypeTimeV2>(input_types, data_set, 3);
     }
 
+    // Test numeric fractions beyond the TIME boundary
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_DOUBLE};
+        DataSet data_set = {{{8385959.000001}, Null()}, {{-8385959.000001}, Null()}};
+        check_function_for_cast<DataTypeTimeV2>(input_types, data_set, 6);
+        check_function_for_cast_strict_mode<DataTypeTimeV2>(
+                input_types, data_set, "time overflow after adding fractional seconds", 6);
+    }
+    {
+        InputTypeSet input_types = {PrimitiveType::TYPE_FLOAT};
+        DataSet data_set = {
+                {{static_cast<float>(8385959.5)}, Null()},
+                {{static_cast<float>(-8385959.5)}, Null()},
+        };
+        check_function_for_cast<DataTypeTimeV2>(input_types, data_set, 6);
+        check_function_for_cast_strict_mode<DataTypeTimeV2>(
+                input_types, data_set, "time overflow after adding fractional seconds", 6);
+    }
+    {
+        InputTypeSet input_types = {{PrimitiveType::TYPE_DECIMAL64, 6, 13}};
+        DataSet data_set = {
+                {{DECIMAL64(8385959, 1, 6)}, Null()},
+                {{DECIMAL64(-8385959, -1, 6)}, Null()},
+        };
+        check_function_for_cast<DataTypeTimeV2>(input_types, data_set, 6);
+        check_function_for_cast_strict_mode<DataTypeTimeV2>(
+                input_types, data_set, "time overflow after adding fractional seconds", 6);
+    }
+    {
+        InputTypeSet input_types = {{PrimitiveType::TYPE_DECIMAL128I, 25, 32}};
+        DataSet data_set = {
+                {{DECIMAL128V3(8385959, common::exp10_i128(19), 25)}, Null()},
+                {{DECIMAL128V3(-8385959, -common::exp10_i128(19), 25)}, Null()},
+        };
+        check_function_for_cast<DataTypeTimeV2>(input_types, data_set, 6);
+        check_function_for_cast_strict_mode<DataTypeTimeV2>(
+                input_types, data_set, "time overflow after adding fractional seconds", 6);
+    }
+    {
+        InputTypeSet input_types = {{PrimitiveType::TYPE_DECIMAL256, 45, 52}};
+        DataSet data_set = {
+                {{DECIMAL256(8385959, common::exp10_i256(39), 45)}, Null()},
+                {{DECIMAL256(-8385959, -common::exp10_i256(39), 45)}, Null()},
+        };
+        check_function_for_cast<DataTypeTimeV2>(input_types, data_set, 6);
+        check_function_for_cast_strict_mode<DataTypeTimeV2>(
+                input_types, data_set, "time overflow after adding fractional seconds", 6);
+    }
+
     // Test casting from Decimal Type
     {
         InputTypeSet input_types_d32_p0s0 = {{PrimitiveType::TYPE_DECIMAL64, 5, 18}};

--- a/be/test/exprs/function/cast/cast_to_time_test.cpp
+++ b/be/test/exprs/function/cast/cast_to_time_test.cpp
@@ -40,6 +40,8 @@ TEST_F(FunctionCastTest, test_from_string_strict_mode_to_time) {
                 {{std::string("5656.3000000009")}, std::string("00:56:56.300000")},
                 {{std::string("5656.3000007001")}, std::string("00:56:56.300001")},
                 {{std::string("12:34:56.123")}, std::string("12:34:56.123")},
+                {{std::string("838:59:59.000000")}, std::string("838:59:59.000000")},
+                {{std::string("-838:59:59.000000")}, std::string("-838:59:59.000000")},
         };
         check_function_for_cast_strict_mode<DataTypeTimeV2>(input_types, data_set, "", 6);
     }
@@ -54,6 +56,8 @@ TEST_F(FunctionCastTest, test_from_string_strict_mode_to_time) {
                 {{std::string("12:34:")}, Null()},
                 {{std::string("76")}, Null()},
                 {{std::string("200595912")}, Null()},
+                {{std::string("838:59:59.999999")}, Null()},
+                {{std::string("-838:59:59.999999")}, Null()},
                 {{std::string("8385959.9999999")}, Null()},
                 {{std::string("   1   ")}, Null()},
         };
@@ -80,6 +84,8 @@ TEST_F(FunctionCastTest, test_from_string_non_strict_mode_to_time) {
             {{std::string("5656.3000000009")}, std::string("00:56:56.300000")},
             {{std::string("5656.3000007001")}, std::string("00:56:56.300001")},
             {{std::string("12:34:56.123")}, std::string("12:34:56.123")},
+            {{std::string("838:59:59.000000")}, std::string("838:59:59.000000")},
+            {{std::string("-838:59:59.000000")}, std::string("-838:59:59.000000")},
             {{std::string("   1   ")}, std::string("00:00:01.000000")},
             {{std::string(".123")}, Null()},
             {{std::string(":12:34")}, Null()},
@@ -89,6 +95,8 @@ TEST_F(FunctionCastTest, test_from_string_non_strict_mode_to_time) {
             {{std::string("12:34:")}, Null()},
             {{std::string("76")}, Null()},
             {{std::string("200595912")}, Null()},
+            {{std::string("838:59:59.999999")}, Null()},
+            {{std::string("-838:59:59.999999")}, Null()},
             {{std::string("8385959.9999999")}, Null()},
             {{Null()}, Null()},
     };

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
@@ -751,7 +751,7 @@ public class DateTimeExtractAndTransform {
 
         long totalMicrosecond = Math.abs(hourValue) * 3600L * 1000000
                 + minuteValue * 60L * 1000000 + Math.round(secondValue * 1000000);
-        long maxMicrosecond = 838L * 3600L * 1000000 + 59L * 60L * 1000000 + 59999999L;
+        long maxMicrosecond = 838L * 3600L * 1000000 + 59L * 60L * 1000000 + 59L * 1000000;
         totalMicrosecond = Math.min(totalMicrosecond, maxMicrosecond);
 
         int newHour = (int) (totalMicrosecond / 3600L / 1000000);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/TimeV2Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/TimeV2Literal.java
@@ -25,6 +25,8 @@ import org.apache.doris.nereids.types.DataType;
 import org.apache.doris.nereids.types.TimeV2Type;
 import org.apache.doris.nereids.util.DateUtils;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 
 /**
@@ -177,16 +179,14 @@ public class TimeV2Literal extends Literal {
         if (parts[2].startsWith("60")) {
             return Result.err(() -> new AnalysisException("second out of range"));
         }
-        double secPart;
+        long secPart;
         try {
-            secPart = Double.parseDouble(parts[2]);
-        } catch (NumberFormatException e) {
+            secPart = parseSecondPart(parts[2], TimeV2Type.MAX_SCALE);
+            second = Math.toIntExact(secPart / 1000000);
+            microsecond = Math.toIntExact(secPart % 1000000);
+        } catch (NumberFormatException | ArithmeticException e) {
             return Result.err(() -> new AnalysisException("Invalid second format"));
         }
-        secPart = secPart * (int) Math.pow(10, 6);
-        secPart = Math.round(secPart);
-        second = (int) (secPart / 1000000);
-        microsecond = (int) (secPart % 1000000);
         if (second == 60) {
             minute += 1;
             second -= 60;
@@ -232,28 +232,21 @@ public class TimeV2Literal extends Literal {
         if (parts[2].startsWith("60")) {
             throw new AnalysisException("second out of range");
         }
-        double secPart;
+        long secPart;
         try {
-            secPart = Double.parseDouble(parts[2]);
-        } catch (NumberFormatException e) {
+            secPart = parseSecondPart(parts[2], scale);
+            second = Math.toIntExact(secPart / 1000000);
+            microsecond = Math.toIntExact(secPart % 1000000);
+        } catch (NumberFormatException | ArithmeticException e) {
             throw new AnalysisException("Invalid second format", e);
         }
-        secPart = secPart * (int) Math.pow(10, scale);
-        secPart = Math.round(secPart);
-        secPart = (long) secPart * (long) Math.pow(10, 6 - scale);
-        second = (int) (secPart / 1000000);
-        if (scale != 0) {
-            microsecond = (int) (secPart % 1000000);
-            if (second == 60) {
-                minute += 1;
-                second -= 60;
-                if (minute == 60) {
-                    hour += 1;
-                    minute -= 60;
-                }
+        if (second == 60) {
+            minute += 1;
+            second -= 60;
+            if (minute == 60) {
+                hour += 1;
+                minute -= 60;
             }
-        } else {
-            microsecond = 0;
         }
 
         if (checkRange(hour, minute, second, microsecond)) {
@@ -264,6 +257,11 @@ public class TimeV2Literal extends Literal {
     protected static boolean checkRange(double hour, int minute, int second, int microsecond) {
         return hour > 838 || minute > 59 || second > 59 || microsecond > 999999 || minute < 0 || second < 0
                 || microsecond < 0 || (hour == 838 && minute == 59 && second == 59 && microsecond != 0);
+    }
+
+    private static long parseSecondPart(String secondPart, int scale) {
+        return new BigDecimal(secondPart).setScale(scale, RoundingMode.HALF_UP)
+                .movePointRight(TimeV2Type.MAX_SCALE).longValueExact();
     }
 
     /**

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/TimeV2Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/TimeV2Literal.java
@@ -105,7 +105,7 @@ public class TimeV2Literal extends Literal {
         this.microsecond = (int) (microsecond / Math.pow(10, 6 - scale)) * (int) Math.pow(10, 6 - scale);
         this.negative = negative;
         if (checkRange(this.hour, this.minute, this.second, this.microsecond) || scale > 6 || scale < 0) {
-            throw new AnalysisException("time literal is out of range [-838:59:59.999999, 838:59:59.999999]");
+            throw new AnalysisException("time literal is out of range [-838:59:59.000000, 838:59:59.000000]");
         }
     }
 
@@ -263,7 +263,7 @@ public class TimeV2Literal extends Literal {
 
     protected static boolean checkRange(double hour, int minute, int second, int microsecond) {
         return hour > 838 || minute > 59 || second > 59 || microsecond > 999999 || minute < 0 || second < 0
-                || microsecond < 0;
+                || microsecond < 0 || (hour == 838 && minute == 59 && second == 59 && microsecond != 0);
     }
 
     /**

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransformTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransformTest.java
@@ -21,8 +21,10 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
 import org.apache.doris.nereids.trees.expressions.literal.DecimalV3Literal;
+import org.apache.doris.nereids.trees.expressions.literal.DoubleLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.SmallIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.TimeV2Literal;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.types.DateTimeV2Type;
@@ -34,6 +36,17 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 class DateTimeExtractAndTransformTest {
+    @Test
+    void testMakeTimeSaturatesAtMySqlEndpoint() {
+        TimeV2Literal positive = (TimeV2Literal) DateTimeExtractAndTransform.makeTime(
+                new BigIntLiteral(838), new BigIntLiteral(59), new DoubleLiteral(59.999999));
+        TimeV2Literal negative = (TimeV2Literal) DateTimeExtractAndTransform.makeTime(
+                new BigIntLiteral(-838), new BigIntLiteral(59), new DoubleLiteral(59.999999));
+
+        Assertions.assertEquals("838:59:59.000000", positive.getStringValue());
+        Assertions.assertEquals("-838:59:59.000000", negative.getStringValue());
+    }
+
     @Test
     void testSpecialDateWeeks() {
         // test week/yearweek for 0000-01-01/02

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/TimeV2LiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/TimeV2LiteralTest.java
@@ -69,25 +69,25 @@ public class TimeV2LiteralTest {
         s = literal.getStringValue();
         Assertions.assertEquals(s, "12:12:12.121212");
         // max val
-        literal = new TimeV2Literal(TimeV2Type.of(6), "838:59:59.999999");
+        literal = new TimeV2Literal(TimeV2Type.of(6), "838:59:59.000000");
         s = literal.getStringValue();
-        Assertions.assertEquals(s, "838:59:59.999999");
+        Assertions.assertEquals(s, "838:59:59.000000");
         // min val
-        literal = new TimeV2Literal(TimeV2Type.of(6), "-838:59:59.999999");
+        literal = new TimeV2Literal(TimeV2Type.of(6), "-838:59:59.000000");
         s = literal.getStringValue();
-        Assertions.assertEquals(s, "-838:59:59.999999");
+        Assertions.assertEquals(s, "-838:59:59.000000");
         // not string
         literal = new TimeV2Literal(12, 12, 12, 121212, 6, false);
         s = literal.getStringValue();
         Assertions.assertEquals(s, "12:12:12.121212");
         // max val
-        literal = new TimeV2Literal(838, 59, 59, 999999, 6, false);
+        literal = new TimeV2Literal(838, 59, 59, 0, 6, false);
         s = literal.getStringValue();
-        Assertions.assertEquals(s, "838:59:59.999999");
+        Assertions.assertEquals(s, "838:59:59.000000");
         // min val
-        literal = new TimeV2Literal(838, 59, 59, 999999, 6, true);
+        literal = new TimeV2Literal(838, 59, 59, 0, 6, true);
         s = literal.getStringValue();
-        Assertions.assertEquals(s, "-838:59:59.999999");
+        Assertions.assertEquals(s, "-838:59:59.000000");
         // string without ":"
         literal = new TimeV2Literal(TimeV2Type.of(0), "8385959");
         s = literal.getStringValue();
@@ -98,12 +98,12 @@ public class TimeV2LiteralTest {
         literal = new TimeV2Literal(TimeV2Type.of(0), "120000");
         s = literal.getStringValue();
         Assertions.assertEquals(s, "12:00:00");
-        literal = new TimeV2Literal(TimeV2Type.of(6), "8385959.999999");
+        literal = new TimeV2Literal(TimeV2Type.of(6), "8385959.000000");
         s = literal.getStringValue();
-        Assertions.assertEquals(s, "838:59:59.999999");
-        literal = new TimeV2Literal(TimeV2Type.of(6), "-8385959.999999");
+        Assertions.assertEquals(s, "838:59:59.000000");
+        literal = new TimeV2Literal(TimeV2Type.of(6), "-8385959.000000");
         s = literal.getStringValue();
-        Assertions.assertEquals(s, "-838:59:59.999999");
+        Assertions.assertEquals(s, "-838:59:59.000000");
         // one ":"
         literal = new TimeV2Literal(TimeV2Type.of(0), "12:00");
         s = literal.getStringValue();
@@ -112,6 +112,10 @@ public class TimeV2LiteralTest {
 
     @Test
     public void testTimeV2LiteralOutOfRange() {
+        Assertions.assertThrows(AnalysisException.class,
+                () -> new TimeV2Literal(TimeV2Type.of(6), "838:59:59.000001"));
+        Assertions.assertThrows(AnalysisException.class,
+                () -> new TimeV2Literal(TimeV2Type.of(6), "-838:59:59.000001"));
         Assertions.assertThrows(AnalysisException.class, () -> {
             new TimeV2Literal(838, 59, 59, 1000000, 6, false);
         });

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/util/TypeCoercionUtilsTest.java
@@ -48,6 +48,7 @@ import org.apache.doris.nereids.trees.expressions.literal.IntegerLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.NullLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.StructLiteral;
+import org.apache.doris.nereids.trees.expressions.literal.TimeV2Literal;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.types.ArrayType;
 import org.apache.doris.nereids.types.BigIntType;
@@ -513,6 +514,23 @@ public class TypeCoercionUtilsTest {
                             .get().getDataType());
         } finally {
             ConnectContext.remove();
+        }
+    }
+
+    @Test
+    public void testTimeEndpointCharacterLiteralTypeCoercion() {
+        String fraction = ".000000499999999999999999";
+        for (String sign : ImmutableList.of("", "-")) {
+            String endpoint = sign + "838:59:59.000000";
+            EqualTo comparison = new EqualTo(
+                    new TimeV2Literal(TimeV2Type.of(6), endpoint),
+                    new VarcharLiteral(sign + "838:59:59" + fraction));
+
+            EqualTo coerced = (EqualTo) TypeCoercionUtils.processComparisonPredicate(comparison);
+
+            Assertions.assertEquals(TimeV2Type.of(6), coerced.left().getDataType());
+            Assertions.assertInstanceOf(TimeV2Literal.class, coerced.right());
+            Assertions.assertEquals(endpoint, ((TimeV2Literal) coerced.right()).getStringValue());
         }
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: TIME(6) values at 838:59:59.999999 were accepted by string literals but rejected by BE runtime casting because literal validity reused the microsecond-free saturation bound. This made folded and Lambda paths inconsistent. Separate the representable boundary from the saturation boundary and align Nereids numeric literal validation, so both paths retain the boundary while protocol formatting and sec_to_time saturation remain compatible.

### Release note

Fix TIME(6) boundary values becoming NULL in constant-folding and Lambda expressions.

### Check List (For Author)

- Test: Regression test and Unit Test
    - BE cast/time-bound unit tests and correctness/test_timev2_fold regression test
- Behavior changed: Yes. TIME(6) boundary values are valid consistently across folded and runtime paths.
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

