### PR TITLE
branch-3.1: [fix](compaction) Avoid repeatedly compacting large cumulative rowset #64954 #65470

### DIFF
--- a/be/src/cloud/cloud_cumulative_compaction_policy.cpp
+++ b/be/src/cloud/cloud_cumulative_compaction_policy.cpp
@@ -18,6 +18,7 @@
 #include "cloud/cloud_cumulative_compaction_policy.h"
 
 #include <algorithm>
+#include <iterator>
 #include <list>
 #include <ostream>
 #include <string>
@@ -153,10 +154,6 @@ int64_t CloudSizeBasedCumulativeCompactionPolicy::pick_input_rowsets(
         input_rowsets->push_back(rowset);
     }
 
-    if (total_size >= promotion_size) {
-        return transient_size;
-    }
-
     // if there is delete version, do compaction directly
     if (last_delete_version->first != -1) {
         if (input_rowsets->size() == 1) {
@@ -191,6 +188,9 @@ int64_t CloudSizeBasedCumulativeCompactionPolicy::pick_input_rowsets(
 
     auto rs_begin = input_rowsets->begin();
     size_t new_compaction_score = *compaction_score;
+    const bool can_handle_exhausted_input =
+            (config::prioritize_query_perf_in_compaction && tablet->keys_type() != DUP_KEYS) ||
+            *compaction_score >= static_cast<size_t>(max_compaction_score);
     while (rs_begin != input_rowsets->end()) {
         auto& rs_meta = (*rs_begin)->rowset_meta();
         int64_t current_level = _level_size(rs_meta->total_disk_size());
@@ -200,9 +200,16 @@ int64_t CloudSizeBasedCumulativeCompactionPolicy::pick_input_rowsets(
         if (current_level <= remain_level) {
             break;
         }
+
+        auto next = std::next(rs_begin);
+        // Keep the last suffix rowset for the singleton checks unless the exhausted-input
+        // fallback below can select a useful input.
+        if (next == input_rowsets->end() && !can_handle_exhausted_input) {
+            break;
+        }
         total_size -= rs_meta->total_disk_size();
         new_compaction_score -= rs_meta->get_compaction_score();
-        ++rs_begin;
+        rs_begin = next;
     }
     if (rs_begin == input_rowsets->end()) { // No suitable level size found in `input_rowsets`
         if (config::prioritize_query_perf_in_compaction && tablet->keys_type() != DUP_KEYS) {

--- a/be/src/olap/cumulative_compaction_policy.cpp
+++ b/be/src/olap/cumulative_compaction_policy.cpp
@@ -18,6 +18,7 @@
 #include "olap/cumulative_compaction_policy.h"
 
 #include <algorithm>
+#include <iterator>
 #include <list>
 #include <ostream>
 #include <string>
@@ -303,10 +304,6 @@ int SizeBasedCumulativeCompactionPolicy::pick_input_rowsets(
     DBUG_EXECUTE_IF("SizeBaseCumulativeCompactionPolicy.pick_input_rowsets.return_input_rowsets",
                     { return transient_size; })
 
-    if (total_size >= promotion_size) {
-        return transient_size;
-    }
-
     // if there is delete version, do compaction directly
     if (last_delete_version->first != -1) {
         if (input_rowsets->size() == 1) {
@@ -323,6 +320,8 @@ int SizeBasedCumulativeCompactionPolicy::pick_input_rowsets(
 
     auto rs_begin = input_rowsets->begin();
     size_t new_compaction_score = *compaction_score;
+    const bool can_handle_exhausted_input =
+            *compaction_score >= static_cast<size_t>(max_compaction_score);
     while (rs_begin != input_rowsets->end()) {
         auto& rs_meta = (*rs_begin)->rowset_meta();
         int current_level = _level_size(rs_meta->total_disk_size());
@@ -332,9 +331,16 @@ int SizeBasedCumulativeCompactionPolicy::pick_input_rowsets(
         if (current_level <= remain_level) {
             break;
         }
+
+        auto next = std::next(rs_begin);
+        // Keep the last suffix rowset for the singleton checks unless the exhausted-input
+        // fallback below can select a useful input.
+        if (next == input_rowsets->end() && !can_handle_exhausted_input) {
+            break;
+        }
         total_size -= rs_meta->total_disk_size();
         new_compaction_score -= rs_meta->get_compaction_score();
-        ++rs_begin;
+        rs_begin = next;
     }
     if (rs_begin == input_rowsets->end() && *compaction_score >= max_compaction_score) {
         // No suitable level size found in `input_rowsets` but score of `input_rowsets` exceed max compaction score,

--- a/be/test/cloud/cloud_cumulative_compaction_policy_test.cpp
+++ b/be/test/cloud/cloud_cumulative_compaction_policy_test.cpp
@@ -32,6 +32,9 @@
 
 namespace doris {
 
+static constexpr int64_t kMiB = 1024L * 1024;
+static constexpr int64_t kGiB = 1024L * kMiB;
+
 class TestCloudSizeBasedCumulativeCompactionPolicy : public testing::Test {
 public:
     TestCloudSizeBasedCumulativeCompactionPolicy() : _engine(CloudStorageEngine({})) {}
@@ -113,7 +116,7 @@ private:
 };
 
 static RowsetSharedPtr create_rowset(Version version, int num_segments, bool overlapping,
-                                     int data_size) {
+                                     int64_t data_size) {
     auto rs_meta = std::make_shared<RowsetMeta>();
     rs_meta->set_rowset_type(BETA_ROWSET); // important
     rs_meta->_rowset_meta_pb.set_start_version(version.first);
@@ -127,6 +130,14 @@ static RowsetSharedPtr create_rowset(Version version, int num_segments, bool ove
         return nullptr;
     }
     return rowset;
+}
+
+static int64_t total_disk_size(const std::vector<RowsetSharedPtr>& rowsets) {
+    int64_t total_size = 0;
+    for (const auto& rowset : rowsets) {
+        total_size += rowset->total_disk_size();
+    }
+    return total_size;
 }
 
 TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy, new_cumulative_point) {
@@ -145,4 +156,109 @@ TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy, new_cumulative_point) {
     Version version(1, 1);
     EXPECT_EQ(policy.new_cumulative_point(&_tablet, output_rowset, version, 2), 6);
 }
+TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_large_head_not_repeated_when_output_below_promotion) {
+    CloudTablet _tablet(_engine, _tablet_meta);
+    _tablet._base_size = 20L * kGiB;
+
+    std::vector<RowsetSharedPtr> candidate_rowsets;
+    auto large_head = create_rowset(Version(2, 2), 1, false, 1023L * kMiB);
+    candidate_rowsets.push_back(large_head);
+    for (int i = 0; i < 20; i++) {
+        candidate_rowsets.push_back(create_rowset(Version(i + 3, i + 3), 1, true, kMiB));
+    }
+    ASSERT_GT(total_disk_size(candidate_rowsets), kGiB);
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+
+    CloudSizeBasedCumulativeCompactionPolicy policy;
+    policy.pick_input_rowsets(&_tablet, candidate_rowsets, 100, 5, &input_rowsets,
+                              &last_delete_version, &compaction_score, true);
+
+    EXPECT_EQ(20, input_rowsets.size());
+    EXPECT_EQ(20, compaction_score);
+    EXPECT_EQ(3, input_rowsets.front()->start_version());
+    EXPECT_EQ(22, input_rowsets.back()->end_version());
+    EXPECT_LT(total_disk_size(input_rowsets), kGiB);
+
+    auto output_rowset = create_rowset(Version(3, 22), 1, false, 20L * kMiB);
+    EXPECT_EQ(2, policy.new_cumulative_point(&_tablet, output_rowset, last_delete_version, 2));
+
+    std::vector<RowsetSharedPtr> next_candidate_rowsets {large_head, output_rowset};
+    input_rowsets.clear();
+    compaction_score = 0;
+    policy.pick_input_rowsets(&_tablet, next_candidate_rowsets, 100, 5, &input_rowsets,
+                              &last_delete_version, &compaction_score, true);
+
+    EXPECT_TRUE(input_rowsets.empty());
+    EXPECT_EQ(0, compaction_score);
+}
+
+TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_large_head_single_overlapping_tail_selected) {
+    CloudTablet _tablet(_engine, _tablet_meta);
+    _tablet._base_size = 20L * kGiB;
+
+    std::vector<RowsetSharedPtr> candidate_rowsets {
+            create_rowset(Version(2, 2), 1, false, 900L * kMiB),
+            create_rowset(Version(3, 3), 5, true, 128L * kMiB)};
+    ASSERT_GT(total_disk_size(candidate_rowsets), kGiB);
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+
+    CloudSizeBasedCumulativeCompactionPolicy policy;
+    policy.pick_input_rowsets(&_tablet, candidate_rowsets, 100, 5, &input_rowsets,
+                              &last_delete_version, &compaction_score, true);
+
+    ASSERT_EQ(1, input_rowsets.size());
+    EXPECT_EQ(5, compaction_score);
+    EXPECT_EQ(3, input_rowsets.front()->start_version());
+    EXPECT_EQ(128L * kMiB, input_rowsets.front()->total_disk_size());
+}
+
+TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_single_overlapping_rowset_not_trimmed_empty) {
+    CloudTablet _tablet(_engine, _tablet_meta);
+    _tablet._base_size = 20L * kGiB;
+
+    std::vector<RowsetSharedPtr> candidate_rowsets {
+            create_rowset(Version(2, 2), 3, true, 2L * kGiB)};
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+
+    CloudSizeBasedCumulativeCompactionPolicy policy;
+    policy.pick_input_rowsets(&_tablet, candidate_rowsets, 100, 5, &input_rowsets,
+                              &last_delete_version, &compaction_score, true);
+
+    EXPECT_EQ(1, input_rowsets.size());
+    EXPECT_EQ(3, compaction_score);
+    EXPECT_EQ(2, input_rowsets.front()->start_version());
+}
+
+TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_single_non_overlapping_rowset_still_skipped) {
+    CloudTablet _tablet(_engine, _tablet_meta);
+    _tablet._base_size = 20L * kGiB;
+
+    std::vector<RowsetSharedPtr> candidate_rowsets {
+            create_rowset(Version(2, 2), 1, false, 2L * kGiB)};
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+
+    CloudSizeBasedCumulativeCompactionPolicy policy;
+    policy.pick_input_rowsets(&_tablet, candidate_rowsets, 100, 5, &input_rowsets,
+                              &last_delete_version, &compaction_score, true);
+
+    EXPECT_TRUE(input_rowsets.empty());
+    EXPECT_EQ(0, compaction_score);
+}
+
 } // namespace doris

--- a/be/test/cloud/cloud_cumulative_compaction_policy_test.cpp
+++ b/be/test/cloud/cloud_cumulative_compaction_policy_test.cpp
@@ -140,6 +140,21 @@ static int64_t total_disk_size(const std::vector<RowsetSharedPtr>& rowsets) {
     return total_size;
 }
 
+static std::vector<RowsetSharedPtr> create_max_score_trim_candidates(bool include_stranded_head) {
+    std::vector<RowsetSharedPtr> candidate_rowsets;
+    if (include_stranded_head) {
+        candidate_rowsets.push_back(create_rowset(Version(13, 56), 0, false, 0));
+    }
+    candidate_rowsets.push_back(create_rowset(Version(57, 57), 192, true, 256 * kMiB));
+    candidate_rowsets.push_back(create_rowset(Version(58, 58), 0, false, 0));
+    candidate_rowsets.push_back(create_rowset(Version(59, 59), 0, false, 0));
+    candidate_rowsets.push_back(create_rowset(Version(60, 60), 150, true, 256 * kMiB));
+    for (int64_t version = 61; version <= 67; ++version) {
+        candidate_rowsets.push_back(create_rowset(Version(version, version), 1, false, kMiB));
+    }
+    return candidate_rowsets;
+}
+
 TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy, new_cumulative_point) {
     std::vector<RowsetMetaSharedPtr> rs_metas;
     init_rs_meta_small_base(&rs_metas);
@@ -259,6 +274,46 @@ TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy,
 
     EXPECT_TRUE(input_rowsets.empty());
     EXPECT_EQ(0, compaction_score);
+}
+
+TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_preserves_successor_for_non_overlapping_singleton) {
+    CloudTablet tablet(_engine, _tablet_meta);
+    tablet._base_size = kGiB;
+    tablet._tablet_meta->_enable_unique_key_merge_on_write = true;
+    auto candidate_rowsets = create_max_score_trim_candidates(true);
+    ASSERT_EQ(12, candidate_rowsets.size());
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+    CloudSizeBasedCumulativeCompactionPolicy policy;
+    policy.pick_input_rowsets(&tablet, candidate_rowsets, 100, 5, &input_rowsets,
+                              &last_delete_version, &compaction_score, true);
+
+    ASSERT_EQ(2, input_rowsets.size());
+    EXPECT_EQ(Version(13, 56), input_rowsets[0]->version());
+    EXPECT_EQ(Version(57, 57), input_rowsets[1]->version());
+    EXPECT_GE(compaction_score, 192);
+}
+
+TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_keeps_single_overlapping_rowset_at_max_score) {
+    CloudTablet tablet(_engine, _tablet_meta);
+    tablet._base_size = kGiB;
+    auto candidate_rowsets = create_max_score_trim_candidates(false);
+    ASSERT_EQ(11, candidate_rowsets.size());
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+    CloudSizeBasedCumulativeCompactionPolicy policy;
+    policy.pick_input_rowsets(&tablet, candidate_rowsets, 100, 5, &input_rowsets,
+                              &last_delete_version, &compaction_score, true);
+
+    ASSERT_EQ(1, input_rowsets.size());
+    EXPECT_EQ(Version(57, 57), input_rowsets.front()->version());
+    EXPECT_EQ(192, compaction_score);
 }
 
 } // namespace doris

--- a/be/test/olap/cumulative_compaction_policy_test.cpp
+++ b/be/test/olap/cumulative_compaction_policy_test.cpp
@@ -26,6 +26,7 @@
 #include "json2pb/json_to_pb.h"
 #include "olap/cumulative_compaction.h"
 #include "olap/olap_common.h"
+#include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/rowset_meta.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet.h"
@@ -33,6 +34,9 @@
 #include "util/uid_util.h"
 
 namespace doris {
+
+static constexpr int64_t kMiB = 1024L * 1024;
+static constexpr int64_t kGiB = 1024L * kMiB;
 
 class TestSizeBasedCumulativeCompactionPolicy : public testing::Test {
 public:
@@ -736,6 +740,259 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, _level_size) {
     EXPECT_EQ(0, policy->_level_size(1000));
     EXPECT_EQ(1 << 20, policy->_level_size((1 << 20) + 100));
     EXPECT_EQ(1 << 19, policy->_level_size((1 << 20) - 100));
+}
+
+TEST_F(TestSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_large_head_not_repeated_when_output_below_promotion) {
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+
+    RowsetMetaSharedPtr base_rs(new RowsetMeta());
+    init_rs_meta(base_rs, 0, 1);
+    base_rs->set_total_disk_size(20L * kGiB);
+    base_rs->set_segments_overlap(NONOVERLAPPING);
+    rs_metas.push_back(base_rs);
+
+    RowsetMetaSharedPtr large_head(new RowsetMeta());
+    init_rs_meta(large_head, 2, 2);
+    large_head->set_total_disk_size(1023L * kMiB);
+    large_head->set_num_segments(1);
+    large_head->set_segments_overlap(NONOVERLAPPING);
+    rs_metas.push_back(large_head);
+
+    for (int i = 0; i < 20; i++) {
+        RowsetMetaSharedPtr ptr(new RowsetMeta());
+        init_rs_meta(ptr, i + 3, i + 3);
+        ptr->set_total_disk_size(kMiB);
+        ptr->set_num_segments(1);
+        ptr->set_segments_overlap(OVERLAPPING);
+        rs_metas.push_back(ptr);
+    }
+
+    for (auto& rowset : rs_metas) {
+        static_cast<void>(_tablet_meta->add_rs_meta(rowset));
+    }
+
+    TabletSharedPtr tablet(
+            new Tablet(_engine, _tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    static_cast<void>(tablet->init());
+    tablet->calculate_cumulative_point();
+    ASSERT_EQ(2, tablet->cumulative_layer_point());
+    ASSERT_EQ(kGiB, tablet->cumulative_promotion_size());
+
+    auto candidate_rowsets = tablet->pick_candidate_rowsets_to_cumulative_compaction();
+    ASSERT_EQ(21, candidate_rowsets.size());
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+    tablet->_cumulative_compaction_policy->pick_input_rowsets(
+            tablet.get(), candidate_rowsets, 100, 5, &input_rowsets, &last_delete_version,
+            &compaction_score, config::enable_delete_when_cumu_compaction);
+
+    EXPECT_EQ(20, input_rowsets.size());
+    EXPECT_EQ(20, compaction_score);
+    EXPECT_EQ(3, input_rowsets.front()->start_version());
+    EXPECT_EQ(22, input_rowsets.back()->end_version());
+
+    RowsetMetaSharedPtr output_meta(new RowsetMeta());
+    init_rs_meta(output_meta, 3, 22);
+    output_meta->set_total_disk_size(20L * kMiB);
+    output_meta->set_num_segments(1);
+    output_meta->set_segments_overlap(NONOVERLAPPING);
+    RowsetSharedPtr output_rowset;
+    ASSERT_TRUE(RowsetFactory::create_rowset(nullptr, "", output_meta, &output_rowset).ok());
+
+    tablet->_cumulative_compaction_policy->update_cumulative_point(
+            tablet.get(), input_rowsets, output_rowset, last_delete_version);
+    EXPECT_EQ(2, tablet->cumulative_layer_point());
+
+    std::vector<RowsetSharedPtr> next_candidate_rowsets {candidate_rowsets.front(), output_rowset};
+    input_rowsets.clear();
+    compaction_score = 0;
+    tablet->_cumulative_compaction_policy->pick_input_rowsets(
+            tablet.get(), next_candidate_rowsets, 100, 5, &input_rowsets, &last_delete_version,
+            &compaction_score, config::enable_delete_when_cumu_compaction);
+
+    EXPECT_TRUE(input_rowsets.empty());
+    EXPECT_EQ(0, compaction_score);
+}
+
+TEST_F(TestSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_large_head_single_overlapping_tail_selected) {
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+
+    RowsetMetaSharedPtr base_rs(new RowsetMeta());
+    init_rs_meta(base_rs, 0, 1);
+    base_rs->set_total_disk_size(20L * kGiB);
+    base_rs->set_segments_overlap(NONOVERLAPPING);
+    rs_metas.push_back(base_rs);
+
+    RowsetMetaSharedPtr large_head(new RowsetMeta());
+    init_rs_meta(large_head, 2, 2);
+    large_head->set_total_disk_size(900L * kMiB);
+    large_head->set_num_segments(1);
+    large_head->set_segments_overlap(NONOVERLAPPING);
+    rs_metas.push_back(large_head);
+
+    RowsetMetaSharedPtr tail(new RowsetMeta());
+    init_rs_meta(tail, 3, 3);
+    tail->set_total_disk_size(128L * kMiB);
+    tail->set_num_segments(5);
+    tail->set_segments_overlap(OVERLAPPING);
+    rs_metas.push_back(tail);
+
+    for (auto& rowset : rs_metas) {
+        static_cast<void>(_tablet_meta->add_rs_meta(rowset));
+    }
+
+    TabletSharedPtr tablet(
+            new Tablet(_engine, _tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    static_cast<void>(tablet->init());
+    tablet->calculate_cumulative_point();
+    ASSERT_EQ(2, tablet->cumulative_layer_point());
+    ASSERT_EQ(kGiB, tablet->cumulative_promotion_size());
+
+    auto candidate_rowsets = tablet->pick_candidate_rowsets_to_cumulative_compaction();
+    ASSERT_EQ(2, candidate_rowsets.size());
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+    tablet->_cumulative_compaction_policy->pick_input_rowsets(
+            tablet.get(), candidate_rowsets, 100, 5, &input_rowsets, &last_delete_version,
+            &compaction_score, config::enable_delete_when_cumu_compaction);
+
+    ASSERT_EQ(1, input_rowsets.size());
+    EXPECT_EQ(5, compaction_score);
+    EXPECT_EQ(3, input_rowsets.front()->start_version());
+    EXPECT_EQ(128L * kMiB, input_rowsets.front()->total_disk_size());
+}
+
+TEST_F(TestSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_single_overlapping_rowset_not_trimmed_empty) {
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+
+    RowsetMetaSharedPtr base_rs(new RowsetMeta());
+    init_rs_meta(base_rs, 0, 1);
+    base_rs->set_total_disk_size(20L * kGiB);
+    base_rs->set_segments_overlap(NONOVERLAPPING);
+    rs_metas.push_back(base_rs);
+
+    RowsetMetaSharedPtr ptr(new RowsetMeta());
+    init_rs_meta(ptr, 2, 2);
+    ptr->set_total_disk_size(2L * kGiB);
+    ptr->set_num_segments(3);
+    ptr->set_segments_overlap(OVERLAPPING);
+    rs_metas.push_back(ptr);
+
+    for (auto& rowset : rs_metas) {
+        static_cast<void>(_tablet_meta->add_rs_meta(rowset));
+    }
+
+    TabletSharedPtr tablet(
+            new Tablet(_engine, _tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    static_cast<void>(tablet->init());
+    tablet->calculate_cumulative_point();
+
+    auto candidate_rowsets = tablet->pick_candidate_rowsets_to_cumulative_compaction();
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+    tablet->_cumulative_compaction_policy->pick_input_rowsets(
+            tablet.get(), candidate_rowsets, 100, 5, &input_rowsets, &last_delete_version,
+            &compaction_score, config::enable_delete_when_cumu_compaction);
+
+    EXPECT_EQ(1, input_rowsets.size());
+    EXPECT_EQ(3, compaction_score);
+    EXPECT_EQ(2, input_rowsets.front()->start_version());
+}
+
+TEST_F(TestSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_single_non_overlapping_rowset_still_skipped) {
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+
+    RowsetMetaSharedPtr base_rs(new RowsetMeta());
+    init_rs_meta(base_rs, 0, 1);
+    base_rs->set_total_disk_size(20L * kGiB);
+    base_rs->set_segments_overlap(NONOVERLAPPING);
+    rs_metas.push_back(base_rs);
+
+    RowsetMetaSharedPtr ptr(new RowsetMeta());
+    init_rs_meta(ptr, 2, 2);
+    ptr->set_total_disk_size(2L * kGiB);
+    ptr->set_num_segments(1);
+    ptr->set_segments_overlap(NONOVERLAPPING);
+    rs_metas.push_back(ptr);
+
+    for (auto& rowset : rs_metas) {
+        static_cast<void>(_tablet_meta->add_rs_meta(rowset));
+    }
+
+    TabletSharedPtr tablet(
+            new Tablet(_engine, _tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    static_cast<void>(tablet->init());
+    tablet->calculate_cumulative_point();
+
+    std::vector<RowsetSharedPtr> candidate_rowsets;
+    RowsetSharedPtr rowset;
+    ASSERT_TRUE(RowsetFactory::create_rowset(nullptr, "", ptr, &rowset).ok());
+    candidate_rowsets.push_back(rowset);
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+    tablet->_cumulative_compaction_policy->pick_input_rowsets(
+            tablet.get(), candidate_rowsets, 100, 5, &input_rowsets, &last_delete_version,
+            &compaction_score, config::enable_delete_when_cumu_compaction);
+
+    EXPECT_TRUE(input_rowsets.empty());
+    EXPECT_EQ(0, compaction_score);
+}
+
+TEST_F(TestSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_keep_final_overlapping_below_max) {
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+
+    RowsetMetaSharedPtr base_rs(new RowsetMeta());
+    init_rs_meta(base_rs, 0, 1);
+    base_rs->set_total_disk_size(20L * kGiB);
+    base_rs->set_segments_overlap(NONOVERLAPPING);
+    rs_metas.push_back(base_rs);
+
+    RowsetMetaSharedPtr large_head(new RowsetMeta());
+    init_rs_meta(large_head, 2, 2);
+    large_head->set_total_disk_size(200L * kMiB);
+    large_head->set_num_segments(30);
+    large_head->set_segments_overlap(OVERLAPPING);
+    rs_metas.push_back(large_head);
+
+    RowsetMetaSharedPtr final_suffix(new RowsetMeta());
+    init_rs_meta(final_suffix, 3, 3);
+    final_suffix->set_total_disk_size(100L * kMiB);
+    final_suffix->set_num_segments(20);
+    final_suffix->set_segments_overlap(OVERLAPPING);
+    rs_metas.push_back(final_suffix);
+
+    for (auto& rowset : rs_metas) {
+        static_cast<void>(_tablet_meta->add_rs_meta(rowset));
+    }
+
+    TabletSharedPtr tablet(
+            new Tablet(_engine, _tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    static_cast<void>(tablet->init());
+    tablet->calculate_cumulative_point();
+
+    auto candidate_rowsets = tablet->pick_candidate_rowsets_to_cumulative_compaction();
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+    tablet->_cumulative_compaction_policy->pick_input_rowsets(
+            tablet.get(), candidate_rowsets, 100, 5, &input_rowsets, &last_delete_version,
+            &compaction_score, config::enable_delete_when_cumu_compaction);
+
+    ASSERT_EQ(1, input_rowsets.size());
+    EXPECT_EQ(20, compaction_score);
+    EXPECT_EQ(3, input_rowsets.front()->start_version());
 }
 
 } // namespace doris

--- a/be/test/olap/cumulative_compaction_policy_test.cpp
+++ b/be/test/olap/cumulative_compaction_policy_test.cpp
@@ -329,6 +329,32 @@ public:
         rs_metas->push_back(ptr5);
     }
 
+    std::vector<RowsetMetaSharedPtr> create_rs_meta_max_score_trim(bool include_stranded_head) {
+        std::vector<RowsetMetaSharedPtr> rs_metas;
+        auto add_rowset = [&](int64_t start_version, int64_t end_version, int num_segments,
+                              bool overlapping, int64_t total_disk_size) {
+            RowsetMetaSharedPtr rowset_meta(new RowsetMeta());
+            init_rs_meta(rowset_meta, start_version, end_version);
+            rowset_meta->set_num_segments(num_segments);
+            rowset_meta->set_segments_overlap(overlapping ? OVERLAPPING : NONOVERLAPPING);
+            rowset_meta->set_total_disk_size(total_disk_size);
+            rs_metas.push_back(rowset_meta);
+        };
+
+        add_rowset(0, include_stranded_head ? 12 : 56, 1, false, kGiB);
+        if (include_stranded_head) {
+            add_rowset(13, 56, 0, false, 0);
+        }
+        add_rowset(57, 57, 192, true, 256L * kMiB);
+        add_rowset(58, 58, 0, false, 0);
+        add_rowset(59, 59, 0, false, 0);
+        add_rowset(60, 60, 150, true, 256L * kMiB);
+        for (int64_t version = 61; version <= 67; ++version) {
+            add_rowset(version, version, 1, false, kMiB);
+        }
+        return rs_metas;
+    }
+
 protected:
     std::string _json_rowset_meta;
     TabletMetaSharedPtr _tablet_meta;
@@ -993,6 +1019,61 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy,
     ASSERT_EQ(1, input_rowsets.size());
     EXPECT_EQ(20, compaction_score);
     EXPECT_EQ(3, input_rowsets.front()->start_version());
+}
+
+TEST_F(TestSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_preserves_successor_for_non_overlapping_singleton) {
+    auto rs_metas = create_rs_meta_max_score_trim(true);
+    for (auto& rowset : rs_metas) {
+        static_cast<void>(_tablet_meta->add_rs_meta(rowset));
+    }
+
+    TabletSharedPtr tablet(
+            new Tablet(_engine, _tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    static_cast<void>(tablet->init());
+    tablet->calculate_cumulative_point();
+    EXPECT_EQ(13, tablet->cumulative_layer_point());
+
+    auto candidate_rowsets = tablet->pick_candidate_rowsets_to_cumulative_compaction();
+    ASSERT_EQ(12, candidate_rowsets.size());
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+    tablet->_cumulative_compaction_policy->pick_input_rowsets(
+            tablet.get(), candidate_rowsets, 100, 5, &input_rowsets, &last_delete_version,
+            &compaction_score, config::enable_delete_when_cumu_compaction);
+
+    ASSERT_EQ(2, input_rowsets.size());
+    EXPECT_EQ(Version(13, 56), input_rowsets[0]->version());
+    EXPECT_EQ(Version(57, 57), input_rowsets[1]->version());
+    EXPECT_GE(compaction_score, 192);
+}
+
+TEST_F(TestSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_keeps_single_overlapping_rowset_at_max_score) {
+    auto rs_metas = create_rs_meta_max_score_trim(false);
+    for (auto& rowset : rs_metas) {
+        static_cast<void>(_tablet_meta->add_rs_meta(rowset));
+    }
+
+    TabletSharedPtr tablet(
+            new Tablet(_engine, _tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    static_cast<void>(tablet->init());
+    tablet->calculate_cumulative_point();
+    EXPECT_EQ(57, tablet->cumulative_layer_point());
+
+    auto candidate_rowsets = tablet->pick_candidate_rowsets_to_cumulative_compaction();
+    ASSERT_EQ(11, candidate_rowsets.size());
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+    tablet->_cumulative_compaction_policy->pick_input_rowsets(
+            tablet.get(), candidate_rowsets, 100, 5, &input_rowsets, &last_delete_version,
+            &compaction_score, config::enable_delete_when_cumu_compaction);
+
+    ASSERT_EQ(1, input_rowsets.size());
+    EXPECT_EQ(Version(57, 57), input_rowsets.front()->version());
+    EXPECT_EQ(192, compaction_score);
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #64954, #65470

Problem Summary: Backport the cumulative-compaction large-head fix from #64954 to `branch-3.1`, together with the final mergeable-input protection from #65470.

#64954 removes the promotion-size early return so level-size trimming can exclude an oversized leading rowset instead of repeatedly compacting it. It also keeps the last suffix rowset available for the singleton checks. The same behavior is applied to the cloud and local size-based policies.

`branch-3.1` predates the deferred max-score tail-trimming mechanism changed by #65470, so that later implementation cannot be cherry-picked directly. This backport preserves #65470's final invariant in the branch's collection-time guard: trimming must not strand a single non-overlapping rowset when its direct successor is needed to form a mergeable input. Focused cloud and local regression cases cover both the stranded-head and overlapping-singleton max-score scenarios.

The source commits are `a1e076e8d6969feafd8411f7b19e22664f43c543` (#64954) and `54300f922fddbeac6e679a83d7829444d4a72f77` (#65470). The branch is based on the latest `branch-3.1` at publication time.

### Release note

Avoid repeatedly compacting an oversized cumulative rowset while keeping trimmed inputs mergeable on branch-3.1.

### Check List (For Author)

- Test: Regression coverage added for both cloud and local cumulative-compaction policies
    - Clang Format 16 changed-line check: passed
    - `git diff --check`: passed
    - Full branch-specific BE unit tests were not run locally; hosted CI is requested below
- Behavior changed: Yes
    - Allows level-size trimming to exclude an oversized leading rowset
    - Preserves a mergeable successor for singleton inputs
- Does this need documentation: No
