### PR TITLE
[fix](fe) Isolate image writers and validate checkpoints before publication

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/Env.java
@@ -2395,6 +2395,13 @@ public class Env {
         MetaReader.read(curFile, this);
     }
 
+    // Load the unpublished checkpoint directly, without selecting the latest published image.
+    public void loadImage(File imageFile, long imageVersion) throws IOException, DdlException {
+        getClusterIdFromStorage(new Storage(imageFile.getParent()));
+        replayedJournalId.set(imageVersion);
+        MetaReader.read(imageFile, this);
+    }
+
     public long loadHeader(DataInputStream dis, MetaHeader metaHeader, long checksum) throws IOException, DdlException {
         switch (metaHeader.getMetaFormat()) {
             case COR1:
@@ -2768,21 +2775,12 @@ public class Env {
     }
 
     // Only called by checkpoint thread
-    // return the latest image file's absolute path
-    public String saveImage() throws IOException {
+    // Return the unpublished image's absolute path. Checkpoint publishes it after validation.
+    public String saveCheckpointImage() throws IOException {
         // Write image.ckpt
-        Storage storage = new Storage(this.imageDir);
-        File curFile = storage.getImageFile(replayedJournalId.get());
         File ckpt = new File(this.imageDir, Storage.IMAGE_NEW);
         saveImage(ckpt, replayedJournalId.get());
-
-        // Move image.ckpt to image.dataVersion
-        LOG.info("Move " + ckpt.getAbsolutePath() + " to " + curFile.getAbsolutePath());
-        if (!ckpt.renameTo(curFile)) {
-            curFile.delete();
-            throw new IOException();
-        }
-        return curFile.getAbsolutePath();
+        return ckpt.getAbsolutePath();
     }
 
     public void saveImage(File curFile, long replayedJournalId) throws IOException {

--- a/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -30,6 +30,7 @@ import org.apache.doris.cloud.catalog.CloudReplica;
 import org.apache.doris.common.CheckpointException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.util.DebugPointUtil;
 import org.apache.doris.common.util.HttpURLUtil;
 import org.apache.doris.common.util.MasterDaemon;
 import org.apache.doris.httpv2.entity.ResponseBody;
@@ -174,6 +175,12 @@ public class Checkpoint extends MasterDaemon {
             env = Env.getCurrentEnv();
             createStaticFieldForCkpt();
             File checkpointImage = new File(checkpointImageFilePath);
+            if (DebugPointUtil.isEnable("Checkpoint.doCheckpoint.before_validate")) {
+                LOG.info("Checkpoint paused before validating image.{}", replayedJournalId);
+                while (DebugPointUtil.isEnable("Checkpoint.doCheckpoint.before_validate")) {
+                    Thread.sleep(100);
+                }
+            }
             env.loadImage(checkpointImage, replayedJournalId);
             // A process stop during validation must leave only image.ckpt, which startup ignores.
             File imageFile = storage.getImageFile(replayedJournalId);

--- a/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/master/Checkpoint.java
@@ -48,6 +48,7 @@ import com.google.common.base.Strings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
@@ -148,7 +149,7 @@ public class Checkpoint extends MasterDaemon {
         env.setEditLog(editLog);
         createStaticFieldForCkpt();
         boolean exceptionCaught = false;
-        String latestImageFilePath = null;
+        String checkpointImageFilePath = null;
         try {
             env.loadImage(imageDir);
             env.replayJournal(checkPointVersion);
@@ -159,7 +160,7 @@ public class Checkpoint extends MasterDaemon {
             }
             env.postProcessAfterMetadataReplayed(false);
             postProcessCloudMetadata();
-            latestImageFilePath = env.saveImage();
+            checkpointImageFilePath = env.saveCheckpointImage();
             replayedJournalId = env.getReplayedJournalId();
 
             // destroy checkpoint catalog, reclaim memory
@@ -172,7 +173,12 @@ public class Checkpoint extends MasterDaemon {
             // If failed, just return
             env = Env.getCurrentEnv();
             createStaticFieldForCkpt();
-            env.loadImage(imageDir);
+            File checkpointImage = new File(checkpointImageFilePath);
+            env.loadImage(checkpointImage, replayedJournalId);
+            // A process stop during validation must leave only image.ckpt, which startup ignores.
+            File imageFile = storage.getImageFile(replayedJournalId);
+            LOG.info("Move {} to {}", checkpointImage.getAbsolutePath(), imageFile.getAbsolutePath());
+            Storage.rename(checkpointImage, imageFile);
             if (MetricRepo.isInit) {
                 MetricRepo.COUNTER_IMAGE_WRITE_SUCCESS.increase(1L);
             }
@@ -189,12 +195,11 @@ public class Checkpoint extends MasterDaemon {
             env = null;
             Env.destroyCheckpoint();
             destroyStaticFieldForCkpt();
-            // if new image generated && exception caught, delete the latest image here
-            // delete the newest image file, cuz it is invalid
-            if ((!Strings.isNullOrEmpty(latestImageFilePath)) && exceptionCaught) {
+            // Validation or publication failed. Only remove the unpublished checkpoint.
+            if ((!Strings.isNullOrEmpty(checkpointImageFilePath)) && exceptionCaught) {
                 MetaCleaner cleaner = new MetaCleaner(Config.meta_dir + "/image");
                 try {
-                    cleaner.cleanTheLatestInvalidImageFile(latestImageFilePath);
+                    cleaner.cleanTheLatestInvalidImageFile(checkpointImageFilePath);
                     if (MetricRepo.isInit) {
                         MetricRepo.COUNTER_IMAGE_CLEAN_SUCCESS.increase(1L);
                     }

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/meta/MetaWriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/meta/MetaWriter.java
@@ -20,6 +20,7 @@ package org.apache.doris.persist.meta;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Reference;
 import org.apache.doris.common.io.CountingDataOutputStream;
+import org.apache.doris.common.util.DebugPointUtil;
 
 import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
@@ -109,6 +110,17 @@ public class MetaWriter {
             // 1. write header first
             checksum.setRef(
                     writer.doWork("header", () -> env.saveHeader(dos, replayedJournalId, checksum.getRef())));
+            if (Env.isCheckpointThread() && DebugPointUtil.isEnable("MetaWriter.write.checkpoint_pause")) {
+                LOG.info("MetaWriter checkpoint paused after header");
+                while (DebugPointUtil.isEnable("MetaWriter.write.checkpoint_pause")) {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException("Interrupted while pausing checkpoint writer", e);
+                    }
+                }
+            }
             // 2. write other modules
             for (MetaPersistMethod m : PersistMetaModules.MODULES_IN_ORDER) {
                 checksum.setRef(writer.doWork(m.name, () -> {

--- a/fe/fe-core/src/main/java/org/apache/doris/persist/meta/MetaWriter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/persist/meta/MetaWriter.java
@@ -67,8 +67,6 @@ import java.util.List;
 public class MetaWriter {
     private static final Logger LOG = LogManager.getLogger(MetaWriter.class);
 
-    public static MetaWriter writer = new MetaWriter();
-
     private interface Delegate {
         long doWork(String name, WriteMethod method) throws IOException;
     }
@@ -94,7 +92,8 @@ public class MetaWriter {
     }
 
     public static void write(File imageFile, Env env) throws IOException {
-        // save image does not need any lock. because only checkpoint thread will call this method.
+        // Checkpoint and /dump can write different images concurrently. Keep their indices isolated.
+        MetaWriter writer = new MetaWriter();
         LOG.info("start to save image to {}. is ckpt: {}",
                 imageFile.getAbsolutePath(), Env.isCheckpointThread());
         final Reference<Long> checksum = new Reference<>(0L);

--- a/fe/fe-core/src/test/java/org/apache/doris/master/CheckpointTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/master/CheckpointTest.java
@@ -1,0 +1,121 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.master;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.CheckpointException;
+import org.apache.doris.common.Config;
+import org.apache.doris.metric.MetricRepo;
+import org.apache.doris.persist.EditLog;
+import org.apache.doris.persist.Storage;
+import org.apache.doris.qe.VariableMgr;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+public class CheckpointTest {
+    @TempDir
+    Path directory;
+
+    @Test
+    public void testPublishOnlyAfterValidation() throws Exception {
+        checkPublication(false);
+    }
+
+    @Test
+    public void testInvalidCheckpointKeepsPreviousImage() throws Exception {
+        checkPublication(true);
+    }
+
+    private void checkPublication(boolean invalid) throws Exception {
+        Path imageDirectory = Files.createDirectory(directory.resolve("image"));
+        Path previousImage = Files.write(imageDirectory.resolve("image.1"), new byte[] {1});
+        File checkpointImage = imageDirectory.resolve(Storage.IMAGE_NEW).toFile();
+        Path publishedImage = imageDirectory.resolve("image.2");
+        Env servingEnv = Mockito.mock(Env.class);
+        Env writerEnv = Mockito.mock(Env.class);
+        Env readerEnv = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        Mockito.when(servingEnv.getImageDir()).thenReturn(imageDirectory.toString());
+        Mockito.when(servingEnv.isHttpReady()).thenReturn(true);
+        Mockito.when(servingEnv.getFrontends(null)).thenReturn(Collections.emptyList());
+        Mockito.when(editLog.getFinalizedJournalId()).thenReturn(2L);
+        Mockito.when(writerEnv.getReplayedJournalId()).thenReturn(2L);
+        Mockito.when(writerEnv.saveCheckpointImage()).thenAnswer(invocation -> {
+            Files.write(checkpointImage.toPath(), new byte[] {2});
+            return checkpointImage.getAbsolutePath();
+        });
+        Mockito.doAnswer(invocation -> {
+            Assertions.assertTrue(checkpointImage.exists());
+            Assertions.assertFalse(Files.exists(publishedImage));
+            Assertions.assertEquals(previousImage.toFile(),
+                    new Storage(imageDirectory.toString()).getCurrentImageFile());
+            if (invalid) {
+                throw new IOException("invalid checkpoint checksum");
+            }
+            return null;
+        }).when(readerEnv).loadImage(checkpointImage, 2L);
+
+        boolean enableCheckpoint = Config.enable_checkpoint;
+        boolean forceCheckpoint = Config.force_do_metadata_checkpoint;
+        String metaDir = Config.meta_dir;
+        boolean metricsInitialized = MetricRepo.isInit;
+        try (MockedStatic<Env> envMock = Mockito.mockStatic(Env.class);
+                MockedStatic<VariableMgr> variableMock = Mockito.mockStatic(VariableMgr.class);
+                MockedStatic<Config> configMock = Mockito.mockStatic(Config.class, Mockito.CALLS_REAL_METHODS)) {
+            Config.enable_checkpoint = true;
+            Config.force_do_metadata_checkpoint = true;
+            Config.meta_dir = directory.toString();
+            MetricRepo.isInit = false;
+            configMock.when(Config::isNotCloudMode).thenReturn(true);
+            envMock.when(Env::getServingEnv).thenReturn(servingEnv);
+            envMock.when(Env::getCurrentEnv).thenReturn(writerEnv, readerEnv);
+            Checkpoint checkpoint = new Checkpoint(editLog);
+            if (invalid) {
+                CheckpointException exception = Assertions.assertThrows(CheckpointException.class,
+                        checkpoint::doCheckpoint);
+                Assertions.assertEquals("invalid checkpoint checksum", exception.getMessage());
+                Assertions.assertFalse(Files.exists(publishedImage));
+                Mockito.verify(editLog, Mockito.never()).deleteJournals(Mockito.anyLong());
+            } else {
+                checkpoint.doCheckpoint();
+                Assertions.assertArrayEquals(new byte[] {2}, Files.readAllBytes(publishedImage));
+                Assertions.assertEquals(publishedImage.toFile(),
+                        new Storage(imageDirectory.toString()).getCurrentImageFile());
+            }
+            Mockito.verify(readerEnv).loadImage(checkpointImage, 2L);
+            envMock.verify(Env::destroyCheckpoint, Mockito.times(2));
+            Assertions.assertFalse(checkpointImage.exists());
+            Assertions.assertArrayEquals(new byte[] {1}, Files.readAllBytes(previousImage));
+        } finally {
+            Config.enable_checkpoint = enableCheckpoint;
+            Config.force_do_metadata_checkpoint = forceCheckpoint;
+            Config.meta_dir = metaDir;
+            MetricRepo.isInit = metricsInitialized;
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/persist/meta/MetaWriterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/persist/meta/MetaWriterTest.java
@@ -1,0 +1,112 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.persist.meta;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.cloud.catalog.CloudEnv;
+import org.apache.doris.common.io.CountingDataOutputStream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class MetaWriterTest {
+    @TempDir
+    Path directory;
+
+    @Test
+    public void testConcurrentImagesKeepTheirOwnIndices() throws Exception {
+        File checkpointImage = directory.resolve("image.ckpt").toFile();
+        File dumpImage = directory.resolve("image.dump").toFile();
+        Env checkpointEnv = mockImageEnv(11L);
+        Env dumpEnv = mockImageEnv(29L);
+        CountDownLatch checkpointStarted = new CountDownLatch(1);
+        CountDownLatch dumpFinished = new CountDownLatch(1);
+        Mockito.doAnswer(invocation -> {
+            checkpointStarted.countDown();
+            Assertions.assertTrue(dumpFinished.await(30, TimeUnit.SECONDS));
+            CountingDataOutputStream output = invocation.getArgument(0);
+            output.writeLong(11L);
+            return 11L;
+        }).when(checkpointEnv).saveHeader(Mockito.any(), Mockito.anyLong(), Mockito.anyLong());
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> checkpoint = executor.submit(() -> {
+                MetaWriter.write(checkpointImage, checkpointEnv);
+                return null;
+            });
+            Assertions.assertTrue(checkpointStarted.await(30, TimeUnit.SECONDS));
+            // Replace the old shared delegate while the checkpoint is inside saveHeader.
+            MetaWriter.write(dumpImage, dumpEnv);
+            dumpFinished.countDown();
+            checkpoint.get(30, TimeUnit.SECONDS);
+
+            assertImage(checkpointImage, 11L);
+            assertImage(dumpImage, 29L);
+        } finally {
+            dumpFinished.countDown();
+            executor.shutdownNow();
+            Assertions.assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS));
+        }
+    }
+
+    private Env mockImageEnv(long value) {
+        // Keep real image framing and module dispatch, with one long of payload per module.
+        return Mockito.mock(CloudEnv.class, invocation -> {
+            Object[] arguments = invocation.getArguments();
+            if (invocation.getMethod().getName().startsWith("save")
+                    && arguments.length > 0 && arguments[0] instanceof CountingDataOutputStream) {
+                ((CountingDataOutputStream) arguments[0]).writeLong(value);
+                return (long) arguments[arguments.length - 1] ^ value;
+            }
+            if (invocation.getMethod().getName().startsWith("load")
+                    && arguments.length > 0 && arguments[0] instanceof DataInputStream) {
+                long actual = ((DataInputStream) arguments[0]).readLong();
+                Assertions.assertEquals(value, actual);
+                return (long) arguments[arguments.length - 1] ^ actual;
+            }
+            return Mockito.RETURNS_DEFAULTS.answer(invocation);
+        });
+    }
+
+    private void assertImage(File image, long value) throws Exception {
+        MetaFooter footer = MetaFooter.read(image);
+        Assertions.assertEquals(PersistMetaModules.MODULES_IN_ORDER.size() + 1, footer.metaIndices.size());
+        Assertions.assertEquals("header", footer.metaIndices.get(0).name);
+        long offset = MetaHeader.read(image).getEnd();
+        Assertions.assertEquals(offset, footer.metaIndices.get(0).offset);
+        for (int i = 0; i < PersistMetaModules.MODULES_IN_ORDER.size(); i++) {
+            offset += Long.BYTES;
+            MetaIndex index = footer.metaIndices.get(i + 1);
+            Assertions.assertEquals(PersistMetaModules.MODULES_IN_ORDER.get(i).name, index.name);
+            Assertions.assertEquals(offset, index.offset);
+        }
+        MetaReader.read(image, mockImageEnv(value));
+    }
+}

--- a/regression-test/suites/meta_action_p0/test_checkpoint_with_dump_and_restart.groovy
+++ b/regression-test/suites/meta_action_p0/test_checkpoint_with_dump_and_restart.groovy
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import org.apache.doris.regression.suite.ClusterOptions
+import org.awaitility.Awaitility
+
+import static java.util.concurrent.TimeUnit.SECONDS
+
+suite("test_checkpoint_with_dump_and_restart", "docker") {
+    def options = new ClusterOptions()
+    options.setFeNum(1)
+    options.setBeNum(1)
+    options.cloudMode = null
+    options.enableDebugPoints()
+    // Only start a checkpoint after the data and debug points are ready.
+    // Keep it disabled on disk so restart cannot overwrite the evidence.
+    options.feConfigs += ['enable_checkpoint=false', 'edit_log_roll_num=1',
+                          'force_do_metadata_checkpoint=true']
+
+    docker(options) {
+        def fe = cluster.getFeByIndex(1)
+        def feLog = new File(fe.logFilePath)
+        def imageDir = new File(fe.path, "doris-meta/image")
+        String writerPause = "MetaWriter checkpoint paused after header"
+        String validationPause = "Checkpoint paused before validating image."
+        String writerPoint = "MetaWriter.write.checkpoint_pause"
+        String validationPoint = "Checkpoint.doCheckpoint.before_validate"
+
+        // Search only the current phase's log, never a previous checkpoint's marker.
+        def waitForLog = { int start, String marker ->
+            Awaitility.await().atMost(180, SECONDS).pollInterval(1, SECONDS).until {
+                feLog.getText("UTF-8").substring(start).contains(marker)
+            }
+            feLog.getText("UTF-8").substring(start)
+        }
+        def waitForValidation = { int start ->
+            String log = waitForLog(start, validationPause)
+            def match = log =~ /Checkpoint paused before validating image\.(\d+)/
+            assertTrue(match.find(), "missing checkpoint version in FE log")
+            match.group(1)
+        }
+        def snapshot = {
+            // Compare runtime metadata and ordered rows across recovery.
+            [sql("SHOW CREATE TABLE checkpoint_dump_restart"),
+             sql("SELECT * FROM checkpoint_dump_restart ORDER BY k")]
+        }
+
+        sql "DROP TABLE IF EXISTS checkpoint_dump_restart"
+        sql """
+            CREATE TABLE checkpoint_dump_restart (k INT, v STRING)
+            DISTRIBUTED BY HASH(k) BUCKETS 1
+            PROPERTIES ("replication_num" = "1")
+        """
+        sql "INSERT INTO checkpoint_dump_restart VALUES (1, 'before checkpoint'), (2, 'before dump')"
+        def beforeCheckpoint = snapshot()
+
+        // docker() tears down this isolated cluster even when recovery fails.
+        int start = feLog.getText("UTF-8").length()
+        fe.enableDebugPoint(writerPoint, [timeout: "300"])
+        fe.enableDebugPoint(validationPoint, [timeout: "300"])
+        setFeConfig("enable_checkpoint", true)
+        waitForLog(start, writerPause)
+
+        // The checkpoint already installed its writer delegate. Finish /dump before
+        // resuming it: the old static writer now sends checkpoint indices to the dump.
+        httpTest {
+            basicAuthorization "${context.config.jdbcUser}", "${context.config.jdbcPassword}"
+            endpoint "${fe.host}:${fe.httpPort}"
+            uri "/dump"
+            op "get"
+            check { code, body ->
+                assertEquals(200, code)
+                assertEquals("success", parseJson(body).msg)
+            }
+        }
+        fe.disableDebugPoint(writerPoint)
+        String version = waitForValidation(start)
+        setFeConfig("enable_checkpoint", false)
+        fe.disableDebugPoint(validationPoint)
+        waitForLog(start, "checkpoint finished save image.${version}")
+        assertTrue(new File(imageDir, "image.${version}").isFile())
+
+        // Recovery must read the concurrently written checkpoint, not just replay
+        // journals against an older image after a silently failed checkpoint.
+        cluster.restartFrontends()
+        context.reconnectFe()
+        assertEquals(beforeCheckpoint, snapshot())
+
+        sql "INSERT INTO checkpoint_dump_restart VALUES (3, 'recovered from journal')"
+        def beforeInterruptedCheckpoint = snapshot()
+        start = feLog.getText("UTF-8").length()
+        fe.enableDebugPoint(validationPoint, [timeout: "300"])
+        setFeConfig("enable_checkpoint", true)
+        String pendingVersion = waitForValidation(start)
+        assertTrue(pendingVersion.toLong() > version.toLong())
+        assertFalse(new File(imageDir, "image.${pendingVersion}").exists(),
+                "checkpoint must not be published before read-back validation")
+        def pendingImage = new File(imageDir, "image.ckpt")
+        assertTrue(pendingImage.isFile())
+
+        // Leave an unreadable temporary image and stop while validation is paused.
+        // Startup must ignore it and recover from the previous image plus journals.
+        new RandomAccessFile(pendingImage, "rw").withCloseable { it.setLength(0) }
+        cluster.restartFrontends()
+        context.reconnectFe()
+        assertEquals(beforeInterruptedCheckpoint, snapshot())
+        assertTrue(new File(imageDir, "image.${version}").isFile())
+        assertFalse(new File(imageDir, "image.${pendingVersion}").exists())
+        assertTrue(pendingImage.isFile(), "restart must leave the ignored temporary image intact")
+        assertEquals(0L, pendingImage.length())
+    }
+}


### PR DESCRIPTION
Problem Summary: Background checkpoint and HTTP /dump can write images concurrently. A static MetaWriter shares a mutable delegate between those writes, allowing one image's module indices to be recorded in another image. Checkpoint also renames the new file before reading it back. Stopping FE during that validation window can leave a corrupt image as the newest startup candidate and prevent restart.

Give each write its own MetaWriter, validate the unpublished image.ckpt in a fresh checkpoint Env, and publish it only after validation succeeds. Failed validation cleans the temporary file and preserves the previous published image. Add deterministic concurrent writer and checkpoint publication unit tests.

### Release note

Prevent concurrent checkpoint and metadata dump operations from sharing image indices, and keep unvalidated checkpoints out of FE startup image selection.

### Check List (For Author)

- Test: Unit tests added but not run; compilation and test execution deferred to the user as requested. Checkstyle 9.3 with repository configuration and git diff --check passed.
- Behavior changed: Yes. Checkpoint images become visible only after successful read-back validation.
- Does this need documentation: No

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

