### PR TITLE
[fix](load) Preserve remote tablet writer errors

### DIFF
--- a/be/src/exec/sink/writer/vtablet_writer.cpp
+++ b/be/src/exec/sink/writer/vtablet_writer.cpp
@@ -191,6 +191,17 @@ Status IndexChannel::init(RuntimeState* state, const std::vector<TTabletWithPart
 
 void IndexChannel::mark_as_failed(const VNodeChannel* node_channel, const std::string& err,
                                   int64_t tablet_id) {
+    _mark_as_failed(node_channel, err, nullptr, tablet_id);
+}
+
+void IndexChannel::mark_as_failed(const VNodeChannel* node_channel, const Status& status,
+                                  int64_t tablet_id) {
+    DCHECK(!status.ok());
+    _mark_as_failed(node_channel, status.to_string(), &status, tablet_id);
+}
+
+void IndexChannel::_mark_as_failed(const VNodeChannel* node_channel, const std::string& err,
+                                   const Status* status, int64_t tablet_id) {
     DCHECK(node_channel != nullptr);
     LOG(INFO) << "mark node_id:" << node_channel->channel_info() << " tablet_id: " << tablet_id
               << " as failed, err: " << err;
@@ -202,23 +213,34 @@ void IndexChannel::mark_as_failed(const VNodeChannel* node_channel, const std::s
 
     {
         std::lock_guard<std::mutex> l(_fail_lock);
+        const auto record_failure = [&](int64_t failed_tablet_id) {
+            _failed_channels[failed_tablet_id].insert(node_id);
+            const auto err_with_host = err + ", host: " + node_channel->host();
+            _failed_channels_msgs.emplace(failed_tablet_id, err_with_host);
+            if (status != nullptr) {
+                Status status_with_host = *status;
+                status_with_host.append(", host: " + node_channel->host());
+                _failed_channels_statuses.emplace(failed_tablet_id, std::move(status_with_host));
+            }
+            if (_failed_channels[failed_tablet_id].size() <=
+                        _max_failed_replicas(failed_tablet_id) ||
+                !_intolerable_failure_status.ok()) {
+                return;
+            }
+            const auto status_it = _failed_channels_statuses.find(failed_tablet_id);
+            if (status_it != _failed_channels_statuses.end()) {
+                _intolerable_failure_status = status_it->second;
+            } else {
+                _intolerable_failure_status = Status::Error<ErrorCode::INTERNAL_ERROR, false>(
+                        _failed_channels_msgs.at(failed_tablet_id));
+            }
+        };
         if (tablet_id == -1) {
             for (const auto the_tablet_id : it->second) {
-                _failed_channels[the_tablet_id].insert(node_id);
-                _failed_channels_msgs.emplace(the_tablet_id,
-                                              err + ", host: " + node_channel->host());
-                if (_failed_channels[the_tablet_id].size() > _max_failed_replicas(the_tablet_id)) {
-                    _intolerable_failure_status = Status::Error<ErrorCode::INTERNAL_ERROR, false>(
-                            _failed_channels_msgs[the_tablet_id]);
-                }
+                record_failure(the_tablet_id);
             }
         } else {
-            _failed_channels[tablet_id].insert(node_id);
-            _failed_channels_msgs.emplace(tablet_id, err + ", host: " + node_channel->host());
-            if (_failed_channels[tablet_id].size() > _max_failed_replicas(tablet_id)) {
-                _intolerable_failure_status = Status::Error<ErrorCode::INTERNAL_ERROR, false>(
-                        _failed_channels_msgs[tablet_id]);
-            }
+            record_failure(tablet_id);
         }
     }
 }
@@ -1266,6 +1288,7 @@ void VNodeChannel::_add_block_success_callback(const PTabletWriterAddBlockResult
             _index_channel->notify_close_wait();
         }
     } else {
+        _index_channel->mark_as_failed(this, status);
         _cancel_with_msg(fmt::format("{}, add batch req success but status isn't ok, err: {}",
                                      channel_info(), status.to_string()));
     }

--- a/be/src/exec/sink/writer/vtablet_writer.h
+++ b/be/src/exec/sink/writer/vtablet_writer.h
@@ -522,6 +522,8 @@ public:
 
     void mark_as_failed(const VNodeChannel* node_channel, const std::string& err,
                         int64_t tablet_id = -1);
+    void mark_as_failed(const VNodeChannel* node_channel, const Status& status,
+                        int64_t tablet_id = -1);
     Status check_intolerable_failure();
 
     Status close_wait(RuntimeState* state, WriterStats* writer_stats,
@@ -579,6 +581,7 @@ public:
     VExprContextSPtr get_where_clause() { return _where_clause; }
 
 private:
+    friend class IndexChannelTestAccessor;
     friend class VNodeChannel;
     friend class VTabletWriter;
     friend class VRowDistribution;
@@ -588,6 +591,9 @@ private:
     int _max_failed_replicas(int64_t tablet_id);
 
     int _load_required_replicas_num(int64_t tablet_id);
+
+    void _mark_as_failed(const VNodeChannel* node_channel, const std::string& err,
+                         const Status* status, int64_t tablet_id);
 
     bool _quorum_success(const std::unordered_set<int64_t>& unfinished_node_channel_ids,
                          const std::unordered_set<int64_t>& need_finish_tablets);
@@ -619,6 +625,8 @@ private:
     std::unordered_map<int64_t, std::unordered_set<int64_t>> _failed_channels;
     // key is tablet_id, value is error message
     std::unordered_map<int64_t, std::string> _failed_channels_msgs;
+    // key is tablet_id, value is the first typed failure status
+    std::unordered_map<int64_t, Status> _failed_channels_statuses;
     Status _intolerable_failure_status = Status::OK();
 
     std::unique_ptr<MemTracker> _index_channel_tracker;
@@ -662,6 +670,7 @@ public:
     Status _send_new_partition_batch();
 
 private:
+    friend class IndexChannelTestAccessor;
     friend class VNodeChannel;
     friend class IndexChannel;
 

--- a/be/test/exec/sink/vtablet_writer_test.cpp
+++ b/be/test/exec/sink/vtablet_writer_test.cpp
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "exec/sink/writer/vtablet_writer.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace doris {
+
+class IndexChannelTestAccessor {
+public:
+    static void set_replica_info(VTabletWriter* writer, int64_t tablet_id, int num_replicas,
+                                 int required_replicas) {
+        writer->_num_replicas = num_replicas;
+        writer->_tablet_replica_info[tablet_id] = {num_replicas, required_replicas};
+    }
+
+    static void add_tablet(IndexChannel* index_channel, int64_t node_id, int64_t tablet_id) {
+        index_channel->_tablets_by_channel[node_id].insert(tablet_id);
+    }
+};
+
+TEST(IndexChannelTest, preservesFirstFailureStatus) {
+    TDataSink sink;
+    VExprContextSPtrs output_exprs;
+    VTabletWriter writer(sink, output_exprs, nullptr, nullptr);
+    IndexChannelTestAccessor::set_replica_info(&writer, 1, 3, 2);
+
+    IndexChannel index_channel(&writer, 1, nullptr);
+    VNodeChannel first_channel(&writer, &index_channel, 1, false);
+    VNodeChannel second_channel(&writer, &index_channel, 2, false);
+    IndexChannelTestAccessor::add_tablet(&index_channel, 1, 1);
+    IndexChannelTestAccessor::add_tablet(&index_channel, 2, 1);
+
+    index_channel.mark_as_failed(
+            &first_channel,
+            Status::InvalidArgument("Cannot found origin partitions in auto detect overwriting"));
+    ASSERT_TRUE(index_channel.check_intolerable_failure().ok());
+
+    index_channel.mark_as_failed(&second_channel, Status::InternalError("later channel failure"));
+    const auto failure_status = index_channel.check_intolerable_failure();
+
+    EXPECT_EQ(ErrorCode::INVALID_ARGUMENT, failure_status.code());
+    EXPECT_NE(std::string::npos, failure_status.to_string().find("Cannot found origin partitions"));
+    EXPECT_EQ(std::string::npos, failure_status.to_string().find("later channel failure"));
+}
+
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: When multiple VNodeChannels receive a typed remote failure, the writer records only cancel text and later rebuilds an INTERNAL_ERROR after the replica failure threshold is crossed. This hides business errors such as INVALID_ARGUMENT and makes repeated INSERT OVERWRITE failures report inconsistent top-level statuses. Record the first typed Status per tablet and propagate it when the failure becomes intolerable, while retaining channel context. Add a unit test covering a later generic channel failure not overriding the first typed error.

### Release note

Preserve the original error code and message when tablet writer channel failures become intolerable.

### Check List (For Author)

- Test: Unit test added; not run locally as requested, CI will execute it
- Behavior changed: Yes (typed remote errors are preserved instead of being converted to INTERNAL_ERROR)
- Does this need documentation: No