### PR TITLE
branch-4.0: [fix](compaction) Avoid repeatedly compacting large cumulative rowset #64954

### DIFF
--- a/be/src/cloud/cloud_cumulative_compaction_policy.cpp
+++ b/be/src/cloud/cloud_cumulative_compaction_policy.cpp
@@ -18,6 +18,7 @@
 #include "cloud/cloud_cumulative_compaction_policy.h"
 
 #include <algorithm>
+#include <iterator>
 #include <list>
 #include <ostream>
 #include <string>
@@ -173,10 +174,6 @@ int64_t CloudSizeBasedCumulativeCompactionPolicy::pick_input_rowsets(
         input_rowsets->push_back(rowset);
     }
 
-    if (total_size >= promotion_size) {
-        return transient_size;
-    }
-
     // if there is delete version, do compaction directly
     if (last_delete_version->first != -1) {
         if (input_rowsets->size() == 1) {
@@ -213,6 +210,9 @@ int64_t CloudSizeBasedCumulativeCompactionPolicy::pick_input_rowsets(
 
     auto rs_begin = input_rowsets->begin();
     size_t new_compaction_score = *compaction_score;
+    const bool can_handle_exhausted_input =
+            (config::prioritize_query_perf_in_compaction && tablet->keys_type() != DUP_KEYS) ||
+            *compaction_score >= static_cast<size_t>(max_compaction_score);
     while (rs_begin != input_rowsets->end()) {
         auto& rs_meta = (*rs_begin)->rowset_meta();
         int64_t current_level = _level_size(rs_meta->total_disk_size());
@@ -222,9 +222,16 @@ int64_t CloudSizeBasedCumulativeCompactionPolicy::pick_input_rowsets(
         if (current_level <= remain_level) {
             break;
         }
+
+        auto next = std::next(rs_begin);
+        // Keep the last suffix rowset for the singleton checks unless the exhausted-input
+        // fallback below can select a useful input.
+        if (next == input_rowsets->end() && !can_handle_exhausted_input) {
+            break;
+        }
         total_size -= rs_meta->total_disk_size();
         new_compaction_score -= rs_meta->get_compaction_score();
-        ++rs_begin;
+        rs_begin = next;
     }
     if (rs_begin == input_rowsets->end()) { // No suitable level size found in `input_rowsets`
         if (config::prioritize_query_perf_in_compaction && tablet->keys_type() != DUP_KEYS) {

--- a/be/src/olap/cumulative_compaction_policy.cpp
+++ b/be/src/olap/cumulative_compaction_policy.cpp
@@ -18,6 +18,7 @@
 #include "olap/cumulative_compaction_policy.h"
 
 #include <algorithm>
+#include <iterator>
 #include <list>
 #include <ostream>
 #include <string>
@@ -319,10 +320,6 @@ int SizeBasedCumulativeCompactionPolicy::pick_input_rowsets(
     DBUG_EXECUTE_IF("SizeBaseCumulativeCompactionPolicy.pick_input_rowsets.return_input_rowsets",
                     { return transient_size; })
 
-    if (total_size >= promotion_size) {
-        return transient_size;
-    }
-
     // if there is delete version, do compaction directly
     if (last_delete_version->first != -1) {
         if (input_rowsets->size() == 1) {
@@ -339,6 +336,8 @@ int SizeBasedCumulativeCompactionPolicy::pick_input_rowsets(
 
     auto rs_begin = input_rowsets->begin();
     size_t new_compaction_score = *compaction_score;
+    const bool can_handle_exhausted_input =
+            *compaction_score >= static_cast<size_t>(max_compaction_score);
     while (rs_begin != input_rowsets->end()) {
         auto& rs_meta = (*rs_begin)->rowset_meta();
         int64_t current_level = _level_size(rs_meta->total_disk_size());
@@ -348,9 +347,16 @@ int SizeBasedCumulativeCompactionPolicy::pick_input_rowsets(
         if (current_level <= remain_level) {
             break;
         }
+
+        auto next = std::next(rs_begin);
+        // Keep the last suffix rowset for the singleton checks unless the exhausted-input
+        // fallback below can select a useful input.
+        if (next == input_rowsets->end() && !can_handle_exhausted_input) {
+            break;
+        }
         total_size -= rs_meta->total_disk_size();
         new_compaction_score -= rs_meta->get_compaction_score();
-        ++rs_begin;
+        rs_begin = next;
     }
     if (rs_begin == input_rowsets->end() && *compaction_score >= max_compaction_score) {
         // No suitable level size found in `input_rowsets` but score of `input_rowsets` exceed max compaction score,

--- a/be/test/cloud/cloud_cumulative_compaction_policy_test.cpp
+++ b/be/test/cloud/cloud_cumulative_compaction_policy_test.cpp
@@ -36,6 +36,9 @@
 
 namespace doris {
 
+static constexpr int64_t kMiB = 1024L * 1024;
+static constexpr int64_t kGiB = 1024L * kMiB;
+
 class TestCloudSizeBasedCumulativeCompactionPolicy : public testing::Test {
 public:
     TestCloudSizeBasedCumulativeCompactionPolicy()
@@ -118,7 +121,7 @@ private:
 };
 
 static RowsetSharedPtr create_rowset(Version version, int num_segments, bool overlapping,
-                                     int data_size) {
+                                     int64_t data_size) {
     auto rs_meta = std::make_shared<RowsetMeta>();
     rs_meta->set_rowset_type(BETA_ROWSET); // important
     rs_meta->_rowset_meta_pb.set_start_version(version.first);
@@ -132,6 +135,14 @@ static RowsetSharedPtr create_rowset(Version version, int num_segments, bool ove
         return nullptr;
     }
     return rowset;
+}
+
+static int64_t total_disk_size(const std::vector<RowsetSharedPtr>& rowsets) {
+    int64_t total_size = 0;
+    for (const auto& rowset : rowsets) {
+        total_size += rowset->total_disk_size();
+    }
+    return total_size;
 }
 
 TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy, new_cumulative_point) {
@@ -149,6 +160,111 @@ TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy, new_cumulative_point) {
     RowsetSharedPtr output_rowset = create_rowset(Version(3, 5), 5, false, 100 * 1024 * 1024);
     Version version(1, 1);
     EXPECT_EQ(policy.new_cumulative_point(&_tablet, output_rowset, version, 2), 6);
+}
+
+TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_large_head_not_repeated_when_output_below_promotion) {
+    CloudTablet _tablet(_engine, _tablet_meta);
+    _tablet._base_size = 20L * kGiB;
+
+    std::vector<RowsetSharedPtr> candidate_rowsets;
+    auto large_head = create_rowset(Version(2, 2), 1, false, 1023L * kMiB);
+    candidate_rowsets.push_back(large_head);
+    for (int i = 0; i < 20; i++) {
+        candidate_rowsets.push_back(create_rowset(Version(i + 3, i + 3), 1, true, kMiB));
+    }
+    ASSERT_GT(total_disk_size(candidate_rowsets), kGiB);
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+
+    CloudSizeBasedCumulativeCompactionPolicy policy;
+    policy.pick_input_rowsets(&_tablet, candidate_rowsets, 100, 5, &input_rowsets,
+                              &last_delete_version, &compaction_score, true);
+
+    EXPECT_EQ(20, input_rowsets.size());
+    EXPECT_EQ(20, compaction_score);
+    EXPECT_EQ(3, input_rowsets.front()->start_version());
+    EXPECT_EQ(22, input_rowsets.back()->end_version());
+    EXPECT_LT(total_disk_size(input_rowsets), kGiB);
+
+    auto output_rowset = create_rowset(Version(3, 22), 1, false, 20L * kMiB);
+    EXPECT_EQ(2, policy.new_cumulative_point(&_tablet, output_rowset, last_delete_version, 2));
+
+    std::vector<RowsetSharedPtr> next_candidate_rowsets {large_head, output_rowset};
+    input_rowsets.clear();
+    compaction_score = 0;
+    policy.pick_input_rowsets(&_tablet, next_candidate_rowsets, 100, 5, &input_rowsets,
+                              &last_delete_version, &compaction_score, true);
+
+    EXPECT_TRUE(input_rowsets.empty());
+    EXPECT_EQ(0, compaction_score);
+}
+
+TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_large_head_single_overlapping_tail_selected) {
+    CloudTablet _tablet(_engine, _tablet_meta);
+    _tablet._base_size = 20L * kGiB;
+
+    std::vector<RowsetSharedPtr> candidate_rowsets {
+            create_rowset(Version(2, 2), 1, false, 900L * kMiB),
+            create_rowset(Version(3, 3), 5, true, 128L * kMiB)};
+    ASSERT_GT(total_disk_size(candidate_rowsets), kGiB);
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+
+    CloudSizeBasedCumulativeCompactionPolicy policy;
+    policy.pick_input_rowsets(&_tablet, candidate_rowsets, 100, 5, &input_rowsets,
+                              &last_delete_version, &compaction_score, true);
+
+    ASSERT_EQ(1, input_rowsets.size());
+    EXPECT_EQ(5, compaction_score);
+    EXPECT_EQ(3, input_rowsets.front()->start_version());
+    EXPECT_EQ(128L * kMiB, input_rowsets.front()->total_disk_size());
+}
+
+TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_single_overlapping_rowset_not_trimmed_empty) {
+    CloudTablet _tablet(_engine, _tablet_meta);
+    _tablet._base_size = 20L * kGiB;
+
+    std::vector<RowsetSharedPtr> candidate_rowsets {
+            create_rowset(Version(2, 2), 3, true, 2L * kGiB)};
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+
+    CloudSizeBasedCumulativeCompactionPolicy policy;
+    policy.pick_input_rowsets(&_tablet, candidate_rowsets, 100, 5, &input_rowsets,
+                              &last_delete_version, &compaction_score, true);
+
+    EXPECT_EQ(1, input_rowsets.size());
+    EXPECT_EQ(3, compaction_score);
+    EXPECT_EQ(2, input_rowsets.front()->start_version());
+}
+
+TEST_F(TestCloudSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_single_non_overlapping_rowset_still_skipped) {
+    CloudTablet _tablet(_engine, _tablet_meta);
+    _tablet._base_size = 20L * kGiB;
+
+    std::vector<RowsetSharedPtr> candidate_rowsets {
+            create_rowset(Version(2, 2), 1, false, 2L * kGiB)};
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+
+    CloudSizeBasedCumulativeCompactionPolicy policy;
+    policy.pick_input_rowsets(&_tablet, candidate_rowsets, 100, 5, &input_rowsets,
+                              &last_delete_version, &compaction_score, true);
+
+    EXPECT_TRUE(input_rowsets.empty());
+    EXPECT_EQ(0, compaction_score);
 }
 
 // Test case: Empty rowset compaction with skip_trim

--- a/be/test/olap/cumulative_compaction_policy_test.cpp
+++ b/be/test/olap/cumulative_compaction_policy_test.cpp
@@ -26,6 +26,7 @@
 #include "json2pb/json_to_pb.h"
 #include "olap/cumulative_compaction.h"
 #include "olap/olap_common.h"
+#include "olap/rowset/rowset_factory.h"
 #include "olap/rowset/rowset_meta.h"
 #include "olap/storage_engine.h"
 #include "olap/tablet.h"
@@ -33,6 +34,9 @@
 #include "util/uid_util.h"
 
 namespace doris {
+
+static constexpr int64_t kMiB = 1024L * 1024;
+static constexpr int64_t kGiB = 1024L * kMiB;
 
 class TestSizeBasedCumulativeCompactionPolicy : public testing::Test {
 public:
@@ -1085,6 +1089,218 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_trim_after_pr
     EXPECT_EQ(100, input_rowsets.size());
 }
 
+TEST_F(TestSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_large_head_not_repeated_when_output_below_promotion) {
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+
+    RowsetMetaSharedPtr base_rs(new RowsetMeta());
+    init_rs_meta(base_rs, 0, 1);
+    base_rs->set_total_disk_size(20L * kGiB);
+    base_rs->set_segments_overlap(NONOVERLAPPING);
+    rs_metas.push_back(base_rs);
+
+    RowsetMetaSharedPtr large_head(new RowsetMeta());
+    init_rs_meta(large_head, 2, 2);
+    large_head->set_total_disk_size(1023L * kMiB);
+    large_head->set_num_segments(1);
+    large_head->set_segments_overlap(NONOVERLAPPING);
+    rs_metas.push_back(large_head);
+
+    for (int i = 0; i < 20; i++) {
+        RowsetMetaSharedPtr ptr(new RowsetMeta());
+        init_rs_meta(ptr, i + 3, i + 3);
+        ptr->set_total_disk_size(kMiB);
+        ptr->set_num_segments(1);
+        ptr->set_segments_overlap(OVERLAPPING);
+        rs_metas.push_back(ptr);
+    }
+
+    for (auto& rowset : rs_metas) {
+        static_cast<void>(_tablet_meta->add_rs_meta(rowset));
+    }
+
+    TabletSharedPtr _tablet(
+            new Tablet(_engine, _tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    static_cast<void>(_tablet->init());
+    _tablet->calculate_cumulative_point();
+    ASSERT_EQ(2, _tablet->cumulative_layer_point());
+    ASSERT_EQ(kGiB, _tablet->cumulative_promotion_size());
+
+    auto candidate_rowsets = _tablet->pick_candidate_rowsets_to_cumulative_compaction();
+    ASSERT_EQ(21, candidate_rowsets.size());
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+
+    _tablet->_cumulative_compaction_policy->pick_input_rowsets(
+            _tablet.get(), candidate_rowsets, 100, 5, &input_rowsets, &last_delete_version,
+            &compaction_score, config::enable_delete_when_cumu_compaction);
+
+    EXPECT_EQ(20, input_rowsets.size());
+    EXPECT_EQ(20, compaction_score);
+    EXPECT_EQ(3, input_rowsets.front()->start_version());
+    EXPECT_EQ(22, input_rowsets.back()->end_version());
+
+    RowsetMetaSharedPtr output_meta(new RowsetMeta());
+    init_rs_meta(output_meta, 3, 22);
+    output_meta->set_total_disk_size(20L * kMiB);
+    output_meta->set_num_segments(1);
+    output_meta->set_segments_overlap(NONOVERLAPPING);
+    RowsetSharedPtr output_rowset;
+    ASSERT_TRUE(RowsetFactory::create_rowset(nullptr, "", output_meta, &output_rowset).ok());
+
+    _tablet->_cumulative_compaction_policy->update_cumulative_point(
+            _tablet.get(), input_rowsets, output_rowset, last_delete_version);
+    EXPECT_EQ(2, _tablet->cumulative_layer_point());
+
+    std::vector<RowsetSharedPtr> next_candidate_rowsets {candidate_rowsets.front(), output_rowset};
+    input_rowsets.clear();
+    compaction_score = 0;
+    _tablet->_cumulative_compaction_policy->pick_input_rowsets(
+            _tablet.get(), next_candidate_rowsets, 100, 5, &input_rowsets, &last_delete_version,
+            &compaction_score, config::enable_delete_when_cumu_compaction);
+
+    EXPECT_TRUE(input_rowsets.empty());
+    EXPECT_EQ(0, compaction_score);
+}
+
+TEST_F(TestSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_large_head_single_overlapping_tail_selected) {
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+
+    RowsetMetaSharedPtr base_rs(new RowsetMeta());
+    init_rs_meta(base_rs, 0, 1);
+    base_rs->set_total_disk_size(20L * kGiB);
+    base_rs->set_segments_overlap(NONOVERLAPPING);
+    rs_metas.push_back(base_rs);
+
+    RowsetMetaSharedPtr large_head(new RowsetMeta());
+    init_rs_meta(large_head, 2, 2);
+    large_head->set_total_disk_size(900L * kMiB);
+    large_head->set_num_segments(1);
+    large_head->set_segments_overlap(NONOVERLAPPING);
+    rs_metas.push_back(large_head);
+
+    RowsetMetaSharedPtr tail(new RowsetMeta());
+    init_rs_meta(tail, 3, 3);
+    tail->set_total_disk_size(128L * kMiB);
+    tail->set_num_segments(5);
+    tail->set_segments_overlap(OVERLAPPING);
+    rs_metas.push_back(tail);
+
+    for (auto& rowset : rs_metas) {
+        static_cast<void>(_tablet_meta->add_rs_meta(rowset));
+    }
+
+    TabletSharedPtr _tablet(
+            new Tablet(_engine, _tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    static_cast<void>(_tablet->init());
+    _tablet->calculate_cumulative_point();
+    ASSERT_EQ(2, _tablet->cumulative_layer_point());
+    ASSERT_EQ(kGiB, _tablet->cumulative_promotion_size());
+
+    auto candidate_rowsets = _tablet->pick_candidate_rowsets_to_cumulative_compaction();
+    ASSERT_EQ(2, candidate_rowsets.size());
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+
+    _tablet->_cumulative_compaction_policy->pick_input_rowsets(
+            _tablet.get(), candidate_rowsets, 100, 5, &input_rowsets, &last_delete_version,
+            &compaction_score, config::enable_delete_when_cumu_compaction);
+
+    ASSERT_EQ(1, input_rowsets.size());
+    EXPECT_EQ(5, compaction_score);
+    EXPECT_EQ(3, input_rowsets.front()->start_version());
+    EXPECT_EQ(128L * kMiB, input_rowsets.front()->total_disk_size());
+}
+
+TEST_F(TestSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_single_overlapping_rowset_not_trimmed_empty) {
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+
+    RowsetMetaSharedPtr base_rs(new RowsetMeta());
+    init_rs_meta(base_rs, 0, 1);
+    base_rs->set_total_disk_size(20L * kGiB);
+    base_rs->set_segments_overlap(NONOVERLAPPING);
+    rs_metas.push_back(base_rs);
+
+    RowsetMetaSharedPtr ptr(new RowsetMeta());
+    init_rs_meta(ptr, 2, 2);
+    ptr->set_total_disk_size(2L * kGiB);
+    ptr->set_num_segments(3);
+    ptr->set_segments_overlap(OVERLAPPING);
+    rs_metas.push_back(ptr);
+
+    for (auto& rowset : rs_metas) {
+        static_cast<void>(_tablet_meta->add_rs_meta(rowset));
+    }
+
+    TabletSharedPtr _tablet(
+            new Tablet(_engine, _tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    static_cast<void>(_tablet->init());
+    _tablet->calculate_cumulative_point();
+
+    auto candidate_rowsets = _tablet->pick_candidate_rowsets_to_cumulative_compaction();
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+
+    _tablet->_cumulative_compaction_policy->pick_input_rowsets(
+            _tablet.get(), candidate_rowsets, 100, 5, &input_rowsets, &last_delete_version,
+            &compaction_score, config::enable_delete_when_cumu_compaction);
+
+    EXPECT_EQ(1, input_rowsets.size());
+    EXPECT_EQ(3, compaction_score);
+    EXPECT_EQ(2, input_rowsets.front()->start_version());
+}
+
+TEST_F(TestSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_single_non_overlapping_rowset_still_skipped) {
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+
+    RowsetMetaSharedPtr base_rs(new RowsetMeta());
+    init_rs_meta(base_rs, 0, 1);
+    base_rs->set_total_disk_size(20L * kGiB);
+    base_rs->set_segments_overlap(NONOVERLAPPING);
+    rs_metas.push_back(base_rs);
+
+    RowsetMetaSharedPtr ptr(new RowsetMeta());
+    init_rs_meta(ptr, 2, 2);
+    ptr->set_total_disk_size(2L * kGiB);
+    ptr->set_num_segments(1);
+    ptr->set_segments_overlap(NONOVERLAPPING);
+    rs_metas.push_back(ptr);
+
+    for (auto& rowset : rs_metas) {
+        static_cast<void>(_tablet_meta->add_rs_meta(rowset));
+    }
+
+    TabletSharedPtr _tablet(
+            new Tablet(_engine, _tablet_meta, nullptr, CUMULATIVE_SIZE_BASED_POLICY));
+    static_cast<void>(_tablet->init());
+    _tablet->calculate_cumulative_point();
+
+    std::vector<RowsetSharedPtr> candidate_rowsets;
+    RowsetSharedPtr rowset;
+    ASSERT_TRUE(RowsetFactory::create_rowset(nullptr, "", ptr, &rowset).ok());
+    candidate_rowsets.push_back(rowset);
+
+    std::vector<RowsetSharedPtr> input_rowsets;
+    Version last_delete_version {-1, -1};
+    size_t compaction_score = 0;
+
+    _tablet->_cumulative_compaction_policy->pick_input_rowsets(
+            _tablet.get(), candidate_rowsets, 100, 5, &input_rowsets, &last_delete_version,
+            &compaction_score, config::enable_delete_when_cumu_compaction);
+
+    EXPECT_TRUE(input_rowsets.empty());
+    EXPECT_EQ(0, compaction_score);
+}
+
 // Test case: Trim with varying scores (high score rowsets at tail)
 TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_trim_high_score_tail) {
     std::vector<RowsetMetaSharedPtr> rs_metas;
@@ -1765,8 +1981,9 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_single_non_ov
     EXPECT_EQ(0, compaction_score);
 }
 
-// Test case: Fallback when all removed by level_size but score < max
-TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_fallback_score_below_max) {
+// Test case: Keep the final overlapping suffix when exhausted-input fallback is unavailable
+TEST_F(TestSizeBasedCumulativeCompactionPolicy,
+       pick_input_rowsets_keep_final_overlapping_below_max) {
     std::vector<RowsetMetaSharedPtr> rs_metas;
 
     // Base rowset: 20GB
@@ -1807,15 +2024,14 @@ TEST_F(TestSizeBasedCumulativeCompactionPolicy, pick_input_rowsets_fallback_scor
     Version last_delete_version {-1, -1};
     size_t compaction_score = 0;
 
-    // All rowsets removed by level_size, score=50 < max=100
-    // Does not trigger fallback, goes to normal flow with empty result
+    // The original score is below max, so the loop must stop before removing the final rowset.
     _tablet->_cumulative_compaction_policy->pick_input_rowsets(
             _tablet.get(), candidate_rowsets, 100, 5, &input_rowsets, &last_delete_version,
             &compaction_score, config::enable_delete_when_cumu_compaction);
 
-    // After level_size removes all, result is empty (no fallback since score < max)
-    EXPECT_EQ(0, input_rowsets.size());
-    EXPECT_EQ(0, compaction_score);
+    ASSERT_EQ(1, input_rowsets.size());
+    EXPECT_EQ(20, compaction_score);
+    EXPECT_EQ(3, input_rowsets.front()->start_version());
 }
 
 // Test case: level_size removes large head, then trim after


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #64954

Problem Summary: Backport #64954 to `branch-4.0` so an oversized leading cumulative rowset can be excluded by level-size trimming instead of being selected repeatedly.

The change removes the promotion-size early return, keeps the singleton guard intact, and applies the behavior to both cloud and local size-based cumulative-compaction policies. The test conflict was resolved against this branch's `olap` layout while preserving the source regression scenarios.

Source commit: `a1e076e8d6969feafd8411f7b19e22664f43c543`. The branch is based on the latest `branch-4.0` at publication time.

### Release note

Avoid repeatedly compacting an oversized cumulative rowset on branch-4.0.

### Check List (For Author)

- Test: Source cloud and local regression coverage backported
    - Clang Format 16 changed-line check: passed
    - `git diff --check`: passed
    - Full branch-specific BE unit tests were not run locally; hosted CI is requested below
- Behavior changed: Yes
    - Allows level-size trimming to exclude an oversized leading rowset
- Does this need documentation: No
