### PR TITLE
[fix](regression) Run restore auth case non-concurrently on branch-4.1 (#65668)

### DIFF
--- a/regression-test/suites/auth_call/test_ddl_restore_auth.groovy
+++ b/regression-test/suites/auth_call/test_ddl_restore_auth.groovy
@@ -18,7 +18,7 @@
 import org.junit.Assert;
 import java.util.UUID
 
-suite("test_ddl_restore_auth","p0,auth_call") {
+suite("test_ddl_restore_auth","p0,auth_call,nonConcurrent") {
     UUID uuid = UUID.randomUUID()
     String randomValue = uuid.toString()
     int hashCode = randomValue.hashCode()


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #65668

Backport #65668 to `branch-4.1`. When `test_ddl_restore_auth` submits a backup concurrently with the repository authorization case, it can hold `BackupHandler`'s global submission lock beyond the latter's 10-second `DROP REPOSITORY` lock timeout.

Add `test_ddl_restore_auth` to the `nonConcurrent` group, consistent with `test_ddl_backup_auth`. The original commit is `e7b0e4e22d538447f3bd31ecf89c5d2cf5b16665`. The cherry-pick required resolving context around the older suite declaration; the final change is the same one-line group addition.

### Release note

None

### Check List (For Author)

- Test:
  - [x] Manual test: static validation with `git diff --check` and review of the `branch-4.1` scheduler. It runs `nonConcurrent` suites through its single-thread executor after ordinary suites complete.
  - [ ] Regression test: not run locally; this workspace has no running Doris test cluster.
- Behavior changed:
  - [x] Yes: this regression suite runs in the serial phase.
- Does this need documentation?
  - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
