### PR TITLE
[improvement](parser) Avoid empty identifier suffix contexts

### DIFF
--- a/fe/fe-sql-parser-benchmark/src/main/java/org/apache/doris/sqlparser/benchmark/IdentifierPostProcessorBenchmark.java
+++ b/fe/fe-sql-parser-benchmark/src/main/java/org/apache/doris/sqlparser/benchmark/IdentifierPostProcessorBenchmark.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-/** Measures identifier post-processing through the public facade and with pre-tokenized input. */
+/** Measures identifier-heavy parsing through the public facade and with pre-tokenized input. */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Fork(value = 3, jvmArgsAppend = {"-Xms1g", "-Xmx1g"})
@@ -51,7 +51,7 @@ import java.util.stream.IntStream;
 @Measurement(iterations = 7, time = 400, timeUnit = TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
 public class IdentifierPostProcessorBenchmark {
-    @Param({"control", "typical", "wide", "nonReserved", "quoted"})
+    @Param({"control", "typical", "wide", "multipart", "nonReserved", "quoted"})
     public String workload;
 
     private final DorisSqlParser facade = new DorisSqlParser();
@@ -95,6 +95,10 @@ public class IdentifierPostProcessorBenchmark {
                         .mapToObj(index -> "c" + index + " AS alias" + index)
                         .collect(Collectors.joining(", "))
                         + " FROM catalog.db.fact_table";
+            case "multipart":
+                return "SELECT 1 FROM " + IntStream.range(0, 64)
+                        .mapToObj(index -> "catalog" + index + ".database" + index + ".table" + index)
+                        .collect(Collectors.joining(", "));
             case "nonReserved":
                 return "SELECT action, branch, cache, catalog, connection, engine, format, global, name "
                         + "FROM aggregate AS alias WHERE action = 1";

--- a/fe/fe-sql-parser-benchmark/src/main/java/org/apache/doris/sqlparser/benchmark/LocalRulePrefixBenchmark.java
+++ b/fe/fe-sql-parser-benchmark/src/main/java/org/apache/doris/sqlparser/benchmark/LocalRulePrefixBenchmark.java
@@ -19,7 +19,6 @@ package org.apache.doris.sqlparser.benchmark;
 
 import org.apache.doris.nereids.DorisParser;
 import org.apache.doris.nereids.parser.ParseErrorListener;
-import org.apache.doris.nereids.parser.PostProcessor;
 import org.apache.doris.sqlparser.DorisSqlParser;
 
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -58,7 +57,6 @@ public class LocalRulePrefixBenchmark {
     public String workload;
 
     private final DorisSqlParser facade = new DorisSqlParser();
-    private final PostProcessor postProcessor = new PostProcessor();
     private final ParseErrorListener errorListener = new ParseErrorListener();
 
     private String sql;
@@ -113,7 +111,6 @@ public class LocalRulePrefixBenchmark {
     private DorisParser newParser(List<Token> input) {
         CommonTokenStream stream = new CommonTokenStream(new ListTokenSource(input));
         DorisParser parser = new DorisParser(stream);
-        parser.addParseListener(postProcessor);
         parser.removeErrorListeners();
         parser.addErrorListener(errorListener);
         parser.getInterpreter().setPredictionMode(PredictionMode.SLL);

--- a/fe/fe-sql-parser-benchmark/src/main/java/org/apache/doris/sqlparser/benchmark/QueryOrganizationBenchmark.java
+++ b/fe/fe-sql-parser-benchmark/src/main/java/org/apache/doris/sqlparser/benchmark/QueryOrganizationBenchmark.java
@@ -19,7 +19,6 @@ package org.apache.doris.sqlparser.benchmark;
 
 import org.apache.doris.nereids.DorisParser;
 import org.apache.doris.nereids.parser.ParseErrorListener;
-import org.apache.doris.nereids.parser.PostProcessor;
 import org.apache.doris.sqlparser.DorisSqlParser;
 
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -58,7 +57,6 @@ public class QueryOrganizationBenchmark {
     @Param({"plainSelect", "orderedSelect", "unionTail", "parenthesizedUnion", "inlineValues"})
     public String workload;
 
-    private final PostProcessor postProcessor = new PostProcessor();
     private final ParseErrorListener errorListener = new ParseErrorListener();
 
     private DorisSqlParser facade;
@@ -104,7 +102,6 @@ public class QueryOrganizationBenchmark {
         CommonTokenStream stream = new CommonTokenStream(new ListTokenSource(tokens));
         DorisParser parser = new DorisParser(stream);
         parser.ansiSQLSyntax = ansi;
-        parser.addParseListener(postProcessor);
         parser.removeErrorListeners();
         parser.addErrorListener(errorListener);
         parser.getInterpreter().setPredictionMode(PredictionMode.SLL);

--- a/fe/fe-sql-parser/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
+++ b/fe/fe-sql-parser/src/main/antlr4/org/apache/doris/nereids/DorisParser.g4
@@ -2216,18 +2216,15 @@ tableSnapshot
 // replace identifier with errorCapturingIdentifier where the immediate follow symbol is not an expression, otherwise
 // valid expressions such as "a-b" can be recognized as an identifier
 errorCapturingIdentifier
-    : identifier errorCapturingIdentifierExtra
+    : identifier errorCapturingIdentifierExtra?
     ;
 
 // extra left-factoring grammar
 errorCapturingIdentifierExtra
     : (SUBTRACT identifier)+ #errorIdent
-    |                        #realIdent
     ;
 finally {
-    if ($ctx instanceof ErrorIdentContext) {
-        reportUnquotedIdentifier((ErrorIdentContext) $ctx);
-    }
+    reportUnquotedIdentifier((ErrorIdentContext) $ctx);
 }
 
 identifier

--- a/fe/fe-sql-parser/src/test/java/org/apache/doris/sqlparser/DorisSqlParserTest.java
+++ b/fe/fe-sql-parser/src/test/java/org/apache/doris/sqlparser/DorisSqlParserTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.sqlparser;
 
 import org.apache.doris.nereids.DorisParser;
+import org.apache.doris.nereids.DorisParser.ErrorCapturingIdentifierContext;
 import org.apache.doris.nereids.DorisParser.ExpressionContext;
 import org.apache.doris.nereids.DorisParser.MultiStatementsContext;
 import org.apache.doris.nereids.DorisParser.SingleStatementContext;
@@ -123,6 +124,15 @@ class DorisSqlParserTest {
         Assertions.assertEquals(facadeException.getMessage(), generatedException.getMessage());
         Assertions.assertTrue(facadeException.getMessage().contains(
                 "Possibly unquoted identifier test-tbl detected"));
+    }
+
+    @Test
+    void doesNotBuildEmptyUnquotedIdentifierSuffixContext() {
+        DorisParser generatedParser = parser.newParser(parser.newLexer("ordinary"));
+        ErrorCapturingIdentifierContext ctx = generatedParser.errorCapturingIdentifier();
+
+        Assertions.assertNull(ctx.errorCapturingIdentifierExtra());
+        Assertions.assertEquals(Token.EOF, generatedParser.getCurrentToken().getType());
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

The `errorCapturingIdentifier` rule always entered a nullable helper for valid identifiers. In the tracked SQL corpus this created 25,406 empty CST contexts. Move the optionality to the caller and make `errorCapturingIdentifierExtra` non-empty, while preserving the existing unquoted-identifier error action. This avoids allocating an empty `RealIdentContext` on the common path and keeps the grammar structure straightforward.

This PR also removes stale `PostProcessor` references from two JMH harnesses. Identifier post-processing already moved into grammar actions and the class no longer exists, so those references prevented the benchmark profile from compiling.

Add a multipart-identifier JMH workload and a direct CST regression test. Across two JMH runs, normalized allocation for that workload decreased from 174,368.9 to 159,004.1 B/op (-8.81%) end-to-end and from 146,097.7 to 130,741.3 B/op (-10.51%) with pre-tokenized input.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
        - `mvn -pl fe-sql-parser -am -Dmaven.build.cache.enabled=false test` (248 tests passed)
        - `./run-fe-ut.sh --run org.apache.doris.nereids.parser.NereidsParserTest,org.apache.doris.nereids.parser.NereidsParserDigestTest` (89 tests passed)
    - [x] Manual test (add detailed scripts or steps below)
        - `mvn -Pbenchmark -pl fe-sql-parser-benchmark -am -DskipTests -Dmaven.build.cache.enabled=false package`
        - Compared the baseline and candidate across 4,610 tracked SQL files in both legacy and ANSI modes: 4,275 successful parses, 335 expected failures, and 1,413,680 tokens in each run.
        - Compared error snapshots for valid, quoted, non-reserved, multipart, arithmetic, and malformed identifiers; baseline and candidate results matched.
        - Ran the multipart JMH allocation benchmark twice.
        - `./build.sh --fe` passed the SQL parser and connector modules, then was blocked by pre-existing JUnit 4 Checkstyle violations in `CacheHotspotManagerSchedulerTest` on the current base branch.
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No. SQL syntax, tokens, AST behavior, and parse errors are unchanged. The internal CST and generated visitor/listener API no longer contain `RealIdentContext` for valid identifiers.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
