### PR TITLE
[fix](iceberg) commit the catalog URI for position-delete and DV files, not the normalized path

### DIFF
--- a/be/src/exec/sink/viceberg_delete_sink.cpp
+++ b/be/src/exec/sink/viceberg_delete_sink.cpp
@@ -107,6 +107,13 @@ Status load_rewritable_delete_rows(RuntimeState* state, RuntimeProfile* profile,
     return Status::OK();
 }
 
+std::string join_delete_file_path(std::string base_path, const std::string& file_name) {
+    if (!base_path.empty() && base_path.back() != '/') {
+        base_path += '/';
+    }
+    return base_path + file_name;
+}
+
 } // namespace
 
 Status calculate_iceberg_deletion_vector_content_size(size_t bitmap_size, int64_t* content_size) {
@@ -487,12 +494,13 @@ Status VIcebergDeleteSink::_write_position_delete_files(
             continue;
         }
         // Generate unique delete file path
-        std::string delete_file_path = _generate_delete_file_path(data_file_path);
+        DeleteFileLocation delete_file = _generate_delete_file_path(data_file_path);
 
-        // Create delete file writer
+        // Create delete file writer. It writes through the normalized path and reports the
+        // original one, so the manifest never records a backend-internal URI.
         auto writer = VIcebergDeleteFileWriterFactory::create_writer(
-                TFileContent::POSITION_DELETES, delete_file_path, _file_format_type,
-                _compress_type);
+                TFileContent::POSITION_DELETES, delete_file.write_path, delete_file.original_path,
+                _file_format_type, _compress_type);
 
         // Build column names for position delete
         std::vector<std::string> column_names = {"file_path", "pos"};
