### PR TITLE
[fix](fe) Use updated Routine Load CSV parser properties

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -282,10 +282,6 @@ public abstract class RoutineLoadJob
     @SerializedName("ccid")
     private String cloudClusterId;
 
-    protected byte enclose = 0;
-
-    protected byte escape = 0;
-
     protected boolean emptyFieldAsNull = false;
 
     // use for cloud cluster mode
@@ -415,8 +411,6 @@ public abstract class RoutineLoadJob
                     new String(new byte[]{csvFileFormatProperties.getEscape()}));
             jobProperties.put(CsvFileFormatProperties.PROP_EMPTY_FIELD_AS_NULL,
                     String.valueOf(csvFileFormatProperties.getEmptyFieldAsNull()));
-            this.enclose = csvFileFormatProperties.getEnclose();
-            this.escape = csvFileFormatProperties.getEscape();
             this.emptyFieldAsNull = csvFileFormatProperties.getEmptyFieldAsNull();
         } else if (fileFormatProperties instanceof JsonFileFormatProperties) {
             JsonFileFormatProperties jsonFileFormatProperties = (JsonFileFormatProperties) fileFormatProperties;
@@ -619,11 +613,13 @@ public abstract class RoutineLoadJob
     }
 
     public byte getEnclose() {
-        return enclose;
+        String value = jobProperties.get(CsvFileFormatProperties.PROP_ENCLOSE);
+        return Strings.isNullOrEmpty(value) ? 0 : (byte) value.charAt(0);
     }
 
     public byte getEscape() {
-        return escape;
+        String value = jobProperties.get(CsvFileFormatProperties.PROP_ESCAPE);
+        return Strings.isNullOrEmpty(value) ? 0 : value.getBytes()[0];
     }
 
     public boolean getEmptyFieldAsNull() {

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kafka/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kafka/KafkaRoutineLoadJob.java
@@ -1119,7 +1119,8 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         }
         return new NereidsRoutineLoadTaskInfo(execMemLimit, new HashMap<>(jobProperties), maxBatchIntervalS,
                 partitionNamesInfo, mergeType, deleteCondition, sequenceCol, maxFilterRatio, importColumnDescs,
-                precedingFilter, whereExpr, columnSeparator, lineDelimiter, enclose, escape, sendBatchParallelism,
+                precedingFilter, whereExpr, columnSeparator, lineDelimiter, getEnclose(), getEscape(),
+                sendBatchParallelism,
                 loadToSingleTablet, uniqueKeyUpdateMode, partialUpdateNewKeyPolicy, memtableOnSinkNode);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kinesis/KinesisRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kinesis/KinesisRoutineLoadJob.java
@@ -875,7 +875,8 @@ public class KinesisRoutineLoadJob extends RoutineLoadJob {
         }
         return new NereidsRoutineLoadTaskInfo(execMemLimit, new HashMap<>(jobProperties), maxBatchIntervalS,
                 partitionNamesInfo, mergeType, deleteCondition, sequenceCol, maxFilterRatio, importColumnDescs,
-                precedingFilter, whereExpr, columnSeparator, lineDelimiter, enclose, escape, sendBatchParallelism,
+                precedingFilter, whereExpr, columnSeparator, lineDelimiter, getEnclose(), getEscape(),
+                sendBatchParallelism,
                 loadToSingleTablet, uniqueKeyUpdateMode, partialUpdateNewKeyPolicy, memtableOnSinkNode);
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/KafkaRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/KafkaRoutineLoadJobTest.java
@@ -32,6 +32,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.datasource.kafka.KafkaUtil;
+import org.apache.doris.datasource.property.fileformat.CsvFileFormatProperties;
 import org.apache.doris.load.RoutineLoadDesc;
 import org.apache.doris.load.loadv2.LoadTask;
 import org.apache.doris.load.routineload.kafka.KafkaConfiguration;
@@ -40,10 +41,14 @@ import org.apache.doris.load.routineload.kafka.KafkaProgress;
 import org.apache.doris.load.routineload.kafka.KafkaRoutineLoadJob;
 import org.apache.doris.load.routineload.kafka.KafkaTaskInfo;
 import org.apache.doris.mysql.privilege.MockedAuth;
+import org.apache.doris.nereids.load.NereidsRoutineLoadTaskInfo;
+import org.apache.doris.nereids.trees.plans.commands.AlterRoutineLoadCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateRoutineLoadInfo;
 import org.apache.doris.nereids.trees.plans.commands.info.LabelNameInfo;
 import org.apache.doris.nereids.trees.plans.commands.load.LoadProperty;
 import org.apache.doris.nereids.trees.plans.commands.load.LoadSeparator;
+import org.apache.doris.persist.AlterRoutineLoadJobOperationLog;
+import org.apache.doris.persist.EditLog;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.thrift.TResourceInfo;
 import org.apache.doris.thrift.TRoutineLoadTask;
