### PR TITLE
[fix](be) Initialize bthread context key before first use

### DIFF
--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -76,9 +76,10 @@ void AttachTask::init(const std::shared_ptr<ResourceContext>& rc) {
                 "AttachTask::init: rc->task_controller() is null. signal_query_id={:x}-{:x}",
                 signal::query_id_hi, signal::query_id_lo));
     }
-    ThreadLocalHandle::create_thread_local_if_not_exits();
+    is_bthread_ = bthread_self() != 0;
+    thread_context_ = ThreadLocalHandle::create_thread_local_if_not_exits();
     signal::set_signal_task_id(rc->task_controller()->task_id());
-    thread_context()->attach_task(rc);
+    thread_context_->attach_task(rc);
 }
 
 AttachTask::AttachTask(const std::shared_ptr<ResourceContext>& rc) {
@@ -140,8 +141,8 @@ AttachTask::AttachTask(QueryContext* query_ctx) {
 
 AttachTask::~AttachTask() {
     signal::set_signal_task_id(TUniqueId());
-    thread_context()->detach_task();
-    ThreadLocalHandle::del_thread_local_if_count_is_zero();
+    thread_context_->detach_task();
+    ThreadLocalHandle::del_thread_local_if_count_is_zero(thread_context_, is_bthread_);
 }
 
 SwitchResourceContext::SwitchResourceContext(const std::shared_ptr<ResourceContext>& rc) {
@@ -222,27 +223,29 @@ SwitchThreadMemTrackerLimiter::~SwitchThreadMemTrackerLimiter() {
 }
 
 AddThreadMemTrackerConsumer::AddThreadMemTrackerConsumer(MemTracker* mem_tracker) {
-    ThreadLocalHandle::create_thread_local_if_not_exits();
+    _is_bthread = bthread_self() != 0;
+    _thread_context = ThreadLocalHandle::create_thread_local_if_not_exits();
     if (mem_tracker) {
-        _need_pop = thread_context()->thread_mem_tracker_mgr->push_consumer_tracker(mem_tracker);
+        _need_pop = _thread_context->thread_mem_tracker_mgr->push_consumer_tracker(mem_tracker);
     }
 }
 
 AddThreadMemTrackerConsumer::AddThreadMemTrackerConsumer(
         const std::shared_ptr<MemTracker>& mem_tracker)
         : _mem_tracker(mem_tracker) {
-    ThreadLocalHandle::create_thread_local_if_not_exits();
+    _is_bthread = bthread_self() != 0;
+    _thread_context = ThreadLocalHandle::create_thread_local_if_not_exits();
     if (_mem_tracker) {
         _need_pop =
-                thread_context()->thread_mem_tracker_mgr->push_consumer_tracker(_mem_tracker.get());
+                _thread_context->thread_mem_tracker_mgr->push_consumer_tracker(_mem_tracker.get());
     }
 }
 
 AddThreadMemTrackerConsumer::~AddThreadMemTrackerConsumer() {
     if (_need_pop) {
-        thread_context()->thread_mem_tracker_mgr->pop_consumer_tracker();
+        _thread_context->thread_mem_tracker_mgr->pop_consumer_tracker();
     }
-    ThreadLocalHandle::del_thread_local_if_count_is_zero();
+    ThreadLocalHandle::del_thread_local_if_count_is_zero(_thread_context, _is_bthread);
 }
 
 } // namespace doris

--- a/be/src/runtime/thread_context.cpp
+++ b/be/src/runtime/thread_context.cpp
@@ -17,6 +17,8 @@
 
 #include "runtime/thread_context.h"
 
+#include <mutex>
+
 #include "common/signal_handler.h"
 #include "runtime/exec_env.h"
 #include "runtime/query_context.h"
@@ -25,6 +27,22 @@
 
 namespace doris {
 class MemTracker;
+
+bthread_key_t btls_key;
+
+namespace {
+
+void thread_context_deleter(void* data) {
+    delete static_cast<ThreadContext*>(data);
+}
+
+} // namespace
+
+void init_thread_context_btls_key() {
+    static std::once_flag btls_key_once;
+    std::call_once(btls_key_once,
+                   []() { CHECK_EQ(0, bthread_key_create(&btls_key, thread_context_deleter)); });
+}
 
 void ThreadContext::attach_task(const std::shared_ptr<ResourceContext>& rc) {
     // will only attach_task at the beginning of the thread function, there should be no duplicate attach_task.
@@ -76,10 +94,9 @@ void AttachTask::init(const std::shared_ptr<ResourceContext>& rc) {
                 "AttachTask::init: rc->task_controller() is null. signal_query_id={:x}-{:x}",
                 signal::query_id_hi, signal::query_id_lo));
     }
-    is_bthread_ = bthread_self() != 0;
-    thread_context_ = ThreadLocalHandle::create_thread_local_if_not_exits();
+    ThreadLocalHandle::create_thread_local_if_not_exits();
     signal::set_signal_task_id(rc->task_controller()->task_id());
-    thread_context_->attach_task(rc);
+    thread_context()->attach_task(rc);
 }
 
 AttachTask::AttachTask(const std::shared_ptr<ResourceContext>& rc) {
@@ -141,8 +158,8 @@ AttachTask::AttachTask(QueryContext* query_ctx) {
 
 AttachTask::~AttachTask() {
     signal::set_signal_task_id(TUniqueId());
-    thread_context_->detach_task();
-    ThreadLocalHandle::del_thread_local_if_count_is_zero(thread_context_, is_bthread_);
+    thread_context()->detach_task();
+    ThreadLocalHandle::del_thread_local_if_count_is_zero();
 }
 
 SwitchResourceContext::SwitchResourceContext(const std::shared_ptr<ResourceContext>& rc) {
@@ -223,29 +240,27 @@ SwitchThreadMemTrackerLimiter::~SwitchThreadMemTrackerLimiter() {
 }
 
 AddThreadMemTrackerConsumer::AddThreadMemTrackerConsumer(MemTracker* mem_tracker) {
-    _is_bthread = bthread_self() != 0;
-    _thread_context = ThreadLocalHandle::create_thread_local_if_not_exits();
+    ThreadLocalHandle::create_thread_local_if_not_exits();
     if (mem_tracker) {
-        _need_pop = _thread_context->thread_mem_tracker_mgr->push_consumer_tracker(mem_tracker);
+        _need_pop = thread_context()->thread_mem_tracker_mgr->push_consumer_tracker(mem_tracker);
     }
 }
 
 AddThreadMemTrackerConsumer::AddThreadMemTrackerConsumer(
         const std::shared_ptr<MemTracker>& mem_tracker)
         : _mem_tracker(mem_tracker) {
-    _is_bthread = bthread_self() != 0;
-    _thread_context = ThreadLocalHandle::create_thread_local_if_not_exits();
+    ThreadLocalHandle::create_thread_local_if_not_exits();
     if (_mem_tracker) {
         _need_pop =
-                _thread_context->thread_mem_tracker_mgr->push_consumer_tracker(_mem_tracker.get());
+                thread_context()->thread_mem_tracker_mgr->push_consumer_tracker(_mem_tracker.get());
     }
 }
 
 AddThreadMemTrackerConsumer::~AddThreadMemTrackerConsumer() {
     if (_need_pop) {
-        _thread_context->thread_mem_tracker_mgr->pop_consumer_tracker();
+        thread_context()->thread_mem_tracker_mgr->pop_consumer_tracker();
     }
-    ThreadLocalHandle::del_thread_local_if_count_is_zero(_thread_context, _is_bthread);
+    ThreadLocalHandle::del_thread_local_if_count_is_zero();
 }
 
 } // namespace doris

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -140,6 +140,10 @@ class SwitchResourceContext;
 
 extern bthread_key_t btls_key;
 
+// Initialize btls_key exactly once before it is used by any thread context. The key has
+// process lifetime so an existing bthread context never becomes invalid while the BE is running.
+void init_thread_context_btls_key();
+
 static std::string NO_THREAD_CONTEXT_MSG =
         "Current thread not exist ThreadContext, usually after the thread is started, using "
         "SCOPED_ATTACH_TASK macro to create a ThreadContext and bind a Task.";
@@ -212,7 +216,8 @@ private:
 
 class ThreadLocalHandle {
 public:
-    static ThreadContext* create_thread_local_if_not_exits() {
+    static void create_thread_local_if_not_exits() {
+        init_thread_context_btls_key();
         if (bthread_self() == 0) {
             if (!pthread_context_ptr_init) {
                 thread_context_ptr = new ThreadContext();
@@ -220,7 +225,6 @@ public:
             }
             DCHECK(thread_context_ptr != nullptr);
             thread_context_ptr->thread_local_handle_count++;
-            return thread_context_ptr;
         } else {
             // Avoid calling bthread_getspecific frequently to get bthread local.
             // Very frequent bthread_getspecific will slow, but create_thread_local_if_not_exits is not expected to be much.
@@ -240,19 +244,13 @@ public:
             }
             DCHECK(bthread_context != nullptr);
             bthread_context->thread_local_handle_count++;
-            return bthread_context;
         }
     }
 
     // `create_thread_local_if_not_exits` and `del_thread_local_if_count_is_zero` should be used in pairs,
     // `del_thread_local_if_count_is_zero` should only be called if `create_thread_local_if_not_exits` returns true
     static void del_thread_local_if_count_is_zero() {
-        if (bthread_self() != 0) {
-            // in bthread
-            auto* bthread_context = static_cast<ThreadContext*>(bthread_getspecific(btls_key));
-            DCHECK(bthread_context != nullptr);
-            bthread_context->thread_local_handle_count--;
-        } else if (pthread_context_ptr_init) {
+        if (pthread_context_ptr_init) {
             // in pthread
             thread_context_ptr->thread_local_handle_count--;
             if (thread_context_ptr->thread_local_handle_count == 0) {
@@ -260,39 +258,31 @@ public:
                 delete doris::thread_context_ptr;
                 thread_context_ptr = nullptr;
             }
+        } else if (bthread_self() != 0) {
+            // in bthread
+            auto* bthread_context = static_cast<ThreadContext*>(bthread_getspecific(btls_key));
+            DCHECK(bthread_context != nullptr);
+            bthread_context->thread_local_handle_count--;
         } else {
             throw Exception(Status::FatalError("__builtin_unreachable"));
-        }
-    }
-
-    // Release the exact context acquired by create_thread_local_if_not_exits(). A bthread may
-    // resume on another pthread, so looking up the context again during scope destruction is
-    // unnecessarily fragile.
-    static void del_thread_local_if_count_is_zero(ThreadContext* context, bool is_bthread) {
-        DCHECK(context != nullptr);
-        context->thread_local_handle_count--;
-        if (!is_bthread && context->thread_local_handle_count == 0) {
-            DCHECK(context == thread_context_ptr);
-            pthread_context_ptr_init = false;
-            delete context;
-            thread_context_ptr = nullptr;
         }
     }
 };
 
 // must call create_thread_local_if_not_exits() before use thread_context().
 static ThreadContext* thread_context() {
+    if (pthread_context_ptr_init) {
+        // in pthread
+        DCHECK(bthread_self() == 0);
+        DCHECK(thread_context_ptr != nullptr);
+        return thread_context_ptr;
+    }
     if (bthread_self() != 0) {
         // in bthread
         // bthread switching pthread may be very frequent, remember not to use lock or other time-consuming operations.
         auto* bthread_context = static_cast<ThreadContext*>(bthread_getspecific(btls_key));
         DCHECK(bthread_context != nullptr && bthread_context->thread_local_handle_count > 0);
         return bthread_context;
-    }
-    if (pthread_context_ptr_init) {
-        // in pthread
-        DCHECK(thread_context_ptr != nullptr);
-        return thread_context_ptr;
     }
     // It means that use thread_context() but this thread not attached a query/load using SCOPED_ATTACH_TASK macro.
     throw Exception(Status::FatalError("{}", doris::NO_THREAD_CONTEXT_MSG));
@@ -344,10 +334,6 @@ public:
     void init(const std::shared_ptr<ResourceContext>& rc);
 
     ~AttachTask();
-
-private:
-    ThreadContext* thread_context_ = nullptr;
-    bool is_bthread_ = false;
 };
 
 class SwitchResourceContext {
@@ -384,9 +370,7 @@ public:
 
 private:
     std::shared_ptr<MemTracker> _mem_tracker; // Avoid mem_tracker being released midway.
-    ThreadContext* _thread_context = nullptr;
     bool _need_pop = false;
-    bool _is_bthread = false;
 };
 
 class ScopeSkipMemoryCheck {
@@ -409,7 +393,10 @@ public:
         if (size == 0) {                                                                           \
             break;                                                                                 \
         }                                                                                          \
-        if (bthread_self() != 0) {                                                                 \
+        if (doris::pthread_context_ptr_init) {                                                     \
+            DCHECK(bthread_self() == 0);                                                           \
+            doris::thread_context_ptr->thread_mem_tracker_mgr->consume(size);                      \
+        } else if (bthread_self() != 0) {                                                          \
             auto* bthread_context =                                                                \
                     static_cast<doris::ThreadContext*>(bthread_getspecific(doris::btls_key));      \
             DCHECK(bthread_context != nullptr);                                                    \
@@ -418,8 +405,6 @@ public:
             } else {                                                                               \
                 doris::ExecEnv::GetInstance()->orphan_mem_tracker()->consume_no_update_peak(size); \
             }                                                                                      \
-        } else if (doris::pthread_context_ptr_init) {                                              \
-            doris::thread_context_ptr->thread_mem_tracker_mgr->consume(size);                      \
         } else if (doris::ExecEnv::ready()) {                                                      \
             DCHECK(doris::k_doris_exit || !doris::config::enable_memory_orphan_check)              \
                     << doris::NO_THREAD_CONTEXT_MSG;                                               \

--- a/be/src/runtime/thread_context.h
+++ b/be/src/runtime/thread_context.h
@@ -212,7 +212,7 @@ private:
 
 class ThreadLocalHandle {
 public:
-    static void create_thread_local_if_not_exits() {
+    static ThreadContext* create_thread_local_if_not_exits() {
         if (bthread_self() == 0) {
             if (!pthread_context_ptr_init) {
                 thread_context_ptr = new ThreadContext();
@@ -220,6 +220,7 @@ public:
             }
             DCHECK(thread_context_ptr != nullptr);
             thread_context_ptr->thread_local_handle_count++;
+            return thread_context_ptr;
         } else {
             // Avoid calling bthread_getspecific frequently to get bthread local.
             // Very frequent bthread_getspecific will slow, but create_thread_local_if_not_exits is not expected to be much.
@@ -239,13 +240,19 @@ public:
             }
             DCHECK(bthread_context != nullptr);
             bthread_context->thread_local_handle_count++;
+            return bthread_context;
         }
     }
 
     // `create_thread_local_if_not_exits` and `del_thread_local_if_count_is_zero` should be used in pairs,
     // `del_thread_local_if_count_is_zero` should only be called if `create_thread_local_if_not_exits` returns true
     static void del_thread_local_if_count_is_zero() {
-        if (pthread_context_ptr_init) {
+        if (bthread_self() != 0) {
+            // in bthread
+            auto* bthread_context = static_cast<ThreadContext*>(bthread_getspecific(btls_key));
+            DCHECK(bthread_context != nullptr);
+            bthread_context->thread_local_handle_count--;
+        } else if (pthread_context_ptr_init) {
             // in pthread
             thread_context_ptr->thread_local_handle_count--;
             if (thread_context_ptr->thread_local_handle_count == 0) {
@@ -253,31 +260,39 @@ public:
                 delete doris::thread_context_ptr;
                 thread_context_ptr = nullptr;
             }
-        } else if (bthread_self() != 0) {
-            // in bthread
-            auto* bthread_context = static_cast<ThreadContext*>(bthread_getspecific(btls_key));
-            DCHECK(bthread_context != nullptr);
-            bthread_context->thread_local_handle_count--;
         } else {
             throw Exception(Status::FatalError("__builtin_unreachable"));
+        }
+    }
+
+    // Release the exact context acquired by create_thread_local_if_not_exits(). A bthread may
+    // resume on another pthread, so looking up the context again during scope destruction is
+    // unnecessarily fragile.
+    static void del_thread_local_if_count_is_zero(ThreadContext* context, bool is_bthread) {
+        DCHECK(context != nullptr);
+        context->thread_local_handle_count--;
+        if (!is_bthread && context->thread_local_handle_count == 0) {
+            DCHECK(context == thread_context_ptr);
+            pthread_context_ptr_init = false;
+            delete context;
+            thread_context_ptr = nullptr;
         }
     }
 };
 
 // must call create_thread_local_if_not_exits() before use thread_context().
 static ThreadContext* thread_context() {
-    if (pthread_context_ptr_init) {
-        // in pthread
-        DCHECK(bthread_self() == 0);
-        DCHECK(thread_context_ptr != nullptr);
-        return thread_context_ptr;
-    }
     if (bthread_self() != 0) {
         // in bthread
         // bthread switching pthread may be very frequent, remember not to use lock or other time-consuming operations.
         auto* bthread_context = static_cast<ThreadContext*>(bthread_getspecific(btls_key));
         DCHECK(bthread_context != nullptr && bthread_context->thread_local_handle_count > 0);
         return bthread_context;
+    }
+    if (pthread_context_ptr_init) {
+        // in pthread
+        DCHECK(thread_context_ptr != nullptr);
+        return thread_context_ptr;
     }
     // It means that use thread_context() but this thread not attached a query/load using SCOPED_ATTACH_TASK macro.
     throw Exception(Status::FatalError("{}", doris::NO_THREAD_CONTEXT_MSG));
@@ -329,6 +344,10 @@ public:
     void init(const std::shared_ptr<ResourceContext>& rc);
 
     ~AttachTask();
+
+private:
+    ThreadContext* thread_context_ = nullptr;
+    bool is_bthread_ = false;
 };
 
 class SwitchResourceContext {
@@ -365,7 +384,9 @@ public:
 
 private:
     std::shared_ptr<MemTracker> _mem_tracker; // Avoid mem_tracker being released midway.
+    ThreadContext* _thread_context = nullptr;
     bool _need_pop = false;
+    bool _is_bthread = false;
 };
 
 class ScopeSkipMemoryCheck {
@@ -388,10 +409,7 @@ public:
         if (size == 0) {                                                                           \
             break;                                                                                 \
         }                                                                                          \
-        if (doris::pthread_context_ptr_init) {                                                     \
-            DCHECK(bthread_self() == 0);                                                           \
-            doris::thread_context_ptr->thread_mem_tracker_mgr->consume(size);                      \
-        } else if (bthread_self() != 0) {                                                          \
+        if (bthread_self() != 0) {                                                                 \
             auto* bthread_context =                                                                \
                     static_cast<doris::ThreadContext*>(bthread_getspecific(doris::btls_key));      \
             DCHECK(bthread_context != nullptr);                                                    \
@@ -400,6 +418,8 @@ public:
             } else {                                                                               \
                 doris::ExecEnv::GetInstance()->orphan_mem_tracker()->consume_no_update_peak(size); \
             }                                                                                      \
+        } else if (doris::pthread_context_ptr_init) {                                              \
+            doris::thread_context_ptr->thread_mem_tracker_mgr->consume(size);                      \
         } else if (doris::ExecEnv::ready()) {                                                      \
             DCHECK(doris::k_doris_exit || !doris::config::enable_memory_orphan_check)              \
                     << doris::NO_THREAD_CONTEXT_MSG;                                               \

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -159,12 +159,6 @@ DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(arrow_flight_work_max_threads, MetricUnit::NO
 
 static bvar::LatencyRecorder g_process_remote_fetch_rowsets_latency("process_remote_fetch_rowsets");
 
-bthread_key_t btls_key;
-
-static void thread_context_deleter(void* d) {
-    delete static_cast<ThreadContext*>(d);
-}
-
 static int32_t resolved_brpc_peer_fetch_pool_threads() {
     return config::brpc_peer_fetch_pool_threads != -1 ? config::brpc_peer_fetch_pool_threads
                                                       : std::max(64, CpuInfo::num_cores() * 2);
@@ -285,7 +279,6 @@ PInternalService::PInternalService(ExecEnv* exec_env)
 
     _exec_env->load_stream_mgr()->set_heavy_work_pool(&_heavy_work_pool);
 
-    CHECK_EQ(0, bthread_key_create(&btls_key, thread_context_deleter));
     CHECK_EQ(0, bthread_key_create(&AsyncIO::btls_io_ctx_key, AsyncIO::io_ctx_key_deleter));
 }
 
@@ -314,7 +307,6 @@ PInternalService::~PInternalService() {
     DEREGISTER_HOOK_METRIC(arrow_flight_work_pool_max_queue_size);
     DEREGISTER_HOOK_METRIC(arrow_flight_work_max_threads);
 
-    CHECK_EQ(0, bthread_key_delete(btls_key));
     CHECK_EQ(0, bthread_key_delete(AsyncIO::btls_io_ctx_key));
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

A background sender could finish all of its work and then crash while destroying
`AddThreadMemTrackerConsumer`:

```text
AddThreadMemTrackerConsumer::~AddThreadMemTrackerConsumer()
VTabletWriter::_send_batch_process()
periodic_send_batch(void*)
bthread::TaskGroup::task_runner(...)
```

The core file shows that `thread_context()` returned `nullptr`; the
`ThreadMemTrackerMgr` and its consumer stack were not corrupted. The original
`ThreadContext` was still present in the bthread key table, but it could no longer be
retrieved:

```text
global btls_key:          { index = 0, version = 1 }
bthread key-table slot 0: { version = 0, ptr = valid ThreadContext }
```

`btls_key` was zero-initialized as `{0, 0}` and was not created until
`PInternalService` was constructed. The BE starts its Thrift backend service before
constructing the BRPC internal service, so work can arrive during that startup window.
A bthread could therefore store its context with `{0, 0}`. BRPC accepts that value
before the real key is created because key slot 0 also starts at version 0.

Later, `bthread_key_create()` changed the global key to `{0, 1}`. A lookup using the
new version did not match the existing version-0 entry and returned `nullptr`, causing
the crash during scoped tracker cleanup.

This is a key-initialization race. It is not caused by a bthread migrating between
worker pthreads or by `pthread_context_ptr_init` changing during migration.

### What is changed?

- Move the bthread ThreadContext key and its deleter into the `thread_context` module.
- Initialize the key with `std::call_once` before any `ThreadLocalHandle` creates or
  accesses a context. The BE's early `SCOPED_INIT_THREAD_CONTEXT()` initializes it
  before services start, while the lazy guard also protects other entry points.
- Keep the key valid for the complete process lifetime instead of deleting it with
  `PInternalService`, so existing bthread contexts cannot be invalidated by service
  lifetime.
- Revert the earlier context-pointer caching and lookup-order changes. Those changes
  only masked the null lookup and did not fix the key-version mismatch.

The change does not alter memory-accounting semantics. It guarantees that every
bthread context is stored and retrieved with the same valid key version.
