### PR TITLE
[fix](build) Update Doris compose to Debian 12 with Liberica JDK 17

### DIFF
--- a/docker/runtime/doris-compose/Dockerfile
+++ b/docker/runtime/doris-compose/Dockerfile
@@ -23,7 +23,7 @@
 
 # choose a base image
 # doris 2.1, 3.0+, master use JDK 17
-ARG JDK_IMAGE=openjdk:17.0.1-jdk-slim
+ARG JDK_IMAGE=bellsoft/liberica-openjdk-debian:17
 
 # doris 2.0 use JDK 8
 # build 2.0 image, example:
@@ -55,12 +55,13 @@ FROM ${JDK_IMAGE}
 # set environment variables
 ENV JACOCO_VERSION=0.8.8
 
-RUN sed -i -e s@/deb.debian.org/@/mirrors.aliyun.com/@g -e s@/security.debian.org/@/mirrors.aliyun.com/@g /etc/apt/sources.list \
+RUN find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) -exec \
+        sed -i -e s@/deb.debian.org/@/mirrors.aliyun.com/@g -e s@/security.debian.org/@/mirrors.aliyun.com/@g {} + \
     && apt-get clean \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         default-mysql-client \
-        python \
+        python-is-python3 \
         lsof \
         tzdata \
         curl \

--- a/docker/runtime/doris-compose/Readme.md
+++ b/docker/runtime/doris-compose/Readme.md
@@ -49,7 +49,7 @@ If build doris use `sh build.sh --fe --be --cloud` **without do any change on th
 docker build -f docker/runtime/doris-compose/Dockerfile -t <image> .
 ```
 
-The Dockerfile default use JDK 17, for doris 2.1, 3.0, master, they all default use JDK 17.
+The Dockerfile defaults to `bellsoft/liberica-openjdk-debian:17`, which provides Debian 12 (bookworm) and Liberica JDK 17 for Doris 2.1, 3.0 and master.
 
 But doris 2.0 still use JDK 8, for build 2.0 image, user need specific use JDK 8 with arg `JDK_IMAGE=openjdk:8u342-jdk`. Here is build 2.0 image command:
 


### PR DESCRIPTION
Problem Summary: Building the Doris compose image fails during apt-get update because openjdk:17.0.1-jdk-slim is based on Debian 11. Bullseye LTS ended on August 31, 2026, and its security repository metadata subsequently expired. The same expired metadata is served by both the Aliyun mirror and Debian upstream, so switching mirror hosts does not resolve the failure.

Use bellsoft/liberica-openjdk-debian:17, currently based on Debian 12, while preserving the JDK_IMAGE build argument and the base image's Java environment. Update mirror rewriting to support both legacy .list and deb822 .sources files, and install python-is-python3 because Debian 12 does not provide the old python package. Document the new default image.

### Release note

The Doris compose image now uses Debian 12 with BellSoft Liberica JDK 17. The python command now runs Python 3.

### Check List (For Author)

- Test: Manual test
    - Build the complete Docker image using existing local output artifacts.
    - Run docker build --check: no warnings.
    - Verify mirror rewriting for both legacy .list and deb822 .sources files.
    - Verify Debian 12, Java/javac 17, JAVA_HOME/libjvm, Python, MySQL client, and JaCoCo agent loading in the built image.
    - Run FE start_fe.sh --version and BE doris_be --version successfully.
    - Run git diff --check.
    - No kernel rebuild or full cluster regression: this changes image packaging.
- Behavior changed: Yes; update the base OS/JDK distribution and use Python 3.
- Does this need documentation: Yes; update the Doris compose README in this commit.

### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [x] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

