### PR TITLE
[fix](fe) Preserve Kinesis job state when ALTER validation fails

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -2048,6 +2048,16 @@ public abstract class RoutineLoadJob
 
     // for ALTER ROUTINE LOAD
     protected void modifyCommonJobProperties(Map<String, String> jobProperties) throws UserException {
+        TUniqueKeyUpdateMode newMode = uniqueKeyUpdateMode;
+        if (jobProperties.containsKey(CreateRoutineLoadInfo.UNIQUE_KEY_UPDATE_MODE)) {
+            newMode = CreateRoutineLoadInfo.parseAndValidateUniqueKeyUpdateMode(
+                    jobProperties.get(CreateRoutineLoadInfo.UNIQUE_KEY_UPDATE_MODE));
+            // Validate before changing any job properties, including batch and error limits.
+            if (newMode == TUniqueKeyUpdateMode.UPDATE_FLEXIBLE_COLUMNS) {
+                validateFlexiblePartialUpdateForAlter();
+            }
+        }
+
         if (jobProperties.containsKey(CreateRoutineLoadInfo.DESIRED_CONCURRENT_NUMBER_PROPERTY)) {
             this.desireTaskConcurrentNum = Integer.parseInt(
                     jobProperties.remove(CreateRoutineLoadInfo.DESIRED_CONCURRENT_NUMBER_PROPERTY));
@@ -2080,12 +2090,7 @@ public abstract class RoutineLoadJob
         }
 
         if (jobProperties.containsKey(CreateRoutineLoadInfo.UNIQUE_KEY_UPDATE_MODE)) {
-            String modeStr = jobProperties.remove(CreateRoutineLoadInfo.UNIQUE_KEY_UPDATE_MODE);
-            TUniqueKeyUpdateMode newMode = CreateRoutineLoadInfo.parseAndValidateUniqueKeyUpdateMode(modeStr);
-            // Validate flexible partial update constraints when changing to UPDATE_FLEXIBLE_COLUMNS
-            if (newMode == TUniqueKeyUpdateMode.UPDATE_FLEXIBLE_COLUMNS) {
-                validateFlexiblePartialUpdateForAlter();
-            }
+            jobProperties.remove(CreateRoutineLoadInfo.UNIQUE_KEY_UPDATE_MODE);
             this.uniqueKeyUpdateMode = newMode;
             this.isPartialUpdate = (uniqueKeyUpdateMode == TUniqueKeyUpdateMode.UPDATE_FIXED_COLUMNS);
             this.jobProperties.put(CreateRoutineLoadInfo.UNIQUE_KEY_UPDATE_MODE, uniqueKeyUpdateMode.name());

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kinesis/KinesisRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kinesis/KinesisRoutineLoadJob.java
@@ -699,18 +699,43 @@ public class KinesisRoutineLoadJob extends RoutineLoadJob {
     private void modifyPropertiesInternal(Map<String, String> jobProperties,
                                           KinesisDataSourceProperties dataSourceProperties)
             throws UserException {
+        List<Pair<String, String>> shardPositions = Lists.newArrayList();
+        Map<String, String> customKinesisProperties = Maps.newHashMap();
+        boolean resetProgress = false;
+        boolean hasExplicitShardPositions = false;
         if (dataSourceProperties != null) {
-            List<Pair<String, String>> shardPositions = Lists.newArrayList();
-            Map<String, String> customKinesisProperties = Maps.newHashMap();
-            boolean resetProgress = false;
-            boolean hasExplicitShardPositions = false;
-
             if (MapUtils.isNotEmpty(dataSourceProperties.getOriginalDataSourceProperties())) {
                 shardPositions = dataSourceProperties.getKinesisShardPositions();
                 customKinesisProperties = dataSourceProperties.getCustomKinesisProperties();
                 hasExplicitShardPositions = !shardPositions.isEmpty();
             }
+            resetProgress = !Strings.isNullOrEmpty(dataSourceProperties.getStream());
+        }
 
+        // Check membership before changing properties or the explicit shard list.
+        if (hasExplicitShardPositions && !resetProgress) {
+            ((KinesisProgress) progress).checkShards(shardPositions);
+        }
+
+        // Common property validation must also finish before changing Kinesis state.
+        if (!jobProperties.isEmpty()) {
+            Map<String, String> copiedJobProperties = Maps.newHashMap(jobProperties);
+            modifyCommonJobProperties(copiedJobProperties);
+            this.jobProperties.putAll(copiedJobProperties);
+            if (jobProperties.containsKey(CreateRoutineLoadInfo.PARTIAL_COLUMNS)) {
+                this.isPartialUpdate = BooleanUtils.toBoolean(jobProperties.get(CreateRoutineLoadInfo.PARTIAL_COLUMNS));
+            }
+            if (jobProperties.containsKey(CreateRoutineLoadInfo.PARTIAL_UPDATE_NEW_KEY_POLICY)) {
+                String policy = jobProperties.get(CreateRoutineLoadInfo.PARTIAL_UPDATE_NEW_KEY_POLICY);
+                if ("ERROR".equalsIgnoreCase(policy)) {
+                    this.partialUpdateNewKeyPolicy = TPartialUpdateNewRowPolicy.ERROR;
+                } else {
+                    this.partialUpdateNewKeyPolicy = TPartialUpdateNewRowPolicy.APPEND;
+                }
+            }
+        }
+
+        if (dataSourceProperties != null) {
             // Update custom properties
             if (!customKinesisProperties.isEmpty()) {
                 this.customProperties.putAll(customKinesisProperties);
@@ -720,7 +745,6 @@ public class KinesisRoutineLoadJob extends RoutineLoadJob {
             // Modify stream if provided
             if (!Strings.isNullOrEmpty(dataSourceProperties.getStream())) {
                 this.stream = dataSourceProperties.getStream();
-                resetProgress = true;
             }
 
             // Modify region if provided
@@ -751,27 +775,7 @@ public class KinesisRoutineLoadJob extends RoutineLoadJob {
             }
 
             if (!shardPositions.isEmpty()) {
-                if (!resetProgress) {
-                    ((KinesisProgress) progress).checkShards(shardPositions);
-                }
                 ((KinesisProgress) progress).modifyPosition(shardPositions);
-            }
-        }
-
-        if (!jobProperties.isEmpty()) {
-            Map<String, String> copiedJobProperties = Maps.newHashMap(jobProperties);
-            modifyCommonJobProperties(copiedJobProperties);
-            this.jobProperties.putAll(copiedJobProperties);
-            if (jobProperties.containsKey(CreateRoutineLoadInfo.PARTIAL_COLUMNS)) {
-                this.isPartialUpdate = BooleanUtils.toBoolean(jobProperties.get(CreateRoutineLoadInfo.PARTIAL_COLUMNS));
-            }
-            if (jobProperties.containsKey(CreateRoutineLoadInfo.PARTIAL_UPDATE_NEW_KEY_POLICY)) {
-                String policy = jobProperties.get(CreateRoutineLoadInfo.PARTIAL_UPDATE_NEW_KEY_POLICY);
-                if ("ERROR".equalsIgnoreCase(policy)) {
-                    this.partialUpdateNewKeyPolicy = TPartialUpdateNewRowPolicy.ERROR;
-                } else {
-                    this.partialUpdateNewKeyPolicy = TPartialUpdateNewRowPolicy.APPEND;
-                }
             }
         }
         LOG.info("modify the properties of kinesis routine load job: {}, jobProperties: {}, datasource properties: {}",

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/KinesisRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/KinesisRoutineLoadJobTest.java
@@ -18,19 +18,32 @@
 package org.apache.doris.load.routineload;
 
 import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.DdlException;
 import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.datasource.kinesis.KinesisUtil;
 import org.apache.doris.load.routineload.kinesis.KinesisConfiguration;
 import org.apache.doris.load.routineload.kinesis.KinesisDataSourceProperties;
 import org.apache.doris.load.routineload.kinesis.KinesisProgress;
 import org.apache.doris.load.routineload.kinesis.KinesisRoutineLoadJob;
 import org.apache.doris.load.routineload.kinesis.KinesisTaskInfo;
+import org.apache.doris.nereids.trees.plans.commands.AlterRoutineLoadCommand;
+import org.apache.doris.nereids.trees.plans.commands.info.CreateRoutineLoadInfo;
+import org.apache.doris.persist.AlterRoutineLoadJobOperationLog;
+import org.apache.doris.persist.EditLog;
+import org.apache.doris.persist.gson.GsonUtils;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -227,6 +240,159 @@ public class KinesisRoutineLoadJobTest {
         KinesisProgress progress = Deencapsulation.getField(routineLoadJob, "progress");
         Assertions.assertEquals("101", progress.getSequenceNumberByShard("shard-1"));
         Assertions.assertEquals("202", progress.getSequenceNumberByShard("shard-2"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testFailedAlterPreservesStateAndShardDiscovery(boolean explicitShards) throws Exception {
+        KinesisRoutineLoadJob job = createPausedJobForAlter(explicitShards);
+        Map<String, String> sourceProperties = new HashMap<>();
+        sourceProperties.put(KinesisConfiguration.KINESIS_REGION.getName(), "us-west-2");
+        sourceProperties.put(KinesisConfiguration.KINESIS_ENDPOINT.getName(), "http://new-endpoint:4566");
+        sourceProperties.put(KinesisConfiguration.KINESIS_DEFAULT_POSITION.getName(), "TRIM_HORIZON");
+        sourceProperties.put(KinesisConfiguration.KINESIS_SHARDS.getName(), "shard-0,shard-unknown");
+        AlterRoutineLoadCommand command = createAlterCommand(
+                Map.of(CreateRoutineLoadInfo.MAX_ERROR_NUMBER_PROPERTY, "123"), sourceProperties);
+
+        assertAlterFailsWithoutChanges(job, command,
+                "The specified shard shard-unknown is not in the consumed shards");
+
+        job.updateState(RoutineLoadJob.JobState.NEED_SCHEDULE, null, true);
+        try (MockedStatic<KinesisUtil> kinesisUtil = Mockito.mockStatic(KinesisUtil.class)) {
+            kinesisUtil.when(() -> KinesisUtil.getAllKinesisShards(
+                    job.getRegion(), job.getStream(), job.getEndpoint(), job.getConvertedCustomProperties()))
+                    .thenReturn(Lists.newArrayList("shard-0", "shard-new"));
+            Assertions.assertTrue((Boolean) Deencapsulation.invoke(job, "refreshKafkaPartitions", false));
+            if (explicitShards) {
+                kinesisUtil.verifyNoInteractions();
+                Assertions.assertFalse((Boolean) Deencapsulation.invoke(job, "isKinesisShardsChanged"));
+                Assertions.assertEquals(List.of("shard-0"), Deencapsulation.getField(job, "openKinesisShards"));
+            } else {
+                kinesisUtil.verify(() -> KinesisUtil.getAllKinesisShards(
+                        job.getRegion(), job.getStream(), job.getEndpoint(), job.getConvertedCustomProperties()));
+                Assertions.assertTrue((Boolean) Deencapsulation.invoke(job, "isKinesisShardsChanged"));
+                List<String> openShards = Deencapsulation.getField(job, "openKinesisShards");
+                Assertions.assertEquals(Set.of("shard-0", "shard-new"), new HashSet<>(openShards));
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testFailedCommonPropertyValidationPreservesKinesisState(boolean changeStream) throws Exception {
+        KinesisRoutineLoadJob job = createPausedJobForAlter(true);
+        Deencapsulation.setField(job, "isMultiTable", true);
+        Map<String, String> sourceProperties = new HashMap<>();
+        sourceProperties.put(KinesisConfiguration.KINESIS_DEFAULT_POSITION.getName(), "TRIM_HORIZON");
+        sourceProperties.put(KinesisConfiguration.KINESIS_SHARDS.getName(), "shard-0");
+        if (changeStream) {
+            sourceProperties.put(KinesisConfiguration.KINESIS_STREAM.getName(), "stream-2");
+        }
+        AlterRoutineLoadCommand command = createAlterCommand(Map.of(
+                CreateRoutineLoadInfo.MAX_ERROR_NUMBER_PROPERTY, "123",
+                CreateRoutineLoadInfo.UNIQUE_KEY_UPDATE_MODE, "UPDATE_FLEXIBLE_COLUMNS"), sourceProperties);
+
+        assertAlterFailsWithoutChanges(job, command,
+                "Flexible partial update is not supported in multi-table load");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testSuccessfulAlterMatchesJournalReplay(boolean changeStream) throws Exception {
+        KinesisRoutineLoadJob job = createPausedJobForAlter(true);
+        KinesisRoutineLoadJob replayedJob = createPausedJobForAlter(true);
+        Map<String, String> sourceProperties = new HashMap<>();
+        sourceProperties.put(KinesisConfiguration.KINESIS_REGION.getName(), "us-west-2");
+        sourceProperties.put(KinesisConfiguration.KINESIS_DEFAULT_POSITION.getName(), "TRIM_HORIZON");
+        sourceProperties.put(KinesisConfiguration.KINESIS_SHARDS.getName(), changeStream ? "shard-new" : "shard-0");
+        if (changeStream) {
+            sourceProperties.put(KinesisConfiguration.KINESIS_STREAM.getName(), "stream-2");
+        }
+        AlterRoutineLoadCommand command = createAlterCommand(
+                Map.of(CreateRoutineLoadInfo.MAX_ERROR_NUMBER_PROPERTY, "123"), sourceProperties);
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            job.modifyProperties(command);
+
+            ArgumentCaptor<AlterRoutineLoadJobOperationLog> logCaptor =
+                    ArgumentCaptor.forClass(AlterRoutineLoadJobOperationLog.class);
+            Mockito.verify(editLog).logAlterRoutineLoadJob(logCaptor.capture());
+            AlterRoutineLoadJobOperationLog log = GsonUtils.GSON.fromJson(
+                    GsonUtils.GSON.toJson(logCaptor.getValue()), AlterRoutineLoadJobOperationLog.class);
+            replayedJob.replayModifyProperties(log);
+        }
+
+        Assertions.assertEquals(123L, (long) Deencapsulation.getField(job, "maxErrorNum"));
+        Assertions.assertEquals("us-west-2", job.getRegion());
+        Assertions.assertEquals(changeStream ? "stream-2" : "stream-1", job.getStream());
+        KinesisProgress progress = Deencapsulation.getField(job, "progress");
+        Assertions.assertEquals("TRIM_HORIZON",
+                progress.getSequenceNumberByShard(changeStream ? "shard-new" : "shard-0"));
+        Assertions.assertEquals(snapshotAlterState(job), snapshotAlterState(replayedJob));
+    }
+
+    private KinesisRoutineLoadJob createPausedJobForAlter(boolean explicitShards) throws Exception {
+        KinesisRoutineLoadJob job = new KinesisRoutineLoadJob(1L, "kinesis_routine_load_job", 1L,
+                1L, "ap-southeast-1", "stream-1", UserIdentity.ADMIN);
+        Deencapsulation.setField(job, "state", RoutineLoadJob.JobState.PAUSED);
+        Deencapsulation.setField(job, "createTimestamp", 1L);
+        Deencapsulation.setField(job, "endpoint", "http://old-endpoint:4566");
+        List<String> openShards = Lists.newArrayList("shard-0");
+        Deencapsulation.setField(job, "openKinesisShards", openShards);
+        if (explicitShards) {
+            // The scheduler can make the open and explicit shard lists share the same instance.
+            Deencapsulation.setField(job, "customKinesisShards", openShards);
+        }
+        Deencapsulation.setField(job, "closedKinesisShards", Lists.newArrayList("shard-closed"));
+        Deencapsulation.setField(job, "progress", new KinesisProgress(Map.of("shard-0", "100", "shard-closed", "200")));
+        Deencapsulation.setField(job, "cachedShardWithMillsBehindLatest",
+                new HashMap<>(Map.of("shard-0", 10L)));
+        Deencapsulation.setField(job, "customProperties", new HashMap<>(Map.of("kinesis_default_pos", "LATEST")));
+        job.prepare();
+        return job;
+    }
+
+    private AlterRoutineLoadCommand createAlterCommand(Map<String, String> jobProperties,
+            Map<String, String> sourceProperties) throws Exception {
+        KinesisDataSourceProperties dataSourceProperties = new KinesisDataSourceProperties(sourceProperties);
+        dataSourceProperties.setAlter(true);
+        dataSourceProperties.setTimezone("Asia/Shanghai");
+        dataSourceProperties.analyze();
+        AlterRoutineLoadCommand command = Mockito.mock(AlterRoutineLoadCommand.class);
+        Mockito.when(command.getAnalyzedJobProperties()).thenReturn(jobProperties);
+        Mockito.when(command.getDataSourceProperties()).thenReturn(dataSourceProperties);
+        return command;
+    }
+
+    private Map<String, Object> snapshotAlterState(KinesisRoutineLoadJob job) {
+        Map<String, Object> snapshot = new HashMap<>();
+        snapshot.put("persisted", GsonUtils.GSON.toJsonTree(job));
+        // Include derived and transient fields that the persisted representation does not cover.
+        for (String field : List.of("convertedCustomProperties", "kinesisDefaultPosition",
+                "cachedShardWithMillsBehindLatest", "newCurrentKinesisShards", "maxFilterRatio",
+                "uniqueKeyUpdateMode", "isPartialUpdate", "partialUpdateNewKeyPolicy")) {
+            Object value = Deencapsulation.getField(job, field);
+            snapshot.put(field, new Gson().toJsonTree(value));
+        }
+        return snapshot;
+    }
+
+    private void assertAlterFailsWithoutChanges(KinesisRoutineLoadJob job, AlterRoutineLoadCommand command,
+            String expectedMessage) throws Exception {
+        Map<String, Object> before = snapshotAlterState(job);
+        Env env = Mockito.mock(Env.class);
+        EditLog editLog = Mockito.mock(EditLog.class);
+        try (MockedStatic<Env> envStatic = Mockito.mockStatic(Env.class)) {
+            envStatic.when(Env::getCurrentEnv).thenReturn(env);
+            Mockito.when(env.getEditLog()).thenReturn(editLog);
+            DdlException exception = Assertions.assertThrows(DdlException.class, () -> job.modifyProperties(command));
+            Assertions.assertTrue(exception.getMessage().contains(expectedMessage), exception.getMessage());
+            Mockito.verifyNoInteractions(editLog);
+        }
+        Assertions.assertEquals(before, snapshotAlterState(job));
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

A failed `ALTER ROUTINE LOAD` can leave a Kinesis job partially modified in memory, even though the statement returns an error and no ALTER journal entry is written.

For example, pause a job whose progress contains `shard-0`, then alter its region, endpoint, or default position together with an explicit shard list containing an unknown shard. Omit `kinesis_stream` so that the existing-progress membership check applies. Before this change, `modifyPropertiesInternal()` updates the live data-source properties and replaces `customKinesisShards` before `KinesisProgress.checkShards()` rejects the unknown shard. The exception releases the job lock without restoring those fields.

The leader can therefore retain configuration that journal replay does not apply to other FEs. A residual explicit shard list can also bypass remote shard discovery after resume. There is another failure point in the same ALTER path: common-property validation for flexible partial updates can fail after Kinesis state and some common properties have already changed.

This change orders validation before mutation:

1. Read the requested Kinesis changes into local variables and check shard membership before modifying any job state. Preserve the existing progress-reset behavior when a stream is provided.
2. Validate the requested unique-key update mode and flexible partial-update constraints before assigning any common job properties in `RoutineLoadJob`.
3. Apply the common properties before updating Kinesis configuration, shard lists, and progress. The existing successful ALTER path then writes its journal entry.

The guarantee covers shard-membership and common-property validation failures. These failures now occur before any live state changes, so they require no rollback. The shared `RoutineLoadJob` adjustment is necessary to keep common-property validation from becoming another source of partial Kinesis ALTER updates.

### Release note

Kinesis Routine Load preserves its previous configuration, shard selection, and progress when ALTER fails shard-membership or common-property validation.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
- Behavior changed:
    - [ ] No.
    - [x] Yes. Failed validation leaves the Kinesis job state unchanged and does not write an ALTER journal entry.
- Does this need documentation?
    - [x] No.
    - [ ] Yes.

Validation:

- Before the fix, the four new failure-atomicity test cases fail because job state changes after the expected ALTER error. The other 11 Kinesis job tests pass.
- After the fix, all 47 tests pass, with no failures, errors, or skipped tests:

  ```bash
  ./run-fe-ut.sh --run org.apache.doris.load.routineload.KinesisRoutineLoadJobTest,org.apache.doris.load.routineload.RoutineLoadJobTest,org.apache.doris.load.routineload.KafkaRoutineLoadJobTest,org.apache.doris.load.routineload.kinesis.KinesisDataSourcePropertiesTest
  ```

- New tests cover dynamic and explicit shard selection, shared open/explicit shard list instances, unchanged state and no journal entry on failure, shard discovery after the resume state transition, common-property validation failures with and without a stream change, and successful ALTER journal serialization/replay.
- FE build via `build.sh --fe -j48` passes with `DISABLE_BUILD_UI=ON` and `DISABLE_JAVA_CHECK_STYLE=OFF`; output is directed to a separate local build directory. Checkstyle reports zero violations. UI building is disabled because the local npm dependency installation fails.
- `git diff --check` passes.
- Real AWS Kinesis consumption and multi-FE failover have not been tested. Shard discovery is mocked in the unit tests.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
