### PR TITLE
[fix](regression) retry uncompacted tablets in test_fix_tablet_stat_fault_injection

### DIFF
--- a/regression-test/plugins/plugin_compaction.groovy
+++ b/regression-test/plugins/plugin_compaction.groovy
@@ -62,7 +62,8 @@ Suite.metaClass.be_run_full_compaction_by_table_id = { String ip, String port, S
 }
 
 logger.info("Added 'be_run_full_compaction' function to Suite")
-Suite.metaClass.trigger_and_wait_compaction = { String table_name, String compaction_type, int timeout_seconds=300, String[] ignored_errors=[] ->
+Suite.metaClass.trigger_and_wait_compaction = { String table_name, String compaction_type, int timeout_seconds=300,
+                                                String[] ignored_errors=[], Collection tablet_ids=[] ->
     if (!(compaction_type in ["cumulative", "base", "full"])) {
         throw new IllegalArgumentException("invalid compaction type: ${compaction_type}, supported types: cumulative, base, full")
     }
@@ -71,6 +72,15 @@ Suite.metaClass.trigger_and_wait_compaction = { String table_name, String compac
     def backendId_to_backendHttpPort = [:]
     getBackendIpHttpPort(backendId_to_backendIP, backendId_to_backendHttpPort);
     def tablets = sql_return_maparray """show tablets from ${table_name}"""
+    if (!tablet_ids.isEmpty()) {
+        // Only operate on the requested tablets, e.g. to re-trigger the tablets whose
+        // previous asynchronous compaction failed.
+        def requestedTabletIds = tablet_ids.collect { it.toString() }.toSet()
+        tablets = tablets.findAll { requestedTabletIds.contains(it.TabletId.toString()) }
+        def foundTabletIds = tablets.collect { it.TabletId.toString() }.toSet()
+        assert foundTabletIds == requestedTabletIds:
+                "Unable to find all requested tablets for ${table_name}, requested: ${requestedTabletIds}, found: ${foundTabletIds}"
+    }
     def exit_code, stdout, stderr
 
     def auto_compaction_disabled = sql("show create table ${table_name}")[0][1].contains('"disable_auto_compaction" = "true"')

--- a/regression-test/suites/fault_injection_p0/test_fix_tablet_stat_fault_injection.groovy
+++ b/regression-test/suites/fault_injection_p0/test_fix_tablet_stat_fault_injection.groovy
@@ -82,10 +82,36 @@ suite("test_fix_tablet_stat_fault_injection", "nonConcurrent") {
 
                 // trigger full compactions for all tablets in ${tableName}
                 trigger_and_wait_compaction(tableName, "full")
+                // In cloud mode the compaction trigger is asynchronous and trigger_and_wait_compaction
+                // returns once every tablet reports a completion timestamp, no matter whether the
+                // compaction succeeded or failed. With 1000 full compactions on one MoW table a few
+                // of them may fail with a transient delete bitmap lock conflict
+                // (DELETE_BITMAP_LOCK_ERROR) after the meta-service retry budget is exhausted. Such a
+                // tablet keeps its original rowsets and misses one injected size delta, which breaks
+                // the SHOW DATA golden below. Re-trigger only the tablets that are still uncompacted.
+                def uncompactedTablets = { ->
+                    tablets.findAll { tablet ->
+                        def (code, out, err) = curl("GET", tablet.CompactionStatus)
+                        assertEquals(code, 0)
+                        def tabletJson = parseJson(out.trim())
+                        assert tabletJson.rowsets instanceof List
+                        // a compacted tablet only holds [0-1] and the compacted [2-6] rowset
+                        ((List<String>) tabletJson.rowsets).size() != 2
+                    }
+                }
+                for (int round = 1; round <= 5; round++) {
+                    def pending = uncompactedTablets()
+                    if (pending.isEmpty()) {
+                        break
+                    }
+                    logger.info("round ${round}: re-trigger full compaction for ${pending.size()} tablets: ${pending.collect { it.TabletId }}")
+                    trigger_and_wait_compaction(tableName, "full", 300, [] as String[], pending.collect { it.TabletId })
+                }
 
                 sleep(60000)
                 // after full compaction, there are 2 rowsets.
                 rowsetCount = 0
+                def notCompacted = []
                 for (def tablet in tablets) {
                     String tablet_id = tablet.TabletId
                     def (code, out, err) = curl("GET", tablet.CompactionStatus)
@@ -93,9 +119,14 @@ suite("test_fix_tablet_stat_fault_injection", "nonConcurrent") {
                     assertEquals(code, 0)
                     def tabletJson = parseJson(out.trim())
                     assert tabletJson.rowsets instanceof List
-                    rowsetCount +=((List<String>) tabletJson.rowsets).size()
+                    def rowsets = (List<String>) tabletJson.rowsets
+                    rowsetCount += rowsets.size()
+                    if (rowsets.size() != 2) {
+                        notCompacted.add("tablet_id=${tablet_id} rowsets=${rowsets.size()} last_full_status=${tabletJson['last full status']}")
+                    }
                 }
-                // assert (rowsetCount == 2 * bucketSize * partitionSize)
+                assert notCompacted.isEmpty() : "full compaction did not finish on ${notCompacted.size()} tablets: ${notCompacted}"
+                assert (rowsetCount == 2 * bucketSize * partitionSize)
 
                 // data size should be very large
                 sql "select count(*) from ${tableName};"


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

`fault_injection_p0/test_fix_tablet_stat_fault_injection` triggers full compaction on 1000 tablets of one MoW table and compares `SHOW DATA` against a golden that assumes every compaction ran exactly once (each run injects a fixed size delta).

In cloud mode the HTTP compaction trigger is asynchronous, and `trigger_and_wait_compaction` returns once every tablet reports a completion timestamp, no matter whether the compaction succeeded or failed. Under 1000 concurrent full compactions on one table, all of them contend on the same delete bitmap lock key in meta-service; occasionally one request exhausts the meta-service txn conflict retry budget and the compaction fails with `[DELETE_BITMAP_LOCK_ERROR]txn conflict when get delete bitmap update lock`. That tablet silently keeps its 6 rowsets and misses one injected delta, so the case fails at the golden check:

```
Check tag 'select_2' failed
ExpectRow: [test_fix_tablet_stat_fault_injection, ..., 9.314 GB, 1000, 100, 0.000 ]
RealRow  : [test_fix_tablet_stat_fault_injection, ..., 9.304 GB, 1000, 100, 0.000 ]
```

Changes:

- `trigger_and_wait_compaction`: add an optional `tablet_ids` argument (default empty, existing callers unchanged) so a suite can trigger and wait on a subset of tablets.
- `test_fix_tablet_stat_fault_injection`: after the first round, re-trigger only the tablets that still hold more than 2 rowsets, at most 5 rounds, then assert that every tablet is compacted (the previously commented `rowsetCount` assertion is restored) before comparing `SHOW DATA`. A remaining failure now reports the tablet ids and their `last full status` instead of an opaque size mismatch.

The lock conflict itself is a transient, recoverable failure (production compaction is rescheduled by the compaction scheduler); this PR only makes the case tolerate it without touching the golden.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->
