### PR TITLE
[improvement](hive) Push partition filters to HMS

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitSourceManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/SplitSourceManager.java
@@ -19,41 +19,20 @@ package org.apache.doris.datasource;
 
 import org.apache.doris.common.util.MasterDaemon;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import java.lang.ref.ReferenceQueue;
-import java.lang.ref.WeakReference;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * `SplitSource` is obtained by RPC call of `FrontendServiceImpl#fetchSplitBatch`.
  * Each `SplitSource` is reference by its unique ID. `SplitSourceManager` provides the register, get, and remove
- * function to manage the split sources. In order to clean the split source when the query finished,
- * `SplitSource` is stored as a weak reference, and use `ReferenceQueue` to remove split source when GC.
+ * function to manage the split sources. Each source remains strongly reachable until the query explicitly
+ * releases it through {@link FileQueryScanNode#stop()}.
  */
 public class SplitSourceManager extends MasterDaemon {
-    private static final Logger LOG = LogManager.getLogger(SplitSourceManager.class);
-
-    public static class SplitSourceReference extends WeakReference<SplitSource> {
-        private final long uniqueId;
-
-        public SplitSourceReference(SplitSource splitSource, ReferenceQueue<? super SplitSource> queue) {
-            super(splitSource, queue);
-            uniqueId = splitSource.getUniqueId();
-        }
-
-        public long getUniqueId() {
-            return uniqueId;
-        }
-    }
-
-    private final ReferenceQueue<SplitSource> splitsRefQueue = new ReferenceQueue<>();
-    private final Map<Long, WeakReference<SplitSource>> splits = new ConcurrentHashMap<>();
+    private final Map<Long, SplitSource> splits = new ConcurrentHashMap<>();
 
     public void registerSplitSource(SplitSource splitSource) {
-        splits.put(splitSource.getUniqueId(), new SplitSourceReference(splitSource, splitsRefQueue));
+        splits.put(splitSource.getUniqueId(), splitSource);
     }
 
     public void removeSplitSource(long uniqueId) {
@@ -61,23 +40,10 @@ public class SplitSourceManager extends MasterDaemon {
     }
 
     public SplitSource getSplitSource(long uniqueId) {
-        WeakReference<SplitSource> ref = splits.get(uniqueId);
-        if (ref == null) {
-            return null;
-        } else {
-            return ref.get();
-        }
+        return splits.get(uniqueId);
     }
 
     @Override
     protected void runAfterCatalogReady() {
-        while (true) {
-            try {
-                SplitSourceReference reference = (SplitSourceReference) splitsRefQueue.remove();
-                removeSplitSource(reference.getUniqueId());
-            } catch (Exception e) {
-                LOG.warn("Failed to clean split source", e);
-            }
-        }
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSCachedClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSCachedClient.java
@@ -54,6 +54,8 @@ public interface HMSCachedClient {
 
     List<Partition> listPartitions(String dbName, String tblName);
 
+    List<Partition> listPartitionsByFilter(String dbName, String tblName, String filter);
+
     List<String> listPartitionNames(String dbName, String tblName, long maxListPartitionNum);
 
     Partition getPartition(String dbName, String tblName, List<String> partitionValues);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HMSExternalTable.java
@@ -56,6 +56,14 @@ import org.apache.doris.mtmv.MTMVRelatedTableIf;
 import org.apache.doris.mtmv.MTMVSnapshotIf;
 import org.apache.doris.nereids.exceptions.NotSupportedException;
 import org.apache.doris.nereids.rules.expression.rules.SortedPartitionRanges;
+import org.apache.doris.nereids.trees.expressions.And;
+import org.apache.doris.nereids.trees.expressions.ComparisonPredicate;
+import org.apache.doris.nereids.trees.expressions.EqualTo;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.InPredicate;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.plans.algebra.CatalogRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFileScan.SelectedPartitions;
 import org.apache.doris.qe.GlobalVariable;
@@ -79,6 +87,7 @@ import com.google.gson.JsonObject;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.DateColumnStatsData;
@@ -360,6 +369,86 @@ public class HMSExternalTable extends ExternalTable implements MTMVRelatedTableI
     @Override
     public boolean supportInternalPartitionPruned() {
         return getDlaType() == DLAType.HIVE || getDlaType() == DLAType.HUDI;
+    }
+
+    @Override
+    public SelectedPartitions initSelectedPartitions(Optional<MvccSnapshot> snapshot) {
+        if (getDlaType() == DLAType.HIVE && !getPartitionColumns(snapshot).isEmpty()) {
+            return SelectedPartitions.NOT_PRUNED;
+        }
+        return super.initSelectedPartitions(snapshot);
+    }
+
+    public String getHmsPartitionFilter(Expression predicate, List<Slot> partitionSlots) {
+        if (getDlaType() != DLAType.HIVE) {
+            return null;
+        }
+        Set<String> partitionNames = partitionSlots.stream()
+                .map(slot -> slot.getName().toLowerCase(Locale.ROOT)).collect(Collectors.toSet());
+        return toHmsPartitionFilter(predicate, partitionNames);
+    }
+
+    private String toHmsPartitionFilter(Expression predicate, Set<String> partitionNames) {
+        if (predicate instanceof And) {
+            List<String> filters = new ArrayList<>();
+            for (Expression child : predicate.children()) {
+                String filter = toHmsPartitionFilter(child, partitionNames);
+                if (filter != null) {
+                    filters.add(filter);
+                }
+            }
+            return filters.isEmpty() ? null : "(" + String.join(" AND ", filters) + ")";
+        }
+        if (predicate instanceof EqualTo) {
+            return toHmsComparisonFilter((ComparisonPredicate) predicate, partitionNames);
+        }
+        if (predicate instanceof InPredicate) {
+            InPredicate inPredicate = (InPredicate) predicate;
+            if (!(inPredicate.getCompareExpr() instanceof SlotReference)
+                    || !partitionNames.contains(inPredicate.getCompareExpr().getInputSlots().iterator().next()
+                            .getName().toLowerCase(Locale.ROOT))) {
+                return null;
+            }
+            List<String> filters = new ArrayList<>();
+            for (Expression option : inPredicate.getOptions()) {
+                if (!(option instanceof Literal)) {
+                    return null;
+                }
+                filters.add(inPredicate.getCompareExpr().toSql() + " = " + option.toSql());
+            }
+            return filters.isEmpty() ? null : "(" + String.join(" OR ", filters) + ")";
+        }
+        return null;
+    }
+
+    private String toHmsComparisonFilter(ComparisonPredicate predicate, Set<String> partitionNames) {
+        if (!(predicate.left() instanceof SlotReference) || !(predicate.right() instanceof Literal)) {
+            return null;
+        }
+        SlotReference slot = (SlotReference) predicate.left();
+        if (!partitionNames.contains(slot.getName().toLowerCase(Locale.ROOT))) {
+            return null;
+        }
+        return slot.getName() + " = " + predicate.right().toSql();
+    }
+
+    public SelectedPartitions getSelectedPartitionsByHmsFilter(String filter,
+            Optional<MvccSnapshot> snapshot) {
+        List<Column> partitionColumns = getPartitionColumns(snapshot);
+        List<Type> partitionTypes = getPartitionColumnTypes(snapshot);
+        List<String> partitionColumnNames = partitionColumns.stream()
+                .map(Column::getName).collect(Collectors.toList());
+        List<Partition> partitions = ((HMSExternalCatalog) catalog).getClient().listPartitionsByFilter(
+                getRemoteDbName(), getRemoteName(), filter);
+        HiveMetaStoreCache cache = Env.getCurrentEnv().getExtMetaCacheMgr()
+                .getMetaStoreCache((HMSExternalCatalog) catalog);
+        Map<String, PartitionItem> selected = Maps.newHashMapWithExpectedSize(partitions.size());
+        for (Partition partition : partitions) {
+            String partitionName = FileUtils.makePartName(partitionColumnNames, partition.getValues());
+            selected.put(partitionName, cache.toListPartitionItem(partitionName, partitionTypes));
+        }
+        cache.putPartitionsCache(this, partitions);
+        return new SelectedPartitions(selected.size(), selected, true);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/HiveMetaStoreCache.java
@@ -499,6 +499,16 @@ public class HiveMetaStoreCache {
         return getAllPartitions(dorisTable, partitionValuesList, true);
     }
 
+    public void putPartitionsCache(ExternalTable dorisTable, List<Partition> partitions) {
+        NameMapping nameMapping = dorisTable.getOrBuildNameMapping();
+        for (Partition partition : partitions) {
+            StorageDescriptor sd = partition.getSd();
+            partitionCache.put(new PartitionCacheKey(nameMapping, partition.getValues()),
+                    new HivePartition(nameMapping, false, sd.getInputFormat(), sd.getLocation(),
+                            partition.getValues(), partition.getParameters()));
+        }
+    }
+
     public List<HivePartition> getAllPartitionsWithoutCache(ExternalTable dorisTable,
             List<List<String>> partitionValuesList) {
         return getAllPartitions(dorisTable, partitionValuesList, false);

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/ThriftHMSCachedClient.java
@@ -297,6 +297,22 @@ public class ThriftHMSCachedClient implements HMSCachedClient {
     }
 
     @Override
+    public List<Partition> listPartitionsByFilter(String dbName, String tblName, String filter) {
+        try (ThriftHMSClient client = getClient()) {
+            try {
+                return ugiDoAs(() -> client.client.listPartitionsByFilter(dbName, tblName, filter,
+                        MAX_LIST_PARTITION_NUM));
+            } catch (Exception e) {
+                client.setThrowable(e);
+                throw e;
+            }
+        } catch (Exception e) {
+            throw new HMSClientException("failed to list partitions by filter for table %s in db %s", e,
+                    tblName, dbName);
+        }
+    }
+
+    @Override
     public List<String> listPartitionNames(String dbName, String tblName, long maxListPartitionNum) {
         // list all parts when the limit is greater than the short maximum
         short limited = maxListPartitionNum <= Short.MAX_VALUE ? (short) maxListPartitionNum : MAX_LIST_PARTITION_NUM;

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/hive/source/HiveScanNode.java
@@ -147,8 +147,15 @@ public class HiveScanNode extends FileQueryScanNode {
                 throw new AnalysisException("Should use Nereids to prune partitions. "
                         + "set enable_fallback_to_original_planner=false and try again");
             }
-            this.totalPartitionNum = selectedPartitions.totalPartitionNum;
-            partitionItems = selectedPartitions.selectedPartitions.values();
+            if (selectedPartitions == SelectedPartitions.NOT_PRUNED) {
+                HiveMetaStoreCache.HivePartitionValues partitionValues = hmsTable.getHivePartitionValues(
+                        MvccUtil.getSnapshotFromContext(hmsTable));
+                this.totalPartitionNum = partitionValues.getIdToPartitionItem().size();
+                partitionItems = partitionValues.getIdToPartitionItem().values();
+            } else {
+                this.totalPartitionNum = selectedPartitions.totalPartitionNum;
+                partitionItems = selectedPartitions.selectedPartitions.values();
+            }
             Preconditions.checkNotNull(partitionItems);
             this.selectedPartitionNum = partitionItems.size();
 
@@ -607,5 +614,4 @@ public class HiveScanNode extends FileQueryScanNode {
         return compressType;
     }
 }
-
 

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneFileScanPartition.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/PruneFileScanPartition.java
@@ -19,6 +19,8 @@ package org.apache.doris.nereids.rules.rewrite;
 
 import org.apache.doris.catalog.PartitionItem;
 import org.apache.doris.datasource.ExternalTable;
+import org.apache.doris.datasource.hive.HMSClientException;
+import org.apache.doris.datasource.hive.HMSExternalTable;
 import org.apache.doris.nereids.CascadesContext;
 import org.apache.doris.nereids.rules.Rule;
 import org.apache.doris.nereids.rules.RuleType;
@@ -33,6 +35,8 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,6 +54,7 @@ import java.util.stream.Collectors;
  * external file ScanNode could do the partition filter by themselves.
  */
 public class PruneFileScanPartition extends OneRewriteRuleFactory {
+    private static final Logger LOG = LogManager.getLogger(PruneFileScanPartition.class);
 
     @Override
     public Rule build() {
@@ -89,7 +94,26 @@ public class PruneFileScanPartition extends OneRewriteRuleFactory {
                 .map(column -> scanOutput.get(column.getName().toLowerCase()))
                 .collect(Collectors.toList());
 
+        if (externalTable instanceof HMSExternalTable) {
+            String hmsFilter = ((HMSExternalTable) externalTable).getHmsPartitionFilter(
+                    filter.getPredicate(), partitionSlots);
+            if (hmsFilter != null) {
+                try {
+                    return ((HMSExternalTable) externalTable).getSelectedPartitionsByHmsFilter(
+                            hmsFilter, ctx.getStatementContext().getSnapshot(externalTable));
+                } catch (HMSClientException e) {
+                    LOG.warn("Failed to prune Hive partitions through HMS filter for {}.{} with filter '{}', "
+                                    + "falling back to local partition pruning",
+                            externalTable.getDbName(), externalTable.getName(), hmsFilter, e);
+                }
+            }
+        }
+
         Map<String, PartitionItem> nameToPartitionItem = scan.getSelectedPartitions().selectedPartitions;
+        if (nameToPartitionItem.isEmpty() && scan.getSelectedPartitions() == SelectedPartitions.NOT_PRUNED) {
+            nameToPartitionItem = externalTable.getNameToPartitionItems(
+                    ctx.getStatementContext().getSnapshot(externalTable));
+        }
         Optional<SortedPartitionRanges<String>> sortedPartitionRanges = Optional.empty();
         boolean enableBinarySearch = ctx.getConnectContext() == null
                 || ctx.getConnectContext().getSessionVariable().enableBinarySearchFilteringPartitions;

--- a/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/service/FrontendServiceImpl.java
@@ -1065,7 +1065,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         SplitSource splitSource =
                 Env.getCurrentEnv().getSplitSourceManager().getSplitSource(request.getSplitSourceId());
         if (splitSource == null) {
-            throw new TException("Split source " + request.getSplitSourceId() + " is released");
+            result.setSplits(Collections.emptyList());
+            result.status = new TStatus(TStatusCode.OK);
+            return result;
         }
         try {
             List<TScanRangeLocations> locations = splitSource.getNextBatch(request.getMaxNumSplits());

--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -1686,8 +1686,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   @Override
   public List<Partition> listPartitionsByFilter(String catName, String db_name, String tbl_name,
                                                 String filter, int max_parts) throws TException {
-    List<Partition> parts =client.get_partitions_by_filter(prependCatalogToDbName(
-        catName, db_name, conf), tbl_name, filter, shrinkMaxtoShort(max_parts));
+    String databaseName = hiveVersion == HiveVersion.V1_0 || hiveVersion == HiveVersion.V2_0
+        || hiveVersion == HiveVersion.V2_3 ? db_name : prependCatalogToDbName(catName, db_name, conf);
+    List<Partition> parts =client.get_partitions_by_filter(
+        databaseName, tbl_name, filter, shrinkMaxtoShort(max_parts));
     return deepCopyPartitions(filterHook.filterPartitions(parts));
   }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/TestHMSCachedClient.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/TestHMSCachedClient.java
@@ -110,6 +110,11 @@ public class TestHMSCachedClient implements HMSCachedClient {
     }
 
     @Override
+    public List<Partition> listPartitionsByFilter(String dbName, String tblName, String filter) {
+        return getPartitionList(dbName, tblName);
+    }
+
+    @Override
     public List<String> listPartitionNames(String dbName, String tblName, long maxListPartitionNum) {
         return listPartitionNames(dbName, tblName);
     }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Hive partition pruning loaded every partition name into FE before applying predicates. On tables with very large partition counts, planning could wait for a full HMS listing and time out. This change pushes supported partition-only predicates to HMS get_partitions_by_filter, expands IN predicates into HMS-compatible OR expressions, caches the returned partition metadata, and falls back to the existing local pruning path when HMS rejects a filter. It also keeps batch split sources reachable until explicit query cleanup and treats a released source as end of input instead of closing the Thrift connection.

### Release note

Improve planning latency and stability for selective Hive partition queries.

### Check List (For Author)

- Test: Manual test
    - Java HMS probe against music_dwd.dwd_xx_tbl: equality, IN/OR, and range filters succeeded; IN/OR returned 116 partitions.
    - Rolled the FE jar through a three-FE test cluster and verified a query with dt plus pt_action/pt_os IN predicates returns rows without setting num_partitions_in_batch_mode.
    - build.sh --fe succeeded.
- Behavior changed: Yes (supported Hive partition predicates are pushed to HMS; rejected HMS filters fall back to local pruning)
- Does this need documentation: No