### PR TITLE
[improvement](be) Reduce LRU lookup and release lock contention

### DIFF
--- a/be/src/runtime/memory/lru_cache_policy.h
+++ b/be/src/runtime/memory/lru_cache_policy.h
@@ -167,8 +167,8 @@ public:
             COUNTER_SET(_cost_timer, (int64_t)0);
             const int64_t curtime = UnixMillis();
             auto pred = [this, curtime](const LRUHandle* handle) -> bool {
-                return static_cast<bool>((handle->last_visit_time + _stale_sweep_time_s * 1000) <
-                                         curtime);
+                return static_cast<bool>((handle->last_visit_time.load(std::memory_order_relaxed) +
+                                          _stale_sweep_time_s * 1000) < curtime);
             };
 
             LOG(INFO) << fmt::format("[MemoryGC] {} prune stale start, consumption {}, usage {}",

--- a/be/src/util/lru_cache.cpp
+++ b/be/src/util/lru_cache.cpp
@@ -27,6 +27,7 @@
 #include <string>
 
 #include "common/metrics/metrics.h"
+#include "cpp/sync_point.h"
 #include "util/time.h"
 
 using std::string;
@@ -216,13 +217,11 @@ PrunedInfo LRUCache::set_capacity(size_t capacity) {
 }
 
 uint64_t LRUCache::get_lookup_count() {
-    std::lock_guard l(_mutex);
-    return _lookup_count;
+    return _lookup_count.load(std::memory_order_relaxed);
 }
 
 uint64_t LRUCache::get_hit_count() {
-    std::lock_guard l(_mutex);
-    return _hit_count;
+    return _hit_count.load(std::memory_order_relaxed);
 }
 
 uint64_t LRUCache::get_stampede_count() {
@@ -231,8 +230,7 @@ uint64_t LRUCache::get_stampede_count() {
 }
 
 uint64_t LRUCache::get_miss_count() {
-    std::lock_guard l(_mutex);
-    return _miss_count;
+    return _miss_count.load(std::memory_order_relaxed);
 }
 
 size_t LRUCache::get_usage() {
@@ -250,10 +248,19 @@ size_t LRUCache::get_element_count() {
     return _table.element_count();
 }
 
-bool LRUCache::_unref(LRUHandle* e) {
-    DCHECK(e->refs > 0);
-    e->refs--;
-    return e->refs == 0;
+void LRUCache::_ref(LRUHandle* e) {
+    // The shard lock protects publication/lifetime and the entry is off the LRU
+    // list. Fast releases cannot reduce refs below 2 while we hold a shared lock.
+    e->refs.fetch_add(1, std::memory_order_relaxed);
+    _hit_count.fetch_add(1, std::memory_order_relaxed);
+    // Expiration only needs an approximate visit time; concurrent hits may move it backwards.
+    e->last_visit_time.store(UnixMillis(), std::memory_order_relaxed);
+}
+
+uint32_t LRUCache::_unref(LRUHandle* e) {
+    auto refs = e->refs.fetch_sub(1, std::memory_order_acq_rel);
+    DCHECK_GT(refs, 0);
+    return refs;
 }
 
 void LRUCache::_lru_remove(LRUHandle* e) {
@@ -305,21 +312,39 @@ void LRUCache::_lru_append(LRUHandle* list, LRUHandle* e) {
 }
 
 Cache::Handle* LRUCache::lookup(const CacheKey& key, uint32_t hash) {
+    _lookup_count.fetch_add(1, std::memory_order_relaxed);
+    {
+        std::shared_lock l(_mutex);
+        LRUHandle* e = _table.lookup(key, hash);
+        if (e == nullptr) {
+            // LRU-K misses must update the visits list under the exclusive lock.
+            if (!_is_lru_k) {
+                _miss_count.fetch_add(1, std::memory_order_relaxed);
+                return nullptr;
+            }
+        } else {
+            DCHECK(e->in_cache);
+            if (e->refs.load(std::memory_order_relaxed) > 1) {
+                _ref(e);
+                return reinterpret_cast<Cache::Handle*>(e);
+            }
+        }
+    }
+    // Do not upgrade in place or retain an unowned pointer across unlock: erase,
+    // replacement or eviction may remove this entry before we acquire the lock.
+    TEST_SYNC_POINT("LRUCache::lookup:before_exclusive_lock");
     std::lock_guard l(_mutex);
-    ++_lookup_count;
     LRUHandle* e = _table.lookup(key, hash);
     if (e != nullptr) {
         // we get it from _table, so in_cache must be true
         DCHECK(e->in_cache);
-        if (e->refs == 1) {
+        if (e->refs.load(std::memory_order_relaxed) == 1) {
             // only in LRU free list, remove it from list
             _lru_remove(e);
         }
-        e->refs++;
-        ++_hit_count;
-        e->last_visit_time = UnixMillis();
+        _ref(e);
     } else {
-        ++_miss_count;
+        _miss_count.fetch_add(1, std::memory_order_relaxed);
     }
 
     // If key not exist in cache, and is lru k cache, and key in visits list,
@@ -340,13 +365,26 @@ void LRUCache::release(Cache::Handle* handle) {
         return;
     }
     auto* e = reinterpret_cast<LRUHandle*>(handle);
+    auto refs = e->refs.load(std::memory_order_relaxed);
+    while (refs > 2) {
+        if (e->refs.compare_exchange_weak(refs, refs - 1, std::memory_order_acq_rel,
+                                          std::memory_order_relaxed)) {
+            // Our reference is gone; another thread may immediately free e.
+            return;
+        }
+    }
+    // Keep our reference until the exclusive lock is held. Only this path may
+    // return a cached entry to the LRU list or destroy an erased entry.
     bool last_ref = false;
     {
         std::lock_guard l(_mutex);
         // if last_ref is true, key may have been evict from the cache,
         // or if it is lru k, first insert of key may have failed.
-        last_ref = _unref(e);
-        if (e->in_cache && e->refs == 1) {
+        refs = _unref(e);
+        last_ref = refs == 1;
+        if (last_ref) {
+            DCHECK(!e->in_cache);
+        } else if (refs == 2 && e->in_cache) {
             // only exists in cache
             if (_usage > _capacity) {
                 // take this opportunity and remove the item
@@ -424,7 +462,7 @@ void LRUCache::_evict_from_lru(size_t total_size, LRUHandle** to_remove_head) {
 
 void LRUCache::_evict_one_entry(LRUHandle* e) {
     DCHECK(e->in_cache);
-    DCHECK(e->refs == 1); // LRU list contains elements which may be evicted
+    DCHECK_EQ(e->refs.load(std::memory_order_relaxed), 1);
     _lru_remove(e);
     bool removed = _table.remove(e);
     DCHECK(removed);
@@ -478,7 +516,7 @@ bool LRUCache::_lru_k_insert_visits_list(size_t total_size, visits_lru_cache_key
 Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value, size_t charge,
                                 CachePriority priority) {
     size_t handle_size = sizeof(LRUHandle) - 1 + key.size();
-    auto* e = reinterpret_cast<LRUHandle*>(malloc(handle_size));
+    auto* e = new (malloc(handle_size)) LRUHandle;
     e->value = value;
     e->charge = charge;
     e->key_length = key.size();
@@ -486,13 +524,13 @@ Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value,
     // because charge at this time is no longer the memory size, but an weight.
     e->total_size = (_type == LRUCacheType::SIZE ? handle_size + charge : charge);
     e->hash = hash;
-    e->refs = 1; // only one for the returned handle.
+    e->refs.store(1, std::memory_order_relaxed); // only the returned handle.
     e->next = e->prev = nullptr;
     e->in_cache = false;
     e->priority = priority;
     e->type = _type;
     memcpy(e->key_data, key.data(), key.size());
-    e->last_visit_time = UnixMillis();
+    e->last_visit_time.store(UnixMillis(), std::memory_order_relaxed);
 
     LRUHandle* to_remove_head = nullptr;
     {
@@ -516,7 +554,7 @@ Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value,
         auto* old = _table.insert(e);
         e->in_cache = true;
         _usage += e->total_size;
-        e->refs++; // one for the returned handle, one for LRUCache.
+        e->refs.fetch_add(1, std::memory_order_relaxed); // returned handle and LRUCache.
         if (old != nullptr) {
             _stampede_count++;
             old->in_cache = false;
@@ -528,9 +566,9 @@ Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value,
             // will be released from the cache memory_tracker.
             _usage -= old->total_size;
             // if false, old entry is being used externally, just ref-- and sub _usage,
-            if (_unref(old)) {
+            if (_unref(old) == 1) {
                 // old is on LRU because it's in cache and its reference count
-                // was just 1 (Unref returned 0)
+                // was just 1 (_unref returned the previous count).
                 _lru_remove(old);
                 old->next = to_remove_head;
                 to_remove_head = old;
@@ -556,7 +594,7 @@ void LRUCache::erase(const CacheKey& key, uint32_t hash) {
         std::lock_guard l(_mutex);
         e = _table.remove(key, hash);
         if (e != nullptr) {
-            last_ref = _unref(e);
+            last_ref = _unref(e) == 1;
             // if last_ref is false or in_cache is false, e must not be in lru
             if (last_ref && e->in_cache) {
                 // locate in free list
@@ -860,13 +898,13 @@ void ShardedLRUCache::update_cache_metrics() const {
 Cache::Handle* DummyLRUCache::insert(const CacheKey& key, void* value, size_t charge,
                                      CachePriority priority) {
     size_t handle_size = sizeof(LRUHandle);
-    auto* e = reinterpret_cast<LRUHandle*>(malloc(handle_size));
+    auto* e = new (malloc(handle_size)) LRUHandle;
     e->value = value;
     e->charge = charge;
     e->key_length = 0;
     e->total_size = 0;
     e->hash = 0;
-    e->refs = 1; // only one for the returned handle
+    e->refs.store(1, std::memory_order_relaxed); // only the returned handle
     e->next = e->prev = nullptr;
     e->in_cache = false;
     return reinterpret_cast<Cache::Handle*>(e);

--- a/be/src/util/lru_cache.h
+++ b/be/src/util/lru_cache.h
@@ -34,6 +34,7 @@
 #include <functional>
 #include <memory>
 #include <set>
+#include <shared_mutex>
 #include <string>
 #include <utility>
 
@@ -238,8 +239,9 @@ private:
 
 // An entry is a variable length heap-allocated structure.  Entries
 // are kept in a circular doubly linked list ordered by access time.
-// Note: member variables can only be POD types and raw pointer,
-// cannot be class objects or smart pointers, because LRUHandle will be created using malloc.
+// Heap entries use placement construction in malloc-allocated storage to allow
+// an inline variable-length key. Members must remain trivially destructible:
+// free() deletes the value and frees the storage without calling a destructor.
 struct LRUHandle {
     void* value = nullptr;
     struct LRUHandle* next_hash = nullptr; // next entry in hash table
@@ -248,13 +250,13 @@ struct LRUHandle {
     size_t charge;
     size_t key_length;
     size_t total_size; // Entry charge, used to limit cache capacity, LRUCacheType::SIZE including key length.
-    bool in_cache; // Whether entry is in the cache.
-    uint32_t refs;
+    bool in_cache; // Protected by the shard mutex; includes one cache-owned reference.
+    std::atomic<uint32_t> refs {0};
     uint32_t hash; // Hash of key(); used for fast sharding and comparisons
     CachePriority priority = CachePriority::NORMAL;
     LRUCacheType type;
-    int64_t last_visit_time; // Save the last visit time of this cache entry.
-    char key_data[1];        // Beginning of key
+    std::atomic<int64_t> last_visit_time {0}; // Updated by concurrent lookups.
+    char key_data[1];                         // Beginning of key
     // Note! key_data must be at the end.
 
     CacheKey key() const {
@@ -368,7 +370,10 @@ public:
 private:
     void _lru_remove(LRUHandle* e);
     void _lru_append(LRUHandle* list, LRUHandle* e);
-    bool _unref(LRUHandle* e);
+    void _ref(LRUHandle* e);
+    // Returns the reference count BEFORE decrementing. The caller holds the
+    // exclusive shard lock, but non-final releases can still run concurrently.
+    uint32_t _unref(LRUHandle* e);
     void _evict_from_lru(size_t total_size, LRUHandle** to_remove_head);
     void _evict_from_lru_with_time(size_t total_size, LRUHandle** to_remove_head);
     void _evict_one_entry(LRUHandle* e);
@@ -381,8 +386,10 @@ private:
     // Initialized before use.
     size_t _capacity = 0;
 
-    // _mutex protects the following state.
-    std::mutex _mutex;
+    // The table, LRU lists, in_cache and usage require the exclusive lock for
+    // mutation. Shared lookup can only pin an already-pinned entry. Atomic
+    // releases may run without the lock, but never cross refs == 2 that way.
+    std::shared_mutex _mutex;
     size_t _usage = 0;
 
     // Dummy head of LRU list.
@@ -394,9 +401,9 @@ private:
 
     HandleTable _table;
 
-    uint64_t _lookup_count = 0; // number of cache lookups
-    uint64_t _hit_count = 0;    // number of cache hits
-    uint64_t _miss_count = 0;   // number of cache misses
+    std::atomic<uint64_t> _lookup_count {0}; // number of cache lookups
+    std::atomic<uint64_t> _hit_count {0};    // number of cache hits
+    std::atomic<uint64_t> _miss_count {0};   // number of cache misses
     uint64_t _stampede_count = 0;
 
     CacheValueTimeExtractor _cache_value_time_extractor;

--- a/be/test/storage/cache/lru_cache_test.cpp
+++ b/be/test/storage/cache/lru_cache_test.cpp
@@ -21,15 +21,21 @@
 #include <gtest/gtest-message.h>
 #include <gtest/gtest-test-part.h>
 
+#include <chrono>
 #include <iosfwd>
+#include <new>
+#include <thread>
 #include <vector>
 
+#include "cpp/sync_point.h"
 #include "gtest/gtest.h"
 #include "gtest/gtest_pred_impl.h"
 #include "runtime/memory/lru_cache_policy.h"
 #include "runtime/memory/lru_cache_value_base.h"
 #include "runtime/memory/mem_tracker_limiter.h"
+#include "runtime/thread_context.h"
 #include "testutil/test_util.h"
+#include "util/countdown_latch.h"
 
 using namespace doris;
 using namespace std;
@@ -622,7 +628,7 @@ TEST(CacheHandleTest, HandleTableTest) {
     LRUHandle* hs[count];
     for (int i = 0; i < count; ++i) {
         CacheKey* key = &keys[i];
-        auto* h = reinterpret_cast<LRUHandle*>(malloc(sizeof(LRUHandle) - 1 + key->size()));
+        auto* h = new (malloc(sizeof(LRUHandle) - 1 + key->size())) LRUHandle;
         h->value = nullptr;
         h->charge = 1;
         h->total_size = sizeof(LRUHandle) - 1 + key->size() + 1;
@@ -654,7 +660,7 @@ TEST(CacheHandleTest, HandleTableTest) {
 
     for (int i = 0; i < count; ++i) {
         CacheKey* key = &keys[i];
-        auto* h = reinterpret_cast<LRUHandle*>(malloc(sizeof(LRUHandle) - 1 + key->size()));
+        auto* h = new (malloc(sizeof(LRUHandle) - 1 + key->size())) LRUHandle;
         h->value = nullptr;
         h->charge = 1;
         h->total_size = sizeof(LRUHandle) - 1 + key->size() + 1;
@@ -669,7 +675,7 @@ TEST(CacheHandleTest, HandleTableTest) {
 
         EXPECT_EQ(ht.insert(h), hs[i]); // there is an entry with the same key and hash
         EXPECT_EQ(ht._elems, count);
-        free(hs[i]);
+        hs[i]->free();
         hs[i] = h;
     }
     EXPECT_EQ(ht._elems, count);
@@ -697,7 +703,7 @@ TEST(CacheHandleTest, HandleTableTest) {
     EXPECT_EQ(ht._elems, count - 4);
 
     for (auto& h : hs) {
-        free(h);
+        h->free();
     }
 }
 
@@ -855,6 +861,329 @@ TEST_F(CacheTest, ResetInitialCapacity) {
     ASSERT_EQ(prune_num, kCacheSize / 2);
     ASSERT_EQ(kCacheSize / 2, cache()->get_capacity());
     ASSERT_EQ(kCacheSize / 2, cache()->get_usage());
+}
+
+class LRUCacheConcurrencyTest : public testing::Test {
+protected:
+    struct Value : LRUCacheValueBase {
+        Value(int key, std::atomic<int>& destroyed) : key(key), destroyed(destroyed) {}
+        ~Value() override { destroyed.fetch_add(1, std::memory_order_relaxed); }
+        const int key;
+        std::atomic<int>& destroyed;
+    };
+
+    void SetUp() override { cache.set_capacity(2048); }
+    void TearDown() override {
+        auto* sync_point = SyncPoint::get_instance();
+        sync_point->disable_processing();
+        sync_point->clear_call_back("LRUCache::lookup:before_exclusive_lock");
+        cache.prune();
+        EXPECT_EQ(0, cache.get_usage());
+    }
+
+    Cache::Handle* insert(int key, CachePriority priority = CachePriority::NORMAL) {
+        return cache.insert(std::to_string(key), key, new Value(key, destroyed), 1, priority);
+    }
+    Cache::Handle* lookup(int key) { return cache.lookup(std::to_string(key), key); }
+    void erase(int key) { cache.erase(std::to_string(key), key); }
+    static LRUHandle* entry(Cache::Handle* handle) { return reinterpret_cast<LRUHandle*>(handle); }
+
+    std::atomic<int> destroyed {0};
+    LRUCache cache {LRUCacheType::NUMBER};
+};
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) -- GTest macros inflate the transition checks.
+TEST_F(LRUCacheConcurrencyTest, ReferenceTransitions) {
+    for (auto priority : {CachePriority::NORMAL, CachePriority::DURABLE}) {
+        auto* handle = insert(1, priority);
+        auto* e = entry(handle);
+        auto* list = priority == CachePriority::NORMAL ? &cache._lru_normal : &cache._lru_durable;
+        EXPECT_EQ(2, e->refs.load());
+        EXPECT_EQ(list, list->next);
+        auto* hit = lookup(1);
+        ASSERT_EQ(handle, hit);
+        EXPECT_EQ(3, e->refs.load());
+        cache.release(hit);
+        EXPECT_EQ(2, e->refs.load());
+        cache.release(handle);
+        EXPECT_EQ(1, e->refs.load());
+        EXPECT_EQ(e, list->next);
+        hit = lookup(1);
+        ASSERT_EQ(e, entry(hit));
+        EXPECT_EQ(2, e->refs.load());
+        EXPECT_EQ(list, list->next);
+        cache.release(hit);
+        cache.prune();
+        EXPECT_EQ(0, cache.get_usage());
+    }
+    EXPECT_EQ(2, destroyed.load());
+}
+
+TEST_F(LRUCacheConcurrencyTest, ConcurrentPinnedHitsUseFastPaths) {
+    auto* pinned = insert(1);
+    std::atomic<int> slow_lookups {0};
+    auto* sync_point = SyncPoint::get_instance();
+    sync_point->set_call_back("LRUCache::lookup:before_exclusive_lock",
+                              [&](auto&&) { ++slow_lookups; });
+    sync_point->enable_processing();
+    constexpr int num_threads = 8;
+    constexpr int iterations = 2000;
+    CountDownLatch start(1);
+    std::vector<std::thread> threads;
+    for (int i = 0; i < num_threads; ++i) {
+        threads.emplace_back([&] {
+            ScopedInitThreadContext scoped_context;
+            start.wait();
+            for (int j = 0; j < iterations; ++j) {
+                auto* hit = lookup(1);
+                EXPECT_EQ(pinned, hit);
+                cache.release(hit);
+            }
+        });
+    }
+    start.count_down();
+    for (auto& thread : threads) {
+        thread.join();
+    }
+    EXPECT_EQ(0, slow_lookups.load());
+    EXPECT_EQ(num_threads * iterations, cache.get_lookup_count());
+    EXPECT_EQ(num_threads * iterations, cache.get_hit_count());
+    EXPECT_EQ(2, entry(pinned)->refs.load());
+    EXPECT_EQ(0, destroyed.load());
+    cache.release(pinned);
+}
+
+TEST_F(LRUCacheConcurrencyTest, PinnedLookupDoesNotNeedExclusiveLock) {
+    auto* pinned = insert(1);
+    CountDownLatch done(1);
+    std::shared_lock lock(cache._mutex);
+    std::thread thread([&] {
+        ScopedInitThreadContext scoped_context;
+        auto* hit = lookup(1);
+        EXPECT_EQ(pinned, hit);
+        cache.release(hit);
+        done.count_down();
+    });
+    // Completion while another reader holds the shard proves neither operation
+    // needs the exclusive lock. The timeout only bounds a locking regression.
+    const bool completed = done.wait_for(std::chrono::seconds(5));
+    lock.unlock();
+    thread.join();
+    EXPECT_TRUE(completed);
+    cache.release(pinned);
+}
+
+TEST_F(LRUCacheConcurrencyTest, NonFinalReleaseDoesNotNeedAnyShardLock) {
+    auto* pinned = insert(1);
+    auto* hit = lookup(1);
+    CountDownLatch done(1);
+    std::unique_lock lock(cache._mutex);
+    std::thread thread([&] {
+        ScopedInitThreadContext scoped_context;
+        cache.release(hit);
+        done.count_down();
+    });
+    const bool completed = done.wait_for(std::chrono::seconds(5));
+    lock.unlock();
+    thread.join();
+    EXPECT_TRUE(completed);
+    EXPECT_EQ(2, entry(pinned)->refs.load());
+    cache.release(pinned);
+}
+
+TEST_F(LRUCacheConcurrencyTest, ReleaseEvictsOverCapacityOutsideLock) {
+    struct ReentrantValue : LRUCacheValueBase {
+        ReentrantValue(LRUCache& cache, bool& destroyed) : cache(cache), destroyed(destroyed) {}
+        ~ReentrantValue() override {
+            // Destruction must be outside the shard lock, and usage updated first.
+            EXPECT_EQ(0, cache.prune().pruned_count);
+            EXPECT_EQ(0, cache.get_usage());
+            destroyed = true;
+        }
+        LRUCache& cache;
+        bool& destroyed;
+    };
+    bool destroyed_outside_lock = false;
+    cache.set_capacity(0);
+    auto* handle = cache.insert("1", 1, new ReentrantValue(cache, destroyed_outside_lock), 1);
+    cache.release(handle);
+    EXPECT_TRUE(destroyed_outside_lock);
+    EXPECT_EQ(0, cache.get_element_count());
+}
+
+TEST_F(LRUCacheConcurrencyTest, LookupRechecksAfterErase) {
+    cache.release(insert(1));
+    auto* sync_point = SyncPoint::get_instance();
+    sync_point->set_call_back("LRUCache::lookup:before_exclusive_lock", [&](auto&&) { erase(1); });
+    sync_point->enable_processing();
+    EXPECT_EQ(nullptr, lookup(1));
+    EXPECT_EQ(1, destroyed.load());
+    EXPECT_EQ(1, cache.get_lookup_count());
+    EXPECT_EQ(0, cache.get_hit_count());
+    EXPECT_EQ(1, cache.get_miss_count());
+}
+
+TEST_F(LRUCacheConcurrencyTest, LookupRechecksAfterReplacement) {
+    cache.release(insert(1));
+    Cache::Handle* replacement = nullptr;
+    auto* sync_point = SyncPoint::get_instance();
+    sync_point->set_call_back("LRUCache::lookup:before_exclusive_lock",
+                              [&](auto&&) { replacement = insert(1); });
+    sync_point->enable_processing();
+    auto* hit = lookup(1);
+    ASSERT_NE(nullptr, hit);
+    EXPECT_EQ(replacement, hit);
+    EXPECT_EQ(1, destroyed.load());
+    EXPECT_EQ(3, entry(hit)->refs.load());
+    EXPECT_EQ(1, cache.get_lookup_count());
+    EXPECT_EQ(1, cache.get_hit_count());
+    cache.release(hit);
+    cache.release(replacement);
+}
+
+TEST_F(LRUCacheConcurrencyTest, ConcurrentReleaseAndLookup) {
+    // Race lookup against release without depending on an injection point inside release.
+    for (int i = 0; i < 100; ++i) {
+        auto* handle = insert(1);
+        CountDownLatch start(2);
+        std::thread thread([&] {
+            ScopedInitThreadContext scoped_context;
+            start.count_down();
+            start.wait();
+            cache.release(handle);
+        });
+        start.count_down();
+        start.wait();
+        auto* hit = lookup(1);
+        thread.join();
+        ASSERT_EQ(handle, hit);
+        EXPECT_EQ(2, entry(hit)->refs.load());
+        EXPECT_EQ(nullptr, entry(hit)->next);
+        cache.prune();
+        EXPECT_EQ(i, destroyed.load());
+        cache.release(hit);
+        cache.prune();
+        EXPECT_EQ(i + 1, destroyed.load());
+    }
+}
+
+TEST_F(LRUCacheConcurrencyTest, ConcurrentReleaseAndErase) {
+    for (int i = 0; i < 100; ++i) {
+        auto* handle = insert(1);
+        CountDownLatch start(2);
+        std::thread thread([&] {
+            ScopedInitThreadContext scoped_context;
+            start.count_down();
+            start.wait();
+            cache.release(handle);
+        });
+        start.count_down();
+        start.wait();
+        erase(1);
+        thread.join();
+        EXPECT_EQ(i + 1, destroyed.load());
+        EXPECT_EQ(0, cache.get_usage());
+        EXPECT_EQ(0, cache.get_element_count());
+    }
+}
+
+TEST_F(LRUCacheConcurrencyTest, ConcurrentFinalReleasesAfterErase) {
+    for (int i = 0; i < 100; ++i) {
+        auto* first = insert(1);
+        auto* second = lookup(1);
+        erase(1);
+        EXPECT_EQ(2, entry(first)->refs.load());
+        CountDownLatch start(1);
+        std::thread thread([&] {
+            ScopedInitThreadContext scoped_context;
+            start.wait();
+            cache.release(second);
+        });
+        start.count_down();
+        cache.release(first);
+        thread.join();
+        EXPECT_EQ(i + 1, destroyed.load());
+        EXPECT_EQ(0, cache.get_usage());
+    }
+}
+
+TEST_F(LRUCacheConcurrencyTest, ReplacementKeepsPinnedEntryAlive) {
+    auto* old = insert(1);
+    auto* first = lookup(1);
+    auto* second = lookup(1);
+    auto* replacement = insert(1);
+    EXPECT_EQ(0, destroyed.load());
+    EXPECT_EQ(3, entry(old)->refs.load());
+    EXPECT_FALSE(entry(old)->in_cache);
+    EXPECT_EQ(1, cache.get_usage());
+    cache.release(first);  // Detached 3 -> 2, fast path.
+    cache.release(second); // Detached 2 -> 1, exclusive path, still alive.
+    EXPECT_EQ(0, destroyed.load());
+    cache.release(old); // Detached 1 -> 0, only the old entry is freed.
+    EXPECT_EQ(1, destroyed.load());
+    EXPECT_EQ(1, cache.get_usage());
+    auto* hit = lookup(1);
+    EXPECT_EQ(replacement, hit);
+    cache.release(hit);
+    cache.release(replacement);
+}
+
+TEST_F(LRUCacheConcurrencyTest, LastVisitUpdatedOnLookup) {
+    auto* handle = insert(1);
+    auto* e = entry(handle);
+    e->last_visit_time.store(0, std::memory_order_relaxed);
+    auto* hit = lookup(1);
+    EXPECT_EQ(handle, hit);
+    EXPECT_GT(e->last_visit_time.load(std::memory_order_relaxed), 0);
+    cache.release(hit);
+    cache.release(handle);
+}
+
+TEST_F(LRUCacheConcurrencyTest, ConcurrentLookupReplaceEraseAndPrune) {
+    constexpr int iterations = 4096;
+    constexpr int num_keys = 1024;
+    // Grow the table while readers traverse it, then replace and erase entries.
+    CountDownLatch start(1);
+    std::vector<std::thread> readers;
+    for (int i = 0; i < 4; ++i) {
+        readers.emplace_back([&, i] {
+            ScopedInitThreadContext scoped_context;
+            start.wait();
+            for (int j = 0; j < iterations; ++j) {
+                const int key = (j + i) % num_keys;
+                auto* hit = lookup(key);
+                if (hit != nullptr) {
+                    EXPECT_EQ(key, static_cast<Value*>(entry(hit)->value)->key);
+                    cache.release(hit);
+                }
+            }
+        });
+    }
+    start.count_down();
+    for (int j = 0; j < iterations; ++j) {
+        cache.release(insert(j % num_keys));
+        if (j >= num_keys && j % 3 == 0) {
+            erase((j + 1) % num_keys);
+        }
+        if (j >= num_keys && j % 128 == 0) {
+            cache.prune_if([](const LRUHandle*) { return true; });
+        }
+    }
+    for (auto& reader : readers) {
+        reader.join();
+    }
+    cache.prune();
+    EXPECT_EQ(iterations, destroyed.load());
+    EXPECT_EQ(0, cache.get_usage());
+    EXPECT_EQ(0, cache.get_element_count());
+    EXPECT_EQ(4 * iterations, cache.get_lookup_count());
+    EXPECT_EQ(cache.get_lookup_count(), cache.get_hit_count() + cache.get_miss_count());
+}
+
+TEST_F(LRUCacheConcurrencyTest, DummyHandleLifetime) {
+    DummyLRUCache dummy;
+    dummy.release(dummy.insert("key", new Value(1, destroyed), 1));
+    EXPECT_EQ(1, destroyed.load());
 }
 
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary: Concurrent users of a pinned LRU entry serialize lookup and release on the shard mutex even when neither operation changes the eviction list. use shared locking for pinned hits and atomic reference decrements for non-final releases, retaining exclusive locking for list transitions and entry removal. Recheck lookup after reacquiring the lock and preserve destruction outside the shard lock.

### Release note

Reduce shard lock contention for concurrent lookups and releases of already-pinned LRU cache entries.


### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

