### PR TITLE
branch-3.1: [chore](tde) Add scoped KMS credentials to regression clusters #64564

### DIFF
--- a/docker/runtime/doris-compose/cluster.py
+++ b/docker/runtime/doris-compose/cluster.py
@@ -356,6 +356,18 @@ class Node(object):
     def get_tde_sk(self):
         return self.cluster.tde_sk
 
+    def get_tde_aws_ak(self):
+        return getattr(self.cluster, "tde_aws_ak", "")
+
+    def get_tde_aws_sk(self):
+        return getattr(self.cluster, "tde_aws_sk", "")
+
+    def get_tde_aliyun_ak(self):
+        return getattr(self.cluster, "tde_aliyun_ak", "")
+
+    def get_tde_aliyun_sk(self):
+        return getattr(self.cluster, "tde_aliyun_sk", "")
+
     def get_default_named_ports(self):
         # port_name : default_port
         # the port_name come from fe.conf, be.conf, cloud.conf, etc
@@ -398,6 +410,10 @@ class Node(object):
             "SQL_MODE_NODE_MGR": 1 if self.cluster.sql_mode_node_mgr else 0,
             "TDE_AK": self.get_tde_ak(),
             "TDE_SK": self.get_tde_sk(),
+            "TDE_AWS_AK": self.get_tde_aws_ak(),
+            "TDE_AWS_SK": self.get_tde_aws_sk(),
+            "TDE_ALIYUN_AK": self.get_tde_aliyun_ak(),
+            "TDE_ALIYUN_SK": self.get_tde_aliyun_sk(),
         }
 
         if self.cluster.is_cloud:
@@ -818,7 +834,8 @@ class Cluster(object):
                  be_config, ms_config, recycle_config, remote_master_fe,
                  local_network_ip, fe_follower, be_disks, be_cluster, reg_be,
                  extra_hosts, coverage_dir, cloud_store_config,
-                 sql_mode_node_mgr, be_metaservice_endpoint, be_cluster_id, tde_ak, tde_sk):
+                 sql_mode_node_mgr, be_metaservice_endpoint, be_cluster_id, tde_ak, tde_sk,
+                 tde_aws_ak, tde_aws_sk, tde_aliyun_ak, tde_aliyun_sk):
         self.name = name
         self.subnet = subnet
         self.image = image
@@ -849,13 +866,18 @@ class Cluster(object):
         self.be_cluster_id = be_cluster_id
         self.tde_ak = tde_ak
         self.tde_sk = tde_sk
+        self.tde_aws_ak = tde_aws_ak
+        self.tde_aws_sk = tde_aws_sk
+        self.tde_aliyun_ak = tde_aliyun_ak
+        self.tde_aliyun_sk = tde_aliyun_sk
 
     @staticmethod
     def new(name, image, is_cloud, is_root_user, fe_config, be_config,
             ms_config, recycle_config, remote_master_fe, local_network_ip,
             fe_follower, be_disks, be_cluster, reg_be, extra_hosts,
             coverage_dir, cloud_store_config, sql_mode_node_mgr,
-            be_metaservice_endpoint, be_cluster_id, tde_ak, tde_sk):
+            be_metaservice_endpoint, be_cluster_id, tde_ak, tde_sk,
+            tde_aws_ak, tde_aws_sk, tde_aliyun_ak, tde_aliyun_sk):
         if not os.path.exists(LOCAL_DORIS_PATH):
             os.makedirs(LOCAL_DORIS_PATH, exist_ok=True)
             os.chmod(LOCAL_DORIS_PATH, 0o777)
@@ -870,7 +892,8 @@ class Cluster(object):
                               be_disks, be_cluster, reg_be, extra_hosts,
                               coverage_dir, cloud_store_config,
                               sql_mode_node_mgr, be_metaservice_endpoint,
-                              be_cluster_id, tde_ak, tde_sk)
+                              be_cluster_id, tde_ak, tde_sk,
+                              tde_aws_ak, tde_aws_sk, tde_aliyun_ak, tde_aliyun_sk)
             os.makedirs(cluster.get_path(), exist_ok=True)
             os.makedirs(get_status_path(name), exist_ok=True)
             cluster._save_meta()

--- a/docker/runtime/doris-compose/command.py
+++ b/docker/runtime/doris-compose/command.py
@@ -505,6 +505,30 @@ class UpCommand(Command):
             default="",
             help="tde sk")
 
