### PR TITLE
[fix](be) fix disk metrics staying empty on LVM/device-mapper mounts

### DIFF
--- a/be/src/util/disk_info.cpp
+++ b/be/src/util/disk_info.cpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/detail/classification.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <fstream>
 #include <iterator>
@@ -75,7 +76,7 @@ void DiskInfo::get_device_names() {
         }
 
         // Remove the partition# from the name.  e.g. sda2 --> sda
-        boost::trim_right_if(name, boost::is_any_of("0123456789"));
+        name = strip_partition_suffix(name);
 
         // Create a mapping of all device ids (one per partition) to the disk id.
         int major_dev_id = atoi(fields[0].c_str());
@@ -127,6 +128,13 @@ void DiskInfo::get_device_names() {
             rotational.close();
         }
     }
+}
+
+std::string DiskInfo::strip_partition_suffix(std::string name) {
+    if (!boost::starts_with(name, "dm-")) {
+        boost::trim_right_if(name, boost::is_any_of("0123456789"));
+    }
+    return name;
 }
 
 void DiskInfo::init() {
@@ -206,11 +214,19 @@ Status DiskInfo::get_disk_devices(const std::vector<std::string>& paths,
                 strncmp(path.c_str(), mount_path, mount_size) != 0) {
                 continue;
             }
-            std::string dev(basename(dev_path));
-            boost::trim_right_if(dev, boost::is_any_of("0123456789"));
-            if (_s_disk_name_to_disk_id.find(dev) != std::end(_s_disk_name_to_disk_id)) {
+            // Match by the device's actual major:minor (as /proc/partitions saw it),
+            // not by name. LVM/device-mapper mounts show up in /proc/mounts as
+            // /dev/mapper/<vg-lv>, a different name than the dm-N entry
+            // get_device_names() indexed, so a basename comparison never matches
+            // and the disk metrics for that mount stay empty.
+            struct stat dev_stat;
+            if (stat(dev_path, &dev_stat) != 0) {
+                continue;
+            }
+            auto dev_it = _s_device_id_to_disk_id.find(dev_stat.st_rdev);
+            if (dev_it != std::end(_s_device_id_to_disk_id)) {
                 max_mount_size = mount_size;
-                match_dev = dev;
+                match_dev = _s_disks[dev_it->second].name;
             }
         }
         if (ferror(fp) != 0) {

--- a/be/src/util/disk_info.h
+++ b/be/src/util/disk_info.h
@@ -69,6 +69,13 @@ public:
     static Status get_disk_devices(const std::vector<std::string>& paths,
                                    std::set<std::string>* devices);
 
+    // Strips the trailing partition number from a /proc/partitions device name,
+    // e.g. sda2 -> sda. dm-N (device-mapper / LVM logical volumes) is left as-is:
+    // the trailing number there names a distinct device, not a partition, so
+    // trimming it would collapse dm-0 and dm-1 into the same disk.
+    // Exposed for testing.
+    static std::string strip_partition_suffix(std::string name);
+
 private:
     static bool _s_initialized;
 

--- a/be/test/util/disk_info_test.cpp
+++ b/be/test/util/disk_info_test.cpp
@@ -1,0 +1,41 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "util/disk_info.h"
+
+#include <gtest/gtest-message.h>
+#include <gtest/gtest-test-part.h>
+
+#include "gtest/gtest_pred_impl.h"
+
+namespace doris {
+
+TEST(DiskInfoTest, StripPartitionSuffix) {
+    // Regular disks: the trailing digits are a partition number, strip them.
+    EXPECT_EQ(DiskInfo::strip_partition_suffix("sda"), "sda");
+    EXPECT_EQ(DiskInfo::strip_partition_suffix("sda1"), "sda");
+    EXPECT_EQ(DiskInfo::strip_partition_suffix("sda15"), "sda");
+    EXPECT_EQ(DiskInfo::strip_partition_suffix("nvme0n1p1"), "nvme0n1p");
+
+    // Device-mapper (LVM) devices: dm-N is the whole device, not a partition
+    // of some "dm" disk, so distinct dm-N devices must stay distinct.
+    EXPECT_EQ(DiskInfo::strip_partition_suffix("dm-0"), "dm-0");
+    EXPECT_EQ(DiskInfo::strip_partition_suffix("dm-1"), "dm-1");
+    EXPECT_NE(DiskInfo::strip_partition_suffix("dm-0"), DiskInfo::strip_partition_suffix("dm-1"));
+}
+
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #62365

Problem Summary:

BE disk metrics come back empty when a data dir sits on an LVM (device-mapper) volume.

`DiskInfo::get_disk_devices()` in `be/src/util/disk_info.cpp` looks up a mount's device by comparing basenames: it takes the device column from `/proc/mounts`, strips trailing digits (`sda2` -> `sda`), and checks that name against the table `get_device_names()` built from `/proc/partitions`. For an LVM mount, `/proc/mounts` shows `/dev/mapper/<vg-lv>`, which never matches the `dm-N` name `/proc/partitions` uses, so the lookup always fails and no per-disk metrics get installed for that mount.

`get_device_names()` already builds `_s_device_id_to_disk_id`, a table keyed by the device's real `dev_t` (major:minor), for exactly this kind of lookup. `get_disk_devices()` just wasn't using it. This PR resolves the mount's device with `stat()` and matches on `st_rdev` against that table instead of comparing names.

Also stopped trimming trailing digits off `dm-N` names in `get_device_names()`. For a regular disk the digits mark a partition (`sda1`, `sda2` are both `sda`), but for device-mapper the number identifies a distinct logical volume, not a partition, so `dm-0` and `dm-1` were being collapsed into one bogus `dm-` entry.

Added `be/test/util/disk_info_test.cpp` covering the extracted `DiskInfo::strip_partition_suffix` helper.

### Release note

None

### Check List (For Author)

- Test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)

Manual test: hand-traced the `/proc/mounts` / `/proc/partitions` parsing against a real LVM layout (`/dev/mapper/vg-lv0` mounted, backed by `dm-0`) to confirm the new `stat()`-based match resolves correctly, plus the new unit test for `strip_partition_suffix`. Also running the BE unit test build on a separate box to confirm `DiskInfoTest.*` passes; will update this PR when that finishes.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Disk metrics now populate for data dirs on LVM/device-mapper mounts, which previously stayed empty.

- Does this need documentation?
    - [x] No.
