### PR TITLE
branch-4.1: [fix](paimon) tolerate removed paimon-cpp session variable #67472

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/VariableMgr.java
@@ -41,6 +41,7 @@ import org.apache.doris.statistics.util.StatisticsUtil;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -144,6 +145,18 @@ public class VariableMgr {
     private static final ReadWriteLock rwlock = new ReentrantReadWriteLock();
     private static final Lock rlock = rwlock.readLock();
     private static final Lock wlock = rwlock.writeLock();
+
+    // Session variables that have been removed from SessionVariable.java but may still appear in
+    // user scripts, JDBC client connection init, or older replayed-edit logs. Looking up these
+    // names by SET or SELECT @@ silently no-ops instead of throwing ERR_UNKNOWN_SYSTEM_VARIABLE,
+    // so a BE-then-FE rolling upgrade does not break existing workloads. All entries in this set
+    // must use lowercase to match the case-insensitive comparison.
+    private static final ImmutableSet<String> REMOVED_SESSION_VAR_NAMES = ImmutableSet.of(
+            "enable_paimon_cpp_reader");
+
+    private static boolean isRemovedSessionVar(String varName) {
+        return varName != null && REMOVED_SESSION_VAR_NAMES.contains(varName.toLowerCase());
+    }
 
     // Form map from variable name to its field in Java class.
     static {
@@ -302,6 +315,13 @@ public class VariableMgr {
             throws DdlException {
         VarContext varCtx = getVarContext(setVar.getVariable());
         if (varCtx == null) {
+            // Silently ignore variables that have been removed from SessionVariable.
+            // This preserves backward compatibility for clients still issuing SET on the old name
+            // during a BE-then-FE rolling upgrade.
+            if (isRemovedSessionVar(setVar.getVariable())) {
+                LOG.debug("Ignoring removed session variable: {}", setVar.getVariable());
+                return;
+            }
             // Check if the variable is in the MySQL compatibility whitelist
             if (isInMySQLCompatWhitelist(setVar.getVariable())) {
                 // Silently ignore whitelisted variables for MySQL compatibility
@@ -347,6 +367,10 @@ public class VariableMgr {
             throws DdlException {
         VarContext varCtx = getVarContext(setVar.getVariable());
         if (varCtx == null) {
+            if (isRemovedSessionVar(setVar.getVariable())) {
+                LOG.debug("Ignoring removed session variable: {}", setVar.getVariable());
+                return;
+            }
             // Check if the variable is in the MySQL compatibility whitelist
             if (isInMySQLCompatWhitelist(setVar.getVariable())) {
                 // Silently ignore whitelisted variables for MySQL compatibility
@@ -528,6 +552,13 @@ public class VariableMgr {
     public static void fillValue(SessionVariable var, VariableExpr desc) throws AnalysisException {
         VarContext ctx = getVarContext(desc.getName());
         if (ctx == null) {
+            if (isRemovedSessionVar(desc.getName())) {
+                // Treat removed session variables as empty string for read access,
+                // preserving compatibility with clients that still SELECT @@<removed_var>.
+                desc.setType(Type.VARCHAR);
+                desc.setStringValue("");
+                return;
+            }
             ErrorReport.reportAnalysisException(ErrorCode.ERR_UNKNOWN_SYSTEM_VARIABLE, desc.getName());
         }
 
@@ -605,6 +636,9 @@ public class VariableMgr {
     private static String getValue(SessionVariable var, String name, SetType setType) throws AnalysisException {
         VarContext ctx = ctxByVarName.get(name);
         if (ctx == null) {
+            if (isRemovedSessionVar(name)) {
+                return "";
+            }
             ErrorReport.reportAnalysisException(ErrorCode.ERR_UNKNOWN_SYSTEM_VARIABLE, name);
         }
 
@@ -628,6 +662,12 @@ public class VariableMgr {
 
     // For Nereids optimizer
     public static @Nullable Literal getLiteral(SessionVariable var, String name, SetType setType) {
+        if (isRemovedSessionVar(name)) {
+            // Match the no-op behavior used by setVar/getValue for removed session
+            // variables so that SELECT @@<removed_var> doesn't break clients during
+            // a BE-then-FE rolling upgrade.
+            return new org.apache.doris.nereids.trees.expressions.literal.StringLiteral("");
+        }
         VarContext ctx = getVarContext(name);
         if (ctx == null) {
             return null;

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/VariableMgrTest.java
@@ -187,6 +187,26 @@ public class VariableMgrTest {
     }
 
     @Test
+    public void testRemovedPaimonCppReaderVariableCompatibility() throws Exception {
+        String removedVariable = "ENABLE_PAIMON_CPP_READER";
+        SessionVariable sessionVariable = new SessionVariable();
+        SetVar setVar = new SetVar(SetType.SESSION, removedVariable, new StringLiteral("true"));
+
+        VariableMgr.setVar(sessionVariable, setVar);
+        VariableMgr.setVarForNonMasterFE(sessionVariable, setVar);
+
+        VariableExpr variableExpr = new VariableExpr(removedVariable);
+        VariableMgr.fillValue(sessionVariable, variableExpr);
+        Assert.assertEquals(Type.VARCHAR, variableExpr.getType());
+        Assert.assertEquals("", variableExpr.getLiteralExpr().getStringValue());
+        Assert.assertEquals("", VariableMgr.getValue(sessionVariable, variableExpr));
+
+        Literal literal = VariableMgr.getLiteral(sessionVariable, removedVariable, SetType.SESSION);
+        Assert.assertNotNull(literal);
+        Assert.assertEquals("", literal.getStringValue());
+    }
+
+    @Test
     public void testCheckSqlConvertorFeatures() throws DdlException {
         // set wrong var
         SetVar setVar = new SetVar(SetType.SESSION, SessionVariable.ENABLE_SQL_CONVERTOR_FEATURES,


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #67472, #67378

Problem Summary:

branch-4.1 removed the paimon-cpp reader and enable_paimon_cpp_reader session variable in #67378. Older clients and replayed state may still reference the removed variable and receive an unknown-system-variable error.

Master PR #67472 adds the name to the existing generic removed-session-variable compatibility allowlist. branch-4.1 does not contain that framework, so this backport resolves the cherry-pick conflict by adding equivalent handling for this variable across SET, non-master FE SET, legacy reads, and Nereids reads. It also adds a focused unit test for the compatibility behavior.

### Release note

None

### Check List (For Author)

- Test:
    - [x] ./run-fe-ut.sh --run org.apache.doris.qe.VariableMgrTest#testRemovedPaimonCppReaderVariableCompatibility (1 test passed; 15 reactor modules succeeded)
    - [x] git diff origin/branch-4.1...HEAD --check
- Behavior changed:
    - [x] Yes. References to the removed enable_paimon_cpp_reader variable are tolerated.
- Does this need documentation:
    - [x] No