### PR TITLE
[fix](be) Return fetch errors when result buffer is unavailable

### DIFF
--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -683,6 +683,7 @@ void PInternalService::fetch_data(google::protobuf::RpcController* controller,
     Status st = ExecEnv::GetInstance()->result_mgr()->find_buffer(unique_id, buffer);
     if (!st.ok()) {
         LOG(WARNING) << "Result buffer not found! finst ID: " << print_id(unique_id);
+        ctx->on_failure(st);
         return;
     }
     if (st = buffer->get_batch(ctx); !st.ok()) {


### PR DESCRIPTION
### What problem does this PR solve?


Problem Summary: When a BE ResultBuffer was already removed, the MySQL/JDBC `fetch_data` RPC logged the lookup failure and returned without completing its callback. FE clients could therefore wait until an outer timeout instead of receiving the actual failure. The missing-buffer path now reports the existing `Status` through `GetResultBatchCtx::on_failure`, completing the RPC and exposing the error to FE/JDBC clients.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

