### PR TITLE
[fix](plsql) Reject CALL of a stored procedure on a non-MySQL connection

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/call/CallProcedure.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/call/CallProcedure.java
@@ -17,8 +17,10 @@
 
 package org.apache.doris.nereids.trees.plans.commands.call;
 
+import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.plsql.executor.PlSqlOperation;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.ConnectContext.ConnectType;
 
 import java.util.Objects;
 
@@ -40,6 +42,18 @@ public class CallProcedure extends CallFunc {
      * Create a CallFunc
      */
     public static CallFunc create(ConnectContext ctx, String source) {
+        // The PL/SQL interpreter is wired to the session's MySQL channel: PlSqlOperation.execute()
+        // ends with ctx.getMysqlChannel().reset(), PlsqlResult writes rows with
+        // MysqlChannel.sendOnePacket(), and PlsqlQueryExecutor runs every inner statement on a
+        // ConnectContext.cloneContext() whose connect type is always MYSQL. On an Arrow Flight SQL
+        // connection getMysqlChannel() throws, but only after the procedure body has already run,
+        // so a CALL carrying DML reports an error to the client while its side effect is applied.
+        // Refuse the statement here -- create() runs before run(), so nothing has executed yet.
+        if (ctx.getConnectType() != ConnectType.MYSQL) {
+            throw new AnalysisException("Stored procedure is only supported on the MySQL protocol,"
+                    + " but the current connection type is " + ctx.getConnectType()
+                    + ". Please run CALL over a MySQL protocol connection.");
+        }
         PlSqlOperation plSqlOperation = ctx.getPlSqlOperation();
         return new CallProcedure(plSqlOperation, ctx, source);
     }

--- a/regression-test/suites/arrow_flight_sql_p0/test_call_procedure_not_supported.groovy
+++ b/regression-test/suites/arrow_flight_sql_p0/test_call_procedure_not_supported.groovy
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_call_procedure_not_supported", "arrow_flight_sql") {
+    def tableName = "test_call_procedure_not_supported_tbl"
+    def procName = "test_call_procedure_not_supported_proc"
+
+    jdbc_sql "DROP TABLE IF EXISTS ${tableName}"
+    jdbc_sql """
+        CREATE TABLE ${tableName} (id INT, name VARCHAR(20)) DUPLICATE KEY(`id`)
+        DISTRIBUTED BY HASH(`id`) BUCKETS 1 PROPERTIES ("replication_num"="1");
+        """
+    jdbc_sql """
+        CREATE OR REPLACE PROCEDURE ${procName}(IN id INT, IN name STRING)
+        BEGIN
+            INSERT INTO ${tableName} VALUES(id, name);
+        END;
+        """
+
+    // The PL/SQL interpreter writes through the session's MySQL channel, which an Arrow Flight SQL
+    // connection does not have. Before the guard, the CALL ran its body first and only then hit
+    // `getMysqlChannel not in mysql connection`, so the client saw an error while the INSERT had
+    // already been applied. The statement must now be refused before anything is executed.
+    def rejected = false
+    try {
+        arrow_flight_sql """CALL ${procName}(444, "adbc444")"""
+    } catch (Exception e) {
+        rejected = true
+        assertTrue(e.getMessage().contains("only supported on the MySQL protocol"),
+                "unexpected error message: " + e.getMessage())
+    }
+    assertTrue(rejected, "CALL of a stored procedure must be rejected on an Arrow Flight SQL connection")
+
+    // The refused CALL must not have applied its side effect.
+    def rows = jdbc_sql """SELECT COUNT(*) FROM ${tableName}"""
+    assertEquals(0L, rows[0][0] as long)
+
+    // CALL is still served on the MySQL protocol.
+    jdbc_sql """CALL ${procName}(555, "jdbc555")"""
+    rows = jdbc_sql """SELECT COUNT(*) FROM ${tableName}"""
+    assertEquals(1L, rows[0][0] as long)
+
+    jdbc_sql "DROP PROCEDURE IF EXISTS ${procName}"
+    jdbc_sql "DROP TABLE IF EXISTS ${tableName}"
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67369

Related PR: #58700 (removed PL/SQL from master)

Problem Summary:

Running a PL/SQL `CALL` over an Arrow Flight SQL / ADBC connection returns
`INTERNAL: getMysqlChannel not in mysql connection` to the client **after** the procedure body has
already run, so a `CALL` that contains DML applies its side effect and still reports failure. Clients
that retry on that error duplicate the write.

The PL/SQL interpreter is wired to the session's MySQL channel throughout:

- `PlSqlOperation.execute()` ends its `finally` block with an unconditional `ctx.getMysqlChannel().reset()`;
- `PlsqlResult` writes rows with `MysqlChannel.sendOnePacket()` / `getSerializer()`;
- `PlsqlQueryExecutor.executeQuery()` runs every inner statement on a `ConnectContext.cloneContext()`,
  and `cloneContext()` builds a plain `ConnectContext` (`connectType = MYSQL`) while copying
  `mysqlChannel`, which is `null` on a Flight SQL session.

`FlightSqlConnectContext.getMysqlChannel()` throws, but the throw happens in the `finally` block, i.e.
after `Exec.parseAndEval()` has already executed the body. The exception is swallowed into an ERR state,
`DorisFlightSqlProducer.executeQueryStatement()` turns that into `after executeQueryStatement handleQuery`,
and the client sees `INTERNAL`.

This PR refuses the statement in `CallProcedure.create()`. `CallCommand.run()` calls
`CallFunc.getFunc()` — and therefore `create()` — before `CallFunc.run()`, so the check fires before
anything is executed and before the `PlSqlOperation` interpreter is even constructed. The two built-in
`CALL` functions (`EXECUTE_STMT`, `FLUSH_AUDIT_LOG`) are matched earlier in `CallFunc.getFunc()` and are
unaffected; they keep working on Arrow Flight SQL.

**Why this targets `branch-4.1` directly:** PL/SQL no longer exists on master — #58700 deleted the whole
`org.apache.doris.plsql` package, the `PLLexer.g4` / `PLParser.g4` grammars, `CallProcedure`, and the
`CREATE|DROP|SHOW CREATE PROCEDURE` grammar rules. On master `CALL <procedure>` is already rejected by
`CallFunc.getFunc()` with `do not support call function X` before any execution, so the bug is not
reproducible there and there is no master change to pick from. `branch-4.0` and `branch-3.1` still carry
the same code and can take this commit as-is.

**Not covered:** on a follower/observer FE, `CallCommand` is `ForwardWithSync`, so the statement is
forwarded to the master before this check runs and is executed there against a proxy MySQL context. That
path does not go through `FlightSqlConnectContext.getMysqlChannel()` and is left unchanged by this PR.

### Release note

Fix a `CALL <stored procedure>` over an Arrow Flight SQL connection returning an error after its DML had
already been applied. Stored procedures are now rejected up front on non-MySQL protocol connections.

### Check List (For Author)

- Test
    - [x] Regression test
        - `regression-test/suites/arrow_flight_sql_p0/test_call_procedure_not_supported.groovy`:
          creates a procedure that inserts one row, calls it over Arrow Flight SQL, asserts the call is
          rejected, asserts the table is still empty, then asserts the same `CALL` still works over the
          MySQL protocol.
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:

- Behavior changed:
    - [x] Yes. `CALL <stored procedure>` on a non-MySQL protocol connection (today: Arrow Flight SQL)
      now fails with `Stored procedure is only supported on the MySQL protocol, but the current
      connection type is ARROW_FLIGHT_SQL. Please run CALL over a MySQL protocol connection.` instead of
      executing the body and then reporting `getMysqlChannel not in mysql connection`. It never worked on
      that protocol; it now fails without a side effect.

- Does this need documentation?
    - [x] No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEqxvGojqgh8LpovPdTDJt
