### PR TITLE
[Enhance](ai_func) Support dedicate embed properties in AI RESOURCE

### DIFF
--- a/be/src/exprs/function/ai/ai_adapter.h
+++ b/be/src/exprs/function/ai/ai_adapter.h
@@ -59,6 +59,7 @@ struct AIResource {
     int32_t retry_delay_second;
     std::string anthropic_version;
     int32_t dimensions;
+    std::string effort;
 
     void serialize(BufferWritable& buf) const {
         buf.write_binary(endpoint);
@@ -71,6 +72,7 @@ struct AIResource {
         buf.write_binary(retry_delay_second);
         buf.write_binary(anthropic_version);
         buf.write_binary(dimensions);
+        buf.write_binary(effort);
     }
 
     void deserialize(BufferReadable& buf) {
@@ -84,6 +86,7 @@ struct AIResource {
         buf.read_binary(retry_delay_second);
         buf.read_binary(anthropic_version);
         buf.read_binary(dimensions);
+        buf.read_binary(effort);
     }
 
 private:
@@ -99,7 +102,8 @@ private:
               max_retries(tai.max_retries),
               retry_delay_second(tai.retry_delay_second),
               anthropic_version(tai.anthropic_version),
-              dimensions(tai.dimensions) {}
+              dimensions(tai.dimensions),
+              effort(tai.effort) {}
 };
 
 enum class MultimodalType { IMAGE, VIDEO, AUDIO };
@@ -135,6 +139,7 @@ public:
         _config.retry_delay_second = config.retry_delay_second;
         _config.anthropic_version = config.anthropic_version;
         _config.dimensions = config.dimensions;
+        _config.effort = config.effort;
     }
 
     // Build request payload based on input text strings
@@ -758,7 +763,8 @@ public:
                 {"role": "user", "content": "xxx"}
               ],
               "temperature": 0.7,
-              "max_output_tokens": 150
+              "max_output_tokens": 150,
+              "reasoning": {"effort": "max"}
             }*/
             doc.AddMember("model", rapidjson::Value(_config.model_name.c_str(), allocator),
                           allocator);
@@ -769,6 +775,12 @@ public:
             }
             if (_config.max_tokens != -1) {
                 doc.AddMember("max_output_tokens", _config.max_tokens, allocator);
+            }
+            if (!_config.effort.empty()) {
+                rapidjson::Value reasoning(rapidjson::kObjectType);
+                reasoning.AddMember("effort", rapidjson::Value(_config.effort.c_str(), allocator),
+                                    allocator);
+                doc.AddMember("reasoning", reasoning, allocator);
             }
 
             // input
@@ -795,6 +807,7 @@ public:
               ],
               "temperature": x,
               "max_tokens": x,
+              "reasoning_effort": "low"
             }*/
             doc.AddMember("model", rapidjson::Value(_config.model_name.c_str(), allocator),
                           allocator);
@@ -805,6 +818,10 @@ public:
             }
             if (_config.max_tokens != -1) {
                 doc.AddMember("max_tokens", _config.max_tokens, allocator);
+            }
+            if (!_config.effort.empty()) {
+                doc.AddMember("reasoning_effort",
+                              rapidjson::Value(_config.effort.c_str(), allocator), allocator);
             }
 
             rapidjson::Value messages(rapidjson::kArrayType);
@@ -1256,7 +1273,8 @@ public:
           ],
           "generationConfig": {
           "temperature": 0.7,
-          "maxOutputTokens": 1024
+          "maxOutputTokens": 1024,
+          "thinkingConfig": {"thinkingLevel": "high"}
           }
 
         }*/
@@ -1293,6 +1311,12 @@ public:
         }
         if (_config.max_tokens != -1) {
             generationConfig.AddMember("maxOutputTokens", _config.max_tokens, allocator);
+        }
+        if (!_config.effort.empty()) {
+            rapidjson::Value thinking_config(rapidjson::kObjectType);
+            thinking_config.AddMember("thinkingLevel",
+                                      rapidjson::Value(_config.effort.c_str(), allocator), allocator);
+            generationConfig.AddMember("thinkingConfig", thinking_config, allocator);
         }
         doc.AddMember("generationConfig", generationConfig, allocator);
 