+        parser.add_argument(
+            "--tde-aws-ak",
+            type=str,
+            default="",
+            help="tde aws ak")
+
+        parser.add_argument(
+            "--tde-aws-sk",
+            type=str,
+            default="",
+            help="tde aws sk")
+
+        parser.add_argument(
+            "--tde-aliyun-ak",
+            type=str,
+            default="",
+            help="tde aliyun ak")
+
+        parser.add_argument(
+            "--tde-aliyun-sk",
+            type=str,
+            default="",
+            help="tde aliyun sk")
+
         # if default==True, use this style to parser, like --detach
         if self._support_boolean_action():
             parser.add_argument(
@@ -615,7 +639,8 @@ class UpCommand(Command):
                 args.remote_master_fe, args.local_network_ip, args.fe_follower,
                 args.be_disks, args.be_cluster, args.reg_be, args.extra_hosts,
                 args.coverage_dir, cloud_store_config, args.sql_mode_node_mgr,
-                args.be_metaservice_endpoint, args.be_cluster_id, args.tde_ak, args.tde_sk)
+                args.be_metaservice_endpoint, args.be_cluster_id, args.tde_ak, args.tde_sk,
+                args.tde_aws_ak, args.tde_aws_sk, args.tde_aliyun_ak, args.tde_aliyun_sk)
             LOG.info("Create new cluster {} succ, cluster path is {}".format(
                 args.NAME, cluster.get_path()))
 

