### PR TITLE
branch-3.1: [fix](cloud) Refresh base tablet before schema change V1 #64312

### DIFF
--- a/be/src/cloud/cloud_schema_change_job.cpp
+++ b/be/src/cloud/cloud_schema_change_job.cpp
@@ -97,7 +97,9 @@ Status CloudSchemaChangeJob::process_alter_tablet(const TAlterTabletReqV2& reque
                                               request.base_tablet_id);
     }
     // MUST sync rowsets before capturing rowset readers and building DeleteHandler
-    RETURN_IF_ERROR(_base_tablet->sync_rowsets(request.alter_version));
+    // The SC boundary (V1) must be calculated from the latest visible rowsets of the base
+    // tablet. Do not cap this sync by request.alter_version, which may be stale across retries.
+    RETURN_IF_ERROR(_base_tablet->sync_rowsets());
     // ATTN: Only convert rowsets of version larger than 1, MUST let the new tablet cache have rowset [0-1]
     _output_cumulative_point = _base_tablet->cumulative_layer_point();
     std::vector<RowSetSplits> rs_splits;

--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -324,6 +324,18 @@ Status CloudTablet::sync_rowsets(int64_t query_version, bool warmup_delta_data,
     RETURN_IF_ERROR(sync_if_not_running(stats));
 
     if (query_version > 0) {
+        DBUG_EXECUTE_IF("CloudTablet::sync_rowsets.stale_local_max_for_query_version", {
+            auto target_tablet_id = dp->param<int64_t>("tablet_id", -1);
+            auto stale_version = dp->param<int64_t>("version", -1);
+            if (target_tablet_id == tablet_id() && stale_version >= 0) {
+                std::unique_lock wlock(_meta_lock);
+                LOG(INFO) << "override cloud tablet local max_version for query_version sync"
+                          << ", tablet_id=" << tablet_id() << ", old_max_version=" << _max_version
+                          << ", stale_version=" << stale_version
+                          << ", query_version=" << query_version;
+                _max_version = stale_version;
+            }
+        });
         std::shared_lock rlock(_meta_lock);
         if (_max_version >= query_version) {
             return Status::OK();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #64312

Problem Summary: Backport the Cloud schema-change base-tablet refresh fix from #64312 to `branch-3.1`.

Before capturing rowset readers and registering schema change V1, the base tablet now performs an uncapped rowset refresh. This prevents a stale request alter version from hiding newer visible rowsets across retries. The implementation is adapted to this branch's older `CloudTablet::sync_rowsets()` API.

The master regression fixture depends on later cross-V1 test infrastructure that is absent from this branch, so this backport keeps the production fix and its diagnostic debug point without importing unsupported test scaffolding.

The branch is rebased onto the latest `branch-3.1`.

### Release note

Refresh the Cloud schema-change base tablet before calculating and registering V1.

### Check List (For Author)

- Test: Manual / static validation
    - `clang-format` 16 `--dry-run --Werror`: passed for all changed C++ files
    - `git diff --check`: passed
    - Exact-base linked BE tests were not run locally; hosted CI is requested with `run buildall`
- Behavior changed: Yes
    - Schema change uses the latest visible base-tablet rowsets instead of a query-version-capped refresh
- Does this need documentation: No