@@ -506,7 +514,7 @@ Status VIcebergDeleteSink::_write_position_delete_files(
                 writer->open(_state, _state->runtime_profile(), _position_delete_output_expr_ctxs,
                              column_names, _hadoop_conf, _file_type, _broker_addresses);
         if (writer->file_system() != nullptr) {
-            _created_files.emplace_back(writer->file_system(), delete_file_path);
+            _created_files.emplace_back(writer->file_system(), delete_file.write_path);
         }
         RETURN_IF_ERROR(open_status);
 
@@ -542,8 +550,11 @@ Status VIcebergDeleteSink::_write_position_delete_files(
         _commit_data_list.push_back(commit_data);
         _delete_file_count++;
 
-        VLOG(1) << fmt::format("Written position delete file: path={}, rows={}, referenced_file={}",
-                               delete_file_path, commit_data.row_count, data_file_path);
+        VLOG(1) << fmt::format(
+                "Written position delete file: path={}, manifest_path={}, rows={}, "
+                "referenced_file={}",
+                delete_file.write_path, delete_file.original_path, commit_data.row_count,
+                data_file_path);
     }
 
     return Status::OK();
@@ -687,13 +698,13 @@ Status VIcebergDeleteSink::_write_deletion_vector_files(
         return Status::OK();
     }
 
-    std::string puffin_path = _generate_puffin_file_path();
+    DeleteFileLocation puffin_file = _generate_puffin_file_path();
     int64_t puffin_file_size = 0;
-    RETURN_IF_ERROR(_write_puffin_file(puffin_path, &blobs, &puffin_file_size));
+    RETURN_IF_ERROR(_write_puffin_file(puffin_file.write_path, &blobs, &puffin_file_size));
 
     for (const auto& blob : blobs) {
         TIcebergCommitData commit_data;
-        commit_data.__set_file_path(puffin_path);
+        commit_data.__set_file_path(puffin_file.original_path);
         commit_data.__set_row_count(blob.merged_count);
         commit_data.__set_affected_rows(blob.delete_count);
         commit_data.__set_file_size(puffin_file_size);
@@ -803,37 +814,35 @@ std::string VIcebergDeleteSink::_build_puffin_footer_json(
     return {buffer.GetString(), buffer.GetSize()};
 }
 
-std::string VIcebergDeleteSink::_generate_delete_file_path(
+VIcebergDeleteSink::DeleteFileLocation VIcebergDeleteSink::_resolve_delete_file_location(
+        const std::string& file_name) const {
+    // `_output_path` and `_table_location` denote the same directory in two URI forms. Writing must
+    // use the normalized form, committing must use the original one; when either is absent, the
+    // other stands in for both (a location that was never rewritten is identical in both forms).
+    const std::string& write_base = _output_path.empty() ? _table_location : _output_path;
+    const std::string& original_base = _table_location.empty() ? write_base : _table_location;
+
+    // Delete files are data files in Iceberg, write under data location
+    return {join_delete_file_path(write_base, file_name),
+            join_delete_file_path(original_base, file_name)};
+}
+
+VIcebergDeleteSink::DeleteFileLocation VIcebergDeleteSink::_generate_delete_file_path(
         const std::string& referenced_data_file) {
     // Generate unique delete file name using UUID
     std::string uuid = generate_uuid_string();
-    std::string file_name;
 
     std::string file_extension = _get_file_extension();
-    file_name =
+    std::string file_name =
             fmt::format("delete_pos_{}_{}{}", uuid,
                         std::hash<std::string> {}(referenced_data_file) % 10000000, file_extension);
 
-    // Combine with output path or table location
-    std::string base_path = _output_path.empty() ? _table_location : _output_path;
-
-    // Ensure base path ends with /
-    if (!base_path.empty() && base_path.back() != '/') {
-        base_path += '/';
-    }
-
-    // Delete files are data files in Iceberg, write under data location
-    return fmt::format("{}{}", base_path, file_name);
+    return _resolve_delete_file_location(file_name);
 }
 
-std::string VIcebergDeleteSink::_generate_puffin_file_path() {
+VIcebergDeleteSink::DeleteFileLocation VIcebergDeleteSink::_generate_puffin_file_path() {
     std::string uuid = generate_uuid_string();
-    std::string file_name = fmt::format("delete_dv_{}.puffin", uuid);
-    std::string base_path = _output_path.empty() ? _table_location : _output_path;
-    if (!base_path.empty() && base_path.back() != '/') {
-        base_path += '/';
-    }
-    return fmt::format("{}{}", base_path, file_name);
+    return _resolve_delete_file_location(fmt::format("delete_dv_{}.puffin", uuid));
 }
 
 } // namespace doris

--- a/be/src/exec/sink/viceberg_delete_sink.h
+++ b/be/src/exec/sink/viceberg_delete_sink.h
@@ -114,12 +114,33 @@ private:
 
     std::string _build_puffin_footer_json(const std::vector<DeletionVectorBlob>& blobs);
 
-    std::string _generate_puffin_file_path();
+    /**
+     * The two full paths every delete artifact needs. `write_path` is the backend-normalized URI
+     * used for filesystem I/O; `original_path` is the same file expressed with the URI the catalog
+     * itself uses, and is the one committed to the iceberg manifest.
+     *
+     * The two differ whenever the FE rewrites the location on the way to the backend: an ADLS
+     * `abfss://` location is normalized to an internal `s3://` form that names no real bucket.
+     * Committing that form leaves the table unreadable, so it must stay on the I/O side only.
+     * This mirrors the data lane's write_path / original_write_path pair in
+     * VIcebergPartitionWriter.
+     */
+    struct DeleteFileLocation {
+        std::string write_path;
+        std::string original_path;
+    };
+
+    /**
+     * Place `file_name` in the delete-file directory, resolving both the I/O and the manifest form.
+     */
+    DeleteFileLocation _resolve_delete_file_location(const std::string& file_name) const;
+
+    DeleteFileLocation _generate_puffin_file_path();
 
     /**
      * Generate unique delete file path
      */
-    std::string _generate_delete_file_path(const std::string& referenced_data_file = "");
+    DeleteFileLocation _generate_delete_file_path(const std::string& referenced_data_file = "");
 
     /**
      * Get $row_id column index from block
@@ -163,7 +184,9 @@ private:
     TFileFormatType::type _file_format_type = TFileFormatType::FORMAT_PARQUET;
     TFileCompressType::type _compress_type = TFileCompressType::SNAPPYBLOCK;
 
-    // Output directory for delete files
+    // Output directory for delete files. Both name the same directory: `_output_path` in the
+    // backend-normalized form used for I/O, `_table_location` in the catalog's original form used
+    // for the manifest (IcebergWritePlanProvider#buildDeleteSink sends both).
     std::string _output_path;
     std::string _table_location;
 

--- a/be/src/exec/sink/writer/iceberg/viceberg_delete_file_writer.cpp
+++ b/be/src/exec/sink/writer/iceberg/viceberg_delete_file_writer.cpp
@@ -44,10 +44,12 @@ std::unique_ptr<iceberg::Schema> build_position_delete_schema() {
 
 VIcebergDeleteFileWriter::VIcebergDeleteFileWriter(TFileContent::type delete_type,
                                                    const std::string& output_path,
+                                                   const std::string& original_output_path,
                                                    TFileFormatType::type file_format,
                                                    TFileCompressType::type compress_type)
         : _delete_type(delete_type),
           _output_path(output_path),
+          _original_output_path(original_output_path),
           _file_format(file_format),
           _compress_type(compress_type) {}
 
@@ -146,8 +148,9 @@ Status VIcebergDeleteFileWriter::close(TIcebergCommitData& commit_data) {
         _file_size = _file_format_transformer->written_len();
     }
 
-    // Fill commit data (use __set_ to mark optional fields as present)
-    commit_data.__set_file_path(_output_path);
+    // Fill commit data (use __set_ to mark optional fields as present).
+    // The manifest gets the original path, never the normalized one the file was written through.
+    commit_data.__set_file_path(_original_output_path);
     commit_data.__set_row_count(_written_rows);
     commit_data.__set_affected_rows(_written_rows);
     commit_data.__set_file_size(_file_size);
@@ -169,9 +172,10 @@ Status VIcebergDeleteFileWriter::close(TIcebergCommitData& commit_data) {
 // Factory method
 std::unique_ptr<VIcebergDeleteFileWriter> VIcebergDeleteFileWriterFactory::create_writer(
         TFileContent::type delete_type, const std::string& output_path,
-        TFileFormatType::type file_format, TFileCompressType::type compress_type) {
-    return std::make_unique<VIcebergDeleteFileWriter>(delete_type, output_path, file_format,
-                                                      compress_type);
+        const std::string& original_output_path, TFileFormatType::type file_format,
+        TFileCompressType::type compress_type) {
+    return std::make_unique<VIcebergDeleteFileWriter>(
+            delete_type, output_path, original_output_path, file_format, compress_type);
 }
 
 } // namespace doris

--- a/be/src/exec/sink/writer/iceberg/viceberg_delete_file_writer.h
+++ b/be/src/exec/sink/writer/iceberg/viceberg_delete_file_writer.h
@@ -50,7 +50,14 @@ class VFileFormatTransformer;
  */
 class VIcebergDeleteFileWriter {
 public:
+    /**
+     * @param output_path          full path the file is physically written to (backend-normalized)
+     * @param original_output_path the same file under the catalog's own URI; this is what is
+     *                             reported back for the iceberg manifest. Pass the same value as
+     *                             `output_path` when the location was never rewritten.
+     */
     VIcebergDeleteFileWriter(TFileContent::type delete_type, const std::string& output_path,
+                             const std::string& original_output_path,
                              TFileFormatType::type file_format,
                              TFileCompressType::type compress_type);
 
@@ -98,7 +105,11 @@ public:
 
 private:
     TFileContent::type _delete_type;
+    // Path used for filesystem I/O; may be a backend-internal URI (e.g. ADLS is normalized to an
+    // `s3://` form) and must therefore never be committed to iceberg metadata.
     std::string _output_path;
+    // Path reported in TIcebergCommitData.file_path, i.e. what the manifest will record.
+    std::string _original_output_path;
     TFileFormatType::type _file_format;
     TFileCompressType::type _compress_type = TFileCompressType::SNAPPYBLOCK;
 
@@ -123,7 +134,8 @@ class VIcebergDeleteFileWriterFactory {
 public:
     static std::unique_ptr<VIcebergDeleteFileWriter> create_writer(
             TFileContent::type delete_type, const std::string& output_path,
-            TFileFormatType::type file_format, TFileCompressType::type compress_type);
+            const std::string& original_output_path, TFileFormatType::type file_format,
+            TFileCompressType::type compress_type);
 };
 
 } // namespace doris

--- a/be/test/exec/sink/viceberg_delete_sink_test.cpp
+++ b/be/test/exec/sink/viceberg_delete_sink_test.cpp
@@ -53,8 +53,10 @@ protected:
         delete_sink.__set_delete_type(TFileContent::POSITION_DELETES);
         delete_sink.__set_file_format(TFileFormatType::FORMAT_PARQUET);
         delete_sink.__set_compress_type(TFileCompressType::SNAPPYBLOCK);
-        delete_sink.__set_output_path("/tmp/iceberg/test");
-        delete_sink.__set_table_location("/tmp/iceberg/test_table");
+        // The same directory in two URI forms, as the FE sends it: output_path normalized for
+        // backend I/O, table_location as the catalog reports it. They are never two directories.
+        delete_sink.__set_output_path("s3://container/tbl/data");
+        delete_sink.__set_table_location("abfss://container@account.dfs.core.windows.net/tbl/data");
 
         std::map<std::string, std::string> hadoop_conf;
         hadoop_conf["fs.defaultFS"] = "hdfs://localhost:9000";
@@ -64,6 +66,13 @@ protected:
     }
 
     TDataSink build_local_delete_sink(const std::string& output_path, int32_t format_version) {
+        return build_local_delete_sink(output_path, output_path, format_version);
+    }
+
+    // `table_location` is the location as the catalog reports it, `output_path` the form the
+    // backend actually writes through. They differ whenever the FE rewrites the URI (ADLS).
+    TDataSink build_local_delete_sink(const std::string& output_path,
+                                      const std::string& table_location, int32_t format_version) {
         TDataSink t_data_sink;
         t_data_sink.__set_type(TDataSinkType::ICEBERG_DELETE_SINK);
 
@@ -74,7 +83,7 @@ protected:
         delete_sink.__set_file_format(TFileFormatType::FORMAT_PARQUET);
         delete_sink.__set_compress_type(TFileCompressType::SNAPPYBLOCK);
         delete_sink.__set_output_path(output_path);
-        delete_sink.__set_table_location(output_path);
+        delete_sink.__set_table_location(table_location);
         delete_sink.__set_file_type(TFileType::FILE_LOCAL);
         delete_sink.__set_format_version(format_version);
 
@@ -479,18 +488,90 @@ TEST_F(VIcebergDeleteSinkTest, TestGenerateDeleteFilePath) {
     ASSERT_TRUE(status.ok());
 
     std::string data_file_path = "data/file1.parquet";
-    std::string delete_file_path = sink->_generate_delete_file_path(data_file_path);
+    auto delete_file = sink->_generate_delete_file_path(data_file_path);
 
     // Verify the path format
-    ASSERT_FALSE(delete_file_path.empty());
+    ASSERT_FALSE(delete_file.write_path.empty());
     const auto& delete_sink = _t_data_sink.iceberg_delete_sink;
-    std::string expected_base =
-            delete_sink.__isset.output_path ? delete_sink.output_path : delete_sink.table_location;
-    if (!expected_base.empty() && expected_base.back() != '/') {
-        expected_base += '/';
+    std::string expected_base = delete_sink.output_path + "/";
+    ASSERT_TRUE(delete_file.write_path.rfind(expected_base, 0) == 0);
+    ASSERT_NE(std::string::npos, delete_file.write_path.find("delete_pos_"));
+
+    std::string expected_original_base = delete_sink.table_location + "/";
+    ASSERT_TRUE(delete_file.original_path.rfind(expected_original_base, 0) == 0);
+
+    // One file, two URIs: the name must not differ between what is written and what is committed.
+    ASSERT_EQ(delete_file.write_path.substr(expected_base.size()),
+              delete_file.original_path.substr(expected_original_base.size()));
+}
+
+// Regression for apache/doris#67544: an ADLS location reaches the backend normalized to an
+// internal `s3://` form. That form is fine for I/O but unresolvable on a read, so committing it to
+// the manifest leaves the table permanently unreadable. Both delete lanes must place the same file
+// name under the catalog's own URI for the manifest.
+TEST_F(VIcebergDeleteSinkTest, TestDeleteFilePathsKeepCatalogUriForManifest) {
+    const std::string normalized_location = "s3://container/tbl/data";
+    const std::string original_location = "abfss://container@account.dfs.core.windows.net/tbl/data";
+    TDataSink t_data_sink = build_local_delete_sink(normalized_location, original_location, 2);
+
+    VExprContextSPtrs output_exprs;
+    auto sink = std::make_shared<VIcebergDeleteSink>(t_data_sink, output_exprs, nullptr, nullptr);
+    ObjectPool pool;
+    ASSERT_TRUE(sink->init_properties(&pool).ok());
+
+    auto position_delete = sink->_generate_delete_file_path("data/file1.parquet");
+    ASSERT_EQ(normalized_location + "/",
+              position_delete.write_path.substr(0, normalized_location.size() + 1));
+    ASSERT_EQ(original_location + "/",
+              position_delete.original_path.substr(0, original_location.size() + 1));
+    // Same file, two URIs: only the directory prefix may differ.
+    ASSERT_EQ(position_delete.write_path.substr(normalized_location.size() + 1),
+              position_delete.original_path.substr(original_location.size() + 1));
+
+    auto puffin = sink->_generate_puffin_file_path();
+    ASSERT_EQ(normalized_location + "/",
+              puffin.write_path.substr(0, normalized_location.size() + 1));
+    ASSERT_EQ(original_location + "/",
+              puffin.original_path.substr(0, original_location.size() + 1));
+    ASSERT_EQ(puffin.write_path.substr(normalized_location.size() + 1),
+              puffin.original_path.substr(original_location.size() + 1));
+}
+
+// When only one form is present it has to stand in for both: a location that was never rewritten
+// is identical either way, and an older FE may send only one of the two fields.
+TEST_F(VIcebergDeleteSinkTest, TestDeleteFilePathsFallBackWhenOneFormIsMissing) {
+    VExprContextSPtrs output_exprs;
+    ObjectPool pool;
+
+    {
+        TDataSink t_data_sink = build_local_delete_sink("s3://bucket/tbl/data", "", 2);
+        auto sink =
+                std::make_shared<VIcebergDeleteSink>(t_data_sink, output_exprs, nullptr, nullptr);
+        ASSERT_TRUE(sink->init_properties(&pool).ok());
+        auto location = sink->_generate_delete_file_path("data/file1.parquet");
+        ASSERT_EQ(location.write_path, location.original_path);
+        ASSERT_EQ("s3://bucket/tbl/data/", location.write_path.substr(0, 21));
     }
-    ASSERT_TRUE(delete_file_path.rfind(expected_base, 0) == 0);
-    ASSERT_NE(std::string::npos, delete_file_path.find("delete_pos_"));
+    {
+        TDataSink t_data_sink = build_local_delete_sink("", "s3://bucket/tbl/data", 2);
+        auto sink =
+                std::make_shared<VIcebergDeleteSink>(t_data_sink, output_exprs, nullptr, nullptr);
+        ASSERT_TRUE(sink->init_properties(&pool).ok());
+        auto location = sink->_generate_delete_file_path("data/file1.parquet");
+        ASSERT_EQ(location.write_path, location.original_path);
+        ASSERT_EQ("s3://bucket/tbl/data/", location.write_path.substr(0, 21));
+    }
+    {
+        // The old-FE shape: table_location is not merely empty, it is never set at all.
+        TDataSink t_data_sink = build_local_delete_sink("s3://bucket/tbl/data", "", 2);
+        t_data_sink.iceberg_delete_sink.__isset.table_location = false;
+        auto sink =
+                std::make_shared<VIcebergDeleteSink>(t_data_sink, output_exprs, nullptr, nullptr);
+        ASSERT_TRUE(sink->init_properties(&pool).ok());
+        auto location = sink->_generate_delete_file_path("data/file1.parquet");
+        ASSERT_EQ(location.write_path, location.original_path);
+        ASSERT_EQ("s3://bucket/tbl/data/", location.write_path.substr(0, 21));
+    }
 }
 
 TEST_F(VIcebergDeleteSinkTest, TestUnsupportedDeleteType) {
@@ -574,6 +655,8 @@ TEST_F(VIcebergDeleteSinkTest, TestWriteDeletionVectorsToSingleSharedPuffin) {
     }
     ASSERT_EQ(1, puffin_file_count);
 
+    // file_path is the manifest path; it doubles as the on-disk path only because this sink was
+    // built with table_location == output_path. See the divergent-URI test below.
     std::ifstream input(first_commit.file_path, std::ios::binary);
     ASSERT_TRUE(input.good());
     std::string file_bytes((std::istreambuf_iterator<char>(input)),
@@ -615,6 +698,90 @@ TEST_F(VIcebergDeleteSinkTest, TestWriteDeletionVectorsToSingleSharedPuffin) {
         ASSERT_EQ(commit_data->content_size_in_bytes, blob["length"].GetInt64());
         ASSERT_EQ(std::to_string(commit_data->row_count), properties["cardinality"].GetString());
     }
+
+    std::filesystem::remove_all(temp_dir);
+}
+
+// End-to-end counterpart of TestDeleteFilePathsKeepCatalogUriForManifest on the v3 deletion-vector
+// lane: the puffin file is created under the path the backend writes through, while the commit
+// data that becomes the manifest entry carries the catalog's own URI.
+TEST_F(VIcebergDeleteSinkTest, TestDeletionVectorCommitsCatalogUriAndWritesNormalizedPath) {
+    std::filesystem::path temp_dir = std::filesystem::temp_directory_path() /
+                                     ("iceberg_delete_sink_test_" + generate_uuid_string());
+    ASSERT_TRUE(std::filesystem::create_directories(temp_dir));
+
+    const std::string original_location = "abfss://container@account.dfs.core.windows.net/tbl/data";
+    TDataSink t_data_sink = build_local_delete_sink(temp_dir.string(), original_location, 3);
+    VExprContextSPtrs output_exprs;
+    auto sink = std::make_shared<VIcebergDeleteSink>(t_data_sink, output_exprs, nullptr, nullptr);
+    ObjectPool pool;
+    ASSERT_TRUE(sink->init_properties(&pool).ok());
+
+    std::map<std::string, IcebergFileDeletion> file_deletions;
+    auto [it, inserted] = file_deletions.emplace("file1.parquet", IcebergFileDeletion(0, ""));
+    ASSERT_TRUE(inserted);
+    it->second.rows_to_delete.add((uint32_t)10);
+
+    ASSERT_TRUE(sink->_write_deletion_vector_files(file_deletions).ok());
+    ASSERT_EQ(1, sink->_commit_data_list.size());
+
+    const auto& commit = sink->_commit_data_list[0];
+    ASSERT_EQ(original_location + "/", commit.file_path.substr(0, original_location.size() + 1));
+    ASSERT_NE(std::string::npos, commit.file_path.find("delete_dv_"));
+
+    // The bytes themselves went to the local (normalized) location, under the same file name.
+    std::filesystem::path written_puffin;
+    for (const auto& entry : std::filesystem::directory_iterator(temp_dir)) {
+        if (entry.path().extension() == ".puffin") {
+            ASSERT_TRUE(written_puffin.empty());
+            written_puffin = entry.path();
+        }
+    }
+    ASSERT_FALSE(written_puffin.empty());
+    ASSERT_EQ(written_puffin.filename().string(),
+              commit.file_path.substr(original_location.size() + 1));
+    ASSERT_EQ(static_cast<int64_t>(std::filesystem::file_size(written_puffin)), commit.file_size);
+
+    std::filesystem::remove_all(temp_dir);
+}
+
+// TestWriteDeletionVectorsToSingleSharedPuffin covers many blobs sharing one puffin, but with
+// table_location == output_path, so it cannot see a normalized path leaking into the manifest.
+// This covers the combination: several blobs, one puffin, two URI forms -- every commit entry must
+// carry the catalog URI, not just the first.
+TEST_F(VIcebergDeleteSinkTest, TestSharedPuffinCommitsCatalogUriForEveryBlob) {
+    std::filesystem::path temp_dir = std::filesystem::temp_directory_path() /
+                                     ("iceberg_delete_sink_test_" + generate_uuid_string());
+    ASSERT_TRUE(std::filesystem::create_directories(temp_dir));
+
+    const std::string original_location = "abfss://container@account.dfs.core.windows.net/tbl/data";
+    TDataSink t_data_sink = build_local_delete_sink(temp_dir.string(), original_location, 3);
+    VExprContextSPtrs output_exprs;
+    auto sink = std::make_shared<VIcebergDeleteSink>(t_data_sink, output_exprs, nullptr, nullptr);
+    ObjectPool pool;
+    ASSERT_TRUE(sink->init_properties(&pool).ok());
+
+    std::map<std::string, IcebergFileDeletion> file_deletions;
+    auto [file1_it, file1_inserted] =
+            file_deletions.emplace("file1.parquet", IcebergFileDeletion(1, "[\"p=1\"]"));
+    ASSERT_TRUE(file1_inserted);
+    file1_it->second.rows_to_delete.add(static_cast<uint32_t>(10));
+
+    auto [file2_it, file2_inserted] =
+            file_deletions.emplace("file2.parquet", IcebergFileDeletion(2, "[\"p=2\"]"));
+    ASSERT_TRUE(file2_inserted);
+    file2_it->second.rows_to_delete.add(static_cast<uint32_t>(30));
+
+    ASSERT_TRUE(sink->_write_deletion_vector_files(file_deletions).ok());
+    ASSERT_EQ(2, sink->_commit_data_list.size());
+
+    for (const auto& commit : sink->_commit_data_list) {
+        ASSERT_EQ(original_location + "/", commit.file_path.substr(0, original_location.size() + 1))
+                << "commit for " << commit.referenced_data_file_path
+                << " leaked the write path into the manifest: " << commit.file_path;
+    }
+    // Both entries still name the one physical puffin.
+    ASSERT_EQ(sink->_commit_data_list[0].file_path, sink->_commit_data_list[1].file_path);
 
     std::filesystem::remove_all(temp_dir);
 }

--- a/be/test/exec/sink/writer/iceberg/viceberg_delete_file_writer_test.cpp
+++ b/be/test/exec/sink/writer/iceberg/viceberg_delete_file_writer_test.cpp
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exec/sink/writer/iceberg/viceberg_delete_file_writer.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "gen_cpp/DataSinks_types.h"
+#include "gen_cpp/PlanNodes_types.h"
+
+namespace doris {
+
+namespace {
+
+// An ADLS location as the catalog reports it, and the internal form the FE normalizes it to before
+// handing it to the backend. Only the first one is resolvable by a reader.
+constexpr const char* kOriginalPath =
+        "abfss://container@account.dfs.core.windows.net/tbl/data/delete_pos_1.parquet";
+constexpr const char* kNormalizedPath = "s3://container/tbl/data/delete_pos_1.parquet";
+
+} // namespace
+
+// The commit data feeds the iceberg manifest, so it must carry the catalog's own URI. Reporting the
+// normalized path instead leaves the table permanently unreadable once the snapshot is committed.
+TEST(VIcebergDeleteFileWriterTest, CommitDataCarriesOriginalPathNotNormalizedPath) {
+    VIcebergDeleteFileWriter writer(TFileContent::POSITION_DELETES, kNormalizedPath, kOriginalPath,
+                                    TFileFormatType::FORMAT_PARQUET, TFileCompressType::ZSTD);
+
+    TIcebergCommitData commit_data;
+    const Status close_status = writer.close(commit_data);
+    ASSERT_TRUE(close_status.ok()) << close_status;
+
+    ASSERT_TRUE(commit_data.__isset.file_path);
+    ASSERT_EQ(kOriginalPath, commit_data.file_path);
+    ASSERT_EQ(TFileContent::POSITION_DELETES, commit_data.file_content);
+}
+
+// A location that was never rewritten passes both forms through unchanged.
+TEST(VIcebergDeleteFileWriterTest, CommitDataKeepsPathWhenLocationWasNotRewritten) {
+    const std::string path = "s3://bucket/tbl/data/delete_pos_1.parquet";
+    VIcebergDeleteFileWriter writer(TFileContent::POSITION_DELETES, path, path,
+                                    TFileFormatType::FORMAT_PARQUET, TFileCompressType::ZSTD);
+
+    TIcebergCommitData commit_data;
+    const Status close_status = writer.close(commit_data);
+    ASSERT_TRUE(close_status.ok()) << close_status;
+
+    ASSERT_EQ(path, commit_data.file_path);
+}
+
+TEST(VIcebergDeleteFileWriterTest, FactoryForwardsBothPaths) {
+    auto writer = VIcebergDeleteFileWriterFactory::create_writer(
+            TFileContent::POSITION_DELETES, kNormalizedPath, kOriginalPath,
+            TFileFormatType::FORMAT_PARQUET, TFileCompressType::ZSTD);
+    ASSERT_NE(nullptr, writer);
+
+    // The physical path stays normalized so the file is created through the backend's own
+    // filesystem handling; only the reported path changes.
+    ASSERT_EQ(kNormalizedPath, writer->_output_path);
+    ASSERT_EQ(kOriginalPath, writer->_original_output_path);
+}
+
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67544

Related PR: #xxx

Problem Summary:

On an Iceberg catalog whose storage URI the FE rewrites on the way to the BE, `UPDATE` / `DELETE`
committed the position-delete file into the manifest under Doris's **internal, normalized** path
instead of the catalog's own URI. The commit succeeds, and every subsequent read of the table then
fails permanently:

```
ERROR 1105 (HY000): errCode = 2, detailMessage =
  Failed to create LocationPath for location: s3://<container>/<uuid>/data/delete_pos_<uuid>_125613.zstd.parquet
```

The table is not recoverable through SQL — the bad path is durable Iceberg metadata and has to be
rolled back to the previous snapshot out-of-band.

This is the asymmetry between the two write lanes:

| lane | writer | reports to the manifest |
|---|---|---|
| data | `VIcebergPartitionWriter` | `original_write_path` ✅ |
| position delete | `VIcebergDeleteFileWriter` | `_output_path` (normalized) ❌ |
| deletion vector (v3) | `VIcebergDeleteSink::_write_deletion_vector_files` | the normalized puffin path ❌ |

The data writer keeps the normalized path for I/O and a second, original path for the manifest.
The delete lanes only ever had one path, and used it for both. So the *same* `UPDATE` writes a
correct `abfss://` data file and a broken `s3://` delete file.

Reproduced on ADLS Gen2 (`abfss://container@account.dfs.core.windows.net/key`, normalized to
`s3://container/key` by `AzurePropertyUtils.validateAndNormalizeUri()`), but it is not
Azure-specific: it applies to any storage whose location is rewritten for the BE. The FE's own
`IcebergWritePlanProviderTest.planWriteBuildsDeleteSinkWithTableDerivedFields` pins exactly this
pair for OSS —

```java
Assertions.assertEquals("s3://bucket/wh/db1/t1/data", sink.getOutputPath(),
        "delete output path is the normalized data location (legacy LocationPath.toStorageLocation)");
Assertions.assertEquals("oss://bucket/wh/db1/t1/data", sink.getTableLocation(),
        "table_location stays the raw data location (legacy IcebergUtils.dataLocation)");
```

### The invariant this relies on

`TIcebergDeleteSink.output_path` and `.table_location` are **the same directory in two URI forms** —
both are derived from a single `resolveLocationFields(table, schemaContext.getDataLocation())` call,
in `IcebergWritePlanProvider#buildDeleteSink` (delete) and `#buildMergeSink` (update/merge), and
`IcebergWritePlanProviderTest.planWriteBuildsDeleteSinkWithTableDerivedFields` pins both literal
values. They are never two different directories, and `table_location` is never the table root.

### The fix

BE-only, no thrift change and no new FE plumbing — as suggested during triage.

`TIcebergDeleteSink` **already** carries both forms of the same directory: `output_path`
(normalized, for I/O) and `table_location` (raw, as the catalog reports it). `VIcebergDeleteSink`
now generates one file *name* and joins it to both bases:

- `DeleteFileLocation::write_path` → filesystem I/O and the abort-time cleanup list,
- `DeleteFileLocation::original_path` → `TIcebergCommitData.file_path`, i.e. the manifest.

`VIcebergDeleteFileWriter` gained an `original_output_path` alongside `_output_path` and reports
*that* in `commit_data`. The v3 deletion-vector / Puffin lane gets the same treatment — it was
code-identical and would have failed the same way once a v3 table saw a DML on rewritten storage.

Both `DELETE` and the delete half of `UPDATE` / `MERGE` go through `VIcebergDeleteSink`
(`VIcebergMergeSink::_build_inner_sinks` synthesizes the inner delete sink and propagates both
`output_path` and `table_location`), so one change covers all three statements.

When only one of the two fields is present, it stands in for both. That keeps the previous behaviour
for any location that was never rewritten, and makes the change safe against an FE that does not
send both. Note the fallback cannot do better than "unchanged from today" in the rewritten case:
`abfss://<container>@<account>.dfs.core.windows.net/<key>` is not recoverable from
`s3://<container>/<key>`, because normalization drops the account. (The data lane does not fall back
at all — `viceberg_table_writer.cpp` concatenates an unset `original_output_path` as an empty
string. The delete lane is deliberately more defensive here; happy to match the data lane instead if
you prefer the consistency.)

#### Why not a new `original_output_path` field on `TIcebergDeleteSink`?

For symmetry with the data lane that would be the tidier shape, and I will add it if you prefer. I
chose not to because a thrift field makes the fix new-FE-only and reopens an old-FE/new-BE window,
whereas this BE-only change corrects the manifest against **every** already-deployed FE, needs no
wire-format change, and backports to `branch-4.1` unchanged (its legacy
`planner/IcebergDeleteSink.java:135-138` sets the same raw-data-location/normalized pair).

### Release note

Fix `UPDATE` / `DELETE` on an Iceberg table whose storage location is rewritten for the backend
(e.g. ADLS `abfss://`, OSS `oss://`) committing position-delete and deletion-vector files under
Doris's internal normalized path, which left the table permanently unreadable.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason

New / updated BE unit tests:

- `be/test/exec/sink/writer/iceberg/viceberg_delete_file_writer_test.cpp` (new) — the commit data
  carries the original path, not the normalized one; the two coincide when the location was never
  rewritten; the factory forwards both.
- `be/test/exec/sink/viceberg_delete_sink_test.cpp`
  - `TestDeleteFilePathsKeepCatalogUriForManifest` — position-delete and Puffin paths both keep the
    `abfss://` prefix for the manifest and the `s3://` prefix for I/O, with an identical file name.
  - `TestDeletionVectorCommitsCatalogUriAndWritesNormalizedPath` — end-to-end on the v3 lane: the
    puffin bytes land under the write path while the commit data names the catalog URI.
  - `TestSharedPuffinCommitsCatalogUriForEveryBlob` — several blobs sharing one puffin: *every*
    commit entry carries the catalog URI, not just the first.
  - `TestDeleteFilePathsFallBackWhenOneFormIsMissing` — one form absent (empty, and genuinely
    unset) means both paths agree. A rolling-upgrade guard; it passes pre-fix too.
  - The fixture at the top of the file previously used two *different* directories for
    `output_path` / `table_location`, which does not model anything the FE can send. It now uses a
    normalized/raw pair of one directory.

Not covered, stated plainly: there is no end-to-end test of the **v2 position-delete** lane
(`_write_position_delete_files`) equivalent to the v3 one — it needs a `RuntimeState` and expression
harness, and I could not build the BE locally to validate such a test (no thirdparty toolchain), so
I did not want to push an unverified test into your CI. A transposition of the two arguments at the
`VIcebergDeleteFileWriterFactory::create_writer` call site would therefore not be caught by a test
today, only by review. Happy to add it if you would like it in this PR.

No regression test: reproducing this needs a catalog on storage whose URI the FE rewrites (ADLS or
OSS), which the local/S3 regression environments do not exercise — an `s3://` location is
normalized to itself. I have a live ADLS Gen2 + Iceberg REST (Lakekeeper) cluster and am happy to
run a patched build against the reproduction in #67544 and report back.

- Behavior changed:
    - [x] Yes. Position-delete and deletion-vector files are now recorded in the Iceberg manifest
      with the catalog's own URI instead of Doris's internal normalized path. On storage that is
      not rewritten (HDFS, S3, local) the recorded path is unchanged.

- Does this need documentation?
    - [x] No.
