### PR TITLE
[fix](test) Deflake insert overwrite auto detect failure

### DIFF
--- a/regression-test/suites/insert_overwrite_p0/test_iot_auto_detect_fail.groovy
+++ b/regression-test/suites/insert_overwrite_p0/test_iot_auto_detect_fail.groovy
@@ -150,16 +150,28 @@ PROPERTIES (
 );
     """
 
-    test {
-        sql "insert overwrite table fail_tag PARTITION(*) select qsrq,lsh,wth,khh,dt from fail_src where dt='20241128';"
-        exception "Cannot found origin partitions"
+    // The overwrite must fail because the source rows fall into a partition that does not exist
+    // in fail_tag and enable_auto_create_when_overwrite is false. With multiple parallel sink
+    // instances, equivalent errors can race to be reported. Accept each expected failure while
+    // still requiring the statement to fail.
+    def checkOverwriteFail = { result, exception, startTime, endTime ->
+        assertTrue(exception != null && (
+                exception.getMessage().contains('Cannot found origin partitions')
+                || exception.getMessage().contains('no partition for this tuple')
+                || exception.getMessage().contains('Insert has filtered data in strict mode')),
+            "expect insert-overwrite auto-detect to fail, "
+                + "but got result=${result}, exception=${exception?.getMessage()}")
     }
     test {
         sql "insert overwrite table fail_tag PARTITION(*) select qsrq,lsh,wth,khh,dt from fail_src where dt='20241128';"
-        exception "Cannot found origin partitions"
+        check checkOverwriteFail
     }
     test {
         sql "insert overwrite table fail_tag PARTITION(*) select qsrq,lsh,wth,khh,dt from fail_src where dt='20241128';"
-        exception "Cannot found origin partitions"
+        check checkOverwriteFail
+    }
+    test {
+        sql "insert overwrite table fail_tag PARTITION(*) select qsrq,lsh,wth,khh,dt from fail_src where dt='20241128';"
+        check checkOverwriteFail
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #64580

Problem Summary: INSERT OVERWRITE auto-detect must fail when source rows do not match an existing target partition and automatic partition creation is disabled. With multiple parallel sink instances, several equivalent failure messages can race to reach the client. The regression test accepted only one message, making repeated executions flaky. Accept the known equivalent errors while still requiring every statement to fail.

### Release note

None

### Check List (For Author)

- Test: Regression test updated; not run locally as requested, CI will execute it
- Behavior changed: No
- Does this need documentation: No