### PR TITLE
[fix](test) move StreamingInsertJobStatusTransitionTest to JUnit 5

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJobStatusTransitionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/job/extensions/insert/streaming/StreamingInsertJobStatusTransitionTest.java
@@ -20,8 +20,8 @@ package org.apache.doris.job.extensions.insert.streaming;
 import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.job.common.JobStatus;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -40,8 +40,8 @@ public class StreamingInsertJobStatusTransitionTest {
     public void testPendingIsPromotedToRunning() throws Exception {
         StreamingInsertJob job = newJob(JobStatus.PENDING);
 
-        Assert.assertTrue(job.updateJobStatusIfCurrent(JobStatus.PENDING, JobStatus.RUNNING));
-        Assert.assertEquals(JobStatus.RUNNING, job.getJobStatus());
+        Assertions.assertTrue(job.updateJobStatusIfCurrent(JobStatus.PENDING, JobStatus.RUNNING));
+        Assertions.assertEquals(JobStatus.RUNNING, job.getJobStatus());
     }
 
     @Test
@@ -51,8 +51,8 @@ public class StreamingInsertJobStatusTransitionTest {
         // job: it holds a canceled task, and only the PAUSED branch can auto resume it.
         StreamingInsertJob job = newJob(JobStatus.PAUSED);
 
-        Assert.assertFalse(job.updateJobStatusIfCurrent(JobStatus.PENDING, JobStatus.RUNNING));
-        Assert.assertEquals(JobStatus.PAUSED, job.getJobStatus());
+        Assertions.assertFalse(job.updateJobStatusIfCurrent(JobStatus.PENDING, JobStatus.RUNNING));
+        Assertions.assertEquals(JobStatus.PAUSED, job.getJobStatus());
     }
 
     @Test
@@ -60,7 +60,7 @@ public class StreamingInsertJobStatusTransitionTest {
         // A concurrent DROP/STOP JOB leaves a terminal status that must not be revived either.
         StreamingInsertJob job = newJob(JobStatus.STOPPED);
 
-        Assert.assertFalse(job.updateJobStatusIfCurrent(JobStatus.PENDING, JobStatus.RUNNING));
-        Assert.assertEquals(JobStatus.STOPPED, job.getJobStatus());
+        Assertions.assertFalse(job.updateJobStatusIfCurrent(JobStatus.PENDING, JobStatus.RUNNING));
+        Assertions.assertEquals(JobStatus.STOPPED, job.getJobStatus());
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #67396, #67529, #66729

Problem Summary:

**master is red on `fe-core` checkstyle.** #67396 removed JUnit 4 from the fe
reactor and added a `banJUnit4` checkstyle rule so it could not come back.
#67529 added `StreamingInsertJobStatusTransitionTest`, written with JUnit 4.
The two crossed in flight: the migration could not cover a file that did not
exist when it was written, and the new test was branched before the rule
existed.

`mvn checkstyle:check -pl fe-core` on master reports exactly two errors, both
in this file, on its two JUnit 4 imports:

```
src/test/java/org/apache/doris/job/extensions/insert/streaming/
    StreamingInsertJobStatusTransitionTest.java:23  error
    StreamingInsertJobStatusTransitionTest.java:24  error
```

The fix is mechanical: two imports and six `Assert.` call sites. All six are
one- or two-argument forms carrying no assertion message, so none is affected
by the JUnit 4 -> 5 message reordering (JUnit 4 puts an assertion message
**first**, JUnit 5 puts it **last**). Every argument stays exactly where it is.

**Why this is worth its own PR rather than waiting.** `junit-vintage-engine` is
what runs a JUnit 4 test in this reactor, and it is on its way out - #66729
removes it once the `be-java-extensions` modules are migrated, which is the last
thing keeping it alive. Without that engine, the jupiter engine does not fail on
a JUnit 4 test, it **ignores** it: these three cases would stop running and
nothing would say so. That silent-skip is exactly the failure #67396 made the
gate a checkstyle rule for, and exactly why it held the engine back until the
tree was clean. Landing this first keeps that ordering safe.

### Release note

None

### Check List (For Author)

- Test
    - [x] Unit Test
    - [ ] Regression test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:

`mvn checkstyle:check -pl fe-core` goes from 2 violations to 0.

`mvn test -pl fe-core -am -Dtest=StreamingInsertJobStatusTransitionTest`:
BUILD SUCCESS, `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0` - matching the
three `@Test` methods in the class, so the class is really running and not being
skipped.

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A58s52vfYcoTyJiMVv3cdA
