### PR TITLE
 [fix](agg) Preserve weighted average when eliminating group by

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupBy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupBy.java
@@ -27,7 +27,6 @@ import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AggregateFunction;
 import org.apache.doris.nereids.trees.expressions.functions.agg.AnyValue;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Avg;
-import org.apache.doris.nereids.trees.expressions.functions.agg.AvgWeighted;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Count;
 import org.apache.doris.nereids.trees.expressions.functions.agg.Max;
 import org.apache.doris.nereids.trees.expressions.functions.agg.MaxBy;
@@ -66,8 +65,9 @@ import java.util.Set;
 public class EliminateGroupBy extends OneRewriteRuleFactory {
     private static final ImmutableSet<Class<? extends Expression>> supportedBasicFunctions
             = ImmutableSet.of(Sum.class, Avg.class, Min.class, Max.class, Median.class, AnyValue.class);
+    // AvgWeighted must retain its aggregate: even one row can have zero weight or overflow v * w.
     private static final ImmutableSet<Class<? extends Expression>> supportedTwoArgsFunctions
-            = ImmutableSet.of(MinBy.class, MaxBy.class, AvgWeighted.class, Percentile.class);
+            = ImmutableSet.of(MinBy.class, MaxBy.class, Percentile.class);
     private static final ImmutableSet<Class<? extends Expression>> supportedDevLikeFunctions
             = ImmutableSet.of(Stddev.class, StddevSamp.class, Variance.class, VarianceSamp.class);
     private static final ImmutableSet<Class<? extends Expression>> supportedFunctionSum0

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByAvgWeightedTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/rewrite/EliminateGroupByAvgWeightedTest.java
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.nereids.rules.rewrite;
+
+import org.apache.doris.nereids.trees.expressions.functions.agg.AvgWeighted;
+import org.apache.doris.nereids.util.MemoPatternMatchSupported;
+import org.apache.doris.nereids.util.PlanChecker;
+import org.apache.doris.utframe.TestWithFeService;
+
+import org.junit.jupiter.api.Test;
+
+class EliminateGroupByAvgWeightedTest extends TestWithFeService implements MemoPatternMatchSupported {
+    @Override
+    protected void runBeforeAll() throws Exception {
+        createDatabase("eliminate_group_by_avg_weighted");
+        connectContext.setDatabase("eliminate_group_by_avg_weighted");
+        connectContext.getSessionVariable().setDisableNereidsRules("PRUNE_EMPTY_PARTITION");
+        createTable("CREATE TABLE t (k INT NOT NULL, v DOUBLE NOT NULL, w DOUBLE NOT NULL)"
+                + " UNIQUE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1"
+                + " PROPERTIES ('replication_num' = '1')");
+    }
+
+    @Test
+    void retainAvgWeighted() {
+        for (String weight : new String[] {"w", "0", "2", "-2"}) {
+            PlanChecker.from(connectContext)
+                    .analyze("SELECT k, avg_weighted(v, " + weight + ") FROM t GROUP BY k")
+                    .rewrite()
+                    .matches(logicalAggregate().when(agg -> agg.getAggregateFunctions().stream()
+                            .anyMatch(function -> function instanceof AvgWeighted)));
+        }
+    }
+
+    @Test
+    void retainAvgWeightedWithOtherAggregates() {
+        PlanChecker.from(connectContext)
+                .analyze("SELECT k, avg_weighted(v, w), sum(v), max(v) FROM t GROUP BY k")
+                .rewrite()
+                .matches(logicalAggregate().when(agg -> agg.getAggregateFunctions().stream()
+                        .anyMatch(function -> function instanceof AvgWeighted)));
+    }
+}

--- a/regression-test/data/nereids_rules_p0/eliminate_gby_key/eliminate_group_by.out
+++ b/regression-test/data/nereids_rules_p0/eliminate_gby_key/eliminate_group_by.out
@@ -151,8 +151,10 @@ PhysicalResultSink
 -- !two_args_func_avg_weighted_shape --
 PhysicalResultSink
 --PhysicalProject
-----filter((test_unique2.__DORIS_DELETE_SIGN__ = 0))
-------PhysicalOlapScan[test_unique2]
+----hashAgg[GLOBAL]
+------PhysicalProject
+--------filter((test_unique2.__DORIS_DELETE_SIGN__ = 0))
+----------PhysicalOlapScan[test_unique2]
 
 -- !two_args_func_percentile_shape --
 PhysicalResultSink


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #48317 

Related PR: #xxx

Problem Summary:
    Grouping by a unique non-null key can rewrite avg_weighted(v, w) to v, bypassing zero-weight NaN results and floating-point multiplication. Remove AvgWeighted from EliminateGroupBy support and add rule and regression coverage for zero, positive, negative and null weights, extreme values, and mixed aggregates.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

