### PR TITLE
[improvement](streaming-job) Adjust CDC request timeout and split batch defaults

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -714,7 +714,7 @@ DEFINE_mBool(enable_stream_load_commit_txn_on_be, "false");
 DEFINE_Int64(stream_tvf_buffer_size, "1048576"); // 1MB
 
 // request cdc client timeout
-DEFINE_mInt32(request_cdc_client_timeout_ms, "60000");
+DEFINE_mInt32(request_cdc_client_timeout_ms, "600000");
 
 // OlapTableSink sender's send interval, should be less than the real response time of a tablet writer rpc.
 // You may need to lower the speed when the sink receiver bes are too busy.

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -714,7 +714,7 @@ DEFINE_mBool(enable_stream_load_commit_txn_on_be, "false");
 DEFINE_Int64(stream_tvf_buffer_size, "1048576"); // 1MB
 
 // request cdc client timeout
-DEFINE_mInt32(request_cdc_client_timeout_ms, "600000");
+DEFINE_mInt32(request_cdc_client_timeout_ms, "120000");
 
 // OlapTableSink sender's send interval, should be less than the real response time of a tablet writer rpc.
 // You may need to lower the speed when the sink receiver bes are too busy.

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1224,7 +1224,7 @@ public class Config extends ConfigBase {
     public static int streaming_pg_max_identifier_length = 63;
 
     @ConfField(mutable = true, masterOnly = true)
-    public static int streaming_cdc_fetch_splits_batch_size = 100;
+    public static int streaming_cdc_fetch_splits_batch_size = 32;
 
     /**
      * the max timeout of get kafka meta.

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -1224,7 +1224,7 @@ public class Config extends ConfigBase {
     public static int streaming_pg_max_identifier_length = 63;
 
     @ConfField(mutable = true, masterOnly = true)
-    public static int streaming_cdc_fetch_splits_batch_size = 32;
+    public static int streaming_cdc_fetch_splits_batch_size = 16;
 
     /**
      * the max timeout of get kafka meta.


### PR DESCRIPTION
### What problem does this PR solve?

Slow CDC control requests, including snapshot split discovery for unevenly distributed keys, can exceed the default 60-second BE HTTP timeout. Retrying split discovery can repeat expensive work before the FE receives progress.

This PR changes only two defaults:

- Increase `request_cdc_client_timeout_ms` from `60000` to `120000` (120 seconds).
- Reduce `streaming_cdc_fetch_splits_batch_size` from `100` to `16` to return smaller batches on batched split-discovery paths.

Explicit configuration overrides remain supported. FE light/heavy RPC deadlines, the retry policy, and split algorithms are unchanged. The HTTP timeout is per attempt and shared by CDC endpoints, not an end-to-end budget. In particular, 120 seconds still exceeds the 90-second FE light deadline; this PR does not resolve that mismatch or propagate cancellation. The tradeoffs are longer waits for failed CDC requests and more split-discovery requests/metadata updates for the same table.

### Release note

Change the default CDC client request timeout from 60 to 120 seconds and the default split-discovery batch size from 100 to 16.

### Check List (For Author)

- Test
    - [x] Manual test (static checks): `git diff --check`; `mvn -o checkstyle:check -pl fe-common` from `fe/` with JDK 17; `build-support/run_clang_format.py` with clang-format 16.0.6 on `be/src/common/config.cpp`. All passed.
    - [x] No need to test or manual test. Explain why:
        - [x] Other reason: only two configuration default literals change; no new branches or algorithms. No build or runtime/regression tests were run.
- Behavior changed:
    - [x] Yes. The two defaults change as described above.
- Does this need documentation?
    - [x] No. No new configuration options; changed defaults are recorded in the release note.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
