### PR TITLE
[improvement](connection) Make max_user_connections upper bound follow qe_max_connection

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/privilege/UserProperty.java
@@ -223,8 +223,9 @@ public class UserProperty {
                     throw new DdlException(PROP_MAX_USER_CONNECTIONS + " is not number");
                 }
 
-                if (newMaxConn <= 0 || newMaxConn > 10000) {
-                    throw new DdlException(PROP_MAX_USER_CONNECTIONS + " is not valid, must between 1 and 10000");
+                // No need to set a hard-coded upper bound for the per-user max connections.
+                if (newMaxConn <= 0) {
+                    throw new DdlException(PROP_MAX_USER_CONNECTIONS + " is not valid, must be greater than 0");
                 }
             } else if (keyArr[0].equalsIgnoreCase(DEFAULT_CLOUD_CLUSTER)) {
                 newDefaultCloudCluster = checkCloudDefaultCluster(keyArr, value, DEFAULT_CLOUD_CLUSTER, isReplay);


### PR DESCRIPTION
Previously the per-user connection limit `max_user_connections` was validated against a hard-coded maximum of 10000. When operators raised the FE global connection limit `qe_max_connection` above 10000, a single user still could not be granted more than 10000 connections, which is unreasonable since the effective limit is already bounded by the global setting at runtime.