### PR TITLE
[fix](cloud) Keep disable_auto_compaction off the shared TabletSchema when syncing tablet meta

### DIFF
--- a/be/src/cloud/cloud_tablet.cpp
+++ b/be/src/cloud/cloud_tablet.cpp
@@ -148,7 +148,11 @@ bvar::LatencyRecorder g_file_cache_warm_up_rowset_all_segments_latency(
         "file_cache_warm_up_rowset_all_segments_latency");
 
 CloudTablet::CloudTablet(CloudStorageEngine& engine, TabletMetaSharedPtr tablet_meta)
-        : BaseTablet(std::move(tablet_meta)), _engine(engine) {}
+        : BaseTablet(std::move(tablet_meta)), _engine(engine) {
+    if (_tablet_meta != nullptr && _tablet_meta->tablet_schema() != nullptr) {
+        set_disable_auto_compaction(_tablet_meta->tablet_schema()->disable_auto_compaction());
+    }
+}
 
 CloudTablet::~CloudTablet() = default;
 
@@ -1588,11 +1592,12 @@ Status CloudTablet::sync_meta() {
             _tablet_meta->set_time_series_compaction_level_threshold(
                     new_time_series_compaction_level_threshold);
         }
-        if (_tablet_meta->tablet_schema()->disable_auto_compaction() !=
-            new_disable_auto_compaction) {
-            _tablet_meta->mutable_tablet_schema()->set_disable_auto_compaction(
-                    new_disable_auto_compaction);
-        }
+        // `disable_auto_compaction` lives in TabletSchema, which is shared across tablets via
+        // TabletSchemaCache (keyed by the serialized schema). Mutating the shared schema in place
+        // pollutes the cache entry of the current schema: a later tablet meta fetched from Meta
+        // Service with the original schema resolves to the same polluted object, so the flag can
+        // never be switched back. Keep the effective value on the tablet itself instead.
+        set_disable_auto_compaction(new_disable_auto_compaction);
         if (_tablet_meta->vertical_compaction_num_columns_per_group() !=
             new_vertical_compaction_num_columns_per_group) {
             _tablet_meta->set_vertical_compaction_num_columns_per_group(

--- a/be/src/cloud/cloud_tablet.h
+++ b/be/src/cloud/cloud_tablet.h
@@ -205,6 +205,19 @@ public:
     void set_full_compaction_cnt(int64_t cnt) { _full_compaction_cnt = cnt; }
     void set_cumulative_layer_point(int64_t new_point);
 
+    // Effective `disable_auto_compaction` of this tablet, initialized from the tablet schema at
+    // load time and refreshed by sync_meta(). The property is carried by TabletSchema in the
+    // protocol, but TabletSchema objects are shared across tablets through TabletSchemaCache and
+    // must never be mutated in place, so the current value is kept here instead. Always read this
+    // accessor; `tablet_meta()->tablet_schema()->disable_auto_compaction()` only reflects the
+    // value at load time.
+    bool disable_auto_compaction() const {
+        return _disable_auto_compaction.load(std::memory_order_relaxed);
+    }
+    void set_disable_auto_compaction(bool disable) {
+        _disable_auto_compaction.store(disable, std::memory_order_relaxed);
+    }
+
     int64_t last_cumu_compaction_failure_time() { return _last_cumu_compaction_failure_millis; }
     void set_last_cumu_compaction_failure_time(int64_t millis) {
         _last_cumu_compaction_failure_millis = millis;
@@ -469,6 +482,8 @@ private:
     std::atomic<int64_t> _approximate_cumu_num_rowsets {-1};
     // Number of sorted arrays (e.g. for rowset with N segments, if rowset is overlapping, delta is N, otherwise 1) after cumu point
     std::atomic<int64_t> _approximate_cumu_num_deltas {-1};
+    // See disable_auto_compaction()
+    std::atomic<bool> _disable_auto_compaction {false};
 
     // timestamp of last cumu compaction failure
     std::atomic<int64_t> _last_cumu_compaction_failure_millis;

--- a/be/src/cloud/cloud_tablet_mgr.cpp
+++ b/be/src/cloud/cloud_tablet_mgr.cpp
@@ -496,7 +496,7 @@ Status CloudTabletMgr::get_topn_tablets_to_compact(
         return is_recent_failure || is_recent_no_suitable_version || is_frozen;
     };
     // We don't schedule tablets that are disabled for compaction
-    auto disable = [](CloudTablet* t) { return t->tablet_meta()->tablet_schema()->disable_auto_compaction(); };
+    auto disable = [](CloudTablet* t) { return t->disable_auto_compaction(); };
 
     auto [num_filtered, num_disabled, num_skipped] = std::make_tuple(0, 0, 0);
 

--- a/be/test/cloud/cloud_compaction_test.cpp
+++ b/be/test/cloud/cloud_compaction_test.cpp
@@ -169,7 +169,7 @@ TEST_F(CloudCompactionTest, failure_base_compaction_tablet_sleep_test) {
                     .count() -
             100000);
     tablet1->set_last_base_compaction_failure_time(0);
-    tablet1->tablet_meta()->tablet_schema()->set_disable_auto_compaction(false);
+    tablet1->set_disable_auto_compaction(false);
     tablet1->_approximate_num_rowsets = 10;
     tablet1->_approximate_cumu_num_rowsets = 0;
     mgr.put_tablet_for_UT(tablet1);
@@ -213,7 +213,7 @@ TEST_F(CloudCompactionTest, failure_cumu_compaction_tablet_sleep_test) {
                     .count() -
             100000);
     tablet1->set_last_cumu_compaction_failure_time(0);
-    tablet1->tablet_meta()->tablet_schema()->set_disable_auto_compaction(false);
+    tablet1->set_disable_auto_compaction(false);
     tablet1->_approximate_cumu_num_deltas = 10;
     mgr.put_tablet_for_UT(tablet1);
 
@@ -240,6 +240,42 @@ TEST_F(CloudCompactionTest, failure_cumu_compaction_tablet_sleep_test) {
     ASSERT_EQ(tablets.size(), 0);
 }
 
+TEST_F(CloudCompactionTest, disable_auto_compaction_toggle_is_read_from_tablet) {
+    auto filter_out = [](CloudTablet* t) { return false; };
+    CloudTabletMgr mgr(_engine);
+
+    std::vector<RowsetMetaSharedPtr> rs_metas;
+    init_rs_meta_small_base(&rs_metas);
+
+    CloudTabletSPtr tablet1 = std::make_shared<CloudTablet>(_engine, _tablet_meta);
+    for (auto& rs_meta : rs_metas) {
+        static_cast<void>(_tablet_meta->add_rs_meta(rs_meta));
+    }
+    tablet1->tablet_meta()->_tablet_id = 10000;
+    tablet1->set_last_cumu_compaction_failure_time(0);
+    tablet1->_approximate_cumu_num_deltas = 10;
+    mgr.put_tablet_for_UT(tablet1);
+
+    CompactionScoreStats score_stats;
+    std::vector<std::shared_ptr<CloudTablet>> tablets {};
+
+    // ALTER TABLE ... SET ("disable_auto_compaction" = "true") synced to the tablet
+    tablet1->set_disable_auto_compaction(true);
+    Status st = mgr.get_topn_tablets_to_compact(1, CompactionType::CUMULATIVE_COMPACTION,
+                                                filter_out, &tablets, &score_stats);
+    ASSERT_EQ(st, Status::OK());
+    ASSERT_EQ(tablets.size(), 0);
+    // The shared TabletSchema object is never mutated by the per-tablet flag
+    ASSERT_FALSE(tablet1->tablet_meta()->tablet_schema()->disable_auto_compaction());
+
+    // ALTER TABLE ... SET ("disable_auto_compaction" = "false") synced again
+    tablet1->set_disable_auto_compaction(false);
+    st = mgr.get_topn_tablets_to_compact(1, CompactionType::CUMULATIVE_COMPACTION, filter_out,
+                                         &tablets, &score_stats);
+    ASSERT_EQ(st, Status::OK());
+    ASSERT_EQ(tablets.size(), 1);
+}
+
 TEST_F(CloudCompactionTest, binlog_compaction_max_score_ignores_normal_tablets) {
     auto filter_out = [](CloudTablet* t) { return !t->is_row_binlog_tablet(); };
     CloudTabletMgr mgr(_engine);
@@ -248,7 +284,7 @@ TEST_F(CloudCompactionTest, binlog_compaction_max_score_ignores_normal_tablets) 
     normal_meta->set_tablet_role(TabletRolePB::TABLET_ROLE_DATA);
     CloudTabletSPtr normal_tablet = std::make_shared<CloudTablet>(_engine, normal_meta);
     normal_tablet->tablet_meta()->_tablet_id = 10001;
-    normal_tablet->tablet_meta()->tablet_schema()->set_disable_auto_compaction(false);
+    normal_tablet->set_disable_auto_compaction(false);
     normal_tablet->_approximate_cumu_num_deltas = 10;
     mgr.put_tablet_for_UT(normal_tablet);
 
@@ -256,7 +292,7 @@ TEST_F(CloudCompactionTest, binlog_compaction_max_score_ignores_normal_tablets) 
     binlog_meta->set_tablet_role(TabletRolePB::TABLET_ROLE_ROW_BINLOG);
     CloudTabletSPtr binlog_tablet = std::make_shared<CloudTablet>(_engine, binlog_meta);
     binlog_tablet->tablet_meta()->_tablet_id = 10002;
-    binlog_tablet->tablet_meta()->tablet_schema()->set_disable_auto_compaction(false);
+    binlog_tablet->set_disable_auto_compaction(false);
     binlog_tablet->_approximate_cumu_num_deltas = 7;
     mgr.put_tablet_for_UT(binlog_tablet);
 
@@ -283,7 +319,7 @@ TEST_F(CloudCompactionTest, split_cumu_compaction_score_stats_before_filter) {
         tablet_meta->_tablet_id = tablet_id;
         tablet_meta->set_compaction_policy(std::string(compaction_policy));
         auto tablet = std::make_shared<CloudTablet>(_engine, tablet_meta);
-        tablet->tablet_meta()->tablet_schema()->set_disable_auto_compaction(false);
+        tablet->set_disable_auto_compaction(false);
         tablet->_approximate_cumu_num_deltas = score;
         mgr.put_tablet_for_UT(tablet);
         return tablet;
@@ -312,7 +348,7 @@ TEST_F(CloudCompactionTest, generate_cloud_compaction_tasks_updates_policy_metri
     tablet_meta->_tablet_id = 11000;
     tablet_meta->set_compaction_policy(std::string(CUMULATIVE_SIZE_BASED_POLICY));
     auto tablet = std::make_shared<CloudTablet>(_engine, tablet_meta);
-    tablet->tablet_meta()->tablet_schema()->set_disable_auto_compaction(false);
+    tablet->set_disable_auto_compaction(false);
     tablet->_approximate_cumu_num_deltas = 7;
     mgr.put_tablet_for_UT(tablet);
 
@@ -341,7 +377,7 @@ TEST_F(CloudCompactionTest, generate_cloud_compaction_tasks_updates_policy_metri
     time_series_meta->_tablet_id = 11001;
     time_series_meta->set_compaction_policy(std::string(CUMULATIVE_TIME_SERIES_POLICY));
     auto time_series = std::make_shared<CloudTablet>(_engine, time_series_meta);
-    time_series->tablet_meta()->tablet_schema()->set_disable_auto_compaction(false);
+    time_series->set_disable_auto_compaction(false);
     time_series->_approximate_cumu_num_deltas = 13;
     mgr.put_tablet_for_UT(time_series);
 
@@ -360,7 +396,7 @@ TEST_F(CloudCompactionTest, generate_cloud_binlog_compaction_tasks_updates_only_
     normal_meta->_tablet_id = 11002;
     normal_meta->set_tablet_role(TabletRolePB::TABLET_ROLE_DATA);
     auto normal_tablet = std::make_shared<CloudTablet>(_engine, normal_meta);
-    normal_tablet->tablet_meta()->tablet_schema()->set_disable_auto_compaction(false);
+    normal_tablet->set_disable_auto_compaction(false);
     normal_tablet->_approximate_cumu_num_deltas = 10;
     mgr.put_tablet_for_UT(normal_tablet);
 
@@ -368,7 +404,7 @@ TEST_F(CloudCompactionTest, generate_cloud_binlog_compaction_tasks_updates_only_
     binlog_meta->_tablet_id = 11003;
     binlog_meta->set_tablet_role(TabletRolePB::TABLET_ROLE_ROW_BINLOG);
     auto binlog_tablet = std::make_shared<CloudTablet>(_engine, binlog_meta);
-    binlog_tablet->tablet_meta()->tablet_schema()->set_disable_auto_compaction(false);
+    binlog_tablet->set_disable_auto_compaction(false);
     binlog_tablet->_approximate_cumu_num_deltas = 7;
     mgr.put_tablet_for_UT(binlog_tablet);
 

--- a/be/test/cloud/cloud_tablet_test.cpp
+++ b/be/test/cloud/cloud_tablet_test.cpp
@@ -750,7 +750,7 @@ protected:
 // Test sync_meta syncs disable_auto_compaction from false to true
 TEST_F(CloudTabletSyncMetaTest, TestSyncMetaDisableAutoCompactionFalseToTrue) {
     // Verify initial state: disable_auto_compaction = false
-    EXPECT_FALSE(_tablet->tablet_meta()->tablet_schema()->disable_auto_compaction());
+    EXPECT_FALSE(_tablet->disable_auto_compaction());
 
     auto sp = SyncPoint::get_instance();
     sp->clear_all_call_backs();
@@ -773,7 +773,7 @@ TEST_F(CloudTabletSyncMetaTest, TestSyncMetaDisableAutoCompactionFalseToTrue) {
     EXPECT_TRUE(st.ok());
 
     // Verify disable_auto_compaction has been synced to true
-    EXPECT_TRUE(_tablet->tablet_meta()->tablet_schema()->disable_auto_compaction());
+    EXPECT_TRUE(_tablet->disable_auto_compaction());
 
     sp->disable_processing();
     sp->clear_all_call_backs();
@@ -803,7 +803,7 @@ TEST_F(CloudTabletSyncMetaTest, TestSyncMetaDisableAutoCompactionTrueToFalse) {
             std::make_shared<CloudTablet>(_engine, std::make_shared<TabletMeta>(*tablet_meta_true));
 
     // Verify initial state: disable_auto_compaction = true
-    EXPECT_TRUE(_tablet->tablet_meta()->tablet_schema()->disable_auto_compaction());
+    EXPECT_TRUE(_tablet->disable_auto_compaction());
 
     auto sp = SyncPoint::get_instance();
     sp->clear_all_call_backs();
@@ -841,7 +841,55 @@ TEST_F(CloudTabletSyncMetaTest, TestSyncMetaDisableAutoCompactionTrueToFalse) {
     EXPECT_TRUE(st.ok());
 
     // Verify disable_auto_compaction has been synced to false
+    EXPECT_FALSE(_tablet->disable_auto_compaction());
+
+    sp->disable_processing();
+    sp->clear_all_call_backs();
+}
+
+// Regression test: disable_auto_compaction false -> true -> false on the SAME tablet.
+//
+// TabletSchema objects are shared across tablets through TabletSchemaCache, keyed by the
+// serialized schema (which includes disable_auto_compaction), so the tablet meta fetched from
+// Meta Service resolves to the cached object for that schema content. Mutating the shared schema
+// in place used to pollute the cache entry of the original (false) schema: the second sync then
+// read "true" from the fetched meta and never re-enabled compaction. The effective value now lives
+// on CloudTablet and the shared schema must stay untouched.
+TEST_F(CloudTabletSyncMetaTest, TestSyncMetaDisableAutoCompactionRoundTrip) {
+    EXPECT_FALSE(_tablet->disable_auto_compaction());
+
+    auto sp = SyncPoint::get_instance();
+    sp->clear_all_call_backs();
+    sp->enable_processing();
+
+    // Step 1: ALTER TABLE ... SET ("disable_auto_compaction" = "true") reaches BE
+    auto meta_true = createMockTabletMeta(true);
+    sp->set_call_back("CloudMetaMgr::get_tablet_meta", [meta_true](auto&& args) {
+        auto* tablet_meta_ptr = try_any_cast<TabletMetaSharedPtr*>(args[1]);
+        *tablet_meta_ptr = meta_true;
+        try_any_cast_ret<Status>(args)->second = true;
+    });
+    EXPECT_TRUE(_tablet->sync_meta().ok());
+    EXPECT_TRUE(_tablet->disable_auto_compaction());
+    // sync_meta must not touch the shared TabletSchema object
     EXPECT_FALSE(_tablet->tablet_meta()->tablet_schema()->disable_auto_compaction());
+
+    // Step 2: ALTER TABLE ... SET ("disable_auto_compaction" = "false") reaches BE. The schema
+    // content is identical to the one used at tablet creation, so it resolves to the same
+    // TabletSchemaCache entry.
+    auto meta_false = createMockTabletMeta(false);
+    EXPECT_FALSE(meta_false->tablet_schema()->disable_auto_compaction())
+            << "TabletSchemaCache entry for the disable_auto_compaction=false schema was mutated "
+               "in place";
+    sp->clear_all_call_backs();
+    sp->set_call_back("CloudMetaMgr::get_tablet_meta", [meta_false](auto&& args) {
+        auto* tablet_meta_ptr = try_any_cast<TabletMetaSharedPtr*>(args[1]);
+        *tablet_meta_ptr = meta_false;
+        try_any_cast_ret<Status>(args)->second = true;
+    });
+    EXPECT_TRUE(_tablet->sync_meta().ok());
+    EXPECT_FALSE(_tablet->disable_auto_compaction())
+            << "compaction was not re-enabled after false -> true -> false round trip";
 
     sp->disable_processing();
     sp->clear_all_call_backs();
@@ -850,7 +898,7 @@ TEST_F(CloudTabletSyncMetaTest, TestSyncMetaDisableAutoCompactionTrueToFalse) {
 // Test sync_meta when disable_auto_compaction is unchanged
 TEST_F(CloudTabletSyncMetaTest, TestSyncMetaDisableAutoCompactionUnchanged) {
     // Verify initial state: disable_auto_compaction = false
-    EXPECT_FALSE(_tablet->tablet_meta()->tablet_schema()->disable_auto_compaction());
+    EXPECT_FALSE(_tablet->disable_auto_compaction());
 
     auto sp = SyncPoint::get_instance();
     sp->clear_all_call_backs();
@@ -873,7 +921,7 @@ TEST_F(CloudTabletSyncMetaTest, TestSyncMetaDisableAutoCompactionUnchanged) {
     EXPECT_TRUE(st.ok());
 
     // Verify disable_auto_compaction remains false
-    EXPECT_FALSE(_tablet->tablet_meta()->tablet_schema()->disable_auto_compaction());
+    EXPECT_FALSE(_tablet->disable_auto_compaction());
 
     sp->disable_processing();
     sp->clear_all_call_backs();
@@ -885,7 +933,7 @@ TEST_F(CloudTabletSyncMetaTest, TestSyncMetaWhenFileCacheDisabled) {
     config::enable_file_cache = false;
 
     // Set initial state: disable_auto_compaction = false
-    EXPECT_FALSE(_tablet->tablet_meta()->tablet_schema()->disable_auto_compaction());
+    EXPECT_FALSE(_tablet->disable_auto_compaction());
 
     auto sp = SyncPoint::get_instance();
     sp->clear_all_call_backs();
@@ -905,7 +953,7 @@ TEST_F(CloudTabletSyncMetaTest, TestSyncMetaWhenFileCacheDisabled) {
     EXPECT_TRUE(st.ok());
     EXPECT_TRUE(callback_called);
 
-    EXPECT_TRUE(_tablet->tablet_meta()->tablet_schema()->disable_auto_compaction());
+    EXPECT_TRUE(_tablet->disable_auto_compaction());
     EXPECT_EQ(_tablet->tablet_meta()->compaction_policy(), "time_series");
 
     sp->disable_processing();
@@ -915,7 +963,7 @@ TEST_F(CloudTabletSyncMetaTest, TestSyncMetaWhenFileCacheDisabled) {
 // Test sync_meta syncs compaction_policy together with disable_auto_compaction
 TEST_F(CloudTabletSyncMetaTest, TestSyncMetaMultipleProperties) {
     // Verify initial states
-    EXPECT_FALSE(_tablet->tablet_meta()->tablet_schema()->disable_auto_compaction());
+    EXPECT_FALSE(_tablet->disable_auto_compaction());
     // Default compaction_policy is "size_based"
     EXPECT_EQ(_tablet->tablet_meta()->compaction_policy(), "size_based");
 
@@ -946,7 +994,7 @@ TEST_F(CloudTabletSyncMetaTest, TestSyncMetaMultipleProperties) {
     EXPECT_TRUE(st.ok());
 
     // Verify both properties are synced
-    EXPECT_TRUE(_tablet->tablet_meta()->tablet_schema()->disable_auto_compaction());
+    EXPECT_TRUE(_tablet->disable_auto_compaction());
     EXPECT_EQ(_tablet->tablet_meta()->compaction_policy(), "time_series");
     EXPECT_EQ(_tablet->tablet_meta()->time_series_compaction_goal_size_mbytes(), 1234);
     EXPECT_EQ(_tablet->tablet_meta()->time_series_compaction_file_count_threshold(), 17);
@@ -982,7 +1030,7 @@ TEST_F(CloudTabletSyncMetaTest, TestSyncMetaSyncsTtlWithoutChangingInMemory) {
 
     EXPECT_EQ(3600, _tablet->tablet_meta()->ttl_seconds());
     EXPECT_FALSE(_tablet->tablet_meta()->tablet_schema()->is_in_memory());
-    EXPECT_TRUE(_tablet->tablet_meta()->tablet_schema()->disable_auto_compaction());
+    EXPECT_TRUE(_tablet->disable_auto_compaction());
     EXPECT_EQ(_tablet->tablet_meta()->compaction_policy(), "time_series");
 
     sp->disable_processing();


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #60544, #65184

Problem Summary:

In cloud mode, `ALTER TABLE ... SET ("disable_auto_compaction" = "false")` never resumed automatic compaction on a BE that had previously observed `disable_auto_compaction = true` for the same tablet. The scheduler kept reporting the tablet as disabled (`num_disabled=1`, `tablets=[]`) until the BE was restarted. The docker case `cloud_p0/compaction/test_cloud_alter_disable_auto_compaction` fails deterministically in its re-enable phase once the sync intervals are short enough for the disable phase to pass (#65184).

Root cause:

`disable_auto_compaction` is carried by `TabletSchema`, and `TabletSchema` objects are shared across tablets through `TabletSchemaCache`, keyed by the serialized schema content (which includes this property). `CloudTablet::sync_meta` applied the new value with `mutable_tablet_schema()->set_disable_auto_compaction()`, i.e. it mutated the shared cached object in place. This silently turned the cache entry of the original (`false`) schema into an object whose content says `true`.

- ALTER to `true`: Meta Service returns a schema with `true`; its key is new, so a fresh object is created and the local (shared) schema object is mutated to `true`. Looks correct.
- ALTER back to `false`: Meta Service returns the original schema; its key hits the polluted entry, so `TabletMeta::init_from_pb` hands back the very same object the tablet already holds. `sync_meta` compares the object with itself, sees no change, and the tablet stays disabled forever.

The same in-place mutation also leaked the value to every other tablet sharing that schema object on the BE.

Fix:

- Keep the effective value in a per-tablet atomic on `CloudTablet`, initialized from the tablet schema at load time and refreshed by `sync_meta`. The shared `TabletSchema` is never mutated again, so cache entries always match their keys.
- The compaction scheduler reads the per-tablet value.

### Release note

Fix `ALTER TABLE ... SET ("disable_auto_compaction" = "false")` not resuming automatic compaction in cloud mode.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

    - `CloudTabletSyncMetaTest.TestSyncMetaDisableAutoCompactionRoundTrip` reproduces the false -> true -> false round trip on the same tablet (fails before this fix at the cache-pollution check and at the re-enable check) and verifies the shared schema object stays untouched.
    - `CloudCompactionTest.disable_auto_compaction_toggle_is_read_from_tablet` covers the scheduler honoring the per-tablet toggle.
    - Existing `cloud_p0/compaction/test_cloud_alter_disable_auto_compaction` docker case covers the end-to-end path.

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
