### PR TITLE
[improvement](ci) Accept Astra and Fable 5.1 review receipts

### DIFF
--- a/.github/scripts/test_validate_review_pass_comment.py
+++ b/.github/scripts/test_validate_review_pass_comment.py
@@ -79,6 +79,13 @@ class ValidateReviewPassCommentTest(unittest.TestCase):
             ("gpt-5.6-sol", "xhigh"),
             ("gpt-5.6-sol", "max"),
             ("gpt-5.6-sol", "ultra"),
+            ("claude-fable-5-1", "xhigh"),
+            ("claude-fable-5-1", "max"),
+            ("claude-fable-5-1[1m]", "xhigh"),
+            ("claude-fable-5-1[1m]", "max"),
+            ("gpt-6-astra", "xhigh"),
+            ("gpt-6-astra", "max"),
+            ("gpt-6-astra", "ultra"),
         )
         for model, effort in combinations:
             with self.subTest(model=model, effort=effort):
@@ -91,18 +98,36 @@ class ValidateReviewPassCommentTest(unittest.TestCase):
             "claude-opus-5[1m]",
             "claude-fable-5",
             "claude-fable-5[1m]",
+            "claude-fable-5-1",
+            "claude-fable-5-1[1m]",
         ):
             with self.subTest(model=model):
                 with self.assertRaisesRegex(ValidationError, "is not allowed for model"):
                     validate(make_comment(model=model, effort="ultra"))
 
     def test_rejects_effort_below_xhigh(self) -> None:
-        with self.assertRaisesRegex(ValidationError, "is not allowed for model"):
-            validate(make_comment(effort="high"))
+        for model in (
+            "gpt-5.6-sol",
+            "gpt-6-astra",
+            "claude-fable-5-1",
+            "claude-fable-5-1[1m]",
+        ):
+            for effort in ("none", "minimal", "low", "medium", "high"):
+                with self.subTest(model=model, effort=effort):
+                    with self.assertRaisesRegex(ValidationError, "is not allowed for model"):
+                        validate(make_comment(model=model, effort=effort))
 
     def test_rejects_unlisted_model(self) -> None:
-        with self.assertRaisesRegex(ValidationError, "model is not allowed"):
-            validate(make_comment(model="gpt-5.6"))
+        for model in (
+            "gpt-5.6",
+            "gpt-6",
+            "gpt-6-astra-latest",
+            "claude-fable-5-1-latest",
+            "claude-fable-5-2",
+        ):
+            with self.subTest(model=model):
+                with self.assertRaisesRegex(ValidationError, "model is not allowed"):
+                    validate(make_comment(model=model))
 
     def test_rejects_a_different_head(self) -> None:
         with self.assertRaisesRegex(ValidationError, "current PR head"):

--- a/.github/scripts/test_validate_review_pass_comment.py
+++ b/.github/scripts/test_validate_review_pass_comment.py
@@ -106,28 +106,12 @@ class ValidateReviewPassCommentTest(unittest.TestCase):
                     validate(make_comment(model=model, effort="ultra"))
 
     def test_rejects_effort_below_xhigh(self) -> None:
-        for model in (
-            "gpt-5.6-sol",
-            "gpt-6-astra",
-            "claude-fable-5-1",
-            "claude-fable-5-1[1m]",
-        ):
-            for effort in ("none", "minimal", "low", "medium", "high"):
-                with self.subTest(model=model, effort=effort):
-                    with self.assertRaisesRegex(ValidationError, "is not allowed for model"):
-                        validate(make_comment(model=model, effort=effort))
+        with self.assertRaisesRegex(ValidationError, "is not allowed for model"):
+            validate(make_comment(effort="high"))
 
     def test_rejects_unlisted_model(self) -> None:
-        for model in (
-            "gpt-5.6",
-            "gpt-6",
-            "gpt-6-astra-latest",
-            "claude-fable-5-1-latest",
-            "claude-fable-5-2",
-        ):
-            with self.subTest(model=model):
-                with self.assertRaisesRegex(ValidationError, "model is not allowed"):
-                    validate(make_comment(model=model))
+        with self.assertRaisesRegex(ValidationError, "model is not allowed"):
+            validate(make_comment(model="gpt-5.6"))
 
     def test_rejects_a_different_head(self) -> None:
         with self.assertRaisesRegex(ValidationError, "current PR head"):

--- a/.github/scripts/validate_review_pass_comment.py
+++ b/.github/scripts/validate_review_pass_comment.py
@@ -20,7 +20,10 @@ ALLOWED_EFFORTS_BY_MODEL = {
     "claude-opus-5[1m]": frozenset({"xhigh", "max"}),
     "claude-fable-5": frozenset({"xhigh", "max"}),
     "claude-fable-5[1m]": frozenset({"xhigh", "max"}),
+    "claude-fable-5-1": frozenset({"xhigh", "max"}),
+    "claude-fable-5-1[1m]": frozenset({"xhigh", "max"}),
     "gpt-5.6-sol": frozenset({"xhigh", "max", "ultra"}),
+    "gpt-6-astra": frozenset({"xhigh", "max", "ultra"}),
 }
 ALLOWED_AUTHOR_PERMISSIONS = frozenset({"write", "admin"})
 EXPECTED_FIELDS = (


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #66959

Problem Summary:

A converged local review using GPT-6 Astra or Claude Fable 5.1 is rejected by the PASS receipt validator with "model is not allowed", even when the review meets the existing effort, commit, reviewer, and findings requirements.

Extend the exact model allowlist:
- `gpt-6-astra`: `xhigh`, `max`, or `ultra`.
- `claude-fable-5-1` and its Claude Code `[1m]` form: `xhigh` or `max`.

Existing model eligibility and receipt checks are preserved. The hosted runner continues to use GPT-5.6 Sol. The `apache/doris-skills` allowlist needs a companion update; land the receiver support first.

Model references:
- [GPT-6 Astra](https://developers.openai.com/api/docs/guides/latest-model)
- [Fable 5.1 migration and effort levels](https://platform.claude.com/docs/en/models/fable-5-1/migration-guide)
- [Claude Code model configuration](https://code.claude.com/docs/en/model-config)

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
        - `python3 .github/scripts/test_validate_review_pass_comment.py` — 25 tests passed, including the expanded model/effort subcases.
        - Expanded tests fail against the previous validator and pass with the allowlist extension.
        - Added Fable 5.1 `ultra` rejection cases; existing insufficient-effort and unlisted-model tests remain unchanged.
        - Whitespace checks passed for both changed files.
    - [ ] No need to test or manual test. Explain why:

- Behavior changed:
    - [ ] No.
    - [x] Yes. Qualified Astra and Fable 5.1 receipts can satisfy the existing code-review check.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label

