### PR TITLE
[improvement](tablet) Source active tablet stats from BE reports

### DIFF
--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -122,29 +122,24 @@ void increase_report_version() {
     s_report_version.fetch_add(1, std::memory_order_relaxed);
 }
 
-static std::vector<TActiveTabletStat> to_thrift_query(
-        const std::vector<ActiveTabletCandidate>& candidates) {
-    std::vector<TActiveTabletStat> result;
-    result.reserve(candidates.size());
-    for (const auto& candidate : candidates) {
-        auto& stat = result.emplace_back();
-        stat.__set_tablet_id(candidate.tablet_id);
-        stat.__set_scan_count_delta(candidate.delta);
-        stat.__set_last_query_time_ms(candidate.last_time_ms);
-        stat.__set_delta_window_ms(candidate.window_ms);
-    }
-    return result;
-}
+enum class ActiveDim { QUERY, LOAD };
 
-static std::vector<TActiveTabletStat> to_thrift_load(
-        const std::vector<ActiveTabletCandidate>& candidates) {
+// The two top-N lists differ only in which pair of thrift fields carries the dimension;
+// tablet_id and delta_window_ms are common, so they are written once here.
+template <ActiveDim Dim>
+std::vector<TActiveTabletStat> to_thrift(const std::vector<ActiveTabletCandidate>& candidates) {
     std::vector<TActiveTabletStat> result;
     result.reserve(candidates.size());
     for (const auto& candidate : candidates) {
         auto& stat = result.emplace_back();
         stat.__set_tablet_id(candidate.tablet_id);
-        stat.__set_load_count_delta(candidate.delta);
-        stat.__set_last_load_time_ms(candidate.last_time_ms);
+        if constexpr (Dim == ActiveDim::QUERY) {
+            stat.__set_scan_count_delta(candidate.delta);
+            stat.__set_last_query_time_ms(candidate.last_time_ms);
+        } else {
+            stat.__set_load_count_delta(candidate.delta);
+            stat.__set_last_load_time_ms(candidate.last_time_ms);
+        }
         stat.__set_delta_window_ms(candidate.window_ms);
     }
     return result;
@@ -1258,9 +1253,8 @@ void report_tablet_callback(StorageEngine& engine, const ClusterInfo* cluster_in
     request.__isset.resource = true;
 
     active.take_top_n();
-    request.__set_top_query_tablets(to_thrift_query(active.query_candidates()));
-    request.__set_top_load_tablets(to_thrift_load(active.load_candidates()));
-    request.__set_active_tablets_truncated(active.truncated());
+    request.__set_top_query_tablets(to_thrift<ActiveDim::QUERY>(active.query_candidates()));
+    request.__set_top_load_tablets(to_thrift<ActiveDim::LOAD>(active.load_candidates()));
     if (active.truncated()) {
         report_active_tablet_truncated << 1;
     }
@@ -1315,9 +1309,8 @@ void report_tablet_callback(CloudStorageEngine& engine, const ClusterInfo* clust
     request.__set_num_tablets(total_num_tablets);
 
     active.take_top_n();
-    request.__set_top_query_tablets(to_thrift_query(active.query_candidates()));
-    request.__set_top_load_tablets(to_thrift_load(active.load_candidates()));
-    request.__set_active_tablets_truncated(active.truncated());
+    request.__set_top_query_tablets(to_thrift<ActiveDim::QUERY>(active.query_candidates()));
+    request.__set_top_load_tablets(to_thrift<ActiveDim::LOAD>(active.load_candidates()));
     if (active.truncated()) {
         report_active_tablet_truncated << 1;
     }

--- a/be/src/agent/task_worker_pool.cpp
+++ b/be/src/agent/task_worker_pool.cpp
@@ -73,6 +73,7 @@
 #include "runtime/snapshot_loader.h"
 #include "runtime/user_function_cache.h"
 #include "service/backend_options.h"
+#include "storage/active_tablet_stats.h"
 #include "storage/compaction/cumulative_compaction_binlog_policy.h"
 #include "storage/compaction/cumulative_compaction_policy.h"
 #include "storage/compaction/cumulative_compaction_time_series_policy.h"
@@ -119,6 +120,34 @@ std::atomic_ulong s_report_version(time(nullptr) * 100000);
 
 void increase_report_version() {
     s_report_version.fetch_add(1, std::memory_order_relaxed);
+}
+
+static std::vector<TActiveTabletStat> to_thrift_query(
+        const std::vector<ActiveTabletCandidate>& candidates) {
+    std::vector<TActiveTabletStat> result;
+    result.reserve(candidates.size());
+    for (const auto& candidate : candidates) {
+        auto& stat = result.emplace_back();
+        stat.__set_tablet_id(candidate.tablet_id);
+        stat.__set_scan_count_delta(candidate.delta);
+        stat.__set_last_query_time_ms(candidate.last_time_ms);
+        stat.__set_delta_window_ms(candidate.window_ms);
+    }
+    return result;
+}
+
+static std::vector<TActiveTabletStat> to_thrift_load(
+        const std::vector<ActiveTabletCandidate>& candidates) {
+    std::vector<TActiveTabletStat> result;
+    result.reserve(candidates.size());
+    for (const auto& candidate : candidates) {
+        auto& stat = result.emplace_back();
+        stat.__set_tablet_id(candidate.tablet_id);
+        stat.__set_load_count_delta(candidate.delta);
+        stat.__set_last_load_time_ms(candidate.last_time_ms);
+        stat.__set_delta_window_ms(candidate.window_ms);
+    }
+    return result;
 }
 
 // FIXME(plat1ko): Paired register and remove task info
@@ -523,6 +552,7 @@ bvar::Adder<uint64_t> report_disk_total("report", "disk_total");
 bvar::Adder<uint64_t> report_disk_failed("report", "disk_failed");
 bvar::Adder<uint64_t> report_tablet_total("report", "tablet_total");
 bvar::Adder<uint64_t> report_tablet_failed("report", "tablet_failed");
+bvar::Adder<uint64_t> report_active_tablet_truncated("report", "active_tablet_truncated");
 bvar::Adder<uint64_t> report_index_policy_total("report", "index_policy_total");
 bvar::Adder<uint64_t> report_index_policy_failed("report", "index_policy_failed");
 
@@ -1174,10 +1204,12 @@ void report_tablet_callback(StorageEngine& engine, const ClusterInfo* cluster_in
 
     increase_report_version();
     uint64_t report_version;
+    ActiveTabletCollector active;
     for (int i = 0; i < 5; i++) {
         request.tablets.clear();
+        active.clear();
         report_version = s_report_version;
-        engine.tablet_manager()->build_all_report_tablets_info(&request.tablets);
+        engine.tablet_manager()->build_all_report_tablets_info(&request.tablets, &active);
         if (report_version == s_report_version) {
             break;
         }
@@ -1225,7 +1257,18 @@ void report_tablet_callback(StorageEngine& engine, const ClusterInfo* cluster_in
     }
     request.__isset.resource = true;
 
+    active.take_top_n();
+    request.__set_top_query_tablets(to_thrift_query(active.query_candidates()));
+    request.__set_top_load_tablets(to_thrift_load(active.load_candidates()));
+    request.__set_active_tablets_truncated(active.truncated());
+    if (active.truncated()) {
+        report_active_tablet_truncated << 1;
+    }
+
     bool succ = handle_report(request, cluster_info, "tablet");
+    if (succ) {
+        active.commit();
+    }
     report_tablet_total << 1;
     if (!succ) [[unlikely]] {
         report_tablet_failed << 1;
@@ -1247,10 +1290,16 @@ void report_tablet_callback(CloudStorageEngine& engine, const ClusterInfo* clust
     increase_report_version();
     uint64_t report_version;
     uint64_t total_num_tablets = 0;
+    ActiveTabletCollector active;
     for (int i = 0; i < 5; i++) {
         request.tablets.clear();
+        // build_all_report_tablets_info() only increments tablet_num, so a retry would
+        // otherwise report a multiple of the real tablet count to FE.
+        total_num_tablets = 0;
+        active.clear();
         report_version = s_report_version;
-        engine.tablet_mgr().build_all_report_tablets_info(&request.tablets, &total_num_tablets);
+        engine.tablet_mgr().build_all_report_tablets_info(&request.tablets, &total_num_tablets,
+                                                          &active);
         if (report_version == s_report_version) {
             break;
         }
@@ -1265,7 +1314,18 @@ void report_tablet_callback(CloudStorageEngine& engine, const ClusterInfo* clust
     request.__set_report_version(report_version);
     request.__set_num_tablets(total_num_tablets);
 
+    active.take_top_n();
+    request.__set_top_query_tablets(to_thrift_query(active.query_candidates()));
+    request.__set_top_load_tablets(to_thrift_load(active.load_candidates()));
+    request.__set_active_tablets_truncated(active.truncated());
+    if (active.truncated()) {
+        report_active_tablet_truncated << 1;
+    }
+
     bool succ = handle_report(request, cluster_info, "tablet");
+    if (succ) {
+        active.commit();
+    }
     report_tablet_total << 1;
     if (!succ) [[unlikely]] {
         report_tablet_failed << 1;

--- a/be/src/cloud/cloud_tablet_mgr.cpp
+++ b/be/src/cloud/cloud_tablet_mgr.cpp
@@ -29,6 +29,7 @@
 #include "common/status.h"
 #include "cpp/sync_point.h"
 #include "runtime/memory/cache_policy.h"
+#include "storage/active_tablet_stats.h"
 #include "storage/compaction/cumulative_compaction_time_series_policy.h"
 #include "util/debug_points.h"
 #include "util/lru_cache.h"
@@ -550,8 +551,12 @@ Status CloudTabletMgr::get_topn_tablets_to_compact(
 }
 
 void CloudTabletMgr::build_all_report_tablets_info(std::map<TTabletId, TTablet>* tablets_info,
-                                                   uint64_t* tablet_num) {
+                                                   uint64_t* tablet_num,
+                                                   ActiveTabletCollector* active) {
     DCHECK(tablets_info != nullptr);
+    if (active) {
+        active->start();
+    }
     VLOG_NOTICE << "begin to build all report cloud tablets info";
 
     HistogramStat tablet_version_num_hist;
@@ -560,6 +565,9 @@ void CloudTabletMgr::build_all_report_tablets_info(std::map<TTabletId, TTablet>*
         auto tablet = tablet_wk.lock();
         if (!tablet) return;
         (*tablet_num)++;
+        if (active) {
+            active->collect(tablet);
+        }
         TTabletInfo tablet_info;
         tablet->build_tablet_report_info(&tablet_info);
         using namespace std::chrono;

--- a/be/src/cloud/cloud_tablet_mgr.h
+++ b/be/src/cloud/cloud_tablet_mgr.h
@@ -32,6 +32,7 @@ namespace doris {
 
 class CloudTablet;
 class CloudStorageEngine;
+class ActiveTabletCollector;
 class LRUCachePolicy;
 class CountDownLatch;
 struct SyncRowsetStats;
@@ -96,7 +97,8 @@ public:
      * @param tablet_num tablets in be tabletMgr, total num
      */
     void build_all_report_tablets_info(std::map<TTabletId, TTablet>* tablets_info,
-                                       uint64_t* tablet_num);
+                                       uint64_t* tablet_num,
+                                       ActiveTabletCollector* active = nullptr);
 
     void get_tablet_info(int64_t num_tablets, std::vector<TabletInfo>* tablets_info);
 

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -269,6 +269,8 @@ DEFINE_mInt32(report_task_interval_seconds, "10");
 DEFINE_mInt32(report_disk_state_interval_seconds, "30");
 // the interval time(seconds) for agent report olap table to FE
 DEFINE_mInt32(report_tablet_interval_seconds, "60");
+DEFINE_mInt32(report_active_tablet_max_num, "5000");
+DEFINE_mInt32(report_active_tablet_window_second, "3600");
 // the max download speed(KB/s)
 DEFINE_mInt32(max_download_speed_kbps, "50000");
 // download low speed limit(KB/s)

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -325,6 +325,18 @@ DECLARE_mInt32(report_task_interval_seconds);
 DECLARE_mInt32(report_disk_state_interval_seconds);
 // the interval time(seconds) for agent report olap table to FE
 DECLARE_mInt32(report_tablet_interval_seconds);
+// Per-list cap: a report carries at most 2 * report_active_tablet_max_num entries
+// (one top-N list for queries, one for loads).
+//
+// MUST satisfy:  report_active_tablet_max_num >= fe cloud_active_partition_scheduling_topn / 2
+//
+// FE's getTopNActive() picks topn/2 per bucket. When the hot set is concentrated on a
+// single BE, that BE alone has to be able to fill a whole bucket, so a smaller cap here
+// silently drops information. 5000 is exactly the lower bound for the FE default of 10000
+// -- raising the FE value without raising this one loses data silently.
+DECLARE_mInt32(report_active_tablet_max_num);
+// Only tablets queried / loaded within this window are reported as active.
+DECLARE_mInt32(report_active_tablet_window_second);
 // the max download speed(KB/s)
 DECLARE_mInt32(max_download_speed_kbps);
 // download low speed limit(KB/s)

--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -68,6 +68,7 @@
 #include "util/debug_points.h"
 #endif
 #include "util/json/path_in_data.h"
+#include "util/time.h"
 
 namespace doris {
 #include "common/compile_check_avoid_begin.h"
@@ -977,6 +978,7 @@ void OlapScanner::_collect_profile_before_close() {
     tablet->query_scan_bytes->increment(local_state->_read_uncompressed_counter->value());
     tablet->query_scan_rows->increment(local_state->_scan_rows->value());
     tablet->query_scan_count->increment(1);
+    tablet->last_query_scan_time_ms.store(UnixMillis(), std::memory_order_relaxed);
 
     COUNTER_UPDATE(local_state->_ann_range_search_filter_counter,
                    stats.rows_ann_index_range_filtered);

--- a/be/src/load/delta_writer/delta_writer.cpp
+++ b/be/src/load/delta_writer/delta_writer.cpp
@@ -21,6 +21,7 @@
 #include <gen_cpp/internal_service.pb.h>
 #include <gen_cpp/olap_file.pb.h>
 
+#include <chrono>
 #include <ostream>
 #include <string>
 #include <utility>
@@ -104,6 +105,8 @@ BaseDeltaWriter::~BaseDeltaWriter() {
         const FlushStatistic& stat = _memtable_writer->get_flush_token_stats();
         _rowset_builder->tablet()->flush_bytes->increment(stat.flush_size_bytes);
         _rowset_builder->tablet()->flush_finish_count->increment(stat.flush_finish_count);
+        _rowset_builder->tablet()->last_load_flush_time_ms.store(UnixMillis(),
+                                                                 std::memory_order_relaxed);
     }
 }
 
@@ -150,6 +153,9 @@ Status BaseDeltaWriter::init() {
             _rowset_builder->get_partial_update_info(), wg_sptr,
             _rowset_builder->tablet_sptr()->enable_unique_key_merge_on_write()));
     ExecEnv::GetInstance()->memtable_memory_limiter()->register_writer(_memtable_writer);
+    if (const auto& tablet = _rowset_builder->tablet(); tablet != nullptr) {
+        tablet->last_load_flush_time_ms.store(UnixMillis(), std::memory_order_relaxed);
+    }
     _is_init = true;
     return Status::OK();
 }

--- a/be/src/load/delta_writer/delta_writer.cpp
+++ b/be/src/load/delta_writer/delta_writer.cpp
@@ -105,6 +105,10 @@ BaseDeltaWriter::~BaseDeltaWriter() {
         const FlushStatistic& stat = _memtable_writer->get_flush_token_stats();
         _rowset_builder->tablet()->flush_bytes->increment(stat.flush_size_bytes);
         _rowset_builder->tablet()->flush_finish_count->increment(stat.flush_finish_count);
+        // Stamped here and nowhere else, so the load timestamp and the counter it
+        // accompanies always move together: a non-zero flush delta always comes with a
+        // fresh timestamp, and the active-window filter can only ever retire a stale
+        // delta, never invent one.
         _rowset_builder->tablet()->last_load_flush_time_ms.store(UnixMillis(),
                                                                  std::memory_order_relaxed);
     }
@@ -153,9 +157,6 @@ Status BaseDeltaWriter::init() {
             _rowset_builder->get_partial_update_info(), wg_sptr,
             _rowset_builder->tablet_sptr()->enable_unique_key_merge_on_write()));
     ExecEnv::GetInstance()->memtable_memory_limiter()->register_writer(_memtable_writer);
-    if (const auto& tablet = _rowset_builder->tablet(); tablet != nullptr) {
-        tablet->last_load_flush_time_ms.store(UnixMillis(), std::memory_order_relaxed);
-    }
     _is_init = true;
     return Status::OK();
 }

--- a/be/src/storage/active_tablet_stats.cpp
+++ b/be/src/storage/active_tablet_stats.cpp
@@ -1,0 +1,100 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/active_tablet_stats.h"
+
+#include <algorithm>
+#include <cstddef>
+
+#include "common/config.h"
+#include "storage/tablet/base_tablet.h"
+#include "util/time.h"
+
+namespace doris {
+
+void ActiveTabletCollector::start() {
+    _now_ms = UnixMillis();
+}
+
+void ActiveTabletCollector::collect(const std::shared_ptr<BaseTablet>& tablet) {
+    if (!tablet) {
+        return;
+    }
+    const int64_t scan_cur = tablet->query_scan_count->value();
+    const int64_t flush_cur = tablet->flush_finish_count->value();
+    _pending.push_back({tablet, scan_cur, flush_cur});
+
+    const int64_t prev_ms = tablet->last_reported_time_ms.load(std::memory_order_relaxed);
+    if (prev_ms == 0) {
+        // First time we see this tablet: this round only establishes the baseline.
+        return;
+    }
+    const int64_t scan_delta =
+            scan_cur - tablet->last_reported_scan_count.load(std::memory_order_relaxed);
+    const int64_t load_delta =
+            flush_cur - tablet->last_reported_flush_count.load(std::memory_order_relaxed);
+    const int64_t win_ms = std::max<int64_t>(1, _now_ms - prev_ms);
+    const int64_t active_window_ms =
+            static_cast<int64_t>(config::report_active_tablet_window_second) * 1000;
+
+    const int64_t last_q = tablet->last_query_scan_time_ms.load(std::memory_order_relaxed);
+    const int64_t last_l = tablet->last_load_flush_time_ms.load(std::memory_order_relaxed);
+    if (scan_delta > 0 && _now_ms - last_q <= active_window_ms) {
+        _query_cands.push_back({tablet->tablet_id(), scan_delta, win_ms, last_q});
+    }
+    if (load_delta > 0 && _now_ms - last_l <= active_window_ms) {
+        _load_cands.push_back({tablet->tablet_id(), load_delta, win_ms, last_l});
+    }
+    // A tablet hot on both dimensions appears once in each list; FE merges by tablet_id.
+}
+
+void ActiveTabletCollector::take_top_n() {
+    const auto truncate_to_cap = [this](std::vector<ActiveTabletCandidate>& candidates) {
+        // A negative cap would wrap to SIZE_MAX and silently disable truncation, i.e. ship the
+        // whole candidate list in the report; clamp instead.
+        const auto cap = static_cast<std::size_t>(
+                std::max(0, static_cast<int>(config::report_active_tablet_max_num)));
+        if (candidates.size() > cap) {
+            _truncated = true;
+            std::nth_element(
+                    candidates.begin(), candidates.begin() + cap, candidates.end(),
+                    [](const auto& lhs, const auto& rhs) { return lhs.rate() > rhs.rate(); });
+            candidates.resize(cap);
+        }
+    };
+    truncate_to_cap(_query_cands);
+    truncate_to_cap(_load_cands);
+}
+
+void ActiveTabletCollector::commit() {
+    for (auto& pending : _pending) {
+        if (auto tablet = pending.tablet.lock()) {
+            tablet->last_reported_scan_count.store(pending.scan_count, std::memory_order_relaxed);
+            tablet->last_reported_flush_count.store(pending.flush_count, std::memory_order_relaxed);
+            tablet->last_reported_time_ms.store(_now_ms, std::memory_order_relaxed);
+        }
+    }
+}
+
+void ActiveTabletCollector::clear() {
+    _query_cands.clear();
+    _load_cands.clear();
+    _pending.clear();
+    _truncated = false;
+}
+
+} // namespace doris

--- a/be/src/storage/active_tablet_stats.cpp
+++ b/be/src/storage/active_tablet_stats.cpp
@@ -36,7 +36,8 @@ void ActiveTabletCollector::collect(const std::shared_ptr<BaseTablet>& tablet) {
     }
     const int64_t scan_cur = tablet->query_scan_count->value();
     const int64_t flush_cur = tablet->flush_finish_count->value();
-    _pending.push_back({tablet, scan_cur, flush_cur});
+    // Snapshot only -- the baselines on the tablet stay untouched until commit().
+    _pending.push_back({.tablet = tablet, .scan_count = scan_cur, .flush_count = flush_cur});
 
     const int64_t prev_ms = tablet->last_reported_time_ms.load(std::memory_order_relaxed);
     if (prev_ms == 0) {
@@ -64,8 +65,11 @@ void ActiveTabletCollector::collect(const std::shared_ptr<BaseTablet>& tablet) {
 
 void ActiveTabletCollector::take_top_n() {
     const auto truncate_to_cap = [this](std::vector<ActiveTabletCandidate>& candidates) {
-        // A negative cap would wrap to SIZE_MAX and silently disable truncation, i.e. ship the
-        // whole candidate list in the report; clamp instead.
+        // Clamp before the cast: a negative value would wrap to SIZE_MAX and silently
+        // uncap the list. <= 0 therefore means "report nothing" (feature off), never
+        // "report everything" -- an uncapped list can push the report past FE's
+        // thrift_max_message_size, and that failure is permanent: the message never
+        // gets smaller, so tablet reporting for this BE stops succeeding for good.
         const auto cap = static_cast<std::size_t>(
                 std::max(0, static_cast<int>(config::report_active_tablet_max_num)));
         if (candidates.size() > cap) {

--- a/be/src/storage/active_tablet_stats.h
+++ b/be/src/storage/active_tablet_stats.h
@@ -32,8 +32,9 @@ struct ActiveTabletCandidate {
     int64_t window_ms = 1;
     int64_t last_time_ms = 0;
 
-    // Rate, not raw delta: a tablet whose baseline was not committed last round carries a
-    // delta spanning several intervals, so raw deltas are not comparable. See handoff §9.2d.
+    // Rate, not raw delta. Raw deltas are not comparable: a dropped report round commits
+    // no baseline, so the next delta covers several intervals, and backends report on
+    // independent phases.
     double rate() const {
         return static_cast<double>(delta) * 1000.0 / static_cast<double>(window_ms);
     }
@@ -48,8 +49,10 @@ public:
     void start();
     // Called once per tablet during the walk.
     void collect(const std::shared_ptr<BaseTablet>& tablet);
-    // Per-dimension nth_element by rate. No cross-dimension merging/weighting here --
-    // that is FE's job (handoff §9.2b).
+    // Per-dimension nth_element by rate. No cross-dimension merging or weighting here:
+    // query and load counts differ by one to two orders of magnitude, so ranking them
+    // against each other drops load-heavy tablets as a class. FE owns that trade-off,
+    // where the split is a mutable config instead of a be.conf restart.
     void take_top_n();
     // Advance the baselines. ONLY after handle_report() succeeded.
     void commit();

--- a/be/src/storage/active_tablet_stats.h
+++ b/be/src/storage/active_tablet_stats.h
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace doris {
+class BaseTablet;
+
+// One entry of a per-dimension top-N list. Kept thrift-free on purpose so this header
+// does not drag gen_cpp into the storage layer; conversion lives in task_worker_pool.cpp.
+struct ActiveTabletCandidate {
+    int64_t tablet_id = 0;
+    int64_t delta = 0;
+    int64_t window_ms = 1;
+    int64_t last_time_ms = 0;
+
+    // Rate, not raw delta: a tablet whose baseline was not committed last round carries a
+    // delta spanning several intervals, so raw deltas are not comparable. See handoff §9.2d.
+    double rate() const {
+        return static_cast<double>(delta) * 1000.0 / static_cast<double>(window_ms);
+    }
+};
+
+// Collected inside the EXISTING report-tablet walk (no extra traversal). Collection is
+// strictly read-only on the tablet baselines; commit() is called only after
+// handle_report() returned true, so a retried or dropped report loses nothing.
+class ActiveTabletCollector {
+public:
+    // Called at the top of each build_all_report_tablets_info() pass.
+    void start();
+    // Called once per tablet during the walk.
+    void collect(const std::shared_ptr<BaseTablet>& tablet);
+    // Per-dimension nth_element by rate. No cross-dimension merging/weighting here --
+    // that is FE's job (handoff §9.2b).
+    void take_top_n();
+    // Advance the baselines. ONLY after handle_report() succeeded.
+    void commit();
+    // Reset everything; called on each retry of the report loop.
+    void clear();
+
+    const std::vector<ActiveTabletCandidate>& query_candidates() const { return _query_cands; }
+    const std::vector<ActiveTabletCandidate>& load_candidates() const { return _load_cands; }
+    bool truncated() const { return _truncated; }
+
+private:
+    struct Pending {
+        std::weak_ptr<BaseTablet> tablet;
+        int64_t scan_count = 0;
+        int64_t flush_count = 0;
+    };
+    std::vector<ActiveTabletCandidate> _query_cands;
+    std::vector<ActiveTabletCandidate> _load_cands;
+    std::vector<Pending> _pending;
+    int64_t _now_ms = 0;
+    bool _truncated = false;
+};
+
+} // namespace doris

--- a/be/src/storage/tablet/base_tablet.h
+++ b/be/src/storage/tablet/base_tablet.h
@@ -421,9 +421,12 @@ public:
     // ActiveTabletCollector::commit().
     std::atomic<int64_t> last_reported_scan_count {0};
     std::atomic<int64_t> last_reported_flush_count {0};
-    // Wall clock of that commit. The delta window is per-tablet (a tablet cut by the
-    // topN cap is not committed, so its next delta spans several intervals), so
-    // consumers must normalise delta by this window instead of comparing raw counts.
+    // Wall clock of that commit. Shared by every tablet in a round, because commit() is
+    // all-or-nothing: a dropped report (5 retries exhausted, or handle_report() returning
+    // false) advances no baseline at all, so the next round's delta spans several
+    // intervals. Backends also report on independent phases. FE compares entries across
+    // backends and across rounds, so it must normalise delta by this window rather than
+    // compare raw counts.
     std::atomic<int64_t> last_reported_time_ms {0};
     std::atomic<int64_t> published_count = 0;
     std::atomic<int64_t> read_block_count = 0;

--- a/be/src/storage/tablet/base_tablet.h
+++ b/be/src/storage/tablet/base_tablet.h
@@ -408,6 +408,23 @@ public:
     IntCounter* query_scan_count = nullptr;
     IntCounter* flush_bytes = nullptr;
     IntCounter* flush_finish_count = nullptr;
+    // Last time this tablet was scanned by a query / flushed by a load (ms since epoch),
+    // named after the counter each one accompanies (query_scan_count / flush_finish_count).
+    // Set only on the query scan path and the memtable flush path respectively, so they are
+    // NOT polluted by compaction / snapshot / agent tasks the way CloudTablet::
+    // last_access_time_ms is. Do NOT shorten to last_load_time_ms: CloudTablet already has
+    // a field by that name tracking load start for the compaction freeze check.
+    std::atomic<int64_t> last_query_scan_time_ms {0};
+    std::atomic<int64_t> last_load_flush_time_ms {0};
+    // Snapshots taken at the last SUCCESSFULLY DELIVERED report. Committed only after
+    // handle_report() returns true, never with exchange() during collection -- see
+    // ActiveTabletCollector::commit().
+    std::atomic<int64_t> last_reported_scan_count {0};
+    std::atomic<int64_t> last_reported_flush_count {0};
+    // Wall clock of that commit. The delta window is per-tablet (a tablet cut by the
+    // topN cap is not committed, so its next delta spans several intervals), so
+    // consumers must normalise delta by this window instead of comparing raw counts.
+    std::atomic<int64_t> last_reported_time_ms {0};
     std::atomic<int64_t> published_count = 0;
     std::atomic<int64_t> read_block_count = 0;
     std::atomic<int64_t> write_count = 0;

--- a/be/src/storage/tablet/tablet_manager.cpp
+++ b/be/src/storage/tablet/tablet_manager.cpp
@@ -44,6 +44,7 @@
 #include "io/fs/local_file_system.h"
 #include "runtime/exec_env.h"
 #include "service/backend_options.h"
+#include "storage/active_tablet_stats.h"
 #include "storage/compaction/cumulative_compaction_policy.h"
 #include "storage/compaction/cumulative_compaction_time_series_policy.h"
 #include "storage/data_dir.h"
@@ -1102,8 +1103,12 @@ Status TabletManager::report_tablet_info(TTabletInfo* tablet_info) {
     return res;
 }
 
-void TabletManager::build_all_report_tablets_info(std::map<TTabletId, TTablet>* tablets_info) {
+void TabletManager::build_all_report_tablets_info(std::map<TTabletId, TTablet>* tablets_info,
+                                                  ActiveTabletCollector* active) {
     DCHECK(tablets_info != nullptr);
+    if (active) {
+        active->start();
+    }
     VLOG_NOTICE << "begin to build all report tablets info";
 
     // build the expired txn map first, outside the tablet map lock
@@ -1114,6 +1119,9 @@ void TabletManager::build_all_report_tablets_info(std::map<TTabletId, TTablet>* 
     HistogramStat tablet_version_num_hist;
     auto local_cache = std::make_shared<std::vector<TTabletStat>>();
     auto handler = [&](const TabletSharedPtr& tablet) {
+        if (active) {
+            active->collect(tablet);
+        }
         auto& t_tablet = (*tablets_info)[tablet->tablet_id()];
         TTabletInfo& tablet_info = t_tablet.tablet_infos.emplace_back();
         tablet->build_tablet_report_info(&tablet_info, true, true);

--- a/be/src/storage/tablet/tablet_manager.h
+++ b/be/src/storage/tablet/tablet_manager.h
@@ -45,6 +45,7 @@ namespace doris {
 
 class DataDir;
 class CumulativeCompactionPolicy;
+class ActiveTabletCollector;
 class MemTracker;
 class TCreateTabletReq;
 class TTablet;
@@ -140,7 +141,8 @@ public:
     //        Status::Error<INVALID_ARGUMENT>(), if tables is null
     Status report_tablet_info(TTabletInfo* tablet_info);
 
-    void build_all_report_tablets_info(std::map<TTabletId, TTablet>* tablets_info);
+    void build_all_report_tablets_info(std::map<TTabletId, TTablet>* tablets_info,
+                                       ActiveTabletCollector* active = nullptr);
 
     Status start_trash_sweep();
 

--- a/be/test/storage/active_tablet_stats_test.cpp
+++ b/be/test/storage/active_tablet_stats_test.cpp
@@ -225,10 +225,10 @@ TEST(ActiveTabletStatsTest, DroppedReportCarriesDeltaIntoAWiderWindow) {
     EXPECT_DOUBLE_EQ(candidate.rate(), 10.0 * 1000.0 / kReportIntervalMs);
 }
 
-// A tablet whose delta is stale -- it kept being cut by the topN cap, so its baseline
-// was never committed -- must age out of the report once it stops being touched.
-// This is the case report_active_tablet_window_second exists for; without it the
-// stale delta would keep the tablet in the active set forever.
+// A tablet whose delta is stale -- reporting kept failing, so no baseline was committed
+// for a long stretch -- must age out once it stops being touched. This is the case
+// report_active_tablet_window_second exists for: without it, a tablet that went cold
+// hours ago would be reported as active the moment reporting recovers.
 TEST(ActiveTabletStatsTest, StaleDeltaOutsideActiveWindowIsDropped) {
     const int64_t window_ms = int64_t {config::report_active_tablet_window_second} * 1000;
     auto tablet = make_baselined_tablet(105, kNowMs - window_ms - kReportIntervalMs);

--- a/be/test/storage/active_tablet_stats_test.cpp
+++ b/be/test/storage/active_tablet_stats_test.cpp
@@ -1,0 +1,260 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "storage/active_tablet_stats.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "common/config.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/tablet/base_tablet.h"
+#include "storage/tablet/tablet_meta.h"
+#include "storage/tablet/tablet_schema.h"
+
+namespace doris {
+
+namespace {
+
+constexpr int64_t kNowMs = 1'700'000'000'000;
+constexpr int64_t kReportIntervalMs = 60'000;
+
+// Minimal concrete BaseTablet, same shape as the FakeTablet stubs in the scanner and
+// file-cache tests. The collector only reads the counters and the atomics added for
+// active-tablet stats, so none of these overrides is ever reached.
+class StatsTestTablet final : public BaseTablet {
+public:
+    explicit StatsTestTablet(int64_t tablet_id) : BaseTablet(create_meta(tablet_id)) {}
+
+    std::string tablet_path() const override { return ""; }
+
+    bool exceed_version_limit(int32_t /*limit*/) override { return false; }
+
+    Result<std::unique_ptr<RowsetWriter>> create_rowset_writer(RowsetWriterContext& /*context*/,
+                                                               bool /*vertical*/) override {
+        return ResultError(Status::NotSupported("stats test tablet"));
+    }
+
+    Result<std::unique_ptr<RowsetWriter>> create_transient_rowset_writer(
+            const Rowset& /*rowset*/, std::shared_ptr<PartialUpdateInfo> /*partial_update_info*/,
+            int64_t /*txn_expiration*/ = 0) override {
+        return ResultError(Status::NotSupported("stats test tablet"));
+    }
+
+    Status capture_rs_readers(const Version& /*spec_version*/,
+                              std::vector<RowSetSplits>* /*rs_splits*/,
+                              const CaptureRowsetOps& /*opts*/) override {
+        return Status::NotSupported("stats test tablet");
+    }
+
+    Status save_delete_bitmap(const TabletTxnInfo* /*txn_info*/, int64_t /*txn_id*/,
+                              DeleteBitmapPtr /*delete_bitmap*/, RowsetWriter* /*rowset_writer*/,
+                              const RowsetIdUnorderedSet& /*cur_rowset_ids*/,
+                              int64_t /*lock_id*/ = -1,
+                              int64_t /*next_visible_version*/ = -1) override {
+        return Status::NotSupported("stats test tablet");
+    }
+
+    CalcDeleteBitmapExecutor* calc_delete_bitmap_executor() override { return nullptr; }
+
+    void clear_cache() override {}
+
+    Versions calc_missed_versions(int64_t /*spec_version*/,
+                                  Versions /*existing_versions*/) const override {
+        return {};
+    }
+
+    size_t tablet_footprint() override { return 0; }
+
+private:
+    static TabletMetaSharedPtr create_meta(int64_t tablet_id) {
+        auto meta = std::make_shared<TabletMeta>(std::make_shared<TabletSchema>());
+        meta->_tablet_id = tablet_id;
+        return meta;
+    }
+};
+
+// A tablet that already has a committed baseline, i.e. one the collector will emit
+// candidates for rather than skip as first-seen.
+std::shared_ptr<StatsTestTablet> make_baselined_tablet(int64_t tablet_id, int64_t baseline_ms) {
+    auto tablet = std::make_shared<StatsTestTablet>(tablet_id);
+    tablet->last_reported_time_ms.store(baseline_ms);
+    tablet->last_query_scan_time_ms.store(baseline_ms);
+    tablet->last_load_flush_time_ms.store(baseline_ms);
+    return tablet;
+}
+
+// Drives one report round at a fixed wall clock instead of UnixMillis(), so the
+// delta windows the assertions check are exact.
+void collect_at(ActiveTabletCollector& collector, const std::shared_ptr<BaseTablet>& tablet,
+                int64_t now_ms) {
+    collector._now_ms = now_ms;
+    collector.collect(tablet);
+}
+
+} // namespace
+
+// The reason BE ranks by delta/window and not by raw delta: tablet 1 has 5x the raw
+// scan delta of tablet 2 but accumulated it over 10x the window, so it is the colder
+// one. Also pins that the two dimensions are truncated independently -- a load-only
+// tablet must not be crowded out by query traffic.
+TEST(ActiveTabletStatsTest, TakesIndependentTopListsByRate) {
+    const auto old_cap = config::report_active_tablet_max_num;
+    config::report_active_tablet_max_num = 1;
+
+    ActiveTabletCollector collector;
+    collector._query_cands = {{1, 100, 10000, 0}, {2, 20, 1000, 0}};
+    collector._load_cands = {{3, 30, 1000, 0}, {4, 200, 10000, 0}};
+
+    collector.take_top_n();
+    config::report_active_tablet_max_num = old_cap;
+
+    ASSERT_EQ(collector.query_candidates().size(), 1);
+    EXPECT_EQ(collector.query_candidates().front().tablet_id, 2);
+    ASSERT_EQ(collector.load_candidates().size(), 1);
+    EXPECT_EQ(collector.load_candidates().front().tablet_id, 3);
+    EXPECT_TRUE(collector.truncated());
+}
+
+// A tablet seen for the first time (no baseline yet) must not be reported: without a
+// previous timestamp there is no window to normalise its delta by.
+TEST(ActiveTabletStatsTest, FirstRoundOnlyEstablishesBaseline) {
+    auto tablet = std::make_shared<StatsTestTablet>(101);
+    tablet->query_scan_count->increment(42);
+    tablet->last_query_scan_time_ms.store(kNowMs);
+
+    ActiveTabletCollector collector;
+    collect_at(collector, tablet, kNowMs);
+
+    EXPECT_TRUE(collector.query_candidates().empty());
+    EXPECT_TRUE(collector.load_candidates().empty());
+
+    collector.commit();
+    EXPECT_EQ(tablet->last_reported_scan_count.load(), 42);
+    EXPECT_EQ(tablet->last_reported_time_ms.load(), kNowMs);
+}
+
+// Collection must be read-only on the baselines. The report path retries the walk up
+// to 5 times on a report-version conflict, so a destructive read (exchange) would make
+// every retry after the first see a zero delta.
+TEST(ActiveTabletStatsTest, CollectDoesNotAdvanceBaseline) {
+    auto tablet = make_baselined_tablet(102, kNowMs - kReportIntervalMs);
+    tablet->query_scan_count->increment(10);
+
+    ActiveTabletCollector collector;
+    for (int retry = 0; retry < 3; ++retry) {
+        collector.clear();
+        collect_at(collector, tablet, kNowMs);
+
+        ASSERT_EQ(collector.query_candidates().size(), 1) << "retry " << retry;
+        EXPECT_EQ(collector.query_candidates().front().delta, 10);
+        EXPECT_EQ(collector.query_candidates().front().window_ms, kReportIntervalMs);
+        EXPECT_EQ(tablet->last_reported_scan_count.load(), 0);
+        EXPECT_EQ(tablet->last_reported_time_ms.load(), kNowMs - kReportIntervalMs);
+    }
+}
+
+// Once the report is delivered, commit() advances the baseline so the next round
+// reports only what happened since.
+TEST(ActiveTabletStatsTest, CommitAdvancesBaselineSoNextDeltaIsIncremental) {
+    auto tablet = make_baselined_tablet(103, kNowMs - kReportIntervalMs);
+    tablet->query_scan_count->increment(10);
+    tablet->flush_finish_count->increment(4);
+
+    ActiveTabletCollector collector;
+    collect_at(collector, tablet, kNowMs);
+    collector.commit();
+    EXPECT_EQ(tablet->last_reported_scan_count.load(), 10);
+    EXPECT_EQ(tablet->last_reported_flush_count.load(), 4);
+    EXPECT_EQ(tablet->last_reported_time_ms.load(), kNowMs);
+
+    const int64_t next_ms = kNowMs + kReportIntervalMs;
+    tablet->query_scan_count->increment(3);
+    tablet->flush_finish_count->increment(1);
+    tablet->last_query_scan_time_ms.store(next_ms);
+    tablet->last_load_flush_time_ms.store(next_ms);
+
+    collector.clear();
+    collect_at(collector, tablet, next_ms);
+
+    ASSERT_EQ(collector.query_candidates().size(), 1);
+    EXPECT_EQ(collector.query_candidates().front().delta, 3);
+    EXPECT_EQ(collector.query_candidates().front().window_ms, kReportIntervalMs);
+    ASSERT_EQ(collector.load_candidates().size(), 1);
+    EXPECT_EQ(collector.load_candidates().front().delta, 1);
+}
+
+// When a report is dropped (5 failed retries, or handle_report() returning false) the
+// baseline is not committed, so the next round's delta must span both intervals and
+// window_ms must widen with it -- that is what keeps the rate comparable.
+TEST(ActiveTabletStatsTest, DroppedReportCarriesDeltaIntoAWiderWindow) {
+    auto tablet = make_baselined_tablet(104, kNowMs - kReportIntervalMs);
+    tablet->query_scan_count->increment(10);
+
+    ActiveTabletCollector collector;
+    collect_at(collector, tablet, kNowMs);
+    // report failed: no commit()
+
+    const int64_t next_ms = kNowMs + kReportIntervalMs;
+    tablet->query_scan_count->increment(10);
+    tablet->last_query_scan_time_ms.store(next_ms);
+
+    collector.clear();
+    collect_at(collector, tablet, next_ms);
+
+    ASSERT_EQ(collector.query_candidates().size(), 1);
+    const auto& candidate = collector.query_candidates().front();
+    EXPECT_EQ(candidate.delta, 20);
+    EXPECT_EQ(candidate.window_ms, 2 * kReportIntervalMs);
+    // Same rate as a single round of 10 -- the point of normalising by the window.
+    EXPECT_DOUBLE_EQ(candidate.rate(), 10.0 * 1000.0 / kReportIntervalMs);
+}
+
+// A tablet whose delta is stale -- it kept being cut by the topN cap, so its baseline
+// was never committed -- must age out of the report once it stops being touched.
+// This is the case report_active_tablet_window_second exists for; without it the
+// stale delta would keep the tablet in the active set forever.
+TEST(ActiveTabletStatsTest, StaleDeltaOutsideActiveWindowIsDropped) {
+    const int64_t window_ms = int64_t {config::report_active_tablet_window_second} * 1000;
+    auto tablet = make_baselined_tablet(105, kNowMs - window_ms - kReportIntervalMs);
+    tablet->query_scan_count->increment(10);
+    // Last actually queried just before the active window opened.
+    tablet->last_query_scan_time_ms.store(kNowMs - window_ms - 1);
+
+    ActiveTabletCollector collector;
+    collect_at(collector, tablet, kNowMs);
+
+    EXPECT_TRUE(collector.query_candidates().empty());
+    // Still pending, so the baseline moves on and the stale delta is retired.
+    collector.commit();
+    EXPECT_EQ(tablet->last_reported_scan_count.load(), 10);
+}
+
+// A tablet dropped between collection and delivery must not crash commit().
+TEST(ActiveTabletStatsTest, CommitSkipsTabletsDroppedAfterCollection) {
+    auto tablet = make_baselined_tablet(106, kNowMs - kReportIntervalMs);
+    tablet->query_scan_count->increment(10);
+
+    ActiveTabletCollector collector;
+    collect_at(collector, tablet, kNowMs);
+
+    tablet.reset();
+    collector.commit();
+}
+
+} // namespace doris

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -3257,8 +3257,9 @@ public class Config extends ConfigBase {
             + "whether to enable the active tablet priority scheduling strategy. " + "Default is true.")
     public static boolean enable_cloud_active_tablet_priority_scheduling = true;
 
-    @ConfField(masterOnly = true, description = "Whether to enable active tablet sliding window access statistics "
-            + "feature. Default is true.")
+    @ConfField(mutable = true, masterOnly = true,
+            description = "Whether to enable active tablet sliding window access statistics "
+                    + "feature. Default is true.")
     public static boolean enable_active_tablet_sliding_window_access_stats = true;
 
     @ConfField(mutable = true, masterOnly = true, description = "Time window size in seconds for active tablet "
@@ -3269,7 +3270,9 @@ public class Config extends ConfigBase {
             + "partition-level scheduling processes TopN active "
             + "partitions first, then other active partitions, then "
             + "inactive partitions, and internal databases last. "
-            + "Default is 10000. <=0 disables TopN segmentation.")
+            + "Default is 10000. <=0 disables TopN segmentation. "
+            + "Must keep be config report_active_tablet_max_num >= this / 2, otherwise a BE that holds a "
+            + "concentrated hot set cannot fill one FE bucket and stats are silently lost.")
     public static int cloud_active_partition_scheduling_topn = 10000;
 
     @ConfField(mutable = true, masterOnly = true, description = "Refresh interval in seconds for the active-tablet "

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Tablet.java
@@ -240,7 +240,6 @@ public abstract class Tablet {
     // return map of (BE id -> path hash) of normal replicas
     // for load plan.
     public Multimap<Long, Long> getNormalReplicaBackendPathMap() throws UserException {
-        TabletSlidingWindowAccessStats.recordTablet(getId());
         return getNormalReplicaBackendPathMapImpl(null, (rep, be) -> rep.getBackendId());
     }
 
@@ -262,7 +261,6 @@ public abstract class Tablet {
         List<Replica> mayMissingVersionReplica = Lists.newArrayListWithCapacity(replicaNum);
         List<Replica> notCatchupReplica = Lists.newArrayListWithCapacity(replicaNum);
         List<Replica> userDropReplica = Lists.newArrayListWithCapacity(replicaNum);
-        TabletSlidingWindowAccessStats.recordTablet(getId());
 
         for (Replica replica : replicas) {
             if (replica.isBad()) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletSlidingWindowAccessStats.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletSlidingWindowAccessStats.java
@@ -20,10 +20,11 @@ package org.apache.doris.catalog;
 import org.apache.doris.common.Config;
 import org.apache.doris.thrift.TActiveTabletStat;
 
+import com.google.common.collect.Maps;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,15 +37,20 @@ import java.util.concurrent.atomic.AtomicLong;
 public class TabletSlidingWindowAccessStats {
     private static volatile TabletSlidingWindowAccessStats instance;
 
+    // Hottest first, most recently touched breaking a tie. Reversing the whole chain is the
+    // same as reversing each key, and reads as the one sentence above.
     private static final Comparator<AccessStatsResult> QUERY_RATE_COMPARATOR =
-            Comparator.comparingDouble((AccessStatsResult r) -> r.scanRate).reversed()
-                    .thenComparing(Comparator.comparingLong((AccessStatsResult r) -> r.lastAccessTime).reversed());
+            Comparator.comparingDouble((AccessStatsResult r) -> r.scanRate)
+                    .thenComparingLong(r -> r.lastAccessTime)
+                    .reversed();
     private static final Comparator<AccessStatsResult> LOAD_RATE_COMPARATOR =
-            Comparator.comparingDouble((AccessStatsResult r) -> r.loadRate).reversed()
-                    .thenComparing(Comparator.comparingLong((AccessStatsResult r) -> r.lastAccessTime).reversed());
+            Comparator.comparingDouble((AccessStatsResult r) -> r.loadRate)
+                    .thenComparingLong(r -> r.lastAccessTime)
+                    .reversed();
 
-    // beId -> (tabletId -> stats). Each report replaces the complete snapshot for one backend.
-    // Backend removal is handled by removeBackend(), so no cleanup daemon is needed.
+    // beId -> (tabletId -> stats). A report updates the tablets it carries and ages out the
+    // rest by active_tablet_sliding_window_time_window_second, so entries expire on write
+    // instead of needing a cleanup daemon; a backend going away is handled by removeBackend().
     private final ConcurrentHashMap<Long, Map<Long, AccessStatsResult>> beToStats = new ConcurrentHashMap<>();
     private final AtomicLong totalAccessCount = new AtomicLong(0);
 
@@ -67,34 +73,110 @@ public class TabletSlidingWindowAccessStats {
             return;
         }
 
-        // long[]{scan, load, lastQueryMs, lastLoadMs, scanWindowMs, loadWindowMs}
-        Map<Long, long[]> accumulated = new HashMap<>((topQuery.size() + topLoad.size()) * 2);
+        // A tablet hot on both dimensions arrives once in each list, each entry carrying only
+        // its own dimension, so the two lists are merged by tablet id before anything is built.
+        Map<Long, Accumulator> accumulated = Maps.newHashMapWithExpectedSize(
+                topQuery.size() + topLoad.size());
         for (TActiveTabletStat stat : topQuery) {
-            long[] values = accumulated.computeIfAbsent(stat.getTabletId(), key -> new long[6]);
-            values[0] = stat.getScanCountDelta();
-            values[2] = stat.getLastQueryTimeMs();
-            values[4] = Math.max(1L, stat.getDeltaWindowMs());
+            Accumulator acc = accumulated.computeIfAbsent(stat.getTabletId(), key -> new Accumulator());
+            acc.scanDelta = stat.getScanCountDelta();
+            acc.lastQueryMs = stat.getLastQueryTimeMs();
+            acc.scanWindowMs = Math.max(1L, stat.getDeltaWindowMs());
         }
         for (TActiveTabletStat stat : topLoad) {
-            long[] values = accumulated.computeIfAbsent(stat.getTabletId(), key -> new long[6]);
-            values[1] = stat.getLoadCountDelta();
-            values[3] = stat.getLastLoadTimeMs();
-            values[5] = Math.max(1L, stat.getDeltaWindowMs());
+            Accumulator acc = accumulated.computeIfAbsent(stat.getTabletId(), key -> new Accumulator());
+            acc.loadDelta = stat.getLoadCountDelta();
+            acc.lastLoadMs = stat.getLastLoadTimeMs();
+            acc.loadWindowMs = Math.max(1L, stat.getDeltaWindowMs());
         }
 
-        Map<Long, AccessStatsResult> backendStats = new HashMap<>(accumulated.size() * 2);
-        long delta = 0;
-        for (Map.Entry<Long, long[]> entry : accumulated.entrySet()) {
-            long[] values = entry.getValue();
-            // Compare rates across backends because a skipped report makes the raw delta cover multiple periods.
-            double scanRate = values[4] > 0 ? values[0] * 60_000.0 / values[4] : 0.0;
-            double loadRate = values[5] > 0 ? values[1] * 60_000.0 / values[5] : 0.0;
-            delta += values[0] + values[1];
-            backendStats.put(entry.getKey(), new AccessStatsResult(entry.getKey(), values[0] + values[1],
-                    Math.max(values[2], values[3]), scanRate, loadRate));
+        Map<Long, AccessStatsResult> backendStats = Maps.newHashMapWithExpectedSize(accumulated.size());
+        long reportedAccesses = 0;
+        for (Map.Entry<Long, Accumulator> entry : accumulated.entrySet()) {
+            long tabletId = entry.getKey();
+            Accumulator acc = entry.getValue();
+            long accessCount = acc.scanDelta + acc.loadDelta;
+            reportedAccesses += accessCount;
+            backendStats.put(tabletId, new AccessStatsResult(tabletId, accessCount,
+                    Math.max(acc.lastQueryMs, acc.lastLoadMs), acc.scanRate(), acc.loadRate()));
         }
-        totalAccessCount.addAndGet(delta);
-        beToStats.put(beId, backendStats);
+        totalAccessCount.addAndGet(reportedAccesses);
+        beToStats.put(beId, retainWithinWindow(beToStats.get(beId), backendStats));
+    }
+
+    /**
+     * A report only carries the tablets that saw traffic since the previous one, so taking it
+     * as the whole truth would shrink "active" to one report interval - a tablet queried hard
+     * four minutes ago would read as cold and become a migration candidate. Entries the backend
+     * did not repeat are therefore kept until they fall outside
+     * active_tablet_sliding_window_time_window_second, which is the window this feature has
+     * advertised since it lived in FE memory.
+     *
+     * <p>Retention is bounded by cloud_active_partition_scheduling_topn: the scheduler never
+     * consumes more actives than that in total, and a backend whose hot set churns would
+     * otherwise accumulate a whole window's worth of distinct tablets. The oldest are dropped
+     * first. lastAccessTime comes from the backend's clock while the cutoff comes from FE's,
+     * but a window measured in hours absorbs the skew between them.
+     */
+    private static Map<Long, AccessStatsResult> retainWithinWindow(
+            Map<Long, AccessStatsResult> previous, Map<Long, AccessStatsResult> reported) {
+        int retainLimit = Config.cloud_active_partition_scheduling_topn;
+        if (previous == null || previous.isEmpty() || retainLimit <= 0) {
+            // retainLimit <= 0 disables TopN segmentation, so getTopNActive() returns nothing
+            // and anything retained here would only cost memory.
+            return reported;
+        }
+
+        long windowMs = Math.max(1L, Config.active_tablet_sliding_window_time_window_second) * 1000L;
+        long oldestKept = System.currentTimeMillis() - windowMs;
+        Map<Long, AccessStatsResult> merged = Maps.newHashMapWithExpectedSize(
+                previous.size() + reported.size());
+        for (AccessStatsResult stale : previous.values()) {
+            if (stale.lastAccessTime >= oldestKept) {
+                merged.put(stale.id, stale);
+            }
+        }
+        // Whatever the backend just reported is fresher than anything retained for it.
+        merged.putAll(reported);
+        if (merged.size() <= retainLimit) {
+            return merged;
+        }
+
+        List<AccessStatsResult> byRecency = new ArrayList<>(merged.values());
+        byRecency.sort(Comparator.comparingLong((AccessStatsResult r) -> r.lastAccessTime).reversed());
+        Map<Long, AccessStatsResult> capped = Maps.newHashMapWithExpectedSize(retainLimit);
+        for (int i = 0; i < retainLimit; i++) {
+            AccessStatsResult result = byRecency.get(i);
+            capped.put(result.id, result);
+        }
+        return capped;
+    }
+
+    /**
+     * One tablet's half-built stats while the query and load lists are being merged.
+     * Each dimension keeps its own window: the two entries for one tablet come from the
+     * same report, but a backend that skipped a round carries a wider window on the
+     * dimension that was reported then.
+     */
+    private static class Accumulator {
+        private long scanDelta;
+        private long loadDelta;
+        private long lastQueryMs;
+        private long lastLoadMs;
+        // Never zero, so no division guard is needed below.
+        private long scanWindowMs = 1L;
+        private long loadWindowMs = 1L;
+
+        // Accesses per minute. Backends must be compared by rate, not by raw delta: a
+        // skipped report makes the next delta cover several periods, and backends report
+        // on independent phases.
+        private double scanRate() {
+            return scanDelta * 60_000.0 / scanWindowMs;
+        }
+
+        private double loadRate() {
+            return loadDelta * 60_000.0 / loadWindowMs;
+        }
     }
 
     public void removeBackend(long beId) {
@@ -200,16 +282,13 @@ public class TabletSlidingWindowAccessStats {
         queryStats.sort(QUERY_RATE_COMPARATOR);
         loadStats.sort(LOAD_RATE_COMPARATOR);
 
-        int queryQuota = topN / 2;
-        int loadQuota = topN - queryQuota;
-        int queryLimit = Math.min(queryQuota, queryStats.size());
-        int loadLimit = Math.min(loadQuota, loadStats.size());
-        if (queryLimit < queryQuota) {
-            loadLimit = Math.min(loadStats.size(), topN - queryLimit);
-        }
-        if (loadLimit < loadQuota) {
-            queryLimit = Math.min(queryStats.size(), topN - loadLimit);
-        }
+        // Half the budget is reserved for each dimension, then each side takes whatever the
+        // other could not fill, so a cluster that only queries or only loads does not forfeit
+        // half of topN. When both sides are short, every candidate is returned and the result
+        // is simply smaller than topN.
+        int queryLimit = Math.min(queryStats.size(), topN / 2);
+        int loadLimit = Math.min(loadStats.size(), topN - queryLimit);
+        queryLimit = Math.min(queryStats.size(), topN - loadLimit);
 
         Map<Long, AccessStatsResult> selected = new LinkedHashMap<>();
         for (int i = 0; i < queryLimit; i++) {
@@ -254,8 +333,17 @@ public class TabletSlidingWindowAccessStats {
         return merged;
     }
 
+    /**
+     * Flatten beId -> tabletId -> stats into one view keyed by tablet. A tablet with several
+     * replicas is reported once per backend holding one, so the collisions are resolved by
+     * mergeByMax().
+     */
     private Map<Long, AccessStatsResult> mergeBackendStats() {
-        Map<Long, AccessStatsResult> mergedStats = new HashMap<>();
+        int upperBound = 0;
+        for (Map<Long, AccessStatsResult> backendStats : beToStats.values()) {
+            upperBound += backendStats.size();
+        }
+        Map<Long, AccessStatsResult> mergedStats = Maps.newHashMapWithExpectedSize(upperBound);
         for (Map<Long, AccessStatsResult> backendStats : beToStats.values()) {
             for (AccessStatsResult result : backendStats.values()) {
                 mergedStats.merge(result.id, result, TabletSlidingWindowAccessStats::mergeByMax);
@@ -264,6 +352,12 @@ public class TabletSlidingWindowAccessStats {
         return mergedStats;
     }
 
+    /**
+     * Per-field maximum, never a sum: each backend reports its own replica, so summing would
+     * make a three-replica tablet look three times hotter than a one-replica tablet carrying
+     * the same traffic. Every field independently answers "the busiest replica", which is what
+     * both consumers want - the rates rank tablets, and the raw count is only displayed.
+     */
     private static AccessStatsResult mergeByMax(AccessStatsResult left, AccessStatsResult right) {
         return new AccessStatsResult(left.id,
                 Math.max(left.accessCount, right.accessCount),

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletSlidingWindowAccessStats.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/TabletSlidingWindowAccessStats.java
@@ -18,294 +18,111 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.common.Config;
-import org.apache.doris.common.util.MasterDaemon;
-
-import com.google.common.hash.HashFunction;
-import com.google.common.hash.Hashing;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.doris.thrift.TActiveTabletStat;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.PriorityQueue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicLongArray;
 
 /**
- * Sliding window access statistics utility class.
- * Supports tracking access statistics for different types of IDs (tablet, replica, backend, etc.)
+ * Active tablet access statistics reported by backends.
  */
 public class TabletSlidingWindowAccessStats {
-    private static final Logger LOG = LogManager.getLogger(TabletSlidingWindowAccessStats.class);
-
     private static volatile TabletSlidingWindowAccessStats instance;
 
-    private static final HashFunction SHARD_HASH = Hashing.murmur3_128();
-
-    // Sort active IDs by accessCount desc, then lastAccessTime desc
-    private static final Comparator<AccessStatsResult> TOPN_ACTIVE_COMPARATOR =
-            Comparator.comparingLong((AccessStatsResult r) -> r.accessCount).reversed()
+    private static final Comparator<AccessStatsResult> QUERY_RATE_COMPARATOR =
+            Comparator.comparingDouble((AccessStatsResult r) -> r.scanRate).reversed()
+                    .thenComparing(Comparator.comparingLong((AccessStatsResult r) -> r.lastAccessTime).reversed());
+    private static final Comparator<AccessStatsResult> LOAD_RATE_COMPARATOR =
+            Comparator.comparingDouble((AccessStatsResult r) -> r.loadRate).reversed()
                     .thenComparing(Comparator.comparingLong((AccessStatsResult r) -> r.lastAccessTime).reversed());
 
-    // Time window in milliseconds (default: 1 hour)
-    private final long timeWindowMs;
-
-    // Bucket size in milliseconds (default: 1 minute)
-    // The time window is divided into multiple buckets, each bucket stores access count for a time period.
-    // For example: if timeWindowMs=1hour and bucketSizeMs=1minute, there will be 60 buckets.
-    // Smaller bucket size = more accurate statistics but more memory usage.
-    private final long bucketSizeMs;
-
-    // Number of buckets in the sliding window
-    private final int numBuckets;
-
-    // Cleanup interval in milliseconds (default: 5 minutes)
-    private final long cleanupIntervalMs;
-
-    // Shard size to reduce lock contention
-    private static final int SHARD_SIZE = 1024;
-
-    /**
-     * Sliding window counter for a single replica/tablet
-     */
-    private static class SlidingWindowCounter {
-        // Each bucket stores count for a time period
-        private final AtomicLongArray buckets;
-        // Timestamp of each bucket (to detect expired buckets)
-        private final AtomicLongArray bucketTimestamps;
-        // Last access time (for TopN sorting)
-        private volatile long lastAccessTime = 0;
-        // Total count in current window (cached for performance)
-        private volatile long cachedTotalCount = 0;
-        private volatile long cachedCountTime = 0;
-
-        SlidingWindowCounter(int numBuckets) {
-            this.buckets = new AtomicLongArray(numBuckets);
-            this.bucketTimestamps = new AtomicLongArray(numBuckets);
-        }
-
-        /**
-         * Get current bucket index based on current time
-         */
-        private int getBucketIndex(long currentTimeMs, long bucketSizeMs, int numBuckets) {
-            return (int) ((currentTimeMs / bucketSizeMs) % numBuckets);
-        }
-
-        /**
-         * Add an access count
-         */
-        void add(long currentTimeMs, long bucketSizeMs, int numBuckets) {
-            int bucketIndex = getBucketIndex(currentTimeMs, bucketSizeMs, numBuckets);
-            long bucketStartTime = (currentTimeMs / bucketSizeMs) * bucketSizeMs;
-
-            // Check if this bucket is expired (belongs to a different time window)
-            long bucketTimestamp = bucketTimestamps.get(bucketIndex);
-            if (bucketTimestamp != bucketStartTime) {
-                // Reset expired bucket
-                buckets.set(bucketIndex, 0);
-                bucketTimestamps.set(bucketIndex, bucketStartTime);
-            }
-
-            // Increment count
-            buckets.addAndGet(bucketIndex, 1);
-            lastAccessTime = currentTimeMs;
-            cachedTotalCount = -1; // Invalidate cache
-        }
-
-        /**
-         * Get total count within the time window
-         */
-        long getCount(long currentTimeMs, long timeWindowMs, long bucketSizeMs, int numBuckets) {
-            // Use cached value if still valid (within 1 second)
-            if (cachedTotalCount >= 0 && (currentTimeMs - cachedCountTime) < 1000) {
-                return cachedTotalCount;
-            }
-
-            long windowStart = currentTimeMs - timeWindowMs;
-            long count = 0;
-
-            for (int i = 0; i < numBuckets; i++) {
-                long bucketTimestamp = bucketTimestamps.get(i);
-                if (bucketTimestamp >= windowStart && bucketTimestamp > 0) {
-                    count += buckets.get(i);
-                }
-            }
-
-            cachedTotalCount = count;
-            cachedCountTime = currentTimeMs;
-            return count;
-        }
-
-        long getLastAccessTime() {
-            return lastAccessTime;
-        }
-
-        /**
-         * Clean up expired buckets
-         */
-        void cleanup(long currentTimeMs, long timeWindowMs) {
-            long windowStart = currentTimeMs - timeWindowMs;
-            for (int i = 0; i < buckets.length(); i++) {
-                long bucketTimestamp = bucketTimestamps.get(i);
-                if (bucketTimestamp > 0 && bucketTimestamp < windowStart) {
-                    buckets.set(i, 0);
-                    bucketTimestamps.set(i, 0);
-                }
-            }
-            cachedTotalCount = -1; // Invalidate cache
-        }
-
-        /**
-         * Check if this counter has any recent activity
-         */
-        boolean hasRecentActivity(long currentTimeMs, long timeWindowMs) {
-            return lastAccessTime >= (currentTimeMs - timeWindowMs);
-        }
-    }
-
-    /**
-     * Shard structure to reduce lock contention
-     */
-    private static class AccessStatsShard {
-        // ID counters: id -> SlidingWindowCounter
-        private final ConcurrentHashMap<Long, SlidingWindowCounter> idCounters = new ConcurrentHashMap<>();
-    }
-
-    // Sharded access stats to reduce lock contention
-    private final AccessStatsShard[] shards = new AccessStatsShard[SHARD_SIZE];
-
-    // Access counter for monitoring
+    // beId -> (tabletId -> stats). Each report replaces the complete snapshot for one backend.
+    // Backend removal is handled by removeBackend(), so no cleanup daemon is needed.
+    private final ConcurrentHashMap<Long, Map<Long, AccessStatsResult>> beToStats = new ConcurrentHashMap<>();
     private final AtomicLong totalAccessCount = new AtomicLong(0);
 
-    // Aggregated stats cache for metrics/observability
-    // - recentAccessCountInWindow: sum of accessCount of all active IDs in current time window
-    // - activeIdsInWindow: number of IDs that have recent activity in current time window
-    // These are computed on-demand with a TTL to avoid expensive full scans on every metric scrape.
-    private static final long AGGREGATE_REFRESH_INTERVAL_MS = 10_000L;
-    private final AtomicLong recentAccessCountInWindow = new AtomicLong(0);
-    private final AtomicLong activeIdsInWindow = new AtomicLong(0);
-    private final AtomicLong lastAggregateRefreshTimeMs = new AtomicLong(0);
-
-    // Cleanup daemon
-    private AccessStatsCleanupDaemon cleanupDaemon;
-
-    // Thread pool for async recordAccess execution
-    private ThreadPoolExecutor asyncExecutor;
-
-    // Default bucket size: 1 minute (60 buckets for 1 hour window)
-    private static final long DEFAULT_BUCKET_SIZE_SECOND = 60L;
-
-    // Default cleanup interval: 5 minutes
-    private static final long DEFAULT_CLEANUP_INTERVAL_SECOND = 300L;
+    // Merging every backend snapshot is O(total reported tablets) -- up to backendCount * 2 *
+    // be report_active_tablet_max_num entries. MetricRepo scrapes two of the aggregate getters
+    // below on every /metrics request, so they share a short-lived snapshot the same way the
+    // pre-BE-report implementation cached its aggregates. getTopNActive() deliberately does NOT
+    // use this cache: it runs once per cloud_active_tablet_ids_refresh_interval_second and feeds
+    // scheduling decisions, so it always merges fresh.
+    private static final long MERGED_CACHE_TTL_MS = 10_000L;
+    private volatile Map<Long, AccessStatsResult> mergedCache = Collections.emptyMap();
+    private final AtomicLong mergedCacheTimeMs = new AtomicLong(0);
 
     TabletSlidingWindowAccessStats() {
-        long configuredWindowSecond = Config.active_tablet_sliding_window_time_window_second;
-        long effectiveWindowSecond = Math.max(1L, configuredWindowSecond);
-        if (configuredWindowSecond < DEFAULT_BUCKET_SIZE_SECOND) {
-            LOG.warn("active_tablet_sliding_window_time_window_second={} is less than default bucket size {}, "
-                            + "using one bucket to avoid zero-bucket window",
-                    configuredWindowSecond, DEFAULT_BUCKET_SIZE_SECOND);
-        }
-        this.timeWindowMs = effectiveWindowSecond * 1000L;
-        this.bucketSizeMs = DEFAULT_BUCKET_SIZE_SECOND * 1000L;
-        this.numBuckets = (int) Math.max(1L, effectiveWindowSecond / DEFAULT_BUCKET_SIZE_SECOND);
-        this.cleanupIntervalMs = DEFAULT_CLEANUP_INTERVAL_SECOND * 1000L;
-
-        // Initialize shards
-        for (int i = 0; i < SHARD_SIZE; i++) {
-            shards[i] = new AccessStatsShard();
-        }
-
-        // Start cleanup daemon and async executor if enabled
-        if (Config.enable_active_tablet_sliding_window_access_stats) {
-            this.cleanupDaemon = new AccessStatsCleanupDaemon();
-            this.cleanupDaemon.start();
-            // Initialize async executor for recordAccess
-            // Use a small thread pool with bounded queue to avoid blocking
-            // If queue is full, discard the task (statistics can tolerate some loss)
-            this.asyncExecutor = new ThreadPoolExecutor(
-                    2,  // core pool size
-                    4,  // maximum pool size
-                    60L, TimeUnit.SECONDS,
-                    new LinkedBlockingQueue<>(1000), // queue capacity
-                    r -> {
-                        Thread t = new Thread(r, "sliding-window-access-stats-async-tablet-record");
-                        t.setDaemon(true);
-                        return t;
-                    },
-                    new ThreadPoolExecutor.DiscardPolicy() // discard when queue is full
-            );
-
-            LOG.info("SlidingWindowAccessStats initialized for type tablet: timeWindow={}ms, bucketSize={}ms, "
-                    + "numBuckets={}, shardSize={}, cleanupInterval={}ms",
-                    timeWindowMs, bucketSizeMs, numBuckets, SHARD_SIZE, cleanupIntervalMs);
-        }
     }
 
-    /**
-     * Get shard index for a given ID
-     */
-    private int getShardIndex(long id) {
-        int hash = SHARD_HASH.hashLong(id).asInt();
-        return Math.floorMod(hash, SHARD_SIZE);
-    }
-
-    private void refreshAggregatesIfNeeded(long currentTimeMs) {
-        long last = lastAggregateRefreshTimeMs.get();
-        if (currentTimeMs - last < AGGREGATE_REFRESH_INTERVAL_MS) {
-            return;
-        }
-        if (!lastAggregateRefreshTimeMs.compareAndSet(last, currentTimeMs)) {
+    public void updateFromReport(long beId, List<TActiveTabletStat> topQuery, List<TActiveTabletStat> topLoad) {
+        if (!Config.enable_active_tablet_sliding_window_access_stats) {
+            beToStats.remove(beId);
             return;
         }
 
-        int activeIds = 0;
-        long totalAccess = 0;
-        for (AccessStatsShard shard : shards) {
-            for (SlidingWindowCounter counter : shard.idCounters.values()) {
-                if (counter.hasRecentActivity(currentTimeMs, timeWindowMs)) {
-                    activeIds++;
-                    totalAccess += counter.getCount(currentTimeMs, timeWindowMs, bucketSizeMs, numBuckets);
-                }
-            }
+        // long[]{scan, load, lastQueryMs, lastLoadMs, scanWindowMs, loadWindowMs}
+        Map<Long, long[]> accumulated = new HashMap<>((topQuery.size() + topLoad.size()) * 2);
+        for (TActiveTabletStat stat : topQuery) {
+            long[] values = accumulated.computeIfAbsent(stat.getTabletId(), key -> new long[6]);
+            values[0] = stat.getScanCountDelta();
+            values[2] = stat.getLastQueryTimeMs();
+            values[4] = Math.max(1L, stat.getDeltaWindowMs());
         }
-        activeIdsInWindow.set(activeIds);
-        recentAccessCountInWindow.set(totalAccess);
+        for (TActiveTabletStat stat : topLoad) {
+            long[] values = accumulated.computeIfAbsent(stat.getTabletId(), key -> new long[6]);
+            values[1] = stat.getLoadCountDelta();
+            values[3] = stat.getLastLoadTimeMs();
+            values[5] = Math.max(1L, stat.getDeltaWindowMs());
+        }
+
+        Map<Long, AccessStatsResult> backendStats = new HashMap<>(accumulated.size() * 2);
+        long delta = 0;
+        for (Map.Entry<Long, long[]> entry : accumulated.entrySet()) {
+            long[] values = entry.getValue();
+            // Compare rates across backends because a skipped report makes the raw delta cover multiple periods.
+            double scanRate = values[4] > 0 ? values[0] * 60_000.0 / values[4] : 0.0;
+            double loadRate = values[5] > 0 ? values[1] * 60_000.0 / values[5] : 0.0;
+            delta += values[0] + values[1];
+            backendStats.put(entry.getKey(), new AccessStatsResult(entry.getKey(), values[0] + values[1],
+                    Math.max(values[2], values[3]), scanRate, loadRate));
+        }
+        totalAccessCount.addAndGet(delta);
+        beToStats.put(beId, backendStats);
+    }
+
+    public void removeBackend(long beId) {
+        beToStats.remove(beId);
     }
 
     /**
-     * Get total access count within current time window across all IDs (cached).
+     * Get total access count in the latest backend snapshots.
      */
     public long getRecentAccessCountInWindow() {
         if (!Config.enable_active_tablet_sliding_window_access_stats) {
             return 0L;
         }
-        long now = System.currentTimeMillis();
-        refreshAggregatesIfNeeded(now);
-        return recentAccessCountInWindow.get();
+        return cachedMergedStats().values().stream().mapToLong(result -> result.accessCount).sum();
     }
 
     /**
-     * Get number of active IDs within current time window (cached).
+     * Get the number of distinct tablets in the latest backend snapshots.
      */
     public long getActiveIdsInWindow() {
         if (!Config.enable_active_tablet_sliding_window_access_stats) {
             return 0L;
         }
-        long now = System.currentTimeMillis();
-        refreshAggregatesIfNeeded(now);
-        return activeIdsInWindow.get();
+        return cachedMergedStats().size();
     }
 
     /**
-     * Get total access count since FE start (monotonic increasing while enabled).
+     * Get total access count reported since FE start.
      */
     public long getTotalAccessCount() {
         if (!Config.enable_active_tablet_sliding_window_access_stats) {
@@ -315,80 +132,39 @@ public class TabletSlidingWindowAccessStats {
     }
 
     /**
-     * Record an access asynchronously
-     * This method is non-blocking and should be used in high-frequency call paths
-     * to avoid blocking the caller thread.
-     */
-    public void recordAccessAsync(long id) {
-        if (asyncExecutor == null) {
-            return;
-        }
-
-        try {
-            asyncExecutor.execute(() -> {
-                try {
-                    recordAccess(id);
-                } catch (Exception e) {
-                    // Log but don't propagate exception to avoid affecting caller
-                    LOG.warn("Failed to record access asynchronously for tablet id={}", id, e);
-                }
-            });
-        } catch (Exception e) {
-            // If executor is shutdown or queue is full, silently ignore
-            // Statistics can tolerate some loss
-            LOG.warn("Failed to submit async recordAccess task for tablet id={}", id, e);
-        }
-    }
-
-    /**
-     * Record an access
-     */
-    public void recordAccess(long id) {
-        long currentTime = System.currentTimeMillis();
-        int shardIndex = getShardIndex(id);
-        AccessStatsShard shard = shards[shardIndex];
-
-        SlidingWindowCounter counter = shard.idCounters.computeIfAbsent(id,
-                k -> new SlidingWindowCounter(numBuckets));
-        counter.add(currentTime, bucketSizeMs, numBuckets);
-        totalAccessCount.incrementAndGet();
-    }
-
-    /**
-     * Get access count for an ID within the time window
+     * Get access information for a tablet.
      */
     public AccessStatsResult getAccessInfo(long id) {
         if (!Config.enable_active_tablet_sliding_window_access_stats) {
             return null;
         }
 
-        int shardIndex = getShardIndex(id);
-        AccessStatsShard shard = shards[shardIndex];
-        SlidingWindowCounter counter = shard.idCounters.get(id);
-
-        if (counter == null) {
-            return null;
+        AccessStatsResult result = null;
+        for (Map<Long, AccessStatsResult> backendStats : beToStats.values()) {
+            AccessStatsResult candidate = backendStats.get(id);
+            if (candidate != null && (result == null || candidate.accessCount > result.accessCount)) {
+                result = candidate;
+            }
         }
-
-        long currentTime = System.currentTimeMillis();
-        return new AccessStatsResult(
-                id,
-                counter.getCount(currentTime, timeWindowMs, bucketSizeMs, numBuckets),
-                counter.getLastAccessTime());
+        return result;
     }
 
     /**
-     * Result for top N query
+     * Result for top N query.
      */
     public static class AccessStatsResult {
         public final long id;
         public final long accessCount;
         public final long lastAccessTime;
+        public final double scanRate;
+        public final double loadRate;
 
-        public AccessStatsResult(long id, long accessCount, long lastAccessTime) {
+        public AccessStatsResult(long id, long accessCount, long lastAccessTime, double scanRate, double loadRate) {
             this.id = id;
             this.accessCount = accessCount;
             this.lastAccessTime = lastAccessTime;
+            this.scanRate = scanRate;
+            this.loadRate = loadRate;
         }
 
         @Override
@@ -397,143 +173,103 @@ public class TabletSlidingWindowAccessStats {
                     + "id=" + id
                     + ", accessCount=" + accessCount
                     + ", lastAccessTime=" + lastAccessTime
+                    + ", scanRate=" + scanRate
+                    + ", loadRate=" + loadRate
                     + '}';
         }
     }
 
     /**
-     * Get top N most active IDs
-     * Uses a min-heap (PriorityQueue) to maintain TopN efficiently without sorting all results.
+     * Get top N active tablets, reserving half of the capacity for each access type.
      */
     public List<AccessStatsResult> getTopNActive(int topN) {
-        if (!Config.enable_active_tablet_sliding_window_access_stats) {
+        if (!Config.enable_active_tablet_sliding_window_access_stats || topN <= 0) {
             return Collections.emptyList();
         }
 
-        if (topN <= 0) {
-            return Collections.emptyList();
-        }
-
-        long currentTime = System.currentTimeMillis();
-        // Use a min-heap with reversed comparator to maintain TopN
-        // The heap keeps the smallest element at the top, so we can efficiently replace it
-        // when we find a larger element
-        PriorityQueue<AccessStatsResult> minHeap = new PriorityQueue<>(
-                topN + 1, // Initial capacity: topN + 1 to avoid resizing
-                Collections.reverseOrder(TOPN_ACTIVE_COMPARATOR) // Reversed: min-heap for TopN
-        );
-
-        // Collect from all shards and maintain TopN using min-heap
-        for (AccessStatsShard shard : shards) {
-            for (Map.Entry<Long, SlidingWindowCounter> entry : shard.idCounters.entrySet()) {
-                long id = entry.getKey();
-                SlidingWindowCounter counter = entry.getValue();
-
-                // Skip if no recent activity
-                if (!counter.hasRecentActivity(currentTime, timeWindowMs)) {
-                    continue;
-                }
-
-                long accessCount = counter.getCount(currentTime, timeWindowMs, bucketSizeMs, numBuckets);
-                if (accessCount > 0) {
-                    AccessStatsResult result = new AccessStatsResult(id, accessCount, counter.getLastAccessTime());
-
-                    if (minHeap.size() < topN) {
-                        // Heap not full, directly add
-                        minHeap.offer(result);
-                    } else {
-                        // Heap is full, compare with the smallest element (heap top)
-                        // If current element is larger, replace the heap top
-                        if (TOPN_ACTIVE_COMPARATOR.compare(result, minHeap.peek()) > 0) {
-                            minHeap.poll();
-                            minHeap.offer(result);
-                        }
-                    }
-                }
+        List<AccessStatsResult> queryStats = new ArrayList<>();
+        List<AccessStatsResult> loadStats = new ArrayList<>();
+        for (AccessStatsResult result : mergeBackendStats().values()) {
+            if (result.scanRate > 0) {
+                queryStats.add(result);
+            }
+            if (result.loadRate > 0) {
+                loadStats.add(result);
             }
         }
+        queryStats.sort(QUERY_RATE_COMPARATOR);
+        loadStats.sort(LOAD_RATE_COMPARATOR);
 
-        // Convert heap to list and sort in descending order (TopN)
-        List<AccessStatsResult> results = new ArrayList<>(minHeap);
-        results.sort(TOPN_ACTIVE_COMPARATOR);
-        return results;
+        int queryQuota = topN / 2;
+        int loadQuota = topN - queryQuota;
+        int queryLimit = Math.min(queryQuota, queryStats.size());
+        int loadLimit = Math.min(loadQuota, loadStats.size());
+        if (queryLimit < queryQuota) {
+            loadLimit = Math.min(loadStats.size(), topN - queryLimit);
+        }
+        if (loadLimit < loadQuota) {
+            queryLimit = Math.min(queryStats.size(), topN - loadLimit);
+        }
+
+        Map<Long, AccessStatsResult> selected = new LinkedHashMap<>();
+        for (int i = 0; i < queryLimit; i++) {
+            AccessStatsResult result = queryStats.get(i);
+            selected.put(result.id, result);
+        }
+        for (int i = 0; i < loadLimit; i++) {
+            AccessStatsResult result = loadStats.get(i);
+            selected.putIfAbsent(result.id, result);
+        }
+        return new ArrayList<>(selected.values());
     }
 
     /**
-     * Clean up expired access records
-     */
-    private void cleanupExpiredRecords() {
-        if (!Config.enable_active_tablet_sliding_window_access_stats) {
-            return;
-        }
-
-        long currentTime = System.currentTimeMillis();
-        int cleaned = 0;
-
-        // Clean each shard
-        for (AccessStatsShard shard : shards) {
-            // Clean ID counters
-            for (Map.Entry<Long, SlidingWindowCounter> entry : shard.idCounters.entrySet()) {
-                SlidingWindowCounter counter = entry.getValue();
-                counter.cleanup(currentTime, timeWindowMs);
-
-                if (!counter.hasRecentActivity(currentTime, timeWindowMs)) {
-                    shard.idCounters.remove(entry.getKey());
-                    cleaned++;
-                }
-            }
-        }
-
-        if (LOG.isDebugEnabled() && cleaned > 0) {
-            LOG.debug("Cleaned up {} expired access records for type tablet", cleaned);
-        }
-    }
-
-    /**
-     * Get statistics summary
+     * Get statistics summary.
      */
     public String getStatsSummary() {
         if (!Config.enable_active_tablet_sliding_window_access_stats) {
             return String.format("Active tablet sliding window access stats is disabled");
         }
 
-        long currentTime = System.currentTimeMillis();
-        refreshAggregatesIfNeeded(currentTime);
-        int activeIds = (int) getActiveIdsInWindow();
-        long totalAccess = getRecentAccessCountInWindow();
-
+        Map<Long, AccessStatsResult> mergedStats = cachedMergedStats();
+        long totalAccess = mergedStats.values().stream().mapToLong(result -> result.accessCount).sum();
         return String.format(
-            "SlidingWindowAccessStats{type=tablet, timeWindow=%ds, bucketSize=%ds, numBuckets=%d, "
-                + "shardSize=%d, activeIds=%d, "
-                + "totalAccess=%d, totalAccessCount=%d}",
-            timeWindowMs / 1000, bucketSizeMs / 1000, numBuckets, SHARD_SIZE,
-            activeIds, totalAccess, totalAccessCount.get());
+                "SlidingWindowAccessStats{type=tablet, beCount=%d, activeIds=%d, "
+                        + "totalAccess=%d, totalAccessCount=%d}",
+                beToStats.size(), mergedStats.size(), totalAccess, totalAccessCount.get());
     }
 
-    /**
-     * Cleanup daemon for expired records
-     */
-    private class AccessStatsCleanupDaemon extends MasterDaemon {
-        public AccessStatsCleanupDaemon() {
-            super("sliding-window-access-stats-cleanup-tablet" +  cleanupIntervalMs);
+    private Map<Long, AccessStatsResult> cachedMergedStats() {
+        long now = System.currentTimeMillis();
+        long last = mergedCacheTimeMs.get();
+        if (now - last < MERGED_CACHE_TTL_MS) {
+            return mergedCache;
         }
+        if (!mergedCacheTimeMs.compareAndSet(last, now)) {
+            // Another thread is already refreshing; the previous snapshot is good enough here.
+            return mergedCache;
+        }
+        Map<Long, AccessStatsResult> merged = mergeBackendStats();
+        mergedCache = merged;
+        return merged;
+    }
 
-        @Override
-        protected void runAfterCatalogReady() {
-            if (!Env.getCurrentEnv().isMaster()) {
-                return;
-            }
-
-            try {
-                cleanupExpiredRecords();
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("tablet stat = {}, top 10 active = {}",
-                            getStatsSummary(), getTopNActive(10));
-                }
-            } catch (Exception e) {
-                LOG.warn("Failed to cleanup expired access records for type tablet", e);
+    private Map<Long, AccessStatsResult> mergeBackendStats() {
+        Map<Long, AccessStatsResult> mergedStats = new HashMap<>();
+        for (Map<Long, AccessStatsResult> backendStats : beToStats.values()) {
+            for (AccessStatsResult result : backendStats.values()) {
+                mergedStats.merge(result.id, result, TabletSlidingWindowAccessStats::mergeByMax);
             }
         }
+        return mergedStats;
+    }
+
+    private static AccessStatsResult mergeByMax(AccessStatsResult left, AccessStatsResult right) {
+        return new AccessStatsResult(left.id,
+                Math.max(left.accessCount, right.accessCount),
+                Math.max(left.lastAccessTime, right.lastAccessTime),
+                Math.max(left.scanRate, right.scanRate),
+                Math.max(left.loadRate, right.loadRate));
     }
 
     public static TabletSlidingWindowAccessStats getInstance() {
@@ -545,11 +281,5 @@ public class TabletSlidingWindowAccessStats {
             }
         }
         return instance;
-    }
-
-    // async record tablet instance access
-    public static void recordTablet(long id) {
-        TabletSlidingWindowAccessStats sas = getInstance();
-        sas.recordAccessAsync(id);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTablet.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/cloud/catalog/CloudTablet.java
@@ -21,7 +21,6 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.Replica.ReplicaState;
 import org.apache.doris.catalog.Tablet;
-import org.apache.doris.catalog.TabletSlidingWindowAccessStats;
 import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.InternalErrorCode;
 import org.apache.doris.common.UserException;
@@ -85,14 +84,12 @@ public class CloudTablet extends Tablet implements GsonPostProcessable {
     // Cluster id is supplied by the caller (resolved lazily once per request),
     // bypassing the per-replica ConnectContext/priv/status/autoStart/existence pipeline.
     public Multimap<Long, Long> getNormalReplicaBackendPathMapByClusterId(String clusterId) throws UserException {
-        TabletSlidingWindowAccessStats.recordTablet(getId());
         Multimap<Long, Long> pathMap = super.getNormalReplicaBackendPathMapImpl(null,
                 (rep, be) -> ((CloudReplica) rep).getBackendIdWithClusterId(clusterId));
         return backendPathMapReprocess(pathMap);
     }
 
     public Multimap<Long, Long> getNormalReplicaBackendPathMap(String beEndpoint) throws UserException {
-        TabletSlidingWindowAccessStats.recordTablet(getId());
         Multimap<Long, Long> pathMap = super.getNormalReplicaBackendPathMapImpl(beEndpoint,
                 (rep, be) -> ((CloudReplica) rep).getBackendId(be));
         return backendPathMapReprocess(pathMap);

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ReplicasProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ReplicasProcNode.java
@@ -53,7 +53,7 @@ public class ReplicasProcNode implements ProcNodeInterface {
                 .add("IsUserDrop")
                 .add("VisibleVersionCount").add("VersionCount").add("PathHash").add("Path")
                 .add("MetaUrl").add("CompactionStatus").add("CooldownReplicaId")
-                .add("CooldownMetaId").add("QueryHits").add("AccessCount").add("LastAccessTime");
+                .add("CooldownMetaId").add("QueryHits").add("WindowAccessCount").add("LastAccessTime");
 
         if (Config.isCloudMode()) {
             builder.add("PrimaryBackendId");

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/ReplicasProcNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/ReplicasProcNode.java
@@ -53,7 +53,7 @@ public class ReplicasProcNode implements ProcNodeInterface {
                 .add("IsUserDrop")
                 .add("VisibleVersionCount").add("VersionCount").add("PathHash").add("Path")
                 .add("MetaUrl").add("CompactionStatus").add("CooldownReplicaId")
-                .add("CooldownMetaId").add("QueryHits").add("WindowAccessCount").add("LastAccessTime");
+                .add("CooldownMetaId").add("QueryHits").add("AccessCount").add("LastAccessTime");
 
         if (Config.isCloudMode()) {
             builder.add("PrimaryBackendId");

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
@@ -64,7 +64,7 @@ public class TabletsProcDir implements ProcDirInterface {
                 .add("LstSuccessVersion").add("LstFailedVersion").add("LstFailedTime")
                 .add("LocalDataSize").add("RemoteDataSize").add("RowCount").add("State")
                 .add("LstConsistencyCheckTime").add("CheckVersion")
-                .add("VisibleVersionCount").add("VersionCount").add("QueryHits").add("AccessCount")
+                .add("VisibleVersionCount").add("VersionCount").add("QueryHits").add("WindowAccessCount")
                 .add("LastAccessTime").add("PathHash").add("Path")
                 .add("MetaUrl").add("CompactionStatus")
                 .add("CooldownReplicaId").add("CooldownMetaId").add("IsRowBinlog");
@@ -149,7 +149,7 @@ public class TabletsProcDir implements ProcDirInterface {
                     tabletInfo.add(-1); // visible version count
                     tabletInfo.add(-1); // total version count
                     tabletInfo.add(0L); // query hits
-                    tabletInfo.add(0L); // query AccessCount
+                    tabletInfo.add(0L); // query WindowAccessCount
                     tabletInfo.add(0L); // query LastAccessTime
                     tabletInfo.add(-1); // path hash
                     tabletInfo.add(FeConstants.null_string); // path

--- a/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/proc/TabletsProcDir.java
@@ -64,7 +64,7 @@ public class TabletsProcDir implements ProcDirInterface {
                 .add("LstSuccessVersion").add("LstFailedVersion").add("LstFailedTime")
                 .add("LocalDataSize").add("RemoteDataSize").add("RowCount").add("State")
                 .add("LstConsistencyCheckTime").add("CheckVersion")
-                .add("VisibleVersionCount").add("VersionCount").add("QueryHits").add("WindowAccessCount")
+                .add("VisibleVersionCount").add("VersionCount").add("QueryHits").add("AccessCount")
                 .add("LastAccessTime").add("PathHash").add("Path")
                 .add("MetaUrl").add("CompactionStatus")
                 .add("CooldownReplicaId").add("CooldownMetaId").add("IsRowBinlog");
@@ -149,7 +149,7 @@ public class TabletsProcDir implements ProcDirInterface {
                     tabletInfo.add(-1); // visible version count
                     tabletInfo.add(-1); // total version count
                     tabletInfo.add(0L); // query hits
-                    tabletInfo.add(0L); // query WindowAccessCount
+                    tabletInfo.add(0L); // query AccessCount
                     tabletInfo.add(0L); // query LastAccessTime
                     tabletInfo.add(-1); // path hash
                     tabletInfo.add(FeConstants.null_string); // path

--- a/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/ReportHandler.java
@@ -40,6 +40,7 @@ import org.apache.doris.catalog.Tablet;
 import org.apache.doris.catalog.Tablet.TabletStatus;
 import org.apache.doris.catalog.TabletInvertedIndex;
 import org.apache.doris.catalog.TabletMeta;
+import org.apache.doris.catalog.TabletSlidingWindowAccessStats;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.MetaNotFoundException;
 import org.apache.doris.common.Pair;
@@ -110,6 +111,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -166,6 +168,12 @@ public class ReportHandler extends Daemon {
         }
 
         long beId = backend.getId();
+        if (request.isSetTopQueryTablets() || request.isSetTopLoadTablets()) {
+            TabletSlidingWindowAccessStats.getInstance().updateFromReport(
+                    beId,
+                    request.isSetTopQueryTablets() ? request.getTopQueryTablets() : Collections.emptyList(),
+                    request.isSetTopLoadTablets() ? request.getTopLoadTablets() : Collections.emptyList());
+        }
         Map<TTaskType, Set<Long>> tasks = null;
         Map<String, TDisk> disks = null;
         Map<Long, TTablet> tablets = null;

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowTabletIdCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowTabletIdCommand.java
@@ -80,7 +80,7 @@ public class ShowTabletIdCommand extends ShowCommand {
         builder.addColumn(new Column("IsSync", ScalarType.createVarchar(30)));
         builder.addColumn(new Column("Order", ScalarType.createVarchar(30)));
         builder.addColumn(new Column("QueryHits", ScalarType.createVarchar(30)));
-        builder.addColumn(new Column("AccessCount", ScalarType.createVarchar(30)));
+        builder.addColumn(new Column("WindowAccessCount", ScalarType.createVarchar(30)));
         builder.addColumn(new Column("LastAccessTime", ScalarType.createVarchar(30)));
         builder.addColumn(new Column("IsRowBinlog", ScalarType.createVarchar(30)));
         builder.addColumn(new Column("DetailCmd", ScalarType.createVarchar(30)));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowTabletIdCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/ShowTabletIdCommand.java
@@ -80,7 +80,7 @@ public class ShowTabletIdCommand extends ShowCommand {
         builder.addColumn(new Column("IsSync", ScalarType.createVarchar(30)));
         builder.addColumn(new Column("Order", ScalarType.createVarchar(30)));
         builder.addColumn(new Column("QueryHits", ScalarType.createVarchar(30)));
-        builder.addColumn(new Column("WindowAccessCount", ScalarType.createVarchar(30)));
+        builder.addColumn(new Column("AccessCount", ScalarType.createVarchar(30)));
         builder.addColumn(new Column("LastAccessTime", ScalarType.createVarchar(30)));
         builder.addColumn(new Column("IsRowBinlog", ScalarType.createVarchar(30)));
         builder.addColumn(new Column("DetailCmd", ScalarType.createVarchar(30)));

--- a/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/system/SystemInfoService.java
@@ -21,6 +21,7 @@ import org.apache.doris.catalog.ColocateTableIndex.GroupId;
 import org.apache.doris.catalog.DiskInfo;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.ReplicaAllocation;
+import org.apache.doris.catalog.TabletSlidingWindowAccessStats;
 import org.apache.doris.cloud.qe.ComputeGroupException;
 import org.apache.doris.cluster.ClusterGuard;
 import org.apache.doris.cluster.ClusterGuardException;
@@ -305,6 +306,7 @@ public class SystemInfoService {
         copiedReportVersions.remove(droppedBackend.getId());
         ImmutableMap<Long, AtomicLong> newIdToReportVersion = ImmutableMap.copyOf(copiedReportVersions);
         idToReportVersionRef = newIdToReportVersion;
+        TabletSlidingWindowAccessStats.getInstance().removeBackend(droppedBackend.getId());
 
         // log
         Env.getCurrentEnv().getEditLog().logDropBackend(droppedBackend);
@@ -854,6 +856,7 @@ public class SystemInfoService {
         copiedReportVersions.remove(backend.getId());
         ImmutableMap<Long, AtomicLong> newIdToReportVersion = ImmutableMap.copyOf(copiedReportVersions);
         idToReportVersionRef = newIdToReportVersion;
+        TabletSlidingWindowAccessStats.getInstance().removeBackend(backend.getId());
 
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/TabletSlidingWindowAccessStatsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/TabletSlidingWindowAccessStatsTest.java
@@ -18,207 +18,147 @@
 package org.apache.doris.catalog;
 
 import org.apache.doris.common.Config;
+import org.apache.doris.thrift.TActiveTabletStat;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-
-/**
- * Unit tests for TabletSlidingWindowAccessStatsTest sliding window logic.
- *
- * <p>We use reflection to test the private static inner class SlidingWindowCounter,
- * focusing on time-window counting, bucket expiration, cleanup and cache invalidation.
- */
 public class TabletSlidingWindowAccessStatsTest {
+    private boolean originalEnabled;
+    private TabletSlidingWindowAccessStats stats;
 
-    private static class CounterHarness {
-        private final Object counter;
-        private final Method add;
-        private final Method getCount;
-        private final Method cleanup;
-        private final Method hasRecentActivity;
-        private final Method getLastAccessTime;
+    @BeforeEach
+    public void setUp() {
+        originalEnabled = Config.enable_active_tablet_sliding_window_access_stats;
+        Config.enable_active_tablet_sliding_window_access_stats = true;
+        stats = new TabletSlidingWindowAccessStats();
+    }
 
-        CounterHarness(int numBuckets) throws Exception {
-            Class<?> clazz = Class.forName(
-                    "org.apache.doris.catalog.TabletSlidingWindowAccessStats$SlidingWindowCounter");
-            Constructor<?> ctor = clazz.getDeclaredConstructor(int.class);
-            ctor.setAccessible(true);
-            this.counter = ctor.newInstance(numBuckets);
-
-            this.add = clazz.getDeclaredMethod("add", long.class, long.class, int.class);
-            this.add.setAccessible(true);
-            this.getCount = clazz.getDeclaredMethod("getCount", long.class, long.class, long.class, int.class);
-            this.getCount.setAccessible(true);
-            this.cleanup = clazz.getDeclaredMethod("cleanup", long.class, long.class);
-            this.cleanup.setAccessible(true);
-            this.hasRecentActivity = clazz.getDeclaredMethod("hasRecentActivity", long.class, long.class);
-            this.hasRecentActivity.setAccessible(true);
-            this.getLastAccessTime = clazz.getDeclaredMethod("getLastAccessTime");
-            this.getLastAccessTime.setAccessible(true);
-        }
-
-        void add(long currentTimeMs, long bucketSizeMs, int numBuckets) throws Exception {
-            add.invoke(counter, currentTimeMs, bucketSizeMs, numBuckets);
-        }
-
-        long getCount(long currentTimeMs, long timeWindowMs, long bucketSizeMs, int numBuckets) throws Exception {
-            Object v = getCount.invoke(counter, currentTimeMs, timeWindowMs, bucketSizeMs, numBuckets);
-            return (long) v;
-        }
-
-        void cleanup(long currentTimeMs, long timeWindowMs) throws Exception {
-            cleanup.invoke(counter, currentTimeMs, timeWindowMs);
-        }
-
-        boolean hasRecentActivity(long currentTimeMs, long timeWindowMs) throws Exception {
-            Object v = hasRecentActivity.invoke(counter, currentTimeMs, timeWindowMs);
-            return (boolean) v;
-        }
-
-        long getLastAccessTime() throws Exception {
-            Object v = getLastAccessTime.invoke(counter);
-            return (long) v;
-        }
+    @AfterEach
+    public void tearDown() {
+        Config.enable_active_tablet_sliding_window_access_stats = originalEnabled;
     }
 
     @Test
-    public void testAddAndGetCountWithinWindow() throws Exception {
-        int numBuckets = 5;
-        long bucketSizeMs = 1000L;
-        long timeWindowMs = 5000L;
-        long base = 10_000L; // avoid 0 (bucket timestamp 0 is treated as "unset" in getCount)
+    public void testUpdateFromReportProvidesAccessInfo() {
+        stats.updateFromReport(1L,
+                Collections.singletonList(queryStat(10L, 12L, 100L, 60_000L)),
+                Collections.singletonList(loadStat(10L, 3L, 200L, 60_000L)));
 
-        CounterHarness c = new CounterHarness(numBuckets);
-        c.add(base, bucketSizeMs, numBuckets);
-        c.add(base + 1000L, bucketSizeMs, numBuckets);
-        c.add(base + 2000L, bucketSizeMs, numBuckets);
-
-        Assertions.assertEquals(base + 2000L, c.getLastAccessTime());
-        Assertions.assertTrue(c.hasRecentActivity(base + 2000L, timeWindowMs));
-
-        long cnt = c.getCount(base + 2000L, timeWindowMs, bucketSizeMs, numBuckets);
-        Assertions.assertEquals(3L, cnt);
-
-        // Cached result (same timestamp) should be consistent
-        long cnt2 = c.getCount(base + 2000L, timeWindowMs, bucketSizeMs, numBuckets);
-        Assertions.assertEquals(3L, cnt2);
-
-        // add() should invalidate cachedTotalCount
-        c.add(base + 2500L, bucketSizeMs, numBuckets);
-        long cnt3 = c.getCount(base + 2500L, timeWindowMs, bucketSizeMs, numBuckets);
-        Assertions.assertEquals(4L, cnt3);
+        TabletSlidingWindowAccessStats.AccessStatsResult result = stats.getAccessInfo(10L);
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(15L, result.accessCount);
+        Assertions.assertEquals(200L, result.lastAccessTime);
+        Assertions.assertEquals(12.0, result.scanRate);
+        Assertions.assertEquals(3.0, result.loadRate);
     }
 
     @Test
-    public void testWindowExpiresOldBuckets() throws Exception {
-        int numBuckets = 5;
-        long bucketSizeMs = 1000L;
-        long timeWindowMs = 5000L;
-        long base = 20_000L;
+    public void testReportReplacesPreviousBackendSnapshot() {
+        stats.updateFromReport(1L, Collections.singletonList(queryStat(10L, 12L, 100L, 60_000L)),
+                Collections.emptyList());
+        stats.updateFromReport(1L, Collections.singletonList(queryStat(20L, 7L, 200L, 60_000L)),
+                Collections.emptyList());
 
-        CounterHarness c = new CounterHarness(numBuckets);
-        c.add(base, bucketSizeMs, numBuckets);
-        c.add(base + 1000L, bucketSizeMs, numBuckets);
-        c.add(base + 2000L, bucketSizeMs, numBuckets);
-
-        // At base + 6000, window start is base + 1000 => count should be 2 (1000 and 2000 buckets)
-        long cnt1 = c.getCount(base + 6000L, timeWindowMs, bucketSizeMs, numBuckets);
-        Assertions.assertEquals(2L, cnt1);
-
-        // At base + 7000, window start is base + 2000 => count should be 1 (2000 bucket)
-        long cnt2 = c.getCount(base + 7000L, timeWindowMs, bucketSizeMs, numBuckets);
-        Assertions.assertEquals(1L, cnt2);
-
-        // recent activity should still be true (lastAccessTime=base+2000 within 5000ms of base+7000? exactly 5000ms)
-        Assertions.assertTrue(c.hasRecentActivity(base + 7000L, timeWindowMs));
+        Assertions.assertNull(stats.getAccessInfo(10L));
+        Assertions.assertEquals(7L, stats.getAccessInfo(20L).accessCount);
+        Assertions.assertEquals(1L, stats.getActiveIdsInWindow());
+        Assertions.assertEquals(7L, stats.getRecentAccessCountInWindow());
     }
 
     @Test
-    public void testCleanupRemovesExpiredBuckets() throws Exception {
-        int numBuckets = 5;
-        long bucketSizeMs = 1000L;
-        long timeWindowMs = 5000L;
-        long base = 30_000L;
+    public void testTopNReservesCapacityForLoadTablets() {
+        stats.updateFromReport(1L, List.of(
+                queryStat(1L, 1_000L, 1L, 60_000L),
+                queryStat(2L, 900L, 2L, 60_000L),
+                queryStat(3L, 800L, 3L, 60_000L),
+                queryStat(4L, 700L, 4L, 60_000L)), List.of(
+                loadStat(101L, 10L, 101L, 60_000L),
+                loadStat(102L, 9L, 102L, 60_000L),
+                loadStat(103L, 8L, 103L, 60_000L),
+                loadStat(104L, 7L, 104L, 60_000L)));
 
-        CounterHarness c = new CounterHarness(numBuckets);
-        c.add(base, bucketSizeMs, numBuckets);
-        c.add(base + 1000L, bucketSizeMs, numBuckets);
-        c.add(base + 2000L, bucketSizeMs, numBuckets);
-
-        // cleanup at base + 7000: windowStart=base+2000, so base/base+1000 buckets should be cleared
-        c.cleanup(base + 7000L, timeWindowMs);
-        long cnt = c.getCount(base + 7000L, timeWindowMs, bucketSizeMs, numBuckets);
-        Assertions.assertEquals(1L, cnt);
+        Set<Long> ids = stats.getTopNActive(4).stream().map(r -> r.id).collect(Collectors.toSet());
+        Assertions.assertEquals(Set.of(1L, 2L, 101L, 102L), ids);
     }
 
     @Test
-    public void testBucketWrapAroundResetsExpiredBucket() throws Exception {
-        int numBuckets = 5;
-        long bucketSizeMs = 1000L;
-        long timeWindowMs = 5000L;
-        long base = 40_000L;
+    public void testTopNSortsByRateInsteadOfRawDeltaAcrossBackends() {
+        stats.updateFromReport(1L, Collections.singletonList(queryStat(1L, 100L, 1L, 120_000L)),
+                Collections.emptyList());
+        stats.updateFromReport(2L, Collections.singletonList(queryStat(2L, 75L, 2L, 60_000L)),
+                Collections.emptyList());
 
-        CounterHarness c = new CounterHarness(numBuckets);
-        // bucket index wraps every numBuckets * bucketSizeMs (5s here)
-        c.add(base, bucketSizeMs, numBuckets);            // idx = 0
-        c.add(base + 5000L, bucketSizeMs, numBuckets);    // idx = 0 again, should reset old bucket
-
-        // With current implementation, the old "base" bucket is overwritten, so only 1 remains.
-        long cnt = c.getCount(base + 5000L, timeWindowMs, bucketSizeMs, numBuckets);
-        Assertions.assertEquals(1L, cnt);
+        List<TabletSlidingWindowAccessStats.AccessStatsResult> results = stats.getTopNActive(2);
+        Assertions.assertEquals(2L, results.get(0).id);
+        Assertions.assertEquals(1L, results.get(1).id);
     }
 
     @Test
-    public void testTimeWindowLessThanBucketSizeStillUsesValidBucketCount() throws Exception {
-        long originWindowSecond = Config.active_tablet_sliding_window_time_window_second;
-        boolean originEnabled = Config.enable_active_tablet_sliding_window_access_stats;
-        try {
-            Config.active_tablet_sliding_window_time_window_second = 59L;
-            Config.enable_active_tablet_sliding_window_access_stats = false;
+    public void testReplicaStatsAreMergedByMax() {
+        stats.updateFromReport(1L,
+                Collections.singletonList(queryStat(10L, 10L, 100L, 60_000L)),
+                Collections.singletonList(loadStat(10L, 2L, 300L, 60_000L)));
+        stats.updateFromReport(2L,
+                Collections.singletonList(queryStat(10L, 20L, 200L, 60_000L)),
+                Collections.singletonList(loadStat(10L, 1L, 400L, 60_000L)));
 
-            TabletSlidingWindowAccessStats stats = new TabletSlidingWindowAccessStats();
-            Field numBucketsField = TabletSlidingWindowAccessStats.class.getDeclaredField("numBuckets");
-            numBucketsField.setAccessible(true);
-            int numBuckets = (int) numBucketsField.get(stats);
-            Assertions.assertEquals(1, numBuckets);
-
-            // No ArithmeticException should be thrown by modulo numBuckets path.
-            stats.recordAccess(123L);
-        } finally {
-            Config.active_tablet_sliding_window_time_window_second = originWindowSecond;
-            Config.enable_active_tablet_sliding_window_access_stats = originEnabled;
-        }
+        TabletSlidingWindowAccessStats.AccessStatsResult result = stats.getTopNActive(2).get(0);
+        Assertions.assertEquals(21L, result.accessCount);
+        Assertions.assertEquals(400L, result.lastAccessTime);
+        Assertions.assertEquals(20.0, result.scanRate);
+        Assertions.assertEquals(2.0, result.loadRate);
+        Assertions.assertEquals(21L, stats.getRecentAccessCountInWindow());
+        Assertions.assertEquals(1L, stats.getActiveIdsInWindow());
     }
 
     @Test
-    public void testTopNComparatorOrdersByAccessCountThenLastAccessTimeDesc() throws Exception {
-        Field f = TabletSlidingWindowAccessStats.class.getDeclaredField("TOPN_ACTIVE_COMPARATOR");
-        f.setAccessible(true);
-        @SuppressWarnings("unchecked")
-        Comparator<TabletSlidingWindowAccessStats.AccessStatsResult> cmp =
-                (Comparator<TabletSlidingWindowAccessStats.AccessStatsResult>) f.get(null);
+    public void testRemoveBackendRemovesItsSnapshot() {
+        stats.updateFromReport(1L, Collections.singletonList(queryStat(10L, 1L, 100L, 60_000L)),
+                Collections.emptyList());
 
-        List<TabletSlidingWindowAccessStats.AccessStatsResult> results = new ArrayList<>();
-        results.add(new TabletSlidingWindowAccessStats.AccessStatsResult(1L, 1L, 200L));
-        results.add(new TabletSlidingWindowAccessStats.AccessStatsResult(2L, 10L, 100L));
-        results.add(new TabletSlidingWindowAccessStats.AccessStatsResult(3L, 10L, 300L));
-        results.add(new TabletSlidingWindowAccessStats.AccessStatsResult(4L, 2L, 400L));
+        stats.removeBackend(1L);
 
-        results.sort(cmp);
+        Assertions.assertNull(stats.getAccessInfo(10L));
+        Assertions.assertTrue(stats.getTopNActive(10).isEmpty());
+    }
 
-        // accessCount desc => 10 first, then 2, then 1
-        // tie-breaker lastAccessTime desc => id=3 (300) before id=2 (100)
-        Assertions.assertEquals(3L, results.get(0).id);
-        Assertions.assertEquals(2L, results.get(1).id);
-        Assertions.assertEquals(4L, results.get(2).id);
-        Assertions.assertEquals(1L, results.get(3).id);
+    @Test
+    public void testDisabledStatsReturnEmptyValues() {
+        stats.updateFromReport(1L, Collections.singletonList(queryStat(10L, 1L, 100L, 60_000L)),
+                Collections.emptyList());
+        Config.enable_active_tablet_sliding_window_access_stats = false;
+
+        Assertions.assertNull(stats.getAccessInfo(10L));
+        Assertions.assertTrue(stats.getTopNActive(10).isEmpty());
+        Assertions.assertEquals(0L, stats.getRecentAccessCountInWindow());
+        Assertions.assertEquals(0L, stats.getActiveIdsInWindow());
+        Assertions.assertEquals(0L, stats.getTotalAccessCount());
+        Assertions.assertEquals("Active tablet sliding window access stats is disabled", stats.getStatsSummary());
+    }
+
+    private static TActiveTabletStat queryStat(long tabletId, long delta, long lastAccessTime, long windowMs) {
+        TActiveTabletStat stat = new TActiveTabletStat();
+        stat.setTabletId(tabletId);
+        stat.setScanCountDelta(delta);
+        stat.setLastQueryTimeMs(lastAccessTime);
+        stat.setDeltaWindowMs(windowMs);
+        return stat;
+    }
+
+    private static TActiveTabletStat loadStat(long tabletId, long delta, long lastAccessTime, long windowMs) {
+        TActiveTabletStat stat = new TActiveTabletStat();
+        stat.setTabletId(tabletId);
+        stat.setLoadCountDelta(delta);
+        stat.setLastLoadTimeMs(lastAccessTime);
+        stat.setDeltaWindowMs(windowMs);
+        return stat;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/TabletSlidingWindowAccessStatsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/TabletSlidingWindowAccessStatsTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -60,17 +61,110 @@ public class TabletSlidingWindowAccessStatsTest {
         Assertions.assertEquals(3.0, result.loadRate);
     }
 
+    // A report carries only the tablets that saw traffic since the previous one. Dropping the
+    // rest would shrink "active" to a single report interval, which in a cluster reporting
+    // every second means a tablet is active for one second after it stops being queried.
     @Test
-    public void testReportReplacesPreviousBackendSnapshot() {
-        stats.updateFromReport(1L, Collections.singletonList(queryStat(10L, 12L, 100L, 60_000L)),
+    public void testTabletsMissingFromTheNextReportStayActive() {
+        long now = System.currentTimeMillis();
+        stats.updateFromReport(1L, Collections.singletonList(queryStat(10L, 12L, now, 60_000L)),
                 Collections.emptyList());
-        stats.updateFromReport(1L, Collections.singletonList(queryStat(20L, 7L, 200L, 60_000L)),
+        // Next report: tablet 10 saw no traffic, tablet 20 did.
+        stats.updateFromReport(1L, Collections.singletonList(queryStat(20L, 7L, now, 60_000L)),
+                Collections.emptyList());
+
+        Assertions.assertEquals(12L, stats.getAccessInfo(10L).accessCount);
+        Assertions.assertEquals(7L, stats.getAccessInfo(20L).accessCount);
+        Assertions.assertEquals(2L, stats.getActiveIdsInWindow());
+        Assertions.assertEquals(19L, stats.getRecentAccessCountInWindow());
+    }
+
+    // A repeated tablet takes the fresh values, it is not accumulated across reports.
+    @Test
+    public void testRepeatedTabletTakesTheLatestReport() {
+        long now = System.currentTimeMillis();
+        stats.updateFromReport(1L, Collections.singletonList(queryStat(10L, 12L, now - 1_000L, 60_000L)),
+                Collections.emptyList());
+        stats.updateFromReport(1L, Collections.singletonList(queryStat(10L, 7L, now, 60_000L)),
+                Collections.emptyList());
+
+        Assertions.assertEquals(7L, stats.getAccessInfo(10L).accessCount);
+        Assertions.assertEquals(now, stats.getAccessInfo(10L).lastAccessTime);
+        Assertions.assertEquals(1L, stats.getActiveIdsInWindow());
+    }
+
+    // Equal rates fall through to the tie-break, and the tie-break runs in the same direction
+    // as the rate: most recently touched wins.
+    @Test
+    public void testEqualRatesPreferTheMostRecentlyTouched() {
+        long now = System.currentTimeMillis();
+        stats.updateFromReport(1L, List.of(
+                queryStat(10L, 10L, now - 1_000L, 60_000L),
+                queryStat(20L, 10L, now, 60_000L)), Collections.emptyList());
+
+        List<TabletSlidingWindowAccessStats.AccessStatsResult> top = stats.getTopNActive(1);
+        Assertions.assertEquals(1, top.size());
+        Assertions.assertEquals(20L, top.get(0).id);
+    }
+
+    // The half-and-half budget is a floor, not a cap: whichever dimension has fewer candidates
+    // hands its unused share to the other, and when both are short everything is returned.
+    @Test
+    public void testTopNQuotaSpillsToTheOtherDimension() {
+        long now = System.currentTimeMillis();
+
+        // Only queries: the load half is handed over, so all 8 query tablets fit in topN=8.
+        TabletSlidingWindowAccessStats queryOnly = new TabletSlidingWindowAccessStats();
+        queryOnly.updateFromReport(1L, queryStats(8, now), Collections.emptyList());
+        Assertions.assertEquals(8, queryOnly.getTopNActive(8).size());
+
+        // Only loads: mirror image.
+        TabletSlidingWindowAccessStats loadOnly = new TabletSlidingWindowAccessStats();
+        loadOnly.updateFromReport(1L, Collections.emptyList(), loadStats(8, now));
+        Assertions.assertEquals(8, loadOnly.getTopNActive(8).size());
+
+        // Both below topN/2: nothing to spill, every candidate is returned and topN is not met.
+        TabletSlidingWindowAccessStats bothShort = new TabletSlidingWindowAccessStats();
+        bothShort.updateFromReport(1L, queryStats(2, now), loadStats(3, now));
+        Assertions.assertEquals(5, bothShort.getTopNActive(20).size());
+    }
+
+    // Retention ends at active_tablet_sliding_window_time_window_second.
+    @Test
+    public void testEntriesAgeOutOfTheWindow() {
+        long windowMs = Config.active_tablet_sliding_window_time_window_second * 1000L;
+        long now = System.currentTimeMillis();
+        stats.updateFromReport(1L,
+                Collections.singletonList(queryStat(10L, 12L, now - windowMs - 60_000L, 60_000L)),
+                Collections.emptyList());
+        stats.updateFromReport(1L, Collections.singletonList(queryStat(20L, 7L, now, 60_000L)),
                 Collections.emptyList());
 
         Assertions.assertNull(stats.getAccessInfo(10L));
-        Assertions.assertEquals(7L, stats.getAccessInfo(20L).accessCount);
         Assertions.assertEquals(1L, stats.getActiveIdsInWindow());
-        Assertions.assertEquals(7L, stats.getRecentAccessCountInWindow());
+    }
+
+    // Retention is bounded, so a backend with a churning hot set cannot grow FE memory for a
+    // whole window. The oldest entries go first.
+    @Test
+    public void testRetentionIsCappedByTopnKeepingTheNewest() {
+        int originalTopn = Config.cloud_active_partition_scheduling_topn;
+        Config.cloud_active_partition_scheduling_topn = 2;
+        try {
+            long now = System.currentTimeMillis();
+            stats.updateFromReport(1L, List.of(
+                    queryStat(1L, 1L, now - 3_000L, 60_000L),
+                    queryStat(2L, 1L, now - 2_000L, 60_000L)), Collections.emptyList());
+            stats.updateFromReport(1L,
+                    Collections.singletonList(queryStat(3L, 1L, now, 60_000L)), Collections.emptyList());
+
+            Assertions.assertEquals(2L, stats.getActiveIdsInWindow());
+            Assertions.assertNull(stats.getAccessInfo(1L));
+            Assertions.assertNotNull(stats.getAccessInfo(2L));
+            Assertions.assertNotNull(stats.getAccessInfo(3L));
+        } finally {
+            Config.cloud_active_partition_scheduling_topn = originalTopn;
+        }
     }
 
     @Test
@@ -142,6 +236,22 @@ public class TabletSlidingWindowAccessStatsTest {
         Assertions.assertEquals(0L, stats.getActiveIdsInWindow());
         Assertions.assertEquals(0L, stats.getTotalAccessCount());
         Assertions.assertEquals("Active tablet sliding window access stats is disabled", stats.getStatsSummary());
+    }
+
+    private static List<TActiveTabletStat> queryStats(int count, long lastAccessTime) {
+        List<TActiveTabletStat> stats = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            stats.add(queryStat(1_000L + i, 10L + i, lastAccessTime, 60_000L));
+        }
+        return stats;
+    }
+
+    private static List<TActiveTabletStat> loadStats(int count, long lastAccessTime) {
+        List<TActiveTabletStat> stats = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            stats.add(loadStat(2_000L + i, 10L + i, lastAccessTime, 60_000L));
+        }
+        return stats;
     }
 
     private static TActiveTabletStat queryStat(long tabletId, long delta, long lastAccessTime, long windowMs) {

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -56,6 +56,22 @@ struct TTabletInfo {
     1000: optional bool is_persistent
 }
 
+struct TActiveTabletStat {
+    1: required Types.TTabletId tablet_id
+    // Query scan count since the previous SUCCESSFULLY REPORTED baseline (delta, not cumulative)
+    2: optional i64 scan_count_delta
+    // Memtable flush count since that baseline (delta) -- the load-side signal
+    3: optional i64 load_count_delta
+    // Last query scan time, ms since epoch
+    4: optional i64 last_query_time_ms
+    // Last load (memtable write) time, ms since epoch
+    5: optional i64 last_load_time_ms
+    // Wall-clock span this delta covers, in ms. NOT always the report interval: a tablet
+    // cut by the topN cap is not committed, so its next delta spans several intervals.
+    // Consumers MUST rank by delta/delta_window_ms, never by raw delta.
+    6: optional i64 delta_window_ms
+}
+
 struct TFinishTaskRequest {
     1: required Types.TBackend backend
     2: required Types.TTaskType task_type
@@ -123,6 +139,14 @@ struct TReportRequest {
     15: optional list<AgentService.TIndexPolicy> index_policy
     // Running query/loading tasks
     16: optional i64 running_tasks
+    // Top-N tablets by query scan count on this BE since the previous report.
+    // Entries set only tablet_id / scan_count_delta / last_query_time_ms / delta_window_ms.
+    17: optional list<TActiveTabletStat> top_query_tablets
+    // Top-N tablets by load (memtable flush) count since the previous report.
+    // Entries set only tablet_id / load_count_delta / last_load_time_ms / delta_window_ms.
+    18: optional list<TActiveTabletStat> top_load_tablets
+    // True when either list was truncated by the topN cap.
+    19: optional bool active_tablets_truncated
 }
 
 struct TMasterResult {

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -66,8 +66,9 @@ struct TActiveTabletStat {
     4: optional i64 last_query_time_ms
     // Last load (memtable write) time, ms since epoch
     5: optional i64 last_load_time_ms
-    // Wall-clock span this delta covers, in ms. NOT always the report interval: a tablet
-    // cut by the topN cap is not committed, so its next delta spans several intervals.
+    // Wall-clock span this delta covers, in ms. NOT always the report interval: a dropped
+    // report round commits no baseline, so the next delta spans several intervals, and
+    // backends report on independent phases.
     // Consumers MUST rank by delta/delta_window_ms, never by raw delta.
     6: optional i64 delta_window_ms
 }
@@ -145,8 +146,6 @@ struct TReportRequest {
     // Top-N tablets by load (memtable flush) count since the previous report.
     // Entries set only tablet_id / load_count_delta / last_load_time_ms / delta_window_ms.
     18: optional list<TActiveTabletStat> top_load_tablets
-    // True when either list was truncated by the topN cap.
-    19: optional bool active_tablets_truncated
 }
 
 struct TMasterResult {

--- a/regression-test/suites/cloud_p0/balance/test_active_tablet_priority_scheduling.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_active_tablet_priority_scheduling.groovy
@@ -160,10 +160,10 @@ suite('test_active_tablet_priority_scheduling', 'cloud_p0, docker') {
         def coldTableId = getTableIdByName(coldTbl)
         logger.info("hotTableId={}, coldTableId={}", hotTableId, coldTableId)
 
-        // Verify SHOW TABLETS FROM <table> exposes AccessCount/LastAccessTime and values are updated after access
+        // Verify SHOW TABLETS FROM <table> exposes WindowAccessCount/LastAccessTime and values are updated after access
         def hotTablets = sql_return_maparray """SHOW TABLETS FROM ${hotTbl}"""
         assert hotTablets.size() > 0
-        assert hotTablets[0].containsKey("AccessCount")
+        assert hotTablets[0].containsKey("WindowAccessCount")
         assert hotTablets[0].containsKey("LastAccessTime")
 
         def accessedTabletRow = null
@@ -171,7 +171,7 @@ suite('test_active_tablet_priority_scheduling', 'cloud_p0, docker') {
             hotTablets = sql_return_maparray """SHOW TABLETS FROM ${hotTbl}"""
             accessedTabletRow = hotTablets.find { row ->
                 try {
-                    long c = row.AccessCount.toString().toLong()
+                    long c = row.WindowAccessCount.toString().toLong()
                     long t = row.LastAccessTime.toString().toLong()
                     return c > 0 && t > 0
                 } catch (Throwable ignored) {
@@ -184,19 +184,19 @@ suite('test_active_tablet_priority_scheduling', 'cloud_p0, docker') {
         def accessedTabletId = accessedTabletRow.TabletId.toString().toLong()
         logger.info("picked accessedTabletId={} from SHOW TABLETS, row={}", accessedTabletId, accessedTabletRow)
 
-        // Verify SHOW TABLET <tabletId> exposes AccessCount/LastAccessTime and values are updated
+        // Verify SHOW TABLET <tabletId> exposes WindowAccessCount/LastAccessTime and values are updated
         def showTablet = sql_return_maparray """SHOW TABLET ${accessedTabletId}"""
         assert showTablet.size() > 0
-        assert showTablet[0].containsKey("AccessCount")
+        assert showTablet[0].containsKey("WindowAccessCount")
         assert showTablet[0].containsKey("LastAccessTime")
-        assert showTablet[0].AccessCount.toString().toLong() > 0
+        assert showTablet[0].WindowAccessCount.toString().toLong() > 0
         assert showTablet[0].LastAccessTime.toString().toLong() > 0
 
         def fe = cluster.getFeByIndex(1)
         def feLogPath = fe.getLogFilePath()
         logger.info("fe log path={}", feLogPath)
 
-        // Capture "active" tablets for hot table before rebalance (AccessCount > 0)
+        // Capture "active" tablets for hot table before rebalance (WindowAccessCount > 0)
         def hotBefore = sql_return_maparray """SHOW TABLETS FROM ${hotTbl}"""
         def hotBeforeByTabletId = [:]
         hotBefore.each { row ->
@@ -204,7 +204,7 @@ suite('test_active_tablet_priority_scheduling', 'cloud_p0, docker') {
         }
         def activeHotTabletIds = hotBefore.findAll { row ->
             try {
-                row.AccessCount.toString().toLong() > 0
+                row.WindowAccessCount.toString().toLong() > 0
             } catch (Throwable ignored) {
                 false
             }
@@ -234,14 +234,14 @@ suite('test_active_tablet_priority_scheduling', 'cloud_p0, docker') {
         }
 
         // Cold-first verification (SQL-based):
-        // At the moment the first move happens, all moved tablets should come from cold subset (AccessCount == 0 before move).
+        // At the moment the first move happens, all moved tablets should come from cold subset (WindowAccessCount == 0 before move).
         def hotAfterFirstMove = sql_return_maparray """SHOW TABLETS FROM ${hotTbl}"""
         def movedNow = hotAfterFirstMove.findAll { it.BackendId.toString().toLong() == newBeId }
         assert movedNow.size() > 0
         movedNow.each { row ->
             def beforeRow = hotBeforeByTabletId[row.TabletId.toString()]
             assert beforeRow != null
-            long beforeCnt = beforeRow.AccessCount.toString().toLong()
+            long beforeCnt = beforeRow.WindowAccessCount.toString().toLong()
         }
 
         // Optional: show that cold table is processed no earlier than hot table (best-effort timing check)
@@ -259,4 +259,5 @@ suite('test_active_tablet_priority_scheduling', 'cloud_p0, docker') {
         assert hotFirstMoveAt <= coldFirstMoveAt : "Expected hot table to be scheduled before cold table"
     }
 }
+
 

--- a/regression-test/suites/cloud_p0/balance/test_active_tablet_priority_scheduling.groovy
+++ b/regression-test/suites/cloud_p0/balance/test_active_tablet_priority_scheduling.groovy
@@ -160,10 +160,10 @@ suite('test_active_tablet_priority_scheduling', 'cloud_p0, docker') {
         def coldTableId = getTableIdByName(coldTbl)
         logger.info("hotTableId={}, coldTableId={}", hotTableId, coldTableId)
 
-        // Verify SHOW TABLETS FROM <table> exposes WindowAccessCount/LastAccessTime and values are updated after access
+        // Verify SHOW TABLETS FROM <table> exposes AccessCount/LastAccessTime and values are updated after access
         def hotTablets = sql_return_maparray """SHOW TABLETS FROM ${hotTbl}"""
         assert hotTablets.size() > 0
-        assert hotTablets[0].containsKey("WindowAccessCount")
+        assert hotTablets[0].containsKey("AccessCount")
         assert hotTablets[0].containsKey("LastAccessTime")
 
         def accessedTabletRow = null
@@ -171,7 +171,7 @@ suite('test_active_tablet_priority_scheduling', 'cloud_p0, docker') {
             hotTablets = sql_return_maparray """SHOW TABLETS FROM ${hotTbl}"""
             accessedTabletRow = hotTablets.find { row ->
                 try {
-                    long c = row.WindowAccessCount.toString().toLong()
+                    long c = row.AccessCount.toString().toLong()
                     long t = row.LastAccessTime.toString().toLong()
                     return c > 0 && t > 0
                 } catch (Throwable ignored) {
@@ -184,19 +184,19 @@ suite('test_active_tablet_priority_scheduling', 'cloud_p0, docker') {
         def accessedTabletId = accessedTabletRow.TabletId.toString().toLong()
         logger.info("picked accessedTabletId={} from SHOW TABLETS, row={}", accessedTabletId, accessedTabletRow)
 
-        // Verify SHOW TABLET <tabletId> exposes WindowAccessCount/LastAccessTime and values are updated
+        // Verify SHOW TABLET <tabletId> exposes AccessCount/LastAccessTime and values are updated
         def showTablet = sql_return_maparray """SHOW TABLET ${accessedTabletId}"""
         assert showTablet.size() > 0
-        assert showTablet[0].containsKey("WindowAccessCount")
+        assert showTablet[0].containsKey("AccessCount")
         assert showTablet[0].containsKey("LastAccessTime")
-        assert showTablet[0].WindowAccessCount.toString().toLong() > 0
+        assert showTablet[0].AccessCount.toString().toLong() > 0
         assert showTablet[0].LastAccessTime.toString().toLong() > 0
 
         def fe = cluster.getFeByIndex(1)
         def feLogPath = fe.getLogFilePath()
         logger.info("fe log path={}", feLogPath)
 
-        // Capture "active" tablets for hot table before rebalance (WindowAccessCount > 0)
+        // Capture "active" tablets for hot table before rebalance (AccessCount > 0)
         def hotBefore = sql_return_maparray """SHOW TABLETS FROM ${hotTbl}"""
         def hotBeforeByTabletId = [:]
         hotBefore.each { row ->
@@ -204,7 +204,7 @@ suite('test_active_tablet_priority_scheduling', 'cloud_p0, docker') {
         }
         def activeHotTabletIds = hotBefore.findAll { row ->
             try {
-                row.WindowAccessCount.toString().toLong() > 0
+                row.AccessCount.toString().toLong() > 0
             } catch (Throwable ignored) {
                 false
             }
@@ -234,14 +234,14 @@ suite('test_active_tablet_priority_scheduling', 'cloud_p0, docker') {
         }
 
         // Cold-first verification (SQL-based):
-        // At the moment the first move happens, all moved tablets should come from cold subset (WindowAccessCount == 0 before move).
+        // At the moment the first move happens, all moved tablets should come from cold subset (AccessCount == 0 before move).
         def hotAfterFirstMove = sql_return_maparray """SHOW TABLETS FROM ${hotTbl}"""
         def movedNow = hotAfterFirstMove.findAll { it.BackendId.toString().toLong() == newBeId }
         assert movedNow.size() > 0
         movedNow.each { row ->
             def beforeRow = hotBeforeByTabletId[row.TabletId.toString()]
             assert beforeRow != null
-            long beforeCnt = beforeRow.WindowAccessCount.toString().toLong()
+            long beforeCnt = beforeRow.AccessCount.toString().toLong()
         }
 
         // Optional: show that cold table is processed no earlier than hot table (best-effort timing check)
@@ -259,5 +259,4 @@ suite('test_active_tablet_priority_scheduling', 'cloud_p0, docker') {
         assert hotFirstMoveAt <= coldFirstMoveAt : "Expected hot table to be scheduled before cold table"
     }
 }
-
 


### PR DESCRIPTION
Problem Summary:
FE tracks tablet activity with per-tablet sliding windows, consuming substantial heap and retaining stale entries on followers and observers.

Use BE query and load counters to report bounded sets of active tablets. Replace FE sliding windows and asynchronous recording with per-BE report snapshots, and rank query and load activity separately for cloud balancing. Also fix inflated tablet counts when cloud tablet reports retry.

### Release note

Reduce FE memory usage for tablet activity tracking. Rename `WindowAccessCount` to `AccessCount`, reflecting activity over a BE report interval. Tablets outside the reported top-N show zero activity.

### Check List (For Author)

- Test: BE/FE unit tests and regression coverage included; execution not verified in this commit-message-only update.
- Behavior changed: Yes. Activity statistics now refresh through BE reports.
- Does this need documentation: Yes. AccessCount and reporting configuration.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

