### PR TITLE
[fix](profile) Nereids Optimize Time shows N/A when MV pre-rewrite is skipped

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -945,9 +945,6 @@ public class SummaryProfile {
     }
 
     public int getNereidsOptimizeTimeMs() {
-        // Collection marker is only set by InitMaterializationContextHook, which
-        // is only installed when MV rewrite is enabled. Fall back to rewrite to
-        // keep numeric telemetry (metrics / audit log) valid on the no-hook path.
         long start = nereidsCollectTablePartitionFinishTime != -1
                 ? nereidsCollectTablePartitionFinishTime
                 : nereidsRewriteFinishTime;
@@ -1056,10 +1053,6 @@ public class SummaryProfile {
     }
 
     public String getPrettyNereidsOptimizeTime() {
-        // preRewriteByMvFinish is now recorded whenever the phase is actually
-        // entered, so a missing marker means the phase was truly skipped (e.g.
-        // MV rewrite disabled, DpHyper, non-MV query). Fall back through the
-        // earlier phase finish times so CBO's real elapsed still shows up.
         long start = nereidsPreRewriteByMvFinishTime != -1
                 ? nereidsPreRewriteByMvFinishTime
                 : (nereidsCollectTablePartitionFinishTime != -1

--- a/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/profile/SummaryProfile.java
@@ -945,7 +945,13 @@ public class SummaryProfile {
     }
 
     public int getNereidsOptimizeTimeMs() {
-        return getTimeMs(nereidsOptimizeFinishTime, nereidsCollectTablePartitionFinishTime);
+        // Collection marker is only set by InitMaterializationContextHook, which
+        // is only installed when MV rewrite is enabled. Fall back to rewrite to
+        // keep numeric telemetry (metrics / audit log) valid on the no-hook path.
+        long start = nereidsCollectTablePartitionFinishTime != -1
+                ? nereidsCollectTablePartitionFinishTime
+                : nereidsRewriteFinishTime;
+        return getTimeMs(nereidsOptimizeFinishTime, start);
     }
 
     public int getNereidsTranslateTimeMs() {
@@ -1050,7 +1056,16 @@ public class SummaryProfile {
     }
 
     public String getPrettyNereidsOptimizeTime() {
-        return getPrettyTime(nereidsOptimizeFinishTime, nereidsPreRewriteByMvFinishTime, TUnit.TIME_MS);
+        // preRewriteByMvFinish is now recorded whenever the phase is actually
+        // entered, so a missing marker means the phase was truly skipped (e.g.
+        // MV rewrite disabled, DpHyper, non-MV query). Fall back through the
+        // earlier phase finish times so CBO's real elapsed still shows up.
+        long start = nereidsPreRewriteByMvFinishTime != -1
+                ? nereidsPreRewriteByMvFinishTime
+                : (nereidsCollectTablePartitionFinishTime != -1
+                        ? nereidsCollectTablePartitionFinishTime
+                        : nereidsRewriteFinishTime);
+        return getPrettyTime(nereidsOptimizeFinishTime, start, TUnit.TIME_MS);
     }
 
     public String getPrettyNereidsTranslateTime() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -592,9 +592,6 @@ public class NereidsPlanner extends Planner {
                 LOG.debug("End pre rewrite plan by mv");
             }
         } finally {
-            // Record the finish time whenever the phase is actually entered, so that a
-            // near-timeout attempt that produced no MV plan is still attributed to
-            // "Pre Rewrite By Mv Time" instead of leaking into "Optimize Time".
             if (statementContext.getConnectContext().getExecutor() != null) {
                 statementContext.getConnectContext().getExecutor().getSummaryProfile()
                         .setNereidsPreRewriteByMvFinishTime(TimeUtils.getStartTimeMs());

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/NereidsPlanner.java
@@ -536,64 +536,69 @@ public class NereidsPlanner extends Planner {
         if (!cascadesContext.getStatementContext().isNeedPreMvRewrite()) {
             return;
         }
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Start pre rewrite plan by mv");
-        }
-        List<Plan> tmpPlansForMvRewrite = cascadesContext.getStatementContext().getTmpPlanForMvRewrite();
-        Plan originalPlan = cascadesContext.getRewritePlan();
-        List<Plan> plansWhichContainMv = new ArrayList<>();
-        // because tmpPlansForMvRewrite only one, so timeout is cumulative which is ok
-        for (Plan planForRewrite : tmpPlansForMvRewrite) {
-            SessionVariable sessionVariable = cascadesContext.getConnectContext()
-                    .getSessionVariable();
-            int timeoutSecond = sessionVariable.nereidsTimeoutSecond;
-            boolean enableTimeout = sessionVariable.enableNereidsTimeout;
-            try {
-                // set mv rewrite timeout
-                sessionVariable.nereidsTimeoutSecond = PreMaterializedViewRewriter.convertMillisToCeilingSeconds(
-                                sessionVariable.materializedViewRewriteDurationThresholdMs);
-                sessionVariable.enableNereidsTimeout = true;
-                // pre rewrite
-                Plan rewrittenPlan = MaterializedViewUtils.rewriteByRules(cascadesContext,
-                        PreMaterializedViewRewriter::rewrite, planForRewrite, planForRewrite, true);
-                Plan ruleOptimizedPlan = MaterializedViewUtils.rewriteByRules(cascadesContext,
-                        childOptContext -> {
-                            Rewriter.getWholeTreeRewriterWithoutCostBasedJobs(childOptContext).execute();
-                            return childOptContext.getRewritePlan();
-                        }, rewrittenPlan, planForRewrite, false);
-                if (ruleOptimizedPlan == null) {
-                    continue;
-                }
-                // after rbo, maybe the plan changed a lot, so we need to normalize it with original plan
-                Plan normalizedPlan = MaterializedViewUtils.normalizeSinkExpressions(
-                        ruleOptimizedPlan, originalPlan);
-                if (normalizedPlan != null) {
-                    plansWhichContainMv.add(normalizedPlan);
-                }
-            } catch (Exception e) {
-                LOG.error("pre mv rewrite in rbo rewrite fail, query id is {}",
-                        cascadesContext.getConnectContext().getQueryIdentifier(), e);
-
-            } finally {
-                sessionVariable.nereidsTimeoutSecond = timeoutSecond;
-                sessionVariable.enableNereidsTimeout = enableTimeout;
+        try {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Start pre rewrite plan by mv");
             }
-        }
-        // clear the rewritten plans which are tmp optimized, should be filled by full optimize later
-        statementContext.getRewrittenPlansByMv().clear();
-        // if rule-based optimized, would not be rewritten by cbo, so clear materialized hooks
-        this.cascadesContext.getStatementContext().setPreMvRewritten(true);
-        if (plansWhichContainMv.isEmpty()) {
-            return;
-        }
-        plansWhichContainMv.forEach(statementContext::addRewrittenPlanByMv);
-        NereidsTracer.logImportantTime("EndPreRewritePlanByMv");
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("End pre rewrite plan by mv");
-        }
-        if (statementContext.getConnectContext().getExecutor() != null) {
-            statementContext.getConnectContext().getExecutor().getSummaryProfile()
-                    .setNereidsPreRewriteByMvFinishTime(TimeUtils.getStartTimeMs());
+            List<Plan> tmpPlansForMvRewrite = cascadesContext.getStatementContext().getTmpPlanForMvRewrite();
+            Plan originalPlan = cascadesContext.getRewritePlan();
+            List<Plan> plansWhichContainMv = new ArrayList<>();
+            // because tmpPlansForMvRewrite only one, so timeout is cumulative which is ok
+            for (Plan planForRewrite : tmpPlansForMvRewrite) {
+                SessionVariable sessionVariable = cascadesContext.getConnectContext()
+                        .getSessionVariable();
+                int timeoutSecond = sessionVariable.nereidsTimeoutSecond;
+                boolean enableTimeout = sessionVariable.enableNereidsTimeout;
+                try {
+                    // set mv rewrite timeout
+                    sessionVariable.nereidsTimeoutSecond = PreMaterializedViewRewriter.convertMillisToCeilingSeconds(
+                                    sessionVariable.materializedViewRewriteDurationThresholdMs);
+                    sessionVariable.enableNereidsTimeout = true;
+                    // pre rewrite
+                    Plan rewrittenPlan = MaterializedViewUtils.rewriteByRules(cascadesContext,
+                            PreMaterializedViewRewriter::rewrite, planForRewrite, planForRewrite, true);
+                    Plan ruleOptimizedPlan = MaterializedViewUtils.rewriteByRules(cascadesContext,
+                            childOptContext -> {
+                                Rewriter.getWholeTreeRewriterWithoutCostBasedJobs(childOptContext).execute();
+                                return childOptContext.getRewritePlan();
+                            }, rewrittenPlan, planForRewrite, false);
+                    if (ruleOptimizedPlan == null) {
+                        continue;
+                    }
+                    // after rbo, maybe the plan changed a lot, so we need to normalize it with original plan
+                    Plan normalizedPlan = MaterializedViewUtils.normalizeSinkExpressions(
+                            ruleOptimizedPlan, originalPlan);
+                    if (normalizedPlan != null) {
+                        plansWhichContainMv.add(normalizedPlan);
+                    }
+                } catch (Exception e) {
+                    LOG.error("pre mv rewrite in rbo rewrite fail, query id is {}",
+                            cascadesContext.getConnectContext().getQueryIdentifier(), e);
+
+                } finally {
+                    sessionVariable.nereidsTimeoutSecond = timeoutSecond;
+                    sessionVariable.enableNereidsTimeout = enableTimeout;
+                }
+            }
+            // clear the rewritten plans which are tmp optimized, should be filled by full optimize later
+            statementContext.getRewrittenPlansByMv().clear();
+            // if rule-based optimized, would not be rewritten by cbo, so clear materialized hooks
+            this.cascadesContext.getStatementContext().setPreMvRewritten(true);
+            if (!plansWhichContainMv.isEmpty()) {
+                plansWhichContainMv.forEach(statementContext::addRewrittenPlanByMv);
+            }
+            NereidsTracer.logImportantTime("EndPreRewritePlanByMv");
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("End pre rewrite plan by mv");
+            }
+        } finally {
+            // Record the finish time whenever the phase is actually entered, so that a
+            // near-timeout attempt that produced no MV plan is still attributed to
+            // "Pre Rewrite By Mv Time" instead of leaking into "Optimize Time".
+            if (statementContext.getConnectContext().getExecutor() != null) {
+                statementContext.getConnectContext().getExecutor().getSummaryProfile()
+                        .setNereidsPreRewriteByMvFinishTime(TimeUtils.getStartTimeMs());
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/SummaryProfileTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/SummaryProfileTest.java
@@ -131,4 +131,61 @@ public class SummaryProfileTest {
                 SummaryProfile.EXTERNAL_TABLE_GET_FILE_SCAN_TASKS_TIME));
         Assertions.assertEquals(28, profile.getExternalCatalogMetaTimeMs());
     }
+
+    // Simulates a query where MV rewrite is disabled or the query doesn't touch any MV:
+    // InitMaterializationContextHook is never installed, so neither collectTablePartition
+    // nor preRewriteByMv marker is set, but optimize() still runs.
+    // Both pretty and numeric getters must fall back to rewrite so CBO's real elapsed
+    // shows up in the profile and audit / metrics stay valid.
+    @Test
+    public void testOptimizeTimeFallbackWhenPreMvSkipped() {
+        SummaryProfile profile = new SummaryProfile();
+        profile.setQueryBeginTime(1);
+        profile.setParseSqlStartTime(3);
+        profile.setParseSqlFinishTime(6);
+        profile.setNereidsLockTableStartTime(8);
+        profile.setNereidsLockTableFinishTime(10);
+        profile.setNereidsAnalysisTime(15);
+        profile.setNereidsRewriteTime(21);
+        // no InitMaterializationContextHook, no preMaterializedViewRewrite entry
+        profile.setNereidsOptimizeTime(36);
+        profile.setNereidsTranslateTime(45);
+        profile.setNereidsDistributeTime(55);
+        profile.setQueryPlanFinishTime(66);
+
+        profile.update(ImmutableMap.of());
+        RuntimeProfile executionSummary = profile.getExecutionSummary();
+
+        Assertions.assertEquals("N/A", executionSummary.getInfoString(SummaryProfile.NEREIDS_PRE_REWRITE_BY_MV_TIME));
+        Assertions.assertEquals("15ms", executionSummary.getInfoString(SummaryProfile.NEREIDS_OPTIMIZE_TIME));
+        Assertions.assertEquals(15, profile.getNereidsOptimizeTimeMs());
+    }
+
+    // Simulates a query where preMaterializedViewRewrite was actually entered but no MV
+    // was chosen (rewrite returned null / caught exception / empty result). The phase
+    // must record its own finish so that its elapsed shows up under Pre Rewrite By Mv Time
+    // instead of silently leaking into Optimize Time.
+    @Test
+    public void testPreMvAttemptedButEmpty() {
+        SummaryProfile profile = new SummaryProfile();
+        profile.setQueryBeginTime(1);
+        profile.setParseSqlStartTime(3);
+        profile.setParseSqlFinishTime(6);
+        profile.setNereidsLockTableStartTime(8);
+        profile.setNereidsLockTableFinishTime(10);
+        profile.setNereidsAnalysisTime(15);
+        profile.setNereidsRewriteTime(21);
+        profile.setNereidsCollectTablePartitionFinishTime(28);
+        // preMaterializedViewRewrite entered, took 30ms, produced nothing
+        profile.setNereidsPreRewriteByMvFinishTime(58);
+        profile.setNereidsOptimizeTime(60);
+        profile.setNereidsTranslateTime(65);
+
+        profile.update(ImmutableMap.of());
+        RuntimeProfile executionSummary = profile.getExecutionSummary();
+
+        Assertions.assertEquals("30ms", executionSummary.getInfoString(SummaryProfile.NEREIDS_PRE_REWRITE_BY_MV_TIME));
+        Assertions.assertEquals("2ms", executionSummary.getInfoString(SummaryProfile.NEREIDS_OPTIMIZE_TIME));
+        Assertions.assertEquals(32, profile.getNereidsOptimizeTimeMs());
+    }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/common/profile/SummaryProfileTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/profile/SummaryProfileTest.java
@@ -132,11 +132,6 @@ public class SummaryProfileTest {
         Assertions.assertEquals(28, profile.getExternalCatalogMetaTimeMs());
     }
 
-    // Simulates a query where MV rewrite is disabled or the query doesn't touch any MV:
-    // InitMaterializationContextHook is never installed, so neither collectTablePartition
-    // nor preRewriteByMv marker is set, but optimize() still runs.
-    // Both pretty and numeric getters must fall back to rewrite so CBO's real elapsed
-    // shows up in the profile and audit / metrics stay valid.
     @Test
     public void testOptimizeTimeFallbackWhenPreMvSkipped() {
         SummaryProfile profile = new SummaryProfile();
@@ -147,7 +142,6 @@ public class SummaryProfileTest {
         profile.setNereidsLockTableFinishTime(10);
         profile.setNereidsAnalysisTime(15);
         profile.setNereidsRewriteTime(21);
-        // no InitMaterializationContextHook, no preMaterializedViewRewrite entry
         profile.setNereidsOptimizeTime(36);
         profile.setNereidsTranslateTime(45);
         profile.setNereidsDistributeTime(55);
@@ -161,10 +155,6 @@ public class SummaryProfileTest {
         Assertions.assertEquals(15, profile.getNereidsOptimizeTimeMs());
     }
 
-    // Simulates a query where preMaterializedViewRewrite was actually entered but no MV
-    // was chosen (rewrite returned null / caught exception / empty result). The phase
-    // must record its own finish so that its elapsed shows up under Pre Rewrite By Mv Time
-    // instead of silently leaking into Optimize Time.
     @Test
     public void testPreMvAttemptedButEmpty() {
         SummaryProfile profile = new SummaryProfile();
@@ -176,7 +166,6 @@ public class SummaryProfileTest {
         profile.setNereidsAnalysisTime(15);
         profile.setNereidsRewriteTime(21);
         profile.setNereidsCollectTablePartitionFinishTime(28);
-        // preMaterializedViewRewrite entered, took 30ms, produced nothing
         profile.setNereidsPreRewriteByMvFinishTime(58);
         profile.setNereidsOptimizeTime(60);
         profile.setNereidsTranslateTime(65);


### PR DESCRIPTION
`getPrettyNereidsOptimizeTime` computes the elapsed time as `optimizeFinish - preRewriteByMvFinish`,

But `preRewriteByMvFinish` is only set at the tail of `preMaterializedViewRewrite`, which early-exits whenever pre-rewrite is not needed. 

The start marker stays at -1, `getPrettyTime` sees -1 and returns "N/A" — even though CBO did run and `optimizeFinish` is set.

This misleads users on any query that skips MV pre-rewrite: 
1.MV refresh,
2.INSERT, large joins using DpHyper,
3.Sessions with `enable_materialized_view_rewrite=false`, 
4.Queries that don't touch any MV at all

Example:
an MV refresh with
`Rewrite Time: 4ms`,
`Translate Time:239ms`
 still prints `Optimize Time: N/A`, misleading anyone reading the profile into thinking CBO was skipped.

Fall back the start marker through earlier phase finish times (`preRewriteByMv -> collectTablePartition -> rewrite`) so the elapsed time is shown whenever the upstream phase actually finished.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

