### PR TITLE
[fix](be) Preserve time field extraction timestamp bounds

### DIFF
--- a/be/src/exprs/function/date_time_transforms.h
+++ b/be/src/exprs/function/date_time_transforms.h
@@ -684,8 +684,26 @@ public:
         }
     }
 
-    // (UTC 9999-12-31 23:59:59) - 24 * 3600
-    static const int64_t TIMESTAMP_VALID_MAX = 253402243199L;
+    struct TimeZoneState {
+        int64_t max_timestamp;
+    };
+
+    static int64_t get_max_timestamp(const cctz::time_zone& time_zone) {
+        return cctz::convert(cctz::civil_second(9999, 12, 31, 23, 59, 59), time_zone)
+                .time_since_epoch()
+                .count();
+    }
+
+    Status open(FunctionContext* context, FunctionContext::FunctionStateScope scope) override {
+        if (scope == FunctionContext::FRAGMENT_LOCAL) {
+            auto state = std::make_shared<TimeZoneState>();
+            // Compute the session time zone's boundary once, keeping date conversion out of
+            // the row loop (including its cold branches, which can inhibit loop optimization).
+            state->max_timestamp = get_max_timestamp(context->state()->timezone_obj());
+            context->set_function_state(scope, state);
+        }
+        return IFunction::open(context, scope);
+    }
 
     Status execute_impl(FunctionContext* context, Block& block, const ColumnNumbers& arguments,
                         uint32_t result, size_t input_rows_count) const override {
@@ -694,6 +712,10 @@ public:
                                               ColumnInt32, ColumnInt8>;
         using ResItemType = typename ResColType::value_type;
         auto res = ResColType::create();
+        const auto max_timestamp =
+                static_cast<const TimeZoneState*>(
+                        context->get_function_state(FunctionContext::FRAGMENT_LOCAL))
+                        ->max_timestamp;
 
         const auto* ts_col =
                 assert_cast<const ArgColType*>(block.get_by_position(arguments[0]).column.get());
@@ -705,10 +727,9 @@ public:
                 const auto seconds = ts_col->get_intergral_part(i);
                 const auto fraction = ts_col->get_fractional_part(i);
 
-                if (seconds < 0 || seconds > TIMESTAMP_VALID_MAX) {
+                if (seconds < 0 || seconds > max_timestamp) [[unlikely]] {
                     return Status::InvalidArgument(
-                            "The input value of TimeFiled(from_unixtime()) must between 0 and "
-                            "253402243199L");
+                            "The input value of {} is out of range in the session time zone", name);
                 }
 
                 ResItemType value = Impl::extract_field(fraction, scale);
@@ -719,10 +740,9 @@ public:
             for (int i = 0; i < input_rows_count; ++i) {
                 auto date = ts_col->get_element(i);
 
-                if (date < 0 || date > TIMESTAMP_VALID_MAX) {
+                if (date < 0 || date > max_timestamp) [[unlikely]] {
                     return Status::InvalidArgument(
-                            "The input value of TimeFiled(from_unixtime()) must between 0 and "
-                            "253402243199L");
+                            "The input value of {} is out of range in the session time zone", name);
                 }
 
                 ResItemType value = Impl::extract_field(date, ctz);

--- a/be/test/exprs/function/function_time_test.cpp
+++ b/be/test/exprs/function/function_time_test.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <string>
 
 #include "core/data_type/data_type_date.h"
@@ -29,6 +30,7 @@
 #include "core/types.h"
 #include "core/value/time_value.h"
 #include "core/value/vdatetime_value.h"
+#include "exprs/function/date_time_transforms.h"
 #include "exprs/function/function_date_or_datetime_computation.h"
 #include "exprs/function/function_test_util.h"
 #include "util/timezone_utils.h"
@@ -239,6 +241,57 @@ TEST(VTimestampFunctionsTest, second_test) {
     };
 
     static_cast<void>(check_function<DataTypeInt8, true>(func_name, input_types, data_set));
+}
+
+TEST(VTimestampFunctionsTest, time_field_from_unixtime_boundary_test) {
+    using Function = FunctionTimeFieldFromUnixtime<HourFromUnixtimeImpl>;
+    TimezoneUtils::load_timezones_to_cache();
+    for (const auto& [zone, offset] :
+         std::vector<std::pair<std::string, int>> {{"UTC", 0},
+                                                   {"Asia/Shanghai", 8 * 3600},
+                                                   {"-08:00", -8 * 3600},
+                                                   {"+14:00", 14 * 3600}}) {
+        SCOPED_TRACE(zone);
+        cctz::time_zone time_zone;
+        ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(zone, time_zone));
+        int64_t last_second = 253402300799L - offset;
+        EXPECT_EQ(last_second, Function::get_max_timestamp(time_zone));
+        EXPECT_TRUE((FromUnixTimeImpl<false, true>::get_datetime_value(last_second, time_zone)
+                             .is_valid_date()));
+        EXPECT_FALSE((FromUnixTimeImpl<false, true>::get_datetime_value(last_second + 1, time_zone)
+                              .is_valid_date()));
+    }
+}
+
+TEST(VTimestampFunctionsTest, time_field_from_unixtime_execution_test) {
+    TimezoneUtils::load_timezones_to_cache();
+    const InputTypeSet input_types = {PrimitiveType::TYPE_BIGINT};
+    const DataSet hours = {{{int64_t(253402243199)}, int8_t(15)},
+                           {{int64_t(253402243200)}, int8_t(16)},
+                           {{int64_t(253402271999)}, int8_t(23)},
+                           {{Null()}, Null()}};
+    EXPECT_TRUE(
+            (check_function<DataTypeInt8, true>("hour_from_unixtime", input_types, hours).ok()));
+    for (const auto* name : {"minute_from_unixtime", "second_from_unixtime"}) {
+        const DataSet fields = {{{int64_t(253402243199)}, int8_t(59)},
+                                {{int64_t(253402243200)}, int8_t(0)},
+                                {{int64_t(253402271999)}, int8_t(59)},
+                                {{Null()}, Null()}};
+        EXPECT_TRUE((check_function<DataTypeInt8, true>(name, input_types, fields).ok()));
+    }
+    const InputTypeSet decimal_types = {{PrimitiveType::TYPE_DECIMAL64, 6, 18}};
+    const DataSet fractions = {{{DECIMAL64(253402243200, 123456, 6)}, int32_t(123456)},
+                               {{DECIMAL64(253402271999, 999999, 6)}, int32_t(999999)}};
+    EXPECT_TRUE((check_function<DataTypeInt32, true>("microsecond_from_unixtime", decimal_types,
+                                                     fractions)
+                         .ok()));
+    for (int64_t seconds : {int64_t(253402272000), int64_t(-1), std::numeric_limits<int64_t>::min(),
+                            std::numeric_limits<int64_t>::max()}) {
+        const DataSet invalid = {{{seconds}, int8_t(0)}};
+        EXPECT_FALSE((check_function<DataTypeInt8, true>("hour_from_unixtime", input_types, invalid,
+                                                         -1, -1, true)
+                              .ok()));
+    }
 }
 
 TEST(VTimestampFunctionsTest, from_unix_test) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransform.java
