### PR TITLE
[fix](index) Reject 'default' for partition.inverted_index_storage_format

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PropertyAnalyzer.java
@@ -1293,14 +1293,21 @@ public class PropertyAnalyzer {
             return null;
         }
 
-        Map<String, String> formatProperties = new HashMap<>();
-        formatProperties.put(PROPERTIES_INVERTED_INDEX_STORAGE_FORMAT,
-                properties.remove(PROPERTIES_PARTITION_INVERTED_INDEX_STORAGE_FORMAT));
-        TInvertedIndexFileStorageFormat format = analyzeInvertedIndexFileStorageFormat(formatProperties);
-        if (format == TInvertedIndexFileStorageFormat.V1) {
+        String formatValue = properties.remove(PROPERTIES_PARTITION_INVERTED_INDEX_STORAGE_FORMAT);
+        // "default" resolves to the FE config inverted_index_storage_format, which is neither the format the
+        // table was created with nor stable across versions, so a rollout target has to be spelled out.
+        if ("default".equalsIgnoreCase(formatValue)) {
+            throw new AnalysisException("partition inverted index storage format does not support 'default', "
+                    + "please specify V2, V3 or SNII explicitly");
+        }
+        // V1 has to be caught before the table-level analyzer, which rejects it with a create-index wording.
+        if ("V1".equalsIgnoreCase(formatValue)) {
             throw new AnalysisException("partition inverted index storage format only supports V2, V3 and SNII");
         }
-        return format;
+
+        Map<String, String> formatProperties = new HashMap<>();
+        formatProperties.put(PROPERTIES_INVERTED_INDEX_STORAGE_FORMAT, formatValue);
+        return analyzeInvertedIndexFileStorageFormat(formatProperties);
     }
 
     // analyze common boolean properties, such as "in_memory" = "false"

--- a/fe/fe-core/src/test/java/org/apache/doris/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/common/PropertyAnalyzerTest.java
@@ -397,9 +397,14 @@ public class PropertyAnalyzerTest {
 
             Map<String, String> properties = new HashMap<>();
             Config.inverted_index_storage_format = "SNII";
-            properties.put(PropertyAnalyzer.PROPERTIES_PARTITION_INVERTED_INDEX_STORAGE_FORMAT, "default");
-            Assertions.assertEquals(TInvertedIndexFileStorageFormat.SNII,
+            properties.put(PropertyAnalyzer.PROPERTIES_PARTITION_INVERTED_INDEX_STORAGE_FORMAT, "V3");
+            Assertions.assertEquals(TInvertedIndexFileStorageFormat.V3,
                     PropertyAnalyzer.analyzePartitionInvertedIndexFileStorageFormat(properties));
+
+            properties.put(PropertyAnalyzer.PROPERTIES_PARTITION_INVERTED_INDEX_STORAGE_FORMAT, "default");
+            AnalysisException defaultException = Assertions.assertThrows(AnalysisException.class,
+                    () -> PropertyAnalyzer.analyzePartitionInvertedIndexFileStorageFormat(properties));
+            Assertions.assertTrue(defaultException.getMessage().contains("does not support 'default'"));
 
             properties.put(PropertyAnalyzer.PROPERTIES_PARTITION_INVERTED_INDEX_STORAGE_FORMAT, "V1");
             AnalysisException v1Exception = Assertions.assertThrows(AnalysisException.class,

--- a/regression-test/suites/cloud_p0/test_partition_cloud_inverted_index_storage_format_rollout.groovy
+++ b/regression-test/suites/cloud_p0/test_partition_cloud_inverted_index_storage_format_rollout.groovy
@@ -115,6 +115,39 @@ suite("test_partition_cloud_inverted_index_storage_format_rollout", "p0, docker"
         assertPartitionFormat(
                 "test_cloud_partition_inverted_index_storage_format_rollout", "p_downgrade", "V2")
 
+        test {
+            sql """ALTER TABLE test_cloud_partition_inverted_index_storage_format_rollout
+                    SET ("partition.inverted_index_storage_format" = "default")"""
+            exception "does not support 'default'"
+        }
+
+        test {
+            sql """ALTER TABLE test_cloud_partition_inverted_index_storage_format_rollout
+                    SET ("partition.inverted_index_storage_format" = "V1")"""
+            exception "only supports V2, V3 and SNII"
+        }
+
+        test {
+            sql """
+                CREATE TABLE test_cloud_partition_inverted_index_storage_format_forbid_default (
+                    k DATE NOT NULL,
+                    v VARCHAR(100) NULL,
+                    INDEX idx_v (v) USING INVERTED PROPERTIES("parser" = "english")
+                ) ENGINE=OLAP
+                DUPLICATE KEY(k)
+                PARTITION BY RANGE(k) (
+                    PARTITION p_old VALUES LESS THAN ("2024-01-01")
+                )
+                DISTRIBUTED BY HASH(k) BUCKETS 1
+                PROPERTIES (
+                    "replication_num" = "1",
+                    "inverted_index_storage_format" = "V2",
+                    "partition.inverted_index_storage_format" = "default"
+                )
+            """
+            exception "does not support 'default'"
+        }
+
         sql "set enable_memtable_on_sink_node = true"
         try {
             sql """


### PR DESCRIPTION


partition inverted index storage format only supports "V2, V3 and SNII"

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

