### PR TITLE
[improvement](snapshot) Add snapshot retained analysis interface

### DIFF
--- a/cloud/src/common/http_helper.cpp
+++ b/cloud/src/common/http_helper.cpp
@@ -425,6 +425,18 @@ const std::unordered_map<std::string_view, HttpHandlerInfo>& get_http_handlers()
                               return process_adjust_rate_limiter((RS*)s, c);
                           },
                   .role = HttpRole::RECYCLER}},
+                {"analyze_snapshot_retained",
+                 {.handler =
+                          [](void* s, brpc::Controller* c) {
+                              return process_analyze_snapshot_retained((RS*)s, c);
+                          },
+                  .role = HttpRole::RECYCLER}},
+                {"get_snapshot_retained_analysis",
+                 {.handler =
+                          [](void* s, brpc::Controller* c) {
+                              return process_get_snapshot_retained_analysis((RS*)s, c);
+                          },
+                  .role = HttpRole::RECYCLER}},
 
                 // Shared APIs
                 {"show_config",
@@ -861,6 +873,26 @@ HttpResponse process_adjust_rate_limiter(RecyclerServiceImpl*, brpc::Controller*
         return http_json_reply(MetaServiceCode::UNDEFINED_ERR, "adjust failed");
     }
     return http_json_reply(MetaServiceCode::OK, "");
+}
+
+HttpResponse process_analyze_snapshot_retained(RecyclerServiceImpl* service,
+                                               brpc::Controller* cntl) {
+    auto [code, message, result] =
+            service->recycler()->snapshot_manager()->analyze_snapshot_retained(
+                    cntl->request_attachment().to_string());
+    return http_json_reply(code, message,
+                           result.empty() ? std::nullopt : std::optional<std::string>(result));
+}
+
+HttpResponse process_get_snapshot_retained_analysis(RecyclerServiceImpl* service,
+                                                    brpc::Controller* cntl) {
+    const auto& uri = cntl->http_request().uri();
+    auto [code, message, result] =
+            service->recycler()->snapshot_manager()->get_snapshot_retained_analysis(
+                    cntl->request_attachment().to_string(), http_query(uri, "instance_id"),
+                    http_query(uri, "analysis_id"));
+    return http_json_reply(code, message,
+                           result.empty() ? std::nullopt : std::optional<std::string>(result));
 }
 
 HttpResponse process_show_config(MetaServiceImpl*, brpc::Controller* cntl) {

--- a/cloud/src/common/http_helper.h
+++ b/cloud/src/common/http_helper.h
@@ -215,6 +215,12 @@ const std::unordered_map<std::string_view, HttpHandlerInfo>& get_http_handlers()
 [[maybe_unused]] HttpResponse process_adjust_rate_limiter(RecyclerServiceImpl*,
                                                           brpc::Controller* cntl);
 
+[[maybe_unused]] HttpResponse process_analyze_snapshot_retained(RecyclerServiceImpl*,
+                                                                brpc::Controller* cntl);
+
+[[maybe_unused]] HttpResponse process_get_snapshot_retained_analysis(RecyclerServiceImpl*,
+                                                                     brpc::Controller* cntl);
+
 // Both http handlers
 [[maybe_unused]] HttpResponse process_show_config(MetaServiceImpl*, brpc::Controller* cntl);
 

--- a/cloud/src/recycler/recycler.h
+++ b/cloud/src/recycler/recycler.h
@@ -96,6 +96,8 @@ public:
 
     RecyclerThreadPoolGroup& thread_pool_group() { return _thread_pool_group; }
 
+    const std::shared_ptr<SnapshotManager>& snapshot_manager() const { return snapshot_manager_; }
+
 private:
     void recycle_callback();
 

--- a/cloud/src/snapshot/snapshot_manager.cpp
+++ b/cloud/src/snapshot/snapshot_manager.cpp
@@ -222,6 +222,16 @@ std::pair<MetaServiceCode, std::string> SnapshotManager::set_multi_version_statu
     return {MetaServiceCode::UNDEFINED_ERR, "Not implemented"};
 }
 
+SnapshotRetainedAnalysisResult SnapshotManager::analyze_snapshot_retained(std::string_view) {
+    return {MetaServiceCode::UNDEFINED_ERR, "Snapshot retained analysis is not supported", {}};
+}
+
+SnapshotRetainedAnalysisResult SnapshotManager::get_snapshot_retained_analysis(std::string_view,
+                                                                               std::string_view,
+                                                                               std::string_view) {
+    return {MetaServiceCode::UNDEFINED_ERR, "Snapshot retained analysis is not supported", {}};
+}
+
 int SnapshotManager::recycle_snapshots(InstanceRecycler* recycler) {
     return 0;
 }

--- a/cloud/src/snapshot/snapshot_manager.h
+++ b/cloud/src/snapshot/snapshot_manager.h
@@ -19,6 +19,9 @@
 
 #include <gen_cpp/cloud.pb.h>
 
+#include <string>
+#include <string_view>
+
 #include "meta-store/txn_kv.h"
 #include "meta-store/versionstamp.h"
 
@@ -30,6 +33,12 @@ class StorageVaultAccessor;
 class InstanceDataMigrator;
 class InstanceChainCompactor;
 class MetaChecker;
+
+struct SnapshotRetainedAnalysisResult {
+    MetaServiceCode code;
+    std::string message;
+    std::string result_json;
+};
 
 // A abstract class for managing cluster snapshots.
 class SnapshotManager {
@@ -65,6 +74,12 @@ public:
 
     virtual std::pair<MetaServiceCode, std::string> set_multi_version_status(
             std::string_view instance_id, MultiVersionStatus multi_version_status);
+
+    virtual SnapshotRetainedAnalysisResult analyze_snapshot_retained(std::string_view request_body);
+
+    virtual SnapshotRetainedAnalysisResult get_snapshot_retained_analysis(
+            std::string_view request_body, std::string_view instance_id,
+            std::string_view analysis_id);
 
     virtual int check_snapshots(InstanceChecker* checker);
 

--- a/cloud/test/meta_service_http_test.cpp
+++ b/cloud/test/meta_service_http_test.cpp
@@ -416,6 +416,12 @@ TEST(MetaServiceHttpTest, ResolveHttpHandlerByVersion) {
     ASSERT_EQ(resolve_http_handler(it->second, ""), &it->second.handler);
     ASSERT_EQ(resolve_http_handler(it->second, "v1"), &it->second.handler);
     ASSERT_EQ(resolve_http_handler(it->second, "v2"), nullptr);
+
+    for (std::string_view route : {"analyze_snapshot_retained", "get_snapshot_retained_analysis"}) {
+        it = handlers.find(route);
+        ASSERT_NE(it, handlers.end());
+        ASSERT_EQ(it->second.role, HttpRole::RECYCLER);
+    }
 }
 
 TEST(MetaServiceHttpTest, InstanceTest) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Add public Recycler HTTP routing and SnapshotManager extension methods for read-only snapshot retained diagnostics. The OSS SnapshotManager returns unsupported so enterprise implementations can override the interface without public code depending on enterprise types.

### Release note

None

### Check List (For Author)

- Test: Unit Test
  - ASAN Cloud build
  - MetaServiceHttpTest.ResolveHttpHandlerByVersion
- Behavior changed: Yes. Adds two Recycler HTTP routes whose OSS implementation reports unsupported.
- Does this need documentation: No