### PR TITLE
[fix](row binlog) make time-based incremental reads use a safe fence

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgr.java
@@ -2590,6 +2590,12 @@ public class CloudGlobalTransactionMgr implements GlobalTransactionMgrIface {
     }
 
     @Override
+    public long getTransactionIdWatermark() throws UserException {
+        // MetaService's conflict check treats end_txn_id as an exclusive upper bound.
+        return getNextTransactionId() + 1;
+    }
+
+    @Override
     public int getRunningTxnNums(Long dbId) throws AnalysisException {
         return 0;
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -711,11 +711,13 @@ public class BindRelation extends OneAnalysisRuleFactory {
         Map<String, String> params = scanParams.getMapParams();
         Long startTimestamp = OlapScanNode.parseChangeTimestamp(
                 params.getOrDefault(OlapScanNode.OLAP_START_TIMESTAMP, "0"));
-        startTimestamp = TSOTimestamp.composeFullTimestamp(startTimestamp);
+        // BE applies start_tso < commit_tso <= end_tso. Logical zero on both boundaries
+        // therefore gives the user-facing physical interval [startTimestamp, endTimestamp).
+        startTimestamp = TSOTimestamp.composePhysicalTimestamp(startTimestamp);
         Long endTimestamp = null;
         if (params.containsKey((OlapScanNode.OLAP_END_TIMESTAMP))) {
             endTimestamp = OlapScanNode.parseChangeTimestamp(params.get(OlapScanNode.OLAP_END_TIMESTAMP));
-            endTimestamp = TSOTimestamp.composeFullTimestamp(endTimestamp);
+            endTimestamp = TSOTimestamp.composePhysicalTimestamp(endTimestamp);
         }
         return Pair.of(startTimestamp, endTimestamp);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/TimeBasedChangeVisibleWaiter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/TimeBasedChangeVisibleWaiter.java
@@ -18,67 +18,170 @@
 package org.apache.doris.qe;
 
 import org.apache.doris.analysis.TableScanParams;
+import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.ClientPool;
 import org.apache.doris.common.Config;
-import org.apache.doris.common.Pair;
 import org.apache.doris.common.UserException;
 import org.apache.doris.nereids.analyzer.UnboundRelation;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.util.RelationUtil;
 import org.apache.doris.planner.OlapScanNode;
+import org.apache.doris.thrift.FrontendService;
+import org.apache.doris.thrift.TAcquireTimeBasedChangeReadFenceRequest;
+import org.apache.doris.thrift.TAcquireTimeBasedChangeReadFenceResult;
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TStatusCode;
 import org.apache.doris.transaction.GlobalTransactionMgrIface;
-import org.apache.doris.transaction.TransactionState;
-import org.apache.doris.transaction.TransactionStatus;
+import org.apache.doris.tso.TSOService;
 import org.apache.doris.tso.TSOTimestamp;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 
 /**
- * Before executing a time-based incremental read, wait for relevant target-table transactions to
- * become visible. In cloud mode, drain transactions registered before a query-start transaction ID
- * watermark. In non-cloud mode, wait for committed transactions whose commit TSO is within the
- * requested read timestamp.
+ * Establishes a closed upper fence before planning a time-based incremental read.
  *
- * <p>Skipped entirely when the session enables eventual-consistent change reads, or when no table
- * is involved. Waiting is bounded by session variable {@code change_visible_timeout_ms}; timing out
- * raises a {@link UserException}.
+ * <p>The master FE first captures its TSO, validates an explicit end timestamp, then captures a
+ * transaction ID watermark and drains earlier transactions involving the target tables. In classic
+ * mode, it also synchronizes with transaction publishers through the target table locks and returns
+ * a journal watermark for a follower FE to replay. In cloud mode, partition versions are refreshed
+ * directly from MetaService after this waiter completes.
  */
 public class TimeBasedChangeVisibleWaiter {
-    private static final long CLOUD_TXN_POLL_INTERVAL_MS = 100;
+    private static final long TXN_POLL_INTERVAL_MS = 100;
 
-    private final ConnectContext context;
+    /** Immutable result of establishing the fence on the master FE. */
+    public static final class ChangeReadFence {
+        private final long currentTso;
+        private final long maxJournalId;
+
+        public ChangeReadFence(long currentTso, long maxJournalId) {
+            this.currentTso = currentTso;
+            this.maxJournalId = maxJournalId;
+        }
+
+        public long getCurrentTso() {
+            return currentTso;
+        }
+
+        public long getMaxJournalId() {
+            return maxJournalId;
+        }
+    }
+
+    @VisibleForTesting
+    static final class ChangeReadInfo {
+        private final Map<Long, List<Long>> dbToTableIds;
+        private final Long maxEndTimestampMs;
+
+        private ChangeReadInfo(Map<Long, List<Long>> dbToTableIds, Long maxEndTimestampMs) {
+            this.dbToTableIds = dbToTableIds;
+            this.maxEndTimestampMs = maxEndTimestampMs;
+        }
+
+        Map<Long, List<Long>> getDbToTableIds() {
+            return dbToTableIds;
+        }
+
+        Long getMaxEndTimestampMs() {
+            return maxEndTimestampMs;
+        }
+    }
 
     public static void waitForVisible(ConnectContext context, Plan plan, Map<List<String>, TableIf> tables)
             throws UserException {
-        if (context.getSessionVariable().isEnableEventualConsistentChange() || tables.isEmpty()) {
+        if (tables.isEmpty()) {
             return;
         }
-        Map<Long, Map<Long, Long>> dbToTableEndTSO = collectDbToTableEndTSO(
-                context, plan, tables, System.currentTimeMillis());
-        new TimeBasedChangeVisibleWaiter(context).waitForDbToTableEndTSO(dbToTableEndTSO);
-    }
+        ChangeReadInfo changeReadInfo = collectChangeReadInfo(context, plan, tables);
+        if (changeReadInfo.getDbToTableIds().isEmpty()) {
+            return;
+        }
 
-    private TimeBasedChangeVisibleWaiter(ConnectContext context) {
-        this.context = context;
+        boolean waitForTransactions = !context.getSessionVariable().isEnableEventualConsistentChange();
+        // Eventual-consistent reads without an explicit end do not need a closed fence.
+        if (!waitForTransactions && changeReadInfo.getMaxEndTimestampMs() == null) {
+            return;
+        }
+
+        long timeoutMs = context.getSessionVariable().getChangeVisibleTimeoutMs();
+        long deadlineMs = System.currentTimeMillis() + timeoutMs;
+        ChangeReadFence fence;
+        boolean acquiredFromRemoteMaster = !context.getEnv().isMaster();
+        if (!acquiredFromRemoteMaster) {
+            fence = acquireFenceOnMaster(changeReadInfo.getDbToTableIds(),
+                    changeReadInfo.getMaxEndTimestampMs(), timeoutMs, waitForTransactions);
+        } else {
+            fence = acquireFenceFromMaster(context, changeReadInfo, timeoutMs, waitForTransactions);
+        }
+
+        if (acquiredFromRemoteMaster && waitForTransactions && !Config.isCloudMode()
+                && context.getEnv().getReplayedJournalId() < fence.getMaxJournalId()) {
+            long remainingMs = deadlineMs - System.currentTimeMillis();
+            if (remainingMs <= 0) {
+                throw new UserException(String.format(
+                        "timeout waiting follower journal replay for time-based read, maxJournalId=%d",
+                        fence.getMaxJournalId()));
+            }
+            context.getEnv().getJournalObservable().waitOn(
+                    fence.getMaxJournalId(), (int) Math.min(Integer.MAX_VALUE, remainingMs));
+        }
     }
 
     /**
-     * Walk the plan, pick out relations doing an incremental read, and for each OlapTable record the
-     * read end timestamp (converted to a full TSO) aggregated as dbId -> (tableId -> max endTSO).
+     * Capture and validate the TSO before acquiring the transaction ID watermark. This method must
+     * execute on the master FE; follower FEs invoke it through FrontendService.
      */
+    public static ChangeReadFence acquireFenceOnMaster(Map<Long, List<Long>> dbToTableIds,
+            Long maxEndTimestampMs, long timeoutMs, boolean waitForTransactions) throws UserException {
+        Env env = Env.getCurrentEnv();
+        if (!env.isMaster()) {
+            throw new UserException("time-based change read fence must be acquired on the master FE");
+        }
+
+        TSOService.TSOStatusSnapshot tsoSnapshot = env.getTSOService().getStatusSnapshot();
+        if (!tsoSnapshot.isInitialized()) {
+            throw new UserException("TSO timestamp is not calibrated, please check");
+        }
+        long currentTso = tsoSnapshot.getCurrentTso();
+        validateEndTimestamp(maxEndTimestampMs, currentTso);
+
+        if (waitForTransactions) {
+            long deadlineMs = System.currentTimeMillis() + timeoutMs;
+            GlobalTransactionMgrIface txnMgr = Env.getCurrentGlobalTransactionMgr();
+            long txnIdWatermark;
+            try {
+                txnIdWatermark = txnMgr.getTransactionIdWatermark();
+            } catch (UserException e) {
+                throw new UserException("get transaction id watermark failed for time-based read", e);
+            }
+            waitForPreviousTransactions(txnMgr, txnIdWatermark, dbToTableIds, deadlineMs);
+            if (!Config.isCloudMode()) {
+                synchronizeClassicPublishers(dbToTableIds, deadlineMs);
+            }
+        }
+        return new ChangeReadFence(currentTso, env.getMaxJournalId());
+    }
+
     @VisibleForTesting
-    static Map<Long, Map<Long, Long>> collectDbToTableEndTSO(ConnectContext context, Plan plan,
-            Map<List<String>, TableIf> tables, long defaultEndTsMs) {
-        Map<Long, Map<Long, Long>> dbToTableEndTSO = new HashMap<>();
+    static ChangeReadInfo collectChangeReadInfo(ConnectContext context, Plan plan,
+            Map<List<String>, TableIf> tables) {
+        Map<Long, Set<Long>> dbToTableIdSets = new TreeMap<>();
+        long[] maxEndTimestampMs = {-1L};
         plan.foreach(node -> {
             if (!(node instanceof UnboundRelation)) {
                 return;
@@ -89,52 +192,44 @@ public class TimeBasedChangeVisibleWaiter {
                 return;
             }
             TableIf table = tables.get(RelationUtil.getQualifierName(context, relation.getNameParts()));
-            if (table instanceof OlapTable) {
-                addTableEndTSO(dbToTableEndTSO, (OlapTable) table, getEndTsMs(scanParams, defaultEndTsMs));
+            if (!(table instanceof OlapTable)) {
+                return;
             }
-        });
-        return dbToTableEndTSO;
-    }
-
-    /** Wait for relevant transactions using the transaction manager implementation for the cluster mode. */
-    private void waitForDbToTableEndTSO(Map<Long, Map<Long, Long>> dbToTableEndTSO) throws UserException {
-        if (dbToTableEndTSO.isEmpty()) {
-            return;
-        }
-        long deadlineMs = System.currentTimeMillis() + context.getSessionVariable().getChangeVisibleTimeoutMs();
-        if (Config.isCloudMode()) {
-            waitForCloudTransactions(dbToTableEndTSO, deadlineMs);
-            return;
-        }
-        for (Map.Entry<Long, Map<Long, Long>> dbEntry : dbToTableEndTSO.entrySet()) {
-            long dbId = dbEntry.getKey();
-            Map<Long, Long> tableEndTSO = dbEntry.getValue();
-            for (TransactionState txn : getCommittedTransactions(dbId)) {
-                Pair<Long, Long> matchedTableEndTSO = findMatchedTableEndTSO(txn, tableEndTSO);
-                if (matchedTableEndTSO != null) {
-                    waitTransactionVisible(txn, dbId, matchedTableEndTSO.first, matchedTableEndTSO.second,
-                            deadlineMs);
+            OlapTable olapTable = (OlapTable) table;
+            dbToTableIdSets.computeIfAbsent(olapTable.getDatabase().getId(), ignored -> new TreeSet<>())
+                    .add(olapTable.getId());
+            if (scanParams.getMapParams().containsKey(OlapScanNode.OLAP_END_TIMESTAMP)) {
+                long endTimestampMs = OlapScanNode.parseChangeTimestamp(
+                        scanParams.getMapParams().get(OlapScanNode.OLAP_END_TIMESTAMP));
+                if (endTimestampMs > 0) {
+                    maxEndTimestampMs[0] = Math.max(maxEndTimestampMs[0], endTimestampMs);
                 }
             }
+        });
+
+        Map<Long, List<Long>> dbToTableIds = new TreeMap<>();
+        dbToTableIdSets.forEach((dbId, tableIds) -> dbToTableIds.put(dbId, new ArrayList<>(tableIds)));
+        return new ChangeReadInfo(dbToTableIds, maxEndTimestampMs[0] < 0 ? null : maxEndTimestampMs[0]);
+    }
+
+    private static void validateEndTimestamp(Long maxEndTimestampMs, long currentTso) throws UserException {
+        if (maxEndTimestampMs == null) {
+            return;
+        }
+        long maxSupportedEndTimestampMs = TSOTimestamp.extractPhysicalTime(currentTso);
+        if (maxEndTimestampMs > maxSupportedEndTimestampMs) {
+            throw new UserException(String.format(
+                    "endTimestamp exceeds the maximum supported time for an INCR read: "
+                            + "requestedEndTimestampMs=%d, CURRENT_TSO_PHYSICAL_TIME=%d",
+                    maxEndTimestampMs, maxSupportedEndTimestampMs));
         }
     }
 
-    private void waitForCloudTransactions(Map<Long, Map<Long, Long>> dbToTableEndTSO, long deadlineMs)
-            throws UserException {
-        GlobalTransactionMgrIface txnMgr = Env.getCurrentGlobalTransactionMgr();
-        long txnIdWatermark;
-        try {
-            // MetaService returns the current maximum transaction ID, while check_txn_conflict
-            // uses an exclusive upper bound.
-            txnIdWatermark = txnMgr.getNextTransactionId() + 1;
-        } catch (UserException e) {
-            throw new UserException("get transaction id watermark failed for time-based read", e);
-        }
-
-        for (Map.Entry<Long, Map<Long, Long>> dbEntry : dbToTableEndTSO.entrySet()) {
+    private static void waitForPreviousTransactions(GlobalTransactionMgrIface txnMgr, long txnIdWatermark,
+            Map<Long, List<Long>> dbToTableIds, long deadlineMs) throws UserException {
+        for (Map.Entry<Long, List<Long>> dbEntry : dbToTableIds.entrySet()) {
             long dbId = dbEntry.getKey();
-            List<Long> tableIds = new ArrayList<>(dbEntry.getValue().keySet());
-            Collections.sort(tableIds);
+            List<Long> tableIds = dbEntry.getValue();
             while (!isPreviousTransactionsFinished(txnMgr, txnIdWatermark, dbId, tableIds)) {
                 long remainingMs = deadlineMs - System.currentTimeMillis();
                 if (remainingMs <= 0) {
@@ -144,7 +239,7 @@ public class TimeBasedChangeVisibleWaiter {
                             txnIdWatermark, dbId, tableIds));
                 }
                 try {
-                    Thread.sleep(Math.min(CLOUD_TXN_POLL_INTERVAL_MS, remainingMs));
+                    Thread.sleep(Math.min(TXN_POLL_INTERVAL_MS, remainingMs));
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new UserException(String.format(
@@ -156,7 +251,7 @@ public class TimeBasedChangeVisibleWaiter {
         }
     }
 
-    private boolean isPreviousTransactionsFinished(GlobalTransactionMgrIface txnMgr, long txnIdWatermark,
+    private static boolean isPreviousTransactionsFinished(GlobalTransactionMgrIface txnMgr, long txnIdWatermark,
             long dbId, List<Long> tableIds) throws UserException {
         try {
             return txnMgr.isPreviousTransactionsFinished(txnIdWatermark, dbId, tableIds);
@@ -169,68 +264,76 @@ public class TimeBasedChangeVisibleWaiter {
     }
 
     /**
-     * Return (tableId, endTSO) if the transaction is COMMITTED and its commit TSO is within the
-     * requested endTSO of one of its tables; otherwise null (no need to wait).
+     * A classic transaction becomes VISIBLE in memory while its publisher still owns table write
+     * locks. Taking the corresponding read locks after the transaction drain guarantees that the
+     * visible journal and partition metadata updates have completed before maxJournalId is read.
      */
-    private Pair<Long, Long> findMatchedTableEndTSO(TransactionState txn, Map<Long, Long> tableEndTSO) {
-        long commitTSO = txn.getCommitTSO();
-        if (txn.getTransactionStatus() != TransactionStatus.COMMITTED || commitTSO < 0) {
-            return null;
-        }
-        for (Long tableId : txn.getTableIdList()) {
-            Long endTSO = tableEndTSO.get(tableId);
-            if (endTSO != null && commitTSO <= endTSO) {
-                return Pair.of(tableId, endTSO);
-            }
-        }
-        return null;
-    }
-
-    private List<TransactionState> getCommittedTransactions(long dbId) throws UserException {
-        try {
-            return Env.getCurrentGlobalTransactionMgr().getCommittedTransactions(dbId);
-        } catch (Exception e) {
-            throw new UserException("get committed transactions failed. dbId=" + dbId, e);
-        }
-    }
-
-    /**
-     * Poll-wait until the transaction leaves COMMITTED (becomes visible) or the deadline passes;
-     * throw if it is still COMMITTED at timeout.
-     */
-    private void waitTransactionVisible(TransactionState txn, long dbId, long tableId,
-            long endTSO, long deadlineMs) throws UserException {
-        long remainingMs = deadlineMs - System.currentTimeMillis();
-        while (txn.getTransactionStatus() == TransactionStatus.COMMITTED && remainingMs > 0) {
+    private static void synchronizeClassicPublishers(Map<Long, List<Long>> dbToTableIds, long deadlineMs)
+            throws UserException {
+        for (Map.Entry<Long, List<Long>> dbEntry : dbToTableIds.entrySet()) {
+            Database db = Env.getCurrentInternalCatalog().getDbOrMetaException(dbEntry.getKey());
+            List<Table> tables = db.getTablesOnIdOrderIfExist(dbEntry.getValue());
+            List<Table> lockedTables = new ArrayList<>(tables.size());
             try {
-                txn.waitTransactionVisible(remainingMs);
-            } catch (InterruptedException ignored) {
-                // Keep the previous wait behavior.
+                for (Table table : tables) {
+                    long remainingMs = deadlineMs - System.currentTimeMillis();
+                    if (remainingMs <= 0 || !table.tryReadLock(remainingMs, TimeUnit.MILLISECONDS)) {
+                        throw new UserException(String.format(
+                                "timeout synchronizing visible versions for time-based read, dbId=%d tableId=%d",
+                                dbEntry.getKey(), table.getId()));
+                    }
+                    lockedTables.add(table);
+                }
+            } finally {
+                Collections.reverse(lockedTables);
+                lockedTables.forEach(Table::readUnlock);
             }
-            remainingMs = deadlineMs - System.currentTimeMillis();
-        }
-        if (txn.getTransactionStatus() == TransactionStatus.COMMITTED) {
-            throw new UserException(String.format(
-                    "timeout waiting transaction become visible for time-based read, "
-                            + "txnId=%d dbId=%d tableId=%d endTSO=%d",
-                    txn.getTransactionId(), dbId, tableId, endTSO));
         }
     }
 
-    // Resolve the read end timestamp (ms) from scan params; fall back to defaultEndTsMs (the query
-    // start time) when absent or non-positive.
-    private static long getEndTsMs(TableScanParams scanParams, long defaultEndTsMs) {
-        if (scanParams.getMapParams().containsKey(OlapScanNode.OLAP_END_TIMESTAMP)) {
-            long endTsMs = OlapScanNode.parseChangeTimestamp(
-                    scanParams.getMapParams().get(OlapScanNode.OLAP_END_TIMESTAMP));
-            return endTsMs > 0 ? endTsMs : defaultEndTsMs;
+    private static ChangeReadFence acquireFenceFromMaster(ConnectContext context, ChangeReadInfo changeReadInfo,
+            long timeoutMs, boolean waitForTransactions) throws UserException {
+        TAcquireTimeBasedChangeReadFenceRequest request = new TAcquireTimeBasedChangeReadFenceRequest();
+        request.setDbToTableIds(changeReadInfo.getDbToTableIds());
+        request.setTimeoutMs(timeoutMs);
+        request.setWaitForTransactions(waitForTransactions);
+        if (changeReadInfo.getMaxEndTimestampMs() != null) {
+            request.setEndTimestampMs(changeReadInfo.getMaxEndTimestampMs());
         }
-        return defaultEndTsMs;
-    }
 
-    // Compose endTsMs into a full TSO and merge into dbId -> (tableId -> endTSO), keeping the max.
-    private static void addTableEndTSO(Map<Long, Map<Long, Long>> dbToTableEndTSO, OlapTable table, long endTsMs) {
-        dbToTableEndTSO.computeIfAbsent(table.getDatabase().getId(), ignored -> new HashMap<>())
-                .merge(table.getId(), TSOTimestamp.composeFullTimestamp(endTsMs), Math::max);
+        TNetworkAddress masterAddress = new TNetworkAddress(
+                context.getEnv().getMasterHost(), context.getEnv().getMasterRpcPort());
+        int thriftTimeoutMs = (int) Math.min(Integer.MAX_VALUE, Math.max(1L, timeoutMs));
+        FrontendService.Client client;
+        try {
+            client = ClientPool.frontendPool.borrowObject(masterAddress, thriftTimeoutMs);
+        } catch (Exception e) {
+            throw new UserException("failed to get master FE client for time-based read", e);
+        }
+
+        boolean returnToPool = false;
+        try {
+            TAcquireTimeBasedChangeReadFenceResult result = client.acquireTimeBasedChangeReadFence(request);
+            returnToPool = true;
+            if (result.getStatus().getStatusCode() != TStatusCode.OK) {
+                String error = result.getStatus().isSetErrorMsgs()
+                        ? String.join(". ", result.getStatus().getErrorMsgs())
+                        : "unknown error";
+                throw new UserException("acquire time-based read fence from master FE failed: " + error);
+            }
+            Preconditions.checkState(result.isSetCurrentTso(), "master FE did not return current_tso");
+            Preconditions.checkState(result.isSetMaxJournalId(), "master FE did not return max_journal_id");
+            return new ChangeReadFence(result.getCurrentTso(), result.getMaxJournalId());
+        } catch (UserException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new UserException("acquire time-based read fence from master FE failed", e);
+        } finally {
+            if (returnToPool) {
+                ClientPool.frontendPool.returnObject(masterAddress, client);
+            } else {
+                ClientPool.frontendPool.invalidateObject(masterAddress, client);
+            }
+        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -135,6 +135,7 @@ import org.apache.doris.qe.QeProcessorImpl;
 import org.apache.doris.qe.QueryState;
 import org.apache.doris.qe.SessionVariable;
 import org.apache.doris.qe.StmtExecutor;
+import org.apache.doris.qe.TimeBasedChangeVisibleWaiter;
 import org.apache.doris.qe.VariableMgr;
 import org.apache.doris.resource.BackendSelection;
 import org.apache.doris.resource.BackendSelectionManager;
@@ -156,6 +157,8 @@ import org.apache.doris.tablefunction.MetadataGenerator;
 import org.apache.doris.thrift.FrontendService;
 import org.apache.doris.thrift.TAbortRemoteTxnRequest;
 import org.apache.doris.thrift.TAbortRemoteTxnResult;
+import org.apache.doris.thrift.TAcquireTimeBasedChangeReadFenceRequest;
+import org.apache.doris.thrift.TAcquireTimeBasedChangeReadFenceResult;
 import org.apache.doris.thrift.TAddOrDropPartitionsRequest;
 import org.apache.doris.thrift.TAddOrDropPartitionsResult;
 import org.apache.doris.thrift.TAutoIncrementRangeRequest;
@@ -3391,6 +3394,35 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             LOG.warn("Failed to fetchSchemaTableData", e);
             return MetadataGenerator.errorResult(e.getMessage());
         }
+    }
+
+    @Override
+    public TAcquireTimeBasedChangeReadFenceResult acquireTimeBasedChangeReadFence(
+            TAcquireTimeBasedChangeReadFenceRequest request) throws TException {
+        TAcquireTimeBasedChangeReadFenceResult result = new TAcquireTimeBasedChangeReadFenceResult();
+        TStatus status = checkMaster();
+        result.setStatus(status);
+        if (status.getStatusCode() != TStatusCode.OK) {
+            return result;
+        }
+
+        try {
+            TimeBasedChangeVisibleWaiter.ChangeReadFence fence =
+                    TimeBasedChangeVisibleWaiter.acquireFenceOnMaster(
+                            request.getDbToTableIds(),
+                            request.isSetEndTimestampMs() ? request.getEndTimestampMs() : null,
+                            request.getTimeoutMs(), request.isWaitForTransactions());
+            result.setCurrentTso(fence.getCurrentTso());
+            result.setMaxJournalId(fence.getMaxJournalId());
+        } catch (UserException e) {
+            status.setStatusCode(TStatusCode.ANALYSIS_ERROR);
+            status.addToErrorMsgs(e.getDetailMessage());
+        } catch (RuntimeException e) {
+            LOG.warn("failed to acquire time-based change read fence", e);
+            status.setStatusCode(TStatusCode.INTERNAL_ERROR);
+            status.addToErrorMsgs(Strings.nullToEmpty(e.getMessage()));
+        }
+        return result;
     }
 
     private TNetworkAddress getClientAddr() {

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgr.java
@@ -929,6 +929,12 @@ public class GlobalTransactionMgr implements GlobalTransactionMgrIface {
     }
 
     @Override
+    public long getTransactionIdWatermark() {
+        // The classic conflict check treats its upper bound as inclusive.
+        return this.idGenerator.getCurrentTransactionId();
+    }
+
+    @Override
     public void write(DataOutput out) throws IOException {
         int numTransactions = getTransactionNum();
         out.writeInt(numTransactions);

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgrIface.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/GlobalTransactionMgrIface.java
@@ -211,6 +211,12 @@ public interface GlobalTransactionMgrIface extends Writable {
 
     public Long getNextTransactionId() throws UserException;
 
+    /**
+     * Return the transaction ID upper bound expected by {@link #isPreviousTransactionsFinished}.
+     * This is a read-only operation and must not allocate a transaction ID.
+     */
+    public long getTransactionIdWatermark() throws UserException;
+
     public void readFields(DataInput in) throws IOException;
 
     public void replayUpsertTransactionState(TransactionState transactionState) throws Exception;

--- a/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionIdGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionIdGenerator.java
@@ -54,6 +54,11 @@ public class TransactionIdGenerator {
         }
     }
 
+    /** Return the current transaction ID watermark without allocating a new ID. */
+    public synchronized long getCurrentTransactionId() {
+        return nextId;
+    }
+
     public synchronized void initTransactionId(long id) {
         if (id > batchEndId) {
             batchEndId = id;

--- a/fe/fe-core/src/main/java/org/apache/doris/tso/TSOTimestamp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tso/TSOTimestamp.java
@@ -113,6 +113,15 @@ public final class TSOTimestamp implements Writable, Comparable<TSOTimestamp> {
     }
 
     /**
+     * Compose the lower boundary of a physical millisecond.
+     *
+     * @return 64-bit TSO timestamp with a zero logical counter
+     */
+    public static long composePhysicalTimestamp(long physicalTimestamp) {
+        return composeTimestamp(physicalTimestamp, 0L);
+    }
+
+    /**
      * Extract physical time (milliseconds) from TSO timestamp
      *
      * @param timestamp 64-bit TSO timestamp

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
@@ -624,6 +624,24 @@ public class CloudGlobalTransactionMgrTest {
         }
     }
 
+    @Test
+    public void testGetTransactionIdWatermarkUsesExclusiveMetaServiceBound() throws Exception {
+        MetaServiceProxy mockProxy = Mockito.mock(MetaServiceProxy.class);
+        try (MockedStatic<MetaServiceProxy> mockedStatic = Mockito.mockStatic(MetaServiceProxy.class)) {
+            mockedStatic.when(MetaServiceProxy::getInstance).thenReturn(mockProxy);
+            GetCurrentMaxTxnResponse response = GetCurrentMaxTxnResponse.newBuilder()
+                    .setStatus(Cloud.MetaServiceResponseStatus.newBuilder()
+                            .setCode(MetaServiceCode.OK).setMsg("OK"))
+                    .setCurrentMaxTxnId(1000)
+                    .build();
+            Mockito.doReturn(response).when(mockProxy).getCurrentMaxTxnId(Mockito.any());
+
+            long result = masterTransMgr.getTransactionIdWatermark();
+
+            Assert.assertEquals(1001, result);
+        }
+    }
+
     private TxnInfoPB buildTxnInfo(long transactionId) {
         return TxnInfoPB.newBuilder()
                 .setDbId(CatalogTestUtil.testDbId1)

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/transaction/CloudGlobalTransactionMgrTest.java
@@ -638,7 +638,7 @@ public class CloudGlobalTransactionMgrTest {
 
             long result = masterTransMgr.getTransactionIdWatermark();
 
-            Assert.assertEquals(1001, result);
+            Assertions.assertEquals(1001, result);
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/ExplainTableStreamPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/ExplainTableStreamPlanTest.java
@@ -586,8 +586,8 @@ public class ExplainTableStreamPlanTest extends TestWithFeService {
         // asserting every incremental scan range carries the composed start/end TSO for its partition.
         String startTs = "2026-05-25 20:51:28";
         String endTs = "2026-05-25 21:51:28";
-        long expectedStartTso = TSOTimestamp.composeFullTimestamp(OlapScanNode.parseChangeTimestamp(startTs));
-        long expectedEndTso = TSOTimestamp.composeFullTimestamp(OlapScanNode.parseChangeTimestamp(endTs));
+        long expectedStartTso = TSOTimestamp.composePhysicalTimestamp(OlapScanNode.parseChangeTimestamp(startTs));
+        long expectedEndTso = TSOTimestamp.composePhysicalTimestamp(OlapScanNode.parseChangeTimestamp(endTs));
 
         ConnectContext ctx = createDefaultCtx();
         ctx.setDatabase("test_stream");

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/TimeBasedChangeVisibleWaiterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/TimeBasedChangeVisibleWaiterTest.java
@@ -21,9 +21,11 @@ import org.apache.doris.analysis.TableScanParams;
 import org.apache.doris.catalog.Database;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.catalog.Table;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.UserException;
+import org.apache.doris.datasource.InternalCatalog;
 import org.apache.doris.nereids.analyzer.UnboundRelation;
 import org.apache.doris.nereids.trees.plans.JoinType;
 import org.apache.doris.nereids.trees.plans.Plan;
@@ -31,42 +33,43 @@ import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.logical.LogicalJoin;
 import org.apache.doris.planner.OlapScanNode;
 import org.apache.doris.transaction.GlobalTransactionMgrIface;
-import org.apache.doris.transaction.TransactionState;
-import org.apache.doris.transaction.TransactionStatus;
+import org.apache.doris.tso.TSOService;
 import org.apache.doris.tso.TSOTimestamp;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.TimeUnit;
 
 public class TimeBasedChangeVisibleWaiterTest {
     private static final List<String> TABLE_QUALIFIER = ImmutableList.of("internal", "db", "tbl");
     private static final long DB_ID = 100L;
     private static final long TABLE_ID = 200L;
-    private static final long DEFAULT_END_TS_MS = 1700000000000L;
+    private static final long CURRENT_PHYSICAL_TIME_MS = 1700000000000L;
+    private static final long CURRENT_TSO = TSOTimestamp.composeTimestamp(CURRENT_PHYSICAL_TIME_MS, 17L);
 
     @Test
-    public void testCollectDbToTableEndTSOUsesDefaultEndTimestamp() {
+    public void testCollectChangeReadInfoWithoutEndTimestamp() {
         OlapTable table = mockOlapTable(DB_ID, TABLE_ID);
 
-        Map<Long, Map<Long, Long>> result = TimeBasedChangeVisibleWaiter.collectDbToTableEndTSO(
+        TimeBasedChangeVisibleWaiter.ChangeReadInfo result = TimeBasedChangeVisibleWaiter.collectChangeReadInfo(
                 mockContext(), newChangeRelation(1, ImmutableMap.of()),
-                ImmutableMap.of(TABLE_QUALIFIER, table), DEFAULT_END_TS_MS);
+                ImmutableMap.of(TABLE_QUALIFIER, table));
 
-        Assertions.assertEquals(TSOTimestamp.composeFullTimestamp(DEFAULT_END_TS_MS),
-                result.get(DB_ID).get(TABLE_ID));
+        Assertions.assertEquals(ImmutableMap.of(DB_ID, ImmutableList.of(TABLE_ID)), result.getDbToTableIds());
+        Assertions.assertNull(result.getMaxEndTimestampMs());
     }
 
     @Test
-    public void testCollectDbToTableEndTSOMergesMaxEndTimestamp() {
+    public void testCollectChangeReadInfoMergesMaximumEndTimestamp() {
         String endTimestamp1 = "2024-01-01 00:00:00";
         String endTimestamp2 = "2024-01-02 00:00:00";
         Plan plan = new LogicalJoin<>(
@@ -76,67 +79,123 @@ public class TimeBasedChangeVisibleWaiterTest {
                 null);
         OlapTable table = mockOlapTable(DB_ID, TABLE_ID);
 
-        Map<Long, Map<Long, Long>> result = TimeBasedChangeVisibleWaiter.collectDbToTableEndTSO(
-                mockContext(), plan, ImmutableMap.of(TABLE_QUALIFIER, table), DEFAULT_END_TS_MS);
+        TimeBasedChangeVisibleWaiter.ChangeReadInfo result = TimeBasedChangeVisibleWaiter.collectChangeReadInfo(
+                mockContext(), plan, ImmutableMap.of(TABLE_QUALIFIER, table));
 
-        Assertions.assertEquals(
-                TSOTimestamp.composeFullTimestamp(OlapScanNode.parseChangeTimestamp(endTimestamp2)),
-                result.get(DB_ID).get(TABLE_ID));
+        Assertions.assertEquals(ImmutableList.of(TABLE_ID), result.getDbToTableIds().get(DB_ID));
+        Assertions.assertEquals(OlapScanNode.parseChangeTimestamp(endTimestamp2), result.getMaxEndTimestampMs());
     }
 
     @Test
-    public void testWaitForVisibleWaitsMatchedCommittedTransactionOnce() throws Exception {
-        ConnectContext context = mockContext();
-        OlapTable table = mockOlapTable(DB_ID, TABLE_ID);
-        TransactionState txn = mockCommittedTxn();
+    public void testFenceCapturesTsoBeforeTransactionWatermark() throws Exception {
+        Env env = mockMasterEnv();
+        TSOService tsoService = mockTsoService(env, CURRENT_TSO);
         GlobalTransactionMgrIface txnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
-        Mockito.when(txnMgr.getCommittedTransactions(DB_ID)).thenReturn(ImmutableList.of(txn));
-
-        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
-            mockedEnv.when(Env::getCurrentGlobalTransactionMgr).thenReturn(txnMgr);
-
-            TimeBasedChangeVisibleWaiter.waitForVisible(context, newChangeRelation(1, ImmutableMap.of()),
-                    ImmutableMap.of(TABLE_QUALIFIER, table));
-        }
-
-        Mockito.verify(txnMgr, Mockito.times(1)).getCommittedTransactions(DB_ID);
-        Mockito.verify(txn, Mockito.times(1)).waitTransactionVisible(Mockito.anyLong());
-    }
-
-    @Test
-    public void testCloudWaitForVisibleUsesTransactionIdWatermark() throws Exception {
-        ConnectContext context = mockContext();
-        OlapTable table = mockOlapTable(DB_ID, TABLE_ID);
-        GlobalTransactionMgrIface txnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
-        long currentMaxTxnId = 300L;
-        long txnIdWatermark = currentMaxTxnId + 1;
-        Mockito.when(txnMgr.getNextTransactionId()).thenReturn(currentMaxTxnId);
+        long txnIdWatermark = 301L;
+        Mockito.when(txnMgr.getTransactionIdWatermark()).thenReturn(txnIdWatermark);
         Mockito.when(txnMgr.isPreviousTransactionsFinished(
                 txnIdWatermark, DB_ID, ImmutableList.of(TABLE_ID))).thenReturn(false, true);
 
         try (MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class);
                 MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
             mockedConfig.when(Config::isCloudMode).thenReturn(true);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
             mockedEnv.when(Env::getCurrentGlobalTransactionMgr).thenReturn(txnMgr);
 
-            TimeBasedChangeVisibleWaiter.waitForVisible(context, newChangeRelation(1, ImmutableMap.of()),
-                    ImmutableMap.of(TABLE_QUALIFIER, table));
+            TimeBasedChangeVisibleWaiter.ChangeReadFence fence =
+                    TimeBasedChangeVisibleWaiter.acquireFenceOnMaster(
+                            ImmutableMap.of(DB_ID, ImmutableList.of(TABLE_ID)),
+                            CURRENT_PHYSICAL_TIME_MS, 1000L, true);
+
+            Assertions.assertEquals(CURRENT_TSO, fence.getCurrentTso());
         }
 
-        Mockito.verify(txnMgr, Mockito.times(1)).getNextTransactionId();
+        InOrder inOrder = Mockito.inOrder(tsoService, txnMgr);
+        inOrder.verify(tsoService).getStatusSnapshot();
+        inOrder.verify(txnMgr).getTransactionIdWatermark();
         Mockito.verify(txnMgr, Mockito.times(2)).isPreviousTransactionsFinished(
                 txnIdWatermark, DB_ID, ImmutableList.of(TABLE_ID));
-        Mockito.verify(txnMgr, Mockito.never()).getCommittedTransactions(Mockito.anyLong());
     }
 
     @Test
-    public void testCloudWaitForVisibleFailsWhenConflictCheckFails() throws Exception {
-        ConnectContext context = mockContext();
-        OlapTable table = mockOlapTable(DB_ID, TABLE_ID);
+    public void testFenceAcceptsCurrentTsoPhysicalTime() throws Exception {
+        Env env = mockMasterEnv();
+        mockTsoService(env, CURRENT_TSO);
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+
+            TimeBasedChangeVisibleWaiter.ChangeReadFence fence =
+                    TimeBasedChangeVisibleWaiter.acquireFenceOnMaster(
+                            ImmutableMap.of(DB_ID, ImmutableList.of(TABLE_ID)),
+                            CURRENT_PHYSICAL_TIME_MS, 1000L, false);
+
+            Assertions.assertEquals(CURRENT_TSO, fence.getCurrentTso());
+        }
+    }
+
+    @Test
+    public void testFenceRejectsEndAfterCurrentTsoBeforeWatermark() throws Exception {
+        Env env = mockMasterEnv();
+        mockTsoService(env, CURRENT_TSO);
         GlobalTransactionMgrIface txnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
-        long currentMaxTxnId = 300L;
-        long txnIdWatermark = currentMaxTxnId + 1;
-        Mockito.when(txnMgr.getNextTransactionId()).thenReturn(currentMaxTxnId);
+
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            mockedEnv.when(Env::getCurrentGlobalTransactionMgr).thenReturn(txnMgr);
+
+            UserException exception = Assertions.assertThrows(UserException.class,
+                    () -> TimeBasedChangeVisibleWaiter.acquireFenceOnMaster(
+                            ImmutableMap.of(DB_ID, ImmutableList.of(TABLE_ID)),
+                            CURRENT_PHYSICAL_TIME_MS + 1, 1000L, true));
+
+            Assertions.assertTrue(exception.getDetailMessage().contains(
+                    "CURRENT_TSO_PHYSICAL_TIME=" + CURRENT_PHYSICAL_TIME_MS));
+        }
+
+        Mockito.verify(txnMgr, Mockito.never()).getTransactionIdWatermark();
+    }
+
+    @Test
+    public void testClassicFenceWaitsWatermarkAndSynchronizesPublisherLock() throws Exception {
+        Env env = mockMasterEnv();
+        mockTsoService(env, CURRENT_TSO);
+        GlobalTransactionMgrIface txnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+        long txnIdWatermark = 300L;
+        Mockito.when(txnMgr.getTransactionIdWatermark()).thenReturn(txnIdWatermark);
+        Mockito.when(txnMgr.isPreviousTransactionsFinished(
+                txnIdWatermark, DB_ID, ImmutableList.of(TABLE_ID))).thenReturn(true);
+        InternalCatalog catalog = Mockito.mock(InternalCatalog.class);
+        Database database = Mockito.mock(Database.class);
+        Table table = Mockito.mock(Table.class);
+        Mockito.when(catalog.getDbOrMetaException(DB_ID)).thenReturn(database);
+        Mockito.when(database.getTablesOnIdOrderIfExist(ImmutableList.of(TABLE_ID)))
+                .thenReturn(ImmutableList.of(table));
+        Mockito.when(table.tryReadLock(Mockito.anyLong(), Mockito.eq(TimeUnit.MILLISECONDS))).thenReturn(true);
+
+        try (MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class);
+                MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            mockedConfig.when(Config::isCloudMode).thenReturn(false);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            mockedEnv.when(Env::getCurrentGlobalTransactionMgr).thenReturn(txnMgr);
+            mockedEnv.when(Env::getCurrentInternalCatalog).thenReturn(catalog);
+
+            TimeBasedChangeVisibleWaiter.acquireFenceOnMaster(
+                    ImmutableMap.of(DB_ID, ImmutableList.of(TABLE_ID)), null, 1000L, true);
+        }
+
+        Mockito.verify(txnMgr).getTransactionIdWatermark();
+        Mockito.verify(table).tryReadLock(Mockito.anyLong(), Mockito.eq(TimeUnit.MILLISECONDS));
+        Mockito.verify(table).readUnlock();
+    }
+
+    @Test
+    public void testFenceFailsWhenConflictCheckFails() throws Exception {
+        Env env = mockMasterEnv();
+        mockTsoService(env, CURRENT_TSO);
+        GlobalTransactionMgrIface txnMgr = Mockito.mock(GlobalTransactionMgrIface.class);
+        long txnIdWatermark = 301L;
+        Mockito.when(txnMgr.getTransactionIdWatermark()).thenReturn(txnIdWatermark);
         Mockito.when(txnMgr.isPreviousTransactionsFinished(
                 txnIdWatermark, DB_ID, ImmutableList.of(TABLE_ID)))
                 .thenThrow(new AnalysisException("check transaction conflict failed"));
@@ -144,13 +203,13 @@ public class TimeBasedChangeVisibleWaiterTest {
         try (MockedStatic<Config> mockedConfig = Mockito.mockStatic(Config.class);
                 MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
             mockedConfig.when(Config::isCloudMode).thenReturn(true);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
             mockedEnv.when(Env::getCurrentGlobalTransactionMgr).thenReturn(txnMgr);
 
             UserException exception = Assertions.assertThrows(UserException.class,
-                    () -> TimeBasedChangeVisibleWaiter.waitForVisible(
-                            context, newChangeRelation(1, ImmutableMap.of()),
-                            ImmutableMap.of(TABLE_QUALIFIER, table)));
-            Assertions.assertTrue(exception.getMessage().contains("check previous transactions failed"));
+                    () -> TimeBasedChangeVisibleWaiter.acquireFenceOnMaster(
+                            ImmutableMap.of(DB_ID, ImmutableList.of(TABLE_ID)), null, 1000L, true));
+            Assertions.assertTrue(exception.getDetailMessage().contains("check previous transactions failed"));
         }
     }
 
@@ -160,6 +219,21 @@ public class TimeBasedChangeVisibleWaiterTest {
         sessionVariable.setChangeVisibleTimeoutMs(1000);
         Mockito.when(context.getSessionVariable()).thenReturn(sessionVariable);
         return context;
+    }
+
+    private Env mockMasterEnv() {
+        Env env = Mockito.mock(Env.class);
+        Mockito.when(env.isMaster()).thenReturn(true);
+        Mockito.when(env.getMaxJournalId()).thenReturn(123L);
+        return env;
+    }
+
+    private TSOService mockTsoService(Env env, long currentTso) {
+        TSOService tsoService = Mockito.mock(TSOService.class);
+        Mockito.when(tsoService.getStatusSnapshot()).thenReturn(
+                new TSOService.TSOStatusSnapshot(true, currentTso, CURRENT_PHYSICAL_TIME_MS + 1000));
+        Mockito.when(env.getTSOService()).thenReturn(tsoService);
+        return tsoService;
     }
 
     private UnboundRelation newChangeRelation(int relationId, Map<String, String> mapParams) {
@@ -177,18 +251,5 @@ public class TimeBasedChangeVisibleWaiterTest {
         Mockito.when(table.getDatabase()).thenReturn(database);
         Mockito.when(table.getId()).thenReturn(tableId);
         return table;
-    }
-
-    private TransactionState mockCommittedTxn() throws Exception {
-        AtomicReference<TransactionStatus> status = new AtomicReference<>(TransactionStatus.COMMITTED);
-        TransactionState txn = Mockito.mock(TransactionState.class);
-        Mockito.when(txn.getTransactionStatus()).thenAnswer(invocation -> status.get());
-        Mockito.when(txn.getTableIdList()).thenReturn(ImmutableList.of(TABLE_ID));
-        Mockito.when(txn.getCommitTSO()).thenReturn(TSOTimestamp.composeFullTimestamp(1L));
-        Mockito.doAnswer(invocation -> {
-            status.set(TransactionStatus.VISIBLE);
-            return null;
-        }).when(txn).waitTransactionVisible(Mockito.anyLong());
-        return txn;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/transaction/TransactionIdGeneratorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/transaction/TransactionIdGeneratorTest.java
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.transaction;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TransactionIdGeneratorTest {
+    @Test
+    public void testGetCurrentTransactionIdDoesNotAllocateId() {
+        TransactionIdGenerator generator = new TransactionIdGenerator();
+        generator.initTransactionId(1000L);
+
+        Assert.assertEquals(1000L, generator.getCurrentTransactionId());
+        Assert.assertEquals(1000L, generator.getCurrentTransactionId());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/transaction/TransactionIdGeneratorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/transaction/TransactionIdGeneratorTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.doris.transaction;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TransactionIdGeneratorTest {
     @Test
@@ -26,7 +26,7 @@ public class TransactionIdGeneratorTest {
         TransactionIdGenerator generator = new TransactionIdGenerator();
         generator.initTransactionId(1000L);
 
-        Assert.assertEquals(1000L, generator.getCurrentTransactionId());
-        Assert.assertEquals(1000L, generator.getCurrentTransactionId());
+        Assertions.assertEquals(1000L, generator.getCurrentTransactionId());
+        Assertions.assertEquals(1000L, generator.getCurrentTransactionId());
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/tso/TSOTimestampTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/tso/TSOTimestampTest.java
@@ -59,6 +59,16 @@ public class TSOTimestampTest {
     }
 
     @Test
+    public void testComposePhysicalTimestampUsesZeroLogicalCounter() {
+        long physicalTime = 1625097600000L;
+
+        long composed = TSOTimestamp.composePhysicalTimestamp(physicalTime);
+
+        Assert.assertEquals(physicalTime, TSOTimestamp.extractPhysicalTime(composed));
+        Assert.assertEquals(0L, TSOTimestamp.extractLogicalCounter(composed));
+    }
+
+    @Test
     public void testBitWidthLimitations() {
         // Test that values are properly masked to fit in their respective bit widths
         long largePhysicalTime = (1L << 46) + 1000L; // Larger than 46 bits

--- a/fe/fe-core/src/test/java/org/apache/doris/tso/TSOTimestampTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/tso/TSOTimestampTest.java
@@ -19,7 +19,6 @@ package org.apache.doris.tso;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -65,8 +64,8 @@ public class TSOTimestampTest {
 
         long composed = TSOTimestamp.composePhysicalTimestamp(physicalTime);
 
-        Assertions.assertEquals(physicalTime, TSOTimestamp.extractPhysicalTime(composed));
-        Assertions.assertEquals(0L, TSOTimestamp.extractLogicalCounter(composed));
+        org.junit.jupiter.api.Assertions.assertEquals(physicalTime, TSOTimestamp.extractPhysicalTime(composed));
+        org.junit.jupiter.api.Assertions.assertEquals(0L, TSOTimestamp.extractLogicalCounter(composed));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/tso/TSOTimestampTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/tso/TSOTimestampTest.java
@@ -19,6 +19,7 @@ package org.apache.doris.tso;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -64,8 +65,8 @@ public class TSOTimestampTest {
 
         long composed = TSOTimestamp.composePhysicalTimestamp(physicalTime);
 
-        Assert.assertEquals(physicalTime, TSOTimestamp.extractPhysicalTime(composed));
-        Assert.assertEquals(0L, TSOTimestamp.extractLogicalCounter(composed));
+        Assertions.assertEquals(physicalTime, TSOTimestamp.extractPhysicalTime(composed));
+        Assertions.assertEquals(0L, TSOTimestamp.extractLogicalCounter(composed));
     }
 
     @Test

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1980,6 +1980,22 @@ struct TSyncCloudTabletStatsRequest {
     1: optional binary tablet_stats_pb
 }
 
+// Establishes a closed upper bound for a time-based incremental read. The master FE
+// captures its current TSO before the transaction watermark and waits for transactions
+// involving the requested tables when wait_for_transactions is true.
+struct TAcquireTimeBasedChangeReadFenceRequest {
+    1: required map<i64, list<i64>> db_to_table_ids
+    2: optional i64 end_timestamp_ms
+    3: required i64 timeout_ms
+    4: required bool wait_for_transactions
+}
+
+struct TAcquireTimeBasedChangeReadFenceResult {
+    1: required Status.TStatus status
+    2: optional i64 current_tso
+    3: optional i64 max_journal_id
+}
+
 service FrontendService {
     TGetDbsResult getDbNames(1: TGetDbsParams params)
     TGetTablesResult getTableNames(1: TGetTablesParams params)
@@ -2037,6 +2053,9 @@ service FrontendService {
     TInitExternalCtlMetaResult initExternalCtlMeta(1: TInitExternalCtlMetaRequest request)
 
     TFetchSchemaTableDataResult fetchSchemaTableData(1: TFetchSchemaTableDataRequest request)
+
+    TAcquireTimeBasedChangeReadFenceResult acquireTimeBasedChangeReadFence(
+        1: TAcquireTimeBasedChangeReadFenceRequest request)
 
     TMySqlLoadAcquireTokenResult acquireToken()
 

--- a/regression-test/suites/row_binlog_p0/test_binlog_changes_syntax.groovy
+++ b/regression-test/suites/row_binlog_p0/test_binlog_changes_syntax.groovy
@@ -161,14 +161,30 @@ suite("test_binlog_changes_syntax", "nonConcurrent") {
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
         """
 
-        //  - far-past start + far-future end: equivalent to full binlog.
+        //  - CURRENT_TSO_PHYSICAL_TIME converted to an INCR timestamp is accepted.
+        sleep(1200)
+        def currentTsoPhysicalTime = Long.parseLong(sql("""
+            SELECT CURRENT_TSO_PHYSICAL_TIME FROM information_schema.tso_status
+        """)[0][0].toString())
+        def currentTsoEnd = incrTimeFormat.format(new Date(currentTsoPhysicalTime))
         order_qt_dup_full_cover """
             SELECT id, v1, __DORIS_BINLOG_OP__
             FROM ${dupTable}@incr('startTimestamp' = '1971-01-01 00:00:00',
-                "endTimestamp" = "2999-01-01 00:00:00",
+                "endTimestamp" = "${currentTsoEnd}",
                 "incrementType" = "DETAIL")
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
         """
+
+        //  - a future end cannot be closed safely and must be rejected.
+        test {
+            sql """
+                SELECT id, v1, __DORIS_BINLOG_OP__
+                FROM ${dupTable}@incr('startTimestamp' = '1971-01-01 00:00:00',
+                    "endTimestamp" = "2999-01-01 00:00:00",
+                    "incrementType" = "DETAIL")
+            """
+            exception "CURRENT_TSO_PHYSICAL_TIME="
+        }
 
         // 1.8 Cross-check against binlog() TVF — DETAIL with full window must
         //     return the same rowset as the underlying binlog TVF for a dup
@@ -394,14 +410,31 @@ suite("test_binlog_changes_syntax", "nonConcurrent") {
                 "incrementType" = "MIN_DELTA")
         """
 
-        // 2.9 Far-past + far-future window covers everything.
+        // 2.9 CURRENT_TSO_PHYSICAL_TIME converted to an INCR timestamp covers
+        //     all changes that were visible before it was captured.
+        sleep(1200)
+        def mowCurrentTsoPhysicalTime = Long.parseLong(sql("""
+            SELECT CURRENT_TSO_PHYSICAL_TIME FROM information_schema.tso_status
+        """)[0][0].toString())
+        def mowCurrentTsoEnd = incrTimeFormat.format(new Date(mowCurrentTsoPhysicalTime))
         order_qt_mow_full_cover """
             SELECT id, v1, __DORIS_BINLOG_OP__
             FROM ${mowTable}@incr('startTimestamp' = '1971-01-01 00:00:00',
-                "endTimestamp" = "2999-01-01 00:00:00",
+                "endTimestamp" = "${mowCurrentTsoEnd}",
                 "incrementType" = "DETAIL")
             ORDER BY __DORIS_BINLOG_TSO__, __DORIS_BINLOG_LSN__
         """
+
+        // A future end cannot be closed safely and must be rejected.
+        test {
+            sql """
+                SELECT id, v1, __DORIS_BINLOG_OP__
+                FROM ${mowTable}@incr('startTimestamp' = '1971-01-01 00:00:00',
+                    "endTimestamp" = "2999-01-01 00:00:00",
+                    "incrementType" = "DETAIL")
+            """
+            exception "endTimestamp exceeds the maximum supported time for an INCR read"
+        }
 
         // ============================================================
         // 3. MoW table with sequence column.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #65850

Problem Summary:

Time-based `@incr` reads previously allowed an `endTimestamp` later than the FE's current TSO. Such a future boundary cannot be closed by the transaction waiting logic: a transaction may start after the request begins but still fall before that future boundary, so the scan cannot guarantee a complete result.

In addition, waiting only for currently running transactions is insufficient unless the TSO boundary, transaction watermark, transaction visibility, and table visible versions are coordinated under one authoritative fence. Otherwise, especially on a follower FE, a transaction can already be `VISIBLE` while the local catalog still exposes an older visible version, causing the incremental scan to miss rows.

This PR establishes a safe read fence for both classic and cloud modes:

1. Acquire the current TSO from the master FE.
2. Capture the transaction ID watermark after the TSO snapshot.
3. Wait for transactions at or below the watermark that involve the scanned OLAP tables to reach a final visible or aborted state.
4. In classic mode, synchronize table publishers and wait for follower journal replay so catalog visible versions cross the same fence.
5. In cloud mode, refresh the latest visible versions from MetaService after the transaction wait.
6. Reject an `endTimestamp` later than the captured `CURRENT_TSO_PHYSICAL_TIME`.
7. Convert a physical timestamp `P` to TSO boundary `(P, 0)`, preserving half-open range semantics: `[startTimestamp, endTimestamp)`.

#### Future endTimestamp error example

Request:

```sql
SELECT id, value, __DORIS_BINLOG_OP__
FROM example_table@incr(
    "startTimestamp" = "2026-09-01 00:00:00",
    "endTimestamp" = "2999-01-01 00:00:00",
    "incrementType" = "DETAIL"
);
```

Response:

```text
ERROR 1105 (HY000): errCode = 2, detailMessage =
endTimestamp exceeds the maximum supported time for an INCR read:
requestedEndTimestampMs=<requested epoch milliseconds>,
CURRENT_TSO_PHYSICAL_TIME=<maximum supported epoch milliseconds>
```

The maximum currently supported boundary can be obtained from:

```sql
SELECT CURRENT_TSO_PHYSICAL_TIME
FROM information_schema.tso_status;
```

### Release note

Time-based `@incr` reads now reject `endTimestamp` values after `CURRENT_TSO_PHYSICAL_TIME`. Timestamp ranges use half-open semantics `[startTimestamp, endTimestamp)`, with each physical timestamp mapped to logical counter zero.

### Check List (For Author)

- Test: FE unit tests, FE and BE builds, and `row_binlog_p0/test_binlog_changes_syntax` regression test
- Behavior changed: Yes
    - Future `endTimestamp` values are rejected with the maximum supported TSO physical time in the error message.
    - Physical timestamp boundaries are interpreted as `(physicalTime, 0)`.
- Does this need documentation: No
