### PR TITLE
[fix](fe) Adapt warm-up scheduler tests to JUnit 5

### DIFF
--- a/fe/fe-common/src/test/java/org/apache/doris/common/ConfigTest.java
+++ b/fe/fe-common/src/test/java/org/apache/doris/common/ConfigTest.java
@@ -170,17 +170,17 @@ public class ConfigTest {
         int original = Config.cloud_warm_up_job_scheduler_interval_millisecond;
         try {
             ConfigBase.setMutableConfig("cloud_warm_up_job_scheduler_interval_millisecond", "2000");
-            Assert.assertEquals(2000, Config.cloud_warm_up_job_scheduler_interval_millisecond);
+            Assertions.assertEquals(2000, Config.cloud_warm_up_job_scheduler_interval_millisecond);
 
-            ConfigException zeroException = Assert.assertThrows(ConfigException.class,
+            ConfigException zeroException = Assertions.assertThrows(ConfigException.class,
                     () -> ConfigBase.setMutableConfig("cloud_warm_up_job_scheduler_interval_millisecond", "0"));
-            Assert.assertTrue(zeroException.getMessage().contains("must be greater than 0"));
-            Assert.assertEquals(2000, Config.cloud_warm_up_job_scheduler_interval_millisecond);
+            Assertions.assertTrue(zeroException.getMessage().contains("must be greater than 0"));
+            Assertions.assertEquals(2000, Config.cloud_warm_up_job_scheduler_interval_millisecond);
 
-            ConfigException negativeException = Assert.assertThrows(ConfigException.class,
+            ConfigException negativeException = Assertions.assertThrows(ConfigException.class,
                     () -> ConfigBase.setMutableConfig("cloud_warm_up_job_scheduler_interval_millisecond", "-1"));
-            Assert.assertTrue(negativeException.getMessage().contains("must be greater than 0"));
-            Assert.assertEquals(2000, Config.cloud_warm_up_job_scheduler_interval_millisecond);
+            Assertions.assertTrue(negativeException.getMessage().contains("must be greater than 0"));
+            Assertions.assertEquals(2000, Config.cloud_warm_up_job_scheduler_interval_millisecond);
         } finally {
             Config.cloud_warm_up_job_scheduler_interval_millisecond = original;
         }

--- a/fe/fe-core/src/test/java/org/apache/doris/cloud/CacheHotspotManagerSchedulerTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/cloud/CacheHotspotManagerSchedulerTest.java
@@ -21,10 +21,10 @@ import org.apache.doris.cloud.system.CloudSystemInfoService;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -40,7 +40,7 @@ public class CacheHotspotManagerSchedulerTest {
     private ThreadPoolExecutor executor;
     private CacheHotspotManager manager;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         originalRunningUnitTest = FeConstants.runningUnitTest;
         originalMaxActiveCloudWarmUpJob = Config.max_active_cloud_warm_up_job;
@@ -52,7 +52,7 @@ public class CacheHotspotManagerSchedulerTest {
         manager = new CacheHotspotManager(Mockito.mock(CloudSystemInfoService.class), executor);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         FeConstants.runningUnitTest = originalRunningUnitTest;
         Config.max_active_cloud_warm_up_job = originalMaxActiveCloudWarmUpJob;
@@ -76,7 +76,7 @@ public class CacheHotspotManagerSchedulerTest {
         manager.runCloudWarmUpJob();
         manager.runCloudWarmUpJob();
 
-        Assert.assertEquals(Arrays.asList(4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L), runOrder);
+        Assertions.assertEquals(Arrays.asList(4L, 1L, 2L, 3L, 4L, 1L, 2L, 3L), runOrder);
     }
 
     @Test
@@ -92,11 +92,11 @@ public class CacheHotspotManagerSchedulerTest {
 
         manager.runCloudWarmUpJob();
         manager.runCloudWarmUpJob();
-        Assert.assertEquals(1, submittedTasks.size());
+        Assertions.assertEquals(1, submittedTasks.size());
 
         submittedTasks.get(0).run();
         manager.runCloudWarmUpJob();
-        Assert.assertEquals(2, submittedTasks.size());
+        Assertions.assertEquals(2, submittedTasks.size());
         submittedTasks.get(1).run();
         Mockito.verify(job, Mockito.times(2)).run();
     }
@@ -119,7 +119,7 @@ public class CacheHotspotManagerSchedulerTest {
         Mockito.verify(job, Mockito.never()).run();
         manager.runCloudWarmUpJob();
 
-        Assert.assertEquals(2, submitCount.get());
+        Assertions.assertEquals(2, submitCount.get());
         Mockito.verify(job, Mockito.times(1)).run();
     }
 


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #67527, #67396

Problem Summary: #67527 added seven JUnit 4 `Assert` calls to `ConfigTest` after #67396 migrated the class to JUnit 5, causing `fe-common:testCompile` to fail with `cannot find symbol: Assert`. Use the existing JUnit 5 `Assertions` import. Also migrate the scheduler test introduced by the same PR to JUnit 5 assertions and lifecycle annotations, consistent with the FE test migration.

### Release note

None

### Check List (For Author)

- Test: `./run-fe-ut.sh --run org.apache.doris.common.ConfigTest,org.apache.doris.cloud.CacheHotspotManagerSchedulerTest` completed with BUILD SUCCESS: ConfigTest 10/10 and CacheHotspotManagerSchedulerTest 4/4 passed, with no failures, errors, or skipped tests. Checkstyle passed for fe-common and fe-core with zero violations; `git diff --check` passed.
- Behavior changed: No
- Does this need documentation: No