@@ -270,6 +275,45 @@ public class KafkaRoutineLoadJobTest {
 
         String otherMsg = Deencapsulation.getField(routineLoadJob, "otherMsg");
         Assert.assertTrue(otherMsg.contains("some records may be in uncommitted transactions"));
+    }
+
+    @Test
+    public void testAlterCsvParserPropertiesUpdateNewTasksAndReplay() throws Exception {
+        KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob(1L, "kafka_routine_load_job", 1L,
+                1L, "127.0.0.1:9020", "topic1", UserIdentity.ADMIN);
+        Map<String, String> jobProperties = Deencapsulation.getField(routineLoadJob, "jobProperties");
+        jobProperties.put(CsvFileFormatProperties.PROP_ENCLOSE, "~");
+        jobProperties.put(CsvFileFormatProperties.PROP_ESCAPE, "!");
+
+        Map<String, String> alteredProperties = Maps.newHashMap();
+        alteredProperties.put(CsvFileFormatProperties.PROP_ENCLOSE, "^");
+        alteredProperties.put(CsvFileFormatProperties.PROP_ESCAPE, "?");
+        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.PAUSED);
+        AlterRoutineLoadCommand command = Mockito.mock(AlterRoutineLoadCommand.class);
+        Mockito.when(command.getAnalyzedJobProperties()).thenReturn(alteredProperties);
+        Mockito.when(command.getDataSourceProperties()).thenReturn(null);
+        Env env = Mockito.mock(Env.class);
+        Mockito.when(env.getEditLog()).thenReturn(Mockito.mock(EditLog.class));
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            routineLoadJob.modifyProperties(command);
+        }
+
+        Assert.assertEquals((byte) '^', routineLoadJob.getEnclose());
+        Assert.assertEquals((byte) '?', routineLoadJob.getEscape());
+        NereidsRoutineLoadTaskInfo taskInfo = routineLoadJob.toNereidsRoutineLoadTaskInfo();
+        Assert.assertEquals((byte) '^', taskInfo.getEnclose());
+        Assert.assertEquals((byte) '?', taskInfo.getEscape());
+
+        KafkaRoutineLoadJob replayJob = new KafkaRoutineLoadJob(2L, "replay_job", 1L,
+                1L, "127.0.0.1:9020", "topic1", UserIdentity.ADMIN);
+        Map<String, String> replayJobProperties = Deencapsulation.getField(replayJob, "jobProperties");
+        replayJobProperties.put(CsvFileFormatProperties.PROP_ENCLOSE, "~");
+        replayJobProperties.put(CsvFileFormatProperties.PROP_ESCAPE, "!");
+        replayJob.replayModifyProperties(new AlterRoutineLoadJobOperationLog(
+                replayJob.getId(), alteredProperties, null));
+        Assert.assertEquals((byte) '^', replayJob.getEnclose());
+        Assert.assertEquals((byte) '?', replayJob.getEscape());
     }
 
     @Test

--- a/regression-test/suites/load_p0/routine_load/test_routine_load_property.groovy
+++ b/regression-test/suites/load_p0/routine_load/test_routine_load_property.groovy
@@ -139,7 +139,24 @@ suite("test_routine_load_property","p0") {
             sql "pause routine load for ${jobName}"
             def res = sql "show routine load for ${jobName}"
             log.info("routine load job properties: ${res[0][11].toString()}".toString())
-            sql "ALTER ROUTINE LOAD FOR ${jobName} PROPERTIES(\"enclose\" = \"g\");"
+            sql "ALTER ROUTINE LOAD FOR ${jobName} PROPERTIES(\"enclose\" = \"^\", \"escape\" = \"?\");"
+            sql "truncate table ${tableName}"
+
+            def alteredProps = new Properties()
+            alteredProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "${kafka_broker}".toString())
+            alteredProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                    "org.apache.kafka.common.serialization.StringSerializer")
+            alteredProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                    "org.apache.kafka.common.serialization.StringSerializer")
+            alteredProps.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, "10000")
+            alteredProps.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, "10000")
+            def alteredProducer = new KafkaProducer<>(alteredProps)
+            try {
+                alteredProducer.send(new ProducerRecord<>(kafkaCsvTpoics[0], null,
+                        "1,^ab,ced^,2023-07-15,d?e,2023-07-20 05:48:31,\"ghi\"")).get()
+            } finally {
+                alteredProducer.close()
+            }
             sql "resume routine load for ${jobName}"
             count = 0
             while (true) {
@@ -152,9 +169,7 @@ suite("test_routine_load_property","p0") {
                     break
                 }
                 if (count >= 120) {
-                    log.error("routine load can not visible for long time")
-                    assertEquals(20, res[0][0])
-                    break
+                    throw new IllegalStateException("altered routine load data can not be visible for long time")
                 }
                 sleep(1000)
                 count++


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: `RoutineLoadJob` kept CSV `enclose` and `escape` values in both persisted `jobProperties` and separate in-memory byte fields. `ALTER ROUTINE LOAD` updated only `jobProperties`, while newly planned Kafka and Kinesis tasks used the stale fields from `CREATE ROUTINE LOAD`.

This change makes persisted `jobProperties` the single job-level source of truth. `RoutineLoadJob` derives the parser bytes through its getters, and each new task receives a snapshot of the current values. ALTER execution, journal replay, and checkpoint loading already preserve `jobProperties`, so no load-description replay or checkpoint-specific repair is needed.

### Release note

`ALTER ROUTINE LOAD` now applies updated CSV `enclose` and `escape` characters to subsequent tasks.

### Check List (For Author)

- Test
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

Unit test executed:

`DORIS_THIRDPARTY=/path/to/thirdparty-with-thrift-0.24.0 ./run-fe-ut.sh --run org.apache.doris.load.routineload.KafkaRoutineLoadJobTest`

Result: 12 tests passed.

The Kafka regression test truncates the table after ALTER and publishes a row that requires the new `enclose` and `escape` values while preserving the existing deterministic expected output. It was not run locally because the configured Kafka regression service is unavailable; CI will run it in the Kafka-enabled environment.

- Behavior changed:
    - [ ] No.
    - [x] Yes. New Routine Load tasks use CSV parser properties changed by ALTER.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label