@@ -1572,6 +1596,7 @@ public:
         /*
             "model": "claude-opus-4-1-20250805",
             "max_tokens": 1024,
+            "output_config": {"effort": "medium"},
             "system": "system_prompt here",
             "messages": [
               {"role": "user", "content": "xxx"}
@@ -1589,6 +1614,12 @@ public:
         } else {
             // Keep the default value, Anthropic requires this parameter
             doc.AddMember("max_tokens", 2048, allocator);
+        }
+        if (!_config.effort.empty()) {
+            rapidjson::Value output_config(rapidjson::kObjectType);
+            output_config.AddMember("effort", rapidjson::Value(_config.effort.c_str(), allocator),
+                                    allocator);
+            doc.AddMember("output_config", output_config, allocator);
         }
         if (system_prompt && *system_prompt) {
             doc.AddMember("system", rapidjson::Value(system_prompt, allocator), allocator);

--- a/be/src/exprs/function/ai/ai_adapter.h
+++ b/be/src/exprs/function/ai/ai_adapter.h
@@ -1315,7 +1315,8 @@ public:
         if (!_config.effort.empty()) {
             rapidjson::Value thinking_config(rapidjson::kObjectType);
             thinking_config.AddMember("thinkingLevel",
-                                      rapidjson::Value(_config.effort.c_str(), allocator), allocator);
+                                      rapidjson::Value(_config.effort.c_str(), allocator),
+                                      allocator);
             generationConfig.AddMember("thinkingConfig", thinking_config, allocator);
         }
         doc.AddMember("generationConfig", generationConfig, allocator);

--- a/be/src/exprs/function/ai/ai_adapter.h
+++ b/be/src/exprs/function/ai/ai_adapter.h
@@ -42,16 +42,12 @@ namespace doris {
 struct AIResource {
     AIResource() = default;
     AIResource(const TAIResource& tai)
-            : endpoint(tai.endpoint),
-              provider_type(tai.provider_type),
-              model_name(tai.model_name),
-              api_key(tai.api_key),
-              temperature(tai.temperature),
-              max_tokens(tai.max_tokens),
-              max_retries(tai.max_retries),
-              retry_delay_second(tai.retry_delay_second),
-              anthropic_version(tai.anthropic_version),
-              dimensions(tai.dimensions) {}
+            : AIResource(tai, tai.endpoint, tai.provider_type, tai.model_name, tai.api_key) {}
+
+    static AIResource from_embed(const TAIResource& tai) {
+        return AIResource(tai, tai.embed_endpoint, tai.embed_provider_type, tai.embed_model_name,
+                          tai.embed_api_key);
+    }
 
     std::string endpoint;
     std::string provider_type;
@@ -89,6 +85,21 @@ struct AIResource {
         buf.read_binary(anthropic_version);
         buf.read_binary(dimensions);
     }
+
+private:
+    AIResource(const TAIResource& tai, const std::string& selected_endpoint,
+               const std::string& selected_provider_type, const std::string& selected_model_name,
+               const std::string& selected_api_key)
+            : endpoint(selected_endpoint),
+              provider_type(selected_provider_type),
+              model_name(selected_model_name),
+              api_key(selected_api_key),
+              temperature(tai.temperature),
+              max_tokens(tai.max_tokens),
+              max_retries(tai.max_retries),
+              retry_delay_second(tai.retry_delay_second),
+              anthropic_version(tai.anthropic_version),
+              dimensions(tai.dimensions) {}
 };
 
 enum class MultimodalType { IMAGE, VIDEO, AUDIO };
@@ -123,6 +134,7 @@ public:
         _config.max_retries = config.max_retries;
         _config.retry_delay_second = config.retry_delay_second;
         _config.anthropic_version = config.anthropic_version;
+        _config.dimensions = config.dimensions;
     }
 
     // Build request payload based on input text strings

--- a/be/src/exprs/function/ai/ai_functions.h
+++ b/be/src/exprs/function/ai/ai_functions.h
@@ -96,7 +96,7 @@ public:
             return Status::OK();
         }
 
-        TAIResource config;
+        AIResource config;
         std::shared_ptr<AIAdapter> adapter;
         if (Status status = this->_init_from_resource(context, block, arguments, config, adapter);
             !status.ok()) {
@@ -130,7 +130,7 @@ protected:
         return Status::OK();
     }
 
-    static void normalize_endpoint(TAIResource& config) {
+    static void normalize_endpoint(AIResource& config) {
         // 1. If users configure only the version root like `.../v1` or `.../v1beta`, append
         //    `models/<model>:batchEmbedContents` for `embed`, and `models/<model>:generateContent`
         //    for other AI scalar functions.
@@ -171,7 +171,7 @@ protected:
 
     // Executes one HTTP POST request and validates transport-level success.
     Status do_send_request(HttpClient* client, const std::string& request_body,
-                           std::string& response, const TAIResource& config,
+                           std::string& response, const AIResource& config,
                            std::shared_ptr<AIAdapter>& adapter, FunctionContext* context) const {
         RETURN_IF_ERROR(client->init(config.endpoint, false));
 
@@ -207,7 +207,7 @@ protected:
 
     // Sends the request with retry mechanism for handling transient failures
     Status send_request_to_llm(const std::string& request_body, std::string& response,
-                               const TAIResource& config, std::shared_ptr<AIAdapter>& adapter,
+                               const AIResource& config, std::shared_ptr<AIAdapter>& adapter,
                                FunctionContext* context) const {
         return HttpClient::execute_with_retry(config.max_retries, config.retry_delay_second,
                                               [this, &request_body, &response, &config, &adapter,
@@ -228,7 +228,7 @@ protected:
     // Provider-reusable helper for string-returning functions.
     // Executes one batch request and parses the provider result into one string per input row.
     Status execute_batch_request(const std::vector<std::string>& batch_prompts,
-                                 std::vector<std::string>& results, const TAIResource& config,
+                                 std::vector<std::string>& results, const AIResource& config,
                                  std::shared_ptr<AIAdapter>& adapter,
                                  FunctionContext* context) const {
 #ifdef BE_TEST
@@ -292,7 +292,7 @@ protected:
     // Runs the common batch execution flow; derived classes only need to define how one batch of
     // string results is inserted into the final output column.
     Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
-                   uint32_t result, size_t input_rows_count, const TAIResource& config,
+                   uint32_t result, size_t input_rows_count, const AIResource& config,
                    std::shared_ptr<AIAdapter>& adapter) const {
         Columns prompt_columns;
         prompt_columns.reserve(arguments.size() - 1);
@@ -417,7 +417,7 @@ protected:
 private:
     // The ai resource must be literal
     Status _init_from_resource(FunctionContext* context, const Block& block,
-                               const ColumnNumbers& arguments, TAIResource& config,
+                               const ColumnNumbers& arguments, AIResource& config,
                                std::shared_ptr<AIAdapter>& adapter) const {
         const ColumnWithTypeAndName& resource_column = block.get_by_position(arguments[0]);
         StringRef resource_name_ref = resource_column.column->get_data_at(0);
@@ -428,7 +428,7 @@ private:
         DORIS_CHECK(ai_resources);
         auto it = ai_resources->find(resource_name);
         DORIS_CHECK(it != ai_resources->end());
-        config = it->second;
+        config = assert_cast<const Derived&>(*this).select_ai_resource(it->second);
 
         normalize_endpoint(config);
 
@@ -438,6 +438,8 @@ private:
         adapter->init(config);
         return Status::OK();
     }
+
+    AIResource select_ai_resource(const TAIResource& resource) const { return AIResource(resource); }
 
     // Serializes one text batch into the shared JSON-array prompt format consumed by LLM
     // providers for batch string functions.

--- a/be/src/exprs/function/ai/ai_functions.h
+++ b/be/src/exprs/function/ai/ai_functions.h
@@ -439,7 +439,9 @@ private:
         return Status::OK();
     }
 
-    AIResource select_ai_resource(const TAIResource& resource) const { return AIResource(resource); }
+    AIResource select_ai_resource(const TAIResource& resource) const {
+        return AIResource(resource);
+    }
 
     // Serializes one text batch into the shared JSON-array prompt format consumed by LLM
     // providers for batch string functions.

--- a/be/src/exprs/function/ai/embed.h
+++ b/be/src/exprs/function/ai/embed.h
@@ -45,9 +45,9 @@ public:
     using PreparedFunctionImpl::execute;
 
     AIResource select_ai_resource(const TAIResource& resource) const {
-        bool has_embed_properties = resource.__isset.embed_endpoint ||
-                resource.__isset.embed_provider_type || resource.__isset.embed_model_name ||
-                resource.__isset.embed_api_key;
+        bool has_embed_properties =
+                resource.__isset.embed_endpoint || resource.__isset.embed_provider_type ||
+                resource.__isset.embed_model_name || resource.__isset.embed_api_key;
         return has_embed_properties ? AIResource::from_embed(resource) : AIResource(resource);
     }
 

--- a/be/src/exprs/function/ai/embed.h
+++ b/be/src/exprs/function/ai/embed.h
@@ -44,8 +44,15 @@ public:
 
     using PreparedFunctionImpl::execute;
 
+    AIResource select_ai_resource(const TAIResource& resource) const {
+        bool has_embed_properties = resource.__isset.embed_endpoint ||
+                resource.__isset.embed_provider_type || resource.__isset.embed_model_name ||
+                resource.__isset.embed_api_key;
+        return has_embed_properties ? AIResource::from_embed(resource) : AIResource(resource);
+    }
+
     Status execute(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
-                   uint32_t result, size_t input_rows_count, const TAIResource& config,
+                   uint32_t result, size_t input_rows_count, const AIResource& config,
                    std::shared_ptr<AIAdapter>& adapter) const {
         if (arguments.size() != 2) {
             return Status::InvalidArgument("Function EMBED expects 2 arguments, but got {}",
@@ -102,7 +109,7 @@ private:
     }
 
     Status _execute_text_embed(FunctionContext* context, Block& block, uint32_t result,
-                               size_t input_rows_count, const TAIResource& config,
+                               size_t input_rows_count, const AIResource& config,
                                std::shared_ptr<AIAdapter>& adapter, const ColumnPtr& input_column,
                                ColumnUInt8::MutablePtr result_null_map) const {
         auto col_result = ColumnArray::create(
@@ -159,7 +166,7 @@ private:
     }
 
     Status _execute_multimodal_embed(FunctionContext* context, Block& block, uint32_t result,
-                                     size_t input_rows_count, const TAIResource& config,
+                                     size_t input_rows_count, const AIResource& config,
                                      std::shared_ptr<AIAdapter>& adapter,
                                      const ColumnPtr& input_column,
                                      ColumnUInt8::MutablePtr result_null_map) const {
@@ -222,7 +229,7 @@ private:
     // Sends one embedding request with a prebuilt request body and validates returned row count.
     Status _execute_prebuilt_embedding_request(const std::string& request_body,
                                                std::vector<std::vector<float>>& results,
-                                               size_t expected_size, const TAIResource& config,
+                                               size_t expected_size, const AIResource& config,
                                                std::shared_ptr<AIAdapter>& adapter,
                                                FunctionContext* context) const {
         std::string response;
@@ -255,7 +262,7 @@ private:
     // EMBED-private helper.
     // Flushes one accumulated text embedding batch into the output array column.
     Status _flush_text_embedding_batch(std::vector<std::string>& batch_prompts,
-                                       ColumnArray& col_result, const TAIResource& config,
+                                       ColumnArray& col_result, const AIResource& config,
                                        std::shared_ptr<AIAdapter>& adapter,
                                        FunctionContext* context) const {
         if (batch_prompts.empty()) {
@@ -279,7 +286,7 @@ private:
     Status _flush_multimodal_embedding_batch(std::vector<MultimodalType>& batch_media_types,
                                              std::vector<std::string>& batch_media_content_types,
                                              std::vector<std::string>& batch_media_urls,
-                                             ColumnArray& col_result, const TAIResource& config,
+                                             ColumnArray& col_result, const AIResource& config,
                                              std::shared_ptr<AIAdapter>& adapter,
                                              FunctionContext* context) const {
         if (batch_media_urls.empty()) {

--- a/be/test/ai/ai_adapter_test.cpp
+++ b/be/test/ai/ai_adapter_test.cpp
@@ -248,6 +248,7 @@ TEST(AI_ADAPTER_TEST, openai_adapter_completions_request) {
     config.temperature = 0.5;
     config.max_tokens = 64;
     config.api_key = "test_openai_key";
+    config.effort = "low";
     adapter.init(config);
 
     // header
@@ -284,6 +285,8 @@ TEST(AI_ADAPTER_TEST, openai_adapter_completions_request) {
     ASSERT_TRUE(doc.HasMember("max_tokens")) << "Missing max_tokens field";
     ASSERT_TRUE(doc["max_tokens"].IsInt()) << "Max_tokens field is not an integer";
     ASSERT_EQ(doc["max_tokens"].GetInt(), 64);
+    ASSERT_TRUE(doc.HasMember("reasoning_effort"));
+    ASSERT_STREQ(doc["reasoning_effort"].GetString(), "low");
     // msg
     ASSERT_TRUE(doc.HasMember("messages")) << "Missing messages field";
     ASSERT_TRUE(doc["messages"].IsArray()) << "Messages is not an array";
@@ -321,6 +324,7 @@ TEST(AI_ADAPTER_TEST, openai_adatper_responses_request) {
     config.max_tokens = 64;
     config.api_key = "test_openai_key";
     config.endpoint = "https://api.openai.com/v1/responses";
+    config.effort = "max";
     adapter.init(config);
 
     // header
@@ -357,6 +361,9 @@ TEST(AI_ADAPTER_TEST, openai_adatper_responses_request) {
     ASSERT_TRUE(doc.HasMember("max_output_tokens")) << "Missing max_output_tokens field";
     ASSERT_TRUE(doc["max_output_tokens"].IsInt()) << "max_output_tokens field is not an integer";
     ASSERT_EQ(doc["max_output_tokens"].GetInt(), 64);
+    ASSERT_TRUE(doc.HasMember("reasoning"));
+    ASSERT_TRUE(doc["reasoning"].IsObject());
+    ASSERT_STREQ(doc["reasoning"]["effort"].GetString(), "max");
 
     // input
     ASSERT_TRUE(doc.HasMember("input")) << "Missing input field";
@@ -671,6 +678,7 @@ TEST(AI_ADAPTER_TEST, gemini_adapter_request) {
     config.temperature = 0.2;
     config.max_tokens = 32;
     config.api_key = "test_gemini_key";
+    config.effort = "high";
     adapter.init(config);
 
     // header test
@@ -705,6 +713,9 @@ TEST(AI_ADAPTER_TEST, gemini_adapter_request) {
     ASSERT_TRUE(gen_cfg.HasMember("maxOutputTokens")) << "Missing maxOutputTokens field";
     ASSERT_TRUE(gen_cfg["maxOutputTokens"].IsInt());
     ASSERT_EQ(gen_cfg["maxOutputTokens"].GetInt(), 32);
+    ASSERT_TRUE(gen_cfg.HasMember("thinkingConfig"));
+    ASSERT_TRUE(gen_cfg["thinkingConfig"].IsObject());
+    ASSERT_STREQ(gen_cfg["thinkingConfig"]["thinkingLevel"].GetString(), "high");
 
     // system_prompt
     ASSERT_TRUE(doc.HasMember("systemInstruction")) << "Missing system field";
@@ -753,6 +764,7 @@ TEST(AI_ADAPTER_TEST, anthropic_adapter_request) {
     config.max_tokens = 256;
     config.api_key = "test_anthropic_key";
     config.anthropic_version = "2023-06-01";
+    config.effort = "medium";
     adapter.init(config);
 
     // header
@@ -790,6 +802,9 @@ TEST(AI_ADAPTER_TEST, anthropic_adapter_request) {
     ASSERT_TRUE(doc.HasMember("max_tokens")) << "Missing max_tokens field";
     ASSERT_TRUE(doc["max_tokens"].IsInt()) << "Max_tokens field is not an integer";
     ASSERT_EQ(doc["max_tokens"].GetInt(), 256);
+    ASSERT_TRUE(doc.HasMember("output_config"));
+    ASSERT_TRUE(doc["output_config"].IsObject());
+    ASSERT_STREQ(doc["output_config"]["effort"].GetString(), "medium");
 
     // system_prompt
     ASSERT_TRUE(doc.HasMember("system")) << "Missing system field";

--- a/be/test/ai/ai_function_test.cpp
+++ b/be/test/ai/ai_function_test.cpp
@@ -1564,14 +1564,14 @@ public:
 };
 
 TEST(AIFunctionTest, NormalizeLegacyCompletionsEndpoint) {
-    TAIResource resource;
+    AIResource resource;
     resource.endpoint = "https://api.openai.com/v1/completions";
     FunctionAISentimentTestHelper::normalize_endpoint(resource);
     ASSERT_EQ(resource.endpoint, "https://api.openai.com/v1/chat/completions");
 }
 
 TEST(AIFunctionTest, NormalizeEndpointNoopForOtherPaths) {
-    TAIResource resource;
+    AIResource resource;
     resource.endpoint = "https://api.openai.com/v1/chat/completions";
     FunctionAISentimentTestHelper::normalize_endpoint(resource);
     ASSERT_EQ(resource.endpoint, "https://api.openai.com/v1/chat/completions");
@@ -1582,7 +1582,7 @@ TEST(AIFunctionTest, NormalizeEndpointNoopForOtherPaths) {
 }
 
 TEST(AIFunctionTest, NormalizeGeminiGenerateEndpointFromBaseVersion) {
-    TAIResource resource;
+    AIResource resource;
     resource.provider_type = "gemini";
     resource.model_name = "gemini-pro";
     resource.endpoint = "https://generativelanguage.googleapis.com/v1beta";
@@ -1593,7 +1593,7 @@ TEST(AIFunctionTest, NormalizeGeminiGenerateEndpointFromBaseVersion) {
 }
 
 TEST(AIFunctionTest, NormalizeGeminiEmbedEndpointFromBaseVersion) {
-    TAIResource resource;
+    AIResource resource;
     resource.provider_type = "GEMINI";
     resource.model_name = "gemini-embedding-2-preview";
     resource.endpoint = "https://generativelanguage.googleapis.com/v1beta";
@@ -1605,7 +1605,7 @@ TEST(AIFunctionTest, NormalizeGeminiEmbedEndpointFromBaseVersion) {
 }
 
 TEST(AIFunctionTest, NormalizeGeminiEndpointNoopForNonBasePath) {
-    TAIResource resource;
+    AIResource resource;
     resource.provider_type = "gemini";
     resource.model_name = "gemini-pro";
     resource.endpoint =
@@ -1617,7 +1617,7 @@ TEST(AIFunctionTest, NormalizeGeminiEndpointNoopForNonBasePath) {
 }
 
 TEST(AIFunctionTest, NormalizeGeminiEmbedLegacySingleEndpointToBatchEndpoint) {
-    TAIResource resource;
+    AIResource resource;
     resource.provider_type = "gemini";
     resource.model_name = "gemini-embedding-2-preview";
     resource.endpoint =

--- a/be/test/ai/embed_test.cpp
+++ b/be/test/ai/embed_test.cpp
@@ -299,8 +299,8 @@ TEST(EMBED_TEST, prefer_embed_resource_properties) {
                                query_ctx.get());
     auto ctx = FunctionContext::create_context(&runtime_state, {}, {});
 
-    auto col_resource =
-            ColumnHelper::create_column<DataTypeString>(std::vector<std::string> {"embed_resource"});
+    auto col_resource = ColumnHelper::create_column<DataTypeString>(
+            std::vector<std::string> {"embed_resource"});
     auto col_text =
             ColumnHelper::create_column<DataTypeString>(std::vector<std::string> {"test input"});
 

--- a/be/test/ai/embed_test.cpp
+++ b/be/test/ai/embed_test.cpp
@@ -273,6 +273,51 @@ TEST(EMBED_TEST, embed_function_test) {
     }
 }
 
+TEST(EMBED_TEST, prefer_embed_resource_properties) {
+    TQueryOptions query_options = create_fake_query_options();
+    auto query_ctx = MockQueryContext::create(TUniqueId(), ExecEnv::GetInstance(), query_options);
+
+    TAIResource ai_resource;
+    ai_resource.__set_endpoint("invalid://general-endpoint");
+    ai_resource.__set_provider_type("OPENAI");
+    ai_resource.__set_model_name("general-model");
+    ai_resource.__set_api_key("general-api-key");
+    ai_resource.__set_embed_endpoint("http://localhost");
+    ai_resource.__set_embed_provider_type("MOCK");
+    ai_resource.__set_embed_model_name("embed-model");
+    ai_resource.__set_embed_api_key("embed-api-key");
+    ai_resource.__set_temperature(0.5);
+    ai_resource.__set_max_tokens(16);
+    ai_resource.__set_max_retries(1);
+    ai_resource.__set_retry_delay_second(1);
+    ai_resource.__set_dimensions(514);
+    query_ctx->set_ai_resources(
+            std::map<std::string, TAIResource> {{"embed_resource", ai_resource}});
+
+    TQueryGlobals query_globals;
+    RuntimeState runtime_state(TUniqueId(), 0, query_options, query_globals, nullptr,
+                               query_ctx.get());
+    auto ctx = FunctionContext::create_context(&runtime_state, {}, {});
+
+    auto col_resource =
+            ColumnHelper::create_column<DataTypeString>(std::vector<std::string> {"embed_resource"});
+    auto col_text =
+            ColumnHelper::create_column<DataTypeString>(std::vector<std::string> {"test input"});
+
+    Block block;
+    block.insert({std::move(col_resource), std::make_shared<DataTypeString>(), "resource"});
+    block.insert({std::move(col_text), std::make_shared<DataTypeString>(), "text"});
+    block.insert(
+            {nullptr,
+             std::make_shared<DataTypeArray>(make_nullable(std::make_shared<DataTypeFloat32>())),
+             "result"});
+
+    auto embed_func = FunctionEmbed::create();
+    Status exec_status = embed_func->execute_impl(ctx.get(), block, {0, 1}, 2, 1);
+
+    ASSERT_TRUE(exec_status.ok()) << exec_status.to_string();
+}
+
 TEST(EMBED_TEST, embed_function_text_multi_rows) {
     auto runtime_state = std::make_unique<MockRuntimeState>();
     auto ctx = FunctionContext::create_context(runtime_state.get(), {}, {});

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/AIResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/AIResource.java
@@ -23,6 +23,7 @@ import org.apache.doris.datasource.property.constants.AIProperties;
 import org.apache.doris.thrift.TAIResource;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -94,6 +95,13 @@ public class AIResource extends Resource {
 
     public String getProperty(String propertyKey) {
         return properties.get(propertyKey);
+    }
+
+    public boolean hasCompleteGeneralProperties() {
+        return AIProperties.REQUIRED_FIELDS.stream()
+                .allMatch(field -> !Strings.isNullOrEmpty(properties.get(field)))
+                && ("LOCAL".equalsIgnoreCase(properties.get(AIProperties.PROVIDER_TYPE))
+                        || !Strings.isNullOrEmpty(properties.get(AIProperties.API_KEY)));
     }
 
     private boolean isNeedCheck(Map<String, String> newProperties) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/AIResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/AIResource.java
@@ -127,7 +127,8 @@ public class AIResource extends Resource {
         writeLock();
         for (Map.Entry<String, String> kv : properties.entrySet()) {
             replaceIfEffectiveValue(this.properties, kv.getKey(), kv.getValue());
-            if (kv.getKey().equals(AIProperties.API_KEY)) {
+            if (kv.getKey().equals(AIProperties.API_KEY)
+                    || kv.getKey().equals(AIProperties.EMBED_API_KEY)) {
                 this.properties.put(kv.getKey(), kv.getValue());
             }
         }
@@ -148,7 +149,8 @@ public class AIResource extends Resource {
         readLock();
         result.addRow(Lists.newArrayList(name, lowerCaseType, "version", String.valueOf(version)));
         for (Map.Entry<String, String> entry : properties.entrySet()) {
-            if (entry.getKey().equals(AIProperties.API_KEY)) {
+            if (entry.getKey().equals(AIProperties.API_KEY)
+                    || entry.getKey().equals(AIProperties.EMBED_API_KEY)) {
                 result.addRow(Lists.newArrayList(name, lowerCaseType, entry.getKey(), "******"));
             } else {
                 result.addRow(Lists.newArrayList(name, lowerCaseType, entry.getKey(), entry.getValue()));
@@ -159,10 +161,30 @@ public class AIResource extends Resource {
 
     public TAIResource toThrift() throws NumberFormatException {
         TAIResource tAIResource = new TAIResource();
-        tAIResource.setProviderType(properties.get(AIProperties.PROVIDER_TYPE));
-        tAIResource.setEndpoint(properties.get(AIProperties.ENDPOINT));
-        tAIResource.setApiKey(properties.get(AIProperties.API_KEY));
-        tAIResource.setModelName(properties.get(AIProperties.MODEL_NAME));
+        if (properties.containsKey(AIProperties.PROVIDER_TYPE)) {
+            tAIResource.setProviderType(properties.get(AIProperties.PROVIDER_TYPE));
+        }
+        if (properties.containsKey(AIProperties.ENDPOINT)) {
+            tAIResource.setEndpoint(properties.get(AIProperties.ENDPOINT));
+        }
+        if (properties.containsKey(AIProperties.API_KEY)) {
+            tAIResource.setApiKey(properties.get(AIProperties.API_KEY));
+        }
+        if (properties.containsKey(AIProperties.MODEL_NAME)) {
+            tAIResource.setModelName(properties.get(AIProperties.MODEL_NAME));
+        }
+        if (properties.containsKey(AIProperties.EMBED_PROVIDER_TYPE)) {
+            tAIResource.setEmbedProviderType(properties.get(AIProperties.EMBED_PROVIDER_TYPE));
+        }
+        if (properties.containsKey(AIProperties.EMBED_ENDPOINT)) {
+            tAIResource.setEmbedEndpoint(properties.get(AIProperties.EMBED_ENDPOINT));
+        }
+        if (properties.containsKey(AIProperties.EMBED_API_KEY)) {
+            tAIResource.setEmbedApiKey(properties.get(AIProperties.EMBED_API_KEY));
+        }
+        if (properties.containsKey(AIProperties.EMBED_MODEL_NAME)) {
+            tAIResource.setEmbedModelName(properties.get(AIProperties.EMBED_MODEL_NAME));
+        }
         tAIResource.setAnthropicVersion(properties.get(AIProperties.ANTHROPIC_VERSION));
 
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/AIResource.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/AIResource.java
@@ -185,6 +185,9 @@ public class AIResource extends Resource {
         if (properties.containsKey(AIProperties.EMBED_MODEL_NAME)) {
             tAIResource.setEmbedModelName(properties.get(AIProperties.EMBED_MODEL_NAME));
         }
+        if (!Strings.isNullOrEmpty(properties.get(AIProperties.EFFORT))) {
+            tAIResource.setEffort(properties.get(AIProperties.EFFORT));
+        }
         tAIResource.setAnthropicVersion(properties.get(AIProperties.ANTHROPIC_VERSION));
 
         try {

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/DatasourcePrintableMap.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/DatasourcePrintableMap.java
@@ -44,6 +44,7 @@ public class DatasourcePrintableMap<K, V> extends BasicPrintableMap<K, V> {
         SENSITIVE_KEY.add("jdbc.password");
         SENSITIVE_KEY.add("elasticsearch.password");
         SENSITIVE_KEY.add("ai.api_key");
+        SENSITIVE_KEY.add("ai.embed.api_key");
         SENSITIVE_KEY.addAll(Arrays.asList(
                 MCProperties.SECRET_KEY));
         // DLF 1.0 secret keys. Formerly reflected off AliyunDLFBaseProperties, removed with the DLF 1.0 thrift

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AIProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AIProperties.java
@@ -45,6 +45,7 @@ public class AIProperties extends BaseProperties {
     public static final String RETRY_DELAY_SECOND = "ai.retry_delay_second";
     public static final String ANTHROPIC_VERSION = "ai.anthropic_version";
     public static final String DIMENSIONS = "ai.dimensions";
+    public static final String EFFORT = "ai.effort";
 
     // default_val
     public static final String DEFAULT_TEMPERATURE = "-1";
@@ -62,6 +63,8 @@ public class AIProperties extends BaseProperties {
     public static final List<String> PROVIDERS
             = Arrays.asList("OPENAI", "LOCAL", "GEMINI", "DEEPSEEK", "ANTHROPIC",
             "MOONSHOT", "QWEN", "MINIMAX", "ZHIPU", "BAICHUAN", "VOYAGEAI", "JINA");
+    public static final List<String> EFFORT_LEVELS =
+            Arrays.asList("none", "minimal", "low", "medium", "high", "xhigh", "max");
 
     public static void requiredAIProperties(Map<String, String> properties) throws DdlException {
         boolean hasGeneralProperties = hasAnyProperty(properties, REQUIRED_FIELDS, API_KEY);
@@ -75,6 +78,11 @@ public class AIProperties extends BaseProperties {
         }
         if (hasEmbedProperties) {
             validatePropertyGroup(properties, EMBED_REQUIRED_FIELDS, EMBED_PROVIDER_TYPE, EMBED_API_KEY);
+        }
+
+        String effort = properties.get(EFFORT);
+        if (!Strings.isNullOrEmpty(effort) && !EFFORT_LEVELS.contains(effort)) {
+            throw new DdlException("[" + EFFORT + "] must be one of " + EFFORT_LEVELS);
         }
 
         // Check weather the 'temperature' is valid

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AIProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/property/constants/AIProperties.java
@@ -32,9 +32,13 @@ public class AIProperties extends BaseProperties {
     public static final String ENDPOINT = "ai.endpoint";
     public static final String PROVIDER_TYPE = "ai.provider_type";
     public static final String MODEL_NAME = "ai.model_name";
+    public static final String EMBED_ENDPOINT = "ai.embed.endpoint";
+    public static final String EMBED_PROVIDER_TYPE = "ai.embed.provider_type";
+    public static final String EMBED_MODEL_NAME = "ai.embed.model_name";
 
     // optional
     public static final String API_KEY = "ai.api_key";
+    public static final String EMBED_API_KEY = "ai.embed.api_key";
     public static final String TEMPERATURE = "ai.temperature";
     public static final String MAX_TOKEN = "ai.max_token";
     public static final String MAX_RETRIES = "ai.max_retries";
@@ -53,29 +57,24 @@ public class AIProperties extends BaseProperties {
     public static final String VALIDITY_CHECK = "ai.validity_check";
 
     public static final List<String> REQUIRED_FIELDS = Arrays.asList(ENDPOINT, PROVIDER_TYPE, MODEL_NAME);
+    public static final List<String> EMBED_REQUIRED_FIELDS =
+            Arrays.asList(EMBED_ENDPOINT, EMBED_PROVIDER_TYPE, EMBED_MODEL_NAME);
     public static final List<String> PROVIDERS
             = Arrays.asList("OPENAI", "LOCAL", "GEMINI", "DEEPSEEK", "ANTHROPIC",
             "MOONSHOT", "QWEN", "MINIMAX", "ZHIPU", "BAICHUAN", "VOYAGEAI", "JINA");
 
     public static void requiredAIProperties(Map<String, String> properties) throws DdlException {
-        // Check required field
-        for (String field : REQUIRED_FIELDS) {
-            if (Strings.isNullOrEmpty(properties.get(field))) {
-                throw new DdlException("Missing [" + field + "] in properties.");
-            }
+        boolean hasGeneralProperties = hasAnyProperty(properties, REQUIRED_FIELDS, API_KEY);
+        boolean hasEmbedProperties = hasAnyProperty(properties, EMBED_REQUIRED_FIELDS, EMBED_API_KEY);
+        if (!hasGeneralProperties && !hasEmbedProperties) {
+            throw new DdlException("At least one complete AI property group must be configured.");
         }
 
-        // Check the provider is valid
-        properties.put(PROVIDER_TYPE, properties.get(PROVIDER_TYPE).toUpperCase());
-        if (PROVIDERS.stream().noneMatch(s -> s.equals(properties.get(PROVIDER_TYPE).toUpperCase()))) {
-            throw new DdlException("Provider must be one of " + PROVIDERS);
+        if (hasGeneralProperties) {
+            validatePropertyGroup(properties, REQUIRED_FIELDS, PROVIDER_TYPE, API_KEY);
         }
-
-        // Only the 'local' provider can ignore the 'api-key'
-        if (!"LOCAL".equals(properties.get(AIProperties.PROVIDER_TYPE))
-                && Strings.isNullOrEmpty(properties.get(AIProperties.API_KEY))) {
-            throw new DdlException("Missing [" + API_KEY + "] in properties for provider: "
-                    + properties.get(AIProperties.PROVIDER_TYPE));
+        if (hasEmbedProperties) {
+            validatePropertyGroup(properties, EMBED_REQUIRED_FIELDS, EMBED_PROVIDER_TYPE, EMBED_API_KEY);
         }
 
         // Check weather the 'temperature' is valid
@@ -94,6 +93,30 @@ public class AIProperties extends BaseProperties {
             if (tempVal <= 0) {
                 throw new DdlException("Dimensions must be a positive integer");
             }
+        }
+    }
+
+    private static boolean hasAnyProperty(Map<String, String> properties, List<String> requiredFields,
+            String apiKeyField) {
+        return properties.containsKey(apiKeyField) || requiredFields.stream().anyMatch(properties::containsKey);
+    }
+
+    private static void validatePropertyGroup(Map<String, String> properties, List<String> requiredFields,
+            String providerTypeField, String apiKeyField) throws DdlException {
+        for (String field : requiredFields) {
+            if (Strings.isNullOrEmpty(properties.get(field))) {
+                throw new DdlException("Missing [" + field + "] in properties.");
+            }
+        }
+
+        String providerType = properties.get(providerTypeField).toUpperCase();
+        properties.put(providerTypeField, providerType);
+        if (!PROVIDERS.contains(providerType)) {
+            throw new DdlException("Provider must be one of " + PROVIDERS);
+        }
+
+        if (!"LOCAL".equals(providerType) && Strings.isNullOrEmpty(properties.get(apiKeyField))) {
+            throw new DdlException("Missing [" + apiKeyField + "] in properties for provider: " + providerType);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/AIAgg.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/agg/AIAgg.java
@@ -90,6 +90,10 @@ public class AIAgg extends NullableAggregateFunction
             if (!(resource instanceof AIResource)) {
                 throw new AnalysisException("AI resource '" + resourceName + "' does not exist");
             }
+            if (!((AIResource) resource).hasCompleteGeneralProperties()) {
+                throw new AnalysisException("AI resource '" + resourceName
+                        + "' does not contain complete general AI properties");
+            }
             Resource.registerUsedAIResourceName(resourceName);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ai/AIFunction.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ai/AIFunction.java
@@ -61,6 +61,10 @@ public abstract class AIFunction extends ScalarFunction
             if (!(resource instanceof AIResource)) {
                 throw new AnalysisException("AI resource '" + resourceName + "' does not exist");
             }
+            if (!((AIResource) resource).hasCompleteGeneralProperties()) {
+                throw new AnalysisException("AI resource '" + resourceName
+                        + "' does not contain complete general AI properties");
+            }
             Resource.registerUsedAIResourceName(resourceName);
         }
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ai/Embed.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ai/Embed.java
@@ -31,8 +31,10 @@ import org.apache.doris.nereids.types.FloatType;
 import org.apache.doris.nereids.types.JsonType;
 import org.apache.doris.nereids.types.StringType;
 import org.apache.doris.nereids.types.VarcharType;
+import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -58,7 +60,7 @@ public class Embed extends AIFunction {
      * constructor with 1 argument.
      */
     public Embed(Expression arg) {
-        this(new StringLiteral(getResourceName()), arg);
+        this(new StringLiteral(getResourceName(arg)), arg);
     }
 
     /**
@@ -68,12 +70,22 @@ public class Embed extends AIFunction {
         super("embed", arg0, arg1);
     }
 
+    /**
+     * Get the default resource for EMBED.
+     */
+    private static String getResourceName(Expression input) throws AnalysisException {
+        String resourceName = input.getDataType().isJsonType()
+                ? ConnectContext.get().getSessionVariable().defaultMultimodalEmbedResource
+                : ConnectContext.get().getSessionVariable().defaultEmbedResource;
+        return Strings.isNullOrEmpty(resourceName) ? AIFunction.getResourceName() : resourceName;
+    }
+
     @Override
     public Embed withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() >= 1 && children.size() <= 2,
                 "Function EMBED only accepts 1 or 2 arguments");
         if (children.size() == 1) {
-            return new Embed(new StringLiteral(getResourceName()),
+            return new Embed(new StringLiteral(getResourceName(children.get(0))),
                     children.get(0));
         }
         return new Embed(children.get(0), children.get(1));

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ai/Embed.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ai/Embed.java
@@ -108,6 +108,11 @@ public class Embed extends AIFunction {
         throw new AnalysisException("Function EMBED only accepts 1 or 2 arguments");
     }
 
+    @Override
+    public void checkLegalityAfterRewrite() {
+        checkLegalityBeforeTypeCoercion();
+    }
+
     private static String requireStringLiteral(Expression arg, String argName, String errorMsg) {
         if (!(arg instanceof StringLikeLiteral)) {
             throw new AnalysisException(errorMsg);

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ai/Embed.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/ai/Embed.java
@@ -31,10 +31,8 @@ import org.apache.doris.nereids.types.FloatType;
 import org.apache.doris.nereids.types.JsonType;
 import org.apache.doris.nereids.types.StringType;
 import org.apache.doris.nereids.types.VarcharType;
-import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -60,7 +58,7 @@ public class Embed extends AIFunction {
      * constructor with 1 argument.
      */
     public Embed(Expression arg) {
-        this(new StringLiteral(getResourceName(arg)), arg);
+        this(new StringLiteral(getResourceName()), arg);
     }
 
     /**
@@ -70,22 +68,12 @@ public class Embed extends AIFunction {
         super("embed", arg0, arg1);
     }
 
-    /**
-     * Get the default resource for EMBED.
-     */
-    private static String getResourceName(Expression input) throws AnalysisException {
-        String resourceName = input.getDataType().isJsonType()
-                ? ConnectContext.get().getSessionVariable().defaultMultimodalEmbedResource
-                : ConnectContext.get().getSessionVariable().defaultEmbedResource;
-        return Strings.isNullOrEmpty(resourceName) ? AIFunction.getResourceName() : resourceName;
-    }
-
     @Override
     public Embed withChildren(List<Expression> children) {
         Preconditions.checkArgument(children.size() >= 1 && children.size() <= 2,
                 "Function EMBED only accepts 1 or 2 arguments");
         if (children.size() == 1) {
-            return new Embed(new StringLiteral(getResourceName(children.get(0))),
+            return new Embed(new StringLiteral(getResourceName()),
                     children.get(0));
         }
         return new Embed(children.get(0), children.get(1));

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -999,8 +999,6 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_STRICT_CAST = "enable_strict_cast";
 
     public static final String DEFAULT_AI_RESOURCE = "default_ai_resource";
-    public static final String DEFAULT_EMBED_RESOURCE = "default_embed_resource";
-    public static final String DEFAULT_MULTIMODAL_EMBED_RESOURCE = "default_multimodal_embed_resource";
     public static final String FILE_PRESIGNED_URL_TTL_SECONDS = "file_presigned_url_ttl_seconds";
     public static final String EMBED_MAX_BATCH_SIZE = "embed_max_batch_size";
     public static final String AI_CONTEXT_WINDOW_SIZE = "ai_context_window_size";
@@ -3448,14 +3446,6 @@ public class SessionVariable implements Serializable, Writable {
             description = "Defines the default AI resource to be used when no specific AI resource is specified "
                     + "in the function arguments.")
     public String defaultAIResource = "";
-
-    @VarAttrDef.VarAttr(name = DEFAULT_EMBED_RESOURCE, needForward = true,
-            description = "Defines the default AI resource used by EMBED when no resource is specified.")
-    public String defaultEmbedResource = "";
-
-    @VarAttrDef.VarAttr(name = DEFAULT_MULTIMODAL_EMBED_RESOURCE, needForward = true,
-            description = "Defines the default AI resource used by multimodal EMBED when no resource is specified.")
-    public String defaultMultimodalEmbedResource = "";
 
     @VarAttrDef.VarAttr(name = FILE_PRESIGNED_URL_TTL_SECONDS, needForward = true,
             description = "Expiration time in seconds for S3 presigned URL used by multimodal EMBED.")

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/SessionVariable.java
@@ -999,6 +999,8 @@ public class SessionVariable implements Serializable, Writable {
     public static final String ENABLE_STRICT_CAST = "enable_strict_cast";
 
     public static final String DEFAULT_AI_RESOURCE = "default_ai_resource";
+    public static final String DEFAULT_EMBED_RESOURCE = "default_embed_resource";
+    public static final String DEFAULT_MULTIMODAL_EMBED_RESOURCE = "default_multimodal_embed_resource";
     public static final String FILE_PRESIGNED_URL_TTL_SECONDS = "file_presigned_url_ttl_seconds";
     public static final String EMBED_MAX_BATCH_SIZE = "embed_max_batch_size";
     public static final String AI_CONTEXT_WINDOW_SIZE = "ai_context_window_size";
@@ -3446,6 +3448,14 @@ public class SessionVariable implements Serializable, Writable {
             description = "Defines the default AI resource to be used when no specific AI resource is specified "
                     + "in the function arguments.")
     public String defaultAIResource = "";
+
+    @VarAttrDef.VarAttr(name = DEFAULT_EMBED_RESOURCE, needForward = true,
+            description = "Defines the default AI resource used by EMBED when no resource is specified.")
+    public String defaultEmbedResource = "";
+
+    @VarAttrDef.VarAttr(name = DEFAULT_MULTIMODAL_EMBED_RESOURCE, needForward = true,
+            description = "Defines the default AI resource used by multimodal EMBED when no resource is specified.")
+    public String defaultMultimodalEmbedResource = "";
 
     @VarAttrDef.VarAttr(name = FILE_PRESIGNED_URL_TTL_SECONDS, needForward = true,
             description = "Expiration time in seconds for S3 presigned URL used by multimodal EMBED.")

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/AIResourceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/AIResourceTest.java
@@ -23,6 +23,7 @@ import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.FeMetaVersion;
 import org.apache.doris.common.UserException;
 import org.apache.doris.common.io.Text;
+import org.apache.doris.common.proc.BaseProcResult;
 import org.apache.doris.datasource.property.constants.AIProperties;
 import org.apache.doris.meta.MetaContext;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
@@ -210,6 +211,91 @@ public class AIResourceTest {
                 Resource.fromCommand(createResourceCommand);
             }
         });
+    }
+
+    @Test
+    public void testEmbedOnlyResource() throws DdlException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(AIProperties.EMBED_ENDPOINT, "https://api.example.com/v1/embeddings");
+        properties.put(AIProperties.EMBED_PROVIDER_TYPE, "openai");
+        properties.put(AIProperties.EMBED_MODEL_NAME, "text-embedding-model");
+        properties.put(AIProperties.EMBED_API_KEY, "embed-api-key");
+
+        AIResource aiResource = new AIResource("embed-only-resource");
+        aiResource.setProperties(ImmutableMap.copyOf(properties));
+
+        Assertions.assertEquals("OPENAI", aiResource.getProperty(AIProperties.EMBED_PROVIDER_TYPE));
+        Assertions.assertEquals("https://api.example.com/v1/embeddings",
+                aiResource.toThrift().getEmbedEndpoint());
+        Assertions.assertEquals("OPENAI", aiResource.toThrift().getEmbedProviderType());
+        Assertions.assertEquals("text-embedding-model", aiResource.toThrift().getEmbedModelName());
+        Assertions.assertEquals("embed-api-key", aiResource.toThrift().getEmbedApiKey());
+        Assertions.assertFalse(aiResource.toThrift().isSetEndpoint());
+    }
+
+    @Test
+    public void testLocalEmbedResourceWithoutApiKey() throws DdlException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(AIProperties.EMBED_ENDPOINT, "http://localhost:8000/v1/embeddings");
+        properties.put(AIProperties.EMBED_PROVIDER_TYPE, "local");
+        properties.put(AIProperties.EMBED_MODEL_NAME, "local-embedding-model");
+
+        AIResource aiResource = new AIResource("local-embed-resource");
+        aiResource.setProperties(ImmutableMap.copyOf(properties));
+
+        Assertions.assertEquals("LOCAL", aiResource.getProperty(AIProperties.EMBED_PROVIDER_TYPE));
+    }
+
+    @Test
+    public void testRejectEmbedResourceWithoutApiKey() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(AIProperties.EMBED_ENDPOINT, "https://api.example.com/v1/embeddings");
+        properties.put(AIProperties.EMBED_PROVIDER_TYPE, "openai");
+        properties.put(AIProperties.EMBED_MODEL_NAME, "text-embedding-model");
+
+        AIResource aiResource = new AIResource("embed-resource-without-api-key");
+        DdlException exception = Assertions.assertThrows(DdlException.class,
+                () -> aiResource.setProperties(ImmutableMap.copyOf(properties)));
+        Assertions.assertTrue(exception.getMessage().contains("ai.embed.api_key"));
+    }
+
+    @Test
+    public void testMaskEmbedApiKey() throws DdlException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(AIProperties.EMBED_ENDPOINT, "https://api.example.com/v1/embeddings");
+        properties.put(AIProperties.EMBED_PROVIDER_TYPE, "openai");
+        properties.put(AIProperties.EMBED_MODEL_NAME, "text-embedding-model");
+        properties.put(AIProperties.EMBED_API_KEY, "embed-api-key");
+
+        AIResource aiResource = new AIResource("embed-resource");
+        aiResource.setProperties(ImmutableMap.copyOf(properties));
+        BaseProcResult result = new BaseProcResult();
+        aiResource.getProcNodeData(result);
+
+        Assertions.assertTrue(result.getRows().stream().anyMatch(row ->
+                AIProperties.EMBED_API_KEY.equals(row.get(2)) && "******".equals(row.get(3))));
+        Assertions.assertFalse(result.getRows().stream().anyMatch(row -> row.contains("embed-api-key")));
+    }
+
+    @Test
+    public void testRejectPartialEmbedProperties() throws DdlException {
+        Map<String, String> properties = new HashMap<>(aiProperties);
+        properties.put(AIProperties.EMBED_ENDPOINT, "https://api.example.com/v1/embeddings");
+
+        AIResource aiResource = new AIResource("partial-embed-resource");
+        DdlException exception = Assertions.assertThrows(DdlException.class,
+                () -> aiResource.setProperties(ImmutableMap.copyOf(properties)));
+        Assertions.assertTrue(exception.getMessage().contains("ai.embed.provider_type"));
+    }
+
+    @Test
+    public void testRejectResourceWithoutCompletePropertyGroup() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("ai.validity_check", "false");
+
+        AIResource aiResource = new AIResource("empty-ai-resource");
+        Assertions.assertThrows(DdlException.class,
+                () -> aiResource.setProperties(ImmutableMap.copyOf(properties)));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/AIResourceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/AIResourceTest.java
@@ -28,6 +28,11 @@ import org.apache.doris.datasource.property.constants.AIProperties;
 import org.apache.doris.meta.MetaContext;
 import org.apache.doris.mysql.privilege.AccessControllerManager;
 import org.apache.doris.mysql.privilege.PrivPredicate;
