### PR TITLE
[fix](inverted index) Close empty index files through the FileWriter lifecycle

### DIFF
--- a/be/src/storage/index/index_file_writer.cpp
+++ b/be/src/storage/index/index_file_writer.cpp
@@ -27,7 +27,6 @@
 #include "common/config.h"
 #include "common/status.h"
 #include "io/fs/packed_file_writer.h"
-#include "io/fs/s3_file_writer.h"
 #include "io/fs/stream_sink_file_writer.h"
 #include "storage/index/ann/ann_index_files.h"
 #include "storage/index/index_file_reader.h"
@@ -535,9 +534,7 @@ Status IndexFileWriter::begin_close() {
     }
     if (_indices_dirs.empty()) {
         // An empty file must still be created even if there are no indexes to write
-        if (dynamic_cast<io::StreamSinkFileWriter*>(_idx_v2_writer.get()) != nullptr ||
-            dynamic_cast<io::S3FileWriter*>(_idx_v2_writer.get()) != nullptr ||
-            dynamic_cast<io::PackedFileWriter*>(_idx_v2_writer.get()) != nullptr) {
+        if (_idx_v2_writer != nullptr && _idx_v2_writer->state() != io::FileWriter::State::CLOSED) {
             return _idx_v2_writer->close(true);
         }
         return Status::OK();
@@ -583,9 +580,7 @@ Status IndexFileWriter::finish_close() {
     }
     if (_indices_dirs.empty()) {
         // An empty file must still be created even if there are no indexes to write
-        if (dynamic_cast<io::StreamSinkFileWriter*>(_idx_v2_writer.get()) != nullptr ||
-            dynamic_cast<io::S3FileWriter*>(_idx_v2_writer.get()) != nullptr ||
-            dynamic_cast<io::PackedFileWriter*>(_idx_v2_writer.get()) != nullptr) {
+        if (_idx_v2_writer != nullptr && _idx_v2_writer->state() != io::FileWriter::State::CLOSED) {
             return _idx_v2_writer->close(false);
         }
         return Status::OK();

--- a/be/test/io/fs/s3_file_writer_test.cpp
+++ b/be/test/io/fs/s3_file_writer_test.cpp
@@ -1530,11 +1530,13 @@ TEST_F(S3FileWriterTest, test_empty_file) {
     doris::io::FileWriterOptions opts;
     io::FileWriterPtr file_writer;
     auto st = s3_fs->create_file("test_empty_file.idx", &file_writer, &opts);
-    EXPECT_TRUE(st.ok()) << st;
+    ASSERT_TRUE(st.ok()) << st;
     auto holder = std::make_shared<ObjClientHolder>(S3ClientConf {});
     auto mock_client = std::make_shared<SimpleMockObjStorageClient>();
     holder->_client = mock_client;
     dynamic_cast<io::S3FileWriter*>(file_writer.get())->_obj_client = holder;
+    auto* s3_writer = file_writer.get();
+    const auto file_path = s3_writer->path().native();
     auto fs = io::global_local_filesystem();
     std::string index_path = "/tmp/empty_index_file_test";
     std::string rowset_id = "1234567890";
@@ -1542,8 +1544,17 @@ TEST_F(S3FileWriterTest, test_empty_file) {
     auto index_file_writer = std::make_unique<segment_v2::IndexFileWriter>(
             fs, index_path, rowset_id, seg_id, InvertedIndexStorageFormatPB::V2,
             std::move(file_writer), false);
-    EXPECT_TRUE(index_file_writer->begin_close().ok());
-    EXPECT_TRUE(index_file_writer->finish_close().ok());
+    ASSERT_TRUE(index_file_writer->begin_close().ok());
+    EXPECT_EQ(s3_writer->state(), io::FileWriter::State::ASYNC_CLOSING);
+    ASSERT_TRUE(index_file_writer->finish_close().ok());
+    EXPECT_EQ(s3_writer->state(), io::FileWriter::State::CLOSED);
+    EXPECT_EQ(s3_writer->bytes_appended(), 0);
+    ASSERT_TRUE(index_file_writer->finish_close().ok());
+    index_file_writer.reset();
+    EXPECT_EQ(mock_client->put_object_count, 1);
+    EXPECT_EQ(mock_client->upload_part_count, 0);
+    ASSERT_EQ(mock_client->objects.count(file_path), 1);
+    EXPECT_TRUE(mock_client->objects.at(file_path).empty());
 }
 
 } // namespace doris

--- a/be/test/storage/index/inverted/empty_index_file_test.cpp
+++ b/be/test/storage/index/inverted/empty_index_file_test.cpp
@@ -20,6 +20,7 @@
 
 #include "exec/sink/load_stream_stub.h"
 #include "gtest/gtest_pred_impl.h"
+#include "io/fs/local_file_system.h"
 #include "io/fs/stream_sink_file_writer.h"
 #include "storage/index/index_file_writer.h"
 #include "storage/index/index_writer.h"
@@ -30,7 +31,7 @@ namespace doris {
 constexpr int64_t LOAD_ID_LO = 1;
 constexpr int64_t LOAD_ID_HI = 2;
 constexpr int64_t NUM_STREAM = 3;
-constexpr static std::string_view tmp_dir = "./ut_dir/tmp";
+constexpr static std::string_view tmp_dir = "./ut_dir/empty_index_file";
 class EmptyIndexFileTest : public testing::TestWithParam<InvertedIndexStorageFormatPB> {
     struct WriteState {
         size_t bytes_appended = 0;
@@ -74,6 +75,53 @@ public:
     ~EmptyIndexFileTest() override = default;
 
 protected:
+    // Deliberately implements only FileWriter, so closing cannot depend on a concrete type.
+    class RecordingFileWriter final : public io::FileWriter {
+    public:
+        Status close(bool non_block = false) override {
+            close_calls.push_back(non_block);
+            EXPECT_NE(_state, State::CLOSED);
+            if (non_block) {
+                EXPECT_EQ(_state, State::OPENED);
+                RETURN_IF_ERROR(begin_status);
+                _state = close_synchronously ? State::CLOSED : State::ASYNC_CLOSING;
+                return Status::OK();
+            }
+            EXPECT_EQ(_state, State::ASYNC_CLOSING);
+            _state = State::CLOSED;
+            return finish_status;
+        }
+
+        Status appendv(const Slice* data, size_t data_cnt) override {
+            ++append_calls;
+            for (size_t i = 0; i < data_cnt; ++i) {
+                _bytes_appended += data[i].size;
+            }
+            return Status::OK();
+        }
+
+        const io::Path& path() const override { return _path; }
+        size_t bytes_appended() const override { return _bytes_appended; }
+        State state() const override { return _state; }
+
+        std::vector<bool> close_calls;
+        int append_calls = 0;
+        bool close_synchronously = false;
+        Status begin_status = Status::OK();
+        Status finish_status = Status::OK();
+
+    private:
+        io::Path _path {"recording_0.idx"};
+        size_t _bytes_appended = 0;
+        State _state = State::OPENED;
+    };
+
+    auto make_index_writer(io::FileWriterPtr file_writer, InvertedIndexStorageFormatPB format) {
+        return std::make_unique<segment_v2::IndexFileWriter>(
+                io::global_local_filesystem(), std::string(tmp_dir) + "/empty_0", "empty", 0,
+                format, std::move(file_writer), false);
+    }
+
     void SetUp() override {
         _load_id.set_hi(LOAD_ID_HI);
         _load_id.set_lo(LOAD_ID_LO);
@@ -101,20 +149,117 @@ protected:
 };
 
 TEST_P(EmptyIndexFileTest, PreservesZeroByteFileWhenNoLogicalIndexes) {
-    io::FileWriterPtr file_writer = std::make_unique<io::StreamSinkFileWriter>(_streams);
-    auto fs = io::global_local_filesystem();
-    std::string index_path = "/tmp/empty_index_file_test";
-    std::string rowset_id = "1234567890";
-    int64_t seg_id = 1234567890;
-    auto index_file_writer = std::make_unique<segment_v2::IndexFileWriter>(
-            fs, index_path, rowset_id, seg_id, GetParam(), std::move(file_writer), false);
-    EXPECT_TRUE(index_file_writer->begin_close().ok());
-    EXPECT_TRUE(index_file_writer->finish_close().ok());
+    auto file_writer = std::make_unique<io::StreamSinkFileWriter>(_streams);
+    file_writer->init(_load_id, 1, 2, 3, 0, FileType::INVERTED_INDEX_FILE);
+    auto* stream_writer = file_writer.get();
+    auto index_file_writer = make_index_writer(std::move(file_writer), GetParam());
+    ASSERT_TRUE(index_file_writer->begin_close().ok());
+    EXPECT_EQ(stream_writer->state(), io::FileWriter::State::ASYNC_CLOSING);
+    ASSERT_TRUE(index_file_writer->finish_close().ok());
+    EXPECT_EQ(stream_writer->state(), io::FileWriter::State::CLOSED);
+    // Finishing an already closed empty file must not send another EOS.
+    ASSERT_TRUE(index_file_writer->finish_close().ok());
+    index_file_writer.reset();
     for (const auto& state : _write_states) {
         EXPECT_EQ(state->bytes_appended, 0);
         EXPECT_EQ(state->data_calls, 0);
         EXPECT_EQ(state->eos_calls, 1);
     }
+}
+
+TEST_P(EmptyIndexFileTest, ClosesOpaqueWriterWithoutAppending) {
+    auto file_writer = std::make_unique<RecordingFileWriter>();
+    auto* recording = file_writer.get();
+    auto index_writer = make_index_writer(std::move(file_writer), GetParam());
+    ASSERT_TRUE(index_writer->_indices_dirs.empty());
+
+    ASSERT_TRUE(index_writer->begin_close().ok());
+    EXPECT_EQ(recording->close_calls, (std::vector<bool> {true}));
+    EXPECT_EQ(recording->state(), io::FileWriter::State::ASYNC_CLOSING);
+    ASSERT_TRUE(index_writer->finish_close().ok());
+    EXPECT_EQ(recording->close_calls, (std::vector<bool> {true, false}));
+    EXPECT_EQ(recording->state(), io::FileWriter::State::CLOSED);
+    ASSERT_TRUE(index_writer->finish_close().ok());
+    EXPECT_EQ(recording->close_calls, (std::vector<bool> {true, false}));
+    EXPECT_EQ(recording->append_calls, 0);
+    EXPECT_EQ(recording->bytes_appended(), 0);
+}
+
+TEST_P(EmptyIndexFileTest, SkipsAlreadyClosedWriter) {
+    auto file_writer = std::make_unique<RecordingFileWriter>();
+    auto* recording = file_writer.get();
+    ASSERT_TRUE(recording->close(true).ok());
+    ASSERT_TRUE(recording->close(false).ok());
+    recording->close_calls.clear();
+    auto index_writer = make_index_writer(std::move(file_writer), GetParam());
+    ASSERT_TRUE(index_writer->begin_close().ok());
+    ASSERT_TRUE(index_writer->finish_close().ok());
+    EXPECT_TRUE(recording->close_calls.empty());
+}
+
+TEST_P(EmptyIndexFileTest, SkipsFinishWhenBeginClosesSynchronously) {
+    auto file_writer = std::make_unique<RecordingFileWriter>();
+    auto* recording = file_writer.get();
+    recording->close_synchronously = true;
+    auto index_writer = make_index_writer(std::move(file_writer), GetParam());
+    ASSERT_TRUE(index_writer->begin_close().ok());
+    EXPECT_EQ(recording->state(), io::FileWriter::State::CLOSED);
+    ASSERT_TRUE(index_writer->finish_close().ok());
+    EXPECT_EQ(recording->close_calls, (std::vector<bool> {true}));
+}
+
+TEST_P(EmptyIndexFileTest, PropagatesBeginCloseError) {
+    auto file_writer = std::make_unique<RecordingFileWriter>();
+    auto* recording = file_writer.get();
+    recording->begin_status = Status::IOError("begin close failed");
+    auto index_writer = make_index_writer(std::move(file_writer), GetParam());
+    auto st = index_writer->begin_close();
+    EXPECT_EQ(st.to_string(), recording->begin_status.to_string());
+    EXPECT_EQ(recording->close_calls, (std::vector<bool> {true}));
+}
+
+TEST_P(EmptyIndexFileTest, PropagatesFinishCloseError) {
+    auto file_writer = std::make_unique<RecordingFileWriter>();
+    auto* recording = file_writer.get();
+    recording->finish_status = Status::IOError("finish close failed");
+    auto index_writer = make_index_writer(std::move(file_writer), GetParam());
+    ASSERT_TRUE(index_writer->begin_close().ok());
+    auto st = index_writer->finish_close();
+    EXPECT_EQ(st.to_string(), recording->finish_status.to_string());
+    EXPECT_EQ(recording->close_calls, (std::vector<bool> {true, false}));
+}
+
+TEST_P(EmptyIndexFileTest, AllowsNullWriter) {
+    for (auto format : {InvertedIndexStorageFormatPB::V1, GetParam()}) {
+        auto index_writer = make_index_writer(nullptr, format);
+        ASSERT_TRUE(index_writer->begin_close().ok());
+        ASSERT_TRUE(index_writer->finish_close().ok());
+    }
+}
+
+TEST_P(EmptyIndexFileTest, PreservesLocalEmptyFileAfterDestruction) {
+    auto fs = io::global_local_filesystem();
+    const auto path = std::string(tmp_dir) + "/empty_0.idx";
+    io::FileWriterPtr file_writer;
+    ASSERT_TRUE(fs->create_file(path, &file_writer).ok());
+    auto* local_writer = file_writer.get();
+    bool exists = false;
+    ASSERT_TRUE(fs->exists(path, &exists).ok());
+    ASSERT_TRUE(exists); // O_CREAT alone does not guarantee persistence after destruction.
+    auto index_writer = make_index_writer(std::move(file_writer), GetParam());
+    ASSERT_TRUE(index_writer->begin_close().ok());
+    EXPECT_EQ(local_writer->state(), io::FileWriter::State::ASYNC_CLOSING);
+    ASSERT_TRUE(index_writer->finish_close().ok());
+    EXPECT_EQ(local_writer->state(), io::FileWriter::State::CLOSED);
+    EXPECT_EQ(local_writer->bytes_appended(), 0);
+    index_writer.reset();
+
+    ASSERT_TRUE(fs->exists(path, &exists).ok());
+    ASSERT_TRUE(exists);
+    int64_t file_size = -1;
+    ASSERT_TRUE(fs->file_size(path, &file_size).ok());
+    EXPECT_EQ(file_size, 0);
+    // TearDown removes this test's directory, including the empty index file.
 }
 
 INSTANTIATE_TEST_SUITE_P(LegacyCompoundFormats, EmptyIndexFileTest,

--- a/regression-test/plugins/plugin_curl_requester.groovy
+++ b/regression-test/plugins/plugin_curl_requester.groovy
@@ -287,13 +287,17 @@ Suite.metaClass.be_report_task = { String ip, int port ->
 logger.info("Added 'be_report_task' function to Suite")
 
 // check nested index file api
-Suite.metaClass.check_nested_index_file = { ip, port, tablet_id, expected_rowsets_count, expected_indices_count, format ->
+Suite.metaClass.check_nested_index_file = { ip, port, tablet_id, expected_rowsets_count, expected_indices_count, format, expected_error = "E-6003" ->
     def (code, out, err) = http_client("GET", String.format("http://%s:%s/api/show_nested_index_file?tablet_id=%s", ip, port, tablet_id))
     logger.info("Run show_nested_index_file_on_tablet: code=" + code + ", out=" + out + ", err=" + err)
-    // only when the expected_indices_count is 0, the tablet may not have the index file.
+    // A closed empty file must report an error from the index reader, not a successful listing.
+    if (expected_error == "E-6004") {
+        assertEquals(500, code)
+    }
+    // With no indices, the index file may be absent or explicitly closed as an empty file.
     if (code == 500 && expected_indices_count == 0) {
-        assertEquals("E-6003", parseJson(out.trim()).status)
-        assertTrue(parseJson(out.trim()).msg.contains("not found"))
+        assertEquals(expected_error, parseJson(out.trim()).status)
+        assertTrue(parseJson(out.trim()).msg.contains(expected_error == "E-6004" ? " is empty" : "not found"))
         return
     }
     assertTrue(code == 0)

--- a/regression-test/suites/inverted_index_p0/index_format_v2/test_drop_index_with_format_v2.groovy
+++ b/regression-test/suites/inverted_index_p0/index_format_v2/test_drop_index_with_format_v2.groovy
@@ -93,5 +93,6 @@ suite("test_drop_index_with_format_v2", "inverted_index_format_v2"){
     // drop index
     sql """ DROP INDEX index_score on ${tableName}; """
     wait_for_latest_op_on_table_finish(tableName, timeout)
-    check_nested_index_file(ip, port, tablet_id, 7, 0, "V2")
+    // Dropping the last index closes and preserves an empty V2 index file.
+    check_nested_index_file(ip, port, tablet_id, 7, 0, "V2", "E-6004")
 }

--- a/regression-test/suites/inverted_index_p0/test_variant_empty_index_file.groovy
+++ b/regression-test/suites/inverted_index_p0/test_variant_empty_index_file.groovy
@@ -16,11 +16,10 @@
 // under the License.
 
 suite("test_variant_empty_index_file", "p0") {
-    def tableName = "test_variant_empty_index_file"
-    sql """ drop table if exists ${tableName} """
+    sql """ drop table if exists test_variant_empty_index_file """
     // create table
     sql """
-        CREATE TABLE IF NOT EXISTS ${tableName}
+        CREATE TABLE IF NOT EXISTS test_variant_empty_index_file
         (   
             `id`   bigint NOT NULL,
             `v`    variant NULL,
@@ -35,10 +34,10 @@ suite("test_variant_empty_index_file", "p0") {
     """
 
     sql """ set enable_memtable_on_sink_node = true """
-    sql """ insert into ${tableName} values (1, NULL) """
-    qt_sql9 "select * from ${tableName}"
+    sql """ insert into test_variant_empty_index_file values (1, NULL) """
+    qt_sql9 "select * from test_variant_empty_index_file order by id"
     sql "sync"
-    def tablets = sql_return_maparray """ show tablets from ${tableName}; """
+    def tablets = sql_return_maparray """ show tablets from test_variant_empty_index_file; """
 
     def backendId_to_backendIP = [:]
     def backendId_to_backendHttpPort = [:]
@@ -53,10 +52,9 @@ suite("test_variant_empty_index_file", "p0") {
     assertEquals("E-6004", parseJson(out.trim()).status)
     assertTrue(out.contains(" is empty"))
 
-    try {
-        sql """ select /*+ SET_VAR(enable_match_without_inverted_index = 0) */  * from ${tableName} where v match 'abcd';  """
-    } catch (Exception e) {
-        log.info(e.getMessage());
-        assertTrue(e.getMessage().contains("VARIANT root column does not support MATCH predicates"))
+    test {
+        sql """ select /*+ SET_VAR(enable_match_without_inverted_index = 0) */
+                    * from test_variant_empty_index_file where v match 'abcd' """
+        exception "VARIANT root column does not support MATCH predicates"
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary: An all-NULL Variant column creates no logical index directory, but its V2/V3 FileWriter has already been created. The empty-index close path only closed StreamSink, S3 and Packed writers, leaving LocalFileWriter and opaque wrappers open. Local writer destruction could consequently remove the empty file. Dispatch both close phases through FileWriter for every non-null, non-CLOSED writer, preserving the asynchronous protocol and returning close errors. Add implementation-independent lifecycle coverage, verify Local empty file persistence and exactly one StreamSink EOS/S3 empty-object commit, and make the Variant regression enforce its expected query error.

### Release note

Persist empty V2/V3 index files for all FileWriter implementations, including wrappers, while preserving V1 and already-closed writer behavior.

### Check List (For Author)

- Test: Unit Test / Regression test / Manual test
    - 64 focused ASAN BE tests passed; the new baseline suite first demonstrated 13 failures before the fix.
    - test_variant_empty_index_file regression passed on the locally built cluster.
    - ASAN BE/FE product build, clang-format 16, check-format and build hygiene passed.
    - clang-tidy was attempted; an existing unmatched NOLINTEND in be/src/core/types.h:576 prevents a complete pass.
- Behavior changed: Yes; explicitly close empty index files for every writer implementation and skip already-closed writers.
- Does this need documentation: No



