### PR TITLE
branch-4.1: [chore](thirdparty) Add Google Cloud C++ OAuth2 dependency

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -1773,6 +1773,27 @@ build_nlohmann_json() {
     "${BUILD_SYSTEM}" install
 }
 
+build_google_cloud_cpp() {
+    check_if_source_exist "${GOOGLE_CLOUD_CPP_SOURCE}"
+    cd "${TP_SOURCE_DIR}/${GOOGLE_CLOUD_CPP_SOURCE}"
+
+    rm -rf "${BUILD_DIR}"
+    "${CMAKE_CMD}" -G "${GENERATOR}" -B "${BUILD_DIR}" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" \
+        -DCMAKE_PREFIX_PATH="${TP_INSTALL_DIR}" \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DBUILD_TESTING=OFF \
+        -DGOOGLE_CLOUD_CPP_ENABLE=oauth2 \
+        -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
+        -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=OFF \
+        -DGOOGLE_CLOUD_CPP_WITH_MOCKS=OFF
+
+    "${CMAKE_CMD}" --build "${BUILD_DIR}" -j "${PARALLEL}"
+    "${CMAKE_CMD}" --install "${BUILD_DIR}" --prefix "${TP_INSTALL_DIR}"
+}
+
 # sse2neon
 build_sse2neon() {
     check_if_source_exist "${SSE2NEON_SOURCE}"
@@ -2209,6 +2230,7 @@ if [[ "${#packages[@]}" -eq 0 ]]; then
         benchmark
         simdjson
         nlohmann_json
+        google_cloud_cpp
         libbacktrace
         sse2neon
         xxhash
@@ -2293,6 +2315,7 @@ cleanup_package_source() {
         benchmark)       src_var="BENCHMARK_SOURCE" ;;
         simdjson)        src_var="SIMDJSON_SOURCE" ;;
         nlohmann_json)   src_var="NLOHMANN_JSON_SOURCE" ;;
+        google_cloud_cpp) src_var="GOOGLE_CLOUD_CPP_SOURCE" ;;
         libbacktrace)    src_var="LIBBACKTRACE_SOURCE" ;;
         sse2neon)        src_var="SSE2NEON_SOURCE" ;;
         xxhash)          src_var="XXHASH_SOURCE" ;;

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -444,6 +444,14 @@ NLOHMANN_JSON_NAME=json-3.10.1.tar.gz
 NLOHMANN_JSON_SOURCE=json-3.10.1
 NLOHMANN_JSON_MD5SUM="7b369d567afc0dffdcf5800fd9abb836"
 
+# Google Cloud C++ OAuth2 authentication library. Only the auth/common REST
+# components are built; the Google Cloud Storage SDK is intentionally excluded.
+GOOGLE_CLOUD_CPP_DOWNLOAD="https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/v2.45.0.tar.gz"
+GOOGLE_CLOUD_CPP_FALLBACK_DOWNLOAD="https://codeload.github.com/googleapis/google-cloud-cpp/tar.gz/refs/tags/v2.45.0"
+GOOGLE_CLOUD_CPP_NAME="google-cloud-cpp-2.45.0.tar.gz"
+GOOGLE_CLOUD_CPP_SOURCE="google-cloud-cpp-2.45.0"
+GOOGLE_CLOUD_CPP_MD5SUM="3cc131764cd9009c20407d7b67afcf6e"
+
 # libbacktrace
 LIBBACKTRACE_DOWNLOAD="https://codeload.github.com/ianlancetaylor/libbacktrace/zip/2446c66076480ce07a6bd868badcbceb3eeecc2e"
 LIBBACKTRACE_NAME=libbacktrace-2446c66076480ce07a6bd868badcbceb3eeecc2e.zip
@@ -635,6 +643,7 @@ export TP_ARCHIVES=(
     'XSIMD'
     'SIMDJSON'
     'NLOHMANN_JSON'
+    'GOOGLE_CLOUD_CPP'
     'LIBBACKTRACE'
     'SSE2NEON'
     'XXHASH'


### PR DESCRIPTION
### What problem does this PR solve?

Add Google Cloud C++ 2.45.0 to the third-party download and build pipeline so its OAuth2 authentication components are available for subsequent integration. Build static libraries with position-independent code, enable only the OAuth2 components, and disable tests, examples, and mocks. Include the source archive checksum, fallback download URL, and source cleanup mapping.

### Release note

None

### Check List (For Author)

- Test:
    - [x] Manual test:
        - `bash -n thirdparty/build-thirdparty.sh`
        - `bash -n thirdparty/vars.sh`
        - `git diff --check HEAD^ HEAD`
        - Verified that the stable patch ID matches the original commit.
    - Full third-party compilation was not run: this local checkout has no `thirdparty/installed` dependencies.
- Behavior changed:
    - [x] Yes. The default third-party build now includes Google Cloud C++ OAuth2; no Doris runtime behavior changes in this PR.
- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
