### PR TITLE
[refactor](qe) Merge the duplicate ConnectType enum and drop the unreachable forward branch

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -74,6 +74,7 @@ import org.apache.doris.nereids.trees.plans.commands.PrepareCommand;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSqlCache;
 import org.apache.doris.proto.Data;
+import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.qe.cache.CacheAnalyzer;
 import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
@@ -108,11 +109,6 @@ import java.util.UUID;
  * Process one connection, the life cycle is the same as connection
  */
 public abstract class ConnectProcessor {
-    public enum ConnectType {
-        MYSQL,
-        ARROW_FLIGHT_SQL
-    }
-
     private static final Logger LOG = LogManager.getLogger(ConnectProcessor.class);
     protected final ConnectContext ctx;
     protected StmtExecutor executor;

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
@@ -40,6 +40,7 @@ import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.plans.PlaceholderId;
 import org.apache.doris.nereids.trees.plans.commands.ExecuteCommand;
 import org.apache.doris.nereids.trees.plans.commands.PrepareCommand;
+import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.base.Preconditions;

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -123,7 +123,6 @@ import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.planner.GroupCommitPlanner;
 import org.apache.doris.planner.OlapTableSink;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.qe.ConnectProcessor;
 import org.apache.doris.qe.Coordinator;
 import org.apache.doris.qe.HttpStreamParams;
@@ -138,7 +137,6 @@ import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.resource.BackendSelection;
 import org.apache.doris.resource.BackendSelectionManager;
-import org.apache.doris.service.arrowflight.FlightSqlConnectProcessor;
 import org.apache.doris.statistics.analysis.AnalysisManager;
 import org.apache.doris.statistics.analysis.TableStatsMeta;
 import org.apache.doris.statistics.cache.InvalidateStatsTarget;
@@ -1158,7 +1156,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
         logForwardRequest(params);
         ConnectContext context = createForwardContext(params, requester);
-        ConnectProcessor processor = createForwardProcessor(context);
+        // createForwardContext() always builds a MySQL proxy context: the master replays the
+        // forwarded statement over a ProxyMysqlChannel and hands the packets back to the
+        // origin FE, whatever protocol the client is speaking there.
+        ConnectProcessor processor = new MysqlConnectProcessor(context);
         Runnable clearCallback = registerProxyQuery(params, context);
         try {
             return executeForward(params, context, processor);
@@ -1268,16 +1269,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             context.setCloudCluster(params.getCloudCluster());
         }
         return context;
-    }
-
-    private ConnectProcessor createForwardProcessor(ConnectContext context) throws TException {
-        if (context.getConnectType().equals(ConnectType.MYSQL)) {
-            return new MysqlConnectProcessor(context);
-        }
-        if (context.getConnectType().equals(ConnectType.ARROW_FLIGHT_SQL)) {
-            return new FlightSqlConnectProcessor(context);
-        }
-        throw new TException("unknown ConnectType: " + context.getConnectType());
     }
 
     private Runnable registerProxyQuery(TMasterOpRequest params, ConnectContext context) {

--- a/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/FlightSqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/arrowflight/FlightSqlConnectProcessor.java
@@ -27,6 +27,7 @@ import org.apache.doris.mysql.MysqlCommand;
 import org.apache.doris.proto.InternalService;
 import org.apache.doris.proto.Types;
 import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.qe.ConnectProcessor;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.rpc.BackendServiceProxy;

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/AuditLogWorkloadGroupTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/AuditLogWorkloadGroupTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.common.ConnectionException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.proto.Data;
+import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
 import org.apache.doris.service.arrowflight.FlightSqlConnectProcessor;
 

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectProcessorDelegatedCredentialTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectProcessorDelegatedCredentialTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.datasource.DelegatedCredential;
 import org.apache.doris.datasource.SessionContext;
 import org.apache.doris.proto.Data;
+import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.thrift.TMasterOpRequest;
 
 import org.junit.jupiter.api.AfterEach;


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Two pieces of dead weight in the connect layer, found while reading the Arrow Flight SQL and MySQL
paths side by side. No behavior change.

**1. `ConnectType` was declared twice.** Once in `ConnectContext` and once in `ConnectProcessor`, so
a processor's `connectType` and its session's `connectType` were unrelated types that only happened
to carry the same two constants — nothing stopped them from disagreeing, and neither could be passed
where the other was expected. Keep the `ConnectContext` one, which is the session's own property,
and let the processors import it. Every subclass (including the four test-only ones) was resolving
the enum through inheritance, so they now import it explicitly.

**2. `FrontendServiceImpl.createForwardProcessor()` dispatched on an outcome that cannot happen.** It
branched on the connect type of the forwarded context, but the context comes from
`createForwardContext()` one line above, which builds it with `new ConnectContext(null, true,
sessionId)` — and that constructor always sets `ConnectType.MYSQL`. So the Arrow Flight branch and
the `unknown ConnectType` throw were unreachable: the master replays a forwarded statement over a
`ProxyMysqlChannel` no matter which protocol the client speaks on the origin FE. The MySQL processor
is now constructed directly at the one call site, with a comment recording why that is the only
possibility.

### Release note

None

### Check List (For Author)

- Test
    - [x] Previous test can cover this change.

  Ran the FE unit tests covering both paths: `ConnectProcessorDelegatedCredentialTest`,
  `ConnectProcessorRetryTest`, `AuditLogWorkloadGroupTest`, `ConnectContextTest`,
  `ConnectAttributesForwardTest`, `ForceForwardAllQueriesTest`, `FrontendServiceImplTest`,
  `DorisFlightSqlProducerTest`, `EncryptSQLTest` — 86 tests, 0 failures, 0 errors.

- Behavior changed:
    - [x] No.

- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCAMVmoWN2MGVVsSRDCf2p