--- a/docker/runtime/doris-compose/resource/init_fe.sh
+++ b/docker/runtime/doris-compose/resource/init_fe.sh
@@ -92,6 +92,10 @@ fe_daemon() {
 run_fe() {
     export DORIS_TDE_AK=${TDE_AK}
     export DORIS_TDE_SK=${TDE_SK}
+    export DORIS_TDE_AWS_AK=${TDE_AWS_AK}
+    export DORIS_TDE_AWS_SK=${TDE_AWS_SK}
+    export DORIS_TDE_ALIYUN_AK=${TDE_ALIYUN_AK}
+    export DORIS_TDE_ALIYUN_SK=${TDE_ALIYUN_SK}
     health_log "run start_fe.sh"
     bash $DORIS_HOME/bin/start_fe.sh --daemon $@ | tee -a $DORIS_HOME/log/fe.out
 }

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/Config.groovy
@@ -171,6 +171,10 @@ class Config {
 
     public String tdeAk
     public String tdeSk
+    public String tdeAwsAk
+    public String tdeAwsSk
+    public String tdeAliyunAk
+    public String tdeAliyunSk
     public String tdeKeyEndpoint
     public String tdeKeyRegion
     public String tdeKeyProvider
@@ -238,6 +242,10 @@ class Config {
             String cloudVersion,
             String tdeAk,
             String tdeSk,
+            String tdeAwsAk,
+            String tdeAwsSk,
+            String tdeAliyunAk,
+            String tdeAliyunSk,
             String tdeKeyEndpoint,
             String tdeKeyRegion,
             String tdeKeyProvider,
@@ -301,11 +309,19 @@ class Config {
         this.cloudVersion = cloudVersion
         this.tdeAk = tdeAk
         this.tdeSk = tdeSk
+        this.tdeAwsAk = tdeAwsAk
+        this.tdeAwsSk = tdeAwsSk
+        this.tdeAliyunAk = tdeAliyunAk
+        this.tdeAliyunSk = tdeAliyunSk
         this.tdeKeyEndpoint = tdeKeyEndpoint
         this.tdeKeyRegion = tdeKeyRegion
         this.tdeKeyProvider = tdeKeyProvider
         this.tdeAlgorithm = tdeAlgorithm
         this.tdeKeyId = tdeKeyId
+    }
+
+    static String secretStatus(String value) {
+        return value == null || value == "" ? "unset" : "set"
     }
 
     static String removeDirectoryPrefix(String str) {
@@ -508,9 +524,17 @@ class Config {
         log.info("cloudVersion is ${config.cloudVersion}".toString())
 
         config.tdeAk = cmd.getOptionValue(tdeAkOpt, config.tdeAk)
-        log.info("tdeAk is ${config.tdeAk}".toString())
+        log.info("tdeAk is ${secretStatus(config.tdeAk)}".toString())
         config.tdeSk = cmd.getOptionValue(tdeSkOpt, config.tdeSk)
-        log.info("tdeSk is ${config.tdeSk}".toString())
+        log.info("tdeSk is ${secretStatus(config.tdeSk)}".toString())
+        config.tdeAwsAk = cmd.getOptionValue(tdeAwsAkOpt, config.tdeAwsAk)
+        log.info("tdeAwsAk is ${secretStatus(config.tdeAwsAk)}".toString())
+        config.tdeAwsSk = cmd.getOptionValue(tdeAwsSkOpt, config.tdeAwsSk)
+        log.info("tdeAwsSk is ${secretStatus(config.tdeAwsSk)}".toString())
+        config.tdeAliyunAk = cmd.getOptionValue(tdeAliyunAkOpt, config.tdeAliyunAk)
+        log.info("tdeAliyunAk is ${secretStatus(config.tdeAliyunAk)}".toString())
+        config.tdeAliyunSk = cmd.getOptionValue(tdeAliyunSkOpt, config.tdeAliyunSk)
+        log.info("tdeAliyunSk is ${secretStatus(config.tdeAliyunSk)}".toString())
         config.tdeKeyEndpoint = cmd.getOptionValue(tdeKeyEndpointOpt, config.tdeKeyEndpoint)
         log.info("tdeKeyEndpoint is ${config.tdeKeyEndpoint}".toString())
         config.tdeKeyRegion = cmd.getOptionValue(tdeKeyRegionOpt, config.tdeKeyRegion)
@@ -654,6 +678,10 @@ class Config {
             configToString(obj.cloudVersion),
             configToString(obj.tdeAk),
             configToString(obj.tdeSk),
+            configToString(obj.tdeAwsAk),
+            configToString(obj.tdeAwsSk),
+            configToString(obj.tdeAliyunAk),
+            configToString(obj.tdeAliyunSk),
             configToString(obj.tdeKeyEndpoint),
             configToString(obj.tdeKeyRegion),
             configToString(obj.tdeKeyProvider),

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/ConfigOptions.groovy
@@ -101,6 +101,10 @@ class ConfigOptions {
     static Option cloudVersionOpt
     static Option tdeAkOpt
     static Option tdeSkOpt
+    static Option tdeAwsAkOpt
+    static Option tdeAwsSkOpt
+    static Option tdeAliyunAkOpt
+    static Option tdeAliyunSkOpt
     static Option tdeKeyEndpointOpt
     static Option tdeKeyRegionOpt
     static Option tdeKeyProviderOpt
@@ -621,13 +625,33 @@ class ConfigOptions {
                 .build()
         tdeAkOpt = Option.builder("tdeAk")
                 .required(false)
-                .hasArg(false)
+                .hasArg(true)
                 .desc("TDE Access Key")
                 .build();
         tdeSkOpt = Option.builder("tdeSk")
                 .required(false)
-                .hasArg(false)
+                .hasArg(true)
                 .desc("TDE Secret Key")
+                .build();
+        tdeAwsAkOpt = Option.builder("tdeAwsAk")
+                .required(false)
+                .hasArg(true)
+                .desc("TDE AWS Access Key")
+                .build();
+        tdeAwsSkOpt = Option.builder("tdeAwsSk")
+                .required(false)
+                .hasArg(true)
+                .desc("TDE AWS Secret Key")
+                .build();
+        tdeAliyunAkOpt = Option.builder("tdeAliyunAk")
+                .required(false)
+                .hasArg(true)
+                .desc("TDE Aliyun Access Key")
+                .build();
+        tdeAliyunSkOpt = Option.builder("tdeAliyunSk")
+                .required(false)
+                .hasArg(true)
+                .desc("TDE Aliyun Secret Key")
                 .build();
         tdeKeyEndpointOpt = Option.builder("tdeKeyEndpoint")
                 .required(false)
@@ -724,6 +748,10 @@ class ConfigOptions {
                 .addOption(cloudVersionOpt)
                 .addOption(tdeAkOpt)
                 .addOption(tdeSkOpt)
+                .addOption(tdeAwsAkOpt)
+                .addOption(tdeAwsSkOpt)
+                .addOption(tdeAliyunAkOpt)
+                .addOption(tdeAliyunSkOpt)
                 .addOption(tdeKeyEndpointOpt)
                 .addOption(tdeKeyRegionOpt)
                 .addOption(tdeKeyProviderOpt)

--- a/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
+++ b/regression-test/framework/src/main/groovy/org/apache/doris/regression/suite/SuiteCluster.groovy
@@ -93,6 +93,10 @@ class ClusterOptions {
 
     String tdeAk = "";
     String tdeSk = "";
+    String tdeAwsAk = "";
+    String tdeAwsSk = "";
+    String tdeAliyunAk = "";
+    String tdeAliyunSk = "";
 
     void enableDebugPoints() {
         feConfigs.add('enable_debug_points=true')
@@ -380,11 +384,31 @@ class SuiteCluster {
             cmd += options.tdeSk
         }
 
+        if (options.tdeAwsAk != null && options.tdeAwsAk != "") {
+            cmd += ['--tde-aws-ak']
+            cmd += options.tdeAwsAk
+        }
+
+        if (options.tdeAwsSk != null && options.tdeAwsSk != "") {
+            cmd += ['--tde-aws-sk']
+            cmd += options.tdeAwsSk
+        }
+
+        if (options.tdeAliyunAk != null && options.tdeAliyunAk != "") {
+            cmd += ['--tde-aliyun-ak']
+            cmd += options.tdeAliyunAk
+        }
+
+        if (options.tdeAliyunSk != null && options.tdeAliyunSk != "") {
+            cmd += ['--tde-aliyun-sk']
+            cmd += options.tdeAliyunSk
+        }
+
         cmd += ['--wait-timeout', String.valueOf(options.waitTimeout)]
 
         sqlModeNodeMgr = options.sqlModeNodeMgr
 
-        runCmd(cmd.join(' '), 180)
+        runCmdList(cmd, 180)
 
         // wait be report disk
         Thread.sleep(5000)
@@ -733,6 +757,56 @@ class SuiteCluster {
         def fullCmd = String.format('python -W ignore %s %s -v --output-json', config.dorisComposePath, cmd)
         logger.info('Run doris compose cmd: {}', fullCmd)
         def proc = fullCmd.execute()
+        def outBuf = new StringBuilder()
+        def errBuf = new StringBuilder()
+        Awaitility.await().atMost(timeoutSecond, SECONDS).until({
+            proc.waitForProcessOutput(outBuf, errBuf)
+            return true
+        })
+        if (proc.exitValue() != 0) {
+            throw new Exception(String.format('Exit value: %s != 0, stdout: %s, stderr: %s',
+                                              proc.exitValue(), outBuf.toString(), errBuf.toString()))
+        }
+        def parser = new JsonSlurper()
+        if (outBuf.toString().size() == 0) {
+            throw new Exception(String.format('doris compose output is empty, err: %s', errBuf.toString()))
+        }
+        def object = (Map<String, Object>) parser.parseText(outBuf.toString())
+        if (object.get('code') != 0) {
+            throw new Exception(String.format('Code: %s != 0, err: %s', object.get('code'), object.get('err')))
+        }
+        return object.get('data')
+    }
+
+    private static List<String> maskSensitiveArgs(List<String> cmdList) {
+        Set<String> sensitiveOptions = [
+                '--tde-ak',
+                '--tde-sk',
+                '--tde-aws-ak',
+                '--tde-aws-sk',
+                '--tde-aliyun-ak',
+                '--tde-aliyun-sk'
+        ] as Set
+        List<String> masked = []
+        boolean maskNext = false
+        for (String arg : cmdList) {
+            if (maskNext) {
+                masked += '***'
+                maskNext = false
+                continue
+            }
+            masked += arg
+            if (sensitiveOptions.contains(arg)) {
+                maskNext = true
+            }
+        }
+        return masked
+    }
+
+    private Object runCmdList(List<String> cmdList, int timeoutSecond = 60) throws Exception {
+        def fullCmdList = ['python', '-W', 'ignore', config.dorisComposePath] + cmdList + ['-v', '--output-json']
+        logger.info('Run doris compose cmd: {}', maskSensitiveArgs(fullCmdList).join(' '))
+        def proc = fullCmdList.execute()
         def outBuf = new StringBuilder()
         def errBuf = new StringBuilder()
         Awaitility.await().atMost(timeoutSecond, SECONDS).until({


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #64564

Problem Summary: Backport scoped AWS and Aliyun KMS credential plumbing from #64564 to `branch-3.1`.

The change carries the four TDE credential values from regression-framework options through `doris-compose` into FE environment variables. Sensitive command arguments are masked in logs. The backport preserves the branch's existing cluster options and command execution model.

The branch is rebased onto the latest `branch-3.1`.

### Release note

Allow regression clusters to receive scoped AWS and Aliyun KMS credentials for TDE tests.

### Check List (For Author)

- Test: Manual / static validation
    - Python AST parsing passed for the changed compose Python modules
    - `bash -n docker/runtime/doris-compose/resource/init_fe.sh`: passed
    - Credential plumbing and sensitive-argument masking checks: passed
    - `git diff --check`: passed
    - Hosted CI is requested with `run buildall`
- Behavior changed: Yes
    - Adds optional scoped KMS credentials to regression cluster startup
    - Does not change production defaults when the options are unset
- Does this need documentation: No
