### PR TITLE
branch-4.1: [fix](fe) Restore rollup show state after metadata reload #65869

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/alter/RollupJobV2.java
@@ -905,12 +905,13 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
 
     @Override
     public void gsonPostProcess() throws IOException {
+        showJobState = jobState;
+
         // analyze define stmt
         if (origStmt == null) {
             return;
         }
 
-        showJobState = jobState;
         if (jobState != JobState.PENDING) {
             return;
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/alter/RollupJobV2Test.java
@@ -45,6 +45,7 @@ import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.info.TableNameInfo;
 import org.apache.doris.meta.MetaContext;
 import org.apache.doris.nereids.trees.plans.commands.CancelAlterTableCommand;
+import org.apache.doris.persist.gson.GsonUtils;
 import org.apache.doris.qe.OriginStatement;
 import org.apache.doris.task.AgentTask;
 import org.apache.doris.task.AgentTaskQueue;
@@ -359,6 +360,42 @@ public class RollupJobV2Test {
         Column resultColumn1 = resultColumns.get(0);
         Assert.assertEquals(mvColumnName,
                 resultColumn1.getName());
+    }
+
+    @Test
+    public void testDeserializeOldRollupJobWithoutOrigStmt() {
+        String oldJson = "{"
+                + "\"clazz\":\"RollupJobV2\","
+                + "\"type\":\"ROLLUP\","
+                + "\"jobId\":1,"
+                + "\"jobState\":\"FINISHED\","
+                + "\"dbId\":1,"
+                + "\"tableId\":1,"
+                + "\"tableName\":\"test\","
+                + "\"errMsg\":\"\","
+                + "\"createTimeMs\":1,"
+                + "\"finishedTimeMs\":2,"
+                + "\"timeoutMs\":3,"
+                + "\"rawSql\":\"\","
+                + "\"watershedTxnId\":4,"
+                + "\"failedTabletBackends\":{},"
+                + "\"partitionIdToBaseRollupTabletIdMap\":{},"
+                + "\"partitionIdToRollupIndex\":{},"
+                + "\"baseIndexId\":1,"
+                + "\"rollupIndexId\":2,"
+                + "\"baseIndexName\":\"base\","
+                + "\"rollupIndexName\":\"rollup\","
+                + "\"rollupSchema\":[],"
+                + "\"baseSchemaHash\":1,"
+                + "\"rollupSchemaHash\":2,"
+                + "\"rollupKeysType\":\"AGG_KEYS\","
+                + "\"rollupShortKeyColumnCount\":1,"
+                + "\"storageFormat\":\"V2\","
+                + "\"sv\":{}"
+                + "}";
+
+        RollupJobV2 result = (RollupJobV2) GsonUtils.GSON.fromJson(oldJson, AlterJobV2.class);
+        Assert.assertEquals(JobState.FINISHED, Deencapsulation.getField(result, "showJobState"));
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #65869

Problem Summary: Backport #65869 to the `branch-4.1`.

`showJobState` is not persisted. For rollup jobs created without `origStmt`, metadata reload returned before reconstructing it, so SHOW ALTER TABLE ROLLUP/MATERIALIZED VIEW could dereference a null state. This restores `showJobState` before the legacy early return and adds deserialization coverage.

The conflict was limited to branch-specific test imports; the backport preserves the branch imports and adds only the required `GsonUtils` dependency.

### Release note

Restore rollup display state after metadata reload when the persisted job has no original statement.

### Check List (For Author)

- Test: Static validation
    - Changed-file scope and source provenance verified
    - `git diff --check`: passed
    - Focused FE unit test was not run locally; hosted CI is pending
- Behavior changed: Yes
    - Reconstructs non-persisted rollup display state before the legacy early return
- Does this need documentation: No