### PR TITLE
[fix](be) Return fragment failure status instead of silent eos in memory scratch sink

### DIFF
--- a/be/src/exec/operator/memory_scratch_sink_operator.cpp
+++ b/be/src/exec/operator/memory_scratch_sink_operator.cpp
@@ -26,6 +26,7 @@
 #include "format/arrow/arrow_block_convertor.h"
 #include "format/arrow/arrow_row_batch.h"
 #include "runtime/record_batch_queue.h"
+#include "runtime/result_queue_mgr.h"
 
 namespace doris {
 Status MemoryScratchSinkLocalState::init(RuntimeState* state, LocalSinkStateInfo& info) {
@@ -57,6 +58,16 @@ Status MemoryScratchSinkLocalState::close(RuntimeState* state, Status exec_statu
     SCOPED_TIMER(exec_time_counter());
     SCOPED_TIMER(_close_timer);
     if (_queue != nullptr) {
+        // Propagate the fragment failure to the result queue, so that
+        // ResultQueueMgr::fetch_result returns the real status (e.g. TIMEOUT,
+        // MEM_LIMIT_EXCEEDED) instead of treating the sentinel below as a
+        // normal end-of-stream and silently truncating the scan.
+        // Must be done before putting the sentinel: a fetcher blocked in
+        // blocking_get wakes up on the sentinel and re-checks the queue status.
+        if (!exec_status.ok()) {
+            state->exec_env()->result_queue_mgr()->update_queue_status(
+                    state->fragment_instance_id(), exec_status);
+        }
         _queue->blocking_put(nullptr);
     }
     RETURN_IF_ERROR(Base::close(state, exec_status));

--- a/be/src/runtime/result_queue_mgr.cpp
+++ b/be/src/runtime/result_queue_mgr.cpp
@@ -63,6 +63,12 @@ Status ResultQueueMgr::fetch_result(const TUniqueId& fragment_instance_id,
     if (success) {
         // sentinel nullptr indicates scan end
         if (*result == nullptr) {
+            // Re-check the queue status: the sink publishes the fragment failure status
+            // right before putting the eos sentinel, while this fetch may have passed the
+            // status check above before blocking on get. The client stops polling at eos,
+            // so this is the last chance to surface the failure instead of returning a
+            // silent truncated eos.
+            RETURN_IF_ERROR(queue->status());
             *eos = true;
             // put sentinel for consistency, avoid repeated invoking fetch result when have no rowbatch
             queue->blocking_put(nullptr);

--- a/be/test/runtime/result_queue_mgr_test.cpp
+++ b/be/test/runtime/result_queue_mgr_test.cpp
@@ -26,8 +26,10 @@
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
 
+#include <chrono>
 #include <memory>
 #include <ostream>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -132,6 +134,35 @@ TEST_F(ResultQueueMgrTest, fetch_result_end) {
     EXPECT_TRUE(queue_mgr.fetch_result(query_id, &result, &eos).ok());
     EXPECT_TRUE(eos);
     EXPECT_TRUE(result == nullptr);
+}
+
+TEST_F(ResultQueueMgrTest, fetch_result_failure_before_eos_sentinel) {
+    ResultQueueMgr queue_mgr;
+    TUniqueId query_id;
+    query_id.lo = 10;
+    query_id.hi = 100;
+
+    BlockQueueSharedPtr block_queue_t;
+    queue_mgr.create_queue(query_id, &block_queue_t);
+    EXPECT_TRUE(block_queue_t != nullptr);
+
+    // Simulate the sink thread failing the fragment: it publishes the failure
+    // status right before putting the eos sentinel, while the fetch thread is
+    // already blocked in blocking_get. fetch_result must surface the failure
+    // instead of returning a silent eos.
+    std::thread sink_thread([&]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        queue_mgr.update_queue_status(query_id, Status::InternalError("fragment failed"));
+        block_queue_t->blocking_put(nullptr);
+    });
+
+    std::shared_ptr<arrow::RecordBatch> result;
+    bool eos = false;
+    Status st = queue_mgr.fetch_result(query_id, &result, &eos);
+    sink_thread.join();
+
+    EXPECT_FALSE(st.ok());
+    EXPECT_NE(std::string::npos, st.to_string().find("fragment failed"));
 }
 
 TEST_F(ResultQueueMgrTest, normal_cancel) {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

For queries whose results are pumped through `MemoryScratchSink` into `ResultQueueMgr` (the external scan context path: `BaseBackendService::get_next` -> `ResultQueueMgr::fetch_result`), when the fragment instance fails -- e.g. query timeout or memory limit exceeded -- `MemoryScratchSinkLocalState::close()` only puts the `nullptr` eos sentinel into the record batch queue and never propagates the failure status to the `ResultQueueMgr`.

A fetcher that already passed the queue status check and is blocked in `blocking_get()` wakes up on the sentinel, treats it as a normal end-of-stream, and returns `eos` to the caller. The client stops polling once it sees eos, so the query silently returns **truncated results** instead of the real error (`TIMEOUT`, `MEM_LIMIT_EXCEEDED`, ...).

This patch:
1. Publishes the fragment failure status to the result queue before putting the eos sentinel in `MemoryScratchSinkLocalState::close()`. It must be done before the sentinel: a fetcher blocked in `blocking_get` wakes up on the sentinel and re-checks the queue status.
2. Re-checks the queue status when `fetch_result` observes the sentinel, so the failure is surfaced on this last fetch instead of a silent truncated eos.
3. Adds a unit test (`fetch_result_failure_before_eos_sentinel`) covering the race: a fetch thread blocked in `blocking_get` while the sink thread publishes the failure status and then puts the sentinel.

### Release note

Fix silently truncated query results when a fragment served by `MemoryScratchSink` fails -- the query now returns the real failure status (e.g. TIMEOUT, MEM_LIMIT_EXCEEDED) instead of an apparent normal end-of-stream.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:

- Behavior changed:
    - [ ] No.
    - [x] Yes. A failed fragment served by `MemoryScratchSink` now surfaces its real failure status to the caller instead of a silent truncated eos.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