@@ -109,8 +109,7 @@ public class DateTimeExtractAndTransform {
         DAY_OF_WEEK.put("SUNDAY", 7);
     }
 
-    // Maximum valid timestamp value (UTC 9999-12-31 23:59:59 - 24 * 3600 for all timezones)
-    private static final long TIMESTAMP_VALID_MAX = 32536771199L;
+    private static final LocalDateTime MAX_TIME_FIELD_DATETIME = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
 
     /**
      * datetime arithmetic function date-v2
@@ -1978,16 +1977,20 @@ public class DateTimeExtractAndTransform {
         return year * 100 + month % 12 + 1;
     }
 
+    private static void checkTimeFieldFromUnixtimeRange(long seconds) {
+        long maxTimestamp = MAX_TIME_FIELD_DATETIME.atZone(DateUtils.getTimeZone()).toEpochSecond();
+        if (seconds < 0 || seconds > maxTimestamp) {
+            throw new AnalysisException("Time field from_unixtime of " + seconds + " out of range");
+        }
+    }
+
     /**
      * date extract function hour_from_unixtime
      */
     @ExecFunction(name = "hour_from_unixtime")
     public static Expression hourFromUnixtime(BigIntLiteral unixTime) {
         long epochSecond = unixTime.getValue();
-        if (epochSecond < 0 || epochSecond > TIMESTAMP_VALID_MAX) {
-            throw new AnalysisException("Function hour_from_unixtime out of range(between 0 and "
-                            + TIMESTAMP_VALID_MAX + "): " + epochSecond);
-        }
+        checkTimeFieldFromUnixtimeRange(epochSecond);
 
         ZoneId timeZone = DateUtils.getTimeZone();
         ZonedDateTime zonedDateTime = Instant.ofEpochSecond(epochSecond).atZone(timeZone);
@@ -2000,10 +2003,7 @@ public class DateTimeExtractAndTransform {
     @ExecFunction(name = "minute_from_unixtime")
     public static Expression minuteFromUnixtime(BigIntLiteral unixTime) {
         long localTime = unixTime.getValue();
-        if (localTime < 0 || localTime > TIMESTAMP_VALID_MAX) {
-            throw new AnalysisException("Function minute_from_unixtime out of range(between 0 and "
-                    + TIMESTAMP_VALID_MAX + "): " + localTime);
-        }
+        checkTimeFieldFromUnixtimeRange(localTime);
 
         localTime = localTime - (localTime / 3600) * 3600;
 
@@ -2017,10 +2017,7 @@ public class DateTimeExtractAndTransform {
     @ExecFunction(name = "second_from_unixtime")
     public static Expression secondFromUnixtime(BigIntLiteral unixTime) {
         long localTime = unixTime.getValue();
-        if (localTime < 0 || localTime > TIMESTAMP_VALID_MAX) {
-            throw new AnalysisException("Function second_from_unixtime out of range(between 0 and "
-                    + TIMESTAMP_VALID_MAX + "): " + localTime);
-        }
+        checkTimeFieldFromUnixtimeRange(localTime);
 
         long remainder;
         if (localTime >= 0) {
@@ -2042,10 +2039,7 @@ public class DateTimeExtractAndTransform {
         BigDecimal value = unixTime.getValue();
 
         long seconds = value.longValue();
-        if (seconds < 0 || seconds > TIMESTAMP_VALID_MAX) {
-            throw new AnalysisException("Function microsecond_from_unixtime out of range(between 0 and "
-                    + TIMESTAMP_VALID_MAX + "): " + seconds);
-        }
+        checkTimeFieldFromUnixtimeRange(seconds);
 
         DecimalV3Type dataType = (DecimalV3Type) unixTime.getDataType();
         int scale = dataType.getScale();

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransformTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/functions/executable/DateTimeExtractAndTransformTest.java
@@ -31,6 +31,7 @@ import org.apache.doris.nereids.trees.expressions.literal.TimeStampNsLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.TinyIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.types.DateTimeV2Type;
+import org.apache.doris.nereids.types.DecimalV3Type;
 import org.apache.doris.qe.ConnectContext;
 
 import org.junit.jupiter.api.Assertions;
@@ -40,6 +41,49 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 class DateTimeExtractAndTransformTest {
+    @Test
+    void testTimeFieldFromUnixtimeBoundary() {
+        ConnectContext previous = ConnectContext.get();
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        try {
+            String[] zones = {"UTC", "Asia/Shanghai", "-08:00", "+14:00"};
+            int[] offsets = {0, 8 * 3600, -8 * 3600, 14 * 3600};
+            for (int i = 0; i < zones.length; i++) {
+                context.getSessionVariable().setTimeZone(zones[i]);
+                long lastSecond = 253402300799L - offsets[i];
+                BigIntLiteral last = new BigIntLiteral(lastSecond);
+                Assertions.assertEquals(new TinyIntLiteral((byte) 23),
+                        DateTimeExtractAndTransform.hourFromUnixtime(last));
+                Assertions.assertEquals(new TinyIntLiteral((byte) 59),
+                        DateTimeExtractAndTransform.minuteFromUnixtime(last));
+                Assertions.assertEquals(new TinyIntLiteral((byte) 59),
+                        DateTimeExtractAndTransform.secondFromUnixtime(last));
+                Assertions.assertEquals(new IntegerLiteral(999999),
+                        DateTimeExtractAndTransform.microsecondFromUnixtime(new DecimalV3Literal(
+                                DecimalV3Type.createDecimalV3Type(18, 6),
+                                new BigDecimal(lastSecond + ".999999"))));
+                Assertions.assertEquals(new TinyIntLiteral((byte) ((8 + offsets[i] / 3600) % 24)),
+                        DateTimeExtractAndTransform.hourFromUnixtime(new BigIntLiteral(253402243200L)));
+                for (long invalid : new long[] {-1, lastSecond + 1, Long.MIN_VALUE, Long.MAX_VALUE}) {
+                    BigIntLiteral input = new BigIntLiteral(invalid);
+                    Assertions.assertThrows(AnalysisException.class,
+                            () -> DateTimeExtractAndTransform.hourFromUnixtime(input));
+                    Assertions.assertThrows(AnalysisException.class,
+                            () -> DateTimeExtractAndTransform.minuteFromUnixtime(input));
+                    Assertions.assertThrows(AnalysisException.class,
+                            () -> DateTimeExtractAndTransform.secondFromUnixtime(input));
+                }
+            }
+        } finally {
+            if (previous == null) {
+                ConnectContext.remove();
+            } else {
+                previous.setThreadLocalInfo();
+            }
+        }
+    }
+
     @Test
     void testAdditionalTimestampNsCalendarFunctions() {
         TimeStampNsLiteral leapDay = new TimeStampNsLiteral("2024-02-29 12:34:56.123456789");

--- a/regression-test/suites/datatype_p0/date/test_from_unixtime.groovy
+++ b/regression-test/suites/datatype_p0/date/test_from_unixtime.groovy
@@ -69,7 +69,7 @@ suite("test_from_unixtime") {
     qt_hour_from_unixtime6 "SELECT HOUR(FROM_UNIXTIME(3));"
     test {
         sql """ SELECT HOUR(FROM_UNIXTIME(-1)); """
-        exception "The input value of TimeFiled(from_unixtime()) must between 0 and 253402243199"
+        exception "The input value of hour_from_unixtime is out of range in the session time zone"
     }
     explain {
         sql """ SELECT HOUR(FROM_UNIXTIME(k0)) FROM test1; """
@@ -93,7 +93,7 @@ suite("test_from_unixtime") {
     qt_minute_from_unixtime5 "SELECT MINUTE(FROM_UNIXTIME(32536771200));"
     test {
         sql """ SELECT MINUTE(FROM_UNIXTIME(-1)); """
-        exception "The input value of TimeFiled(from_unixtime()) must between 0 and 253402243199"
+        exception "The input value of minute_from_unixtime is out of range in the session time zone"
     }
     explain {
         sql """ SELECT MINUTE(FROM_UNIXTIME(k0)) FROM test1; """
@@ -115,7 +115,7 @@ suite("test_from_unixtime") {
     qt_second_from_unixtime5 "SELECT SECOND(FROM_UNIXTIME(32536771200));"
     test {
         sql """ SELECT SECOND(FROM_UNIXTIME(-1)); """
-        exception "The input value of TimeFiled(from_unixtime()) must between 0 and 253402243199"
+        exception "The input value of second_from_unixtime is out of range in the session time zone"
     }
     explain {
         sql """ SELECT SECOND(FROM_UNIXTIME(k0)) FROM test1; """
@@ -137,7 +137,7 @@ suite("test_from_unixtime") {
     qt_microsecond_from_unixtime5 "SELECT MICROSECOND(FROM_UNIXTIME(32536771200));"
     test {
         sql """ SELECT MICROSECOND(FROM_UNIXTIME(-1)); """
-        exception "The input value of TimeFiled(from_unixtime()) must between 0 and 253402243199"
+        exception "The input value of microsecond_from_unixtime is out of range in the session time zone"
     }
     explain {
         sql """ SELECT MICROSECOND(FROM_UNIXTIME(k1)) FROM test1; """

--- a/regression-test/suites/datatype_p0/date/test_time_field_from_unixtime_boundary.groovy
+++ b/regression-test/suites/datatype_p0/date/test_time_field_from_unixtime_boundary.groovy
@@ -1,0 +1,66 @@
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_time_field_from_unixtime_boundary") {
+    sql "DROP TABLE IF EXISTS test_time_field_from_unixtime_boundary"
+    sql """CREATE TABLE test_time_field_from_unixtime_boundary (
+        id INT, ts BIGINT, fractional_ts DECIMAL(18, 6)
+    ) DISTRIBUTED BY HASH(id) BUCKETS 1
+    PROPERTIES ("replication_num" = "1")"""
+
+    def zones = ["UTC": 0, "Asia/Shanghai": 28800, "-08:00": -28800, "+14:00": 50400]
+    zones.each { zone, offset ->
+        sql "SET time_zone='${zone}'"
+        sql "TRUNCATE TABLE test_time_field_from_unixtime_boundary"
+        def lastSecond = 253402300799L - offset
+        sql """INSERT INTO test_time_field_from_unixtime_boundary VALUES
+            (1, 253402243199, 253402243199.123456),
+            (2, 253402243200, 253402243200.123456),
+            (3, ${lastSecond}, ${lastSecond}.999999),
+            (4, NULL, NULL)"""
+        def query = """SELECT id,
+            HOUR(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2)),
+            MINUTE(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2)),
+            SECOND(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2)),
+            MICROSECOND(CAST(FROM_UNIXTIME(fractional_ts) AS DATETIMEV2(6)))
+            FROM test_time_field_from_unixtime_boundary ORDER BY id"""
+        sql "SET disable_nereids_expression_rules=''"
+        def original = query.replace("SELECT", "SELECT /*+ SET_VAR("
+                + "disable_nereids_expression_rules='SIMPLIFY_DATETIME_FUNCTION') */")
+        explain {
+            sql(original)
+            notContains "hour_from_unixtime"
+        }
+        explain {
+            sql(query)
+            contains "hour_from_unixtime"
+        }
+        // Compare the rewrite with the original expression using the framework's two-SQL check.
+        check_sqls_result_equal(original, query)
+        testFoldConst("SELECT HOUR_FROM_UNIXTIME(${lastSecond}), "
+                + "MINUTE_FROM_UNIXTIME(${lastSecond}), SECOND_FROM_UNIXTIME(${lastSecond}), "
+                + "MICROSECOND_FROM_UNIXTIME(CAST(${lastSecond}.999999 AS DECIMAL(18, 6)))")
+        // A column input prevents constant folding from hiding BE boundary checks.
+        sql "INSERT INTO test_time_field_from_unixtime_boundary VALUES (5, ${lastSecond + 1}, NULL)"
+        test {
+            sql """SELECT HOUR(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2))
+                FROM test_time_field_from_unixtime_boundary WHERE id = 5"""
+            exception "The input value of hour_from_unixtime is out of range in the session time zone"
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

Nereids rewrites `HOUR(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2))` to
`hour_from_unixtime(ts)`, but the optimized function rejects valid timestamps
near the upper datetime boundary. For example, `ts = 253402243200` produces
`9999-12-31 08:00:00` in UTC and `9999-12-31 16:00:00` in Asia/Shanghai;
without the rewrite, HOUR returns 8 and 16 respectively, while the rewrite
fails with `INVALID_ARGUMENT`.

The BE helper uses a fixed conservative upper bound of `253402243199`.
The FE constant evaluators use an even smaller legacy bound. This change
computes the Unix timestamp corresponding to local `9999-12-31 23:59:59`
for the session time zone and aligns both implementations with that bound.

BE caches the bound in fragment-local function state during `open()` and
loads it once per block. The row loop retains its range check and field
extraction arithmetic; there are no additional per-row date conversions
or helper calls. The shared validation covers HOUR, MINUTE, SECOND, and
MICROSECOND. Invalid inputs still fail, with an updated range error.

Validation:

- FE `DateTimeExtractAndTransformTest`: 14 tests passed after rebasing onto current master, including UTC,
  Asia/Shanghai, negative/positive offsets, and boundary/invalid inputs.
- `./build.sh --fe -j 48`, including Checkstyle, passed on the original patch.
  The rebased patch also passed the FE unit test build above.
- Modified C++ files passed clang-format 16, clang-tidy, and build hygiene.
- Added BE unit tests for timezone bounds and function execution. The BE
  test build is blocked in unmodified `common/cpp/aws_common.cpp` because
  the local shared AWS SDK lacks `GeneralHTTPCredentialsProvider.h`;
  these tests have not run.
- Added regression tests comparing the rewrite with the original expression,
  checking constant folding and rejecting the first invalid second. Both
  changed Groovy suites passed syntax compilation; cluster execution has
  not been performed.
- An isolated ordinary-input extraction-loop microbenchmark showed no
  material regression (20 measured samples, alternating old/new runs,
  fixed CPU affinity, thread CPU time). It excludes function initialization
  and the complete execution framework and does not establish end-to-end
  query performance.

### Release note

Fix optimized time field extraction rejecting valid FROM_UNIXTIME inputs
near the upper datetime boundary.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (format/static checks and isolated microbenchmark described above)
    - [ ] No need to test or manual test.

- Behavior changed:
    - [ ] No.
    - [x] Yes. Valid boundary timestamps now succeed using the session time zone's upper bound.

- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
