### PR TITLE
branch-4.1: [chore](thirdparty) Upgrade aws-sdk-cpp from 1.11.219 to 1.11.221 #66851

### DIFF
--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -353,10 +353,10 @@ BOOTSTRAP_TABLE_CSS_FILE="bootstrap-table.min.css"
 BOOTSTRAP_TABLE_CSS_MD5SUM="23389d4456da412e36bae30c469a766a"
 
 # aws sdk
-AWS_SDK_DOWNLOAD="https://github.com/aws/aws-sdk-cpp/archive/refs/tags/1.11.219.tar.gz"
-AWS_SDK_NAME="aws-sdk-cpp-1.11.219.tar.gz"
-AWS_SDK_SOURCE="aws-sdk-cpp-1.11.219"
-AWS_SDK_MD5SUM="80aa616efe1a3e7a9bf0dfbc44a97864"
+AWS_SDK_DOWNLOAD="https://github.com/aws/aws-sdk-cpp/archive/refs/tags/1.11.221.tar.gz"
+AWS_SDK_NAME="aws-sdk-cpp-1.11.221.tar.gz"
+AWS_SDK_SOURCE="aws-sdk-cpp-1.11.221"
+AWS_SDK_MD5SUM="95ea128da58829117a544b092bc39033"
 
 # tsan_header
 TSAN_HEADER_DOWNLOAD="https://gcc.gnu.org/git/?p=gcc.git;a=blob_plain;f=libsanitizer/include/sanitizer/tsan_interface_atomic.h;hb=refs/heads/releases/gcc-7"


### PR DESCRIPTION
Cherry-picked from #66851

Applied cleanly, no changes.

### Merge order

This is the producer half of a two-PR pair: it only moves the pin so the pre-built thirdparty
artifacts and the docker image are re-published against 1.11.221. The consumer, #67555 (the branch-4.1 backport of #67076), needs `GeneralHTTPCredentialsProvider.h`, which does not exist before
1.11.221, so **this PR has to land (and the artifacts be re-published) first**.

### CI note

`Build Third Party Libraries (macOS-arm64)` fails on this PR for a reason unrelated to it. This is
the only change here that touches `thirdparty/`, which is what makes that workflow run at all
instead of skipping; the job then dies in `download-thirdparty.sh` on a corrupt
`thirdparty/patches/libunwind-1.6.2-doris-phdr-cache.patch` that has been broken on branch-4.1 since
`4439e6f6b46`. Every branch-4.1 thirdparty PR since (#67378, #67356, #67523) fails there identically.
#67564 fixes it; once that merges and this run is retried, this job should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzUYFcGHQH3bnLGCjpncVj