+import org.apache.doris.nereids.exceptions.AnalysisException;
+import org.apache.doris.nereids.trees.expressions.functions.agg.AIAgg;
+import org.apache.doris.nereids.trees.expressions.functions.ai.AISentiment;
+import org.apache.doris.nereids.trees.expressions.functions.ai.Embed;
+import org.apache.doris.nereids.trees.expressions.literal.StringLiteral;
 import org.apache.doris.nereids.trees.plans.commands.CreateResourceCommand;
 import org.apache.doris.nereids.trees.plans.commands.info.CreateResourceInfo;
 import org.apache.doris.persist.EditLog;
@@ -231,6 +236,67 @@ public class AIResourceTest {
         Assertions.assertEquals("text-embedding-model", aiResource.toThrift().getEmbedModelName());
         Assertions.assertEquals("embed-api-key", aiResource.toThrift().getEmbedApiKey());
         Assertions.assertFalse(aiResource.toThrift().isSetEndpoint());
+    }
+
+    @Test
+    public void testRejectEmbedOnlyResourceForNonEmbedScalarFunction() throws DdlException {
+        AIResource aiResource = createEmbedOnlyResource();
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            ResourceMgr resourceMgr = Mockito.mock(ResourceMgr.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getResourceMgr()).thenReturn(resourceMgr);
+            Mockito.when(resourceMgr.getResource("embed-only-resource")).thenReturn(aiResource);
+
+            AISentiment function = new AISentiment(new StringLiteral("embed-only-resource"),
+                    new StringLiteral("text"));
+            Assertions.assertThrows(AnalysisException.class, function::checkLegalityAfterRewrite);
+        }
+    }
+
+    @Test
+    public void testRejectEmbedOnlyResourceForAiAgg() throws DdlException {
+        AIResource aiResource = createEmbedOnlyResource();
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            ResourceMgr resourceMgr = Mockito.mock(ResourceMgr.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getResourceMgr()).thenReturn(resourceMgr);
+            Mockito.when(resourceMgr.getResource("embed-only-resource")).thenReturn(aiResource);
+
+            AIAgg function = new AIAgg(new StringLiteral("embed-only-resource"),
+                    new StringLiteral("text"), new StringLiteral("task"));
+            Assertions.assertThrows(AnalysisException.class, function::checkLegalityAfterRewrite);
+        }
+    }
+
+    @Test
+    public void testAcceptEmbedOnlyResourceForEmbedFunction() throws DdlException {
+        AIResource aiResource = createEmbedOnlyResource();
+        try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {
+            Env env = Mockito.mock(Env.class);
+            ResourceMgr resourceMgr = Mockito.mock(ResourceMgr.class);
+            mockedEnv.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getResourceMgr()).thenReturn(resourceMgr);
+            Mockito.when(resourceMgr.getResource("embed-only-resource")).thenReturn(aiResource);
+
+            Embed function = new Embed(new StringLiteral("embed-only-resource"),
+                    new StringLiteral("text"));
+            Assertions.assertDoesNotThrow(function::checkLegalityBeforeTypeCoercion);
+            Assertions.assertDoesNotThrow(function::checkLegalityAfterRewrite);
+        }
+    }
+
+    private AIResource createEmbedOnlyResource() throws DdlException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(AIProperties.EMBED_ENDPOINT, "https://api.example.com/v1/embeddings");
+        properties.put(AIProperties.EMBED_PROVIDER_TYPE, "openai");
+        properties.put(AIProperties.EMBED_MODEL_NAME, "text-embedding-model");
+        properties.put(AIProperties.EMBED_API_KEY, "embed-api-key");
+
+        AIResource aiResource = new AIResource("embed-only-resource");
+        aiResource.setProperties(ImmutableMap.copyOf(properties));
+        return aiResource;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/catalog/AIResourceTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/catalog/AIResourceTest.java
@@ -299,6 +299,41 @@ public class AIResourceTest {
     }
 
     @Test
