### PR TITLE
[fix](fe) Propagate JSON properties for multi-table routine load

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsStreamLoadTask.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/load/NereidsStreamLoadTask.java
@@ -382,6 +382,8 @@ public class NereidsStreamLoadTask implements NereidsLoadTaskInfo {
         this.timezone = task.getTimezone();
         this.formatType = task.getFormatType();
         this.stripOuterArray = task.isStripOuterArray();
+        this.numAsString = task.isNumAsString();
+        this.jsonPaths = task.getJsonPaths();
         this.jsonRoot = task.getJsonRoot();
         this.sendBatchParallelism = task.getSendBatchParallelism();
         this.loadToSingleTablet = task.isLoadToSingleTablet();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/load/NereidsStreamLoadTaskTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/load/NereidsStreamLoadTaskTest.java
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.load;
+
+import org.apache.doris.task.LoadTaskInfo;
+import org.apache.doris.thrift.TFileCompressType;
+import org.apache.doris.thrift.TFileFormatType;
+import org.apache.doris.thrift.TFileType;
+import org.apache.doris.thrift.TStreamLoadPutRequest;
+import org.apache.doris.thrift.TUniqueId;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class NereidsStreamLoadTaskTest {
+    @Test
+    public void testMultiTableBaseTaskCopiesJsonProperties() throws Exception {
+        TStreamLoadPutRequest request = new TStreamLoadPutRequest();
+        request.setLoadId(new TUniqueId(1, 2));
+        request.setTxnId(3);
+        request.setFileType(TFileType.FILE_STREAM);
+        request.setFormatType(TFileFormatType.FORMAT_JSON);
+        request.setCompressType(TFileCompressType.PLAIN);
+
+        NereidsStreamLoadTask streamLoadTask = NereidsStreamLoadTask.fromTStreamLoadPutRequest(request);
+        LoadTaskInfo routineLoadTask = Mockito.mock(LoadTaskInfo.class);
+        Mockito.when(routineLoadTask.getFormatType()).thenReturn(TFileFormatType.FORMAT_JSON);
+        Mockito.when(routineLoadTask.getJsonPaths()).thenReturn(
+                "[\"$.meta.id\", \"$.meta.ts\", \"$.value.score\", \"$.value.region\"]");
+        Mockito.when(routineLoadTask.getJsonRoot()).thenReturn("$.payload.items");
+        Mockito.when(routineLoadTask.isStripOuterArray()).thenReturn(true);
+        Mockito.when(routineLoadTask.isNumAsString()).thenReturn(true);
+
+        streamLoadTask.setMultiTableBaseTaskInfo(routineLoadTask);
+
+        Assertions.assertEquals(TFileFormatType.FORMAT_JSON, streamLoadTask.getFormatType());
+        Assertions.assertEquals(
+                "[\"$.meta.id\", \"$.meta.ts\", \"$.value.score\", \"$.value.region\"]",
+                streamLoadTask.getJsonPaths());
+        Assertions.assertEquals("$.payload.items", streamLoadTask.getJsonRoot());
+        Assertions.assertTrue(streamLoadTask.isStripOuterArray());
+        Assertions.assertTrue(streamLoadTask.isNumAsString());
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Multi-table routine load cannot attach a table-specific pipeline plan before the backend discovers the destination table. The backend therefore requests a per-table plan with the format, and FE rebuilds the stream-load task from the Routine Load job. That rebuild already restored `json_root` and `strip_outer_array`, but omitted `jsonpaths` and `num_as_string`. Nested JSON records were consequently planned with an empty JSON path list and filtered as invalid rows. This change restores those two properties before generating each dynamic-table pipeline plan.

### Release note

Fix multi-table routine load to honor `jsonpaths` and `num_as_string` for dynamic target tables.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
        - `sh run-fe-ut.sh --run org.apache.doris.nereids.load.NereidsStreamLoadTaskTest`
        - `DISABLE_BUILD_UI=ON ./build.sh --fe -j48`
    - [ ] Manual test
    - [ ] No need to test or manual test.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Multi-table routine load now applies configured `jsonpaths` and `num_as_string` during per-table planning.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label