### PR TITLE
[fix](mv) Prevent snapshot reads from using current MVs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtils.java
@@ -630,9 +630,11 @@ public class MaterializedViewUtils {
         public Boolean visitLogicalRelation(LogicalRelation relation, Void context) {
             if (relation instanceof LogicalFileScan) {
                 LogicalFileScan fileScan = (LogicalFileScan) relation;
-                // Relation scan parameters can select data different from the MV refresh input.
+                // Relation scan operators can select data different from the MV refresh input.
                 // Treat them as query operators until rewrite can prove equivalent semantics.
-                if (fileScan.getTableSample().isPresent() || fileScan.getScanParams().isPresent()) {
+                if (fileScan.getTableSample().isPresent()
+                        || fileScan.getScanParams().isPresent()
+                        || fileScan.getTableSnapshot().isPresent()) {
                     return true;
                 }
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtilsTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/exploration/mv/MaterializedViewUtilsTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.rules.exploration.mv;
 
 import org.apache.doris.analysis.TableScanParams;
+import org.apache.doris.analysis.TableSnapshot;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.TableIf;
 import org.apache.doris.mtmv.BaseTableInfo;
@@ -1011,6 +1012,17 @@ public class MaterializedViewUtilsTest extends TestWithFeService {
                 TableScanParams.OPTIONS,
                 ImmutableMap.of("scan.snapshot-id", "1"),
                 Collections.emptyList())));
+
+        Assertions.assertTrue(MaterializedViewUtils.TableQueryOperatorChecker.INSTANCE
+                .visitLogicalRelation(fileScan, null));
+    }
+
+    @Test
+    public void containTableQueryOperatorWithTableSnapshotTest() {
+        LogicalFileScan fileScan = Mockito.mock(LogicalFileScan.class);
+        Mockito.when(fileScan.getTableSample()).thenReturn(Optional.empty());
+        Mockito.when(fileScan.getScanParams()).thenReturn(Optional.empty());
+        Mockito.when(fileScan.getTableSnapshot()).thenReturn(Optional.of(TableSnapshot.versionOf("1")));
 
         Assertions.assertTrue(MaterializedViewUtils.TableQueryOperatorChecker.INSTANCE
                 .visitLogicalRelation(fileScan, null));


### PR DESCRIPTION
## Problem

An external-table query that explicitly reads an older snapshot can still enter materialized view rewrite. The candidate materialized view represents the table state at its refresh snapshot, so using a current materialized view for a historical query can silently return data from the wrong point in time.

## Root cause

`LogicalFileScan` stores standard `FOR TIME AS OF` and `FOR VERSION AS OF` clauses in `tableSnapshot`. The materialized-view eligibility checker rejected scans with table samples or scan parameters, but did not inspect `tableSnapshot`. As a result, the historical scan was treated like an ordinary latest-snapshot scan.

## How to reproduce

1. Create an Iceberg table and insert an initial row, then record that snapshot ID.
2. Insert newer data and refresh a materialized view over the table at the current snapshot.
3. Enable materialized-view rewrite and query the Iceberg table with `FOR VERSION AS OF <old_snapshot_id>` (the same issue applies to `FOR TIME AS OF`).
4. Before this change, the historical query can be considered eligible for rewrite by the current-snapshot materialized view, producing current rather than historical results.

The same condition can be reproduced directly in the optimizer by building a `LogicalFileScan` with a non-empty `tableSnapshot`: the table-query-operator checker previously returned false.

## Fix

Treat a non-empty `LogicalFileScan.tableSnapshot` as a table-level query operator, alongside table samples and scan parameters. This conservatively prevents materialized-view rewrite until the optimizer can prove that the query snapshot and materialized-view refresh snapshot are semantically equivalent.

Add a unit test that constructs a file scan with a version snapshot and verifies that the checker rejects it from ordinary rewrite eligibility.

## Tests

`./run-fe-ut.sh --run org.apache.doris.nereids.rules.exploration.mv.MaterializedViewUtilsTest`

- 37 tests run
- 0 failures
- 0 errors
- FE reactor build succeeded