+    public void testRejectInvalidEffort() {
+        Map<String, String> properties = new HashMap<>(aiProperties);
+        properties.put(AIProperties.EFFORT, "invalid");
+
+        AIResource aiResource = new AIResource("invalid-effort-resource");
+        DdlException exception = Assertions.assertThrows(DdlException.class,
+                () -> aiResource.setProperties(ImmutableMap.copyOf(properties)));
+        Assertions.assertTrue(exception.getMessage().contains(AIProperties.EFFORT));
+    }
+
+    @Test
+    public void testValidEffortIsForwarded() throws DdlException {
+        for (String effort : AIProperties.EFFORT_LEVELS) {
+            Map<String, String> properties = new HashMap<>(aiProperties);
+            properties.put(AIProperties.EFFORT, effort);
+
+            AIResource aiResource = new AIResource("effort-resource");
+            aiResource.setProperties(ImmutableMap.copyOf(properties));
+
+            Assertions.assertEquals(effort, aiResource.toThrift().getEffort());
+        }
+    }
+
+    @Test
+    public void testEmptyEffortIsNotForwarded() throws DdlException {
+        Map<String, String> properties = new HashMap<>(aiProperties);
+        properties.put(AIProperties.EFFORT, "");
+
+        AIResource aiResource = new AIResource("empty-effort-resource");
+        aiResource.setProperties(ImmutableMap.copyOf(properties));
+
+        Assertions.assertFalse(aiResource.toThrift().isSetEffort());
+    }
+
+    @Test
     public void testInvalidProvider() throws UserException {
         Assertions.assertThrows(DdlException.class, () -> {
             try (MockedStatic<Env> mockedEnv = Mockito.mockStatic(Env.class)) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/RepositoryAuditEncryptionTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/parser/RepositoryAuditEncryptionTest.java
@@ -66,9 +66,11 @@ public class RepositoryAuditEncryptionTest {
         String sql = "CREATE EXTERNAL RESOURCE \"ai_resource\" PROPERTIES ("
                 + "\"type\" = \"ai\", "
                 + "\"ai.api_key\" = \"sk-test\", "
+                + "\"ai.embed.api_key\" = \"embed-sk-test\", "
                 + "\"ai.endpoint\" = \"https://api.test\")";
         String masked = encrypt(sql);
         Assertions.assertFalse(masked.contains("sk-test"), masked);
+        Assertions.assertFalse(masked.contains("embed-sk-test"), masked);
         Assertions.assertTrue(masked.contains("*XXX"), masked);
         Assertions.assertTrue(masked.contains("https://api.test"), masked);
     }
@@ -77,9 +79,11 @@ public class RepositoryAuditEncryptionTest {
     public void testAlterResourceMasksAiApiKey() {
         String sql = "ALTER RESOURCE \"ai_resource\" PROPERTIES ("
                 + "\"ai.api_key\" = \"sk-test\", "
+                + "\"ai.embed.api_key\" = \"embed-sk-test\", "
                 + "\"ai.endpoint\" = \"https://api.test\")";
         String masked = encrypt(sql);
         Assertions.assertFalse(masked.contains("sk-test"), masked);
+        Assertions.assertFalse(masked.contains("embed-sk-test"), masked);
         Assertions.assertTrue(masked.contains("*XXX"), masked);
         Assertions.assertTrue(masked.contains("https://api.test"), masked);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
@@ -27,6 +27,8 @@ import org.apache.doris.common.ExceptionChecker;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.rules.rewrite.eageraggregation.EagerAggHints.Action;
+import org.apache.doris.nereids.trees.expressions.functions.ai.AIFunction;
+import org.apache.doris.nereids.trees.expressions.functions.ai.Embed;
 import org.apache.doris.thrift.TQueryOptions;
 import org.apache.doris.utframe.TestWithFeService;
 
@@ -274,6 +276,64 @@ public class SessionVariablesTest extends TestWithFeService {
                         SessionVariable.AI_CONTEXT_WINDOW_SIZE, new IntLiteral(-1))));
         Assertions.assertTrue(contextException.getMessage().contains(SessionVariable.AI_CONTEXT_WINDOW_SIZE));
         Assertions.assertEquals(1, sv.aiContextWindowSize);
+    }
+
+    @Test
+    public void testDefaultEmbedResources() throws Exception {
+        SessionVariable sv = new SessionVariable();
+
+        VariableMgr.setVar(sv, new SetVar(SetType.SESSION, SessionVariable.DEFAULT_EMBED_RESOURCE,
+                new StringLiteral("embed_resource")));
+        VariableMgr.setVar(sv, new SetVar(SetType.SESSION, SessionVariable.DEFAULT_MULTIMODAL_EMBED_RESOURCE,
+                new StringLiteral("multimodal_resource")));
+
+        Assertions.assertEquals("embed_resource", sv.defaultEmbedResource);
+        Assertions.assertEquals("multimodal_resource", sv.defaultMultimodalEmbedResource);
+    }
+
+    @Test
+    public void testEmbedDefaultResourceDependsOnLastArgumentTypeAndFallsBackToDefaultAiResource() {
+        connectContext.setThreadLocalInfo();
+        SessionVariable sv = connectContext.getSessionVariable();
+        String originalDefaultAIResource = sv.defaultAIResource;
+        String originalDefaultEmbedResource = sv.defaultEmbedResource;
+        String originalDefaultMultimodalEmbedResource = sv.defaultMultimodalEmbedResource;
+        try {
+            sv.defaultAIResource = "ai_resource";
+            sv.defaultEmbedResource = "embed_resource";
+            sv.defaultMultimodalEmbedResource = "multimodal_embed_resource";
+
+            Embed textEmbed = new Embed(
+                    new org.apache.doris.nereids.trees.expressions.literal.StringLiteral("text"));
+            Assertions.assertEquals("embed_resource",
+                    ((org.apache.doris.nereids.trees.expressions.literal.StringLiteral)
+                            textEmbed.getArgument(0)).getValue());
+
+            Embed multimodalEmbed = new Embed(
+                    new org.apache.doris.nereids.trees.expressions.literal.JsonLiteral("{\"url\":\"image\"}"));
+            Assertions.assertEquals("multimodal_embed_resource",
+                    ((org.apache.doris.nereids.trees.expressions.literal.StringLiteral)
+                            multimodalEmbed.getArgument(0)).getValue());
+            Assertions.assertEquals("ai_resource", AIFunction.getResourceName());
+
+            sv.defaultEmbedResource = "";
+            textEmbed = new Embed(
+                    new org.apache.doris.nereids.trees.expressions.literal.StringLiteral("text"));
+            Assertions.assertEquals("ai_resource",
+                    ((org.apache.doris.nereids.trees.expressions.literal.StringLiteral)
+                            textEmbed.getArgument(0)).getValue());
+
+            sv.defaultMultimodalEmbedResource = "";
+            multimodalEmbed = new Embed(
+                    new org.apache.doris.nereids.trees.expressions.literal.JsonLiteral("{\"url\":\"image\"}"));
+            Assertions.assertEquals("ai_resource",
+                    ((org.apache.doris.nereids.trees.expressions.literal.StringLiteral)
+                            multimodalEmbed.getArgument(0)).getValue());
+        } finally {
+            sv.defaultAIResource = originalDefaultAIResource;
+            sv.defaultEmbedResource = originalDefaultEmbedResource;
+            sv.defaultMultimodalEmbedResource = originalDefaultMultimodalEmbedResource;
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/SessionVariablesTest.java
@@ -27,8 +27,6 @@ import org.apache.doris.common.ExceptionChecker;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.rules.rewrite.eageraggregation.EagerAggHints.Action;
-import org.apache.doris.nereids.trees.expressions.functions.ai.AIFunction;
-import org.apache.doris.nereids.trees.expressions.functions.ai.Embed;
 import org.apache.doris.thrift.TQueryOptions;
 import org.apache.doris.utframe.TestWithFeService;
 
@@ -276,64 +274,6 @@ public class SessionVariablesTest extends TestWithFeService {
                         SessionVariable.AI_CONTEXT_WINDOW_SIZE, new IntLiteral(-1))));
         Assertions.assertTrue(contextException.getMessage().contains(SessionVariable.AI_CONTEXT_WINDOW_SIZE));
         Assertions.assertEquals(1, sv.aiContextWindowSize);
-    }
-
-    @Test
-    public void testDefaultEmbedResources() throws Exception {
-        SessionVariable sv = new SessionVariable();
-
-        VariableMgr.setVar(sv, new SetVar(SetType.SESSION, SessionVariable.DEFAULT_EMBED_RESOURCE,
-                new StringLiteral("embed_resource")));
-        VariableMgr.setVar(sv, new SetVar(SetType.SESSION, SessionVariable.DEFAULT_MULTIMODAL_EMBED_RESOURCE,
-                new StringLiteral("multimodal_resource")));
-
-        Assertions.assertEquals("embed_resource", sv.defaultEmbedResource);
-        Assertions.assertEquals("multimodal_resource", sv.defaultMultimodalEmbedResource);
-    }
-
-    @Test
-    public void testEmbedDefaultResourceDependsOnLastArgumentTypeAndFallsBackToDefaultAiResource() {
-        connectContext.setThreadLocalInfo();
-        SessionVariable sv = connectContext.getSessionVariable();
-        String originalDefaultAIResource = sv.defaultAIResource;
-        String originalDefaultEmbedResource = sv.defaultEmbedResource;
-        String originalDefaultMultimodalEmbedResource = sv.defaultMultimodalEmbedResource;
-        try {
-            sv.defaultAIResource = "ai_resource";
-            sv.defaultEmbedResource = "embed_resource";
-            sv.defaultMultimodalEmbedResource = "multimodal_embed_resource";
-
-            Embed textEmbed = new Embed(
-                    new org.apache.doris.nereids.trees.expressions.literal.StringLiteral("text"));
-            Assertions.assertEquals("embed_resource",
-                    ((org.apache.doris.nereids.trees.expressions.literal.StringLiteral)
-                            textEmbed.getArgument(0)).getValue());
-
-            Embed multimodalEmbed = new Embed(
-                    new org.apache.doris.nereids.trees.expressions.literal.JsonLiteral("{\"url\":\"image\"}"));
-            Assertions.assertEquals("multimodal_embed_resource",
-                    ((org.apache.doris.nereids.trees.expressions.literal.StringLiteral)
-                            multimodalEmbed.getArgument(0)).getValue());
-            Assertions.assertEquals("ai_resource", AIFunction.getResourceName());
-
-            sv.defaultEmbedResource = "";
-            textEmbed = new Embed(
-                    new org.apache.doris.nereids.trees.expressions.literal.StringLiteral("text"));
-            Assertions.assertEquals("ai_resource",
-                    ((org.apache.doris.nereids.trees.expressions.literal.StringLiteral)
-                            textEmbed.getArgument(0)).getValue());
-
-            sv.defaultMultimodalEmbedResource = "";
-            multimodalEmbed = new Embed(
-                    new org.apache.doris.nereids.trees.expressions.literal.JsonLiteral("{\"url\":\"image\"}"));
-            Assertions.assertEquals("ai_resource",
-                    ((org.apache.doris.nereids.trees.expressions.literal.StringLiteral)
-                            multimodalEmbed.getArgument(0)).getValue());
-        } finally {
-            sv.defaultAIResource = originalDefaultAIResource;
-            sv.defaultEmbedResource = originalDefaultEmbedResource;
-            sv.defaultMultimodalEmbedResource = originalDefaultMultimodalEmbedResource;
-        }
     }
 
     @Test

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -678,9 +678,9 @@ enum TCompoundType {
 }
 
 struct TAIResource {
-  1: required string endpoint
-  2: required string provider_type
-  3: required string model_name
+  1: optional string endpoint
+  2: optional string provider_type
+  3: optional string model_name
   4: optional string api_key
   5: optional double temperature
   6: optional i64 max_tokens
@@ -688,6 +688,10 @@ struct TAIResource {
   8: optional i32 retry_delay_second
   9: optional string anthropic_version
   10: optional i32 dimensions
+  11: optional string embed_endpoint
+  12: optional string embed_provider_type
+  13: optional string embed_model_name
+  14: optional string embed_api_key
 }
 
 struct TCondition {

--- a/gensrc/thrift/PaloInternalService.thrift
+++ b/gensrc/thrift/PaloInternalService.thrift
@@ -692,6 +692,7 @@ struct TAIResource {
   12: optional string embed_provider_type
   13: optional string embed_model_name
   14: optional string embed_api_key
+  15: optional string effort
 }
 
 struct TCondition {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #xxx

Problem Summary:

- Add dedicated embedding properties to AI resources:
  - `ai.embed.endpoint`
  - `ai.embed.provider_type`
  - `ai.embed.model_name`
  - `ai.embed.api_key`
- Require at least one complete property group when creating an AI resource:
  - the general `ai.*` group, or
  - the `ai.embed.*` group
- Use `ai.embed.*` when executing the `EMBED` function if the embed property group is configured.
- Fall back to the general `ai.*` properties otherwise.
- Mask `ai.embed.api_key` when displaying resource properties.
- Keep other AI functions using the general `ai.*` properties.

```text
Doris> CREATE RESOURCE 'default_combine_resource'
    -> PROPERTIES (
    ->     'type' = 'ai',
    -> 
    ->     'ai.provider_type' = 'QWEN',
    ->     'ai.endpoint' = 'https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions',
    ->     'ai.model_name' = 'qwen-plus',
    ->     'ai.api_key' = '<general-api-key>',
    ->     'ai.effort' = 'high',
    -> 
    ->     'ai.embed.provider_type' = 'QWEN',
    ->     'ai.embed.endpoint' = 'https://dashscope.aliyuncs.com/compatible-mode/v1/embeddings',
    ->     'ai.embed.model_name' = 'text-embedding-v4',
    ->     'ai.embed.api_key' = '<embedding-api-key>',
    -> 
    ->     'ai.embed.mm.provider_type' = 'QWEN',
    ->     'ai.embed.mm.endpoint' = 'https://dashscope.aliyuncs.com/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding',
    ->     'ai.embed.mm.model_name' = 'qwen3-vl-embedding',
    ->     'ai.embed.mm.api_key' = '<multimodal-api-key>',
    -> 
    ->     'ai.dimensions' = '1024'
    -> );
Query OK, 0 rows affected (0.026 sec)

Doris> set default_ai_resource = 'default_combine_resource';
Query OK, 0 rows affected (0.009 sec)

Doris> SELECT array_size(EMBED('this is a test'));
+-------------------------------------+
| array_size(EMBED('this is a test')) |
+-------------------------------------+
|                                1024 |
+-------------------------------------+
1 row in set (1.729 sec)

Doris> EXPLAIN SELECT array_size(EMBED('this is a test'));
+---------------------------------------------------------------------------+
| Explain String(Nereids Planner)                                           |
+---------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                           |
|   OUTPUT EXPRS:                                                           |
|     array_size(EMBED('this is a test'))[#0]                               |
|   PARTITION: UNPARTITIONED                                                |
|                                                                           |
|   HAS_COLO_PLAN_NODE: false                                               |
|                                                                           |
|   VRESULT SINK                                                            |
|      MYSQL_PROTOCOL                                                       |
|                                                                           |
|   0:VUNION(11)                                                            |
|      constant exprs:                                                      |
|          cardinality(embed('default_combine_resource', 'this is a test')) |
|                                                                           |
|                                                                           |
|                                                                           |
| ========== STATISTICS ==========                                          |
+---------------------------------------------------------------------------+
17 rows in set (0.030 sec)

Doris> SELECT AI_TRANSLATE('this is a test', 'chinese');
+-------------------------------------------+
| AI_TRANSLATE('this is a test', 'chinese') |
+-------------------------------------------+
| 这是一个测试                              |
+-------------------------------------------+
1 row in set (1.269 sec)

Doris> EXPLAIN SELECT AI_TRANSLATE('this is a test', 'chinese');
+--------------------------------------------------------------------------------+
| Explain String(Nereids Planner)                                                |
+--------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                |
|   OUTPUT EXPRS:                                                                |
|     AI_TRANSLATE('this is a test', 'chinese')[#0]                              |
|   PARTITION: UNPARTITIONED                                                     |
|                                                                                |
|   HAS_COLO_PLAN_NODE: false                                                    |
|                                                                                |
|   VRESULT SINK                                                                 |
|      MYSQL_PROTOCOL                                                            |
|                                                                                |
|   0:VUNION(11)                                                                 |
|      constant exprs:                                                           |
|          ai_translate('default_combine_resource', 'this is a test', 'chinese') |
|                                                                                |
|                                                                                |
|                                                                                |
| ========== STATISTICS ==========                                               |
+--------------------------------------------------------------------------------+
17 rows in set (0.010 sec)

Doris> EXPLAIN SELECT EMBED(
    ->     CAST(
    ->         '{"content_type":"image/png","uri":"https://example.com/image.png"}'
    ->         AS JSON
    ->     )
    -> );
+--------------------------------------------------------------------------------------------------------------------------------+
| Explain String(Nereids Planner)                                                                                                |
+--------------------------------------------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                                                                |
|   OUTPUT EXPRS:                                                                                                                |
|     EMBED(                                                                                                                     |
|     CAST(                                                                                                                      |
|         '{"content_type":"image/png","uri":"https://example.com/image.png"}'                                                   |
|         AS JSON                                                                                                                |
|     )                                                                                                                          |
| )[#0]                                                                                                                          |
|   PARTITION: UNPARTITIONED                                                                                                     |
|                                                                                                                                |
|   HAS_COLO_PLAN_NODE: false                                                                                                    |
|                                                                                                                                |
|   VRESULT SINK                                                                                                                 |
|      MYSQL_PROTOCOL                                                                                                            |
|                                                                                                                                |
|   0:VUNION(11)                                                                                                                 |
|      constant exprs:                                                                                                           |
|          embed('default_combine_resource', CAST('{"content_type":"image/png","uri":"https://example.com/image.png"}' AS json)) |
|                                                                                                                                |
|                                                                                                                                |
|                                                                                                                                |
| ========== STATISTICS ==========                                                                                               |
+--------------------------------------------------------------------------------------------------------------------------------+
```
### Release note

None