### PR TITLE
[fix](bin) Read final config lines without trailing newlines

### DIFF
--- a/bin/start_be.sh
+++ b/bin/start_be.sh
@@ -95,7 +95,7 @@ PID_DIR="$(
 export PID_DIR
 
 # read from be.conf
-while read -r line; do
+while read -r line || [[ -n "${line}" ]]; do
     envline="$(echo "${line}" |
         sed 's/[[:blank:]]*=[[:blank:]]*/=/g' |
         sed 's/^[[:blank:]]*//g' |

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -127,7 +127,7 @@ PID_DIR="$(
 )"
 export PID_DIR
 
-while read -r line; do
+while read -r line || [[ -n "${line}" ]]; do
     envline="$(echo "${line}" |
         sed 's/[[:blank:]]*=[[:blank:]]*/=/g' |
         sed 's/^[[:blank:]]*//g' |

--- a/bin/stop_be.sh
+++ b/bin/stop_be.sh
@@ -32,7 +32,7 @@ PID_DIR="$(
 )"
 export PID_DIR
 
-while read -r line; do
+while read -r line || [[ -n "${line}" ]]; do
     envline="$(echo "${line}" |
         sed 's/[[:blank:]]*=[[:blank:]]*/=/g' |
         sed 's/^[[:blank:]]*//g' |

--- a/bin/stop_fe.sh
+++ b/bin/stop_fe.sh
@@ -32,7 +32,7 @@ PID_DIR="$(
 )"
 export PID_DIR
 
-while read -r line; do
+while read -r line || [[ -n "${line}" ]]; do
     envline="$(echo "${line}" |
         sed 's/[[:blank:]]*=[[:blank:]]*/=/g' |
         sed 's/^[[:blank:]]*//g' |


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

FE/BE startup and shutdown scripts silently skip the final environment assignment in `fe.conf` or `be.conf` when the file has no trailing newline. For example, a final `PID_DIR=/custom/pid` is ignored, so the script uses the default or an earlier PID directory.

Bash `read` sets `line` but returns failure when EOF terminates a partial line. Keep each of the four configuration loops running when that final line is nonempty so the existing parser exports it.

### Release note

Fix FE/BE startup and shutdown scripts ignoring the last configuration assignment when the file has no trailing newline.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test
      - Executed the actual configuration parsing block extracted from each of the four scripts using Bash with `set -eo pipefail`, with temporary `fe.conf`/`be.conf` files and a default `PID_DIR`.
      - Checked the exported value for 14 inputs per script: single/multiple assignments with and without a trailing newline, empty/blank/whitespace/comment input, a valid assignment followed by a comment or blank line, spaces around `=`, an empty value, a final override, and variable expansion.
      - Before: 24/56 failed, all from unterminated final assignments. After: 56/56 passed. No FE/BE process was started or stopped.
      - `bash -n` passed for all four scripts; `git diff --check` passed.
      - ShellCheck 0.8.0 and shfmt 3.5.1 found no new issues when compared with the base. Existing startup-script SC2311 diagnostics and case indentation differences remain.
    - [ ] No need to test or manual test.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Valid final environment assignments without a trailing newline are now honored.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
