### PR TITLE
[feature](fe) Add external metadata cache memory governance

### DIFF
--- a/be/src/information_schema/schema_catalog_meta_cache_stats_scanner.cpp
+++ b/be/src/information_schema/schema_catalog_meta_cache_stats_scanner.cpp
@@ -53,7 +53,13 @@ std::vector<SchemaScanner::ColumnDesc> SchemaCatalogMetaCacheStatsScanner::_s_tb
         {"LAST_LOAD_SUCCESS_TIME", TYPE_STRING, sizeof(StringRef), true},
         {"LAST_LOAD_FAILURE_TIME", TYPE_STRING, sizeof(StringRef), true},
         {"LAST_ERROR", TYPE_STRING, sizeof(StringRef), true},
+        {"MAX_WEIGHT", TYPE_BIGINT, sizeof(int64_t), true},
+        {"ESTIMATED_WEIGHT", TYPE_BIGINT, sizeof(int64_t), true},
+        {"WEIGHT_REJECT_COUNT", TYPE_BIGINT, sizeof(int64_t), true},
+        {"LAST_WEIGHT_REJECT_REASON", TYPE_STRING, sizeof(StringRef), true},
 };
+
+static constexpr size_t kLegacyMetaCacheStatsColumnCount = 24;
 
 SchemaCatalogMetaCacheStatsScanner::SchemaCatalogMetaCacheStatsScanner()
         : SchemaScanner(_s_tbls_columns, TSchemaTableType::SCH_CATALOG_META_CACHE_STATISTICS) {}
@@ -67,9 +73,12 @@ Status SchemaCatalogMetaCacheStatsScanner::start(RuntimeState* state) {
     return Status::OK();
 }
 
-Status SchemaCatalogMetaCacheStatsScanner::_get_meta_cache_from_fe() {
+Status SchemaCatalogMetaCacheStatsScanner::_fetch_from_fe(size_t column_count,
+                                                          TFetchSchemaTableDataResult* result,
+                                                          bool* fe_rejected) {
+    *fe_rejected = false;
     TSchemaTableRequestParams schema_table_request_params;
-    for (int i = 0; i < _s_tbls_columns.size(); i++) {
+    for (size_t i = 0; i < column_count; i++) {
         schema_table_request_params.__isset.columns_name = true;
         schema_table_request_params.columns_name.emplace_back(_s_tbls_columns[i].name);
     }
@@ -79,20 +88,36 @@ Status SchemaCatalogMetaCacheStatsScanner::_get_meta_cache_from_fe() {
     request.__set_schema_table_name(TSchemaTableName::CATALOG_META_CACHE_STATS);
     request.__set_schema_table_params(schema_table_request_params);
 
-    TFetchSchemaTableDataResult result;
-
     RETURN_IF_ERROR(ThriftRpcHelper::rpc<FrontendServiceClient>(
             _fe_addr.hostname, _fe_addr.port,
-            [&request, &result](FrontendServiceConnection& client) {
-                client->fetchSchemaTableData(result, request);
+            [&request, result](FrontendServiceConnection& client) {
+                client->fetchSchemaTableData(*result, request);
             },
             _rpc_timeout));
 
-    Status status(Status::create(result.status));
+    Status fe_status = Status::create(result->status);
+    *fe_rejected = !fe_status.ok();
+    return fe_status;
+}
+
+Status SchemaCatalogMetaCacheStatsScanner::_get_meta_cache_from_fe() {
+    TFetchSchemaTableDataResult result;
+    bool fe_rejected = false;
+    Status status = _fetch_from_fe(_s_tbls_columns.size(), &result, &fe_rejected);
     if (!status.ok()) {
-        LOG(WARNING) << "fetch catalog meta cache stats from FE(" << _fe_addr.hostname
-                     << ") failed, errmsg=" << status;
-        return status;
+        if (!fe_rejected) {
+            LOG(WARNING) << "fetch catalog meta cache stats from FE(" << _fe_addr.hostname
+                         << ") failed, errmsg=" << status;
+            return status;
+        }
+        Status first_status = status;
+        result = TFetchSchemaTableDataResult();
+        status = _fetch_from_fe(kLegacyMetaCacheStatsColumnCount, &result, &fe_rejected);
+        if (!status.ok()) {
+            LOG(WARNING) << "fetch catalog meta cache stats from FE(" << _fe_addr.hostname
+                         << ") failed, errmsg=" << first_status;
+            return first_status;
+        }
     }
     std::vector<TRow> result_data = result.data_batch;
 
@@ -106,19 +131,28 @@ Status SchemaCatalogMetaCacheStatsScanner::_get_meta_cache_from_fe() {
 
     _block->reserve(_block_rows_limit);
 
-    if (result_data.size() > 0) {
-        auto col_size = result_data[0].column_value.size();
-        if (col_size != _s_tbls_columns.size()) {
+    size_t col_size = _s_tbls_columns.size();
+    if (!result_data.empty()) {
+        col_size = result_data[0].column_value.size();
+        if (col_size != _s_tbls_columns.size() && col_size != kLegacyMetaCacheStatsColumnCount) {
             return Status::InternalError<false>(
                     "catalog meta cache stats schema is not match for FE and BE");
         }
     }
 
+    int available_columns = static_cast<int>(col_size);
+    int total_columns = static_cast<int>(_s_tbls_columns.size());
     for (int i = 0; i < result_data.size(); i++) {
         TRow row = result_data[i];
-        for (int j = 0; j < _s_tbls_columns.size(); j++) {
-            RETURN_IF_ERROR(insert_block_column(row.column_value[j], j, _block.get(),
-                                                _s_tbls_columns[j].type));
+        for (int j = 0; j < total_columns; j++) {
+            if (j < available_columns) {
+                RETURN_IF_ERROR(insert_block_column(row.column_value[j], j, _block.get(),
+                                                    _s_tbls_columns[j].type));
+            } else {
+                auto column_guard = _block->mutate_column_scoped(j);
+                column_guard.mutable_column()->insert_default();
+                column_guard.restore();
+            }
         }
     }
     return Status::OK();

--- a/be/src/information_schema/schema_catalog_meta_cache_stats_scanner.h
+++ b/be/src/information_schema/schema_catalog_meta_cache_stats_scanner.h
@@ -25,6 +25,7 @@
 namespace doris {
 class RuntimeState;
 class Block;
+class TFetchSchemaTableDataResult;
 
 class SchemaCatalogMetaCacheStatsScanner : public SchemaScanner {
     ENABLE_FACTORY_CREATOR(SchemaCatalogMetaCacheStatsScanner);
@@ -40,6 +41,8 @@ public:
 
 private:
     Status _get_meta_cache_from_fe();
+    Status _fetch_from_fe(size_t column_count, TFetchSchemaTableDataResult* result,
+                          bool* fe_rejected);
 
     TNetworkAddress _fe_addr;
 

--- a/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
+++ b/fe/fe-common/src/main/java/org/apache/doris/common/Config.java
@@ -2204,6 +2204,11 @@ public class Config extends ConfigBase {
     @ConfField(description = "The auto-refresh interval of the external meta cache.")
     public static long external_cache_refresh_time_minutes = 10; // 10 mins
 
+    @ConfField(mutable = false, masterOnly = false,
+            description = "FE-wide maximum weight for managed external metadata caches. Supports byte units "
+                    + "or a percentage of the JVM max heap; 0 disables the global quota.")
+    public static String external_meta_cache_max_weight = "0";
+
     // Enable manual miss load for external meta cache to avoid blocking replayer on slow loaders.
     @ConfField(mutable = true, masterOnly = false,
             description = "Whether external meta cache uses manual miss load instead of Caffeine sync load.")

--- a/fe/fe-connector/fe-connector-adbc/src/main/java/org/apache/doris/connector/adbc/AdbcConnector.java
+++ b/fe/fe-connector/fe-connector-adbc/src/main/java/org/apache/doris/connector/adbc/AdbcConnector.java
@@ -47,7 +47,7 @@ public class AdbcConnector implements Connector {
     private final AdbcSchemaStrategy schemaStrategy = new AdbcSchemaStrategy();
     private final AdbcPartitionedReadSupport partitionedRead = new AdbcPartitionedReadSupport();
     private final AdbcDialectSelector dialectSelector;
-    private final CatalogMetaCache metaCache = new CatalogMetaCache();
+    private final CatalogMetaCache metaCache;
     private final AdbcMetadataCache metadataCache;
 
     private volatile AdbcClient client;
@@ -67,7 +67,13 @@ public class AdbcConnector implements Connector {
         // The raw map, because the cache knobs are the shared framework's keys rather than this
         // connector's: CacheSpec owns their names, and mirroring them as fields here would give the
         // validator and the reader two things to drift apart.
-        this.metadataCache = new AdbcMetadataCache(metaCache, props.getRaw());
+        this.metaCache = CatalogMetaCache.managed(context.getCatalogId(), "adbc", props.getRaw());
+        try {
+            this.metadataCache = new AdbcMetadataCache(metaCache, props.getRaw());
+        } catch (RuntimeException | Error e) {
+            metaCache.close();
+            throw e;
+        }
     }
 
     @Override

--- a/fe/fe-connector/fe-connector-adbc/src/main/java/org/apache/doris/connector/adbc/AdbcConnectorProvider.java
+++ b/fe/fe-connector/fe-connector-adbc/src/main/java/org/apache/doris/connector/adbc/AdbcConnectorProvider.java
@@ -17,10 +17,12 @@
 
 package org.apache.doris.connector.adbc;
 
+import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.spi.Connector;
 import org.apache.doris.connector.spi.ConnectorContext;
 import org.apache.doris.connector.spi.ConnectorProvider;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -49,8 +51,8 @@ public class AdbcConnectorProvider implements ConnectorProvider {
     /**
      * Binds and validates every property this connector owns, by building the typed holder and throwing
      * away the result: the checking is the point, and constructing it is how the checks are expressed.
-     * This guards ALTER as well as CREATE -- the SPI's default {@code validatePropertiesForUpdate} merges
-     * the change into the stored properties and calls this method with the candidate.
+     * ALTER validates the merged candidate separately, tolerating unknown cache entries from older images
+     * but rejecting unknown entries explicitly submitted by that statement.
      *
      * <p>Cheap presence checks only. Resolving {@code driver_url} to a path needs adbc.conf's
      * {@code drivers_dir} and {@code driver_secure_path}, which arrive through the connector context
@@ -59,6 +61,17 @@ public class AdbcConnectorProvider implements ConnectorProvider {
     @Override
     public void validateProperties(Map<String, String> properties) {
         AdbcCatalogProperties.of(properties);
+        CacheSpec.checkWeightProperties(properties, properties, "adbc", "metadata");
+    }
+
+    @Override
+    public void validatePropertiesForUpdate(
+            Map<String, String> currentProperties, Map<String, String> updatedProperties) {
+        Map<String, String> candidate = currentProperties == null
+                ? new HashMap<>() : new HashMap<>(currentProperties);
+        candidate.putAll(updatedProperties);
+        AdbcCatalogProperties.of(candidate);
+        CacheSpec.checkWeightProperties(candidate, updatedProperties, "adbc", "metadata");
     }
 
     @Override

--- a/fe/fe-connector/fe-connector-adbc/src/main/java/org/apache/doris/connector/adbc/AdbcMetadataCache.java
+++ b/fe/fe-connector/fe-connector-adbc/src/main/java/org/apache/doris/connector/adbc/AdbcMetadataCache.java
@@ -21,6 +21,7 @@ import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.cache.MetaCache;
 import org.apache.doris.connector.cache.MetaCacheDefinition;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimators;
 import org.apache.doris.connector.cache.ScopePath;
 
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -97,7 +98,7 @@ public final class AdbcMetadataCache {
      * reads properties and nothing else -- no driver, no filesystem, no remote call.
      */
     public AdbcMetadataCache(Map<String, String> properties) {
-        this(new CatalogMetaCache(), properties);
+        this(CatalogMetaCache.unmanaged(), properties);
     }
 
     AdbcMetadataCache(CatalogMetaCache owner, Map<String, String> properties) {
@@ -105,14 +106,20 @@ public final class AdbcMetadataCache {
         CacheSpec spec = cacheSpec(properties);
         this.namespaces = owner.create(MetaCacheDefinition
                 .<String, List<AdbcNamespace>>builder("adbc-namespaces", spec, ignored -> ScopePath.catalog())
+                .budgetGroup(ENTRY)
+                .sizeEstimator(MetaCacheSizeEstimators.reflective())
                 .build());
         this.tableNames = owner.create(MetaCacheDefinition
                 .<TableNameKey, List<String>>builder("adbc-table-names", spec,
                         key -> ScopePath.database(key.dorisDbName))
+                .budgetGroup(ENTRY)
+                .sizeEstimator(MetaCacheSizeEstimators.reflective())
                 .build());
         this.tableSchemas = owner.create(MetaCacheDefinition
                 .<TableKey, Schema>builder("adbc-table-schema", spec,
                         key -> ScopePath.table(key.dorisDbName, key.table))
+                .budgetGroup(ENTRY)
+                .sizeEstimator(MetaCacheSizeEstimators.reflective())
                 .build());
     }
 

--- a/fe/fe-connector/fe-connector-adbc/src/test/java/org/apache/doris/connector/adbc/AdbcCatalogPropertiesTest.java
+++ b/fe/fe-connector/fe-connector-adbc/src/test/java/org/apache/doris/connector/adbc/AdbcCatalogPropertiesTest.java
@@ -233,6 +233,22 @@ class AdbcCatalogPropertiesTest {
         }
     }
 
+    @Test
+    void weightValidationDistinguishesSubmittedAndPersistedUnknownEntries() {
+        AdbcConnectorProvider provider = new AdbcConnectorProvider();
+        Map<String, String> current = minimal();
+        current.put("meta.cache.adbc.future_entry.max-weight", "future-format");
+        Assertions.assertDoesNotThrow(() -> AdbcCatalogProperties.of(current));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> provider.validateProperties(current));
+        Assertions.assertDoesNotThrow(() -> provider.validatePropertiesForUpdate(current, Map.of("comment", "new")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> provider.validatePropertiesForUpdate(
+                current, Map.of("meta.cache.adbc.metdata.max-weight", "1MB")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> provider.validatePropertiesForUpdate(
+                current, Map.of("meta.cache.adbc.metadata.max-weight", "invalid")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> provider.validatePropertiesForUpdate(
+                current, Map.of("meta.cache.max-weight", "1MB", "meta.cache.adbc.metadata.max-weight", "2MB")));
+    }
+
     /**
      * A cache knob is read through {@code CacheSpec}, which answers an unparseable value with the default
      * rather than an error. Silently caching for ten minutes when the operator wrote {@code ttl-second=6O0}

--- a/fe/fe-connector/fe-connector-adbc/src/test/java/org/apache/doris/connector/adbc/AdbcConnectorCacheHookTest.java
+++ b/fe/fe-connector/fe-connector-adbc/src/test/java/org/apache/doris/connector/adbc/AdbcConnectorCacheHookTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.connector.adbc;
 
+import org.apache.doris.connector.cache.MetaCacheGovernance;
 import org.apache.doris.connector.spi.ConnectorCapability;
 import org.apache.doris.connector.spi.ConnectorContext;
 
@@ -38,6 +39,22 @@ import java.util.concurrent.atomic.AtomicInteger;
  * catalog whose driver file it does not have.
  */
 class AdbcConnectorCacheHookTest {
+
+    @Test
+    void connectorRegistersManagedOwnerAndClosesIt() throws Exception {
+        int before = MetaCacheGovernance.catalogCaches(1L).size();
+        try (AdbcConnector connector = new AdbcConnector(Map.of(
+                AdbcCatalogProperties.URI, "file:/tmp/does-not-matter.db",
+                AdbcCatalogProperties.DRIVER_URL, "libadbc_driver_sqlite.so",
+                "meta.cache.adbc.metadata.max-weight", "1MB"), context())) {
+            Assertions.assertEquals(before + 1, MetaCacheGovernance.catalogCaches(1L).size());
+            rememberSchemaOf(connector.metadataCache(), MAIN_T1);
+            Assertions.assertTrue(MetaCacheGovernance.catalogCaches(1L).stream()
+                    .anyMatch(owner -> owner.entries().values().stream()
+                            .anyMatch(entry -> entry.metrics().getEstimatedWeight() > 0)));
+        }
+        Assertions.assertEquals(before, MetaCacheGovernance.catalogCaches(1L).size());
+    }
 
     private static final AdbcNamespace MAIN = new AdbcNamespace("main", "");
     private static final AdbcTableHandle MAIN_T1 = new AdbcTableHandle(MAIN, "t1");

--- a/fe/fe-connector/fe-connector-adbc/src/test/java/org/apache/doris/connector/adbc/AdbcMetadataCacheTest.java
+++ b/fe/fe-connector/fe-connector-adbc/src/test/java/org/apache/doris/connector/adbc/AdbcMetadataCacheTest.java
@@ -18,7 +18,11 @@
 package org.apache.doris.connector.adbc;
 
 import org.apache.doris.connector.cache.CacheSpec;
+import org.apache.doris.connector.cache.CatalogMetaCache;
+import org.apache.doris.connector.cache.MetaCacheGovernance;
 
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -36,6 +40,51 @@ import java.util.function.Supplier;
  * that only compared returned values would pass against a cache that never caches.
  */
 class AdbcMetadataCacheTest {
+
+    @Test
+    void managedCachesAccountAllPayloadsAndReleaseReservations() {
+        long baseline = MetaCacheGovernance.globalEstimatedWeight();
+        for (String limit : List.of("meta.cache.max-weight", "meta.cache.adbc.metadata.max-weight")) {
+            Map<String, String> properties = Map.of(limit, "1MB");
+            try (CatalogMetaCache owner = CatalogMetaCache.managed(91002L, "adbc", properties)) {
+                AdbcMetadataCache cache = new AdbcMetadataCache(owner, properties);
+                Counting<List<AdbcNamespace>> namespaces = new Counting<>(List.of(MAIN));
+                Counting<List<String>> names = new Counting<>(List.of("t1"));
+                Counting<Schema> schema = new Counting<>(new Schema(List.of(
+                        Field.nullable("payload", new ArrowType.Utf8())), Map.of("source", "adbc")));
+                for (int i = 0; i < 2; i++) {
+                    cache.namespaces(namespaces);
+                    cache.tableNames(MAIN, names);
+                    cache.tableSchema(MAIN_T1, schema);
+                }
+                Assertions.assertEquals(1, namespaces.calls);
+                Assertions.assertEquals(1, names.calls);
+                Assertions.assertEquals(1, schema.calls);
+                Assertions.assertEquals(List.of(owner), MetaCacheGovernance.catalogCaches(91002L));
+                owner.entries().values().forEach(entry -> {
+                    Assertions.assertTrue(entry.metrics().getEstimatedWeight() > 0);
+                    Assertions.assertEquals(0L, entry.metrics().getWeightRejectCount());
+                });
+                Assertions.assertTrue(MetaCacheGovernance.globalEstimatedWeight() > baseline);
+            }
+            Assertions.assertTrue(MetaCacheGovernance.catalogCaches(91002L).isEmpty());
+            Assertions.assertEquals(baseline, MetaCacheGovernance.globalEstimatedWeight());
+        }
+    }
+
+    @Test
+    void rejectedSchemaIsReturnedWithoutBeingCached() {
+        Map<String, String> properties = Map.of("meta.cache.adbc.metadata.max-weight", "1");
+        try (CatalogMetaCache owner = CatalogMetaCache.managed(91003L, "adbc", properties)) {
+            AdbcMetadataCache cache = new AdbcMetadataCache(owner, properties);
+            Counting<Schema> source = new Counting<>(SCHEMA);
+            Assertions.assertSame(SCHEMA, cache.tableSchema(MAIN_T1, source));
+            Assertions.assertSame(SCHEMA, cache.tableSchema(MAIN_T1, source));
+            Assertions.assertEquals(2, source.calls);
+            Assertions.assertEquals(2L,
+                    owner.entries().get("adbc-table-schema").metrics().getWeightRejectCount());
+        }
+    }
 
     private static final AdbcNamespace MAIN = new AdbcNamespace("main", "");
     private static final AdbcNamespace OTHER = new AdbcNamespace("other", "");

--- a/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/CacheSpec.java
+++ b/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/CacheSpec.java
@@ -17,10 +17,21 @@
 
 package org.apache.doris.connector.cache;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.OptionalLong;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Common cache specification for external metadata caches.
@@ -37,29 +48,44 @@ import java.util.OptionalLong;
  * <ul>
  *   <li>enable=false disables cache</li>
  *   <li>ttlSecond=0 disables cache, ttlSecond=-1 means no expiration</li>
- *   <li>capacity=0 disables cache; capacity is count-based</li>
+ *   <li>capacity=0 disables cache; a positive capacity remains the count safety limit</li>
+ *   <li>max-weight is an optional estimated retained-byte admission limit</li>
  * </ul>
  */
 public final class CacheSpec {
+    private static final Logger LOG = LogManager.getLogger(CacheSpec.class);
     public static final long CACHE_NO_TTL = -1L;
     public static final long CACHE_TTL_DISABLE_CACHE = 0L;
     private static final String META_CACHE_PREFIX = "meta.cache.";
     private static final String KEY_ENABLE = ".enable";
     private static final String KEY_TTL_SECOND = ".ttl-second";
     private static final String KEY_CAPACITY = ".capacity";
+    private static final String KEY_MAX_WEIGHT = ".max-weight";
+    private static final Pattern DATA_VOLUME_PATTERN = Pattern.compile(
+            "^([0-9]+)\\s*(B|KB|MB|GB|TB|PB)?$", Pattern.CASE_INSENSITIVE);
+    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
 
     private final boolean enable;
     private final long ttlSecond;
     private final long capacity;
+    private final OptionalLong maxWeight;
 
-    private CacheSpec(boolean enable, long ttlSecond, long capacity) {
+    private CacheSpec(boolean enable, long ttlSecond, long capacity, OptionalLong maxWeight) {
         this.enable = enable;
         this.ttlSecond = ttlSecond;
         this.capacity = capacity;
+        this.maxWeight = Objects.requireNonNull(maxWeight, "maxWeight");
     }
 
     public static CacheSpec of(boolean enable, long ttlSecond, long capacity) {
-        return new CacheSpec(enable, ttlSecond, capacity);
+        return new CacheSpec(enable, ttlSecond, capacity, OptionalLong.empty());
+    }
+
+    public static CacheSpec ofWeight(boolean enable, long ttlSecond, long capacity, long maxWeight) {
+        if (maxWeight <= 0L) {
+            throw new IllegalArgumentException("maxWeight must be positive: " + maxWeight);
+        }
+        return new CacheSpec(enable, ttlSecond, capacity, OptionalLong.of(maxWeight));
     }
 
     /**
@@ -98,7 +124,8 @@ public final class CacheSpec {
         boolean enable = getBooleanProperty(properties, propertySpec.getEnableKey(), propertySpec.isDefaultEnable());
         long ttlSecond = getLongProperty(properties, propertySpec.getTtlKey(), propertySpec.getDefaultTtlSecond());
         long capacity = getLongProperty(properties, propertySpec.getCapacityKey(), propertySpec.getDefaultCapacity());
-        return of(enable, ttlSecond, capacity);
+        OptionalLong maxWeight = getWeightProperty(properties, propertySpec.getMaxWeightKey());
+        return new CacheSpec(enable, ttlSecond, capacity, maxWeight);
     }
 
     /**
@@ -116,6 +143,7 @@ public final class CacheSpec {
                 .enable(cacheKeyPrefix + KEY_ENABLE, defaultSpec.isEnable())
                 .ttl(cacheKeyPrefix + KEY_TTL_SECOND, defaultSpec.getTtlSecond())
                 .capacity(cacheKeyPrefix + KEY_CAPACITY, defaultSpec.getCapacity())
+                .maxWeight(cacheKeyPrefix + KEY_MAX_WEIGHT)
                 .build();
     }
 
@@ -168,8 +196,124 @@ public final class CacheSpec {
         }
     }
 
+    /** Strict CREATE/ALTER-time validation for the catalog weight property. */
+    public static OptionalLong checkCatalogWeightProperty(Map<String, String> properties) {
+        if (properties == null) {
+            return OptionalLong.empty();
+        }
+        String catalogValue = properties.get(MetaCacheBudgetManager.CATALOG_MAX_WEIGHT_PROPERTY);
+        if (catalogValue == null) {
+            return OptionalLong.empty();
+        }
+        long parsed = parseWeight(catalogValue,
+                MetaCacheBudgetManager.CATALOG_MAX_WEIGHT_PROPERTY, false, 0L);
+        if (parsed <= 0L) {
+            throw new IllegalArgumentException(
+                    MetaCacheBudgetManager.CATALOG_MAX_WEIGHT_PROPERTY + " must be positive");
+        }
+        return OptionalLong.of(parsed);
+    }
+
+    /** Validates consumed weight values, tolerating unknown entries persisted by another version. */
+    public static void checkWeightProperties(
+            Map<String, String> properties, String engine, String... knownEntries) {
+        checkWeightProperties(properties, Collections.emptyMap(), engine, knownEntries);
+    }
+
+    /** DDL validation: reject unknown entries only when explicitly submitted by this statement. */
+    public static void checkWeightProperties(Map<String, String> properties,
+            Map<String, String> submittedProperties, String engine, String... knownEntries) {
+        OptionalLong catalogMax = checkCatalogWeightProperty(properties);
+        if (properties == null) {
+            return;
+        }
+        String prefix = metaCacheKeyPrefix(engine);
+        Set<String> weightKeys = new HashSet<>();
+        for (String entry : knownEntries) {
+            weightKeys.add(prefix + entry + KEY_MAX_WEIGHT);
+        }
+        for (String key : submittedProperties.keySet()) {
+            if (key.startsWith(prefix) && key.endsWith(KEY_MAX_WEIGHT) && !weightKeys.contains(key)) {
+                throw new IllegalArgumentException("Unknown metadata cache weight property: " + key);
+            }
+        }
+        for (Map.Entry<String, String> property : properties.entrySet()) {
+            String key = property.getKey();
+            if (!weightKeys.contains(key)) {
+                // ALTER merges properties and cannot remove keys written by a newer connector version.
+                // Like other connector properties, validate consumed values but tolerate unknown keys.
+                continue;
+            }
+            long parsed = parseWeight(property.getValue(), key, false, 0L);
+            if (parsed <= 0L) {
+                throw new IllegalArgumentException(key + " must be positive");
+            }
+            if (catalogMax.isPresent() && parsed > catalogMax.getAsLong()) {
+                throw new IllegalArgumentException(key + " can not exceed "
+                        + MetaCacheBudgetManager.CATALOG_MAX_WEIGHT_PROPERTY);
+            }
+        }
+    }
+
     public static boolean isCacheEnabled(boolean enable, long ttlSecond, long capacity) {
         return enable && ttlSecond != 0 && capacity != 0;
+    }
+
+    /** Parse bytes with an optional binary unit, or a heap percentage when explicitly allowed. */
+    public static long parseWeight(String value, String key, boolean allowPercent, long maxHeapBytes) {
+        String normalized = Objects.requireNonNull(value, "value").trim();
+        if (normalized.isEmpty()) {
+            throw invalidWeight(key, value);
+        }
+        if (normalized.endsWith("%")) {
+            if (!allowPercent || maxHeapBytes <= 0L) {
+                throw invalidWeight(key, value);
+            }
+            try {
+                BigDecimal percentage = new BigDecimal(
+                        normalized.substring(0, normalized.length() - 1).trim());
+                if (percentage.signum() < 0 || percentage.compareTo(BigDecimal.valueOf(100L)) > 0) {
+                    throw invalidWeight(key, value);
+                }
+                return checkedLong(BigDecimal.valueOf(maxHeapBytes)
+                        .multiply(percentage)
+                        .divide(BigDecimal.valueOf(100L))
+                        .toBigInteger(), key, value);
+            } catch (NumberFormatException e) {
+                throw invalidWeight(key, value);
+            }
+        }
+        Matcher matcher = DATA_VOLUME_PATTERN.matcher(normalized);
+        if (!matcher.matches()) {
+            throw invalidWeight(key, value);
+        }
+        BigInteger amount = new BigInteger(matcher.group(1));
+        String rawUnit = matcher.group(2);
+        String unit = rawUnit == null ? "B" : rawUnit.toUpperCase(Locale.ROOT);
+        int power;
+        switch (unit) {
+            case "B":
+                power = 0;
+                break;
+            case "KB":
+                power = 1;
+                break;
+            case "MB":
+                power = 2;
+                break;
+            case "GB":
+                power = 3;
+                break;
+            case "TB":
+                power = 4;
+                break;
+            case "PB":
+                power = 5;
+                break;
+            default:
+                throw invalidWeight(key, value);
+        }
+        return checkedLong(amount.multiply(BigInteger.valueOf(1024L).pow(power)), key, value);
     }
 
     /**
@@ -229,6 +373,37 @@ public final class CacheSpec {
         }
     }
 
+    private static OptionalLong getWeightProperty(Map<String, String> properties, String key) {
+        if (key == null) {
+            return OptionalLong.empty();
+        }
+        String value = properties.get(key);
+        if (value == null) {
+            return OptionalLong.empty();
+        }
+        try {
+            long parsed = parseWeight(value, key, false, 0L);
+            if (parsed <= 0L) {
+                throw invalidWeight(key, value);
+            }
+            return OptionalLong.of(parsed);
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Ignoring invalid persisted metadata cache weight property {}={}", key, value);
+            return OptionalLong.empty();
+        }
+    }
+
+    private static long checkedLong(BigInteger value, String key, String rawValue) {
+        if (value.signum() < 0 || value.compareTo(LONG_MAX) > 0) {
+            throw invalidWeight(key, rawValue);
+        }
+        return value.longValue();
+    }
+
+    private static IllegalArgumentException invalidWeight(String key, String value) {
+        return new IllegalArgumentException("Invalid cache weight for '" + key + "': " + value);
+    }
+
     public boolean isEnable() {
         return enable;
     }
@@ -241,6 +416,19 @@ public final class CacheSpec {
         return capacity;
     }
 
+    public OptionalLong getMaxWeight() {
+        return maxWeight;
+    }
+
+    public boolean isWeightBounded() {
+        return maxWeight.isPresent();
+    }
+
+    public boolean isCacheEnabled() {
+        return isCacheEnabled(enable, ttlSecond, capacity)
+                && (!maxWeight.isPresent() || maxWeight.getAsLong() != 0L);
+    }
+
     public static final class PropertySpec {
         private final String enableKey;
         private final boolean defaultEnable;
@@ -248,15 +436,17 @@ public final class CacheSpec {
         private final long defaultTtlSecond;
         private final String capacityKey;
         private final long defaultCapacity;
+        private final String maxWeightKey;
 
         private PropertySpec(String enableKey, boolean defaultEnable, String ttlKey,
-                long defaultTtlSecond, String capacityKey, long defaultCapacity) {
+                long defaultTtlSecond, String capacityKey, long defaultCapacity, String maxWeightKey) {
             this.enableKey = enableKey;
             this.defaultEnable = defaultEnable;
             this.ttlKey = ttlKey;
             this.defaultTtlSecond = defaultTtlSecond;
             this.capacityKey = capacityKey;
             this.defaultCapacity = defaultCapacity;
+            this.maxWeightKey = maxWeightKey;
         }
 
         public String getEnableKey() {
@@ -283,6 +473,10 @@ public final class CacheSpec {
             return defaultCapacity;
         }
 
+        public String getMaxWeightKey() {
+            return maxWeightKey;
+        }
+
         public static final class Builder {
             private String enableKey;
             private boolean defaultEnable;
@@ -290,6 +484,7 @@ public final class CacheSpec {
             private long defaultTtlSecond;
             private String capacityKey;
             private long defaultCapacity;
+            private String maxWeightKey;
 
             public Builder enable(String key, boolean defaultValue) {
                 this.enableKey = key;
@@ -309,6 +504,11 @@ public final class CacheSpec {
                 return this;
             }
 
+            public Builder maxWeight(String key) {
+                this.maxWeightKey = Objects.requireNonNull(key, "key");
+                return this;
+            }
+
             public PropertySpec build() {
                 return new PropertySpec(
                         Objects.requireNonNull(enableKey, "enableKey is required"),
@@ -316,7 +516,8 @@ public final class CacheSpec {
                         Objects.requireNonNull(ttlKey, "ttlKey is required"),
                         defaultTtlSecond,
                         Objects.requireNonNull(capacityKey, "capacityKey is required"),
-                        defaultCapacity);
+                        defaultCapacity,
+                        maxWeightKey);
             }
         }
     }

--- a/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/CatalogMetaCache.java
+++ b/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/CatalogMetaCache.java
@@ -20,7 +20,9 @@ package org.apache.doris.connector.cache;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -33,15 +35,57 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public final class CatalogMetaCache implements AutoCloseable {
     private final ScopedMetaCacheRegistry registry;
+    private final MetaCacheBudgetManager budgetManager;
+    private final long catalogId;
+    private final String engine;
+    private final OptionalLong catalogMaxWeight;
+    private final boolean managed;
     private final Set<String> names = ConcurrentHashMap.newKeySet();
+    private final Map<String, MetaCache<?, ?>> entries = new ConcurrentHashMap<>();
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    public CatalogMetaCache() {
-        this(new ScopedMetaCacheRegistry());
+    private CatalogMetaCache() {
+        this(new ScopedMetaCacheRegistry(), new MetaCacheBudgetManager(OptionalLong.empty()),
+                0L, "standalone", OptionalLong.empty(), false);
     }
 
     CatalogMetaCache(ScopedMetaCacheRegistry registry) {
+        this(registry, new MetaCacheBudgetManager(OptionalLong.empty()),
+                0L, "standalone", OptionalLong.empty(), false);
+    }
+
+    public CatalogMetaCache(MetaCacheBudgetManager budgetManager, long catalogId,
+            String engine, Map<String, String> catalogProperties) {
+        this(new ScopedMetaCacheRegistry(), budgetManager, catalogId, engine,
+                budgetManager.parseCatalogMaxWeight(catalogProperties), false);
+    }
+
+    /**
+     * Creates an isolated owner without shared global/catalog budgets or unified statistics registration.
+     * Entry-local weight limits still apply. Use for independent caches and tests; governed catalog caches
+     * must use {@link #managed}.
+     */
+    public static CatalogMetaCache unmanaged() {
+        return new CatalogMetaCache();
+    }
+
+    public static CatalogMetaCache managed(long catalogId, String engine,
+            Map<String, String> catalogProperties) {
+        MetaCacheBudgetManager manager = MetaCacheGovernance.budgetManager();
+        CatalogMetaCache cache = new CatalogMetaCache(new ScopedMetaCacheRegistry(), manager,
+                catalogId, engine, manager.parseCatalogMaxWeight(catalogProperties), true);
+        MetaCacheGovernance.register(cache);
+        return cache;
+    }
+
+    CatalogMetaCache(ScopedMetaCacheRegistry registry, MetaCacheBudgetManager budgetManager,
+            long catalogId, String engine, OptionalLong catalogMaxWeight, boolean managed) {
         this.registry = Objects.requireNonNull(registry, "registry can not be null");
+        this.budgetManager = Objects.requireNonNull(budgetManager, "budgetManager can not be null");
+        this.catalogId = catalogId;
+        this.engine = Objects.requireNonNull(engine, "engine can not be null");
+        this.catalogMaxWeight = Objects.requireNonNull(catalogMaxWeight, "catalogMaxWeight can not be null");
+        this.managed = managed;
     }
 
     public <K, V> MetaCache<K, V> create(MetaCacheDefinition<K, V> definition) {
@@ -51,14 +95,39 @@ public final class CatalogMetaCache implements AutoCloseable {
         if (!names.add(nonNullDefinition.name())) {
             throw new IllegalArgumentException("Duplicate meta cache name: " + nonNullDefinition.name());
         }
+        MetaCacheBudgetManager.EntryBudget entryBudget = null;
         try {
-            return new MetaCache<>(nonNullDefinition,
+            boolean weightLimited = budgetManager.hasLimit(
+                    catalogMaxWeight, nonNullDefinition.cacheSpec().getMaxWeight());
+            if (weightLimited && nonNullDefinition.sizeEstimator() == null) {
+                throw new IllegalArgumentException("Weighted metadata cache requires a size estimator: "
+                        + nonNullDefinition.name());
+            }
+            if (weightLimited) {
+                entryBudget = budgetManager.createEntryBudget(catalogId, engine,
+                        nonNullDefinition.name(), nonNullDefinition.budgetGroup(), catalogMaxWeight,
+                        nonNullDefinition.cacheSpec().getMaxWeight());
+            }
+            MetaCache<K, V> created = new MetaCache<>(nonNullDefinition,
                     registry.createCacheWithMetaRemovalListener(nonNullDefinition.name(),
                             nonNullDefinition.cacheSpec(), nonNullDefinition.removalListener(),
                             nonNullDefinition.discardListener(),
-                            nonNullDefinition.refreshAfterWrite(), nonNullDefinition.refreshExecutor()));
+                            nonNullDefinition.refreshAfterWrite(), nonNullDefinition.refreshExecutor(),
+                            entryBudget == null ? null : nonNullDefinition.sizeEstimator(), entryBudget));
+            entries.put(nonNullDefinition.name(), created);
+            return created;
         } catch (RuntimeException | Error throwable) {
+            if (entryBudget != null) {
+                entryBudget.close();
+            }
             names.remove(nonNullDefinition.name());
+            if (managed) {
+                try {
+                    close();
+                } catch (RuntimeException | Error closeFailure) {
+                    throwable.addSuppressed(closeFailure);
+                }
+            }
             throw throwable;
         }
     }
@@ -100,11 +169,38 @@ public final class CatalogMetaCache implements AutoCloseable {
         return registry.metrics();
     }
 
+    public Map<String, MetaCache<?, ?>> entries() {
+        return java.util.Collections.unmodifiableMap(entries);
+    }
+
+    public long catalogId() {
+        return catalogId;
+    }
+
+    public String engine() {
+        return engine;
+    }
+
+    public OptionalLong catalogMaxWeight() {
+        return catalogMaxWeight;
+    }
+
+    public boolean hasEnclosingWeightLimit() {
+        return budgetManager.hasLimit(catalogMaxWeight, OptionalLong.empty());
+    }
+
     @Override
     public void close() {
         if (closed.compareAndSet(false, true)) {
-            registry.close();
-            names.clear();
+            try {
+                registry.close();
+            } finally {
+                names.clear();
+                entries.clear();
+                if (managed) {
+                    MetaCacheGovernance.unregister(this);
+                }
+            }
         }
     }
 

--- a/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/ConnectorMetadataCache.java
+++ b/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/ConnectorMetadataCache.java
@@ -62,7 +62,7 @@ public final class ConnectorMetadataCache<V> {
      *                  {@code null}, treated as empty (defaults apply).
      */
     public ConnectorMetadataCache(String engine, String entryName, Map<String, String> props) {
-        this(new CatalogMetaCache(), engine + "." + entryName, engine, entryName, props);
+        this(CatalogMetaCache.unmanaged(), engine + "." + entryName, engine, entryName, props);
     }
 
     public ConnectorMetadataCache(
@@ -73,20 +73,34 @@ public final class ConnectorMetadataCache<V> {
 
     public ConnectorMetadataCache(CatalogMetaCache owner, String cacheName, String engine, String entryName,
             Map<String, String> props, Function<ConnectorTableKey, ScopePath> scopeResolver) {
+        this(owner, cacheName, engine, entryName, props, scopeResolver, MetaCacheSizeEstimators.reflective());
+    }
+
+    public ConnectorMetadataCache(CatalogMetaCache owner, String cacheName, String engine, String entryName,
+            Map<String, String> props, Function<ConnectorTableKey, ScopePath> scopeResolver,
+            MetaCacheSizeEstimator<ConnectorTableKey, V> sizeEstimator) {
         this.owner = Objects.requireNonNull(owner, "owner can not be null");
         Objects.requireNonNull(engine, "engine can not be null");
         Objects.requireNonNull(entryName, "entryName can not be null");
         Map<String, String> properties = props == null ? Collections.emptyMap() : props;
         CacheSpec spec = CacheSpec.fromProperties(properties, engine, entryName,
                 CacheSpec.of(true, DEFAULT_TTL_SECOND, DEFAULT_CAPACITY));
-        this.entry = owner.create(MetaCacheDefinition
+        MetaCacheDefinition.Builder<ConnectorTableKey, V> builder = MetaCacheDefinition
                 .<ConnectorTableKey, V>builder(cacheName, spec, scopeResolver)
-                .build());
+                .budgetGroup(entryName);
+        if (sizeEstimator != null) {
+            builder.sizeEstimator(sizeEstimator);
+        }
+        this.entry = owner.create(builder.build());
     }
 
     /** Caching is on only when the resolved {@link CacheSpec} is effectively enabled (see {@link #entry}'s spec). */
     public boolean isEnabled() {
         return entry.isEnabled();
+    }
+
+    public boolean isWeightBounded() {
+        return entry.isWeightBounded();
     }
 
     /**

--- a/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/JvmSizeUtils.java
+++ b/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/JvmSizeUtils.java
@@ -1,0 +1,246 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.cache;
+
+import com.sun.management.HotSpotDiagnosticMXBean;
+
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.ToLongFunction;
+
+/**
+ * Low-cost JVM heap layout formulas for type-specific connector cache estimators.
+ *
+ * <p>This class reflects class declarations once to calculate shallow sizes. It never reads fields from a runtime
+ * object and never walks an object graph.
+ */
+public final class JvmSizeUtils {
+    private static final VmLayout VM_LAYOUT = VmLayout.detect();
+    private static final boolean COMPACT_STRINGS = vmBoolean("CompactStrings", true);
+
+    private static final ClassValue<Long> SHALLOW_SIZES = new ClassValue<>() {
+        @Override
+        protected Long computeValue(Class<?> type) {
+            if (type.isArray()) {
+                throw new IllegalArgumentException("Array size depends on its length: " + type);
+            }
+            long size = VM_LAYOUT.objectHeaderBytes();
+            for (Class<?> current = type; current != null; current = current.getSuperclass()) {
+                for (Field field : current.getDeclaredFields()) {
+                    if (!Modifier.isStatic(field.getModifiers())) {
+                        size = saturatedAdd(size, fieldSize(field.getType()));
+                    }
+                }
+            }
+            return align(size);
+        }
+    };
+    private static final long STRING_SHALLOW_BYTES = instanceSize(String.class);
+    private static final long ARRAY_LIST_SHALLOW_BYTES = instanceSize(java.util.ArrayList.class);
+
+    private JvmSizeUtils() {
+    }
+
+    public static long instanceSize(Class<?> type) {
+        return SHALLOW_SIZES.get(type);
+    }
+
+    public static long objectArraySize(int length) {
+        return arraySize(length, VM_LAYOUT.referenceBytes());
+    }
+
+    public static long byteArraySize(int length) {
+        return arraySize(length, Byte.BYTES);
+    }
+
+    /** Returns the full retained heap array, not a slice's capacity; native payload is outside heap accounting. */
+    public static byte[] byteBufferBackingArray(ByteBuffer buffer) {
+        if (buffer.hasArray()) {
+            return buffer.array();
+        }
+        if (buffer.isDirect()) {
+            return null;
+        }
+        // Read-only heap buffers hide their backing array, which can be much larger than their capacity.
+        throw new IllegalStateException("Can not completely estimate heap buffer: " + buffer.getClass().getName());
+    }
+
+    public static long intArraySize(int length) {
+        return arraySize(length, Integer.BYTES);
+    }
+
+    public static long longArraySize(int length) {
+        return arraySize(length, Long.BYTES);
+    }
+
+    /** Estimate an array whose component is a primitive type. */
+    public static long primitiveArraySize(Class<?> componentType, int length) {
+        if (!componentType.isPrimitive() || componentType == void.class) {
+            throw new IllegalArgumentException("Not an array component primitive: " + componentType);
+        }
+        return arraySize(length, Math.toIntExact(fieldSize(componentType)));
+    }
+
+    public static long arrayListSize(int backingArrayCapacity) {
+        return saturatedAdd(ARRAY_LIST_SHALLOW_BYTES, objectArraySize(backingArrayCapacity));
+    }
+
+    /** Estimates list element payload from evenly spaced samples, including both ends of the list. */
+    public static <T> long sampledListPayload(
+            List<T> values, int sampleCount, ToLongFunction<? super T> estimator) {
+        Objects.requireNonNull(values, "values");
+        Objects.requireNonNull(estimator, "estimator");
+        if (sampleCount <= 0) {
+            throw new IllegalArgumentException("sampleCount must be positive: " + sampleCount);
+        }
+        int size = values.size();
+        if (size == 0) {
+            return 0L;
+        }
+        int samples = Math.min(size, sampleCount);
+        long sampledBytes = 0L;
+        for (int sample = 0; sample < samples; sample++) {
+            int index = samples == 1
+                    ? 0 : (int) ((long) sample * (size - 1) / (samples - 1));
+            sampledBytes = saturatedAdd(sampledBytes, estimator.applyAsLong(values.get(index)));
+        }
+        if (samples == size) {
+            return sampledBytes;
+        }
+        double scaled = (double) sampledBytes * size / samples;
+        return scaled >= Long.MAX_VALUE ? Long.MAX_VALUE : (long) scaled;
+    }
+
+    /** Estimate the heap retained by a Java 17 String and its compact-string byte array. */
+    public static long stringSize(String value) {
+        if (value == null) {
+            return 0L;
+        }
+        int bytesPerCharacter = COMPACT_STRINGS && isLatin1(value) ? Byte.BYTES : Character.BYTES;
+        long valueBytes = saturatedMultiply(value.length(), bytesPerCharacter);
+        int arrayLength = valueBytes >= Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) valueBytes;
+        return saturatedAdd(STRING_SHALLOW_BYTES, byteArraySize(arrayLength));
+    }
+
+    public static long saturatedAdd(long left, long right) {
+        if (right > 0L && left > Long.MAX_VALUE - right) {
+            return Long.MAX_VALUE;
+        }
+        return left + right;
+    }
+
+    public static long saturatedMultiply(long left, long right) {
+        if (left == 0L || right == 0L) {
+            return 0L;
+        }
+        if (left > Long.MAX_VALUE / right) {
+            return Long.MAX_VALUE;
+        }
+        return left * right;
+    }
+
+    private static long arraySize(int length, int elementBytes) {
+        long elements = saturatedMultiply(length, elementBytes);
+        return align(saturatedAdd(VM_LAYOUT.arrayHeaderBytes(), elements));
+    }
+
+    private static long fieldSize(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return VM_LAYOUT.referenceBytes();
+        }
+        if (type == long.class || type == double.class) {
+            return Long.BYTES;
+        }
+        if (type == int.class || type == float.class) {
+            return Integer.BYTES;
+        }
+        if (type == short.class || type == char.class) {
+            return Short.BYTES;
+        }
+        return Byte.BYTES;
+    }
+
+    private static boolean isLatin1(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) > 0xff) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static long align(long value) {
+        long remainder = value % VM_LAYOUT.objectAlignmentBytes();
+        return remainder == 0L
+                ? value
+                : saturatedAdd(value, VM_LAYOUT.objectAlignmentBytes() - remainder);
+    }
+
+    private static boolean vmBoolean(String option, boolean defaultValue) {
+        try {
+            HotSpotDiagnosticMXBean diagnostic = hotSpotDiagnostic();
+            return diagnostic == null
+                    ? defaultValue
+                    : Boolean.parseBoolean(diagnostic.getVMOption(option).getValue());
+        } catch (RuntimeException | LinkageError ignored) {
+            return defaultValue;
+        }
+    }
+
+    private static int vmInt(String option, int defaultValue) {
+        try {
+            HotSpotDiagnosticMXBean diagnostic = hotSpotDiagnostic();
+            return diagnostic == null
+                    ? defaultValue
+                    : Integer.parseInt(diagnostic.getVMOption(option).getValue());
+        } catch (RuntimeException | LinkageError ignored) {
+            return defaultValue;
+        }
+    }
+
+    private static HotSpotDiagnosticMXBean hotSpotDiagnostic() {
+        return ManagementFactory.getPlatformMXBean(HotSpotDiagnosticMXBean.class);
+    }
+
+    private record VmLayout(
+            int referenceBytes,
+            int objectHeaderBytes,
+            int arrayHeaderBytes,
+            int objectAlignmentBytes) {
+
+        private static VmLayout detect() {
+            int referenceBytes = vmBoolean("UseCompressedOops", true) ? Integer.BYTES : Long.BYTES;
+            int classPointerBytes = vmBoolean("UseCompressedClassPointers", true)
+                    ? Integer.BYTES : Long.BYTES;
+            int alignment = vmInt("ObjectAlignmentInBytes", Long.BYTES);
+            int objectHeaderBytes = Long.BYTES + classPointerBytes;
+            int arrayHeaderBytes = Math.toIntExact(
+                    alignWithoutLayout(objectHeaderBytes + Integer.BYTES, alignment));
+            return new VmLayout(referenceBytes, objectHeaderBytes, arrayHeaderBytes, alignment);
+        }
+
+        private static long alignWithoutLayout(long value, int alignment) {
+            long remainder = value % alignment;
+            return remainder == 0L ? value : value + alignment - remainder;
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/MetaCache.java
+++ b/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/MetaCache.java
@@ -110,6 +110,11 @@ public final class MetaCache<K, V> {
         return metrics().isEffectiveEnabled();
     }
 
+    /** Whether this entry currently participates in byte-based memory governance. */
+    public boolean isWeightBounded() {
+        return metrics().isWeightBounded();
+    }
+
     public long size() {
         return metrics().getPhysicalEntryCount();
     }

--- a/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/MetaCacheBudgetManager.java
+++ b/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/MetaCacheBudgetManager.java
@@ -1,0 +1,605 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.cache;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongUnaryOperator;
+
+/**
+ * Process-wide admission accounting shared by FE and connector metadata caches.
+ * Estimation happens before this class is entered; its lock covers only arithmetic and small maps.
+ */
+public final class MetaCacheBudgetManager {
+    private static final Logger LOG = LogManager.getLogger(MetaCacheBudgetManager.class);
+    private static final ExecutorService PEER_RECLAIM_EXECUTOR = Executors.newSingleThreadExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "external-meta-cache-peer-reclaim");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    public static final String CATALOG_MAX_WEIGHT_PROPERTY = "meta.cache.max-weight";
+
+    private final Object lock = new Object();
+    private final OptionalLong globalMaxWeight;
+    private final Map<Long, Bucket> catalogBuckets = new HashMap<>();
+    private final Map<EntryGroupScope, Bucket> entryGroupBuckets = new HashMap<>();
+    private final Map<EntryScope, EntryBudget> entryBudgets = new HashMap<>();
+    private final AtomicLong nextEntryBudgetId = new AtomicLong();
+    private long globalUsedWeight;
+
+    public MetaCacheBudgetManager(OptionalLong globalMaxWeight) {
+        this.globalMaxWeight = Objects.requireNonNull(globalMaxWeight, "globalMaxWeight");
+        if (globalMaxWeight.isPresent() && globalMaxWeight.getAsLong() <= 0L) {
+            throw new IllegalArgumentException("global max weight must be positive when enabled");
+        }
+    }
+
+    public OptionalLong parseCatalogMaxWeight(Map<String, String> catalogProperties) {
+        String configured = catalogProperties == null ? null
+                : catalogProperties.get(CATALOG_MAX_WEIGHT_PROPERTY);
+        if (configured == null) {
+            return OptionalLong.empty();
+        }
+        try {
+            long parsed = CacheSpec.parseWeight(configured, CATALOG_MAX_WEIGHT_PROPERTY, false, 0L);
+            if (parsed <= 0L) {
+                throw new IllegalArgumentException(CATALOG_MAX_WEIGHT_PROPERTY + " must be positive");
+            }
+            return OptionalLong.of(parsed);
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Ignoring invalid persisted metadata cache property {}={}",
+                    CATALOG_MAX_WEIGHT_PROPERTY, configured);
+            return OptionalLong.empty();
+        }
+    }
+
+    public boolean hasLimit(OptionalLong catalogMaxWeight, OptionalLong entryMaxWeight) {
+        return globalMaxWeight.isPresent() || catalogMaxWeight.isPresent() || entryMaxWeight.isPresent();
+    }
+
+    public EntryBudget createEntryBudget(long catalogId, String engine, String entryName, String budgetGroup,
+            OptionalLong catalogMaxWeight, OptionalLong entryMaxWeight) {
+        Objects.requireNonNull(engine, "engine");
+        Objects.requireNonNull(entryName, "entryName");
+        Objects.requireNonNull(budgetGroup, "budgetGroup");
+        OptionalLong effectiveMax = minimumPresent(globalMaxWeight, catalogMaxWeight, entryMaxWeight);
+        if (!effectiveMax.isPresent()) {
+            throw new IllegalArgumentException("entry budget requires at least one configured weight bound");
+        }
+
+        EntryGroupScope groupScope = new EntryGroupScope(catalogId, engine, budgetGroup);
+        EntryScope scope = new EntryScope(nextEntryBudgetId.incrementAndGet(), groupScope, entryName);
+        synchronized (lock) {
+            Bucket catalogBucket = catalogBuckets.get(catalogId);
+            long catalogLimit = minimumLimit(globalMaxWeight, catalogMaxWeight);
+            if (catalogBucket == null) {
+                catalogBucket = new Bucket(catalogLimit);
+                catalogBuckets.put(catalogId, catalogBucket);
+            } else if (catalogBucket.maxWeight != catalogLimit) {
+                throw new IllegalStateException("Conflicting catalog cache max weight for catalog " + catalogId);
+            }
+            Bucket groupBucket = entryGroupBuckets.get(groupScope);
+            if (groupBucket == null) {
+                groupBucket = new Bucket(effectiveMax.getAsLong());
+                entryGroupBuckets.put(groupScope, groupBucket);
+            } else if (groupBucket.maxWeight != effectiveMax.getAsLong()) {
+                throw new IllegalStateException("Conflicting metadata cache entry max weight for " + groupScope);
+            }
+            Bucket entryBucket = new Bucket(effectiveMax.getAsLong());
+            EntryBudget budget = new EntryBudget(this, scope, catalogBucket, groupBucket, entryBucket,
+                    effectiveMax.getAsLong());
+            entryBudgets.put(scope, budget);
+            catalogBucket.liveEntries++;
+            groupBucket.liveEntries++;
+            return budget;
+        }
+    }
+
+    public long getGlobalUsedWeight() {
+        synchronized (lock) {
+            return globalUsedWeight;
+        }
+    }
+
+    private Optional<AdmissionReservation> tryReserve(EntryBudget budget, long bytes) {
+        checkWeight(bytes);
+        synchronized (lock) {
+            if (budget.closed) {
+                return Optional.empty();
+            }
+            if (!fits(limitOf(globalMaxWeight), globalUsedWeight, bytes)
+                    || !fits(budget.catalogBucket.maxWeight, budget.catalogBucket.usedWeight, bytes)
+                    || !fits(budget.groupBucket.maxWeight, budget.groupBucket.usedWeight, bytes)) {
+                return Optional.empty();
+            }
+            addUsed(budget, bytes);
+            return Optional.of(new AdmissionReservation(this, budget, bytes));
+        }
+    }
+
+    private Optional<ReservationReplacement> tryReplace(
+            AdmissionReservation previous, long newBytes) {
+        checkWeight(newBytes);
+        synchronized (lock) {
+            if (!previous.active || previous.entryBudget.closed) {
+                return Optional.empty();
+            }
+            EntryBudget budget = previous.entryBudget;
+            long heldBytes = Math.max(previous.accountedBytes, newBytes);
+            long delta = heldBytes - previous.accountedBytes;
+            if (delta > 0L && (!fits(limitOf(globalMaxWeight), globalUsedWeight, delta)
+                    || !fits(budget.catalogBucket.maxWeight, budget.catalogBucket.usedWeight, delta)
+                    || !fits(budget.groupBucket.maxWeight, budget.groupBucket.usedWeight, delta))) {
+                return Optional.empty();
+            }
+            addUsed(budget, delta);
+            previous.active = false;
+            AdmissionReservation replacement = new AdmissionReservation(
+                    this, budget, newBytes, heldBytes);
+            return Optional.of(new ReservationReplacement(this, previous, replacement));
+        }
+    }
+
+    private void commitReplacement(ReservationReplacement replacement) {
+        synchronized (lock) {
+            replacement.checkPending();
+            AdmissionReservation current = replacement.current;
+            subtractUsed(current.entryBudget, current.accountedBytes - current.bytes);
+            current.accountedBytes = current.bytes;
+            replacement.finished = true;
+        }
+    }
+
+    private void rollbackReplacement(ReservationReplacement replacement) {
+        synchronized (lock) {
+            replacement.checkPending();
+            AdmissionReservation previous = replacement.previous;
+            AdmissionReservation current = replacement.current;
+            subtractUsed(current.entryBudget, current.accountedBytes - previous.accountedBytes);
+            current.bytes = 0L;
+            current.accountedBytes = 0L;
+            current.active = false;
+            previous.active = true;
+            replacement.finished = true;
+        }
+    }
+
+    private void release(AdmissionReservation reservation) {
+        synchronized (lock) {
+            if (!reservation.active) {
+                return;
+            }
+            if (!reservation.entryBudget.closed) {
+                subtractUsed(reservation.entryBudget, reservation.accountedBytes);
+            }
+            reservation.bytes = 0L;
+            reservation.accountedBytes = 0L;
+            reservation.active = false;
+        }
+    }
+
+    private void close(EntryBudget budget) {
+        synchronized (lock) {
+            if (budget.closed) {
+                return;
+            }
+            long leaked = budget.entryBucket.usedWeight;
+            if (leaked != 0L) {
+                LOG.error("Force-closing metadata cache budget {} with {} bytes still reserved",
+                        budget.scope, leaked);
+                globalUsedWeight = Math.max(0L, globalUsedWeight - leaked);
+                budget.catalogBucket.usedWeight = Math.max(0L, budget.catalogBucket.usedWeight - leaked);
+                budget.groupBucket.usedWeight = Math.max(0L, budget.groupBucket.usedWeight - leaked);
+                budget.entryBucket.usedWeight = 0L;
+            }
+            budget.closed = true;
+            budget.reclaimer = null;
+            entryBudgets.remove(budget.scope, budget);
+            budget.catalogBucket.liveEntries--;
+            if (budget.catalogBucket.liveEntries == 0) {
+                catalogBuckets.remove(budget.scope.groupScope.catalogId, budget.catalogBucket);
+            }
+            budget.groupBucket.liveEntries--;
+            if (budget.groupBucket.liveEntries == 0) {
+                entryGroupBuckets.remove(budget.scope.groupScope, budget.groupBucket);
+            }
+        }
+    }
+
+    private void addUsed(EntryBudget budget, long bytes) {
+        globalUsedWeight += bytes;
+        budget.catalogBucket.usedWeight += bytes;
+        budget.groupBucket.usedWeight += bytes;
+        budget.entryBucket.usedWeight += bytes;
+    }
+
+    private void subtractUsed(EntryBudget budget, long bytes) {
+        if (bytes > globalUsedWeight || bytes > budget.catalogBucket.usedWeight
+                || bytes > budget.groupBucket.usedWeight
+                || bytes > budget.entryBucket.usedWeight) {
+            throw new IllegalStateException("metadata cache budget accounting underflow");
+        }
+        globalUsedWeight -= bytes;
+        budget.catalogBucket.usedWeight -= bytes;
+        budget.groupBucket.usedWeight -= bytes;
+        budget.entryBucket.usedWeight -= bytes;
+    }
+
+    private void requestPeerReclaim(EntryBudget requester, long additionalBytes) {
+        if (additionalBytes <= 0L || requester.closed) {
+            return;
+        }
+        synchronized (lock) {
+            long globalDeficit = deficit(limitOf(globalMaxWeight), globalUsedWeight, additionalBytes);
+            long catalogDeficit = deficit(
+                    requester.catalogBucket.maxWeight, requester.catalogBucket.usedWeight, additionalBytes);
+            long groupDeficit = deficit(
+                    requester.groupBucket.maxWeight, requester.groupBucket.usedWeight, additionalBytes);
+            if (Math.max(groupDeficit, Math.max(globalDeficit, catalogDeficit)) == 0L) {
+                return;
+            }
+        }
+        requester.requestedAdmissionBytes.accumulateAndGet(additionalBytes, Math::max);
+        schedulePeerReclaim(requester);
+    }
+
+    private void schedulePeerReclaim(EntryBudget requester) {
+        if (!requester.reclaimScheduled.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            PEER_RECLAIM_EXECUTOR.execute(() -> drainPeerReclaim(requester));
+        } catch (RejectedExecutionException e) {
+            requester.reclaimScheduled.set(false);
+            LOG.warn("Failed to schedule metadata cache peer reclamation for {}", requester.scope, e);
+        }
+    }
+
+    private void drainPeerReclaim(EntryBudget requester) {
+        try {
+            long requested = requester.requestedAdmissionBytes.getAndSet(0L);
+            if (requested <= 0L || requester.closed) {
+                return;
+            }
+            List<EntryBudget> candidates;
+            synchronized (lock) {
+                candidates = new ArrayList<>();
+                for (EntryBudget candidate : entryBudgets.values()) {
+                    if (!candidate.closed && candidate.reclaimer != null
+                            && candidate.entryBucket.usedWeight > 0L) {
+                        candidates.add(candidate);
+                    }
+                }
+                candidates.sort((left, right) -> {
+                    boolean leftSibling = left.scope.groupScope.catalogId
+                            == requester.scope.groupScope.catalogId;
+                    boolean rightSibling = right.scope.groupScope.catalogId
+                            == requester.scope.groupScope.catalogId;
+                    if (leftSibling != rightSibling) {
+                        return leftSibling ? -1 : 1;
+                    }
+                    return Long.compare(right.entryBucket.usedWeight, left.entryBucket.usedWeight);
+                });
+            }
+            long remaining = currentDeficit(requester, requested);
+            for (EntryBudget candidate : candidates) {
+                if (currentGroupDeficit(requester, requested) > 0L
+                        && candidate.groupBucket != requester.groupBucket) {
+                    continue;
+                }
+                boolean sibling = candidate.scope.groupScope.catalogId
+                        == requester.scope.groupScope.catalogId;
+                if (!sibling && currentCatalogDeficit(requester, requested) > 0L) {
+                    continue;
+                }
+                try {
+                    candidate.reclaimer.applyAsLong(remaining);
+                } catch (RuntimeException e) {
+                    LOG.warn("Failed to reclaim metadata cache budget from peer {}", candidate.scope, e);
+                }
+                remaining = currentDeficit(requester, requested);
+                if (remaining == 0L) {
+                    break;
+                }
+            }
+        } finally {
+            requester.reclaimScheduled.set(false);
+            if (!requester.closed && requester.requestedAdmissionBytes.get() > 0L) {
+                schedulePeerReclaim(requester);
+            }
+        }
+    }
+
+    private long currentDeficit(EntryBudget requester, long additionalBytes) {
+        synchronized (lock) {
+            if (requester.closed) {
+                return 0L;
+            }
+            return Math.max(
+                    deficit(requester.groupBucket.maxWeight,
+                            requester.groupBucket.usedWeight, additionalBytes),
+                    Math.max(deficit(limitOf(globalMaxWeight), globalUsedWeight, additionalBytes),
+                            deficit(requester.catalogBucket.maxWeight,
+                                    requester.catalogBucket.usedWeight, additionalBytes)));
+        }
+    }
+
+    private long currentGroupDeficit(EntryBudget requester, long additionalBytes) {
+        synchronized (lock) {
+            return requester.closed ? 0L : deficit(requester.groupBucket.maxWeight,
+                    requester.groupBucket.usedWeight, additionalBytes);
+        }
+    }
+
+    private long currentCatalogDeficit(EntryBudget requester, long additionalBytes) {
+        synchronized (lock) {
+            return requester.closed ? 0L : deficit(requester.catalogBucket.maxWeight,
+                    requester.catalogBucket.usedWeight, additionalBytes);
+        }
+    }
+
+    private static long deficit(long maxWeight, long usedWeight, long additionalBytes) {
+        if (maxWeight == Long.MAX_VALUE || additionalBytes <= maxWeight - Math.min(usedWeight, maxWeight)) {
+            return 0L;
+        }
+        return JvmSizeUtils.saturatedAdd(usedWeight, additionalBytes) - maxWeight;
+    }
+
+    private static boolean fits(long maxWeight, long usedWeight, long delta) {
+        return delta >= 0L && usedWeight <= maxWeight && delta <= maxWeight - usedWeight;
+    }
+
+    private static long limitOf(OptionalLong configured) {
+        return configured.isPresent() ? configured.getAsLong() : Long.MAX_VALUE;
+    }
+
+    private static long minimumLimit(OptionalLong first, OptionalLong second) {
+        return Math.min(limitOf(first), limitOf(second));
+    }
+
+    private static OptionalLong minimumPresent(OptionalLong first, OptionalLong second, OptionalLong third) {
+        if (!first.isPresent() && !second.isPresent() && !third.isPresent()) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(Math.min(limitOf(first), Math.min(limitOf(second), limitOf(third))));
+    }
+
+    private static void checkWeight(long bytes) {
+        if (bytes < 0L) {
+            throw new IllegalArgumentException("cache reservation can not be negative: " + bytes);
+        }
+    }
+
+    private static final class Bucket {
+        private final long maxWeight;
+        private long usedWeight;
+        private int liveEntries;
+
+        private Bucket(long maxWeight) {
+            this.maxWeight = maxWeight;
+        }
+    }
+
+    private static final class EntryGroupScope {
+        private final long catalogId;
+        private final String engine;
+        private final String groupName;
+
+        private EntryGroupScope(long catalogId, String engine, String groupName) {
+            this.catalogId = catalogId;
+            this.engine = engine;
+            this.groupName = groupName;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof EntryGroupScope)) {
+                return false;
+            }
+            EntryGroupScope that = (EntryGroupScope) other;
+            return catalogId == that.catalogId && engine.equals(that.engine) && groupName.equals(that.groupName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(catalogId, engine, groupName);
+        }
+
+        @Override
+        public String toString() {
+            return catalogId + "/" + engine + "/" + groupName;
+        }
+    }
+
+    private static final class EntryScope {
+        private final long budgetId;
+        private final EntryGroupScope groupScope;
+        private final String entryName;
+
+        private EntryScope(long budgetId, EntryGroupScope groupScope, String entryName) {
+            this.budgetId = budgetId;
+            this.groupScope = groupScope;
+            this.entryName = entryName;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof EntryScope)) {
+                return false;
+            }
+            EntryScope that = (EntryScope) other;
+            return budgetId == that.budgetId;
+        }
+
+        @Override
+        public int hashCode() {
+            return Long.hashCode(budgetId);
+        }
+
+        @Override
+        public String toString() {
+            return groupScope + "/" + entryName + "#" + budgetId;
+        }
+    }
+
+    public static final class EntryBudget implements AutoCloseable {
+        private final MetaCacheBudgetManager manager;
+        private final EntryScope scope;
+        private final Bucket catalogBucket;
+        private final Bucket groupBucket;
+        private final Bucket entryBucket;
+        private final long effectiveMaxWeight;
+        private final AtomicLong requestedAdmissionBytes = new AtomicLong();
+        private final AtomicBoolean reclaimScheduled = new AtomicBoolean();
+        private volatile LongUnaryOperator reclaimer;
+        private volatile boolean closed;
+
+        private EntryBudget(MetaCacheBudgetManager manager, EntryScope scope, Bucket catalogBucket,
+                Bucket groupBucket, Bucket entryBucket, long effectiveMaxWeight) {
+            this.manager = manager;
+            this.scope = scope;
+            this.catalogBucket = catalogBucket;
+            this.groupBucket = groupBucket;
+            this.entryBucket = entryBucket;
+            this.effectiveMaxWeight = effectiveMaxWeight;
+        }
+
+        public Optional<AdmissionReservation> tryReserve(long bytes) {
+            return manager.tryReserve(this, bytes);
+        }
+
+        public Optional<ReservationReplacement> tryReplace(
+                AdmissionReservation previous, long newBytes) {
+            Objects.requireNonNull(previous, "previous reservation");
+            if (previous.entryBudget != this) {
+                throw new IllegalArgumentException("replacement reservation belongs to another entry");
+            }
+            return manager.tryReplace(previous, newBytes);
+        }
+
+        public void setReclaimer(LongUnaryOperator reclaimer) {
+            this.reclaimer = Objects.requireNonNull(reclaimer, "reclaimer");
+        }
+
+        public void requestPeerReclaim(long additionalBytes) {
+            manager.requestPeerReclaim(this, additionalBytes);
+        }
+
+        public long getEffectiveMaxWeight() {
+            return effectiveMaxWeight;
+        }
+
+        public long getUsedWeight() {
+            synchronized (manager.lock) {
+                return entryBucket.usedWeight;
+            }
+        }
+
+        @Override
+        public void close() {
+            manager.close(this);
+        }
+    }
+
+    public static final class AdmissionReservation {
+        private final MetaCacheBudgetManager manager;
+        private final EntryBudget entryBudget;
+        private long bytes;
+        private long accountedBytes;
+        private boolean active = true;
+
+        private AdmissionReservation(MetaCacheBudgetManager manager, EntryBudget entryBudget, long bytes) {
+            this(manager, entryBudget, bytes, bytes);
+        }
+
+        private AdmissionReservation(MetaCacheBudgetManager manager, EntryBudget entryBudget,
+                long bytes, long accountedBytes) {
+            this.manager = manager;
+            this.entryBudget = entryBudget;
+            this.bytes = bytes;
+            this.accountedBytes = accountedBytes;
+        }
+
+        public void release() {
+            manager.release(this);
+        }
+
+        public long getBytes() {
+            synchronized (manager.lock) {
+                return bytes;
+            }
+        }
+    }
+
+    /**
+     * Atomic accounting hand-off between two generations of the same cache key.
+     * The manager temporarily holds max(old, new), never old + new, and keeps enough
+     * accounting to restore the old generation until publication commits.
+     */
+    public static final class ReservationReplacement {
+        private final MetaCacheBudgetManager manager;
+        private final AdmissionReservation previous;
+        private final AdmissionReservation current;
+        private boolean finished;
+
+        private ReservationReplacement(MetaCacheBudgetManager manager,
+                AdmissionReservation previous, AdmissionReservation current) {
+            this.manager = manager;
+            this.previous = previous;
+            this.current = current;
+        }
+
+        public AdmissionReservation current() {
+            return current;
+        }
+
+        public void commit() {
+            manager.commitReplacement(this);
+        }
+
+        public void rollback() {
+            manager.rollbackReplacement(this);
+        }
+
+        private void checkPending() {
+            if (finished) {
+                throw new IllegalStateException("reservation replacement is already finished");
+            }
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/MetaCacheDefinition.java
+++ b/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/MetaCacheDefinition.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
  */
 public final class MetaCacheDefinition<K, V> {
     private final String name;
+    private final String budgetGroup;
     private final CacheSpec cacheSpec;
     private final Function<K, ScopePath> scopeResolver;
     private final Function<K, V> loader;
@@ -39,9 +40,11 @@ public final class MetaCacheDefinition<K, V> {
     private final BiConsumer<K, V> discardListener;
     private final Duration refreshAfterWrite;
     private final Executor refreshExecutor;
+    private final MetaCacheSizeEstimator<K, V> sizeEstimator;
 
     private MetaCacheDefinition(Builder<K, V> builder) {
         name = requireName(builder.name);
+        budgetGroup = requireName(builder.budgetGroup == null ? builder.name : builder.budgetGroup);
         cacheSpec = Objects.requireNonNull(builder.cacheSpec, "cacheSpec can not be null");
         scopeResolver = Objects.requireNonNull(builder.scopeResolver, "scopeResolver can not be null");
         loader = builder.loader;
@@ -49,6 +52,7 @@ public final class MetaCacheDefinition<K, V> {
         discardListener = builder.discardListener;
         refreshAfterWrite = builder.refreshAfterWrite;
         refreshExecutor = builder.refreshExecutor;
+        sizeEstimator = builder.sizeEstimator;
         if (refreshAfterWrite != null && loader == null) {
             throw new IllegalArgumentException("refresh-after-write requires a default loader");
         }
@@ -61,6 +65,10 @@ public final class MetaCacheDefinition<K, V> {
 
     public String name() {
         return name;
+    }
+
+    String budgetGroup() {
+        return budgetGroup;
     }
 
     CacheSpec cacheSpec() {
@@ -93,6 +101,10 @@ public final class MetaCacheDefinition<K, V> {
         return refreshExecutor;
     }
 
+    MetaCacheSizeEstimator<K, V> sizeEstimator() {
+        return sizeEstimator;
+    }
+
     private static String requireName(String name) {
         String nonNullName = Objects.requireNonNull(name, "name can not be null");
         if (nonNullName.isEmpty()) {
@@ -110,6 +122,8 @@ public final class MetaCacheDefinition<K, V> {
         private BiConsumer<K, V> discardListener;
         private Duration refreshAfterWrite;
         private Executor refreshExecutor;
+        private MetaCacheSizeEstimator<K, V> sizeEstimator;
+        private String budgetGroup;
 
         private Builder(String name, CacheSpec cacheSpec, Function<K, ScopePath> scopeResolver) {
             this.name = name;
@@ -143,6 +157,17 @@ public final class MetaCacheDefinition<K, V> {
             }
             this.refreshAfterWrite = nonNullDuration;
             this.refreshExecutor = Objects.requireNonNull(executor, "refreshExecutor can not be null");
+            return this;
+        }
+
+        public Builder<K, V> sizeEstimator(MetaCacheSizeEstimator<K, V> estimator) {
+            this.sizeEstimator = Objects.requireNonNull(estimator, "estimator can not be null");
+            return this;
+        }
+
+        /** Shares one configured weight limit across physical caches in the same logical entry group. */
+        public Builder<K, V> budgetGroup(String budgetGroup) {
+            this.budgetGroup = requireName(budgetGroup);
             return this;
         }
 

--- a/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/MetaCacheGovernance.java
+++ b/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/MetaCacheGovernance.java
@@ -1,0 +1,90 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.cache;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Process-wide bridge used because connector-cache is parent-first for every connector plugin. */
+public final class MetaCacheGovernance {
+    private static final Object CONFIG_LOCK = new Object();
+    private static final ConcurrentHashMap<Long, Set<CatalogMetaCache>> CATALOG_CACHES =
+            new ConcurrentHashMap<>();
+    private static volatile MetaCacheBudgetManager budgetManager =
+            new MetaCacheBudgetManager(OptionalLong.empty());
+    private static volatile OptionalLong configuredGlobalMaxWeight = OptionalLong.empty();
+
+    private MetaCacheGovernance() {
+    }
+
+    public static void configureGlobalMaxWeight(OptionalLong globalMaxWeight) {
+        synchronized (CONFIG_LOCK) {
+            OptionalLong requested = globalMaxWeight == null ? OptionalLong.empty() : globalMaxWeight;
+            if (same(configuredGlobalMaxWeight, requested)) {
+                return;
+            }
+            if (!CATALOG_CACHES.isEmpty()) {
+                throw new IllegalStateException(
+                        "Can not change external metadata cache global weight after catalogs are initialized");
+            }
+            budgetManager = new MetaCacheBudgetManager(requested);
+            configuredGlobalMaxWeight = requested;
+        }
+    }
+
+    static MetaCacheBudgetManager budgetManager() {
+        return budgetManager;
+    }
+
+    static void register(CatalogMetaCache cache) {
+        CATALOG_CACHES.compute(cache.catalogId(), (ignored, caches) -> {
+            Set<CatalogMetaCache> updated = caches == null ? ConcurrentHashMap.newKeySet() : caches;
+            updated.add(cache);
+            return updated;
+        });
+    }
+
+    static void unregister(CatalogMetaCache cache) {
+        CATALOG_CACHES.computeIfPresent(cache.catalogId(), (ignored, caches) -> {
+            caches.remove(cache);
+            return caches.isEmpty() ? null : caches;
+        });
+    }
+
+    public static List<CatalogMetaCache> catalogCaches(long catalogId) {
+        Set<CatalogMetaCache> caches = CATALOG_CACHES.get(catalogId);
+        return caches == null ? Collections.emptyList() : new ArrayList<>(caches);
+    }
+
+    public static OptionalLong globalMaxWeight() {
+        return configuredGlobalMaxWeight;
+    }
+
+    public static long globalEstimatedWeight() {
+        return budgetManager.getGlobalUsedWeight();
+    }
+
+    private static boolean same(OptionalLong left, OptionalLong right) {
+        return left.isPresent() == right.isPresent()
+                && (!left.isPresent() || left.getAsLong() == right.getAsLong());
+    }
+}

--- a/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/MetaCacheSizeEstimate.java
+++ b/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/MetaCacheSizeEstimate.java
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.cache;
+
+import java.util.Objects;
+
+/** Immutable result of estimating one metadata-cache entry. */
+public final class MetaCacheSizeEstimate {
+    private final long bytes;
+    private final boolean complete;
+    private final String incompleteReason;
+
+    private MetaCacheSizeEstimate(long bytes, boolean complete, String incompleteReason) {
+        this.bytes = bytes;
+        this.complete = complete;
+        this.incompleteReason = Objects.requireNonNull(incompleteReason, "incompleteReason");
+    }
+
+    public static MetaCacheSizeEstimate complete(long bytes) {
+        if (bytes < 0L) {
+            throw new IllegalArgumentException("cache size estimate can not be negative: " + bytes);
+        }
+        return new MetaCacheSizeEstimate(bytes, true, "");
+    }
+
+    public static MetaCacheSizeEstimate incomplete(String reason) {
+        String safeReason = Objects.requireNonNull(reason, "reason").trim();
+        if (safeReason.isEmpty()) {
+            throw new IllegalArgumentException("incomplete cache size estimate requires a reason");
+        }
+        return new MetaCacheSizeEstimate(0L, false, safeReason);
+    }
+
+    public long getBytes() {
+        return bytes;
+    }
+
+    public boolean isComplete() {
+        return complete;
+    }
+
+    public String getIncompleteReason() {
+        return incompleteReason;
+    }
+}

--- a/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/MetaCacheSizeEstimator.java
+++ b/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/MetaCacheSizeEstimator.java
@@ -1,0 +1,39 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.cache;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/** Estimates the retained bytes owned by one connector metadata-cache entry. */
+@FunctionalInterface
+public interface MetaCacheSizeEstimator<K, V> {
+    MetaCacheSizeEstimate estimate(K key, V value);
+
+    /** Estimator incompatibility rejects weighted admission without failing the metadata load. */
+    static MetaCacheSizeEstimate estimateSafely(
+            String failureReason, Supplier<MetaCacheSizeEstimate> estimation) {
+        Objects.requireNonNull(failureReason, "failureReason");
+        Objects.requireNonNull(estimation, "estimation");
+        try {
+            return Objects.requireNonNull(estimation.get(), "size estimate");
+        } catch (RuntimeException | LinkageError e) {
+            return MetaCacheSizeEstimate.incomplete(failureReason + ":" + e.getClass().getName());
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/MetaCacheSizeEstimators.java
+++ b/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/MetaCacheSizeEstimators.java
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.cache;
+
+/** Shared estimators for small or structurally unknown metadata-cache entries. */
+public final class MetaCacheSizeEstimators {
+    private MetaCacheSizeEstimators() {
+    }
+
+    /**
+     * Returns a visit-bounded complete graph estimator. Values that exceed the visit budget are rejected from a
+     * weighted cache instead of admitting an arbitrarily low sample. Large connector values should use a
+     * type-specific construction-time estimator that counts their payload in a cheap linear pass.
+     */
+    public static <K, V> MetaCacheSizeEstimator<K, V> reflective() {
+        return (key, value) -> MetaCacheSizeEstimate.complete(JvmSizeUtils.saturatedAdd(
+                ReflectiveObjectSizeEstimator.estimateComplete(key),
+                ReflectiveObjectSizeEstimator.estimateComplete(value)));
+    }
+}

--- a/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/ReflectiveObjectSizeEstimator.java
+++ b/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/ReflectiveObjectSizeEstimator.java
@@ -1,0 +1,429 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.cache;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.RandomAccess;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Bounded reflective object-graph estimator for validating type-specific cache estimators.
+ *
+ * <p>The expensive class discovery is cached in a {@link ClassValue}: each class hierarchy is reflected once to
+ * retain its shallow size and accessible reference fields. Runtime estimation still reads each new root's actual
+ * fields because two instances of the same class can retain very different lists, maps, arrays, and strings.
+ * The diagnostic API samples collections and object arrays. The admission API instead traverses every element
+ * up to a fixed visit budget: this catches skewed tail values while bounding CPU and temporary identity-set
+ * memory. Strongly encapsulated reference fields, depth truncation, and visit-budget exhaustion fail the
+ * estimate so admission can reject the value without turning an incomplete graph into a false low weight.
+ *
+ * <p>This is intentionally a construction-time safety net, not a Caffeine hit-path weigher. Cache values should
+ * combine it with a type-specific estimate once, store the larger result, and expose that stored number to
+ * admission accounting in O(1).
+ */
+public final class ReflectiveObjectSizeEstimator {
+    private static final int DEFAULT_SAMPLE_SIZE = 5;
+    private static final int DEFAULT_MAX_DEPTH = 20;
+    private static final int DEFAULT_COMPLETE_VISIT_BUDGET = 10_000;
+
+    private static final long HASH_MAP_NODE_BYTES = classSize("java.util.HashMap$Node");
+    private static final long LINKED_HASH_MAP_ENTRY_BYTES = classSize("java.util.LinkedHashMap$Entry");
+    private static final long TREE_MAP_ENTRY_BYTES = classSize("java.util.TreeMap$Entry");
+    private static final long LINKED_LIST_NODE_BYTES = classSize("java.util.LinkedList$Node");
+    private static final long CONCURRENT_HASH_MAP_NODE_BYTES = classSize("java.util.concurrent.ConcurrentHashMap$Node");
+
+    private static final Set<Class<?>> SHALLOW_LEAF_TYPES = Set.of(
+            Boolean.class,
+            Byte.class,
+            Character.class,
+            Short.class,
+            Integer.class,
+            Float.class,
+            Long.class,
+            Double.class);
+
+    private static final ClassValue<ClassPlan> CLASS_PLANS = new ClassValue<>() {
+        @Override
+        protected ClassPlan computeValue(Class<?> type) {
+            List<Field> referenceFields = new ArrayList<>();
+            boolean inaccessibleReferenceField = false;
+            for (Class<?> current = type; current != null; current = current.getSuperclass()) {
+                for (Field field : current.getDeclaredFields()) {
+                    if (Modifier.isStatic(field.getModifiers())
+                            || field.getType().isPrimitive()
+                            || field.getType().isEnum()) {
+                        continue;
+                    }
+                    try {
+                        if (field.trySetAccessible()) {
+                            referenceFields.add(field);
+                        } else {
+                            inaccessibleReferenceField = true;
+                        }
+                    } catch (RuntimeException ignored) {
+                        inaccessibleReferenceField = true;
+                    }
+                }
+            }
+            return new ClassPlan(
+                    JvmSizeUtils.instanceSize(type),
+                    referenceFields.toArray(new Field[0]),
+                    inaccessibleReferenceField);
+        }
+    };
+
+    private ReflectiveObjectSizeEstimator() {
+    }
+
+    public static long estimate(Object root) {
+        return estimate(root, DEFAULT_SAMPLE_SIZE, DEFAULT_MAX_DEPTH);
+    }
+
+    public static long estimate(Object root, int sampleSize, int maxDepth) {
+        if (sampleSize <= 0) {
+            throw new IllegalArgumentException("sampleSize must be positive: " + sampleSize);
+        }
+        if (maxDepth < 0) {
+            throw new IllegalArgumentException("maxDepth can not be negative: " + maxDepth);
+        }
+        return new Walker(sampleSize, Integer.MAX_VALUE).estimate(root, maxDepth);
+    }
+
+    /**
+     * Completely traverses a small or medium object graph for cache admission. The visit budget bounds the
+     * temporary identity set and CPU cost; exceeding it makes the estimate incomplete so weighted admission
+     * rejects the value instead of treating a sample as an exact retained size.
+     */
+    public static long estimateComplete(Object root) {
+        return estimateComplete(root, DEFAULT_COMPLETE_VISIT_BUDGET, DEFAULT_MAX_DEPTH);
+    }
+
+    public static long estimateComplete(Object root, int visitBudget, int maxDepth) {
+        if (visitBudget <= 0) {
+            throw new IllegalArgumentException("visitBudget must be positive: " + visitBudget);
+        }
+        if (maxDepth < 0) {
+            throw new IllegalArgumentException("maxDepth can not be negative: " + maxDepth);
+        }
+        return new Walker(Integer.MAX_VALUE, visitBudget).estimate(root, maxDepth);
+    }
+
+    private static final class Walker {
+        private final int sampleSize;
+        private final int visitBudget;
+        private final Map<Object, Boolean> visited = new IdentityHashMap<>();
+
+        private Walker(int sampleSize, int visitBudget) {
+            this.sampleSize = sampleSize;
+            this.visitBudget = visitBudget;
+        }
+
+        private long estimate(Object value, int depth) {
+            if (value == null || visited.put(value, Boolean.TRUE) != null) {
+                return 0L;
+            }
+            if (visited.size() > visitBudget) {
+                throw new IllegalStateException(
+                        "Complete estimate exceeded visit budget " + visitBudget);
+            }
+
+            Class<?> type = value.getClass();
+            if (type.isEnum() || value instanceof Class<?>) {
+                return 0L;
+            }
+            if (value instanceof String) {
+                return JvmSizeUtils.stringSize((String) value);
+            }
+            if (SHALLOW_LEAF_TYPES.contains(type)) {
+                return JvmSizeUtils.instanceSize(type);
+            }
+            if (type.isHidden()) {
+                throw new IllegalStateException("Can not completely estimate hidden class: " + type.getName());
+            }
+            if (type.isArray()) {
+                return estimateArray(value, depth);
+            }
+            if (value instanceof ByteBuffer) {
+                return estimateByteBuffer((ByteBuffer) value, depth);
+            }
+            if (value instanceof Optional<?>) {
+                return estimateOptional((Optional<?>) value, depth);
+            }
+            if (value instanceof Map<?, ?>) {
+                return estimateMap((Map<?, ?>) value, depth);
+            }
+            if (value instanceof Collection<?>) {
+                return estimateCollection((Collection<?>) value, depth);
+            }
+
+            ClassPlan plan = CLASS_PLANS.get(type);
+            if (plan.inaccessibleReferenceField) {
+                throw new IllegalStateException(
+                        "Can not completely estimate strongly encapsulated class: " + type.getName());
+            }
+            long bytes = plan.shallowBytes;
+            if (depth == 0) {
+                if (plan.referenceFields.length > 0) {
+                    throw incomplete(type);
+                }
+                return bytes;
+            }
+            for (Field field : plan.referenceFields) {
+                bytes = add(bytes, estimateField(value, field, depth - 1));
+            }
+            return bytes;
+        }
+
+        private long estimateArray(Object value, int depth) {
+            int length = Array.getLength(value);
+            Class<?> componentType = value.getClass().getComponentType();
+            if (componentType.isPrimitive()) {
+                return JvmSizeUtils.primitiveArraySize(componentType, length);
+            }
+
+            long bytes = JvmSizeUtils.objectArraySize(length);
+            if (length == 0) {
+                return bytes;
+            }
+            if (depth == 0) {
+                throw incomplete(value.getClass());
+            }
+            int samples = Math.min(length, sampleSize);
+            long sampledBytes = 0L;
+            for (int i = 0; i < samples; i++) {
+                int index = sampleIndex(i, samples, length);
+                sampledBytes = add(sampledBytes, estimate(Array.get(value, index), depth - 1));
+            }
+            return add(bytes, scale(sampledBytes, samples, length));
+        }
+
+        private long estimateByteBuffer(ByteBuffer value, int depth) {
+            long bytes = JvmSizeUtils.instanceSize(value.getClass());
+            byte[] backing = JvmSizeUtils.byteBufferBackingArray(value);
+            if (backing != null) {
+                if (depth == 0) {
+                    throw incomplete(value.getClass());
+                }
+                bytes = add(bytes, estimate(backing, depth - 1));
+            }
+            return bytes;
+        }
+
+        private long estimateOptional(Optional<?> value, int depth) {
+            long bytes = JvmSizeUtils.instanceSize(value.getClass());
+            if (value.isEmpty()) {
+                return bytes;
+            }
+            if (depth == 0) {
+                throw incomplete(value.getClass());
+            }
+            return add(bytes, estimate(value.get(), depth - 1));
+        }
+
+        private long estimateCollection(Collection<?> values, int depth) {
+            int size = values.size();
+            long bytes = add(
+                    JvmSizeUtils.instanceSize(values.getClass()),
+                    collectionStorageBytes(values, size));
+            if (size == 0) {
+                return bytes;
+            }
+            if (depth == 0) {
+                throw incomplete(values.getClass());
+            }
+
+            int samples = Math.min(size, sampleSize);
+            long sampledBytes = 0L;
+            if (values instanceof List<?> && values instanceof RandomAccess) {
+                List<?> list = (List<?>) values;
+                for (int i = 0; i < samples; i++) {
+                    sampledBytes = add(sampledBytes,
+                            estimate(list.get(sampleIndex(i, samples, size)), depth - 1));
+                }
+            } else {
+                sampledBytes = estimateIterableSamples(values, samples, depth - 1);
+            }
+            return add(bytes, scale(sampledBytes, samples, size));
+        }
+
+        private long estimateMap(Map<?, ?> values, int depth) {
+            int size = values.size();
+            long bytes = add(
+                    JvmSizeUtils.instanceSize(values.getClass()),
+                    mapStorageBytes(values, size));
+            if (size == 0) {
+                return bytes;
+            }
+            if (depth == 0) {
+                throw incomplete(values.getClass());
+            }
+
+            int samples = Math.min(size, sampleSize);
+            long sampledBytes = 0L;
+            Iterator<? extends Map.Entry<?, ?>> iterator = values.entrySet().iterator();
+            for (int i = 0; i < samples; i++) {
+                Map.Entry<?, ?> entry = iterator.next();
+                sampledBytes = add(sampledBytes, estimate(entry.getKey(), depth - 1));
+                sampledBytes = add(sampledBytes, estimate(entry.getValue(), depth - 1));
+            }
+            return add(bytes, scale(sampledBytes, samples, size));
+        }
+
+        private long estimateIterableSamples(Collection<?> values, int samples, int depth) {
+            Iterator<?> iterator = values.iterator();
+            long sampledBytes = 0L;
+            for (int i = 0; i < samples; i++) {
+                sampledBytes = add(sampledBytes, estimate(iterator.next(), depth));
+            }
+            return sampledBytes;
+        }
+
+        private long estimateField(Object owner, Field field, int depth) {
+            try {
+                return estimate(field.get(owner), depth);
+            } catch (IllegalAccessException e) {
+                throw new IllegalStateException("Cached reference field is no longer accessible: " + field, e);
+            }
+        }
+    }
+
+    private static long collectionStorageBytes(Collection<?> values, int size) {
+        if (size == 0) {
+            return 0L;
+        }
+        if (values instanceof LinkedHashSet<?>) {
+            return hashStorageBytes(size, LINKED_HASH_MAP_ENTRY_BYTES);
+        }
+        if (values instanceof HashSet<?>) {
+            return hashStorageBytes(size, HASH_MAP_NODE_BYTES);
+        }
+        if (values instanceof TreeSet<?>) {
+            return multiply(size, TREE_MAP_ENTRY_BYTES);
+        }
+        if (values instanceof LinkedList<?>) {
+            return multiply(size, LINKED_LIST_NODE_BYTES);
+        }
+        if (values instanceof Set<?>) {
+            return hashStorageBytes(size, HASH_MAP_NODE_BYTES);
+        }
+        return JvmSizeUtils.objectArraySize(size);
+    }
+
+    private static long mapStorageBytes(Map<?, ?> values, int size) {
+        if (size == 0) {
+            return 0L;
+        }
+        if (values instanceof LinkedHashMap<?, ?>) {
+            return hashStorageBytes(size, LINKED_HASH_MAP_ENTRY_BYTES);
+        }
+        if (values instanceof HashMap<?, ?>) {
+            return hashStorageBytes(size, HASH_MAP_NODE_BYTES);
+        }
+        if (values instanceof ConcurrentHashMap<?, ?>) {
+            return hashStorageBytes(size, CONCURRENT_HASH_MAP_NODE_BYTES);
+        }
+        if (values instanceof TreeMap<?, ?>) {
+            return multiply(size, TREE_MAP_ENTRY_BYTES);
+        }
+        return add(JvmSizeUtils.objectArraySize(saturatedDouble(size)),
+                multiply(size, HASH_MAP_NODE_BYTES));
+    }
+
+    private static long hashStorageBytes(int size, long nodeBytes) {
+        return add(
+                JvmSizeUtils.objectArraySize(hashCapacity(size)),
+                multiply(size, nodeBytes));
+    }
+
+    private static int hashCapacity(int size) {
+        long needed = (size * 4L + 2L) / 3L;
+        int capacity = 16;
+        while (capacity < needed && capacity < 1 << 30) {
+            capacity <<= 1;
+        }
+        return capacity;
+    }
+
+    private static int sampleIndex(int sample, int sampleCount, int totalCount) {
+        return sampleCount == 1
+                ? 0
+                : (int) ((long) sample * (totalCount - 1) / (sampleCount - 1));
+    }
+
+    private static long scale(long sampledBytes, int sampleCount, int totalCount) {
+        if (sampleCount == totalCount) {
+            return sampledBytes;
+        }
+        double scaled = (double) sampledBytes * totalCount / sampleCount;
+        return scaled >= Long.MAX_VALUE ? Long.MAX_VALUE : (long) scaled;
+    }
+
+    private static int saturatedDouble(int value) {
+        return value > Integer.MAX_VALUE / 2 ? Integer.MAX_VALUE : value * 2;
+    }
+
+    private static long classSize(String className) {
+        try {
+            return JvmSizeUtils.instanceSize(Class.forName(className));
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Required JVM collection class is missing: " + className, e);
+        }
+    }
+
+    private static IllegalStateException incomplete(Class<?> type) {
+        return new IllegalStateException("Object graph depth limit reached at: " + type.getName());
+    }
+
+    private static long multiply(long left, long right) {
+        return JvmSizeUtils.saturatedMultiply(left, right);
+    }
+
+    private static long add(long left, long right) {
+        return JvmSizeUtils.saturatedAdd(left, right);
+    }
+
+    private static final class ClassPlan {
+        private final long shallowBytes;
+        private final Field[] referenceFields;
+        private final boolean inaccessibleReferenceField;
+
+        private ClassPlan(long shallowBytes, Field[] referenceFields, boolean inaccessibleReferenceField) {
+            this.shallowBytes = shallowBytes;
+            this.referenceFields = referenceFields;
+            this.inaccessibleReferenceField = inaccessibleReferenceField;
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/ScopedMetaCache.java
+++ b/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/ScopedMetaCache.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
@@ -48,12 +49,14 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * One physical Caffeine cache participating in a {@link ScopedMetaCacheRegistry}.
@@ -65,6 +68,8 @@ import java.util.function.Function;
  */
 public final class ScopedMetaCache<K, V> implements AutoCloseable {
     private static final Logger LOG = LogManager.getLogger(ScopedMetaCache.class);
+    private static final long FIXED_ENTRY_ACCOUNTING_OVERHEAD_BYTES = 512L;
+    private static final long WEIGHT_REJECT_WARN_INTERVAL_NANOS = Duration.ofMinutes(1).toNanos();
     private static final Runnable NO_OP = () -> {
     };
 
@@ -90,6 +95,9 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
     private final AtomicReference<Long> lastLoadSuccessTimeMs = new AtomicReference<>(-1L);
     private final AtomicReference<Long> lastLoadFailureTimeMs = new AtomicReference<>(-1L);
     private final AtomicReference<String> lastError = new AtomicReference<>("");
+    private final AtomicReference<String> lastWeightRejectReason = new AtomicReference<>("");
+    private final LongAdder weightRejectCount = new LongAdder();
+    private final AtomicLong lastWeightRejectWarnNanos = new AtomicLong(Long.MIN_VALUE);
     private final RemovalListener<K, V> beforeRemoval;
     private final BiConsumer<K, V> discardListener;
     private final Ticker ticker;
@@ -98,8 +106,12 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
     private final Runnable afterLoadElection;
     private final Runnable afterBulkStage;
     private final Runnable afterRefreshRegistration;
+    private final MetaCacheSizeEstimator<K, V> sizeEstimator;
+    private final MetaCacheBudgetManager.EntryBudget entryBudget;
+    private final boolean weightBounded;
     private final ThreadLocal<RemovalDeferral<K, V>> removalDeferrals =
             ThreadLocal.withInitial(RemovalDeferral::new);
+    private final ThreadLocal<Registration> budgetEvictionRegistration = new ThreadLocal<>();
     private BigInteger exactInvalidationSequence = BigInteger.ZERO;
 
     ScopedMetaCache(
@@ -113,7 +125,9 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
             Executor refreshExecutor,
             Runnable afterLoadElection,
             Runnable afterBulkStage,
-            Runnable afterRefreshRegistration) {
+            Runnable afterRefreshRegistration,
+            MetaCacheSizeEstimator<K, V> sizeEstimator,
+            MetaCacheBudgetManager.EntryBudget entryBudget) {
         this.registry = Objects.requireNonNull(registry, "registry can not be null");
         this.name = Objects.requireNonNull(name, "name can not be null");
         Objects.requireNonNull(cacheSpec, "cacheSpec can not be null");
@@ -127,8 +141,17 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
         this.afterBulkStage = Objects.requireNonNull(afterBulkStage, "afterBulkStage can not be null");
         this.afterRefreshRegistration = Objects.requireNonNull(
                 afterRefreshRegistration, "afterRefreshRegistration can not be null");
-        this.effectiveEnabled = CacheSpec.isCacheEnabled(
-                cacheSpec.isEnable(), cacheSpec.getTtlSecond(), cacheSpec.getCapacity());
+        this.sizeEstimator = sizeEstimator;
+        this.entryBudget = entryBudget;
+        if ((sizeEstimator == null) != (entryBudget == null)) {
+            throw new IllegalArgumentException(
+                    "Weighted metadata cache requires both estimator and budget: " + name);
+        }
+        this.weightBounded = entryBudget != null;
+        if (weightBounded) {
+            entryBudget.setReclaimer(this::reclaimForPeer);
+        }
+        this.effectiveEnabled = cacheSpec.isCacheEnabled();
 
         Caffeine<Object, Object> builder = Caffeine.newBuilder()
                 .maximumSize(effectiveEnabled ? cacheSpec.getCapacity() : 0L)
@@ -261,18 +284,17 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
     }
 
     private VersionedValue<K, V> currentVersionedValue(K key, ScopePath path) {
-        VersionedValue<K, V> versioned = data.getIfPresent(key);
-        if (versioned == null) {
-            return null;
-        }
-        if (!versioned.scopeSnapshot.path().equals(path)) {
-            return null;
-        }
-        if (!versioned.isCurrent(registry, keyNodes)) {
-            data.asMap().remove(key, versioned);
-            return null;
-        }
-        return versioned;
+        return deferRemovals(() -> {
+            VersionedValue<K, V> versioned = data.getIfPresent(key);
+            if (versioned == null || !versioned.scopeSnapshot.path().equals(path)) {
+                return null;
+            }
+            if (!versioned.isCurrent(registry, keyNodes)) {
+                data.asMap().remove(key, versioned);
+                return null;
+            }
+            return versioned;
+        });
     }
 
     public void put(K key, ScopePath path, V value) {
@@ -284,10 +306,46 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
             return;
         }
         try (PublicationLease<K, V> lease = acquirePublicationLease(key, path, false)) {
-            guardedCommit(lease, () -> {
-                lease.keyNode.loadPublicationState.set(new Object());
-                return publishCommitted(lease, key, value) != null;
-            });
+            AtomicReference<VersionedValue<K, V>> preparedRef = new AtomicReference<>();
+            AtomicReference<ReplacementValue<K, V>> replacementRef = new AtomicReference<>();
+            AtomicBoolean admissionRejected = new AtomicBoolean(false);
+            boolean retained = false;
+            try {
+                retained = guardedCommit(lease, () -> {
+                    VersionedValue<K, V> current = currentVersionedValue(key, path);
+                    if (current != null) {
+                        ReplacementValue<K, V> replacement =
+                                prepareReplacementVersionedValue(lease, key, value, current);
+                        replacementRef.set(replacement);
+                        if (replacement == null) {
+                            admissionRejected.set(true);
+                            lease.keyNode.loadPublicationState.set(new Object());
+                            removeCurrentVersion(key, current);
+                            return false;
+                        }
+                        lease.keyNode.loadPublicationState.set(new Object());
+                        return installReplacement(replacement);
+                    }
+                    VersionedValue<K, V> prepared = prepareVersionedValue(lease, key, value);
+                    preparedRef.set(prepared);
+                    if (prepared == null) {
+                        admissionRejected.set(true);
+                        return false;
+                    }
+                    lease.keyNode.loadPublicationState.set(new Object());
+                    install(prepared, lease);
+                    return true;
+                });
+            } finally {
+                if (!retained && replacementRef.get() != null) {
+                    replacementRef.get().rollback();
+                } else if (!retained && preparedRef.get() != null) {
+                    releaseReservation(preparedRef.get());
+                }
+                if (admissionRejected.get()) {
+                    notifyDiscarded(key, value);
+                }
+            }
         }
     }
 
@@ -306,29 +364,82 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
             return true;
         }
         try (PublicationLease<K, V> lease = acquirePublicationLease(key, path, false)) {
-            return guardedCommit(lease, () -> {
-                VersionedValue<K, V> current = currentVersionedValue(key, path);
-                V currentValue = current == null ? null : current.value;
-                if (currentValue != expectedValue) {
-                    return false;
-                }
-                lease.keyNode.loadPublicationState.set(new Object());
-                action.run();
-                if (updatedValue == currentValue) {
+            AtomicReference<VersionedValue<K, V>> preparedRef = new AtomicReference<>();
+            AtomicReference<ReplacementValue<K, V>> replacementRef = new AtomicReference<>();
+            AtomicBoolean admissionRejected = new AtomicBoolean(false);
+            boolean committed = false;
+            try {
+                committed = guardedCommit(lease, () -> {
+                    VersionedValue<K, V> current = currentVersionedValue(key, path);
+                    V currentValue = current == null ? null : current.value;
+                    if (currentValue != expectedValue) {
+                        return false;
+                    }
+                    if (updatedValue != null && updatedValue != currentValue) {
+                        if (current != null) {
+                            ReplacementValue<K, V> replacement =
+                                    prepareReplacementVersionedValue(lease, key, updatedValue, current);
+                            replacementRef.set(replacement);
+                            if (replacement == null) {
+                                admissionRejected.set(true);
+                                lease.keyNode.loadPublicationState.set(new Object());
+                                action.run();
+                                removeCurrentVersion(key, current);
+                                return true;
+                            }
+                        } else {
+                            VersionedValue<K, V> prepared = prepareVersionedValue(lease, key, updatedValue);
+                            preparedRef.set(prepared);
+                            if (prepared == null) {
+                                admissionRejected.set(true);
+                                lease.keyNode.loadPublicationState.set(new Object());
+                                action.run();
+                                return true;
+                            }
+                        }
+                    }
+                    lease.keyNode.loadPublicationState.set(new Object());
+                    try {
+                        action.run();
+                    } catch (RuntimeException | Error e) {
+                        // Restore the old reservation before removal can acquire this key's lock.
+                        if (replacementRef.get() != null) {
+                            replacementRef.get().rollback();
+                        }
+                        throw e;
+                    }
+                    if (updatedValue == currentValue) {
+                        lease.keyNode.loadPublicationState.set(new Object());
+                        return true;
+                    }
+                    if (updatedValue != null) {
+                        if (replacementRef.get() != null) {
+                            lease.keyNode.loadPublicationState.set(new Object());
+                            return installReplacement(replacementRef.get());
+                        }
+                        lease.keyNode.loadPublicationState.set(new Object());
+                        install(preparedRef.get(), lease);
+                        return true;
+                    }
+                    if (updatedValue == null) {
+                        if (current != null) {
+                            removeCurrentVersion(key, current);
+                        }
+                    }
                     lease.keyNode.loadPublicationState.set(new Object());
                     return true;
+                });
+            } finally {
+                if (!committed && replacementRef.get() != null) {
+                    replacementRef.get().rollback();
+                } else if (!committed && preparedRef.get() != null) {
+                    releaseReservation(preparedRef.get());
                 }
-                if (updatedValue == null) {
-                    if (current != null) {
-                        data.asMap().remove(key, current);
-                        lease.keyNode.registration.compareAndSet(current, null);
-                    }
-                } else {
-                    publishCommitted(lease, key, updatedValue);
+                if (admissionRejected.get()) {
+                    notifyDiscarded(key, updatedValue);
                 }
-                lease.keyNode.loadPublicationState.set(new Object());
-                return true;
-            });
+            }
+            return committed;
         }
     }
 
@@ -366,10 +477,17 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
             return;
         }
         afterStateReplacement.run();
-        VersionedValue<K, V> registered = invalidated.node.registration.get();
-        if (registered != null && registered.keyState == invalidated.keyState) {
-            data.asMap().remove(key, registered);
-            invalidated.node.registration.compareAndSet(registered, null);
+        Registration registered = invalidated.registration;
+        deferRemovals(() -> {
+            VersionedValue<K, V> current = data.getIfPresent(key);
+            if (registered != null && current != null && current.registration == registered
+                    && current.keyState == invalidated.keyState) {
+                data.asMap().remove(key, current);
+            }
+            return null;
+        });
+        if (registered != null && invalidated.node.registration.compareAndSet(registered, null)) {
+            releaseRegistration(registered);
         }
         tryPruneKey(key, invalidated.node);
     }
@@ -411,9 +529,20 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
             return false;
         }
         try (PublicationLease<K, V> lease = acquirePublicationLease(key, actualScope, false)) {
-            VersionedValue<K, V> staged = newVersionedValue(lease, key, value);
-            afterBulkStage.run();
-            return handle.tryCommit(key, lease, staged);
+            VersionedValue<K, V> staged = prepareVersionedValue(lease, key, value);
+            if (staged == null) {
+                return false;
+            }
+            boolean retained = false;
+            try {
+                afterBulkStage.run();
+                retained = handle.tryCommit(key, lease, staged);
+                return retained;
+            } finally {
+                if (!retained) {
+                    releaseReservation(staged);
+                }
+            }
         }
     }
 
@@ -444,7 +573,12 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
                     invalidateCount.sum(),
                     lastLoadSuccessTimeMs.get(),
                     lastLoadFailureTimeMs.get(),
-                    lastError.get()));
+                    lastError.get(),
+                    weightBounded,
+                    entryBudget == null ? -1L : entryBudget.getEffectiveMaxWeight(),
+                    entryBudget == null ? 0L : entryBudget.getUsedWeight(),
+                    weightRejectCount.sum(),
+                    lastWeightRejectReason.get()));
     }
 
     int refreshingCountForTest() {
@@ -453,10 +587,13 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
 
     public void forEach(BiConsumer<K, V> consumer) {
         Objects.requireNonNull(consumer, "consumer can not be null");
-        data.asMap().forEach((key, versioned) -> {
-            if (versioned.isCurrent(registry, keyNodes)) {
-                consumer.accept(key, versioned.value);
-            }
+        deferRemovals(() -> {
+            data.asMap().forEach((key, versioned) -> {
+                if (versioned.isCurrent(registry, keyNodes)) {
+                    consumer.accept(key, versioned.value);
+                }
+            });
+            return null;
         });
     }
 
@@ -487,7 +624,10 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
     }
 
     public void cleanUp() {
-        data.cleanUp();
+        deferRemovals(() -> {
+            data.cleanUp();
+            return null;
+        });
     }
 
     @Override
@@ -510,9 +650,14 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
     void removeExpectedRaw(Object rawKey, Object expectedValue) {
         @SuppressWarnings("unchecked")
         K key = (K) rawKey;
-        @SuppressWarnings("unchecked")
-        VersionedValue<K, V> versionedValue = (VersionedValue<K, V>) expectedValue;
-        data.asMap().remove(key, versionedValue);
+        Registration expectedRegistration = (Registration) expectedValue;
+        deferRemovals(() -> {
+            VersionedValue<K, V> current = data.getIfPresent(key);
+            if (current != null && current.registration == expectedRegistration) {
+                data.asMap().remove(key, current);
+            }
+            return null;
+        });
     }
 
     private PublicationLease<K, V> acquirePublicationLease(
@@ -533,29 +678,25 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
         }
     }
 
-    private VersionedValue<K, V> publish(PublicationLease<K, V> lease, K key, V value) {
-        if (!lease.isCurrent()) {
-            return null;
-        }
-        VersionedValue<K, V> versioned = newVersionedValue(lease, key, value);
-        install(versioned, lease);
-        if (!lease.isCurrent()) {
-            data.asMap().remove(key, versioned);
-            return null;
-        }
-        return versioned;
-    }
-
-    private VersionedValue<K, V> publishCommitted(PublicationLease<K, V> lease, K key, V value) {
-        return publish(lease, key, value);
-    }
-
     private boolean commitLoaded(PublicationLease<K, V> lease, K key, V value, Runnable beforePublication) {
         Runnable action = Objects.requireNonNull(beforePublication, "beforePublication can not be null");
-        return guardedCommit(lease, () -> {
-            action.run();
-            return publishCommitted(lease, key, value) != null;
-        });
+        VersionedValue<K, V> prepared = prepareVersionedValue(lease, key, value);
+        boolean retained = false;
+        try {
+            retained = guardedCommit(lease, () -> {
+                action.run();
+                if (prepared == null) {
+                    return false;
+                }
+                install(prepared, lease);
+                return true;
+            });
+            return retained;
+        } finally {
+            if (!retained && prepared != null) {
+                releaseReservation(prepared);
+            }
+        }
     }
 
     private boolean guardedCommit(PublicationLease<K, V> lease, BooleanSupplier commitAction) {
@@ -568,11 +709,171 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
                         })));
     }
 
-    private VersionedValue<K, V> newVersionedValue(
+    private VersionedValue<K, V> prepareVersionedValue(
             PublicationLease<K, V> lease, K key, V value) {
+        MetaCacheBudgetManager.AdmissionReservation reservation = reserve(key, value);
+        if (weightBounded && reservation == null) {
+            return null;
+        }
         CacheAddress address = new CacheAddress(this, key);
+        ScopeSnapshot scopeSnapshot = lease.scopeLease.snapshot();
+        Registration registration = new Registration(reservation, address, scopeSnapshot);
         return new VersionedValue<>(
-                key, value, address, lease.scopeLease.snapshot(), lease.keyNode, lease.keyState, ticker.read());
+                key, value, address, scopeSnapshot, lease.keyNode, lease.keyState,
+                ticker.read(), registration);
+    }
+
+    private MetaCacheBudgetManager.AdmissionReservation reserve(K key, V value) {
+        if (!weightBounded) {
+            return null;
+        }
+        long bytes = estimateWeight(key, value);
+        return bytes < 0L ? null : reserveEstimated(bytes);
+    }
+
+    private long estimateWeight(K key, V value) {
+        MetaCacheSizeEstimate estimate = MetaCacheSizeEstimator.estimateSafely(
+                "estimator_failure", () -> sizeEstimator.estimate(key, value));
+        if (!estimate.isComplete()) {
+            rejectWeight("incomplete_estimate:" + estimate.getIncompleteReason());
+            return -1L;
+        }
+        if (estimate.getBytes() == 0L) {
+            rejectWeight("invalid_zero_estimate");
+            return -1L;
+        }
+        long bytes = JvmSizeUtils.saturatedAdd(
+                estimate.getBytes(), FIXED_ENTRY_ACCOUNTING_OVERHEAD_BYTES);
+        if (bytes > entryBudget.getEffectiveMaxWeight()) {
+            rejectWeight("entry_too_large");
+            return -1L;
+        }
+        return bytes;
+    }
+
+    private MetaCacheBudgetManager.AdmissionReservation reserveEstimated(long bytes) {
+        Optional<MetaCacheBudgetManager.AdmissionReservation> reservation = entryBudget.tryReserve(bytes);
+        if (!reservation.isPresent()) {
+            entryBudget.requestPeerReclaim(bytes);
+            rejectWeight("budget_exceeded");
+            return null;
+        }
+        return reservation.get();
+    }
+
+    private ReplacementValue<K, V> prepareReplacementVersionedValue(
+            PublicationLease<K, V> lease, K key, V value, VersionedValue<K, V> previous) {
+        if (!weightBounded) {
+            VersionedValue<K, V> versioned = prepareVersionedValue(lease, key, value);
+            return versioned == null ? null : new ReplacementValue<>(versioned, previous, null);
+        }
+        long bytes = estimateWeight(key, value);
+        if (bytes < 0L) {
+            return null;
+        }
+        Optional<MetaCacheBudgetManager.ReservationReplacement> replacement =
+                entryBudget.tryReplace(previous.registration.reservation, bytes);
+        if (!replacement.isPresent()) {
+            long additionalBytes = Math.max(0L,
+                    bytes - previous.registration.reservation.getBytes());
+            entryBudget.requestPeerReclaim(additionalBytes);
+            rejectWeight("budget_exceeded");
+            return null;
+        }
+        MetaCacheBudgetManager.ReservationReplacement accounting = replacement.get();
+        if (!previous.registration.released.compareAndSet(false, true)) {
+            accounting.rollback();
+            return null;
+        }
+        CacheAddress address = new CacheAddress(this, key);
+        ScopeSnapshot scopeSnapshot = lease.scopeLease.snapshot();
+        Registration registration = new Registration(accounting.current(), address, scopeSnapshot);
+        VersionedValue<K, V> versioned = new VersionedValue<>(
+                key, value, address, scopeSnapshot, lease.keyNode, lease.keyState,
+                ticker.read(), registration);
+        return new ReplacementValue<>(versioned, previous, accounting);
+    }
+
+    private boolean installReplacement(ReplacementValue<K, V> replacement) {
+        VersionedValue<K, V> previous = replacement.previous;
+        VersionedValue<K, V> current = replacement.current;
+        registry.register(current.address, current.registration, current.scopeSnapshot);
+        if (!current.keyNode.registration.compareAndSet(
+                previous.registration, current.registration)) {
+            registry.register(previous.address, previous.registration, previous.scopeSnapshot);
+            replacement.rollback();
+            return false;
+        }
+        if (!data.asMap().replace(current.key, previous, current)) {
+            current.keyNode.registration.compareAndSet(current.registration, previous.registration);
+            registry.register(previous.address, previous.registration, previous.scopeSnapshot);
+            replacement.rollback();
+            return false;
+        }
+        replacement.commit();
+        return true;
+    }
+
+    private long evictLocalColdest() {
+        return deferRemovals(this::evictLocalColdestWithDeferredRemovals);
+    }
+
+    private long evictLocalColdestWithDeferredRemovals() {
+        if (!data.policy().eviction().isPresent()) {
+            return 0L;
+        }
+        Map<K, VersionedValue<K, V>> coldest = data.policy().eviction().get().coldest(1);
+        for (Map.Entry<K, VersionedValue<K, V>> candidate : coldest.entrySet()) {
+            VersionedValue<K, V> current = data.getIfPresent(candidate.getKey());
+            if (current == candidate.getValue()) {
+                long weight = current.registration.reservation.getBytes();
+                budgetEvictionRegistration.set(current.registration);
+                try {
+                    if (data.asMap().remove(candidate.getKey(), current)) {
+                        return weight;
+                    }
+                } finally {
+                    budgetEvictionRegistration.remove();
+                }
+            }
+        }
+        return 0L;
+    }
+
+    private long reclaimForPeer(long targetBytes) {
+        if (targetBytes <= 0L || closed.get()) {
+            return 0L;
+        }
+        long reclaimed = 0L;
+        long removed;
+        while (reclaimed < targetBytes && (removed = evictLocalColdest()) > 0L) {
+            reclaimed = JvmSizeUtils.saturatedAdd(reclaimed, removed);
+        }
+        return reclaimed;
+    }
+
+    private void rejectWeight(String reason) {
+        weightRejectCount.increment();
+        lastWeightRejectReason.set(reason);
+        long now = System.nanoTime();
+        long last = lastWeightRejectWarnNanos.get();
+        if ((last == Long.MIN_VALUE || now - last >= WEIGHT_REJECT_WARN_INTERVAL_NANOS)
+                && lastWeightRejectWarnNanos.compareAndSet(last, now)) {
+            LOG.warn("Metadata cache entry '{}' rejected a value by weight: reason={}, used={}, max={}",
+                    name, reason, entryBudget == null ? 0L : entryBudget.getUsedWeight(),
+                    entryBudget == null ? -1L : entryBudget.getEffectiveMaxWeight());
+        }
+    }
+
+    private static void releaseReservation(VersionedValue<?, ?> versioned) {
+        releaseRegistration(versioned.registration);
+    }
+
+    private static void releaseRegistration(Registration registration) {
+        if (registration != null && registration.released.compareAndSet(false, true)
+                && registration.reservation != null) {
+            registration.reservation.release();
+        }
     }
 
     private void scheduleRefresh(K key, ScopePath path, Function<K, V> loader, VersionedValue<K, V> current) {
@@ -587,7 +888,7 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
             refreshing.remove(key, current);
             throw throwable;
         }
-        if (data.getIfPresent(key) != current || !current.isCurrent(registry, keyNodes)) {
+        if (deferRemovals(() -> data.getIfPresent(key)) != current || !current.isCurrent(registry, keyNodes)) {
             refreshing.remove(key, current);
             return;
         }
@@ -598,7 +899,8 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
                         return;
                     }
                     try (PublicationLease<K, V> lease = acquirePublicationLease(key, path, true)) {
-                        if (data.getIfPresent(key) != current || !current.isCurrent(registry, keyNodes)) {
+                        if (deferRemovals(() -> data.getIfPresent(key)) != current
+                                || !current.isCurrent(registry, keyNodes)) {
                             return;
                         }
                         V refreshed = loadAndRecord(key, loader);
@@ -626,34 +928,45 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
 
     private void install(
             VersionedValue<K, V> versioned, PublicationLease<K, V> lease) {
-        registry.register(versioned.address, versioned, versioned.scopeSnapshot);
-        lease.keyNode.registration.set(versioned);
+        registry.register(versioned.address, versioned.registration, versioned.scopeSnapshot);
+        lease.keyNode.registration.set(versioned.registration);
         data.asMap().put(versioned.key, versioned);
     }
 
     private boolean replaceRefreshExpected(PublicationLease<K, V> lease, K key,
             VersionedValue<K, V> expected, V refreshed) {
-        return guardedCommit(lease, () -> {
-            if (data.getIfPresent(key) != expected || !expected.isCurrent(registry, keyNodes)) {
-                return false;
-            }
-            if (refreshed == expected.value) {
+        if (refreshed == expected.value) {
+            return guardedCommit(lease, () -> {
+                if (data.getIfPresent(key) != expected || !expected.isCurrent(registry, keyNodes)) {
+                    return false;
+                }
                 expected.writeTimeNanos = ticker.read();
                 return true;
+            });
+        }
+        AtomicReference<ReplacementValue<K, V>> replacementRef = new AtomicReference<>();
+        boolean retained = false;
+        try {
+            retained = guardedCommit(lease, () -> {
+                if (data.getIfPresent(key) != expected || !expected.isCurrent(registry, keyNodes)) {
+                    return false;
+                }
+                ReplacementValue<K, V> replacement =
+                        prepareReplacementVersionedValue(lease, key, refreshed, expected);
+                replacementRef.set(replacement);
+                if (replacement == null) {
+                    lease.keyNode.loadPublicationState.set(new Object());
+                    removeCurrentVersion(key, expected);
+                    return false;
+                }
+                return installReplacement(replacement);
+            });
+            return retained;
+        } finally {
+            if (!retained && replacementRef.get() != null) {
+                replacementRef.get().rollback();
             }
-            VersionedValue<K, V> replacement = newVersionedValue(lease, key, refreshed);
-            registry.register(replacement.address, replacement, replacement.scopeSnapshot);
-            if (!lease.keyNode.registration.compareAndSet(expected, replacement)) {
-                registry.unregister(replacement.address, replacement, replacement.scopeSnapshot);
-                return false;
-            }
-            if (!data.asMap().replace(key, expected, replacement)) {
-                lease.keyNode.registration.compareAndSet(replacement, null);
-                registry.unregister(replacement.address, replacement, replacement.scopeSnapshot);
-                return false;
-            }
-            return true;
-        });
+        }
     }
 
     private boolean tryCommitBulk(
@@ -685,11 +998,21 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
         }));
     }
 
-    private boolean deferRemovals(BooleanSupplier action) {
+    private void removeCurrentVersion(K key, VersionedValue<K, V> current) {
+        data.asMap().remove(key, current);
+        if (current.keyNode.registration.compareAndSet(current.registration, null)) {
+            releaseRegistration(current.registration);
+        }
+    }
+
+    // Caffeine's direct executor can call removal listeners while holding its maintenance lock, even on a
+    // read or policy snapshot. Drain only after that operation returns, outside both maintenance and (for
+    // publication callers) KeyNode locks; otherwise a full Caffeine write buffer can invert their lock order.
+    private <T> T deferRemovals(Supplier<T> action) {
         RemovalDeferral<K, V> removalDeferral = removalDeferrals.get();
         removalDeferral.depth++;
         try {
-            return action.getAsBoolean();
+            return action.get();
         } finally {
             removalDeferral.depth--;
             if (removalDeferral.depth == 0 && !removalDeferral.draining) {
@@ -753,27 +1076,35 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
 
     private void closePhysicalState() {
         bulkInvalidationGate.write(exactInvalidations::clear);
-        keyNodes.forEach((key, node) -> {
-            replaceKeyState(node);
-            VersionedValue<K, V> versioned = node.registration.get();
-            if (versioned != null) {
-                data.asMap().remove(key, versioned);
-                node.registration.compareAndSet(versioned, null);
-            }
-            tryPruneKey(key, node);
+        deferRemovals(() -> {
+            keyNodes.forEach((key, node) -> {
+                replaceKeyState(node);
+                Registration registered = node.registration.get();
+                VersionedValue<K, V> versioned = data.getIfPresent(key);
+                if (versioned != null && versioned.registration == registered) {
+                    data.asMap().remove(key, versioned);
+                }
+                if (registered != null && node.registration.compareAndSet(registered, null)) {
+                    releaseRegistration(registered);
+                }
+                tryPruneKey(key, node);
+            });
+            data.invalidateAll();
+            data.cleanUp();
+            return null;
         });
-        data.invalidateAll();
-        data.cleanUp();
+        if (entryBudget != null) {
+            entryBudget.close();
+        }
     }
 
     private void onRemoval(
             Object rawKey, Object rawValue, RemovalCause cause) {
-        Objects.requireNonNull(rawKey, "removed cache key can not be null");
-        Objects.requireNonNull(rawValue, "removed cache value can not be null");
         @SuppressWarnings("unchecked")
         VersionedValue<K, V> versioned = (VersionedValue<K, V>) rawValue;
         RemovalDeferral<K, V> removalDeferral = removalDeferrals.get();
-        removalDeferral.removals.addLast(new DeferredRemoval<>(versioned, cause));
+        removalDeferral.removals.addLast(new DeferredRemoval<>(
+                versioned, cause, budgetEvictionRegistration.get() == versioned.registration));
         if (removalDeferral.depth > 0 || removalDeferral.draining) {
             return;
         }
@@ -787,7 +1118,7 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
             DeferredRemoval<K, V> removal;
             while ((removal = removalDeferral.removals.pollFirst()) != null) {
                 try {
-                    completeRemoval(removal.versioned, removal.cause);
+                    completeRemoval(removal.versioned, removal.cause, removal.budgetEviction);
                 } catch (RuntimeException | Error e) {
                     if (failure == null) {
                         failure = e;
@@ -809,8 +1140,9 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
         }
     }
 
-    private void completeRemoval(VersionedValue<K, V> versioned, RemovalCause cause) {
-        if (cause.wasEvicted()) {
+    private void completeRemoval(
+            VersionedValue<K, V> versioned, RemovalCause cause, boolean budgetEviction) {
+        if (cause.wasEvicted() || budgetEviction) {
             evictionCount.increment();
         } else if (cause == RemovalCause.EXPLICIT) {
             invalidateCount.increment();
@@ -823,9 +1155,12 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
                 LOG.warn("Scoped metadata cache removal callback failed", t);
             }
         }
-        registry.unregister(versioned.address, versioned, versioned.scopeSnapshot);
-        versioned.keyNode.registration.compareAndSet(versioned, null);
-        tryPruneKey(key, versioned.keyNode);
+        synchronized (versioned.keyNode) {
+            registry.unregister(versioned.address, versioned.registration, versioned.scopeSnapshot);
+            versioned.keyNode.registration.compareAndSet(versioned.registration, null);
+            releaseRegistration(versioned.registration);
+            tryPruneKey(key, versioned.keyNode);
+        }
     }
 
     private void notifyDiscarded(K key, V value) {
@@ -848,20 +1183,26 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
     private static final class DeferredRemoval<K, V> {
         private final VersionedValue<K, V> versioned;
         private final RemovalCause cause;
+        private final boolean budgetEviction;
 
-        private DeferredRemoval(VersionedValue<K, V> versioned, RemovalCause cause) {
+        private DeferredRemoval(
+                VersionedValue<K, V> versioned, RemovalCause cause, boolean budgetEviction) {
             this.versioned = versioned;
             this.cause = cause;
+            this.budgetEviction = budgetEviction;
         }
     }
 
     private static final class InvalidatedKey<K, V> {
         private final KeyNode<K, V> node;
         private final KeyState keyState;
+        private final Registration registration;
 
         private InvalidatedKey(KeyNode<K, V> node, KeyState keyState) {
             this.node = node;
             this.keyState = keyState;
+            // Captured under the publication fence: cleanup must never detach a newer generation.
+            this.registration = node == null ? null : node.registration.get();
         }
     }
 
@@ -954,6 +1295,11 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
         private final long lastLoadSuccessTimeMs;
         private final long lastLoadFailureTimeMs;
         private final String lastError;
+        private final boolean weightBounded;
+        private final long maxWeight;
+        private final long estimatedWeight;
+        private final long weightRejectCount;
+        private final String lastWeightRejectReason;
 
         private CacheMetrics(
                 long physicalEntryCount,
@@ -972,7 +1318,12 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
                 long invalidateCount,
                 long lastLoadSuccessTimeMs,
                 long lastLoadFailureTimeMs,
-                String lastError) {
+                String lastError,
+                boolean weightBounded,
+                long maxWeight,
+                long estimatedWeight,
+                long weightRejectCount,
+                String lastWeightRejectReason) {
             this.physicalEntryCount = physicalEntryCount;
             this.keyNodeCount = keyNodeCount;
             this.inFlightLoadCount = inFlightLoadCount;
@@ -990,6 +1341,11 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
             this.lastLoadSuccessTimeMs = lastLoadSuccessTimeMs;
             this.lastLoadFailureTimeMs = lastLoadFailureTimeMs;
             this.lastError = lastError;
+            this.weightBounded = weightBounded;
+            this.maxWeight = maxWeight;
+            this.estimatedWeight = estimatedWeight;
+            this.weightRejectCount = weightRejectCount;
+            this.lastWeightRejectReason = lastWeightRejectReason;
         }
 
         public long getPhysicalEntryCount() {
@@ -1059,6 +1415,26 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
         public String getLastError() {
             return lastError;
         }
+
+        public boolean isWeightBounded() {
+            return weightBounded;
+        }
+
+        public long getMaxWeight() {
+            return maxWeight;
+        }
+
+        public long getEstimatedWeight() {
+            return estimatedWeight;
+        }
+
+        public long getWeightRejectCount() {
+            return weightRejectCount;
+        }
+
+        public String getLastWeightRejectReason() {
+            return lastWeightRejectReason;
+        }
     }
 
     private static final class PublicationLease<K, V> implements AutoCloseable {
@@ -1113,6 +1489,7 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
         private final KeyNode<K, V> keyNode;
         private final KeyState keyState;
         private volatile long writeTimeNanos;
+        private final Registration registration;
 
         private VersionedValue(
                 K key,
@@ -1121,7 +1498,8 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
                 ScopeSnapshot scopeSnapshot,
                 KeyNode<K, V> keyNode,
                 KeyState keyState,
-                long writeTimeNanos) {
+                long writeTimeNanos,
+                Registration registration) {
             this.key = key;
             this.value = value;
             this.address = address;
@@ -1129,6 +1507,7 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
             this.keyNode = keyNode;
             this.keyState = keyState;
             this.writeTimeNanos = writeTimeNanos;
+            this.registration = registration;
         }
 
         private boolean isCurrent(
@@ -1137,14 +1516,63 @@ public final class ScopedMetaCache<K, V> implements AutoCloseable {
             return scopeSnapshot.isCurrent(registry)
                     && currentKeyNodes.get(key) == keyNode
                     && keyNode.current.get() == keyState
-                    && keyNode.registration.get() == this;
+                    && keyNode.registration.get() == registration;
+        }
+    }
+
+    private static final class ReplacementValue<K, V> {
+        private final VersionedValue<K, V> current;
+        private final VersionedValue<K, V> previous;
+        private final MetaCacheBudgetManager.ReservationReplacement accounting;
+        private boolean finished;
+
+        private ReplacementValue(VersionedValue<K, V> current,
+                VersionedValue<K, V> previous,
+                MetaCacheBudgetManager.ReservationReplacement accounting) {
+            this.current = current;
+            this.previous = previous;
+            this.accounting = accounting;
+        }
+
+        private void commit() {
+            if (accounting != null) {
+                accounting.commit();
+            }
+            finished = true;
+        }
+
+        private void rollback() {
+            if (finished) {
+                return;
+            }
+            if (accounting != null) {
+                current.registration.released.set(true);
+                previous.registration.released.set(false);
+                accounting.rollback();
+            }
+            finished = true;
+        }
+    }
+
+    /** Lightweight ownership token: deliberately does not retain the cached value. */
+    private static final class Registration {
+        private final MetaCacheBudgetManager.AdmissionReservation reservation;
+        private final CacheAddress address;
+        private final ScopeSnapshot scopeSnapshot;
+        private final AtomicBoolean released = new AtomicBoolean(false);
+
+        private Registration(MetaCacheBudgetManager.AdmissionReservation reservation,
+                CacheAddress address, ScopeSnapshot scopeSnapshot) {
+            this.reservation = reservation;
+            this.address = address;
+            this.scopeSnapshot = scopeSnapshot;
         }
     }
 
     private static final class KeyNode<K, V> {
         private final AtomicReference<KeyState> current = new AtomicReference<>(new KeyState());
         private final AtomicReference<Object> loadPublicationState = new AtomicReference<>(new Object());
-        private final AtomicReference<VersionedValue<K, V>> registration = new AtomicReference<>();
+        private final AtomicReference<Registration> registration = new AtomicReference<>();
         private final AtomicInteger activeLoads = new AtomicInteger();
     }
 

--- a/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/ScopedMetaCacheRegistry.java
+++ b/fe/fe-connector/fe-connector-cache/src/main/java/org/apache/doris/connector/cache/ScopedMetaCacheRegistry.java
@@ -19,6 +19,8 @@ package org.apache.doris.connector.cache;
 
 import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.github.benmanes.caffeine.cache.Ticker;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -46,6 +48,7 @@ import java.util.function.BooleanSupplier;
  * live values and in-flight loads rather than by every name ever observed.
  */
 public final class ScopedMetaCacheRegistry implements AutoCloseable {
+    private static final Logger LOG = LogManager.getLogger(ScopedMetaCacheRegistry.class);
     private static final Runnable NO_OP = () -> {
     };
     private static final BiConsumer<ScopePath.Level, Object> NO_OP_SCOPE = (level, key) -> {
@@ -81,19 +84,23 @@ public final class ScopedMetaCacheRegistry implements AutoCloseable {
             String name, CacheSpec cacheSpec, RemovalListener<K, V> removalListener,
             Duration refreshAfterWrite, Executor refreshExecutor) {
         return createCacheWithRemovalListener(name, cacheSpec, null, removalListener,
-                null, refreshAfterWrite, refreshExecutor, NO_OP, NO_OP, NO_OP);
+                null, refreshAfterWrite, refreshExecutor, NO_OP, NO_OP, NO_OP,
+                null, null);
     }
 
     <K, V> ScopedMetaCache<K, V> createCacheWithMetaRemovalListener(
             String name, CacheSpec cacheSpec, MetaCacheRemovalListener<K, V> removalListener,
             BiConsumer<K, V> discardListener,
-            Duration refreshAfterWrite, Executor refreshExecutor) {
+            Duration refreshAfterWrite, Executor refreshExecutor,
+            MetaCacheSizeEstimator<K, V> sizeEstimator,
+            MetaCacheBudgetManager.EntryBudget entryBudget) {
         RemovalListener<K, V> caffeineListener = removalListener == null ? null
                 : (key, value, cause) -> removalListener.onRemoval(
                         key, value, MetaCacheRemovalReason.valueOf(cause.name()));
         return createCacheWithRemovalListener(
                 name, cacheSpec, null, caffeineListener, discardListener,
-                refreshAfterWrite, refreshExecutor, NO_OP, NO_OP, NO_OP);
+                refreshAfterWrite, refreshExecutor, NO_OP, NO_OP, NO_OP,
+                sizeEstimator, entryBudget);
     }
 
     <K, V> ScopedMetaCache<K, V> createCache(
@@ -125,7 +132,7 @@ public final class ScopedMetaCacheRegistry implements AutoCloseable {
                 : (key, value, cause) -> beforeRemoval.accept(key, value);
         return createCacheWithRemovalListener(
                 name, cacheSpec, ticker, listener, null, null, null,
-                afterLoadElection, afterBulkStage, NO_OP);
+                afterLoadElection, afterBulkStage, NO_OP, null, null);
     }
 
     <K, V> ScopedMetaCache<K, V> createCacheWithRefresh(
@@ -136,7 +143,7 @@ public final class ScopedMetaCacheRegistry implements AutoCloseable {
             Runnable afterRefreshRegistration) {
         return createCacheWithRemovalListener(
                 name, cacheSpec, null, null, null, refreshAfterWrite, refreshExecutor,
-                NO_OP, NO_OP, afterRefreshRegistration);
+                NO_OP, NO_OP, afterRefreshRegistration, null, null);
     }
 
     private <K, V> ScopedMetaCache<K, V> createCacheWithRemovalListener(
@@ -149,7 +156,9 @@ public final class ScopedMetaCacheRegistry implements AutoCloseable {
             Executor refreshExecutor,
             Runnable afterLoadElection,
             Runnable afterBulkStage,
-            Runnable afterRefreshRegistration) {
+            Runnable afterRefreshRegistration,
+            MetaCacheSizeEstimator<K, V> sizeEstimator,
+            MetaCacheBudgetManager.EntryBudget entryBudget) {
         checkOpen();
         ScopedMetaCache<K, V> cache = new ScopedMetaCache<>(
                 this,
@@ -162,7 +171,9 @@ public final class ScopedMetaCacheRegistry implements AutoCloseable {
                 refreshExecutor,
                 afterLoadElection,
                 afterBulkStage,
-                afterRefreshRegistration);
+                afterRefreshRegistration,
+                sizeEstimator,
+                entryBudget);
         caches.add(cache);
         if (closed.get()) {
             caches.remove(cache);
@@ -252,7 +263,25 @@ public final class ScopedMetaCacheRegistry implements AutoCloseable {
         cleanDetachedState(oldState);
         List<ScopedMetaCache<?, ?>> snapshot = new ArrayList<>(caches);
         caches.clear();
-        snapshot.forEach(ScopedMetaCache::closeFromRegistry);
+        Throwable failure = null;
+        for (ScopedMetaCache<?, ?> cache : snapshot) {
+            try {
+                cache.closeFromRegistry();
+            } catch (RuntimeException | Error throwable) {
+                LOG.error("Failed to close scoped metadata cache", throwable);
+                if (failure == null) {
+                    failure = throwable;
+                } else {
+                    failure.addSuppressed(throwable);
+                }
+            }
+        }
+        if (failure instanceof RuntimeException) {
+            throw (RuntimeException) failure;
+        }
+        if (failure != null) {
+            throw (Error) failure;
+        }
     }
 
     ScopeLease acquire(ScopePath path) {
@@ -280,12 +309,12 @@ public final class ScopedMetaCacheRegistry implements AutoCloseable {
         caches.remove(cache);
     }
 
-    void register(CacheAddress address, Object versionedValue, ScopeSnapshot snapshot) {
-        snapshot.leafState().entries.put(address, versionedValue);
+    void register(CacheAddress address, Object ownershipToken, ScopeSnapshot snapshot) {
+        snapshot.leafState().entries.put(address, ownershipToken);
     }
 
-    void unregister(CacheAddress address, Object versionedValue, ScopeSnapshot snapshot) {
-        snapshot.leafState().entries.remove(address, versionedValue);
+    void unregister(CacheAddress address, Object ownershipToken, ScopeSnapshot snapshot) {
+        snapshot.leafState().entries.remove(address, ownershipToken);
         tryPrune(snapshot);
     }
 
@@ -404,9 +433,9 @@ public final class ScopedMetaCacheRegistry implements AutoCloseable {
     }
 
     private void cleanDetachedState(ScopeState state) {
-        state.entries.forEach((address, value) -> {
-            if (state.entries.remove(address, value)) {
-                address.removeExpected(value);
+        state.entries.forEach((address, ownershipToken) -> {
+            if (state.entries.remove(address, ownershipToken)) {
+                address.removeExpected(ownershipToken);
             }
         });
         state.children.values().forEach(child -> cleanDetachedState(child.current.get()));
@@ -859,6 +888,7 @@ public final class ScopedMetaCacheRegistry implements AutoCloseable {
     private static final class ScopeState {
         private final long generation;
         private final ConcurrentMap<Object, ScopeNode> children = new ConcurrentHashMap<>();
+        // Ownership tokens contain no cached value, so the registry does not become a second value owner.
         private final ConcurrentMap<CacheAddress, Object> entries = new ConcurrentHashMap<>();
         private volatile ScopeSnapshot scopeSnapshot;
 

--- a/fe/fe-connector/fe-connector-cache/src/test/java/org/apache/doris/connector/cache/CacheSpecTest.java
+++ b/fe/fe-connector/fe-connector-cache/src/test/java/org/apache/doris/connector/cache/CacheSpecTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.connector.cache;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.OptionalLong;
@@ -245,5 +246,56 @@ public class CacheSpecTest {
         Assertions.assertFalse(
                 CacheSpec.isMetaCacheKeyForEngine("meta.cache.paimon.table.ttl-second", "iceberg"));
         Assertions.assertFalse(CacheSpec.isMetaCacheKeyForEngine(null, "iceberg"));
+    }
+
+    @Test
+    public void parsesAndValidatesWeightProperties() {
+        Assertions.assertEquals(1024L, CacheSpec.parseWeight("1KB", "weight", false, 0L));
+        Assertions.assertEquals(512L, CacheSpec.parseWeight("25%", "weight", true, 2048L));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> CacheSpec.parseWeight("1.5GB", "weight", false, 0L));
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("meta.cache.max-weight", "2GB");
+        properties.put("meta.cache.iceberg.table.max-weight", "1GB");
+        CacheSpec.checkWeightProperties(properties, "iceberg", "table");
+
+        properties.put("meta.cache.iceberg.table.max-weight", "3GB");
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> CacheSpec.checkWeightProperties(properties, "iceberg", "table"));
+
+        properties.put("meta.cache.iceberg.table.max-weight", "0");
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> CacheSpec.checkWeightProperties(properties, "iceberg", "table"));
+
+        properties.put("meta.cache.iceberg.table.max-weight", "1GB");
+        properties.put("meta.cache.iceberg.unknown.max-weight", "1MB");
+        Assertions.assertDoesNotThrow(() -> CacheSpec.checkWeightProperties(properties, "iceberg", "table"));
+
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> CacheSpec.checkWeightProperties(properties, properties, "iceberg", "table"));
+        Assertions.assertDoesNotThrow(() -> CacheSpec.checkWeightProperties(
+                properties, Collections.singletonMap("comment", "updated"), "iceberg", "table"));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> CacheSpec.checkWeightProperties(
+                properties, Collections.singletonMap("meta.cache.iceberg.max-weight", "1MB"), "iceberg", "table"));
+
+        properties.clear();
+        properties.put("meta.cache.max-weight", "invalid");
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> CacheSpec.checkCatalogWeightProperty(properties));
+    }
+
+    @Test
+    public void invalidPersistedEntryWeightFallsBackToUnbounded() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("meta.cache.hive.file.max-weight", "invalid");
+        CacheSpec spec = CacheSpec.fromProperties(
+                properties, "hive", "file", CacheSpec.of(true, 60L, 100L));
+        Assertions.assertFalse(spec.getMaxWeight().isPresent());
+
+        properties.put("meta.cache.hive.file.max-weight", "0");
+        spec = CacheSpec.fromProperties(properties, "hive", "file",
+                CacheSpec.of(true, 10L, 100L));
+        Assertions.assertFalse(spec.getMaxWeight().isPresent());
     }
 }

--- a/fe/fe-connector/fe-connector-cache/src/test/java/org/apache/doris/connector/cache/CatalogMetaCacheTest.java
+++ b/fe/fe-connector/fe-connector-cache/src/test/java/org/apache/doris/connector/cache/CatalogMetaCacheTest.java
@@ -20,6 +20,7 @@ package org.apache.doris.connector.cache;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Modifier;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -32,8 +33,17 @@ class CatalogMetaCacheTest {
     private static final CacheSpec SPEC = CacheSpec.of(true, CacheSpec.CACHE_NO_TTL, 100);
 
     @Test
+    void unmanagedOwnershipMustBeSelectedExplicitly() throws Exception {
+        Assertions.assertTrue(Modifier.isPrivate(CatalogMetaCache.class.getDeclaredConstructor().getModifiers()));
+        try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+            Assertions.assertFalse(owner.hasEnclosingWeightLimit());
+            Assertions.assertFalse(MetaCacheGovernance.catalogCaches(owner.catalogId()).contains(owner));
+        }
+    }
+
+    @Test
     void tableInvalidationAutomaticallyCoversEveryPhysicalCache() {
-        try (CatalogMetaCache catalog = new CatalogMetaCache()) {
+        try (CatalogMetaCache catalog = CatalogMetaCache.unmanaged()) {
             MetaCache<TableKey, String> tableCache = catalog.create(tableDefinition("table"));
             MetaCache<TableKey, String> snapshotCache = catalog.create(tableDefinition("snapshot"));
             MetaCache<TableKey, String> futureCache = catalog.create(tableDefinition("future-derived-cache"));
@@ -56,7 +66,7 @@ class CatalogMetaCacheTest {
 
     @Test
     void databaseInvalidationCoversDescendantsButNotSiblingDatabase() {
-        try (CatalogMetaCache catalog = new CatalogMetaCache()) {
+        try (CatalogMetaCache catalog = CatalogMetaCache.unmanaged()) {
             MetaCache<TableKey, String> cache = catalog.create(tableDefinition("table"));
             TableKey first = new TableKey("db1", "table");
             TableKey second = new TableKey("db2", "table");
@@ -72,7 +82,7 @@ class CatalogMetaCacheTest {
 
     @Test
     void partitionInvalidationCoversCollectionAndSelectedPartitionsOnly() {
-        try (CatalogMetaCache catalog = new CatalogMetaCache()) {
+        try (CatalogMetaCache catalog = CatalogMetaCache.unmanaged()) {
             MetaCache<String, String> collection = catalog.create(MetaCacheDefinition
                     .<String, String>builder("partition-collection", SPEC,
                             ignored -> ScopePath.partitionCollection("db", "table"))
@@ -101,7 +111,7 @@ class CatalogMetaCacheTest {
                 .<TableKey, String>builder("table", SPEC, TableKey::scope)
                 .loader(key -> "default-" + loads.incrementAndGet())
                 .build();
-        try (CatalogMetaCache catalog = new CatalogMetaCache()) {
+        try (CatalogMetaCache catalog = CatalogMetaCache.unmanaged()) {
             MetaCache<TableKey, String> cache = catalog.create(definition);
             TableKey first = new TableKey("db", "first");
             TableKey second = new TableKey("db", "second");
@@ -122,7 +132,7 @@ class CatalogMetaCacheTest {
                 .removalListener((key, value, removalReason) -> removed.set(value))
                 .discardListener((key, value) -> discarded.set(value))
                 .build();
-        try (CatalogMetaCache catalog = new CatalogMetaCache()) {
+        try (CatalogMetaCache catalog = CatalogMetaCache.unmanaged()) {
             MetaCache<TableKey, String> cache = catalog.create(definition);
 
             Assertions.assertEquals("loaded", cache.get(
@@ -137,7 +147,7 @@ class CatalogMetaCacheTest {
         Assertions.assertThrows(NullPointerException.class,
                 () -> MetaCacheDefinition.builder("missing-scope", SPEC, null).build());
 
-        CatalogMetaCache catalog = new CatalogMetaCache();
+        CatalogMetaCache catalog = CatalogMetaCache.unmanaged();
         catalog.create(tableDefinition("duplicate"));
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> catalog.create(tableDefinition("duplicate")));
@@ -154,7 +164,7 @@ class CatalogMetaCacheTest {
                 .loader(key -> "v" + loads.incrementAndGet())
                 .refreshAfterWrite(Duration.ofNanos(1), Runnable::run)
                 .build();
-        try (CatalogMetaCache catalog = new CatalogMetaCache()) {
+        try (CatalogMetaCache catalog = CatalogMetaCache.unmanaged()) {
             MetaCache<TableKey, String> cache = catalog.create(definition);
             TableKey key = new TableKey("db", "table");
 
@@ -169,7 +179,7 @@ class CatalogMetaCacheTest {
         AtomicInteger loads = new AtomicInteger();
         AtomicReference<String> removed = new AtomicReference<>();
         AtomicReference<String> discarded = new AtomicReference<>();
-        CatalogMetaCache catalog = new CatalogMetaCache();
+        CatalogMetaCache catalog = CatalogMetaCache.unmanaged();
         MetaCacheDefinition<TableKey, String> definition = MetaCacheDefinition
                 .<TableKey, String>builder("refresh", SPEC, TableKey::scope)
                 .loader(key -> {
@@ -207,7 +217,7 @@ class CatalogMetaCacheTest {
                 .removalListener((key, removed, reason) -> removals.incrementAndGet())
                 .refreshAfterWrite(Duration.ofNanos(1), Runnable::run)
                 .build();
-        try (CatalogMetaCache catalog = new CatalogMetaCache()) {
+        try (CatalogMetaCache catalog = CatalogMetaCache.unmanaged()) {
             MetaCache<TableKey, Object> cache = catalog.create(definition);
             TableKey key = new TableKey("db", "table");
 
@@ -223,7 +233,7 @@ class CatalogMetaCacheTest {
         Object value = new Object();
         AtomicInteger loads = new AtomicInteger();
         AtomicInteger removals = new AtomicInteger();
-        CatalogMetaCache catalog = new CatalogMetaCache();
+        CatalogMetaCache catalog = CatalogMetaCache.unmanaged();
         MetaCacheDefinition<TableKey, Object> definition = MetaCacheDefinition
                 .<TableKey, Object>builder("refresh", SPEC, TableKey::scope)
                 .loader(key -> {
@@ -256,7 +266,7 @@ class CatalogMetaCacheTest {
                 .loader(key -> "v" + loads.incrementAndGet())
                 .refreshAfterWrite(Duration.ofNanos(1), executor)
                 .build();
-        CatalogMetaCache catalog = new CatalogMetaCache();
+        CatalogMetaCache catalog = CatalogMetaCache.unmanaged();
         MetaCache<TableKey, String> cache = catalog.create(definition);
         TableKey key = new TableKey("db", "table");
 

--- a/fe/fe-connector/fe-connector-cache/src/test/java/org/apache/doris/connector/cache/MetaCacheEstimatorBenchmark.java
+++ b/fe/fe-connector/fe-connector-cache/src/test/java/org/apache/doris/connector/cache/MetaCacheEstimatorBenchmark.java
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.cache;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Dependency-free microbenchmark for bounded estimators versus an exact list traversal.
+ * Run after test compilation with the module's target/classes and target/test-classes on the classpath.
+ */
+public final class MetaCacheEstimatorBenchmark {
+    private static final int WARMUP_WINDOWS = 5;
+    private static final int MEASURE_WINDOWS = 15;
+    private static volatile long blackhole;
+
+    private MetaCacheEstimatorBenchmark() {
+    }
+
+    public static void main(String[] args) {
+        for (int size : new int[] {1_000, 100_000}) {
+            List<String> values = fixture(size);
+            Result sampled = measure(() -> ReflectiveObjectSizeEstimator.estimate(values), 10_000);
+            Result typedSampled = measure(() -> JvmSizeUtils.sampledListPayload(
+                    values, 16, JvmSizeUtils::stringSize), 10_000);
+            int exactOperationsPerWindow = size <= 1_000 ? 1_000 : 20;
+            Result exact = measure(() -> exactStringListSize(values), exactOperationsPerWindow);
+            Result boundedAdmission = measure(
+                    () -> completeOrRejected(values), exactOperationsPerWindow);
+            System.out.printf(
+                    "uniform_size=%d reflective_sampled_ns_op=%d typed_sampled_ns_op=%d "
+                            + "exact_ns_op=%d bounded_admission_ns_op=%d reflective_sampled_ops=%d "
+                            + "typed_sampled_ops=%d exact_ops=%d bounded_admission_ops=%d%n",
+                    size, sampled.medianNanos, typedSampled.medianNanos, exact.medianNanos,
+                    boundedAdmission.medianNanos, sampled.operations, typedSampled.operations,
+                    exact.operations, boundedAdmission.operations);
+        }
+
+        Map<String, String> skewed = skewedFixture();
+        long sampledBytes = ReflectiveObjectSizeEstimator.estimate(skewed);
+        long completeBytes = ReflectiveObjectSizeEstimator.estimateComplete(skewed);
+        Result sampled = measure(() -> ReflectiveObjectSizeEstimator.estimate(skewed), 10_000);
+        Result complete = measure(() -> ReflectiveObjectSizeEstimator.estimateComplete(skewed), 1_000);
+        System.out.printf(
+                "skewed_map_size=%d sampled_bytes=%d complete_bytes=%d sampled_ns_op=%d "
+                        + "complete_ns_op=%d sampled_ops=%d complete_ops=%d%n",
+                skewed.size(), sampledBytes, completeBytes, sampled.medianNanos, complete.medianNanos,
+                sampled.operations, complete.operations);
+    }
+
+    private static List<String> fixture(int size) {
+        List<String> values = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            values.add("partition-" + i + "-value-0123456789");
+        }
+        return values;
+    }
+
+    private static long exactStringListSize(List<String> values) {
+        long bytes = JvmSizeUtils.arrayListSize(values.size());
+        for (String value : values) {
+            bytes = JvmSizeUtils.saturatedAdd(bytes, JvmSizeUtils.stringSize(value));
+        }
+        return bytes;
+    }
+
+    private static long completeOrRejected(Object value) {
+        try {
+            return ReflectiveObjectSizeEstimator.estimateComplete(value);
+        } catch (IllegalStateException expected) {
+            return -1L;
+        }
+    }
+
+    private static Map<String, String> skewedFixture() {
+        Map<String, String> values = new LinkedHashMap<>();
+        for (int i = 0; i < 99; i++) {
+            values.put("small-" + i, "x");
+        }
+        values.put("large-tail", "x".repeat(2 * 1024 * 1024));
+        return values;
+    }
+
+    private static Result measure(LongOperation operation, int operationsPerWindow) {
+        for (int i = 0; i < WARMUP_WINDOWS; i++) {
+            runWindow(operation, operationsPerWindow);
+        }
+        long[] nanosPerOperation = new long[MEASURE_WINDOWS];
+        for (int i = 0; i < MEASURE_WINDOWS; i++) {
+            long start = System.nanoTime();
+            runWindow(operation, operationsPerWindow);
+            nanosPerOperation[i] = (System.nanoTime() - start) / operationsPerWindow;
+        }
+        Arrays.sort(nanosPerOperation);
+        return new Result(nanosPerOperation[MEASURE_WINDOWS / 2],
+                (long) operationsPerWindow * MEASURE_WINDOWS);
+    }
+
+    private static void runWindow(LongOperation operation, int operations) {
+        long value = 0L;
+        for (int i = 0; i < operations; i++) {
+            value ^= operation.run();
+        }
+        blackhole = value;
+    }
+
+    @FunctionalInterface
+    private interface LongOperation {
+        long run();
+    }
+
+    private static final class Result {
+        private final long medianNanos;
+        private final long operations;
+
+        private Result(long medianNanos, long operations) {
+            this.medianNanos = medianNanos;
+            this.operations = operations;
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-cache/src/test/java/org/apache/doris/connector/cache/MetaCacheWeightGovernanceTest.java
+++ b/fe/fe-connector/fe-connector-cache/src/test/java/org/apache/doris/connector/cache/MetaCacheWeightGovernanceTest.java
@@ -1,0 +1,586 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.cache;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.AbstractSet;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+class MetaCacheWeightGovernanceTest {
+    @Test
+    void exactInvalidationCleanupPreservesNewGenerationReservation() {
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.of(4096L));
+        MetaCacheBudgetManager.EntryBudget budget = manager.createEntryBudget(
+                7L, "iceberg", "table", "table", OptionalLong.empty(), OptionalLong.empty());
+        try (ScopedMetaCacheRegistry registry = new ScopedMetaCacheRegistry()) {
+            ScopedMetaCache<String, String> cache = registry.createCacheWithMetaRemovalListener(
+                    "table", CacheSpec.of(true, -1L, 100L), null, null, null, null,
+                    (key, value) -> MetaCacheSizeEstimate.complete(512L), budget);
+            cache.put("key", ScopePath.catalog(), "old");
+            cache.invalidateKey("key", () -> cache.put("key", ScopePath.catalog(), "new"));
+
+            Assertions.assertEquals(1024L, manager.getGlobalUsedWeight(),
+                    "delayed cleanup must not release the replacement's reservation");
+            Assertions.assertEquals("new", cache.getIfPresent("key", ScopePath.catalog()));
+            cache.invalidateKey("key");
+            Assertions.assertEquals(0L, manager.getGlobalUsedWeight());
+        }
+    }
+
+    @Test
+    void admissionRemovalAndCloseKeepHierarchicalAccountingBalanced() {
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.of(4096L));
+        CatalogMetaCache owner = new CatalogMetaCache(manager, 7L, "iceberg", Collections.emptyMap());
+        MetaCache<String, String> entry = owner.create(MetaCacheDefinition
+                .<String, String>builder("table", CacheSpec.ofWeight(true, -1L, 100L, 2048L),
+                        ignored -> ScopePath.catalog())
+                .sizeEstimator((key, value) -> MetaCacheSizeEstimate.complete(512L))
+                .build());
+
+        entry.put("one", "value");
+        Assertions.assertEquals(1024L, entry.metrics().getEstimatedWeight());
+        Assertions.assertEquals(1024L, manager.getGlobalUsedWeight());
+
+        entry.invalidateKey("one");
+        Assertions.assertEquals(0L, manager.getGlobalUsedWeight());
+        owner.close();
+        Assertions.assertEquals(0L, manager.getGlobalUsedWeight());
+    }
+
+    @Test
+    void oversizedValueIsReturnedButNotCached() {
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.of(1024L));
+        try (CatalogMetaCache owner = new CatalogMetaCache(
+                manager, 8L, "paimon", Collections.emptyMap())) {
+            MetaCache<String, String> entry = owner.create(MetaCacheDefinition
+                    .<String, String>builder("partition", CacheSpec.of(true, -1L, 100L),
+                            ignored -> ScopePath.catalog())
+                    .sizeEstimator((key, value) -> MetaCacheSizeEstimate.complete(1024L))
+                    .build());
+
+            Assertions.assertEquals("value", entry.get("key", ignored -> "value"));
+            Assertions.assertNull(entry.getIfPresent("key"));
+            Assertions.assertEquals(1L, entry.metrics().getWeightRejectCount());
+            Assertions.assertEquals("entry_too_large", entry.metrics().getLastWeightRejectReason());
+            Assertions.assertEquals(0L, manager.getGlobalUsedWeight());
+        }
+    }
+
+    @Test
+    void sameKeyReplacementUsesOnlyTheLargerGenerationWeight() {
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.of(1024L));
+        try (CatalogMetaCache owner = new CatalogMetaCache(
+                manager, 9L, "iceberg", Collections.emptyMap())) {
+            MetaCache<String, String> entry = owner.create(MetaCacheDefinition
+                    .<String, String>builder("table", CacheSpec.of(true, -1L, 100L),
+                            ignored -> ScopePath.catalog())
+                    .sizeEstimator((key, value) -> MetaCacheSizeEstimate.complete(512L))
+                    .build());
+
+            entry.put("key", "generation-one");
+            entry.put("key", "generation-two");
+
+            Assertions.assertEquals("generation-two", entry.getIfPresent("key"));
+            Assertions.assertEquals(1024L, entry.metrics().getEstimatedWeight());
+            Assertions.assertEquals(0L, entry.metrics().getWeightRejectCount());
+            entry.invalidateKey("key");
+            Assertions.assertEquals(0L, manager.getGlobalUsedWeight());
+        }
+    }
+
+    @Test
+    void failedCompareAndSetPreservesOldReservation() {
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.of(2048L));
+        try (CatalogMetaCache owner = new CatalogMetaCache(
+                manager, 10L, "iceberg", Collections.emptyMap())) {
+            MetaCache<String, String> entry = owner.create(MetaCacheDefinition
+                    .<String, String>builder("table", CacheSpec.of(true, -1L, 100L),
+                            ignored -> ScopePath.catalog())
+                    .sizeEstimator((key, value) -> MetaCacheSizeEstimate.complete(
+                            "old".equals(value) ? 512L : 1024L))
+                    .build());
+            entry.put("key", "old");
+            IllegalStateException failure = new IllegalStateException("commit failed");
+            Assertions.assertSame(failure, Assertions.assertThrows(IllegalStateException.class,
+                    () -> entry.compareAndSet("key", "old", "new", () -> {
+                        throw failure;
+                    })));
+            Assertions.assertEquals("old", entry.getIfPresent("key"));
+            Assertions.assertEquals(1024L, manager.getGlobalUsedWeight());
+            entry.invalidateKey("key");
+            Assertions.assertEquals(0L, manager.getGlobalUsedWeight());
+        }
+    }
+
+    @Test
+    void failedCompareAndSetRollsBackBeforeConcurrentRemoval() throws Exception {
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.of(2048L));
+        MetaCacheBudgetManager.EntryBudget budget = manager.createEntryBudget(
+                11L, "iceberg", "table", "table", OptionalLong.empty(), OptionalLong.empty());
+        AtomicLong ticker = new AtomicLong();
+        CountDownLatch removalStarted = new CountDownLatch(1);
+        CountDownLatch removalFinished = new CountDownLatch(1);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (ScopedMetaCacheRegistry registry = new ScopedMetaCacheRegistry();
+                ScopedMetaCache<String, String> cache = new ScopedMetaCache<>(
+                        registry, "table", CacheSpec.of(true, 1L, 100L), ticker::get,
+                        (key, value, cause) -> removalStarted.countDown(), null, null, null,
+                        () -> { }, () -> { }, () -> { },
+                        (key, value) -> MetaCacheSizeEstimate.complete(
+                                "old".equals(value) ? 512L : 1024L), budget)) {
+            cache.put("key", ScopePath.catalog(), "old");
+            cache.cleanUp();
+            AtomicReference<Future<?>> removal = new AtomicReference<>();
+            IllegalStateException failure = new IllegalStateException("commit failed");
+            Assertions.assertSame(failure, Assertions.assertThrows(IllegalStateException.class,
+                    () -> cache.compareAndSet("key", ScopePath.catalog(), "old", "new", () -> {
+                        waitForRemovalAtGuardExit(cache, removalFinished);
+                        ticker.set(TimeUnit.SECONDS.toNanos(2L));
+                        removal.set(executor.submit(() -> {
+                            try {
+                                cache.cleanUp();
+                            } finally {
+                                removalFinished.countDown();
+                            }
+                        }));
+                        awaitRemoval(removalStarted);
+                        throw failure;
+                    })));
+            removal.get().get(10L, TimeUnit.SECONDS);
+            Assertions.assertNull(cache.getIfPresent("key", ScopePath.catalog()));
+            Assertions.assertEquals(0L, manager.getGlobalUsedWeight(),
+                    "rollback must not reactivate a reservation after its value was removed");
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    // Freeze the legal schedule after the publication locks unlock, before the outer CAS finally.
+    // This white-box seam avoids a new production hook or a timing-dependent race assertion.
+    private static void waitForRemovalAtGuardExit(ScopedMetaCache<?, ?> cache, CountDownLatch finished) {
+        try {
+            Field deferralsField = ScopedMetaCache.class.getDeclaredField("removalDeferrals");
+            deferralsField.setAccessible(true);
+            Object deferral = ((ThreadLocal<?>) deferralsField.get(cache)).get();
+            Field removalsField = deferral.getClass().getDeclaredField("removals");
+            removalsField.setAccessible(true);
+            removalsField.set(deferral, new ArrayDeque<Object>() {
+                @Override
+                public Object pollFirst() {
+                    awaitRemoval(finished);
+                    return super.pollFirst();
+                }
+            });
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static void awaitRemoval(CountDownLatch latch) {
+        try {
+            Assertions.assertTrue(latch.await(10L, TimeUnit.SECONDS), "removal did not reach its test gate");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
+    }
+
+    @Test
+    void budgetPressureReclaimsOneColdEntryBeforeTheNextAdmission() {
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.of(2048L));
+        try (CatalogMetaCache owner = new CatalogMetaCache(
+                manager, 12L, "iceberg", Collections.emptyMap())) {
+            MetaCache<String, String> entry = owner.create(MetaCacheDefinition
+                    .<String, String>builder("partition", CacheSpec.of(true, -1L, 100L),
+                            ignored -> ScopePath.catalog())
+                    .sizeEstimator((key, value) -> MetaCacheSizeEstimate.complete(512L))
+                    .build());
+
+            entry.put("one", "value-one");
+            entry.put("two", "value-two");
+            entry.put("three", "value-three");
+
+            Assertions.assertNull(entry.getIfPresent("three"));
+            awaitReclaimed(entry, 1L, 1024L);
+            entry.put("three", "value-three");
+            Assertions.assertEquals("value-three", entry.getIfPresent("three"));
+            Assertions.assertEquals(2L, entry.size());
+            Assertions.assertEquals(2048L, entry.metrics().getEstimatedWeight());
+            Assertions.assertEquals(1L, entry.metrics().getWeightRejectCount());
+            Assertions.assertEquals(1L, entry.metrics().getEvictionCount());
+        }
+    }
+
+    @Test
+    void managedOwnerClosesWhenPhysicalCacheConstructionFails() {
+        long catalogId = Long.MIN_VALUE + 31L;
+        Assertions.assertTrue(MetaCacheGovernance.catalogCaches(catalogId).isEmpty());
+        CatalogMetaCache owner = CatalogMetaCache.managed(catalogId, "iceberg", Collections.emptyMap());
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> owner.create(MetaCacheDefinition
+                .<String, String>builder("invalid", CacheSpec.of(true, -1L, -1L),
+                        ignored -> ScopePath.catalog())
+                .sizeEstimator((key, value) -> MetaCacheSizeEstimate.complete(512L))
+                .build()));
+
+        Assertions.assertTrue(MetaCacheGovernance.catalogCaches(catalogId).isEmpty());
+    }
+
+    @Test
+    void concurrentRegistrationCannotBeDetachedByLastOwnerRemoval() throws Exception {
+        long catalogId = Long.MIN_VALUE + 32L;
+        CatalogMetaCache retiring = CatalogMetaCache.managed(
+                catalogId, "iceberg", Collections.emptyMap());
+        CatalogMetaCache replacement = new CatalogMetaCache(
+                new ScopedMetaCacheRegistry(), MetaCacheGovernance.budgetManager(), catalogId,
+                "iceberg", OptionalLong.empty(), true);
+        BlockingEmptySet<CatalogMetaCache> owners = new BlockingEmptySet<>();
+        owners.add(retiring);
+        owners.arm();
+        catalogCacheRegistry().put(catalogId, owners);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        Future<?> unregister = null;
+        Future<?> register = null;
+        try {
+            unregister = executor.submit(retiring::close);
+            Assertions.assertTrue(owners.awaitEmptyObservation(),
+                    "the retiring owner must reach its empty-set decision");
+            CountDownLatch registerStarted = new CountDownLatch(1);
+            register = executor.submit(() -> {
+                registerStarted.countDown();
+                MetaCacheGovernance.register(replacement);
+            });
+            Assertions.assertTrue(registerStarted.await(10L, TimeUnit.SECONDS));
+            boolean registeredBeforeRemovalCompleted = owners.awaitAdd();
+
+            owners.releaseEmptyObservation();
+            unregister.get(10L, TimeUnit.SECONDS);
+            register.get(10L, TimeUnit.SECONDS);
+
+            Assertions.assertFalse(registeredBeforeRemovalCompleted,
+                    "registration must serialize with removal for the same catalog id");
+            Assertions.assertTrue(MetaCacheGovernance.catalogCaches(catalogId).contains(replacement),
+                    "the replacement owner must remain discoverable after the retiring owner closes");
+        } finally {
+            owners.releaseEmptyObservation();
+            if (unregister != null) {
+                unregister.cancel(true);
+            }
+            if (register != null) {
+                register.cancel(true);
+            }
+            retiring.close();
+            replacement.close();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void estimatorIsNotInvokedWhenNoWeightLimitIsConfigured() {
+        AtomicInteger estimates = new AtomicInteger();
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.empty());
+        try (CatalogMetaCache owner = new CatalogMetaCache(
+                manager, 10L, "hive", Collections.emptyMap())) {
+            MetaCache<String, String> entry = owner.create(MetaCacheDefinition
+                    .<String, String>builder("file", CacheSpec.of(true, -1L, 100L),
+                            ignored -> ScopePath.catalog())
+                    .sizeEstimator((key, value) -> {
+                        estimates.incrementAndGet();
+                        return MetaCacheSizeEstimate.complete(512L);
+                    })
+                    .build());
+
+            entry.put("key", "value");
+            Assertions.assertEquals("value", entry.getIfPresent("key"));
+            Assertions.assertFalse(entry.isWeightBounded());
+            Assertions.assertEquals(0, estimates.get());
+        }
+    }
+
+    @Test
+    void estimatorFailureReturnsTheLoadedValueWithoutCachingIt() {
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.of(4096L));
+        try (CatalogMetaCache owner = new CatalogMetaCache(
+                manager, 11L, "hive", Collections.emptyMap())) {
+            MetaCache<String, String> entry = owner.create(MetaCacheDefinition
+                    .<String, String>builder("table", CacheSpec.of(true, -1L, 100L),
+                            ignored -> ScopePath.catalog())
+                    .sizeEstimator((key, value) -> {
+                        throw new IllegalStateException("unsupported value layout");
+                    })
+                    .build());
+
+            Assertions.assertEquals("value", entry.get("key", ignored -> "value"));
+            Assertions.assertNull(entry.getIfPresent("key"));
+            Assertions.assertEquals(1L, entry.metrics().getWeightRejectCount());
+            Assertions.assertTrue(entry.metrics().getLastWeightRejectReason()
+                    .startsWith("incomplete_estimate:estimator_failure:"));
+            Assertions.assertEquals(0L, manager.getGlobalUsedWeight());
+        }
+    }
+
+    @Test
+    void overlappingCatalogOwnersShareCatalogBudgetWithoutNameCollision() {
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.of(4096L));
+        CatalogMetaCache firstOwner = new CatalogMetaCache(
+                manager, 12L, "iceberg", Collections.emptyMap());
+        CatalogMetaCache secondOwner = new CatalogMetaCache(
+                manager, 12L, "iceberg", Collections.emptyMap());
+        try {
+            MetaCache<String, String> first = weightedStringEntry(firstOwner, "table", 512L);
+            MetaCache<String, String> second = weightedStringEntry(secondOwner, "table", 512L);
+
+            first.put("first", "value");
+            second.put("second", "value");
+            Assertions.assertEquals(2048L, manager.getGlobalUsedWeight());
+
+            firstOwner.close();
+            Assertions.assertEquals(1024L, manager.getGlobalUsedWeight());
+        } finally {
+            firstOwner.close();
+            secondOwner.close();
+        }
+        Assertions.assertEquals(0L, manager.getGlobalUsedWeight());
+    }
+
+    @Test
+    void physicalCachesInOneBudgetGroupShareEntryLimit() {
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.empty());
+        try (CatalogMetaCache owner = new CatalogMetaCache(
+                manager, 18L, "iceberg", Collections.emptyMap())) {
+            CacheSpec spec = CacheSpec.ofWeight(true, -1L, 100L, 1536L);
+            MetaCache<String, String> first = owner.create(MetaCacheDefinition
+                    .<String, String>builder("mvcc-partition-view", spec, ignored -> ScopePath.catalog())
+                    .budgetGroup("partition_view")
+                    .sizeEstimator((key, value) -> MetaCacheSizeEstimate.complete(1024L))
+                    .build());
+            MetaCache<String, String> second = owner.create(MetaCacheDefinition
+                    .<String, String>builder("list-partitions-view", spec, ignored -> ScopePath.catalog())
+                    .budgetGroup("partition_view")
+                    .sizeEstimator((key, value) -> MetaCacheSizeEstimate.complete(1024L))
+                    .build());
+
+            first.put("first", "value");
+            second.put("second", "value");
+
+            Assertions.assertNull(second.getIfPresent("second"));
+            Assertions.assertTrue(manager.getGlobalUsedWeight() <= 1536L);
+        }
+    }
+
+    @Test
+    void weightedCompareAndSetRejectionCommitsAndInvalidatesOldValue() {
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.of(1024L));
+        AtomicInteger commits = new AtomicInteger();
+        AtomicReference<String> discarded = new AtomicReference<>();
+        try (CatalogMetaCache owner = new CatalogMetaCache(
+                manager, 13L, "default", Collections.emptyMap())) {
+            MetaCache<String, String> entry = owner.create(MetaCacheDefinition
+                    .<String, String>builder("table", CacheSpec.of(true, -1L, 100L),
+                            ignored -> ScopePath.catalog())
+                    .discardListener((key, value) -> discarded.set(value))
+                    .sizeEstimator((key, value) -> MetaCacheSizeEstimate.complete(
+                            "old".equals(value) ? 512L : 1024L))
+                    .build());
+            entry.put("key", "old");
+
+            Assertions.assertTrue(entry.compareAndSet("key", "old", "new", commits::incrementAndGet));
+            Assertions.assertEquals(1, commits.get());
+            Assertions.assertEquals("new", discarded.get());
+            Assertions.assertNull(entry.getIfPresent("key"));
+            Assertions.assertEquals(0L, manager.getGlobalUsedWeight());
+        }
+    }
+
+    @Test
+    void weightedPutRejectionInvalidatesOldValue() {
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.of(1024L));
+        AtomicReference<String> discarded = new AtomicReference<>();
+        try (CatalogMetaCache owner = new CatalogMetaCache(
+                manager, 14L, "default", Collections.emptyMap())) {
+            MetaCache<String, String> entry = owner.create(MetaCacheDefinition
+                    .<String, String>builder("table", CacheSpec.of(true, -1L, 100L),
+                            ignored -> ScopePath.catalog())
+                    .discardListener((key, value) -> discarded.set(value))
+                    .sizeEstimator((key, value) -> MetaCacheSizeEstimate.complete(
+                            "old".equals(value) ? 512L : 1024L))
+                    .build());
+            entry.put("key", "old");
+
+            entry.put("key", "new");
+            Assertions.assertEquals("new", discarded.get());
+            Assertions.assertNull(entry.getIfPresent("key"));
+            Assertions.assertEquals(0L, manager.getGlobalUsedWeight());
+        }
+    }
+
+    @Test
+    void weightedRefreshRejectionInvalidatesOldValue() {
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.of(1024L));
+        AtomicInteger loads = new AtomicInteger();
+        AtomicReference<String> discarded = new AtomicReference<>();
+        try (CatalogMetaCache owner = new CatalogMetaCache(
+                manager, 15L, "default", Collections.emptyMap())) {
+            MetaCache<String, String> entry = owner.create(MetaCacheDefinition
+                    .<String, String>builder("schema", CacheSpec.of(true, -1L, 100L),
+                            ignored -> ScopePath.catalog())
+                    .loader(key -> "v" + loads.incrementAndGet())
+                    .discardListener((key, value) -> discarded.set(value))
+                    .refreshAfterWrite(Duration.ofNanos(1L), Runnable::run)
+                    .sizeEstimator((key, value) -> MetaCacheSizeEstimate.complete(
+                            "v1".equals(value) ? 512L : 1024L))
+                    .build());
+
+            Assertions.assertEquals("v1", entry.get("key"));
+            Assertions.assertEquals("v1", entry.get("key"));
+            Assertions.assertEquals("v2", discarded.get());
+            Assertions.assertNull(entry.getIfPresent("key"));
+            Assertions.assertEquals(0L, manager.getGlobalUsedWeight());
+        }
+    }
+
+    @Test
+    void globalOrCatalogWeightLimitRequiresEstimator() {
+        MetaCacheBudgetManager globalManager = new MetaCacheBudgetManager(OptionalLong.of(1024L));
+        try (CatalogMetaCache owner = new CatalogMetaCache(
+                globalManager, 16L, "default", Collections.emptyMap())) {
+            Assertions.assertThrows(IllegalArgumentException.class,
+                    () -> owner.create(unestimatedStringDefinition("global")));
+        }
+
+        MetaCacheBudgetManager catalogManager = new MetaCacheBudgetManager(OptionalLong.empty());
+        try (CatalogMetaCache owner = new CatalogMetaCache(catalogManager, 17L, "default",
+                Collections.singletonMap(MetaCacheBudgetManager.CATALOG_MAX_WEIGHT_PROPERTY, "1KB"))) {
+            Assertions.assertThrows(IllegalArgumentException.class,
+                    () -> owner.create(unestimatedStringDefinition("catalog")));
+        }
+    }
+
+    private static MetaCache<String, String> weightedStringEntry(
+            CatalogMetaCache owner, String name, long estimatedBytes) {
+        return owner.create(MetaCacheDefinition
+                .<String, String>builder(name, CacheSpec.of(true, -1L, 100L),
+                        ignored -> ScopePath.catalog())
+                .sizeEstimator((key, value) -> MetaCacheSizeEstimate.complete(estimatedBytes))
+                .build());
+    }
+
+    private static MetaCacheDefinition<String, String> unestimatedStringDefinition(String name) {
+        return MetaCacheDefinition.<String, String>builder(
+                name, CacheSpec.of(true, -1L, 100L), ignored -> ScopePath.catalog()).build();
+    }
+
+    private static void awaitReclaimed(MetaCache<?, ?> cache, long expectedSize, long expectedWeight) {
+        long deadline = System.nanoTime() + Duration.ofSeconds(10L).toNanos();
+        // Physical removal precedes the deferred callback that releases the reservation. Waiting only for
+        // size races the next admission against that callback, even though peer reclamation is asynchronous.
+        while ((cache.size() != expectedSize || cache.metrics().getEstimatedWeight() != expectedWeight)
+                && System.nanoTime() < deadline) {
+            Thread.yield();
+        }
+        Assertions.assertEquals(expectedSize, cache.size());
+        Assertions.assertEquals(expectedWeight, cache.metrics().getEstimatedWeight());
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<Long, Set<CatalogMetaCache>> catalogCacheRegistry() throws ReflectiveOperationException {
+        Field field = MetaCacheGovernance.class.getDeclaredField("CATALOG_CACHES");
+        field.setAccessible(true);
+        return (Map<Long, Set<CatalogMetaCache>>) field.get(null);
+    }
+
+    private static final class BlockingEmptySet<E> extends AbstractSet<E> {
+        private final Set<E> delegate = java.util.concurrent.ConcurrentHashMap.newKeySet();
+        private final CountDownLatch emptyObserved = new CountDownLatch(1);
+        private final CountDownLatch releaseEmpty = new CountDownLatch(1);
+        private final CountDownLatch addObserved = new CountDownLatch(1);
+        private volatile boolean armed;
+
+        void arm() {
+            armed = true;
+        }
+
+        boolean awaitEmptyObservation() throws InterruptedException {
+            return emptyObserved.await(10L, TimeUnit.SECONDS);
+        }
+
+        boolean awaitAdd() throws InterruptedException {
+            return addObserved.await(250L, TimeUnit.MILLISECONDS);
+        }
+
+        void releaseEmptyObservation() {
+            releaseEmpty.countDown();
+        }
+
+        @Override
+        public Iterator<E> iterator() {
+            return delegate.iterator();
+        }
+
+        @Override
+        public int size() {
+            return delegate.size();
+        }
+
+        @Override
+        public boolean add(E value) {
+            boolean added = delegate.add(value);
+            if (armed) {
+                addObserved.countDown();
+            }
+            return added;
+        }
+
+        @Override
+        public boolean remove(Object value) {
+            return delegate.remove(value);
+        }
+
+        @Override
+        public boolean isEmpty() {
+            boolean empty = delegate.isEmpty();
+            if (armed && empty) {
+                emptyObserved.countDown();
+                try {
+                    releaseEmpty.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException("Interrupted while controlling registry removal", e);
+                }
+            }
+            return empty;
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-cache/src/test/java/org/apache/doris/connector/cache/ReflectiveObjectSizeEstimatorTest.java
+++ b/fe/fe-connector/fe-connector-cache/src/test/java/org/apache/doris/connector/cache/ReflectiveObjectSizeEstimatorTest.java
@@ -1,0 +1,154 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.cache;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.AbstractList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.RandomAccess;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class ReflectiveObjectSizeEstimatorTest {
+    @Test
+    void bufferSlicesCountTheWholeBackingArrayAndRejectHiddenHeapPayload() {
+        byte[] backing = new byte[1024 * 1024];
+        ByteBuffer buffer = ByteBuffer.wrap(backing);
+        ByteBuffer slice = buffer.duplicate().limit(1).slice();
+        Assertions.assertTrue(ReflectiveObjectSizeEstimator.estimateComplete(slice) >= backing.length);
+        for (ByteBuffer readOnly : new ByteBuffer[] {buffer.asReadOnlyBuffer(), slice.asReadOnlyBuffer()}) {
+            MetaCacheSizeEstimate estimate = MetaCacheSizeEstimator.estimateSafely("buffer",
+                    () -> MetaCacheSizeEstimate.complete(ReflectiveObjectSizeEstimator.estimateComplete(readOnly)));
+            Assertions.assertFalse(estimate.isComplete());
+        }
+        Assertions.assertNull(JvmSizeUtils.byteBufferBackingArray(ByteBuffer.allocateDirect(16)));
+    }
+
+    @Test
+    void randomAccessContainerTraversalIsBoundedBySampleSize() {
+        AtomicInteger reads = new AtomicInteger();
+        AbstractList<String> millionElements = new CountingList(reads);
+
+        Assertions.assertTrue(ReflectiveObjectSizeEstimator.estimate(millionElements) > 0L);
+        Assertions.assertEquals(5, reads.get());
+    }
+
+    @Test
+    void typedListSamplingHasBoundedWorkAndIncludesTheTail() {
+        AtomicInteger reads = new AtomicInteger();
+        AtomicInteger largestIndex = new AtomicInteger();
+        AbstractList<String> millionElements = new CountingList(reads);
+
+        long estimated = JvmSizeUtils.sampledListPayload(millionElements, 16, value -> {
+            int index = Integer.parseInt(value.substring("value-".length()));
+            largestIndex.accumulateAndGet(index, Math::max);
+            return 1L;
+        });
+
+        Assertions.assertEquals(16, reads.get());
+        Assertions.assertEquals(999_999, largestIndex.get());
+        Assertions.assertEquals(1_000_000L, estimated);
+    }
+
+    @Test
+    void completeAdmissionEstimateIncludesAValueOutsideTheFiveElementSample() {
+        Map<String, String> skewed = new LinkedHashMap<>();
+        for (int i = 0; i < 99; i++) {
+            skewed.put("small-" + i, "x");
+        }
+        String largeTail = "x".repeat(10_000_000);
+        skewed.put("large-tail", largeTail);
+
+        long sampled = ReflectiveObjectSizeEstimator.estimate(skewed);
+        MetaCacheSizeEstimate complete = MetaCacheSizeEstimators
+                .<String, Map<String, String>>reflective().estimate("key", skewed);
+
+        Assertions.assertTrue(complete.isComplete());
+        Assertions.assertTrue(complete.getBytes() >= JvmSizeUtils.stringSize(largeTail));
+        Assertions.assertTrue(complete.getBytes() > sampled * 100L,
+                "weighted admission must not accept the fixed five-element sample as complete");
+    }
+
+    @Test
+    void completeAdmissionEstimateRejectsGraphsBeyondItsVisitBudget() {
+        AtomicInteger reads = new AtomicInteger();
+        MetaCacheSizeEstimate estimate = MetaCacheSizeEstimator.estimateSafely(
+                "bounded_complete_estimate",
+                () -> MetaCacheSizeEstimate.complete(
+                        ReflectiveObjectSizeEstimator.estimateComplete(new CountingList(reads))));
+
+        Assertions.assertFalse(estimate.isComplete());
+        Assertions.assertTrue(reads.get() <= 10_001,
+                "complete fallback must stop when its work budget is exhausted");
+    }
+
+    @Test
+    void inaccessibleJdkReferenceFieldMakesTheEstimateIncomplete() {
+        MetaCacheSizeEstimate estimate = MetaCacheSizeEstimator.estimateSafely(
+                "reflection_failure",
+                () -> MetaCacheSizeEstimate.complete(
+                        ReflectiveObjectSizeEstimator.estimate(URI.create("s3://bucket/path"))));
+
+        Assertions.assertFalse(estimate.isComplete());
+        Assertions.assertTrue(estimate.getIncompleteReason().startsWith("reflection_failure:"));
+    }
+
+    @Test
+    void depthTruncationMakesTheEstimateIncomplete() {
+        Node root = new Node();
+        Node current = root;
+        for (int i = 0; i < 25; i++) {
+            current.next = new Node();
+            current = current.next;
+        }
+
+        MetaCacheSizeEstimate estimate = MetaCacheSizeEstimator.estimateSafely(
+                "depth_limit",
+                () -> MetaCacheSizeEstimate.complete(ReflectiveObjectSizeEstimator.estimate(root)));
+
+        Assertions.assertFalse(estimate.isComplete());
+        Assertions.assertTrue(estimate.getIncompleteReason().startsWith("depth_limit:"));
+    }
+
+    private static final class CountingList extends AbstractList<String> implements RandomAccess {
+        private final AtomicInteger reads;
+
+        private CountingList(AtomicInteger reads) {
+            this.reads = reads;
+        }
+
+        @Override
+        public String get(int index) {
+            reads.incrementAndGet();
+            return "value-" + index;
+        }
+
+        @Override
+        public int size() {
+            return 1_000_000;
+        }
+    }
+
+    private static final class Node {
+        private Node next;
+    }
+}

--- a/fe/fe-connector/fe-connector-cache/src/test/java/org/apache/doris/connector/cache/ScopedMetaCacheConcurrencyTest.java
+++ b/fe/fe-connector/fe-connector-cache/src/test/java/org/apache/doris/connector/cache/ScopedMetaCacheConcurrencyTest.java
@@ -22,9 +22,12 @@ import org.apache.doris.connector.cache.ScopedMetaCache.BulkLoadHandle;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.OptionalLong;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -32,7 +35,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class ScopedMetaCacheConcurrencyTest {
     private static final long TIMEOUT_SECONDS = 10L;
@@ -40,6 +45,53 @@ public class ScopedMetaCacheConcurrencyTest {
             CacheSpec.of(true, CacheSpec.CACHE_NO_TTL, 1_000L);
     private static final ScopePath TABLE = ScopePath.table("db", "tbl");
     private static final ScopePath PARTITION = ScopePath.partition("db", "tbl", "p=1");
+
+    @Test
+    public void maintenanceRemovalRunsAfterCaffeineReleasesItsLock() throws Exception {
+        for (String operation : new String[] {"cleanup", "read", "iterate", "close"}) {
+            AtomicLong ticker = new AtomicLong();
+            AtomicReference<ReentrantLock> maintenanceLock = new AtomicReference<>();
+            AtomicBoolean callbackHeldMaintenanceLock = new AtomicBoolean();
+            AtomicInteger removals = new AtomicInteger();
+            try (ScopedMetaCacheRegistry registry = new ScopedMetaCacheRegistry()) {
+                ScopedMetaCache<String, Integer> cache = registry.createCache("test",
+                        CacheSpec.of(true, 1L, 100L), ticker::get, (key, value) -> {
+                            callbackHeldMaintenanceLock.set(maintenanceLock.get().isHeldByCurrentThread());
+                            removals.incrementAndGet();
+                        });
+                Field dataField = ScopedMetaCache.class.getDeclaredField("data");
+                dataField.setAccessible(true);
+                Object caffeine = dataField.get(cache);
+                Field cacheField = caffeine.getClass().getDeclaredField("cache");
+                cacheField.setAccessible(true);
+                Object bounded = cacheField.get(caffeine);
+                Field lockField = Class.forName("com.github.benmanes.caffeine.cache.BoundedLocalCache")
+                        .getDeclaredField("evictionLock");
+                lockField.setAccessible(true);
+                maintenanceLock.set((ReentrantLock) lockField.get(bounded));
+                cache.put("key", TABLE, 1);
+                cache.cleanUp();
+                ticker.set(TimeUnit.SECONDS.toNanos(2L));
+                switch (operation) {
+                    case "cleanup":
+                        cache.cleanUp();
+                        break;
+                    case "read":
+                        cache.getIfPresent("key", TABLE);
+                        break;
+                    case "iterate":
+                        cache.forEach((key, value) -> { });
+                        break;
+                    default:
+                        registry.close();
+                        break;
+                }
+                Assertions.assertEquals(1, removals.get(), operation);
+                Assertions.assertFalse(callbackHeldMaintenanceLock.get(),
+                        operation + " must not acquire KeyNode monitors under Caffeine's maintenance lock");
+            }
+        }
+    }
 
     @Test
     public void concurrentMissesForTheSameKeyRunOneLoader() throws Exception {
@@ -1183,6 +1235,47 @@ public class ScopedMetaCacheConcurrencyTest {
             assertEmpty(registry, cache);
         } finally {
             registry.close();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void concurrentWeightedReplacementsDoNotEvictAcrossKeyLocks() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch replacementsEstimating = new CountDownLatch(2);
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.of(2048L));
+        try (CatalogMetaCache owner = new CatalogMetaCache(
+                manager, 41L, "iceberg", Collections.emptyMap())) {
+            MetaCache<String, String> cache = owner.create(MetaCacheDefinition
+                    .<String, String>builder("table", CacheSpec.of(true, -1L, 100L),
+                            ignored -> ScopePath.catalog())
+                    .sizeEstimator((key, value) -> {
+                        if (value.startsWith("new")) {
+                            replacementsEstimating.countDown();
+                            await(replacementsEstimating);
+                            return MetaCacheSizeEstimate.complete(1024L);
+                        }
+                        return MetaCacheSizeEstimate.complete(512L);
+                    })
+                    .build());
+            cache.put("a", "old-a");
+            cache.put("b", "old-b");
+
+            Future<?> first = executor.submit(() -> {
+                await(start);
+                cache.put("a", "new-a");
+            });
+            Future<?> second = executor.submit(() -> {
+                await(start);
+                cache.put("b", "new-b");
+            });
+            start.countDown();
+
+            first.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            second.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            Assertions.assertTrue(manager.getGlobalUsedWeight() <= 2048L);
+        } finally {
             executor.shutdownNow();
         }
     }

--- a/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveCatalogProperties.java
+++ b/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveCatalogProperties.java
@@ -184,6 +184,14 @@ public final class HiveCatalogProperties {
      * @return this, so the provider's door reads as one statement
      */
     public HiveCatalogProperties checkCreateTimeOnlyRules() {
+        return checkCreateTimeOnlyRules(raw);
+    }
+
+    public HiveCatalogProperties checkCreateTimeOnlyRules(Map<String, String> submittedProperties) {
+        CacheSpec.checkWeightProperties(raw, submittedProperties, "hive",
+                "table", "partition_names", "partition", "column_stats", "file", "partition_view");
+        CacheSpec.checkWeightProperties(raw, submittedProperties, "iceberg",
+                "table", "partition", "manifest", "partition_view");
         // Restores the legacy HMSExternalCatalog.checkProperties fail-fast for the two meta-cache TTL
         // knobs: after the hms cutover an "hms" catalog is created via the SPI provider (not
         // HMSExternalCatalog), so the old per-property validation no longer ran and an invalid ttl (e.g.

--- a/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveConnector.java
+++ b/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveConnector.java
@@ -87,7 +87,7 @@ public class HiveConnector implements Connector {
     // every (re)build of the connector, including the lazy one an FE does after replaying the edit log.
     private final HiveCatalogProperties props;
     private final ConnectorContext context;
-    private final CatalogMetaCache metaCache = new CatalogMetaCache();
+    private final CatalogMetaCache metaCache;
     private volatile HmsClient hmsClient;
 
     // Lazily-built plugin-side Kerberos authenticator (single-owner auth), null for a non-Kerberos catalog.
@@ -133,17 +133,24 @@ public class HiveConnector implements Connector {
     // NEVER cast (a cast would CCE across the loader split).
     private volatile Connector hudiSibling;
 
+    // Writes are guarded by this; the volatile read rejects post-close fast paths. Closing and lazy sibling
+    // publication share the same monitor so a sibling can never be published after the gateway has released its
+    // managed metadata-cache owner.
+    private volatile boolean closed;
+
     public HiveConnector(Map<String, String> properties, ConnectorContext context) {
         HmsConfHelper.initializeHadoopConfigDir(context);
         this.props = HiveCatalogProperties.of(properties);
         this.properties = props.getRaw();
         this.context = context;
+        this.metaCache = CatalogMetaCache.managed(context.getCatalogId(), "hive", this.properties);
         this.fileListingCache = new HiveFileListingCache(metaCache, props);
         // Reads its own meta.cache.hive.partition_view.(enable|ttl-second|capacity) from the catalog properties
         // via the framework's CacheSpec (default ON / 24h / 1000).
         this.partitionViewCache = new ConnectorMetadataCache<>(metaCache, "hive-partition-view",
                 "hive", "partition_view", this.properties,
-                key -> ScopePath.partitionCollection(key.getDb(), key.getTable()));
+                key -> ScopePath.partitionCollection(key.getDb(), key.getTable()),
+                HivePartitionViewSizeEstimator::estimateEntry);
     }
 
     @Override
@@ -487,36 +494,40 @@ public class HiveConnector implements Connector {
      * memoized (a null sibling leaves the field unset), so a later-available plugin recovers on the next access.
      */
     Connector getOrCreateIcebergSibling() {
-        if (icebergSibling == null) {
-            synchronized (this) {
-                if (icebergSibling == null) {
-                    Connector sibling = context.createSiblingConnector(
-                            ICEBERG_CONNECTOR_TYPE, IcebergSiblingProperties.synthesize(properties));
-                    if (sibling == null) {
-                        throw new DorisConnectorException(
-                                "Cannot serve iceberg-on-HMS tables in catalog '" + context.getCatalogName()
-                                        + "': the iceberg connector plugin is not available");
-                    }
-                    // Fail-loud invariant guard for the cache-isolation security track: the hive gateway FRONT
-                    // DOOR never declares SUPPORTS_USER_SESSION, so fe-core keys its per-user schema/name cache
-                    // bypass off THIS (front-door) connector's capabilities and would NOT bypass for a delegated
-                    // sibling. The iceberg sibling is forced iceberg.catalog.type=hms (IcebergSiblingProperties
-                    // .synthesize) and can never be REST session=user, so this must hold today. If a future change
-                    // ever let the sibling be session=user, the front-door-only bypass would silently leak
-                    // cross-user metadata — fail here instead.
-                    if (sibling.getCapabilities().contains(ConnectorCapability.SUPPORTS_USER_SESSION)) {
-                        throw new DorisConnectorException(
-                                "iceberg-on-HMS sibling in catalog '" + context.getCatalogName()
-                                        + "' unexpectedly declares SUPPORTS_USER_SESSION: the hive gateway front "
-                                        + "door is not session=user, so fe-core's per-user schema/name cache bypass "
-                                        + "would not trigger and cross-user metadata would leak. The sibling must "
-                                        + "stay iceberg.catalog.type=hms (never REST session=user).");
-                    }
-                    icebergSibling = sibling;
-                }
-            }
+        checkOpenForSiblingCreation();
+        Connector current = icebergSibling;
+        if (current != null) {
+            return current;
         }
-        return icebergSibling;
+        synchronized (this) {
+            checkOpenForSiblingCreation();
+            if (icebergSibling == null) {
+                Connector sibling = context.createSiblingConnector(
+                        ICEBERG_CONNECTOR_TYPE, IcebergSiblingProperties.synthesize(properties));
+                if (sibling == null) {
+                    throw new DorisConnectorException(
+                            "Cannot serve iceberg-on-HMS tables in catalog '" + context.getCatalogName()
+                                    + "': the iceberg connector plugin is not available");
+                }
+                // Fail-loud invariant guard for the cache-isolation security track: the hive gateway FRONT
+                // DOOR never declares SUPPORTS_USER_SESSION, so fe-core keys its per-user schema/name cache
+                // bypass off THIS (front-door) connector's capabilities and would NOT bypass for a delegated
+                // sibling. The iceberg sibling is forced iceberg.catalog.type=hms (IcebergSiblingProperties
+                // .synthesize) and can never be REST session=user, so this must hold today. If a future change
+                // ever let the sibling be session=user, the front-door-only bypass would silently leak
+                // cross-user metadata — fail here instead.
+                if (sibling.getCapabilities().contains(ConnectorCapability.SUPPORTS_USER_SESSION)) {
+                    throw new DorisConnectorException(
+                            "iceberg-on-HMS sibling in catalog '" + context.getCatalogName()
+                                    + "' unexpectedly declares SUPPORTS_USER_SESSION: the hive gateway front "
+                                    + "door is not session=user, so fe-core's per-user schema/name cache bypass "
+                                    + "would not trigger and cross-user metadata would leak. The sibling must "
+                                    + "stay iceberg.catalog.type=hms (never REST session=user).");
+                }
+                icebergSibling = sibling;
+            }
+            return icebergSibling;
+        }
     }
 
     /**
@@ -531,21 +542,33 @@ public class HiveConnector implements Connector {
      * memoized (a null sibling leaves the field unset), so a later-available plugin recovers on the next access.
      */
     Connector getOrCreateHudiSibling() {
-        if (hudiSibling == null) {
-            synchronized (this) {
-                if (hudiSibling == null) {
-                    Connector sibling = context.createSiblingConnector(
-                            HUDI_CONNECTOR_TYPE, HudiSiblingProperties.synthesize(properties));
-                    if (sibling == null) {
-                        throw new DorisConnectorException(
-                                "Cannot serve hudi-on-HMS tables in catalog '" + context.getCatalogName()
-                                        + "': the hudi connector plugin is not available");
-                    }
-                    hudiSibling = sibling;
-                }
-            }
+        checkOpenForSiblingCreation();
+        Connector current = hudiSibling;
+        if (current != null) {
+            return current;
         }
-        return hudiSibling;
+        synchronized (this) {
+            checkOpenForSiblingCreation();
+            if (hudiSibling == null) {
+                Connector sibling = context.createSiblingConnector(
+                        HUDI_CONNECTOR_TYPE, HudiSiblingProperties.synthesize(properties));
+                if (sibling == null) {
+                    throw new DorisConnectorException(
+                            "Cannot serve hudi-on-HMS tables in catalog '" + context.getCatalogName()
+                                    + "': the hudi connector plugin is not available");
+                }
+                hudiSibling = sibling;
+            }
+            return hudiSibling;
+        }
+    }
+
+    private void checkOpenForSiblingCreation() {
+        if (closed) {
+            throw new DorisConnectorException(
+                    "Cannot create a sibling connector after Hive catalog '" + context.getCatalogName()
+                            + "' has been closed");
+        }
     }
 
     private HmsClient createClient() {
@@ -701,24 +724,57 @@ public class HiveConnector implements Connector {
 
     @Override
     public void close() throws IOException {
-        metaCache.close();
-        HmsClient c = hmsClient;
-        if (c != null) {
-            c.close();
+        HmsClient client;
+        Connector sibling;
+        Connector hudi;
+        synchronized (this) {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            client = hmsClient;
             hmsClient = null;
+            sibling = icebergSibling;
+            icebergSibling = null;
+            hudi = hudiSibling;
+            hudiSibling = null;
+        }
+        metaCache.close();
+        IOException closeFailure = null;
+        try {
+            if (client != null) {
+                client.close();
+            }
+        } catch (IOException e) {
+            closeFailure = e;
         }
         // Forward close to the embedded iceberg sibling: the engine closes only a catalog's PRIMARY connector,
         // so the gateway owns the sibling's lifecycle. No-op when the sibling was never built (dormant path).
-        Connector sibling = icebergSibling;
-        if (sibling != null) {
-            sibling.close();
-            icebergSibling = null;
+        try {
+            if (sibling != null) {
+                sibling.close();
+            }
+        } catch (IOException e) {
+            if (closeFailure == null) {
+                closeFailure = e;
+            } else {
+                closeFailure.addSuppressed(e);
+            }
         }
         // Same for the embedded hudi sibling — the gateway owns its lifecycle too. No-op when never built.
-        Connector hudi = hudiSibling;
-        if (hudi != null) {
-            hudi.close();
-            hudiSibling = null;
+        try {
+            if (hudi != null) {
+                hudi.close();
+            }
+        } catch (IOException e) {
+            if (closeFailure == null) {
+                closeFailure = e;
+            } else {
+                closeFailure.addSuppressed(e);
+            }
+        }
+        if (closeFailure != null) {
+            throw closeFailure;
         }
     }
 }

--- a/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveConnectorProvider.java
+++ b/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveConnectorProvider.java
@@ -22,6 +22,7 @@ import org.apache.doris.connector.spi.ConnectorContext;
 import org.apache.doris.connector.spi.ConnectorProvider;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -61,13 +62,22 @@ public class HiveConnectorProvider implements ConnectorProvider {
     }
 
     /**
-     * Binds and validates through the typed holder; the ALTER door reaches this same method through the
-     * SPI default {@code validatePropertiesForUpdate}, which validates the merged candidate.
+     * Binds and validates through the typed holder. ALTER validates the merged candidate while distinguishing
+     * explicitly submitted cache keys from unknown entries persisted by another connector version.
      * {@code IllegalArgumentException} — which both halves throw — is required: it is the only type
      * {@code PluginDrivenExternalCatalog.checkProperties} unwraps, preserving the message verbatim.
      */
     @Override
     public void validateProperties(Map<String, String> properties) {
         HiveCatalogProperties.of(properties).checkCreateTimeOnlyRules();
+    }
+
+    @Override
+    public void validatePropertiesForUpdate(
+            Map<String, String> currentProperties, Map<String, String> updatedProperties) {
+        Map<String, String> candidate = currentProperties == null
+                ? new HashMap<>() : new HashMap<>(currentProperties);
+        candidate.putAll(updatedProperties);
+        HiveCatalogProperties.of(candidate).checkCreateTimeOnlyRules(updatedProperties);
     }
 }

--- a/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveFileListingCache.java
+++ b/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveFileListingCache.java
@@ -21,6 +21,8 @@ import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.cache.MetaCache;
 import org.apache.doris.connector.cache.MetaCacheDefinition;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimate;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimator;
 import org.apache.doris.connector.cache.ScopePath;
 import org.apache.doris.connector.spi.DorisConnectorException;
 import org.apache.doris.filesystem.FileEntry;
@@ -107,11 +109,11 @@ public class HiveFileListingCache {
     }
 
     private final CatalogMetaCache owner;
-    private final MetaCache<FileListingKey, List<HiveFileStatus>> cache;
+    private final MetaCache<FileListingKey, FileListingValue> cache;
     private final DirectoryLister lister;
 
     public HiveFileListingCache(HiveCatalogProperties properties) {
-        this(new CatalogMetaCache(), properties, defaultLister(properties));
+        this(CatalogMetaCache.unmanaged(), properties, defaultLister(properties));
     }
 
     public HiveFileListingCache(CatalogMetaCache owner, HiveCatalogProperties properties) {
@@ -130,7 +132,7 @@ public class HiveFileListingCache {
     }
 
     HiveFileListingCache(HiveCatalogProperties properties, DirectoryLister lister) {
-        this(new CatalogMetaCache(), properties, lister);
+        this(CatalogMetaCache.unmanaged(), properties, lister);
     }
 
     HiveFileListingCache(CatalogMetaCache owner, HiveCatalogProperties properties, DirectoryLister lister) {
@@ -149,10 +151,11 @@ public class HiveFileListingCache {
         CacheSpec spec = CacheSpec.fromProperties(props, ENGINE, ENTRY_FILE,
                 CacheSpec.of(true, DEFAULT_TTL_SECOND, DEFAULT_FILE_CAPACITY));
         this.cache = owner.create(MetaCacheDefinition
-                .<FileListingKey, List<HiveFileStatus>>builder("hive-file", spec,
+                .<FileListingKey, FileListingValue>builder("hive-file", spec,
                         key -> key.partitionValues.isEmpty()
                                 ? ScopePath.table(key.dbName, key.tableName)
                                 : ScopePath.partition(key.dbName, key.tableName, key.partitionValues))
+                .sizeEstimator(HiveFileListingSizeEstimator::estimateEntry)
                 .build());
         this.lister = Objects.requireNonNull(lister, "lister can not be null");
     }
@@ -180,7 +183,8 @@ public class HiveFileListingCache {
     public List<HiveFileStatus> listDataFiles(String dbName, String tableName, String location,
             List<String> partitionValues, FileSystem fs) {
         return cache.get(new FileListingKey(dbName, tableName, location, partitionValues),
-                key -> lister.list(key.location, fs));
+                key -> new FileListingValue(lister.list(key.location, fs),
+                        cache.isEnabled() && cache.isWeightBounded())).files;
     }
 
     /** Drops every cached listing for one table. Backs {@code REFRESH TABLE}. */
@@ -345,10 +349,10 @@ public class HiveFileListingCache {
      * size-estimate paths sharing the same entry while making per-partition invalidation possible.
      */
     static final class FileListingKey {
-        private final String dbName;
-        private final String tableName;
-        private final String location;
-        private final List<String> partitionValues;
+        final String dbName;
+        final String tableName;
+        final String location;
+        final List<String> partitionValues;
 
         FileListingKey(String dbName, String tableName, String location, List<String> partitionValues) {
             this.dbName = dbName;
@@ -377,6 +381,22 @@ public class HiveFileListingCache {
         @Override
         public int hashCode() {
             return Objects.hash(dbName, tableName, location, partitionValues);
+        }
+    }
+
+    static final class FileListingValue {
+        final List<HiveFileStatus> files;
+        final MetaCacheSizeEstimate sizeEstimate;
+
+        FileListingValue(List<HiveFileStatus> files, boolean estimateWeight) {
+            this.files = estimateWeight
+                    ? Collections.unmodifiableList(new ArrayList<>(files))
+                    : files;
+            this.sizeEstimate = estimateWeight
+                    ? MetaCacheSizeEstimator.estimateSafely("hive_file_listing_estimator_failure",
+                            () -> MetaCacheSizeEstimate.complete(
+                                    HiveFileListingSizeEstimator.estimateValue(this)))
+                    : MetaCacheSizeEstimate.complete(0L);
         }
     }
 }

--- a/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveFileListingSizeEstimator.java
+++ b/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HiveFileListingSizeEstimator.java
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.hive;
+
+import org.apache.doris.connector.cache.JvmSizeUtils;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimate;
+import org.apache.doris.connector.cache.ReflectiveObjectSizeEstimator;
+import org.apache.doris.connector.hive.HiveFileListingCache.FileListingKey;
+import org.apache.doris.connector.hive.HiveFileListingCache.FileListingValue;
+
+/** Type-specific retained-heap estimator for one Hive directory-listing cache entry. */
+final class HiveFileListingSizeEstimator {
+    private static final long KEY_SHALLOW_BYTES = JvmSizeUtils.instanceSize(FileListingKey.class);
+    private static final long VALUE_SHALLOW_BYTES = JvmSizeUtils.instanceSize(FileListingValue.class);
+    private static final long FILE_STATUS_SHALLOW_BYTES = JvmSizeUtils.instanceSize(HiveFileStatus.class);
+
+    private HiveFileListingSizeEstimator() {
+    }
+
+    /** Admission callback: the large value was sized once during construction. */
+    static MetaCacheSizeEstimate estimateEntry(FileListingKey key, FileListingValue value) {
+        return value.sizeEstimate.isComplete()
+                ? MetaCacheSizeEstimate.complete(add(estimateKey(key), value.sizeEstimate.getBytes()))
+                : value.sizeEstimate;
+    }
+
+    static long estimateKey(FileListingKey key) {
+        long bytes = KEY_SHALLOW_BYTES;
+        bytes = add(bytes, JvmSizeUtils.stringSize(key.dbName));
+        bytes = add(bytes, JvmSizeUtils.stringSize(key.tableName));
+        bytes = add(bytes, JvmSizeUtils.stringSize(key.location));
+        bytes = add(bytes, estimateOwnedStringList(key.partitionValues));
+        return Math.max(bytes, ReflectiveObjectSizeEstimator.estimate(key));
+    }
+
+    static long estimateValue(FileListingValue value) {
+        long bytes = VALUE_SHALLOW_BYTES;
+        bytes = add(bytes, estimateArrayBackedList(value.files));
+        for (HiveFileStatus file : value.files) {
+            bytes = add(bytes, FILE_STATUS_SHALLOW_BYTES);
+            bytes = add(bytes, JvmSizeUtils.stringSize(file.getPath()));
+        }
+        return Math.max(bytes, ReflectiveObjectSizeEstimator.estimate(value));
+    }
+
+    private static long estimateOwnedStringList(java.util.List<String> values) {
+        long bytes = estimateArrayBackedList(values);
+        for (String value : values) {
+            bytes = add(bytes, JvmSizeUtils.stringSize(value));
+        }
+        return bytes;
+    }
+
+    private static long estimateArrayBackedList(java.util.List<?> values) {
+        long bytes = JvmSizeUtils.instanceSize(values.getClass());
+        return add(bytes, JvmSizeUtils.arrayListSize(values.size()));
+    }
+
+    private static long add(long left, long right) {
+        return JvmSizeUtils.saturatedAdd(left, right);
+    }
+}

--- a/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HivePartitionViewSizeEstimator.java
+++ b/fe/fe-connector/fe-connector-hive/src/main/java/org/apache/doris/connector/hive/HivePartitionViewSizeEstimator.java
@@ -1,0 +1,128 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.hive;
+
+import org.apache.doris.connector.cache.ConnectorTableKey;
+import org.apache.doris.connector.cache.JvmSizeUtils;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimate;
+import org.apache.doris.connector.spi.ConnectorPartitionInfo;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Publication-time estimate of Hive's derived partition view, including every variable-length value. */
+final class HivePartitionViewSizeEstimator {
+    private static final long KEY_SHALLOW_BYTES = JvmSizeUtils.instanceSize(ConnectorTableKey.class);
+    private static final long PARTITION_SHALLOW_BYTES = JvmSizeUtils.instanceSize(ConnectorPartitionInfo.class);
+    private static final long ARRAY_LIST_SHALLOW_BYTES = JvmSizeUtils.instanceSize(ArrayList.class);
+    private static final long UNMODIFIABLE_LIST_SHALLOW_BYTES = JvmSizeUtils.instanceSize(
+            Collections.unmodifiableList(Collections.emptyList()).getClass());
+    private static final long UNMODIFIABLE_MAP_SHALLOW_BYTES = JvmSizeUtils.instanceSize(
+            Collections.unmodifiableMap(Collections.emptyMap()).getClass());
+    private static final long LINKED_HASH_MAP_SHALLOW_BYTES = JvmSizeUtils.instanceSize(LinkedHashMap.class);
+    private static final long LINKED_HASH_MAP_ENTRY_SHALLOW_BYTES = classSize("java.util.LinkedHashMap$Entry");
+
+    private HivePartitionViewSizeEstimator() {
+    }
+
+    static MetaCacheSizeEstimate estimateEntry(ConnectorTableKey key, List<ConnectorPartitionInfo> partitions) {
+        long bytes = KEY_SHALLOW_BYTES;
+        bytes = add(bytes, JvmSizeUtils.stringSize(key.getDb()));
+        bytes = add(bytes, JvmSizeUtils.stringSize(key.getTable()));
+        bytes = add(bytes, ARRAY_LIST_SHALLOW_BYTES);
+        bytes = add(bytes, JvmSizeUtils.objectArraySize(partitions.size()));
+        ConnectorPartitionInfo previous = null;
+        long structureBytes = 0L;
+        boolean columnsCounted = false;
+        for (ConnectorPartitionInfo partition : partitions) {
+            // The collector uses the same wrappers and empty properties for every partition. Reuse the
+            // fixed layout while its arity is unchanged; malformed names can have a different arity.
+            if (previous == null
+                    || previous.getPartitionValues().size() != partition.getPartitionValues().size()
+                    || previous.getOrderedPartitionValues().size() != partition.getOrderedPartitionValues().size()
+                    || previous.getPartitionValueNullFlags().size() != partition.getPartitionValueNullFlags().size()) {
+                structureBytes = estimatePartitionStructure(partition);
+                previous = partition;
+            }
+            bytes = add(bytes, structureBytes);
+            bytes = add(bytes, JvmSizeUtils.stringSize(partition.getPartitionName()));
+            // Hive parses map and ordered values separately: these are distinct retained Strings.
+            for (String value : partition.getPartitionValues().values()) {
+                bytes = add(bytes, JvmSizeUtils.stringSize(value));
+            }
+            for (String value : partition.getOrderedPartitionValues()) {
+                bytes = add(bytes, JvmSizeUtils.stringSize(value));
+            }
+            if (!columnsCounted && !partition.getPartitionValues().isEmpty()) {
+                for (String column : partition.getPartitionValues().keySet()) {
+                    bytes = add(bytes, JvmSizeUtils.stringSize(column));
+                }
+                columnsCounted = true;
+            }
+        }
+        return MetaCacheSizeEstimate.complete(bytes);
+    }
+
+    private static long estimatePartitionStructure(ConnectorPartitionInfo partition) {
+        long bytes = PARTITION_SHALLOW_BYTES;
+        bytes = add(bytes, estimateMapStructure(partition.getPartitionValues()));
+        bytes = add(bytes, UNMODIFIABLE_MAP_SHALLOW_BYTES);
+        bytes = add(bytes, estimateReferenceList(partition.getOrderedPartitionValues()));
+        return add(bytes, estimateReferenceList(partition.getPartitionValueNullFlags()));
+    }
+
+    private static long estimateMapStructure(Map<String, String> values) {
+        long bytes = UNMODIFIABLE_MAP_SHALLOW_BYTES;
+        if (values.isEmpty()) {
+            return bytes;
+        }
+        bytes = add(bytes, LINKED_HASH_MAP_SHALLOW_BYTES);
+        bytes = add(bytes, JvmSizeUtils.objectArraySize(hashCapacity(values.size())));
+        bytes = add(bytes, JvmSizeUtils.saturatedMultiply(
+                values.size(), LINKED_HASH_MAP_ENTRY_SHALLOW_BYTES));
+        return bytes;
+    }
+
+    private static long estimateReferenceList(List<?> values) {
+        return add(UNMODIFIABLE_LIST_SHALLOW_BYTES, JvmSizeUtils.arrayListSize(values.size()));
+    }
+
+    private static int hashCapacity(int size) {
+        long needed = (size * 4L + 2L) / 3L;
+        int capacity = 16;
+        while (capacity < needed && capacity < 1 << 30) {
+            capacity <<= 1;
+        }
+        return capacity;
+    }
+
+    private static long classSize(String className) {
+        try {
+            return JvmSizeUtils.instanceSize(Class.forName(className));
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Required JVM collection class is missing: " + className, e);
+        }
+    }
+
+    private static long add(long left, long right) {
+        return JvmSizeUtils.saturatedAdd(left, right);
+    }
+}

--- a/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveCatalogPropertiesTest.java
+++ b/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveCatalogPropertiesTest.java
@@ -227,6 +227,25 @@ class HiveCatalogPropertiesTest {
     }
 
     @Test
+    void icebergSiblingWeightsAreValidatedAtTheHmsCreateTimeDoor() {
+        Map<String, String> invalidWeight = HiveTestProperties.mapWith(
+                "meta.cache.iceberg.manifest.max-weight", "invalid");
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> HiveCatalogProperties.of(invalidWeight).checkCreateTimeOnlyRules());
+
+        Map<String, String> unknownEntry = HiveTestProperties.mapWith(
+                "meta.cache.iceberg.manfiest.max-weight", "64MB");
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> HiveCatalogProperties.of(unknownEntry).checkCreateTimeOnlyRules());
+        HiveConnectorProvider provider = new HiveConnectorProvider();
+        Assertions.assertDoesNotThrow(() -> HiveCatalogProperties.of(unknownEntry));
+        Assertions.assertDoesNotThrow(() -> provider.validatePropertiesForUpdate(unknownEntry,
+                java.util.Collections.singletonMap("comment", "updated")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> provider.validatePropertiesForUpdate(
+                HiveTestProperties.mapWith(), unknownEntry));
+    }
+
+    @Test
     void validCatalogPassesBothDoors() {
         Assertions.assertDoesNotThrow(() -> HiveTestProperties.minimal().checkCreateTimeOnlyRules());
     }

--- a/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveConnectorMetadataPartitionViewCacheTest.java
+++ b/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveConnectorMetadataPartitionViewCacheTest.java
@@ -18,6 +18,8 @@
 package org.apache.doris.connector.hive;
 
 import org.apache.doris.connector.cache.ConnectorMetadataCache;
+import org.apache.doris.connector.cache.ConnectorTableKey;
+import org.apache.doris.connector.cache.JvmSizeUtils;
 import org.apache.doris.connector.hms.HmsClient;
 import org.apache.doris.connector.hms.HmsDatabaseInfo;
 import org.apache.doris.connector.hms.HmsPartitionInfo;
@@ -32,6 +34,7 @@ import org.apache.doris.connector.spi.pushdown.ConnectorLiteral;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -92,6 +95,42 @@ public class HiveConnectorMetadataPartitionViewCacheTest {
 
     private static List<String> names(List<ConnectorPartitionInfo> infos) {
         return infos.stream().map(ConnectorPartitionInfo::getPartitionName).collect(Collectors.toList());
+    }
+
+    @Test
+    public void largePartitionViewCanBeEstimatedWithoutTheReflectiveVisitLimit() {
+        List<ConnectorPartitionInfo> partitions = new ArrayList<>();
+        for (int index = 0; index < 20_000; index++) {
+            String value = Integer.toString(index);
+            partitions.add(new ConnectorPartitionInfo("p=" + value,
+                    Collections.singletonMap("p", value), Collections.emptyMap(),
+                    Collections.singletonList(value), Collections.emptyList()));
+        }
+
+        Assertions.assertTrue(HivePartitionViewSizeEstimator.estimateEntry(
+                new ConnectorTableKey("db", "table", -1L, -1L), partitions).isComplete());
+    }
+
+    @Test
+    public void partitionViewWeightIncludesTailAtEveryPosition() {
+        List<String> partitionNames = new ArrayList<>(Collections.nCopies(1000, "year=x/month=01"));
+        ConnectorTableKey key = new ConnectorTableKey("db1", "t1", -1L, -1L);
+        List<ConnectorPartitionInfo> baseline = metadataWithCache(
+                new CountingHmsClient(partitionNames), null).listPartitions(null, handle(), Optional.empty());
+        long baselineBytes = HivePartitionViewSizeEstimator.estimateEntry(key, baseline).getBytes();
+        String large = "x".repeat(1024 * 1024);
+        String largeName = "year=" + large + "/month=01";
+        long growth = JvmSizeUtils.stringSize(largeName) - JvmSizeUtils.stringSize("year=x/month=01")
+                + 2 * (JvmSizeUtils.stringSize(large) - JvmSizeUtils.stringSize("x"));
+        for (int position : new int[] {0, 333, 998, 999}) {
+            List<String> names = new ArrayList<>(partitionNames);
+            names.set(position, largeName);
+            List<ConnectorPartitionInfo> view = metadataWithCache(
+                    new CountingHmsClient(names), null).listPartitions(null, handle(), Optional.empty());
+            Assertions.assertEquals(baselineBytes + growth,
+                    HivePartitionViewSizeEstimator.estimateEntry(key, view).getBytes(),
+                    "the tail must neither be missed nor extrapolated at index " + position);
+        }
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveConnectorSiblingTest.java
+++ b/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveConnectorSiblingTest.java
@@ -136,6 +136,19 @@ public class HiveConnectorSiblingTest {
         Assertions.assertEquals(0, context.buildCount, "close must not trigger a sibling build");
     }
 
+    @Test
+    public void closePreventsLateSiblingCreation() throws Exception {
+        RecordingSiblingContext context = new RecordingSiblingContext(new FakeSibling());
+        HiveConnector connector = new HiveConnector(HiveTestProperties.minimalMap(), context);
+
+        connector.close();
+
+        Assertions.assertThrows(DorisConnectorException.class, connector::getOrCreateIcebergSibling);
+        Assertions.assertThrows(DorisConnectorException.class, connector::getOrCreateHudiSibling);
+        Assertions.assertEquals(0, context.buildCount,
+                "a closed gateway must not publish a new managed sibling cache owner");
+    }
+
     // ---- hudi sibling holder (mirrors the iceberg cases above; hudi synthesizes props verbatim, no flavor) ----
 
     @Test

--- a/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveFileListingCacheTest.java
+++ b/fe/fe-connector/fe-connector-hive/src/test/java/org/apache/doris/connector/hive/HiveFileListingCacheTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.doris.connector.hive;
 
+import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.hms.HmsPartitionInfo;
 import org.apache.doris.connector.spi.ConnectorSession;
 import org.apache.doris.connector.spi.DorisConnectorException;
@@ -38,6 +39,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Tests {@link HiveFileListingCache}: the connector-owned directory-listing cache (D2's second layer, separate
@@ -73,6 +75,26 @@ public class HiveFileListingCacheTest {
         return m;
     }
 
+    @Test
+    public void disabledBoundedListingDoesNotPrepareCachePayload() {
+        for (String[] disabled : new String[][] {{"enable", "false"}, {"ttl-second", "0"}}) {
+            Map<String, String> properties = props("meta.cache.hive.file.max-weight", "1MB",
+                    "meta.cache.hive.file." + disabled[0], disabled[1]);
+            List<HiveFileStatus> files = Collections.singletonList(new HiveFileStatus("file", 10L, 1L));
+            AtomicInteger loads = new AtomicInteger();
+            try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+                HiveFileListingCache cache = new HiveFileListingCache(owner, HiveCatalogProperties.of(properties),
+                        (location, fileSystem) -> {
+                            loads.incrementAndGet();
+                            return files;
+                        });
+                Assertions.assertSame(files, cache.listDataFiles("db", "t", "loc", FS));
+                Assertions.assertSame(files, cache.listDataFiles("db", "t", "loc", FS));
+                Assertions.assertEquals(2, loads.get());
+            }
+        }
+    }
+
     // ==================== caching: hit / miss keyed by (db, table, location) ====================
 
     @Test
@@ -89,6 +111,22 @@ public class HiveFileListingCacheTest {
         // WHY: a different directory is a different key — must re-list.
         cache.listDataFiles("db", "t", "loc2", FS);
         Assertions.assertEquals(2, lister.totalCalls);
+    }
+
+    @Test
+    public void weightBoundedListingIsEstimatedAndCached() {
+        CountingLister lister = new CountingLister();
+        Map<String, String> properties = props("meta.cache.hive.file.max-weight", "1MB");
+        try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+            HiveFileListingCache cache = new HiveFileListingCache(
+                    owner, HiveCatalogProperties.of(properties), lister);
+
+            List<HiveFileStatus> first = cache.listDataFiles("db", "t", "loc", FS);
+            List<HiveFileStatus> second = cache.listDataFiles("db", "t", "loc", FS);
+
+            Assertions.assertSame(first, second);
+            Assertions.assertEquals(1, lister.totalCalls);
+        }
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/CachingHmsClient.java
+++ b/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/CachingHmsClient.java
@@ -21,6 +21,7 @@ import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.cache.MetaCache;
 import org.apache.doris.connector.cache.MetaCacheDefinition;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimator;
 import org.apache.doris.connector.cache.ScopePath;
 
 import java.io.IOException;
@@ -130,23 +131,28 @@ public class CachingHmsClient implements HmsClient {
         Map<String, String> props = applyLegacyTtlCompatibility(
                 properties == null ? Collections.emptyMap() : properties);
         this.tableCache = newEntry(owner, "hive-table", props, ENTRY_TABLE, DEFAULT_TABLE_CAPACITY,
-                key -> ScopePath.table(key.dbName, key.tableName));
+                key -> ScopePath.table(key.dbName, key.tableName), HmsCacheSizeEstimator::estimateTable);
         this.partitionNamesCache = newEntry(owner, "hive-partition-names", props, ENTRY_PARTITION_NAMES,
                 DEFAULT_PARTITION_NAMES_CAPACITY,
-                key -> ScopePath.partitionCollection(key.dbName, key.tableName));
+                key -> ScopePath.partitionCollection(key.dbName, key.tableName),
+                HmsCacheSizeEstimator::estimatePartitionNames);
         this.partitionsCache = newEntry(owner, "hive-partition", props, ENTRY_PARTITION,
                 DEFAULT_PARTITION_CAPACITY,
-                key -> ScopePath.partition(key.dbName, key.tableName, key.values));
+                key -> ScopePath.partition(key.dbName, key.tableName, key.values),
+                HmsCacheSizeEstimator::estimatePartition);
         this.columnStatsCache = newEntry(owner, "hive-column-stats", props, ENTRY_COLUMN_STATS,
                 DEFAULT_COLUMN_STATS_CAPACITY,
-                key -> ScopePath.table(key.dbName, key.tableName));
+                key -> ScopePath.table(key.dbName, key.tableName), HmsCacheSizeEstimator::estimateColumnStats);
     }
 
     private static <K, V> MetaCache<K, V> newEntry(CatalogMetaCache owner, String name,
-            Map<String, String> props, String entry, long defaultCapacity, Function<K, ScopePath> scopeResolver) {
+            Map<String, String> props, String entry, long defaultCapacity, Function<K, ScopePath> scopeResolver,
+            MetaCacheSizeEstimator<K, V> sizeEstimator) {
         CacheSpec spec = CacheSpec.fromProperties(props, ENGINE, entry,
                 CacheSpec.of(true, DEFAULT_TTL_SECOND, defaultCapacity));
-        return owner.create(MetaCacheDefinition.<K, V>builder(name, spec, scopeResolver).build());
+        return owner.create(MetaCacheDefinition.<K, V>builder(name, spec, scopeResolver)
+                .sizeEstimator(sizeEstimator)
+                .build());
     }
 
     /** Legacy fe-core catalog knob ({@code ExternalCatalog.SCHEMA_CACHE_TTL_SECOND}) for the table/schema cache. */

--- a/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/HmsCacheSizeEstimator.java
+++ b/fe/fe-connector/fe-connector-hms/src/main/java/org/apache/doris/connector/hms/HmsCacheSizeEstimator.java
@@ -1,0 +1,76 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.hms;
+
+import org.apache.doris.connector.cache.JvmSizeUtils;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimate;
+import org.apache.doris.connector.cache.ReflectiveObjectSizeEstimator;
+
+import java.util.List;
+
+/** Construction-time retained-size formulas for HMS cache entries. */
+final class HmsCacheSizeEstimator {
+    private static final long COLUMN_STATS_SHALLOW_BYTES =
+            JvmSizeUtils.instanceSize(HmsColumnStatistics.class);
+
+    private HmsCacheSizeEstimator() {
+    }
+
+    static MetaCacheSizeEstimate estimateTable(Object key, HmsTableInfo value) {
+        return complete(key, value);
+    }
+
+    static MetaCacheSizeEstimate estimatePartition(Object key, HmsPartitionInfo value) {
+        return complete(key, value);
+    }
+
+    static MetaCacheSizeEstimate estimatePartitionNames(Object key, List<String> value) {
+        return MetaCacheSizeEstimate.complete(add(
+                ReflectiveObjectSizeEstimator.estimateComplete(key), estimateStringList(value)));
+    }
+
+    static MetaCacheSizeEstimate estimateColumnStats(Object key, List<HmsColumnStatistics> value) {
+        long bytes = add(JvmSizeUtils.instanceSize(value.getClass()),
+                JvmSizeUtils.objectArraySize(value.size()));
+        for (HmsColumnStatistics stats : value) {
+            bytes = add(bytes, COLUMN_STATS_SHALLOW_BYTES);
+            bytes = add(bytes, JvmSizeUtils.stringSize(stats.getColumnName()));
+        }
+        return MetaCacheSizeEstimate.complete(add(
+                ReflectiveObjectSizeEstimator.estimateComplete(key), bytes));
+    }
+
+    private static MetaCacheSizeEstimate complete(Object key, Object value) {
+        return MetaCacheSizeEstimate.complete(add(
+                ReflectiveObjectSizeEstimator.estimateComplete(key),
+                ReflectiveObjectSizeEstimator.estimateComplete(value)));
+    }
+
+    private static long estimateStringList(List<String> values) {
+        long bytes = add(JvmSizeUtils.instanceSize(values.getClass()),
+                JvmSizeUtils.objectArraySize(values.size()));
+        for (String value : values) {
+            bytes = add(bytes, JvmSizeUtils.stringSize(value));
+        }
+        return bytes;
+    }
+
+    private static long add(long left, long right) {
+        return JvmSizeUtils.saturatedAdd(left, right);
+    }
+}

--- a/fe/fe-connector/fe-connector-hms/src/test/java/org/apache/doris/connector/hms/CachingHmsClientTest.java
+++ b/fe/fe-connector/fe-connector-hms/src/test/java/org/apache/doris/connector/hms/CachingHmsClientTest.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -64,7 +65,7 @@ public class CachingHmsClientTest {
     }
 
     private static CachingHmsClient cache(HmsClient delegate, Map<String, String> properties) {
-        return new CachingHmsClient(new CatalogMetaCache(), delegate, properties);
+        return new CachingHmsClient(CatalogMetaCache.unmanaged(), delegate, properties);
     }
 
     private static void awaitLatch(CountDownLatch latch) {
@@ -93,6 +94,47 @@ public class CachingHmsClientTest {
         HmsTableInfo other = cache.getTable("db", "t2");
         Assertions.assertNotSame(first, other);
         Assertions.assertEquals(2, delegate.getTableCalls);
+    }
+
+    @Test
+    public void weightedTableRejectsALargePropertyOutsideTheOldFiveElementSample() {
+        RecordingHmsClient delegate = new RecordingHmsClient();
+        Map<String, String> parameters = new LinkedHashMap<>();
+        for (int i = 0; i < 99; i++) {
+            parameters.put("small-" + i, "x");
+        }
+        parameters.put("large-tail", "x".repeat(2 * 1024 * 1024));
+        delegate.tableResult = HmsTableInfo.builder()
+                .dbName("db")
+                .tableName("t")
+                .parameters(parameters)
+                .build();
+        CachingHmsClient cache = cache(delegate,
+                props("meta.cache.hive.table.max-weight", "1MB"));
+
+        cache.getTable("db", "t");
+        cache.getTable("db", "t");
+
+        Assertions.assertEquals(2, delegate.getTableCalls,
+                "the 2MB tail must reject weighted admission instead of being hidden by five small samples");
+    }
+
+    @Test
+    public void weightedTableCachesSmallCompleteMetadata() {
+        RecordingHmsClient delegate = new RecordingHmsClient();
+        delegate.tableResult = HmsTableInfo.builder()
+                .dbName("db")
+                .tableName("t")
+                .parameters(Map.of("format", "parquet"))
+                .build();
+        CachingHmsClient cache = cache(delegate,
+                props("meta.cache.hive.table.max-weight", "1MB"));
+
+        cache.getTable("db", "t");
+        cache.getTable("db", "t");
+
+        Assertions.assertEquals(1, delegate.getTableCalls,
+                "a complete small HMS graph must still be admitted to the weighted cache");
     }
 
     @Test
@@ -366,7 +408,7 @@ public class CachingHmsClientTest {
             }
         };
         delegate.absentPartitionNames.add("p=2");
-        CachingHmsClient cache = new CachingHmsClient(new CatalogMetaCache(), delegate,
+        CachingHmsClient cache = new CachingHmsClient(CatalogMetaCache.unmanaged(), delegate,
                 Collections.emptyMap()) {
             @Override
             void afterPartitionLoadRegistrationForTest() {
@@ -424,7 +466,7 @@ public class CachingHmsClientTest {
             }
         };
         delegate.absentPartitionNames.add("p=2");
-        CachingHmsClient cache = new CachingHmsClient(new CatalogMetaCache(), delegate,
+        CachingHmsClient cache = new CachingHmsClient(CatalogMetaCache.unmanaged(), delegate,
                 Collections.emptyMap()) {
             @Override
             void afterPartitionLoadRegistrationForTest() {
@@ -474,7 +516,7 @@ public class CachingHmsClientTest {
                 throw new HmsClientException("HMS unavailable");
             }
         };
-        CachingHmsClient cache = new CachingHmsClient(new CatalogMetaCache(), delegate,
+        CachingHmsClient cache = new CachingHmsClient(CatalogMetaCache.unmanaged(), delegate,
                 Collections.emptyMap()) {
             @Override
             void afterPartitionLoadRegistrationForTest() {
@@ -517,7 +559,7 @@ public class CachingHmsClientTest {
     @Test
     public void getPartitionsInvalidationRacingInFlightFetchDoesNotRecacheStale() {
         RecordingHmsClient delegate = new RecordingHmsClient();
-        CatalogMetaCache owner = new CatalogMetaCache();
+        CatalogMetaCache owner = CatalogMetaCache.unmanaged();
         CachingHmsClient cache = new CachingHmsClient(owner, delegate, Collections.emptyMap());
 
         // Model a REFRESH TABLE landing DURING the cold-cache delegate RPC: the bulk-load handle captures the
@@ -542,7 +584,7 @@ public class CachingHmsClientTest {
     @Test
     public void coldPartitionBatchInvalidationFencesInFlightFetch() throws Exception {
         RecordingHmsClient delegate = new RecordingHmsClient();
-        CatalogMetaCache owner = new CatalogMetaCache();
+        CatalogMetaCache owner = CatalogMetaCache.unmanaged();
         CachingHmsClient cache = new CachingHmsClient(owner, delegate,
                 props("meta.cache.hive.partition_names.ttl-second", "0"));
         CountDownLatch fetchStarted = new CountDownLatch(1);
@@ -588,7 +630,7 @@ public class CachingHmsClientTest {
         CountDownLatch releaseLoad = new CountDownLatch(1);
         CountDownLatch waiterRegistered = new CountDownLatch(1);
         AtomicInteger registrations = new AtomicInteger();
-        CachingHmsClient cache = new CachingHmsClient(new CatalogMetaCache(), delegate,
+        CachingHmsClient cache = new CachingHmsClient(CatalogMetaCache.unmanaged(), delegate,
                 props("meta.cache.hive.partition.capacity", "1")) {
             @Override
             void afterPartitionLoadRegistrationForTest() {
@@ -631,7 +673,7 @@ public class CachingHmsClientTest {
     @Test
     public void handoffWaiterRetriesKeyEvictedByAnotherKeyInTheBatch() throws Exception {
         RecordingHmsClient delegate = new RecordingHmsClient();
-        CatalogMetaCache owner = new CatalogMetaCache();
+        CatalogMetaCache owner = CatalogMetaCache.unmanaged();
         CountDownLatch initialLoadEntered = new CountDownLatch(1);
         CountDownLatch releaseInitialLoad = new CountDownLatch(1);
         CountDownLatch handoffOwnerReady = new CountDownLatch(1);
@@ -740,7 +782,7 @@ public class CachingHmsClientTest {
             awaitLatch(releaseLoad);
         };
         CachingHmsClient cache = new CachingHmsClient(
-                new CatalogMetaCache(), delegate, Collections.emptyMap()) {
+                CatalogMetaCache.unmanaged(), delegate, Collections.emptyMap()) {
             @Override
             void afterPartitionLoadRegistrationForTest() {
                 if (registrations.incrementAndGet() == 2) {
@@ -777,7 +819,7 @@ public class CachingHmsClientTest {
         CountDownLatch releaseLoad = new CountDownLatch(1);
         CountDownLatch waiterRegistered = new CountDownLatch(1);
         AtomicInteger registrations = new AtomicInteger();
-        CachingHmsClient cache = new CachingHmsClient(new CatalogMetaCache(), delegate,
+        CachingHmsClient cache = new CachingHmsClient(CatalogMetaCache.unmanaged(), delegate,
                 props("meta.cache.hive.partition.enable", "false")) {
             @Override
             void afterPartitionLoadRegistrationForTest() {
@@ -867,7 +909,7 @@ public class CachingHmsClientTest {
 
     private void assertWaiterRetriesWhenInvalidationRaces(Map<String, String> properties) throws Exception {
         RecordingHmsClient delegate = new RecordingHmsClient();
-        CatalogMetaCache owner = new CatalogMetaCache();
+        CatalogMetaCache owner = CatalogMetaCache.unmanaged();
         CountDownLatch firstLoadEntered = new CountDownLatch(1);
         CountDownLatch releaseFirstLoad = new CountDownLatch(1);
         CountDownLatch waiterRegistered = new CountDownLatch(1);
@@ -917,7 +959,7 @@ public class CachingHmsClientTest {
     @Test
     public void waiterRetriesHandlelessSecondCheckHandoffAfterInvalidation() throws Exception {
         RecordingHmsClient delegate = new RecordingHmsClient();
-        CatalogMetaCache owner = new CatalogMetaCache();
+        CatalogMetaCache owner = CatalogMetaCache.unmanaged();
         CountDownLatch initialLoadEntered = new CountDownLatch(1);
         CountDownLatch releaseInitialLoad = new CountDownLatch(1);
         CountDownLatch handoffOwnerReady = new CountDownLatch(1);
@@ -1016,7 +1058,7 @@ public class CachingHmsClientTest {
         CountDownLatch waiterRegistered = new CountDownLatch(1);
         AtomicBoolean trackRegistrations = new AtomicBoolean();
         AtomicInteger registrations = new AtomicInteger();
-        CachingHmsClient cache = new CachingHmsClient(new CatalogMetaCache(), delegate, Collections.emptyMap()) {
+        CachingHmsClient cache = new CachingHmsClient(CatalogMetaCache.unmanaged(), delegate, Collections.emptyMap()) {
             @Override
             void afterPartitionLoadRegistrationForTest() {
                 if (trackRegistrations.get() && registrations.incrementAndGet() == 2) {
@@ -1162,7 +1204,7 @@ public class CachingHmsClientTest {
     @Test
     public void tableInvalidationDropsOnlyThatTablesEntries() {
         RecordingHmsClient delegate = new RecordingHmsClient();
-        CatalogMetaCache owner = new CatalogMetaCache();
+        CatalogMetaCache owner = CatalogMetaCache.unmanaged();
         CachingHmsClient cache = new CachingHmsClient(owner, delegate, Collections.emptyMap());
 
         // Populate ALL four caches for BOTH t1 and t2 (t2 must live in the three predicate-invalidated caches
@@ -1210,7 +1252,7 @@ public class CachingHmsClientTest {
     @Test
     public void databaseInvalidationDropsOnlyThatDatabasesEntries() {
         RecordingHmsClient delegate = new RecordingHmsClient();
-        CatalogMetaCache owner = new CatalogMetaCache();
+        CatalogMetaCache owner = CatalogMetaCache.unmanaged();
         CachingHmsClient cache = new CachingHmsClient(owner, delegate, Collections.emptyMap());
 
         // Populate all four caches for db1.t1, plus db1.t2 (a SECOND table in the same db) and db2.t1 (a table in
@@ -1248,7 +1290,7 @@ public class CachingHmsClientTest {
     @Test
     public void catalogInvalidationDropsEverything() {
         RecordingHmsClient delegate = new RecordingHmsClient();
-        CatalogMetaCache owner = new CatalogMetaCache();
+        CatalogMetaCache owner = CatalogMetaCache.unmanaged();
         CachingHmsClient cache = new CachingHmsClient(owner, delegate, Collections.emptyMap());
 
         // Populate all four caches so flushAll's independent invalidateAll() call on each is exercised.
@@ -1331,6 +1373,7 @@ public class CachingHmsClientTest {
         int closeCalls;
         RuntimeException getTableError;
         HmsClientException getPartitionsError;
+        HmsTableInfo tableResult;
         // Partition names the fake has NO partition for (mirrors HMS omitting non-existent partitions).
         final Set<String> absentPartitionNames = new HashSet<>();
         // The partition-name list the decorator actually asked the delegate for on the LAST getPartitions call
@@ -1348,7 +1391,9 @@ public class CachingHmsClientTest {
             if (getTableError != null) {
                 throw getTableError;
             }
-            return HmsTableInfo.builder().dbName(dbName).tableName(tableName).build();
+            return tableResult == null
+                    ? HmsTableInfo.builder().dbName(dbName).tableName(tableName).build()
+                    : tableResult;
         }
 
         @Override

--- a/fe/fe-connector/fe-connector-hms/src/test/java/org/apache/doris/connector/hms/HmsCacheSizeEstimatorBenchmark.java
+++ b/fe/fe-connector/fe-connector-hms/src/test/java/org/apache/doris/connector/hms/HmsCacheSizeEstimatorBenchmark.java
@@ -1,0 +1,113 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.hms;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Dependency-free microbenchmark for the production HMS admission estimators. */
+public final class HmsCacheSizeEstimatorBenchmark {
+    private static final int WARMUP_WINDOWS = 5;
+    private static final int MEASURE_WINDOWS = 15;
+    private static volatile long blackhole;
+
+    private HmsCacheSizeEstimatorBenchmark() {
+    }
+
+    public static void main(String[] args) {
+        for (int size : new int[] {1_000, 100_000}) {
+            List<String> names = partitionNames(size);
+            int operationsPerWindow = size <= 1_000 ? 1_000 : 20;
+            Result result = measure(
+                    () -> HmsCacheSizeEstimator.estimatePartitionNames("db.t", names).getBytes(),
+                    operationsPerWindow);
+            System.out.printf("hms_partition_names=%d estimated_bytes=%d ns_op=%d operations=%d%n",
+                    size, HmsCacheSizeEstimator.estimatePartitionNames("db.t", names).getBytes(),
+                    result.medianNanos, result.operations);
+        }
+
+        HmsTableInfo table = skewedTable();
+        Result tableResult = measure(
+                () -> HmsCacheSizeEstimator.estimateTable("db.t", table).getBytes(), 1_000);
+        System.out.printf("hms_table_properties=%d estimated_bytes=%d ns_op=%d operations=%d%n",
+                table.getParameters().size(), HmsCacheSizeEstimator.estimateTable("db.t", table).getBytes(),
+                tableResult.medianNanos, tableResult.operations);
+    }
+
+    private static List<String> partitionNames(int size) {
+        List<String> values = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            values.add("dt=2026-09-01/hour=" + (i % 24) + "/bucket=" + i);
+        }
+        return values;
+    }
+
+    private static HmsTableInfo skewedTable() {
+        Map<String, String> parameters = new LinkedHashMap<>();
+        for (int i = 0; i < 99; i++) {
+            parameters.put("small-" + i, "x");
+        }
+        parameters.put("large-tail", "x".repeat(2 * 1024 * 1024));
+        return HmsTableInfo.builder()
+                .dbName("db")
+                .tableName("t")
+                .parameters(parameters)
+                .build();
+    }
+
+    private static Result measure(LongOperation operation, int operationsPerWindow) {
+        for (int i = 0; i < WARMUP_WINDOWS; i++) {
+            runWindow(operation, operationsPerWindow);
+        }
+        long[] nanosPerOperation = new long[MEASURE_WINDOWS];
+        for (int i = 0; i < MEASURE_WINDOWS; i++) {
+            long start = System.nanoTime();
+            runWindow(operation, operationsPerWindow);
+            nanosPerOperation[i] = (System.nanoTime() - start) / operationsPerWindow;
+        }
+        Arrays.sort(nanosPerOperation);
+        return new Result(nanosPerOperation[MEASURE_WINDOWS / 2],
+                (long) operationsPerWindow * MEASURE_WINDOWS);
+    }
+
+    private static void runWindow(LongOperation operation, int operations) {
+        long value = 0L;
+        for (int i = 0; i < operations; i++) {
+            value ^= operation.run();
+        }
+        blackhole = value;
+    }
+
+    @FunctionalInterface
+    private interface LongOperation {
+        long run();
+    }
+
+    private static final class Result {
+        private final long medianNanos;
+        private final long operations;
+
+        private Result(long medianNanos, long operations) {
+            this.medianNanos = medianNanos;
+            this.operations = operations;
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnector.java
+++ b/fe/fe-connector/fe-connector-hudi/src/main/java/org/apache/doris/connector/hudi/HudiConnector.java
@@ -68,7 +68,7 @@ public class HudiConnector implements Connector {
     private final HudiCatalogProperties props;
     private final Map<String, String> properties;
     private final ConnectorContext context;
-    private final CatalogMetaCache metaCache = new CatalogMetaCache();
+    private final CatalogMetaCache metaCache;
     private volatile HmsClient hmsClient;
 
     // HMS and storage deliberately have separate authenticators: hive.metastore.username must affect set_ugi
@@ -83,6 +83,7 @@ public class HudiConnector implements Connector {
         this.props = HudiCatalogProperties.of(properties);
         this.properties = props.getRaw();
         this.context = context;
+        this.metaCache = CatalogMetaCache.managed(context.getCatalogId(), "hudi", this.properties);
     }
 
     @Override

--- a/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiConnectorHmsCacheTest.java
+++ b/fe/fe-connector/fe-connector-hudi/src/test/java/org/apache/doris/connector/hudi/HudiConnectorHmsCacheTest.java
@@ -17,6 +17,9 @@
 
 package org.apache.doris.connector.hudi;
 
+import org.apache.doris.connector.cache.CatalogMetaCache;
+import org.apache.doris.connector.cache.MetaCache;
+import org.apache.doris.connector.cache.MetaCacheGovernance;
 import org.apache.doris.connector.hms.CachingHmsClient;
 import org.apache.doris.connector.hms.HmsClient;
 import org.apache.doris.connector.hms.HmsDatabaseInfo;
@@ -24,11 +27,16 @@ import org.apache.doris.connector.hms.HmsPartitionInfo;
 import org.apache.doris.connector.hms.HmsTableInfo;
 import org.apache.doris.connector.spi.ConnectorContext;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -57,6 +65,73 @@ public class HudiConnectorHmsCacheTest {
 
     private static final List<String> YEAR_MONTH = Arrays.asList("year", "month");
     private static final List<String> ONE_PARTITION = Collections.singletonList("year=2024/month=01");
+    private final List<HudiConnector> connectors = new ArrayList<>();
+
+    @AfterEach
+    void closeConnectors() throws Exception {
+        for (HudiConnector connector : connectors) {
+            connector.close();
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"meta.cache.max-weight", "meta.cache.hive.partition_names.max-weight"})
+    void weightLimitAccountsHmsCacheAndRejectsOversizedValues(String property) throws Exception {
+        long catalogId = Long.MIN_VALUE + 71L;
+        long previousGlobalWeight = MetaCacheGovernance.globalEstimatedWeight();
+        Map<String, String> properties = new HashMap<>(HudiTestProperties.minimalMap());
+        properties.put(property, "4KB");
+        HudiConnector connector = connector(properties, catalogId);
+        List<CatalogMetaCache> owners = MetaCacheGovernance.catalogCaches(catalogId);
+        Assertions.assertEquals(1, owners.size());
+        CatalogMetaCache owner = owners.get(0);
+        Assertions.assertEquals("hudi", owner.engine());
+
+        FakeHmsClient delegate = new FakeHmsClient(ONE_PARTITION);
+        HmsClient cache = connector.wrapWithCache(delegate);
+        Assertions.assertEquals(4, owner.entries().size());
+        MetaCache<?, ?> entry = owner.entries().get("hive-partition-names");
+        Assertions.assertTrue(entry.isWeightBounded());
+        Assertions.assertEquals(4096L, entry.metrics().getMaxWeight());
+        Assertions.assertEquals("meta.cache.max-weight".equals(property),
+                owner.entries().get("hive-table").isWeightBounded());
+
+        Assertions.assertEquals(ONE_PARTITION, cache.listPartitionNames("db", "t", -1));
+        Assertions.assertEquals(ONE_PARTITION, cache.listPartitionNames("db", "t", -1));
+        Assertions.assertEquals(1, delegate.cachedCalls);
+        long retainedWeight = entry.metrics().getEstimatedWeight();
+        Assertions.assertTrue(retainedWeight > 0L && retainedWeight <= 4096L);
+        Assertions.assertEquals(previousGlobalWeight + retainedWeight,
+                MetaCacheGovernance.globalEstimatedWeight());
+
+        delegate.names = Collections.singletonList("partition=" + "x".repeat(8192));
+        Assertions.assertEquals(delegate.names, cache.listPartitionNames("db", "large", -1));
+        Assertions.assertEquals(delegate.names, cache.listPartitionNames("db", "large", -1));
+        Assertions.assertEquals(3, delegate.cachedCalls, "oversized values must be returned but not cached");
+        Assertions.assertEquals(2L, entry.metrics().getWeightRejectCount());
+        Assertions.assertEquals("entry_too_large", entry.metrics().getLastWeightRejectReason());
+        Assertions.assertEquals(retainedWeight, entry.metrics().getEstimatedWeight());
+
+        connector.close();
+        Assertions.assertTrue(MetaCacheGovernance.catalogCaches(catalogId).isEmpty());
+        Assertions.assertEquals(0L, entry.metrics().getEstimatedWeight());
+        Assertions.assertEquals(previousGlobalWeight, MetaCacheGovernance.globalEstimatedWeight());
+    }
+
+    @Test
+    void noWeightLimitPreservesCountBasedCaching() {
+        long catalogId = Long.MIN_VALUE + 72L;
+        HudiConnector connector = connector(HudiTestProperties.minimalMap(), catalogId);
+        FakeHmsClient delegate = new FakeHmsClient(ONE_PARTITION);
+        HmsClient cache = connector.wrapWithCache(delegate);
+        CatalogMetaCache owner = MetaCacheGovernance.catalogCaches(catalogId).get(0);
+        MetaCache<?, ?> entry = owner.entries().get("hive-partition-names");
+        Assertions.assertFalse(entry.isWeightBounded());
+        cache.listPartitionNames("db", "t", -1);
+        cache.listPartitionNames("db", "t", -1);
+        Assertions.assertEquals(1, delegate.cachedCalls);
+        Assertions.assertEquals(0L, entry.metrics().getEstimatedWeight());
+    }
 
     // ── wrap ─────────────────────────────────────────────────────────────────────────────────────────────
 
@@ -153,8 +228,12 @@ public class HudiConnectorHmsCacheTest {
 
     // ── helpers ────────────────────────────────────────────────────────────────────────────────────────────
 
-    private static HudiConnector connector() {
-        return new HudiConnector(HudiTestProperties.minimalMap(), new ConnectorContext() {
+    private HudiConnector connector() {
+        return connector(HudiTestProperties.minimalMap(), 1L);
+    }
+
+    private HudiConnector connector(Map<String, String> properties, long catalogId) {
+        HudiConnector connector = new HudiConnector(properties, new ConnectorContext() {
             @Override
             public String getCatalogName() {
                 return "test_catalog";
@@ -162,9 +241,11 @@ public class HudiConnectorHmsCacheTest {
 
             @Override
             public long getCatalogId() {
-                return 1L;
+                return catalogId;
             }
         });
+        connectors.add(connector);
+        return connector;
     }
 
     private static HudiTableHandle partitioned() {
@@ -198,7 +279,7 @@ public class HudiConnectorHmsCacheTest {
     private static final class FakeHmsClient implements HmsClient {
         int cachedCalls;
         int freshCalls;
-        private final List<String> names;
+        private List<String> names;
 
         FakeHmsClient(List<String> names) {
             this.names = names;

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergCacheSizeEstimator.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergCacheSizeEstimator.java
@@ -1,0 +1,734 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.iceberg;
+
+import org.apache.doris.connector.cache.ConnectorTableKey;
+import org.apache.doris.connector.cache.JvmSizeUtils;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimate;
+import org.apache.doris.connector.cache.ReflectiveObjectSizeEstimator;
+import org.apache.doris.connector.iceberg.IcebergPartitionCache.CachedPartitions;
+import org.apache.doris.connector.iceberg.IcebergPartitionCache.Key;
+import org.apache.doris.connector.iceberg.IcebergPartitionUtils.IcebergRawPartition;
+import org.apache.doris.connector.iceberg.IcebergTableCache.TableOwner;
+import org.apache.doris.connector.spi.ConnectorPartitionInfo;
+import org.apache.doris.connector.spi.mvcc.ConnectorMvccPartition;
+import org.apache.doris.connector.spi.mvcc.ConnectorMvccPartitionView;
+
+import org.apache.iceberg.BlobMetadata;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.HistoryEntry;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionStatisticsFile;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.SortField;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.StatisticsFile;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.UnboundPartitionSpec;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Type-specific retained-heap estimators for the large Iceberg connector cache values. */
+final class IcebergCacheSizeEstimator {
+    private static final String[] CONTENT_FILE_FIELD_NAMES = {
+            "content", "file_path", "file_format", "partition", "record_count", "file_size_in_bytes",
+            "column_sizes", "value_counts", "null_value_counts", "nan_value_counts", "lower_bounds",
+            "upper_bounds", "key_metadata", "split_offsets", "equality_ids", "sort_order_id", "first_row_id",
+            "referenced_data_file", "content_offset", "content_size_in_bytes"
+    };
+    private static final long TABLE_IDENTIFIER_SHALLOW_BYTES = JvmSizeUtils.instanceSize(TableIdentifier.class);
+    private static final long CACHED_TABLE_SHALLOW_BYTES = JvmSizeUtils.instanceSize(TableOwner.class);
+    private static final long TABLE_METADATA_SHALLOW_BYTES = JvmSizeUtils.instanceSize(TableMetadata.class);
+    private static final long PARTITION_KEY_SHALLOW_BYTES = JvmSizeUtils.instanceSize(Key.class);
+    private static final long CACHED_PARTITIONS_SHALLOW_BYTES = JvmSizeUtils.instanceSize(CachedPartitions.class);
+    private static final long RAW_PARTITION_SHALLOW_BYTES = JvmSizeUtils.instanceSize(IcebergRawPartition.class);
+    private static final long CONNECTOR_TABLE_KEY_SHALLOW_BYTES = JvmSizeUtils.instanceSize(ConnectorTableKey.class);
+    private static final long CONNECTOR_PARTITION_SHALLOW_BYTES =
+            JvmSizeUtils.instanceSize(ConnectorPartitionInfo.class);
+    private static final long MVCC_PARTITION_VIEW_SHALLOW_BYTES =
+            JvmSizeUtils.instanceSize(ConnectorMvccPartitionView.class);
+    private static final long MVCC_PARTITION_SHALLOW_BYTES =
+            JvmSizeUtils.instanceSize(ConnectorMvccPartition.class);
+    private static final long MANIFEST_KEY_SHALLOW_BYTES = JvmSizeUtils.instanceSize(IcebergManifestEntryKey.class);
+    private static final long MANIFEST_VALUE_SHALLOW_BYTES = JvmSizeUtils.instanceSize(ManifestCacheValue.class);
+    private static final long INTEGER_SHALLOW_BYTES = JvmSizeUtils.instanceSize(Integer.class);
+    private static final long LONG_SHALLOW_BYTES = JvmSizeUtils.instanceSize(Long.class);
+    private static final long HASH_MAP_NODE_SHALLOW_BYTES = classSize("java.util.HashMap$Node");
+    private static final long LINKED_HASH_MAP_ENTRY_SHALLOW_BYTES = classSize("java.util.LinkedHashMap$Entry");
+    private static final long CONTENT_FILE_SCHEMA_BYTES = estimateContentFileSchema();
+
+    private IcebergCacheSizeEstimator() {
+    }
+
+    /** Admission callback: the expensive table graph was sized once when {@link TableOwner} was constructed. */
+    static MetaCacheSizeEstimate estimateTableEntry(TableIdentifier key, TableOwner value) {
+        return value.sizeEstimate.isComplete()
+                ? MetaCacheSizeEstimate.complete(add(estimateTableIdentifier(key), value.sizeEstimate.getBytes()))
+                : value.sizeEstimate;
+    }
+
+    static long estimateTable(Table table) {
+        long bytes = add(CACHED_TABLE_SHALLOW_BYTES, JvmSizeUtils.instanceSize(table.getClass()));
+        bytes = add(bytes, JvmSizeUtils.stringSize(table.name()));
+        if (!(table instanceof HasTableOperations)) {
+            bytes = add(bytes, JvmSizeUtils.stringSize(table.location()));
+            return add(bytes, estimateStringMap(table.properties()));
+        }
+
+        TableOperations operations = ((HasTableOperations) table).operations();
+        bytes = add(bytes, JvmSizeUtils.instanceSize(operations.getClass()));
+        return add(bytes, estimateTableMetadata(operations.current()));
+    }
+
+    static long estimateSerializedTableMetadata(String metadataJson) {
+        return JvmSizeUtils.stringSize(metadataJson);
+    }
+
+    static long estimatePartitionKey(Key key) {
+        return Math.max(add(PARTITION_KEY_SHALLOW_BYTES, estimateTableIdentifier(key.id)),
+                ReflectiveObjectSizeEstimator.estimate(key));
+    }
+
+    static long estimatePartitions(List<IcebergRawPartition> partitions) {
+        long bytes = CACHED_PARTITIONS_SHALLOW_BYTES;
+        // CachedPartitions owns an unmodifiable wrapper around an exact-size ArrayList copy.
+        bytes = add(bytes, JvmSizeUtils.instanceSize(partitions.getClass()));
+        bytes = add(bytes, JvmSizeUtils.arrayListSize(partitions.size()));
+        for (IcebergRawPartition partition : partitions) {
+            bytes = add(bytes, RAW_PARTITION_SHALLOW_BYTES);
+            bytes = add(bytes, JvmSizeUtils.stringSize(partition.nameForWeight()));
+            bytes = add(bytes, estimateStringList(partition.columnNamesForWeight()));
+            bytes = add(bytes, estimateStringList(partition.valuesForWeight()));
+            bytes = add(bytes, estimateStringList(partition.transformsForWeight()));
+        }
+        return Math.max(bytes, ReflectiveObjectSizeEstimator.estimate(partitions));
+    }
+
+    /** Admission callback: the partition list was sized once when {@link CachedPartitions} was constructed. */
+    static MetaCacheSizeEstimate estimatePartitionEntry(Key key, CachedPartitions value) {
+        return value.sizeEstimate.isComplete()
+                ? MetaCacheSizeEstimate.complete(add(estimatePartitionKey(key), value.sizeEstimate.getBytes()))
+                : value.sizeEstimate;
+    }
+
+    static MetaCacheSizeEstimate estimatePartitionInfoViewEntry(
+            ConnectorTableKey key, List<ConnectorPartitionInfo> partitions) {
+        long bytes = estimateConnectorTableKey(key);
+        bytes = add(bytes, estimateListStructure(partitions));
+        int previousArity = -1;
+        long structureBytes = 0L;
+        for (ConnectorPartitionInfo partition : partitions) {
+            // toConnectorPartitions uses one ordered value per map entry and an empty null-flag list.
+            // Specs may evolve, so reuse the fixed structure only while the partition arity matches.
+            int arity = partition.getPartitionValues().size();
+            if (arity != previousArity) {
+                structureBytes = estimateConnectorPartitionStructure(partition);
+                previousArity = arity;
+            }
+            bytes = add(bytes, structureBytes);
+            bytes = add(bytes, JvmSizeUtils.stringSize(partition.getPartitionName()));
+            for (String column : partition.getPartitionValues().keySet()) {
+                bytes = add(bytes, JvmSizeUtils.stringSize(column));
+            }
+            // The map and ordered list share their value Strings.
+            for (String value : partition.getOrderedPartitionValues()) {
+                bytes = add(bytes, JvmSizeUtils.stringSize(value));
+            }
+        }
+        return MetaCacheSizeEstimate.complete(bytes);
+    }
+
+    static MetaCacheSizeEstimate estimateMvccPartitionViewEntry(
+            ConnectorTableKey key, ConnectorMvccPartitionView view) {
+        long bytes = add(estimateConnectorTableKey(key), MVCC_PARTITION_VIEW_SHALLOW_BYTES);
+        bytes = add(bytes, JvmSizeUtils.instanceSize(ArrayList.class));
+        bytes = add(bytes, estimateListStructure(view.getPartitions()));
+        for (ConnectorMvccPartition partition : view.getPartitions()) {
+            bytes = add(bytes, estimateMvccPartition(partition));
+        }
+        return MetaCacheSizeEstimate.complete(bytes);
+    }
+
+    private static long estimateMvccPartition(ConnectorMvccPartition partition) {
+        long bytes = MVCC_PARTITION_SHALLOW_BYTES;
+        bytes = add(bytes, JvmSizeUtils.stringSize(partition.getName()));
+        bytes = add(bytes, estimateWrappedStringList(partition.getLowerBound()));
+        return add(bytes, estimateWrappedStringList(partition.getUpperBound()));
+    }
+
+    private static long estimateConnectorTableKey(ConnectorTableKey key) {
+        long bytes = CONNECTOR_TABLE_KEY_SHALLOW_BYTES;
+        bytes = add(bytes, JvmSizeUtils.stringSize(key.getDb()));
+        return add(bytes, JvmSizeUtils.stringSize(key.getTable()));
+    }
+
+    private static long estimateConnectorPartitionStructure(ConnectorPartitionInfo partition) {
+        long bytes = CONNECTOR_PARTITION_SHALLOW_BYTES;
+        // toConnectorPartitions owns a default-constructed LinkedHashMap behind the SPI wrapper.
+        bytes = add(bytes, JvmSizeUtils.instanceSize(partition.getPartitionValues().getClass()));
+        bytes = add(bytes, JvmSizeUtils.instanceSize(LinkedHashMap.class));
+        int valueCount = partition.getPartitionValues().size();
+        if (valueCount > 0) {
+            bytes = add(bytes, JvmSizeUtils.objectArraySize(hashCapacity(valueCount)));
+            bytes = add(bytes, multiply(valueCount, LINKED_HASH_MAP_ENTRY_SHALLOW_BYTES));
+        }
+        bytes = add(bytes, estimateMapStructure(partition.getProperties()));
+        bytes = add(bytes, estimateWrappedReferenceList(partition.getOrderedPartitionValues()));
+        return add(bytes, estimateWrappedReferenceList(partition.getPartitionValueNullFlags()));
+    }
+
+    private static long estimateWrappedStringList(List<String> values) {
+        long bytes = estimateWrappedReferenceList(values);
+        for (String value : values) {
+            bytes = add(bytes, JvmSizeUtils.stringSize(value));
+        }
+        return bytes;
+    }
+
+    private static long estimateWrappedReferenceList(List<?> values) {
+        return add(JvmSizeUtils.instanceSize(ArrayList.class), estimateListStructure(values));
+    }
+
+    static long estimateManifestKey(IcebergManifestEntryKey key) {
+        return add(MANIFEST_KEY_SHALLOW_BYTES, JvmSizeUtils.stringSize(key.getManifestPath()));
+    }
+
+    static long estimateManifestValue(ManifestCacheValue value) {
+        long bytes = MANIFEST_VALUE_SHALLOW_BYTES;
+        bytes = add(bytes, estimateContentFileList(value.getDataFiles()));
+        bytes = add(bytes, estimateContentFileList(value.getDeleteFiles()));
+        return Math.max(bytes, ReflectiveObjectSizeEstimator.estimate(value));
+    }
+
+    /** Admission callback: the manifest payload size is precomputed during construction. */
+    static MetaCacheSizeEstimate estimateManifestEntry(IcebergManifestEntryKey key, ManifestCacheValue value) {
+        return value.getSizeEstimate().isComplete()
+                ? MetaCacheSizeEstimate.complete(
+                        add(estimateManifestKey(key), value.getSizeEstimate().getBytes()))
+                : value.getSizeEstimate();
+    }
+
+    private static long estimateTableIdentifier(TableIdentifier identifier) {
+        long bytes = TABLE_IDENTIFIER_SHALLOW_BYTES;
+        Namespace namespace = identifier.namespace();
+        bytes = add(bytes, JvmSizeUtils.instanceSize(namespace.getClass()));
+        String[] levels = namespace.levels();
+        bytes = add(bytes, JvmSizeUtils.objectArraySize(levels.length));
+        for (String level : levels) {
+            bytes = add(bytes, JvmSizeUtils.stringSize(level));
+        }
+        return add(bytes, JvmSizeUtils.stringSize(identifier.name()));
+    }
+
+    private static long estimateTableMetadata(TableMetadata metadata) {
+        long bytes = TABLE_METADATA_SHALLOW_BYTES;
+        bytes = add(bytes, JvmSizeUtils.stringSize(metadata.metadataFileLocation()));
+        bytes = add(bytes, JvmSizeUtils.stringSize(metadata.uuid()));
+        bytes = add(bytes, JvmSizeUtils.stringSize(metadata.location()));
+        bytes = add(bytes, estimateStringMap(metadata.properties()));
+
+        List<Schema> schemas = metadata.schemas();
+        bytes = add(bytes, estimateListStructure(schemas));
+        bytes = add(bytes, estimateIntegerIndexMap(metadata.schemasById()));
+        for (Schema schema : schemas) {
+            bytes = add(bytes, estimateSchema(schema));
+        }
+
+        List<PartitionSpec> specs = metadata.specs();
+        bytes = add(bytes, estimateListStructure(specs));
+        bytes = add(bytes, estimateIntegerIndexMap(metadata.specsById()));
+        for (PartitionSpec spec : specs) {
+            bytes = add(bytes, estimatePartitionSpec(spec));
+        }
+
+        List<SortOrder> sortOrders = metadata.sortOrders();
+        bytes = add(bytes, estimateListStructure(sortOrders));
+        bytes = add(bytes, estimateIntegerIndexMap(metadata.sortOrdersById()));
+        for (SortOrder sortOrder : sortOrders) {
+            bytes = add(bytes, estimateSortOrder(sortOrder));
+        }
+
+        List<Snapshot> snapshots = metadata.snapshots();
+        bytes = add(bytes, estimateListStructure(snapshots));
+        bytes = add(bytes, estimateLongIndexMap(snapshots));
+        List<Snapshot> embeddedManifestSnapshots = new ArrayList<>();
+        for (Snapshot snapshot : snapshots) {
+            if (snapshot.manifestListLocation() == null) {
+                embeddedManifestSnapshots.add(snapshot);
+            } else {
+                bytes = add(bytes, estimateSnapshot(snapshot));
+            }
+        }
+        if (!embeddedManifestSnapshots.isEmpty()) {
+            // Serialization materializes legacy embedded manifests. Traverse them without sampling, sharing
+            // one visit budget/identity set across snapshots and their shared Avro schemas. No manifest IO.
+            bytes = add(bytes, ReflectiveObjectSizeEstimator.estimateComplete(embeddedManifestSnapshots));
+        }
+
+        bytes = add(bytes, estimateHistory(metadata.snapshotLog()));
+        bytes = add(bytes, estimateMetadataLog(metadata.previousFiles()));
+        bytes = add(bytes, estimateSnapshotRefs(metadata.refs()));
+        bytes = add(bytes, estimateStatisticsFiles(metadata.statisticsFiles()));
+        bytes = add(bytes, estimatePartitionStatisticsFiles(metadata.partitionStatisticsFiles()));
+        bytes = add(bytes, estimateMetadataUpdates(metadata.changes()));
+        bytes = add(bytes, estimateListStructure(metadata.encryptionKeys()));
+        for (Object key : metadata.encryptionKeys()) {
+            bytes = add(bytes, ReflectiveObjectSizeEstimator.estimateComplete(key));
+        }
+        // TableMetadata retains a serializable snapshot supplier after the immutable snapshot list is loaded.
+        bytes = add(bytes, JvmSizeUtils.objectArraySize(1));
+        return Math.max(bytes, ReflectiveObjectSizeEstimator.estimate(metadata));
+    }
+
+    private static long estimateSchema(Schema schema) {
+        List<Types.NestedField> columns = schema.columns();
+        long bytes = JvmSizeUtils.instanceSize(schema.getClass());
+        bytes = add(bytes, JvmSizeUtils.instanceSize(schema.asStruct().getClass()));
+        bytes = add(bytes, estimateListStructure(columns));
+        for (Types.NestedField field : columns) {
+            bytes = add(bytes, estimateNestedField(field));
+        }
+        bytes = add(bytes, JvmSizeUtils.objectArraySize(schema.identifierFieldIds().size()));
+        bytes = add(bytes, estimateMapStructure(schema.getAliases()));
+        return add(bytes, estimateSchemaIndexes(columns.size()));
+    }
+
+    private static long estimateNestedField(Types.NestedField field) {
+        long bytes = JvmSizeUtils.instanceSize(field.getClass());
+        bytes = add(bytes, JvmSizeUtils.stringSize(field.name()));
+        bytes = add(bytes, JvmSizeUtils.stringSize(field.doc()));
+        // Defaults are owned variable-sized literals, not shared schema infrastructure.
+        if (field.initialDefaultLiteral() != null) {
+            bytes = add(bytes, ReflectiveObjectSizeEstimator.estimateComplete(field.initialDefaultLiteral()));
+        }
+        if (field.writeDefaultLiteral() != null && field.writeDefaultLiteral() != field.initialDefaultLiteral()) {
+            bytes = add(bytes, ReflectiveObjectSizeEstimator.estimateComplete(field.writeDefaultLiteral()));
+        }
+        return add(bytes, estimateIcebergType(field.type()));
+    }
+
+    private static long estimateIcebergType(Type type) {
+        long bytes = JvmSizeUtils.instanceSize(type.getClass());
+        if (type.isStructType()) {
+            List<Types.NestedField> fields = type.asStructType().fields();
+            bytes = add(bytes, estimateListStructure(fields));
+            for (Types.NestedField field : fields) {
+                bytes = add(bytes, estimateNestedField(field));
+            }
+        } else if (type.isListType()) {
+            bytes = add(bytes, estimateNestedField(type.asListType().fields().get(0)));
+        } else if (type.isMapType()) {
+            for (Types.NestedField field : type.asMapType().fields()) {
+                bytes = add(bytes, estimateNestedField(field));
+            }
+        }
+        return bytes;
+    }
+
+    private static long estimatePartitionSpec(PartitionSpec spec) {
+        List<PartitionField> fields = spec.fields();
+        long bytes = add(JvmSizeUtils.instanceSize(spec.getClass()), JvmSizeUtils.objectArraySize(fields.size()));
+        for (PartitionField field : fields) {
+            bytes = add(bytes, JvmSizeUtils.instanceSize(field.getClass()));
+            bytes = add(bytes, JvmSizeUtils.stringSize(field.name()));
+            bytes = add(bytes, JvmSizeUtils.instanceSize(field.transform().getClass()));
+        }
+        return bytes;
+    }
+
+    private static long estimateSortOrder(SortOrder sortOrder) {
+        List<SortField> fields = sortOrder.fields();
+        long bytes = add(JvmSizeUtils.instanceSize(sortOrder.getClass()), JvmSizeUtils.objectArraySize(fields.size()));
+        for (SortField field : fields) {
+            bytes = add(bytes, JvmSizeUtils.instanceSize(field.getClass()));
+            bytes = add(bytes, JvmSizeUtils.instanceSize(field.transform().getClass()));
+        }
+        return bytes;
+    }
+
+    private static long estimateSnapshot(Snapshot snapshot) {
+        long bytes = JvmSizeUtils.instanceSize(snapshot.getClass());
+        bytes = add(bytes, estimateBoxed(snapshot.parentId(), LONG_SHALLOW_BYTES));
+        bytes = add(bytes, estimateBoxed(snapshot.schemaId(), INTEGER_SHALLOW_BYTES));
+        bytes = add(bytes, estimateBoxed(snapshot.firstRowId(), LONG_SHALLOW_BYTES));
+        bytes = add(bytes, estimateBoxed(snapshot.addedRows(), LONG_SHALLOW_BYTES));
+        bytes = add(bytes, JvmSizeUtils.stringSize(snapshot.operation()));
+        bytes = add(bytes, JvmSizeUtils.stringSize(snapshot.manifestListLocation()));
+        bytes = add(bytes, JvmSizeUtils.stringSize(snapshot.keyId()));
+        return add(bytes, estimateStringMap(snapshot.summary()));
+    }
+
+    private static long estimateHistory(List<HistoryEntry> history) {
+        long bytes = estimateListStructure(history);
+        for (HistoryEntry entry : history) {
+            bytes = add(bytes, JvmSizeUtils.instanceSize(entry.getClass()));
+        }
+        return bytes;
+    }
+
+    private static long estimateMetadataLog(List<TableMetadata.MetadataLogEntry> entries) {
+        long bytes = estimateListStructure(entries);
+        for (TableMetadata.MetadataLogEntry entry : entries) {
+            bytes = add(bytes, JvmSizeUtils.instanceSize(entry.getClass()));
+            bytes = add(bytes, JvmSizeUtils.stringSize(entry.file()));
+        }
+        return bytes;
+    }
+
+    private static long estimateSnapshotRefs(Map<String, SnapshotRef> refs) {
+        long bytes = estimateMapStructure(refs);
+        for (Map.Entry<String, SnapshotRef> entry : refs.entrySet()) {
+            bytes = add(bytes, JvmSizeUtils.stringSize(entry.getKey()));
+            SnapshotRef ref = entry.getValue();
+            bytes = add(bytes, JvmSizeUtils.instanceSize(ref.getClass()));
+            bytes = add(bytes, estimateBoxed(ref.minSnapshotsToKeep(), INTEGER_SHALLOW_BYTES));
+            bytes = add(bytes, estimateBoxed(ref.maxSnapshotAgeMs(), LONG_SHALLOW_BYTES));
+            bytes = add(bytes, estimateBoxed(ref.maxRefAgeMs(), LONG_SHALLOW_BYTES));
+        }
+        return bytes;
+    }
+
+    private static long estimateStatisticsFiles(List<StatisticsFile> files) {
+        long bytes = estimateListStructure(files);
+        for (StatisticsFile file : files) {
+            bytes = add(bytes, JvmSizeUtils.instanceSize(file.getClass()));
+            bytes = add(bytes, JvmSizeUtils.stringSize(file.path()));
+            List<BlobMetadata> blobs = file.blobMetadata();
+            bytes = add(bytes, estimateListStructure(blobs));
+            for (BlobMetadata blob : blobs) {
+                bytes = add(bytes, JvmSizeUtils.instanceSize(blob.getClass()));
+                bytes = add(bytes, JvmSizeUtils.stringSize(blob.type()));
+                bytes = add(bytes, estimateBoxedList(blob.fields(), INTEGER_SHALLOW_BYTES));
+                bytes = add(bytes, estimateStringMap(blob.properties()));
+            }
+        }
+        return bytes;
+    }
+
+    private static long estimatePartitionStatisticsFiles(List<PartitionStatisticsFile> files) {
+        long bytes = estimateListStructure(files);
+        for (PartitionStatisticsFile file : files) {
+            bytes = add(bytes, JvmSizeUtils.instanceSize(file.getClass()));
+            bytes = add(bytes, JvmSizeUtils.stringSize(file.path()));
+        }
+        return bytes;
+    }
+
+    private static long estimateMetadataUpdates(List<MetadataUpdate> updates) {
+        long bytes = estimateListStructure(updates);
+        for (MetadataUpdate update : updates) {
+            bytes = add(bytes, JvmSizeUtils.instanceSize(update.getClass()));
+            if (update instanceof MetadataUpdate.SetProperties) {
+                bytes = add(bytes, estimateMapStructure(((MetadataUpdate.SetProperties) update).updated()));
+            } else if (update instanceof MetadataUpdate.AddPartitionSpec) {
+                UnboundPartitionSpec spec = ((MetadataUpdate.AddPartitionSpec) update).spec();
+                bytes = add(bytes, JvmSizeUtils.instanceSize(spec.getClass()));
+                bytes = add(bytes, estimateListStructure(spec.fields()));
+            } else if (update instanceof MetadataUpdate.AddSortOrder) {
+                bytes = add(bytes, JvmSizeUtils.instanceSize(
+                        ((MetadataUpdate.AddSortOrder) update).sortOrder().getClass()));
+            }
+        }
+        return bytes;
+    }
+
+    private static long estimateContentFileList(List<? extends ContentFile<?>> files) {
+        if (files.isEmpty()) {
+            return 0L;
+        }
+        long bytes = add(estimateListStructure(files), CONTENT_FILE_SCHEMA_BYTES);
+        Set<Object> ownedObjects = java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+        for (ContentFile<?> file : files) {
+            bytes = add(bytes, estimateContentFile(file, ownedObjects));
+        }
+        return bytes;
+    }
+
+    private static long estimateContentFileSchema() {
+        long bytes = JvmSizeUtils.instanceSize(Types.StructType.class);
+        bytes = add(bytes, JvmSizeUtils.arrayListSize(CONTENT_FILE_FIELD_NAMES.length));
+        for (String name : CONTENT_FILE_FIELD_NAMES) {
+            bytes = add(bytes, JvmSizeUtils.instanceSize(Types.NestedField.class));
+            bytes = add(bytes, JvmSizeUtils.stringSize(name));
+        }
+        return bytes;
+    }
+
+    private static long estimateContentFile(ContentFile<?> file, Set<Object> ownedObjects) {
+        long bytes = JvmSizeUtils.instanceSize(file.getClass());
+        if (file instanceof StructLike) {
+            bytes = add(bytes, JvmSizeUtils.intArraySize(((StructLike) file).size()));
+            bytes = add(bytes, LONG_SHALLOW_BYTES);
+        }
+        bytes = add(bytes, estimateOwnedCharSequence(file.path(), ownedObjects));
+        bytes = add(bytes, estimateOwnedString(file.manifestLocation(), ownedObjects));
+        bytes = add(bytes, estimatePartition(file.partition(), ownedObjects));
+        bytes = add(bytes, estimateLongMap(file.columnSizes()));
+        bytes = add(bytes, estimateLongMap(file.valueCounts()));
+        bytes = add(bytes, estimateLongMap(file.nullValueCounts()));
+        bytes = add(bytes, estimateLongMap(file.nanValueCounts()));
+        bytes = add(bytes, estimateByteBufferMap(file.lowerBounds()));
+        bytes = add(bytes, estimateByteBufferMap(file.upperBounds()));
+        ByteBuffer keyMetadata = file.keyMetadata();
+        if (keyMetadata != null) {
+            bytes = add(bytes, JvmSizeUtils.byteArraySize(keyMetadata.remaining()));
+        }
+        List<Long> splitOffsets = file.splitOffsets();
+        if (splitOffsets != null) {
+            bytes = add(bytes, JvmSizeUtils.longArraySize(splitOffsets.size()));
+        }
+        List<Integer> equalityFieldIds = file.equalityFieldIds();
+        if (equalityFieldIds != null) {
+            bytes = add(bytes, JvmSizeUtils.intArraySize(equalityFieldIds.size()));
+        }
+        bytes = add(bytes, estimateBoxed(file.pos(), LONG_SHALLOW_BYTES));
+        bytes = add(bytes, estimateBoxed(file.sortOrderId(), INTEGER_SHALLOW_BYTES));
+        bytes = add(bytes, estimateBoxed(file.dataSequenceNumber(), LONG_SHALLOW_BYTES));
+        bytes = add(bytes, estimateBoxed(file.fileSequenceNumber(), LONG_SHALLOW_BYTES));
+        bytes = add(bytes, estimateBoxed(file.firstRowId(), LONG_SHALLOW_BYTES));
+        if (file instanceof DeleteFile) {
+            DeleteFile deleteFile = (DeleteFile) file;
+            bytes = add(bytes, estimateOwnedString(deleteFile.referencedDataFile(), ownedObjects));
+            bytes = add(bytes, estimateBoxed(deleteFile.contentOffset(), LONG_SHALLOW_BYTES));
+            bytes = add(bytes, estimateBoxed(deleteFile.contentSizeInBytes(), LONG_SHALLOW_BYTES));
+        }
+        return bytes;
+    }
+
+    private static long estimatePartition(StructLike partition, Set<Object> ownedObjects) {
+        if (partition == null || !ownedObjects.add(partition)) {
+            return 0L;
+        }
+        long bytes = JvmSizeUtils.instanceSize(partition.getClass());
+        bytes = add(bytes, JvmSizeUtils.objectArraySize(partition.size()));
+        for (int i = 0; i < partition.size(); i++) {
+            bytes = add(bytes, estimateOwnedScalar(partition.get(i, Object.class), ownedObjects));
+        }
+        return bytes;
+    }
+
+    private static long estimateOwnedScalar(Object value, Set<Object> ownedObjects) {
+        if (value == null || !ownedObjects.add(value)) {
+            return 0L;
+        }
+        if (value instanceof CharSequence) {
+            return estimateCharSequence((CharSequence) value);
+        }
+        if (value instanceof ByteBuffer) {
+            return estimateByteBuffer((ByteBuffer) value);
+        }
+        return JvmSizeUtils.instanceSize(value.getClass());
+    }
+
+    private static long estimateOwnedCharSequence(CharSequence value, Set<Object> ownedObjects) {
+        return value == null || !ownedObjects.add(value) ? 0L : estimateCharSequence(value);
+    }
+
+    private static long estimateOwnedString(String value, Set<? super String> ownedStrings) {
+        return value == null || !ownedStrings.add(value) ? 0L : JvmSizeUtils.stringSize(value);
+    }
+
+    private static long estimateCharSequence(CharSequence value) {
+        if (value instanceof String) {
+            return JvmSizeUtils.stringSize((String) value);
+        }
+        return add(JvmSizeUtils.instanceSize(value.getClass()), JvmSizeUtils.stringSize(value.toString()));
+    }
+
+    private static long estimateLongMap(Map<Integer, Long> values) {
+        if (values == null || values.isEmpty()) {
+            return 0L;
+        }
+        return add(estimateMapStructure(values), multiply(values.size(), INTEGER_SHALLOW_BYTES + LONG_SHALLOW_BYTES));
+    }
+
+    private static long estimateByteBufferMap(Map<Integer, ByteBuffer> values) {
+        if (values == null || values.isEmpty()) {
+            return 0L;
+        }
+        long bytes = add(estimateMapStructure(values), multiply(values.size(), INTEGER_SHALLOW_BYTES));
+        for (ByteBuffer value : values.values()) {
+            bytes = add(bytes, estimateByteBuffer(value));
+        }
+        return bytes;
+    }
+
+    private static long estimateByteBuffer(ByteBuffer value) {
+        if (value == null) {
+            return 0L;
+        }
+        long bytes = JvmSizeUtils.instanceSize(value.getClass());
+        byte[] backing = JvmSizeUtils.byteBufferBackingArray(value);
+        return backing == null ? bytes : add(bytes, JvmSizeUtils.byteArraySize(backing.length));
+    }
+
+    private static long estimateSchemaIndexes(int fieldCount) {
+        if (fieldCount == 0) {
+            return 0L;
+        }
+        long oneIndex = JvmSizeUtils.instanceSize(HashMap.class);
+        oneIndex = add(oneIndex, JvmSizeUtils.objectArraySize(hashCapacity(fieldCount)));
+        oneIndex = add(oneIndex, multiply(fieldCount, HASH_MAP_NODE_SHALLOW_BYTES));
+        long bytes = multiply(3L, oneIndex);
+        return add(bytes, multiply(2L * fieldCount, INTEGER_SHALLOW_BYTES));
+    }
+
+    private static long estimateIntegerIndexMap(Map<Integer, ?> values) {
+        return add(estimateMapStructure(values), multiply(values.size(), INTEGER_SHALLOW_BYTES));
+    }
+
+    private static long estimateLongIndexMap(List<?> values) {
+        if (values.isEmpty()) {
+            return JvmSizeUtils.instanceSize(HashMap.class);
+        }
+        long bytes = JvmSizeUtils.instanceSize(HashMap.class);
+        bytes = add(bytes, JvmSizeUtils.objectArraySize(hashCapacity(values.size())));
+        bytes = add(bytes, multiply(values.size(), HASH_MAP_NODE_SHALLOW_BYTES));
+        return add(bytes, multiply(values.size(), LONG_SHALLOW_BYTES));
+    }
+
+    private static long estimateStringMap(Map<String, String> values) {
+        if (values == null) {
+            return 0L;
+        }
+        long bytes = estimateMapStructure(values);
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            bytes = add(bytes, JvmSizeUtils.stringSize(entry.getKey()));
+            bytes = add(bytes, JvmSizeUtils.stringSize(entry.getValue()));
+        }
+        return bytes;
+    }
+
+    private static long estimateStringList(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return 0L;
+        }
+        long bytes = estimateListStructure(values);
+        for (String value : values) {
+            bytes = add(bytes, JvmSizeUtils.stringSize(value));
+        }
+        return bytes;
+    }
+
+    private static long estimateBoxedList(List<?> values, long elementBytes) {
+        if (values == null || values.isEmpty()) {
+            return 0L;
+        }
+        return add(estimateListStructure(values), multiply(values.size(), elementBytes));
+    }
+
+    private static long estimateBoxed(Object value, long bytes) {
+        return value == null ? 0L : bytes;
+    }
+
+    private static long estimateListStructure(List<?> values) {
+        int capacity = values instanceof ArrayList ? arrayListCapacity(values.size()) : values.size();
+        long bytes = JvmSizeUtils.instanceSize(values.getClass());
+        if (values.getClass().getName().equals("java.util.ImmutableCollections$List12")) {
+            return bytes;
+        }
+        return add(bytes, JvmSizeUtils.objectArraySize(capacity));
+    }
+
+    private static long estimateMapStructure(Map<?, ?> values) {
+        if (values == null) {
+            return 0L;
+        }
+        long bytes = JvmSizeUtils.instanceSize(values.getClass());
+        if (values.isEmpty()) {
+            return bytes;
+        }
+        if (values instanceof HashMap) {
+            int capacity = hashCapacity(values.size());
+            long nodeBytes = values instanceof LinkedHashMap
+                    ? LINKED_HASH_MAP_ENTRY_SHALLOW_BYTES
+                    : HASH_MAP_NODE_SHALLOW_BYTES;
+            bytes = add(bytes, JvmSizeUtils.objectArraySize(capacity));
+            return add(bytes, multiply(values.size(), nodeBytes));
+        }
+        bytes = add(bytes, JvmSizeUtils.objectArraySize(saturatedDouble(values.size())));
+        return add(bytes, multiply(values.size(), HASH_MAP_NODE_SHALLOW_BYTES));
+    }
+
+    private static int arrayListCapacity(int size) {
+        if (size == 0) {
+            return 0;
+        }
+        int capacity = 10;
+        while (capacity < size) {
+            int grown = capacity + (capacity >> 1);
+            if (grown < 0) {
+                return Integer.MAX_VALUE;
+            }
+            capacity = grown;
+        }
+        return capacity;
+    }
+
+    private static int hashCapacity(int size) {
+        if (size == 0) {
+            return 0;
+        }
+        long needed = (size * 4L + 2L) / 3L;
+        int capacity = 16;
+        while (capacity < needed && capacity < 1 << 30) {
+            capacity <<= 1;
+        }
+        return capacity;
+    }
+
+    private static int saturatedDouble(int value) {
+        return value > Integer.MAX_VALUE / 2 ? Integer.MAX_VALUE : value * 2;
+    }
+
+    private static long multiply(long left, long right) {
+        return JvmSizeUtils.saturatedMultiply(left, right);
+    }
+
+    private static long classSize(String className) {
+        try {
+            return JvmSizeUtils.instanceSize(Class.forName(className));
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Required JVM collection class is missing: " + className, e);
+        }
+    }
+
+    private static long add(long left, long right) {
+        return JvmSizeUtils.saturatedAdd(left, right);
+    }
+}

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergCatalogProperties.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergCatalogProperties.java
@@ -135,7 +135,11 @@ public final class IcebergCatalogProperties {
      * @return this, so the provider can call it in one expression
      */
     public IcebergCatalogProperties checkCreateTimeOnlyRules() {
-        checkMetaCacheProperties(raw);
+        return checkCreateTimeOnlyRules(raw);
+    }
+
+    public IcebergCatalogProperties checkCreateTimeOnlyRules(Map<String, String> submittedProperties) {
+        checkMetaCacheProperties(raw, submittedProperties);
         // DLF only exposes two-level namespaces; applying a synthetic root would make every lookup miss.
         if (TYPE_DLF.equals(flavor) && externalCatalogName != null) {
             throw new IllegalArgumentException("external_catalog.name is not supported for Iceberg DLF catalogs");
@@ -156,7 +160,10 @@ public final class IcebergCatalogProperties {
      * {@code enable} must be boolean, {@code ttl-second} must be a long &ge; -1 (the "no expiration"
      * sentinel), {@code capacity} must be a long &ge; 0. Absent keys are skipped.
      */
-    private static void checkMetaCacheProperties(Map<String, String> properties) {
+    private static void checkMetaCacheProperties(
+            Map<String, String> properties, Map<String, String> submittedProperties) {
+        CacheSpec.checkWeightProperties(properties, submittedProperties, "iceberg",
+                "table", "partition", "manifest", "partition_view");
         CacheSpec.checkBooleanProperty(properties.get(IcebergConnector.TABLE_CACHE_ENABLE),
                 IcebergConnector.TABLE_CACHE_ENABLE);
         CacheSpec.checkLongProperty(properties.get(IcebergConnector.TABLE_CACHE_TTL_SECOND),

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergCommentCache.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergCommentCache.java
@@ -21,6 +21,7 @@ import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.cache.MetaCache;
 import org.apache.doris.connector.cache.MetaCacheDefinition;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimators;
 import org.apache.doris.connector.cache.ScopePath;
 
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -57,7 +58,7 @@ final class IcebergCommentCache {
     private final MetaCache<TableIdentifier, String> entry;
 
     IcebergCommentCache(long ttlSeconds, int maxSize) {
-        this(new CatalogMetaCache(), ttlSeconds, maxSize);
+        this(CatalogMetaCache.unmanaged(), ttlSeconds, maxSize);
     }
 
     IcebergCommentCache(CatalogMetaCache owner, long ttlSeconds, int maxSize) {
@@ -68,6 +69,7 @@ final class IcebergCommentCache {
         CacheSpec spec = CacheSpec.ofConnectorTtl(ttlSeconds, maxSize);
         this.entry = owner.create(MetaCacheDefinition
                 .<TableIdentifier, String>builder("iceberg-comment", spec, IcebergCommentCache::scope)
+                .sizeEstimator(MetaCacheSizeEstimators.reflective())
                 .build());
     }
 

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnector.java
@@ -17,8 +17,10 @@
 
 package org.apache.doris.connector.iceberg;
 
+import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.cache.ConnectorMetadataCache;
+import org.apache.doris.connector.cache.ScopePath;
 import org.apache.doris.connector.iceberg.dlf.DLFCatalog;
 import org.apache.doris.connector.metastore.DlfMetaStoreProperties;
 import org.apache.doris.connector.metastore.iceberg.jdbc.IcebergJdbcMetaStoreProperties;
@@ -233,10 +235,10 @@ public class IcebergConnector implements Connector {
             mvccPartitionViewCache;
     private final ConnectorMetadataCache<List<ConnectorPartitionInfo>> // null under session=user
             listPartitionsViewCache;
-    private final CatalogMetaCache metaCache = new CatalogMetaCache();
+    private final CatalogMetaCache metaCache;
     // Manifest content cache — pure metadata, default-off (meta.cache.iceberg.manifest.enable), and consumed
     // ONLY after a per-user resolveTable(ForRead) -- exempt: no read path without a per-user load.
-    private final IcebergManifestCache manifestCache = new IcebergManifestCache(metaCache);
+    private final IcebergManifestCache manifestCache;
 
     // Lazily-built plugin-side Kerberos authenticator (single-owner auth; see TcclPinningConnectorContext).
     // null for a non-Kerberos catalog. Its doAs acts on the PLUGIN's UserGroupInformation copy — the one the
@@ -260,6 +262,8 @@ public class IcebergConnector implements Connector {
         // authenticator never logs in — so without this the DDL/read hits secured HDFS as SIMPLE auth.
         this.context = new TcclPinningConnectorContext(context, getClass().getClassLoader(),
                 this::pluginAuthenticator);
+        this.metaCache = CatalogMetaCache.managed(context.getCatalogId(), "iceberg", this.properties);
+        this.manifestCache = new IcebergManifestCache(metaCache, this.properties);
         // Authorization-sensitive projection (snapshotId/schemaId). Under iceberg.rest.session=user the value is
         // per-user AUTHORIZED metadata that a "can-list-cannot-load" principal must not see. beginQuerySnapshot
         // reads this cache WITHOUT a preceding per-user loadTable, so a shared (table-keyed, no user dimension)
@@ -283,7 +287,7 @@ public class IcebergConnector implements Connector {
                 || IcebergScanPlanProvider.restVendedCredentialsEnabled(this.properties))
                 ? null
                 : new IcebergTableCache(
-                        metaCache, resolveTableCacheTtlSecond(this.properties), DEFAULT_TABLE_CACHE_CAPACITY,
+                        metaCache, cacheSpec("table"),
                         this::cachedTableCleanup, catalogResourceTracker);
         // PERF-02: partition-view cache. Authorization-sensitive projection: a shared (table+snapshot-keyed, no
         // user dimension) hit would disclose one user's partition list. Its readers are all downstream of a
@@ -294,7 +298,7 @@ public class IcebergConnector implements Connector {
         this.partitionCache = isUserSessionEnabled()
                 ? null
                 : new IcebergPartitionCache(
-                        metaCache, resolveTableCacheTtlSecond(this.properties), DEFAULT_TABLE_CACHE_CAPACITY);
+                        metaCache, cacheSpec("partition"));
         // PERF-03: inferred-file-format cache. Same authorization-sensitive treatment as partitionCache (disabled
         // under session=user, kept otherwise); readers already tolerate a null cache (resolveFileFormatName).
         this.formatCache = isUserSessionEnabled()
@@ -319,11 +323,15 @@ public class IcebergConnector implements Connector {
         this.mvccPartitionViewCache = isUserSessionEnabled()
                 ? null
                 : new ConnectorMetadataCache<>(metaCache, "iceberg.mvcc-partition-view",
-                        "iceberg", "partition_view", this.properties);
+                        "iceberg", "partition_view", this.properties,
+                        key -> ScopePath.table(key.getDb(), key.getTable()),
+                        IcebergCacheSizeEstimator::estimateMvccPartitionViewEntry);
         this.listPartitionsViewCache = isUserSessionEnabled()
                 ? null
                 : new ConnectorMetadataCache<>(metaCache, "iceberg.list-partitions-view",
-                        "iceberg", "partition_view", this.properties);
+                        "iceberg", "partition_view", this.properties,
+                        key -> ScopePath.table(key.getDb(), key.getTable()),
+                        IcebergCacheSizeEstimator::estimatePartitionInfoViewEntry);
     }
 
     /**
@@ -343,6 +351,15 @@ public class IcebergConnector implements Connector {
                     DEFAULT_TABLE_CACHE_TTL_SECOND);
             return DEFAULT_TABLE_CACHE_TTL_SECOND;
         }
+    }
+
+    private CacheSpec cacheSpec(String entryName) {
+        CacheSpec defaults = CacheSpec.ofConnectorTtl(
+                resolveTableCacheTtlSecond(this.properties), DEFAULT_TABLE_CACHE_CAPACITY);
+        // Normalize the legacy table knob before generic parsing can reinterpret -1 as no expiration.
+        Map<String, String> cacheProperties = new HashMap<>(this.properties);
+        cacheProperties.put(TABLE_CACHE_TTL_SECOND, Long.toString(defaults.getTtlSecond()));
+        return CacheSpec.fromProperties(cacheProperties, "iceberg", entryName, defaults);
     }
 
     @Override

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnectorProvider.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergConnectorProvider.java
@@ -23,6 +23,7 @@ import org.apache.doris.connector.spi.ConnectorProvider;
 import org.apache.doris.connector.spi.DorisConnectorException;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -66,6 +67,15 @@ public class IcebergConnectorProvider implements ConnectorProvider {
     @Override
     public void validateProperties(Map<String, String> properties) {
         IcebergCatalogProperties.of(properties).checkCreateTimeOnlyRules();
+    }
+
+    @Override
+    public void validatePropertiesForUpdate(
+            Map<String, String> currentProperties, Map<String, String> updatedProperties) {
+        Map<String, String> candidate = currentProperties == null
+                ? new HashMap<>() : new HashMap<>(currentProperties);
+        candidate.putAll(updatedProperties);
+        IcebergCatalogProperties.of(candidate).checkCreateTimeOnlyRules(updatedProperties);
     }
 
     @Override

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergFormatCache.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergFormatCache.java
@@ -21,6 +21,7 @@ import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.cache.MetaCache;
 import org.apache.doris.connector.cache.MetaCacheDefinition;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimators;
 import org.apache.doris.connector.cache.ScopePath;
 
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -93,7 +94,7 @@ final class IcebergFormatCache {
     private final MetaCache<Key, String> entry;
 
     IcebergFormatCache(long ttlSeconds, int maxSize) {
-        this(new CatalogMetaCache(), ttlSeconds, maxSize);
+        this(CatalogMetaCache.unmanaged(), ttlSeconds, maxSize);
     }
 
     IcebergFormatCache(CatalogMetaCache owner, long ttlSeconds, int maxSize) {
@@ -102,6 +103,7 @@ final class IcebergFormatCache {
         CacheSpec spec = CacheSpec.ofConnectorTtl(ttlSeconds, maxSize);
         this.entry = owner.create(MetaCacheDefinition
                 .<Key, String>builder("iceberg-format", spec, IcebergFormatCache::scope)
+                .sizeEstimator(MetaCacheSizeEstimators.reflective())
                 .build());
     }
 

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergLatestSnapshotCache.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergLatestSnapshotCache.java
@@ -21,6 +21,7 @@ import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.cache.MetaCache;
 import org.apache.doris.connector.cache.MetaCacheDefinition;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimators;
 import org.apache.doris.connector.cache.ScopePath;
 import org.apache.doris.connector.spi.mvcc.ConnectorMvccPartitionView;
 
@@ -77,7 +78,7 @@ final class IcebergLatestSnapshotCache {
     private final MetaCache<TableIdentifier, CachedSnapshot> entry;
 
     IcebergLatestSnapshotCache(long ttlSeconds, int maxSize) {
-        this(new CatalogMetaCache(), ttlSeconds, maxSize);
+        this(CatalogMetaCache.unmanaged(), ttlSeconds, maxSize);
     }
 
     IcebergLatestSnapshotCache(CatalogMetaCache owner, long ttlSeconds, int maxSize) {
@@ -87,6 +88,7 @@ final class IcebergLatestSnapshotCache {
         this.entry = owner.create(MetaCacheDefinition
                 .<TableIdentifier, CachedSnapshot>builder(
                         "iceberg-latest-snapshot", spec, IcebergLatestSnapshotCache::scope)
+                .sizeEstimator(MetaCacheSizeEstimators.reflective())
                 .build());
     }
 

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergManifestCache.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergManifestCache.java
@@ -21,6 +21,7 @@ import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.cache.MetaCache;
 import org.apache.doris.connector.cache.MetaCacheDefinition;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimators;
 import org.apache.doris.connector.cache.ScopePath;
 
 import org.apache.iceberg.DataFile;
@@ -131,38 +132,52 @@ final class IcebergManifestCache {
     }
 
     IcebergManifestCache() {
-        this(new CatalogMetaCache(), DEFAULT_MANIFEST_CACHE_CAPACITY);
+        this(CatalogMetaCache.unmanaged(), DEFAULT_MANIFEST_CACHE_CAPACITY);
     }
 
     IcebergManifestCache(CatalogMetaCache owner) {
-        this(owner, DEFAULT_MANIFEST_CACHE_CAPACITY);
+        this(owner, Collections.emptyMap());
+    }
+
+    IcebergManifestCache(CatalogMetaCache owner, Map<String, String> properties) {
+        this(owner, DEFAULT_MANIFEST_CACHE_CAPACITY, DEFAULT_STATS_TTL_SECONDS,
+                System::nanoTime, properties);
     }
 
     IcebergManifestCache(int maxSize) {
-        this(new CatalogMetaCache(), maxSize);
+        this(CatalogMetaCache.unmanaged(), maxSize);
     }
 
     private IcebergManifestCache(CatalogMetaCache owner, int maxSize) {
-        this(owner, maxSize, DEFAULT_STATS_TTL_SECONDS, System::nanoTime);
+        this(owner, maxSize, DEFAULT_STATS_TTL_SECONDS, System::nanoTime, Collections.emptyMap());
     }
 
     /** Visible for testing: injectable stats TTL + clock so the leak sweep is deterministic without sleeping. */
     IcebergManifestCache(int maxSize, long statsTtlSeconds, LongSupplier nanoClock) {
-        this(new CatalogMetaCache(), maxSize, statsTtlSeconds, nanoClock);
+        this(CatalogMetaCache.unmanaged(), maxSize, statsTtlSeconds, nanoClock);
     }
 
     private IcebergManifestCache(
             CatalogMetaCache owner, int maxSize, long statsTtlSeconds, LongSupplier nanoClock) {
+        this(owner, maxSize, statsTtlSeconds, nanoClock, Collections.emptyMap());
+    }
+
+    private IcebergManifestCache(
+            CatalogMetaCache owner, int maxSize, long statsTtlSeconds, LongSupplier nanoClock,
+            Map<String, String> properties) {
         this.owner = owner;
         // Always enabled, no expiry, capacity-bounded (CACHE_NO_TTL == -1 means "no expiration", enabled).
-        CacheSpec spec = CacheSpec.of(true, CacheSpec.CACHE_NO_TTL, Math.max(1, maxSize));
+        CacheSpec defaultSpec = CacheSpec.of(true, CacheSpec.CACHE_NO_TTL, Math.max(1, maxSize));
+        CacheSpec spec = CacheSpec.fromProperties(properties, "iceberg", "manifest", defaultSpec);
         this.entry = owner.create(MetaCacheDefinition
                 .<IcebergManifestEntryKey, ManifestCacheValue>builder(
                         "iceberg-manifest", spec, ignored -> ScopePath.catalog())
+                .sizeEstimator(IcebergCacheSizeEstimator::estimateManifestEntry)
                 .build());
         this.equalityDeleteFieldIds = owner.create(MetaCacheDefinition
                 .<SnapshotKey, Set<Integer>>builder(
-                        "iceberg-equality-delete-field-ids", spec, ignored -> ScopePath.catalog())
+                        "iceberg-equality-delete-field-ids", defaultSpec, ignored -> ScopePath.catalog())
+                .sizeEstimator(MetaCacheSizeEstimators.reflective())
                 .build());
         this.statsTtlNanos = TimeUnit.SECONDS.toNanos(Math.max(1L, statsTtlSeconds));
         this.nanoClock = nanoClock;
@@ -187,7 +202,8 @@ final class IcebergManifestCache {
      */
     ManifestCacheValue getManifestCacheValue(ManifestFile manifest, Table table) {
         IcebergManifestEntryKey key = IcebergManifestEntryKey.of(manifest);
-        return entry.get(key, k -> loadManifestCacheValue(manifest, table, k.getContent()));
+        return entry.get(key, k -> loadManifestCacheValue(
+                manifest, table, k.getContent(), entry.isWeightBounded()));
     }
 
     /**
@@ -207,7 +223,8 @@ final class IcebergManifestCache {
                 stats.misses++;
             }
         }
-        return entry.get(key, k -> loadManifestCacheValue(manifest, table, k.getContent()));
+        return entry.get(key, k -> loadManifestCacheValue(
+                manifest, table, k.getContent(), entry.isWeightBounded()));
     }
 
     /**
@@ -254,12 +271,12 @@ final class IcebergManifestCache {
     }
 
     private static ManifestCacheValue loadManifestCacheValue(ManifestFile manifest, Table table,
-            ManifestContent content) {
+            ManifestContent content, boolean estimateWeight) {
         try {
             if (content == ManifestContent.DELETES) {
-                return ManifestCacheValue.forDeleteFiles(loadDeleteFiles(manifest, table));
+                return ManifestCacheValue.forDeleteFiles(loadDeleteFiles(manifest, table), estimateWeight);
             }
-            return ManifestCacheValue.forDataFiles(loadDataFiles(manifest, table));
+            return ManifestCacheValue.forDataFiles(loadDataFiles(manifest, table), estimateWeight);
         } catch (IOException e) {
             throw new RuntimeException("Failed to read iceberg manifest " + manifest.path(), e);
         }

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergPartitionCache.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergPartitionCache.java
@@ -21,11 +21,15 @@ import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.cache.MetaCache;
 import org.apache.doris.connector.cache.MetaCacheDefinition;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimate;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimator;
 import org.apache.doris.connector.cache.ScopePath;
 import org.apache.doris.connector.iceberg.IcebergPartitionUtils.IcebergRawPartition;
 
 import org.apache.iceberg.catalog.TableIdentifier;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -86,19 +90,38 @@ final class IcebergPartitionCache {
         }
     }
 
+    static final class CachedPartitions {
+        final List<IcebergRawPartition> partitions;
+        final MetaCacheSizeEstimate sizeEstimate;
+
+        CachedPartitions(List<IcebergRawPartition> partitions, boolean estimateWeight) {
+            this.partitions = estimateWeight
+                    ? Collections.unmodifiableList(new ArrayList<>(partitions))
+                    : partitions;
+            this.sizeEstimate = estimateWeight
+                    ? MetaCacheSizeEstimator.estimateSafely("iceberg_partition_estimator_failure",
+                            () -> MetaCacheSizeEstimate.complete(
+                                    IcebergCacheSizeEstimator.estimatePartitions(this.partitions)))
+                    : MetaCacheSizeEstimate.complete(0L);
+        }
+    }
+
     private final CatalogMetaCache owner;
-    private final MetaCache<Key, List<IcebergRawPartition>> entry;
+    private final MetaCache<Key, CachedPartitions> entry;
 
     IcebergPartitionCache(long ttlSeconds, int maxSize) {
-        this(new CatalogMetaCache(), ttlSeconds, maxSize);
+        this(CatalogMetaCache.unmanaged(), ttlSeconds, maxSize);
     }
 
     IcebergPartitionCache(CatalogMetaCache owner, long ttlSeconds, int maxSize) {
+        this(owner, CacheSpec.ofConnectorTtl(ttlSeconds, maxSize));
+    }
+
+    IcebergPartitionCache(CatalogMetaCache owner, CacheSpec spec) {
         this.owner = owner;
-        // "<= 0 disables" connector TTL contract, folded to CacheSpec's disable sentinel (CacheSpec.ofConnectorTtl).
-        CacheSpec spec = CacheSpec.ofConnectorTtl(ttlSeconds, maxSize);
         this.entry = owner.create(MetaCacheDefinition
-                .<Key, List<IcebergRawPartition>>builder("iceberg-partition", spec, IcebergPartitionCache::scope)
+                .<Key, CachedPartitions>builder("iceberg-partition", spec, IcebergPartitionCache::scope)
+                .sizeEstimator(IcebergCacheSizeEstimator::estimatePartitionEntry)
                 .build());
     }
 
@@ -113,7 +136,8 @@ final class IcebergPartitionCache {
      * loader runs OUTSIDE Caffeine's compute lock (single-flight per key) and its exception propagates unwrapped.
      */
     List<IcebergRawPartition> getOrLoad(Key key, Supplier<List<IcebergRawPartition>> loader) {
-        return entry.get(key, ignored -> loader.get());
+        return entry.get(key, ignored -> new CachedPartitions(loader.get(),
+                entry.isEnabled() && entry.isWeightBounded())).partitions;
     }
 
     /** Drops every cached snapshot entry for one table so the next read scans live (REFRESH TABLE). */

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergPartitionUtils.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergPartitionUtils.java
@@ -990,6 +990,22 @@ final class IcebergPartitionUtils {
             this.lastUpdateTime = lastUpdateTime;
             this.lastSnapshotId = lastSnapshotId;
         }
+
+        String nameForWeight() {
+            return name;
+        }
+
+        List<String> columnNamesForWeight() {
+            return columnNames;
+        }
+
+        List<String> valuesForWeight() {
+            return values;
+        }
+
+        List<String> transformsForWeight() {
+            return transforms;
+        }
     }
 
     /** A single physical partition's computed range: time interval (for the overlap merge) + pre-rendered bounds. */

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergStatementScope.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergStatementScope.java
@@ -110,7 +110,7 @@ final class IcebergStatementScope {
             Function<Table, T> action) {
         if (session == null || session.getStatementScope() == ConnectorStatementScope.NONE) {
             try (IcebergTableCache.TableLease lease = loader.get()) {
-                return action.apply(snapshotReadTable(lease.table()));
+                return action.apply(lease.snapshotReadTable());
             }
         }
         return action.apply(sharedBorrowedTable(session, dbName, tableName, loader, unscopedLoader));
@@ -148,7 +148,7 @@ final class IcebergStatementScope {
 
         private ScopedBorrow(IcebergTableCache.TableLease lease) {
             this.lease = lease;
-            this.table = snapshotReadTable(lease.table());
+            this.table = lease.snapshotReadTable();
         }
 
         @Override

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergTableCache.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/IcebergTableCache.java
@@ -19,11 +19,18 @@ package org.apache.doris.connector.iceberg;
 
 import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.cache.CatalogMetaCache;
+import org.apache.doris.connector.cache.JvmSizeUtils;
 import org.apache.doris.connector.cache.MetaCache;
 import org.apache.doris.connector.cache.MetaCacheDefinition;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimate;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimator;
 import org.apache.doris.connector.cache.ScopePath;
 
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.TableIdentifier;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -50,9 +57,11 @@ import java.util.function.Supplier;
  * {@code expireAfterAccess} with a {@code maxSize} capacity. Lives on the long-lived per-catalog
  * {@link IcebergConnector}; a REFRESH CATALOG rebuilds the connector and thus the cache.
  *
- * <p><b>Values are RAW tables.</b> The scan provider applies {@code wrapTableForScan} (the Kerberos
+ * <p><b>Values own RAW tables.</b> The scan provider applies {@code wrapTableForScan} (the Kerberos
  * {@code doAs} FileIO wrap) per call on the way out, so no per-request authenticator is ever frozen into a
- * shared entry.
+ * shared entry. A weight-bounded owner also retains and accounts for one serialized metadata generation;
+ * each statement parses that generation into a private read table so Iceberg's lazy manifest fields cannot
+ * grow the already-admitted cache value.
  *
  * <p><b>Credential isolation.</b> A raw table carries its FileIO's credentials, so this cross-query layer is
  * built ONLY when the connector's credentials are query-independent — it is left disabled (the connector
@@ -69,29 +78,33 @@ final class IcebergTableCache {
     private final AtomicBoolean closed = new AtomicBoolean();
 
     IcebergTableCache(long ttlSeconds, int maxSize) {
-        this(new CatalogMetaCache(), ttlSeconds, maxSize, table -> () -> { }, null);
+        this(CatalogMetaCache.unmanaged(), ttlSeconds, maxSize, table -> () -> { }, null);
     }
 
     IcebergTableCache(long ttlSeconds, int maxSize, Function<Table, Runnable> cleanupFactory) {
-        this(new CatalogMetaCache(), ttlSeconds, maxSize, cleanupFactory, null);
+        this(CatalogMetaCache.unmanaged(), ttlSeconds, maxSize, cleanupFactory, null);
     }
 
     IcebergTableCache(long ttlSeconds, int maxSize, Function<Table, Runnable> cleanupFactory,
             IcebergCatalogResourceTracker resourceTracker) {
-        this(new CatalogMetaCache(), ttlSeconds, maxSize, cleanupFactory, resourceTracker);
+        this(CatalogMetaCache.unmanaged(), ttlSeconds, maxSize, cleanupFactory, resourceTracker);
     }
 
     IcebergTableCache(CatalogMetaCache owner, long ttlSeconds, int maxSize,
             Function<Table, Runnable> cleanupFactory, IcebergCatalogResourceTracker resourceTracker) {
+        this(owner, CacheSpec.ofConnectorTtl(ttlSeconds, maxSize), cleanupFactory, resourceTracker);
+    }
+
+    IcebergTableCache(CatalogMetaCache owner, CacheSpec spec,
+            Function<Table, Runnable> cleanupFactory, IcebergCatalogResourceTracker resourceTracker) {
         this.owner = owner;
         this.cleanupFactory = cleanupFactory;
         this.resourceTracker = resourceTracker;
-        // "<= 0 disables" connector TTL contract, folded to CacheSpec's disable sentinel (CacheSpec.ofConnectorTtl).
-        CacheSpec spec = CacheSpec.ofConnectorTtl(ttlSeconds, maxSize);
         this.entry = owner.create(MetaCacheDefinition
                 .<TableIdentifier, TableOwner>builder("iceberg-table", spec, IcebergTableCache::scope)
                 .removalListener((identifier, tableOwner, reason) -> tableOwner.release())
                 .discardListener((identifier, tableOwner) -> tableOwner.release())
+                .sizeEstimator(IcebergCacheSizeEstimator::estimateTableEntry)
                 .build());
     }
 
@@ -130,7 +143,8 @@ final class IcebergTableCache {
                             }
                         }
                     };
-                    TableOwner loaded = new TableOwner(table, cleanup, true);
+                    TableOwner loaded = new TableOwner(table, cleanup, true,
+                            entry.isEnabled() && entry.isWeightBounded());
                     loadedHere[0] = loaded;
                     return loaded;
                 } finally {
@@ -214,6 +228,10 @@ final class IcebergTableCache {
             return owner.table;
         }
 
+        Table snapshotReadTable() {
+            return owner.snapshotReadTable();
+        }
+
         @Override
         public void close() {
             if (closed.compareAndSet(false, true)) {
@@ -222,17 +240,58 @@ final class IcebergTableCache {
         }
     }
 
-    private static final class TableOwner {
+    static final class TableOwner {
         private final Table table;
         private final Runnable cleanup;
+        private final String snapshotMetadataJson;
+        private final String snapshotMetadataLocation;
+        final MetaCacheSizeEstimate sizeEstimate;
         // A newly loaded value starts with a cache reference and a temporary loader reference. The temporary
         // reference bridges publication/discard to the first borrow, including invalidation-before-publication.
         private final AtomicInteger references;
 
-        private TableOwner(Table table, Runnable cleanup, boolean loading) {
+        private TableOwner(Table table, Runnable cleanup, boolean loading, boolean estimateWeight) {
             this.table = table;
             this.cleanup = cleanup;
+            String[] metadataJson = {null};
+            String[] metadataLocation = {null};
+            this.sizeEstimate = estimateWeight
+                    ? MetaCacheSizeEstimator.estimateSafely("iceberg_table_estimator_failure",
+                            () -> {
+                                long serializedMetadataBytes = 0L;
+                                if (table instanceof BaseTable) {
+                                    TableMetadata metadata = ((BaseTable) table).operations().current();
+                                    String json = TableMetadataParser.toJson(metadata);
+                                    metadataJson[0] = json;
+                                    metadataLocation[0] = metadata.metadataFileLocation();
+                                    serializedMetadataBytes =
+                                            IcebergCacheSizeEstimator.estimateSerializedTableMetadata(json);
+                                }
+                                // Iceberg v1 serialization materializes lazy embedded-manifest state on the
+                                // retained BaseSnapshot, so weigh the table only after serialization completes.
+                                long bytes = JvmSizeUtils.saturatedAdd(
+                                        IcebergCacheSizeEstimator.estimateTable(table), serializedMetadataBytes);
+                                return MetaCacheSizeEstimate.complete(bytes);
+                            })
+                    : MetaCacheSizeEstimate.complete(0L);
+            // Serialization materializes v1 manifests with dummy InputFiles. Even an uncached borrower
+            // needs the successful JSON to reconstruct snapshots that can resolve manifests with real IO.
+            this.snapshotMetadataJson = metadataJson[0];
+            this.snapshotMetadataLocation = metadataLocation[0];
             this.references = new AtomicInteger(loading ? 2 : 1);
+        }
+
+        private Table snapshotReadTable() {
+            if (!(table instanceof BaseTable)) {
+                return table;
+            }
+            BaseTable baseTable = (BaseTable) table;
+            TableOperations operations = baseTable.operations();
+            TableMetadata metadata = snapshotMetadataJson == null
+                    ? operations.current()
+                    : TableMetadataParser.fromJson(snapshotMetadataLocation, snapshotMetadataJson);
+            return new BaseTable(new IcebergSnapshotTableOperations(operations, metadata),
+                    table.name(), baseTable.reporter());
         }
 
         private TableLease tryBorrow() {

--- a/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/ManifestCacheValue.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/main/java/org/apache/doris/connector/iceberg/ManifestCacheValue.java
@@ -17,6 +17,9 @@
 
 package org.apache.doris.connector.iceberg;
 
+import org.apache.doris.connector.cache.MetaCacheSizeEstimate;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimator;
+
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 
@@ -33,18 +36,32 @@ import java.util.List;
 public class ManifestCacheValue {
     private final List<DataFile> dataFiles;
     private final List<DeleteFile> deleteFiles;
+    private final MetaCacheSizeEstimate sizeEstimate;
 
-    private ManifestCacheValue(List<DataFile> dataFiles, List<DeleteFile> deleteFiles) {
+    private ManifestCacheValue(List<DataFile> dataFiles, List<DeleteFile> deleteFiles, boolean estimateWeight) {
         this.dataFiles = dataFiles == null ? Collections.emptyList() : dataFiles;
         this.deleteFiles = deleteFiles == null ? Collections.emptyList() : deleteFiles;
+        this.sizeEstimate = estimateWeight
+                ? MetaCacheSizeEstimator.estimateSafely("iceberg_manifest_estimator_failure",
+                        () -> MetaCacheSizeEstimate.complete(
+                                IcebergCacheSizeEstimator.estimateManifestValue(this)))
+                : MetaCacheSizeEstimate.complete(0L);
     }
 
     public static ManifestCacheValue forDataFiles(List<DataFile> dataFiles) {
-        return new ManifestCacheValue(dataFiles, Collections.emptyList());
+        return forDataFiles(dataFiles, false);
+    }
+
+    static ManifestCacheValue forDataFiles(List<DataFile> dataFiles, boolean estimateWeight) {
+        return new ManifestCacheValue(dataFiles, Collections.emptyList(), estimateWeight);
     }
 
     public static ManifestCacheValue forDeleteFiles(List<DeleteFile> deleteFiles) {
-        return new ManifestCacheValue(Collections.emptyList(), deleteFiles);
+        return forDeleteFiles(deleteFiles, false);
+    }
+
+    static ManifestCacheValue forDeleteFiles(List<DeleteFile> deleteFiles, boolean estimateWeight) {
+        return new ManifestCacheValue(Collections.emptyList(), deleteFiles, estimateWeight);
     }
 
     public List<DataFile> getDataFiles() {
@@ -53,5 +70,9 @@ public class ManifestCacheValue {
 
     public List<DeleteFile> getDeleteFiles() {
         return deleteFiles;
+    }
+
+    MetaCacheSizeEstimate getSizeEstimate() {
+        return sizeEstimate;
     }
 }

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergCatalogPropertiesTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergCatalogPropertiesTest.java
@@ -37,6 +37,21 @@ import java.util.Map;
  */
 public class IcebergCatalogPropertiesTest {
 
+    @Test
+    public void alterToleratesPersistedFutureWeightEntryButValidatesKnownValues() {
+        Map<String, String> current = props("iceberg.catalog.type", "hadoop", "warehouse", "s3://bucket/wh",
+                "meta.cache.iceberg.future_entry.max-weight", "future-format");
+        IcebergConnectorProvider provider = new IcebergConnectorProvider();
+        Assertions.assertThrows(IllegalArgumentException.class, () -> provider.validateProperties(current));
+        Assertions.assertDoesNotThrow(() -> IcebergCatalogProperties.of(current));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> provider.validatePropertiesForUpdate(
+                current, Collections.singletonMap("meta.cache.iceberg.partiton.max-weight", "64MB")));
+        Assertions.assertDoesNotThrow(() -> provider.validatePropertiesForUpdate(
+                current, Collections.singletonMap("comment", "updated")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> provider.validatePropertiesForUpdate(
+                current, Collections.singletonMap("meta.cache.iceberg.table.max-weight", "invalid")));
+    }
+
     private static Map<String, String> props(String... kv) {
         Map<String, String> m = new HashMap<>();
         for (int i = 0; i < kv.length; i += 2) {

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergConnectorCacheTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergConnectorCacheTest.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 /**
@@ -235,6 +236,50 @@ public class IcebergConnectorCacheTest {
                 new IcebergConnector(Collections.emptyMap(), new RecordingConnectorContext()).tableCacheForTest();
         Assertions.assertNotNull(cache, "a plain catalog must build the cross-query table cache");
         Assertions.assertTrue(cache.isEnabled(), "the default 24h TTL enables the cache");
+    }
+
+    @Test
+    public void nonPositiveTableTtlKeepsConnectorLoadsLiveWithAndWithoutQuota() throws Exception {
+        for (String ttl : new String[] {"-1", "0"}) {
+            for (String quotaKey : new String[] {"", "meta.cache.max-weight",
+                    "meta.cache.iceberg.table.max-weight"}) {
+                Map<String, String> properties = props(IcebergConnector.TABLE_CACHE_TTL_SECOND, ttl);
+                if (!quotaKey.isEmpty()) {
+                    properties.put(quotaKey, "1MB");
+                }
+                try (IcebergConnector connector =
+                        new IcebergConnector(properties, new RecordingConnectorContext())) {
+                    IcebergTableCache tables = connector.tableCacheForTest();
+                    IcebergLatestSnapshotCache snapshots = connector.latestSnapshotCacheForTest();
+                    TableIdentifier id = TableIdentifier.of("db1", "t1");
+                    AtomicInteger loads = new AtomicInteger();
+                    Supplier<IcebergLatestSnapshotCache.CachedSnapshot> loader = () -> {
+                        Table table = tables.getOrLoad(id, () -> fakeTable(
+                                Integer.toString(loads.incrementAndGet())));
+                        return new IcebergLatestSnapshotCache.CachedSnapshot(
+                                Long.parseLong(table.name()), table.schema().schemaId());
+                    };
+                    Assertions.assertEquals(1L, snapshots.getOrLoad(id, loader).snapshotId);
+                    Assertions.assertEquals(2L, snapshots.getOrLoad(id, loader).snapshotId);
+                    Assertions.assertEquals(2, loads.get());
+                    Assertions.assertFalse(tables.isEnabled(), ttl + " / " + quotaKey);
+                    Assertions.assertEquals(0, tables.size());
+                    Assertions.assertEquals(0, snapshots.size());
+                    Assertions.assertFalse(connector.partitionCacheForTest().isEnabled());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void independentPartitionTtlKeepsItsNoExpirationSemantics() throws Exception {
+        Map<String, String> properties = props(IcebergConnector.TABLE_CACHE_TTL_SECOND, "-1");
+        properties.put("meta.cache.iceberg.partition.ttl-second", "-1");
+        try (IcebergConnector connector =
+                new IcebergConnector(properties, new RecordingConnectorContext())) {
+            Assertions.assertFalse(connector.tableCacheForTest().isEnabled());
+            Assertions.assertTrue(connector.partitionCacheForTest().isEnabled());
+        }
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergConnectorMetadataPartitionViewCacheTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergConnectorMetadataPartitionViewCacheTest.java
@@ -18,6 +18,8 @@
 package org.apache.doris.connector.iceberg;
 
 import org.apache.doris.connector.cache.ConnectorMetadataCache;
+import org.apache.doris.connector.cache.ConnectorTableKey;
+import org.apache.doris.connector.cache.JvmSizeUtils;
 import org.apache.doris.connector.spi.ConnectorPartitionInfo;
 import org.apache.doris.connector.spi.handle.ConnectorTableHandle;
 import org.apache.doris.connector.spi.mvcc.ConnectorMvccPartition;
@@ -37,6 +39,7 @@ import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -123,6 +126,63 @@ public class IcebergConnectorMetadataPartitionViewCacheTest {
     private static List<String> mvccNames(Optional<ConnectorMvccPartitionView> view) {
         return view.get().getPartitions().stream()
                 .map(ConnectorMvccPartition::getName).collect(Collectors.toList());
+    }
+
+    @Test
+    public void derivedViewWeightsIncludeTailAtEveryPosition() {
+        ConnectorTableKey key = new ConnectorTableKey("db", "table", 1L, 1L);
+        String large = "x".repeat(1024 * 1024);
+        long listBaseline = 0L;
+        long mvccBaseline = 0L;
+        for (int position : new int[] {-1, 0, 333, 998, 999}) {
+            List<ConnectorPartitionInfo> listView = new ArrayList<>();
+            List<ConnectorMvccPartition> mvccPartitions = new ArrayList<>();
+            for (int index = 0; index < 1000; index++) {
+                String value = index == position ? large : "x";
+                listView.add(new ConnectorPartitionInfo("p=" + value,
+                        Collections.singletonMap("p", value), Collections.emptyMap(),
+                        Collections.singletonList(value), Collections.emptyList()));
+                mvccPartitions.add(new ConnectorMvccPartition("p=" + value,
+                        Collections.singletonList(value), Collections.singletonList(value), 1L));
+            }
+            long listBytes = IcebergCacheSizeEstimator.estimatePartitionInfoViewEntry(key, listView).getBytes();
+            long mvccBytes = IcebergCacheSizeEstimator.estimateMvccPartitionViewEntry(key,
+                    new ConnectorMvccPartitionView(ConnectorMvccPartitionView.Style.RANGE,
+                            ConnectorMvccPartitionView.Freshness.SNAPSHOT_ID, mvccPartitions, 1L)).getBytes();
+            if (position == -1) {
+                listBaseline = listBytes;
+                mvccBaseline = mvccBytes;
+            } else {
+                long nameGrowth = JvmSizeUtils.stringSize("p=" + large) - JvmSizeUtils.stringSize("p=x");
+                long valueGrowth = JvmSizeUtils.stringSize(large) - JvmSizeUtils.stringSize("x");
+                Assertions.assertEquals(listBaseline + nameGrowth + valueGrowth, listBytes);
+                Assertions.assertEquals(mvccBaseline + nameGrowth + 2 * valueGrowth, mvccBytes);
+            }
+        }
+    }
+
+    @Test
+    public void largePartitionViewsCanBeEstimatedWithoutTheReflectiveVisitLimit() {
+        List<ConnectorPartitionInfo> listView = new ArrayList<>();
+        List<ConnectorMvccPartition> mvccPartitions = new ArrayList<>();
+        for (int index = 0; index < 20_000; index++) {
+            String value = Integer.toString(index);
+            listView.add(new ConnectorPartitionInfo("p=" + value,
+                    Collections.singletonMap("p", value), Collections.emptyMap(),
+                    Collections.singletonList(value), Collections.emptyList()));
+            mvccPartitions.add(new ConnectorMvccPartition(
+                    "p=" + value, Collections.singletonList(value),
+                    Collections.singletonList(value), index));
+        }
+        ConnectorTableKey key = new ConnectorTableKey("db", "table", 1L, 1L);
+        ConnectorMvccPartitionView mvccView = new ConnectorMvccPartitionView(
+                ConnectorMvccPartitionView.Style.RANGE,
+                ConnectorMvccPartitionView.Freshness.SNAPSHOT_ID, mvccPartitions, 1L);
+
+        Assertions.assertTrue(IcebergCacheSizeEstimator.estimatePartitionInfoViewEntry(
+                key, listView).isComplete());
+        Assertions.assertTrue(IcebergCacheSizeEstimator.estimateMvccPartitionViewEntry(
+                key, mvccView).isComplete());
     }
 
     // ---------------------------------------------------------------------

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergManifestCacheTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergManifestCacheTest.java
@@ -17,9 +17,12 @@
 
 package org.apache.doris.connector.iceberg;
 
+import org.apache.doris.connector.cache.CatalogMetaCache;
+
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -30,6 +33,7 @@ import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -40,6 +44,28 @@ import java.util.concurrent.atomic.AtomicInteger;
  * exercised against genuine iceberg {@link ManifestFile}s (no I/O — InMemoryCatalog serves manifests in-memory).
  */
 public class IcebergManifestCacheTest {
+
+    @Test
+    public void manifestEstimationCountsBackingArraysAndRejectsHiddenHeapBuffers() {
+        byte[] backing = new byte[1024 * 1024];
+        ByteBuffer slice = ByteBuffer.wrap(backing, 0, 1).slice();
+        ManifestCacheValue writable = manifestWithLowerBound(slice);
+        Assertions.assertTrue(writable.getSizeEstimate().isComplete());
+        Assertions.assertTrue(writable.getSizeEstimate().getBytes() >= backing.length);
+        ManifestCacheValue readOnly = manifestWithLowerBound(slice.asReadOnlyBuffer());
+        Assertions.assertFalse(readOnly.getSizeEstimate().isComplete());
+        Assertions.assertEquals(1, readOnly.getDataFiles().size(), "rejection must not discard the query result");
+        Assertions.assertFalse(manifestWithLowerBound(ByteBuffer.wrap(backing).asReadOnlyBuffer())
+                .getSizeEstimate().isComplete());
+    }
+
+    private static ManifestCacheValue manifestWithLowerBound(ByteBuffer lowerBound) {
+        DataFile file = DataFiles.builder(PartitionSpec.unpartitioned())
+                .withPath("/data/buffer.parquet").withFileSizeInBytes(100)
+                .withMetrics(new Metrics(1L, null, null, null, null,
+                        Collections.singletonMap(1, lowerBound), null)).build();
+        return ManifestCacheValue.forDataFiles(Collections.singletonList(file), true);
+    }
 
     private static final Schema SCHEMA = new Schema(
             Types.NestedField.required(1, "id", Types.IntegerType.get()));
@@ -78,6 +104,22 @@ public class IcebergManifestCacheTest {
         ManifestCacheValue second = cache.getManifestCacheValue(manifest, table);
         Assertions.assertSame(first, second, "the manifest payload must be served from the cache on a repeat");
         Assertions.assertEquals(1, cache.size());
+    }
+
+    @Test
+    public void weightBoundedManifestIsEstimatedAndCached() {
+        Table table = tableWithTwoDataFiles();
+        ManifestFile manifest = table.currentSnapshot().dataManifests(table.io()).get(0);
+        try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+            IcebergManifestCache cache = new IcebergManifestCache(owner,
+                    Collections.singletonMap("meta.cache.iceberg.manifest.max-weight", "1MB"));
+
+            ManifestCacheValue first = cache.getManifestCacheValue(manifest, table);
+            ManifestCacheValue second = cache.getManifestCacheValue(manifest, table);
+
+            Assertions.assertSame(first, second);
+            Assertions.assertEquals(2, first.getDataFiles().size());
+        }
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergPartitionCacheTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergPartitionCacheTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.connector.iceberg;
 
+import org.apache.doris.connector.cache.CacheSpec;
+import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.iceberg.IcebergPartitionUtils.IcebergRawPartition;
 
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -51,6 +53,26 @@ public class IcebergPartitionCacheTest {
     }
 
     @Test
+    public void disabledBoundedPartitionsDoNotPrepareCachePayload() {
+        for (CacheSpec spec : new CacheSpec[] {CacheSpec.ofWeight(false, 100L, 1000L, 1024L * 1024L),
+                CacheSpec.ofWeight(true, 0L, 1000L, 1024L * 1024L)}) {
+            List<IcebergRawPartition> partitions = raws(3);
+            AtomicInteger loads = new AtomicInteger();
+            try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+                IcebergPartitionCache cache = new IcebergPartitionCache(owner, spec);
+                for (int i = 0; i < 2; i++) {
+                    Assertions.assertSame(partitions, cache.getOrLoad(key("db", "t", 5L), () -> {
+                        loads.incrementAndGet();
+                        return partitions;
+                    }));
+                }
+                Assertions.assertEquals(2, loads.get());
+                Assertions.assertEquals(0, cache.size());
+            }
+        }
+    }
+
+    @Test
     public void cachesWithinTtlAndServesTheSameList() {
         AtomicInteger loads = new AtomicInteger();
         IcebergPartitionCache c = new IcebergPartitionCache(100, 1000);
@@ -71,6 +93,29 @@ public class IcebergPartitionCacheTest {
         Assertions.assertEquals(1, loads.get(), "the live scan must run exactly once within TTL");
         Assertions.assertEquals(1, c.loadCountForTest(), "the metric-gate load count must be 1");
         Assertions.assertTrue(c.isEnabled());
+    }
+
+    @Test
+    public void weightBoundedPartitionsAreEstimatedAndCached() {
+        AtomicInteger loads = new AtomicInteger();
+        try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+            IcebergPartitionCache cache = new IcebergPartitionCache(
+                    owner, CacheSpec.ofWeight(true, 100L, 1000L, 1024L * 1024L));
+
+            List<IcebergRawPartition> first = cache.getOrLoad(key("db", "t", 5L), () -> {
+                loads.incrementAndGet();
+                return raws(3);
+            });
+            List<IcebergRawPartition> second = cache.getOrLoad(key("db", "t", 5L), () -> {
+                loads.incrementAndGet();
+                return raws(7);
+            });
+
+            Assertions.assertSame(first, second);
+            Assertions.assertEquals(1, loads.get());
+            Assertions.assertThrows(UnsupportedOperationException.class,
+                    () -> first.add(raws(1).get(0)));
+        }
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergTableCacheBenchmark.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergTableCacheBenchmark.java
@@ -1,0 +1,167 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.iceberg;
+
+import org.apache.doris.connector.cache.CacheSpec;
+import org.apache.doris.connector.cache.CatalogMetaCache;
+
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.types.Types;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Dependency-free microbenchmark for weighted Iceberg admission and per-statement metadata isolation. */
+public final class IcebergTableCacheBenchmark {
+    private static final int WARMUP_WINDOWS = 5;
+    private static final int MEASURE_WINDOWS = 15;
+    private static volatile long blackhole;
+
+    private IcebergTableCacheBenchmark() {
+    }
+
+    public static void main(String[] args) {
+        Table table = tableFixture();
+        TableMetadata metadata = ((BaseTable) table).operations().current();
+        String json = TableMetadataParser.toJson(metadata);
+        try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+            IcebergTableCache cache = new IcebergTableCache(
+                    owner, CacheSpec.ofWeight(true, 100L, 1000L, 100L * 1024L * 1024L),
+                    ignored -> () -> { }, new IcebergCatalogResourceTracker());
+            try (IcebergTableCache.TableLease lease = cache.borrow(
+                    TableIdentifier.of("db", "table"), () -> table)) {
+                Result result = measure(() -> {
+                    Table statementTable = lease.snapshotReadTable();
+                    return ((BaseTable) statementTable).operations().current().properties().size();
+                }, 100);
+                System.out.printf(
+                        "iceberg_metadata_json_chars=%d properties=%d statement_copy_ns_op=%d operations=%d%n",
+                        json.length(), metadata.properties().size(), result.medianNanos, result.operations);
+            }
+        }
+    }
+
+    private static Table tableFixture() {
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "id", Types.LongType.get()),
+                Types.NestedField.optional(2, "payload", Types.StringType.get()));
+        Map<String, String> properties = new LinkedHashMap<>();
+        for (int i = 0; i < 1_000; i++) {
+            properties.put("property-" + i, "value-" + i + "-" + "x".repeat(48));
+        }
+        TableMetadata metadata = TableMetadata.newTableMetadata(
+                schema, PartitionSpec.unpartitioned(), "file:///tmp/weighted-table", properties);
+        metadata = TableMetadata.buildFrom(metadata)
+                .withMetadataLocation("file:///tmp/weighted-table/metadata/v1.metadata.json")
+                .discardChanges()
+                .build();
+        return new BaseTable(new StaticTableOperations(metadata), "weighted");
+    }
+
+    private static Result measure(LongOperation operation, int operationsPerWindow) {
+        for (int i = 0; i < WARMUP_WINDOWS; i++) {
+            runWindow(operation, operationsPerWindow);
+        }
+        long[] nanosPerOperation = new long[MEASURE_WINDOWS];
+        for (int i = 0; i < MEASURE_WINDOWS; i++) {
+            long start = System.nanoTime();
+            runWindow(operation, operationsPerWindow);
+            nanosPerOperation[i] = (System.nanoTime() - start) / operationsPerWindow;
+        }
+        Arrays.sort(nanosPerOperation);
+        return new Result(nanosPerOperation[MEASURE_WINDOWS / 2],
+                (long) operationsPerWindow * MEASURE_WINDOWS);
+    }
+
+    private static void runWindow(LongOperation operation, int operations) {
+        long value = 0L;
+        for (int i = 0; i < operations; i++) {
+            value ^= operation.run();
+        }
+        blackhole = value;
+    }
+
+    @FunctionalInterface
+    private interface LongOperation {
+        long run();
+    }
+
+    private static final class Result {
+        private final long medianNanos;
+        private final long operations;
+
+        private Result(long medianNanos, long operations) {
+            this.medianNanos = medianNanos;
+            this.operations = operations;
+        }
+    }
+
+    private static final class StaticTableOperations implements TableOperations {
+        private final TableMetadata metadata;
+
+        private StaticTableOperations(TableMetadata metadata) {
+            this.metadata = metadata;
+        }
+
+        @Override
+        public TableMetadata current() {
+            return metadata;
+        }
+
+        @Override
+        public TableMetadata refresh() {
+            return metadata;
+        }
+
+        @Override
+        public void commit(TableMetadata base, TableMetadata newMetadata) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public FileIO io() {
+            return null;
+        }
+
+        @Override
+        public EncryptionManager encryption() {
+            return null;
+        }
+
+        @Override
+        public String metadataFileLocation(String fileName) {
+            return "file:///tmp/weighted-table/metadata/" + fileName;
+        }
+
+        @Override
+        public LocationProvider locationProvider() {
+            return null;
+        }
+    }
+}

--- a/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergTableCacheTest.java
+++ b/fe/fe-connector/fe-connector-iceberg/src/test/java/org/apache/doris/connector/iceberg/IcebergTableCacheTest.java
@@ -17,12 +17,33 @@
 
 package org.apache.doris.connector.iceberg;
 
+import org.apache.doris.connector.cache.CacheSpec;
+import org.apache.doris.connector.cache.CatalogMetaCache;
+import org.apache.doris.connector.cache.JvmSizeUtils;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotParser;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.inmemory.InMemoryInputFile;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.JsonUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +66,73 @@ public class IcebergTableCacheTest {
 
     private static TableIdentifier id() {
         return TableIdentifier.of("db", "t");
+    }
+
+    @Test
+    public void v3DefaultsAndEncryptionKeysCountUnsampledPayloads() throws Exception {
+        String large = "x".repeat(1024 * 1024);
+        long stringGrowth = JvmSizeUtils.stringSize(large) - JvmSizeUtils.stringSize("x");
+        for (String payload : new String[] {"initial-default", "write-default", "encryption-keys"}) {
+            BaseTable baseline = tableWithV3Payload(payload, 998, "x");
+            long baselineBytes = IcebergCacheSizeEstimator.estimateTable(baseline);
+            for (int position : new int[] {0, 333, 998, 999}) {
+                BaseTable table = tableWithV3Payload(payload, position, large);
+                long growth = IcebergCacheSizeEstimator.estimateTable(table) - baselineBytes;
+                // The sampled reflective maximum may overestimate a sampled outlier. The typed estimate
+                // must also include an outlier outside that sample, rather than returning the small baseline.
+                Assertions.assertTrue(growth > stringGrowth / 2L,
+                        payload + " must count the retained payload at position " + position + ": " + growth);
+            }
+
+            BaseTable table = tableWithV3Payload(payload, 998, large);
+            String json = TableMetadataParser.toJson(table.operations().current());
+            long maxWeight = baselineBytes + IcebergCacheSizeEstimator.estimateSerializedTableMetadata(json)
+                    + stringGrowth / 2L;
+            AtomicInteger loads = new AtomicInteger();
+            try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+                IcebergTableCache cache = new IcebergTableCache(owner,
+                        CacheSpec.ofWeight(true, 100L, 1000L, maxWeight),
+                        ignored -> () -> { }, new IcebergCatalogResourceTracker());
+                for (int i = 0; i < 2; i++) {
+                    cache.getOrLoad(id(), () -> {
+                        loads.incrementAndGet();
+                        return table;
+                    });
+                }
+                Assertions.assertEquals(2, loads.get(), payload + " must include raw metadata as well as JSON");
+                Assertions.assertEquals(0, cache.size());
+            }
+        }
+    }
+
+    private static BaseTable tableWithV3Payload(String payload, int position, String value) throws Exception {
+        TableMetadata base = TableMetadata.newTableMetadata(
+                new Schema(Types.NestedField.optional(1, "id", Types.StringType.get())),
+                PartitionSpec.unpartitioned(), "file:///tmp/v3-table",
+                Collections.singletonMap(TableProperties.FORMAT_VERSION, "3"));
+        ObjectNode json = (ObjectNode) JsonUtil.mapper().readTree(TableMetadataParser.toJson(base));
+        if (payload.equals("encryption-keys")) {
+            ArrayNode keys = json.putArray("encryption-keys");
+            for (int i = 0; i < 1000; i++) {
+                ObjectNode key = keys.addObject();
+                key.put("key-id", "k" + i);
+                key.put("encrypted-key-metadata", "AA==");
+                key.putObject("properties").put("p", i == position ? value : "x");
+            }
+        } else {
+            ArrayNode fields = ((ObjectNode) json.get("schemas").get(0)).putArray("fields");
+            for (int i = 0; i < 1000; i++) {
+                ObjectNode field = fields.addObject();
+                field.put("id", i + 1);
+                field.put("name", "c" + i);
+                field.put("required", false);
+                field.put("type", "string");
+                field.put(payload, i == position ? value : "x");
+            }
+            json.put("last-column-id", 1000);
+        }
+        TableMetadata metadata = TableMetadataParser.fromJson("file:///tmp/v3.metadata.json", json.toString());
+        return new BaseTable(new StaticTableOperations(metadata), "weighted-v3");
     }
 
     /** A distinct fake table, distinguishable by {@link Table#name()}. */
@@ -74,6 +162,228 @@ public class IcebergTableCacheTest {
         Assertions.assertSame(first, second, "within TTL the cached table instance must be served");
         Assertions.assertEquals(1, loads.get(), "the live loader must run exactly once within TTL");
         Assertions.assertTrue(c.isEnabled());
+    }
+
+    @Test
+    public void weightBoundedTableIsEstimatedAndCached() {
+        AtomicInteger loads = new AtomicInteger();
+        try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+            IcebergTableCache cache = new IcebergTableCache(
+                    owner, CacheSpec.ofWeight(true, 100L, 1000L, 1024L * 1024L),
+                    ignored -> () -> {
+                    }, new IcebergCatalogResourceTracker());
+
+            Table first = cache.getOrLoad(id(), () -> {
+                loads.incrementAndGet();
+                return table("first");
+            });
+            Table second = cache.getOrLoad(id(), () -> {
+                loads.incrementAndGet();
+                return table("second");
+            });
+
+            Assertions.assertSame(first, second);
+            Assertions.assertEquals(1, loads.get());
+        }
+    }
+
+    @Test
+    public void weightedBorrowUsesAnIndependentSnapshotGenerationPerStatement() {
+        try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+            IcebergTableCache cache = new IcebergTableCache(
+                    owner, CacheSpec.ofWeight(true, 100L, 1000L, 10L * 1024L * 1024L),
+                    ignored -> () -> {
+                    }, new IcebergCatalogResourceTracker());
+
+            try (IcebergTableCache.TableLease lease = cache.borrow(id(),
+                    IcebergTableCacheTest::tableWithSnapshot)) {
+                BaseTable cached = (BaseTable) lease.table();
+                BaseTable firstStatement = (BaseTable) lease.snapshotReadTable();
+                BaseTable secondStatement = (BaseTable) lease.snapshotReadTable();
+
+                Snapshot cachedSnapshot = cached.operations().current().currentSnapshot();
+                Snapshot firstSnapshot = firstStatement.operations().current().currentSnapshot();
+                Snapshot secondSnapshot = secondStatement.operations().current().currentSnapshot();
+                Assertions.assertNotSame(cachedSnapshot, firstSnapshot,
+                        "manifest lazy fields must not be written into the weighted cache generation");
+                Assertions.assertNotSame(firstSnapshot, secondSnapshot,
+                        "each statement must own its snapshot lazy-loading state");
+                Assertions.assertEquals(cachedSnapshot.snapshotId(), firstSnapshot.snapshotId());
+            }
+            Assertions.assertEquals(1, cache.size());
+        }
+    }
+
+    @Test
+    public void disabledBoundedCacheDoesNotPrepareSnapshotGeneration() {
+        for (CacheSpec spec : new CacheSpec[] {
+                CacheSpec.ofWeight(false, 100L, 1000L, 1024L * 1024L),
+                CacheSpec.ofWeight(true, 0L, 1000L, 1024L * 1024L)}) {
+            AtomicInteger cleanups = new AtomicInteger();
+            try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+                IcebergTableCache cache = new IcebergTableCache(owner, spec,
+                        ignored -> cleanups::incrementAndGet, new IcebergCatalogResourceTracker());
+                Table table = tableWithSnapshot();
+                try (IcebergTableCache.TableLease lease = cache.borrow(id(), () -> table)) {
+                    Assertions.assertSame(((BaseTable) table).operations().current(),
+                            ((BaseTable) lease.snapshotReadTable()).operations().current(),
+                            "an uncached table must not serialize and reparse the metadata generation");
+                    Assertions.assertEquals(0, cache.size());
+                    Assertions.assertEquals(0, cleanups.get());
+                }
+                Assertions.assertEquals(1, cleanups.get());
+            }
+        }
+    }
+
+    @Test
+    public void weightedV1TableIsMeasuredAfterSerializationMaterializesEmbeddedManifests() {
+        Table probe = tableWithV1EmbeddedManifests(256);
+        long beforeSerialization = IcebergCacheSizeEstimator.estimateTable(probe);
+        String metadataJson = TableMetadataParser.toJson(((BaseTable) probe).operations().current());
+        long afterSerialization = IcebergCacheSizeEstimator.estimateTable(probe);
+        long materializedBytes = afterSerialization - beforeSerialization;
+        Assertions.assertTrue(materializedBytes > 8192L,
+                "the fixture must materialize enough v1 manifest state to distinguish the two weigh orders");
+
+        long oldOrderPayload = beforeSerialization
+                + IcebergCacheSizeEstimator.estimateSerializedTableMetadata(metadataJson);
+        long maxWeight = oldOrderPayload + materializedBytes / 2L;
+        AtomicInteger loads = new AtomicInteger();
+        try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+            IcebergTableCache cache = new IcebergTableCache(
+                    owner, CacheSpec.ofWeight(true, 100L, 1000L, maxWeight),
+                    ignored -> () -> { }, new IcebergCatalogResourceTracker());
+
+            cache.getOrLoad(id(), () -> {
+                loads.incrementAndGet();
+                return tableWithV1EmbeddedManifests(256);
+            });
+            cache.getOrLoad(id(), () -> {
+                loads.incrementAndGet();
+                return tableWithV1EmbeddedManifests(256);
+            });
+
+            Assertions.assertEquals(2, loads.get(),
+                    "the post-serialization retained graph exceeds the budget and must not be cached");
+            Assertions.assertEquals(0, cache.size());
+        }
+    }
+
+    @Test
+    public void weightedV1HistoricalSnapshotCannotHideEmbeddedManifests() throws Exception {
+        BaseTable small = tableWithV1History(16, 14, 1);
+        TableMetadataParser.toJson(small.operations().current());
+        long smallBytes = IcebergCacheSizeEstimator.estimateTable(small);
+        BaseTable large = tableWithV1History(16, 14, 1000);
+        String largeJson = TableMetadataParser.toJson(large.operations().current());
+        long maxWeight = smallBytes + IcebergCacheSizeEstimator.estimateSerializedTableMetadata(largeJson) + 16384L;
+        Assertions.assertTrue(IcebergCacheSizeEstimator.estimateTable(large) - smallBytes > 16384L,
+                "raw embedded manifests at historical index 14 must be counted independently of JSON");
+        try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+            IcebergTableCache cache = new IcebergTableCache(owner,
+                    CacheSpec.ofWeight(true, 100L, 1000L, maxWeight),
+                    ignored -> () -> { }, new IcebergCatalogResourceTracker());
+            AtomicInteger loads = new AtomicInteger();
+            for (int i = 0; i < 2; i++) {
+                cache.getOrLoad(id(), () -> {
+                    loads.incrementAndGet();
+                    return large;
+                });
+            }
+            Assertions.assertEquals(2, loads.get());
+            Assertions.assertEquals(0, cache.size());
+            cache.getOrLoad(id(), () -> small);
+            Assertions.assertEquals(1, cache.size(), "ordinary v1 history still fits and must be cached");
+        }
+    }
+
+    @Test
+    public void excessiveV1ManifestTraversalDeclinesRetentionWithoutFailingManifestResolution() throws Exception {
+        BaseTable table = tableWithV1History(100, 98, 2000);
+        InputFile input = new InMemoryInputFile("file:///tmp/manifest-99-0.avro", new byte[512]);
+        FileIO io = new FileIO() {
+            @Override
+            public InputFile newInputFile(String path) {
+                Assertions.assertEquals(input.location(), path);
+                return input;
+            }
+
+            @Override
+            public OutputFile newOutputFile(String path) {
+                throw new UnsupportedOperationException("read only");
+            }
+
+            @Override
+            public void deleteFile(String path) {
+                throw new UnsupportedOperationException("read only");
+            }
+        };
+        try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+            IcebergTableCache cache = new IcebergTableCache(owner,
+                    CacheSpec.ofWeight(true, 100L, 1000L, 128L * 1024L * 1024L),
+                    ignored -> () -> { }, new IcebergCatalogResourceTracker());
+            AtomicInteger loads = new AtomicInteger();
+            for (int i = 0; i < 2; i++) {
+                try (IcebergTableCache.TableLease lease = cache.borrow(id(), () -> {
+                    loads.incrementAndGet();
+                    return table;
+                })) {
+                    Assertions.assertSame(table, lease.table());
+                    Table statement = lease.snapshotReadTable();
+                    ManifestFile manifest = statement.currentSnapshot().dataManifests(io).get(0);
+                    // Use FileIO's real ManifestFile overload: it resolves the lazy length as scan planning does.
+                    Assertions.assertSame(input, io.newInputFile(manifest));
+                    Assertions.assertEquals(512L, manifest.length());
+                }
+            }
+            Assertions.assertEquals(2, loads.get());
+            Assertions.assertEquals(0, cache.size());
+        }
+    }
+
+    private static BaseTable tableWithV1History(int snapshotCount, int tailIndex, int tailManifests) throws Exception {
+        BaseTable seed = (BaseTable) tableWithV1EmbeddedManifests(1);
+        ObjectNode json = (ObjectNode) JsonUtil.mapper().readTree(
+                TableMetadataParser.toJson(seed.operations().current()));
+        ArrayNode snapshots = json.putArray("snapshots");
+        for (int i = 0; i < snapshotCount; i++) {
+            ObjectNode snapshot = snapshots.addObject();
+            snapshot.put("snapshot-id", i + 1);
+            snapshot.put("timestamp-ms", 1000 + i);
+            snapshot.put("schema-id", 0);
+            snapshot.putObject("summary").put("operation", "append");
+            ArrayNode manifests = snapshot.putArray("manifests");
+            for (int j = 0; j < (i == tailIndex ? tailManifests : 1); j++) {
+                manifests.add("file:///tmp/manifest-" + i + "-" + j + ".avro");
+            }
+        }
+        json.put("current-snapshot-id", snapshotCount);
+        json.put("last-updated-ms", 1000 + snapshotCount);
+        json.remove("refs");
+        json.putArray("snapshot-log");
+        return new BaseTable(new StaticTableOperations(TableMetadataParser.fromJson(
+                "file:///tmp/v1-history.metadata.json", json.toString())), "weighted-v1-history");
+    }
+
+    @Test
+    public void weightedBorrowSupportsMetadataWithoutAFileLocation() {
+        Schema schema = new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+        TableMetadata metadata = TableMetadata.newTableMetadata(
+                schema, PartitionSpec.unpartitioned(), "file:///tmp/no-metadata-location", Collections.emptyMap());
+        Table table = new BaseTable(new StaticTableOperations(metadata), "no-metadata-location");
+
+        try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+            IcebergTableCache cache = new IcebergTableCache(
+                    owner, CacheSpec.ofWeight(true, 100L, 1000L, 10L * 1024L * 1024L),
+                    ignored -> () -> { }, new IcebergCatalogResourceTracker());
+            try (IcebergTableCache.TableLease lease = cache.borrow(id(), () -> table)) {
+                BaseTable statement = (BaseTable) lease.snapshotReadTable();
+                Assertions.assertNull(statement.operations().current().metadataFileLocation());
+                Assertions.assertEquals(schema.asStruct(), statement.schema().asStruct());
+            }
+            Assertions.assertEquals(1, cache.size());
+        }
     }
 
     @Test
@@ -280,5 +590,92 @@ public class IcebergTableCacheTest {
         Assertions.assertThrows(NoSuchTableException.class, () -> c.getOrLoad(id(), () -> {
             throw new NoSuchTableException("simulated concurrent drop");
         }));
+    }
+
+    private static Table tableWithSnapshot() {
+        Schema schema = new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+        TableMetadata base = TableMetadata.newTableMetadata(
+                schema, PartitionSpec.unpartitioned(), "file:///tmp/weighted-table", Collections.emptyMap());
+        Snapshot snapshot = SnapshotParser.fromJson("{"
+                + "\"sequence-number\":1,"
+                + "\"snapshot-id\":101,"
+                + "\"timestamp-ms\":1000,"
+                + "\"summary\":{\"operation\":\"append\"},"
+                + "\"manifest-list\":\"file:///tmp/snap-101.avro\","
+                + "\"schema-id\":0}");
+        TableMetadata metadata = TableMetadata.buildFrom(base)
+                .upgradeFormatVersion(2)
+                .withMetadataLocation("file:///tmp/v2.metadata.json")
+                .setBranchSnapshot(snapshot, "main")
+                .discardChanges()
+                .build();
+        return new BaseTable(new StaticTableOperations(metadata), "weighted");
+    }
+
+    private static Table tableWithV1EmbeddedManifests(int manifestCount) {
+        Schema schema = new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+        TableMetadata base = TableMetadata.newTableMetadata(
+                schema, PartitionSpec.unpartitioned(), "file:///tmp/weighted-v1-table",
+                Collections.singletonMap(TableProperties.FORMAT_VERSION, "1"));
+        StringBuilder snapshotJson = new StringBuilder()
+                .append("{\"snapshot-id\":101,\"timestamp-ms\":1000,")
+                .append("\"summary\":{\"operation\":\"append\"},\"schema-id\":0,\"manifests\":[");
+        for (int i = 0; i < manifestCount; i++) {
+            if (i > 0) {
+                snapshotJson.append(',');
+            }
+            snapshotJson.append("\"file:///tmp/manifest-").append(i).append(".avro\"");
+        }
+        snapshotJson.append("]}");
+        Snapshot snapshot = SnapshotParser.fromJson(snapshotJson.toString());
+        TableMetadata metadata = TableMetadata.buildFrom(base)
+                .withMetadataLocation("file:///tmp/v1.metadata.json")
+                .setBranchSnapshot(snapshot, "main")
+                .discardChanges()
+                .build();
+        return new BaseTable(new StaticTableOperations(metadata), "weighted-v1");
+    }
+
+    private static final class StaticTableOperations implements TableOperations {
+        private final TableMetadata metadata;
+
+        private StaticTableOperations(TableMetadata metadata) {
+            this.metadata = metadata;
+        }
+
+        @Override
+        public TableMetadata current() {
+            return metadata;
+        }
+
+        @Override
+        public TableMetadata refresh() {
+            return metadata;
+        }
+
+        @Override
+        public void commit(TableMetadata base, TableMetadata updated) {
+            throw new UnsupportedOperationException("read only");
+        }
+
+        @Override
+        public FileIO io() {
+            return null;
+        }
+
+        @Override
+        public EncryptionManager encryption() {
+            return null;
+        }
+
+        @Override
+        public String metadataFileLocation(String fileName) {
+            return "file:///tmp/" + fileName;
+        }
+
+        @Override
+        public LocationProvider locationProvider() {
+            return null;
+        }
     }
 }

--- a/fe/fe-connector/fe-connector-maxcompute/src/main/java/org/apache/doris/connector/maxcompute/MaxComputeConnectorMetadata.java
+++ b/fe/fe-connector/fe-connector-maxcompute/src/main/java/org/apache/doris/connector/maxcompute/MaxComputeConnectorMetadata.java
@@ -36,7 +36,6 @@ import org.apache.doris.connector.spi.pushdown.ConnectorExpression;
 import com.aliyun.odps.Column;
 import com.aliyun.odps.Odps;
 import com.aliyun.odps.OdpsException;
-import com.aliyun.odps.Partition;
 import com.aliyun.odps.PartitionSpec;
 import com.aliyun.odps.Table;
 import com.aliyun.odps.TableSchema;
@@ -260,11 +259,11 @@ public class MaxComputeConnectorMetadata implements ConnectorMetadata {
     public List<String> listPartitionNames(ConnectorSession session,
             ConnectorTableHandle handle) {
         MaxComputeTableHandle mcHandle = (MaxComputeTableHandle) handle;
-        List<Partition> partitions = partitionCache.getPartitions(
+        List<PartitionSpec> partitions = partitionCache.getPartitions(
                 mcHandle.getDbName(), mcHandle.getTableName());
         List<String> names = new ArrayList<>(partitions.size());
-        for (Partition partition : partitions) {
-            names.add(partition.getPartitionSpec().toString(false, true));
+        for (PartitionSpec partition : partitions) {
+            names.add(partition.toString(false, true));
         }
         return names;
     }
@@ -282,11 +281,10 @@ public class MaxComputeConnectorMetadata implements ConnectorMetadata {
     public List<ConnectorPartitionInfo> listPartitions(ConnectorSession session,
             ConnectorTableHandle handle, Optional<ConnectorExpression> filter) {
         MaxComputeTableHandle mcHandle = (MaxComputeTableHandle) handle;
-        List<Partition> partitions = partitionCache.getPartitions(
+        List<PartitionSpec> partitions = partitionCache.getPartitions(
                 mcHandle.getDbName(), mcHandle.getTableName());
         List<ConnectorPartitionInfo> result = new ArrayList<>(partitions.size());
-        for (Partition partition : partitions) {
-            PartitionSpec spec = partition.getPartitionSpec();
+        for (PartitionSpec spec : partitions) {
             Map<String, String> values = new LinkedHashMap<>();
             for (String key : spec.keys()) {
                 values.put(key, spec.get(key));

--- a/fe/fe-connector/fe-connector-maxcompute/src/main/java/org/apache/doris/connector/maxcompute/MaxComputeConnectorProvider.java
+++ b/fe/fe-connector/fe-connector-maxcompute/src/main/java/org/apache/doris/connector/maxcompute/MaxComputeConnectorProvider.java
@@ -17,11 +17,13 @@
 
 package org.apache.doris.connector.maxcompute;
 
+import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.spi.Connector;
 import org.apache.doris.connector.spi.ConnectorContext;
 import org.apache.doris.connector.spi.ConnectorProvider;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -74,5 +76,16 @@ public class MaxComputeConnectorProvider implements ConnectorProvider {
     @Override
     public void validateProperties(Map<String, String> properties) {
         MCCatalogProperties.of(properties).checkCreateTimeOnlyRules();
+        CacheSpec.checkWeightProperties(properties, properties, "max_compute", "partition");
+    }
+
+    @Override
+    public void validatePropertiesForUpdate(
+            Map<String, String> currentProperties, Map<String, String> updatedProperties) {
+        Map<String, String> candidate = currentProperties == null
+                ? new HashMap<>() : new HashMap<>(currentProperties);
+        candidate.putAll(updatedProperties);
+        MCCatalogProperties.of(candidate).checkCreateTimeOnlyRules();
+        CacheSpec.checkWeightProperties(candidate, updatedProperties, "max_compute", "partition");
     }
 }

--- a/fe/fe-connector/fe-connector-maxcompute/src/main/java/org/apache/doris/connector/maxcompute/MaxComputeDorisConnector.java
+++ b/fe/fe-connector/fe-connector-maxcompute/src/main/java/org/apache/doris/connector/maxcompute/MaxComputeDorisConnector.java
@@ -54,7 +54,7 @@ public class MaxComputeDorisConnector implements Connector {
 
     private final MCCatalogProperties props;
     private final ConnectorContext context;
-    private final CatalogMetaCache metaCache = new CatalogMetaCache();
+    private final CatalogMetaCache metaCache;
 
     // Connector-owned partition-listing cache, shared by the (per-call) metadata's three partition-listing
     // methods. One per connector — the metadata is rebuilt per query, so the cache must live on the long-lived
@@ -78,9 +78,14 @@ public class MaxComputeDorisConnector implements Connector {
             ConnectorContext context) {
         this.props = MCCatalogProperties.of(properties);
         this.context = context;
-        // The cache reads the framework's own meta.cache.* keys off the raw map, so it keeps taking one.
-        this.partitionCache = new MaxComputePartitionCache(metaCache, props.getRaw(),
-                (db, t) -> structureHelper.getPartitions(odps, db, t));
+        this.metaCache = CatalogMetaCache.managed(context.getCatalogId(), "max_compute", props.getRaw());
+        try {
+            this.partitionCache = new MaxComputePartitionCache(metaCache, props.getRaw(),
+                    (db, t) -> structureHelper.getPartitions(odps, db, t));
+        } catch (RuntimeException | Error e) {
+            metaCache.close();
+            throw e;
+        }
     }
 
     private void ensureInitialized() {

--- a/fe/fe-connector/fe-connector-maxcompute/src/main/java/org/apache/doris/connector/maxcompute/MaxComputePartitionCache.java
+++ b/fe/fe-connector/fe-connector-maxcompute/src/main/java/org/apache/doris/connector/maxcompute/MaxComputePartitionCache.java
@@ -21,10 +21,13 @@ import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.cache.MetaCache;
 import org.apache.doris.connector.cache.MetaCacheDefinition;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimators;
 import org.apache.doris.connector.cache.ScopePath;
 
 import com.aliyun.odps.Partition;
+import com.aliyun.odps.PartitionSpec;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -45,10 +48,8 @@ import java.util.Objects;
  * {@link MaxComputeDorisConnector} (the only object that outlives a single query; the metadata is rebuilt per
  * call), so a partition read warms the others.
  *
- * <p><b>Read-only convention.</b> The cached {@code List<Partition>} is shared by reference. The consumers only
- * read local partition accessors ({@code getPartitionSpec()}, {@code spec.keys()/get()}, {@code toString()}),
- * never a per-partition lazy reload, so the shared list is safe as long as callers treat it as read-only (the
- * codebase-wide metadata-cache convention).
+ * <p><b>Read-only projection.</b> Only partition specs are retained, not SDK partitions and their ODPS clients.
+ * Consumers share the specs by reference and must treat them as read-only.
  *
  * <p><b>TCCL.</b> The entry is contextual-only + manual-miss + no auto-refresh, so the loader runs synchronously
  * on the CALLING thread — keeping TCCL/classloading byte-identical to today's uncached ODPS call (a background
@@ -87,11 +88,11 @@ public class MaxComputePartitionCache {
     }
 
     private final CatalogMetaCache owner;
-    private final MetaCache<PartitionKey, List<Partition>> cache;
+    private final MetaCache<PartitionKey, List<PartitionSpec>> cache;
     private final PartitionLister lister;
 
     MaxComputePartitionCache(Map<String, String> properties, PartitionLister lister) {
-        this(new CatalogMetaCache(), properties, lister);
+        this(CatalogMetaCache.unmanaged(), properties, lister);
     }
 
     MaxComputePartitionCache(CatalogMetaCache owner, Map<String, String> properties, PartitionLister lister) {
@@ -100,8 +101,10 @@ public class MaxComputePartitionCache {
         CacheSpec spec = CacheSpec.fromProperties(props, ENGINE, ENTRY_PARTITION,
                 CacheSpec.of(true, DEFAULT_TTL_SECOND, DEFAULT_PARTITION_CAPACITY));
         this.cache = owner.create(MetaCacheDefinition
-                .<PartitionKey, List<Partition>>builder("max-compute-partition", spec,
+                .<PartitionKey, List<PartitionSpec>>builder("max-compute-partition", spec,
                         key -> ScopePath.table(key.dbName, key.tableName))
+                .budgetGroup(ENTRY_PARTITION)
+                .sizeEstimator(MetaCacheSizeEstimators.reflective())
                 .build());
         this.lister = Objects.requireNonNull(lister, "lister can not be null");
     }
@@ -112,9 +115,15 @@ public class MaxComputePartitionCache {
      * failure propagates and is NOT cached. The returned list is shared by reference — callers must treat it as
      * read-only (the codebase-wide metadata-cache convention).
      */
-    public List<Partition> getPartitions(String dbName, String tableName) {
-        return cache.get(new PartitionKey(dbName, tableName),
-                key -> lister.list(key.dbName, key.tableName));
+    public List<PartitionSpec> getPartitions(String dbName, String tableName) {
+        return cache.get(new PartitionKey(dbName, tableName), key -> {
+            List<Partition> partitions = lister.list(key.dbName, key.tableName);
+            List<PartitionSpec> specs = new ArrayList<>(partitions.size());
+            for (Partition partition : partitions) {
+                specs.add(partition.getPartitionSpec());
+            }
+            return Collections.unmodifiableList(specs);
+        });
     }
 
     /** Drops the cached partition listing for one table. Backs {@code REFRESH TABLE}. */

--- a/fe/fe-connector/fe-connector-maxcompute/src/test/java/org/apache/doris/connector/maxcompute/MCTestProperties.java
+++ b/fe/fe-connector/fe-connector-maxcompute/src/test/java/org/apache/doris/connector/maxcompute/MCTestProperties.java
@@ -17,6 +17,8 @@
 
 package org.apache.doris.connector.maxcompute;
 
+import org.apache.doris.connector.spi.ConnectorContext;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -30,6 +32,20 @@ final class MCTestProperties {
     static final String ENDPOINT = "http://service.cn-beijing.maxcompute.aliyun-inc.com/api";
 
     private MCTestProperties() {
+    }
+
+    static ConnectorContext context() {
+        return new ConnectorContext() {
+            @Override
+            public String getCatalogName() {
+                return "maxcompute_test";
+            }
+
+            @Override
+            public long getCatalogId() {
+                return 91001L;
+            }
+        };
     }
 
     /** A mutable map carrying only what of() requires. */

--- a/fe/fe-connector/fe-connector-maxcompute/src/test/java/org/apache/doris/connector/maxcompute/MaxComputeConnectorContractTest.java
+++ b/fe/fe-connector/fe-connector-maxcompute/src/test/java/org/apache/doris/connector/maxcompute/MaxComputeConnectorContractTest.java
@@ -53,7 +53,7 @@ public class MaxComputeConnectorContractTest {
 
     @Test
     public void declaredWriteCapabilitiesMatchAndPassContractValidator() {
-        MaxComputeDorisConnector connector = new MaxComputeDorisConnector(validProps(), null);
+        MaxComputeDorisConnector connector = new MaxComputeDorisConnector(validProps(), MCTestProperties.context());
 
         ConnectorWritePlanProvider writeProvider = connector.getWritePlanProvider();
         Assertions.assertNotNull(writeProvider, "MaxCompute connector must expose a write plan provider");

--- a/fe/fe-connector/fe-connector-maxcompute/src/test/java/org/apache/doris/connector/maxcompute/MaxComputeConnectorProviderTest.java
+++ b/fe/fe-connector/fe-connector-maxcompute/src/test/java/org/apache/doris/connector/maxcompute/MaxComputeConnectorProviderTest.java
@@ -287,7 +287,8 @@ public class MaxComputeConnectorProviderTest {
         // PR testCheckWhenCreatingSkipsValidationByDefault: MaxCompute leaves test_connection off by
         // default, so PluginDrivenExternalCatalog.checkWhenCreating skips testConnection entirely.
         Assertions.assertFalse(
-                new MaxComputeDorisConnector(connectivityProps(true), null).defaultTestConnection());
+                new MaxComputeDorisConnector(connectivityProps(true), MCTestProperties.context())
+                        .defaultTestConnection());
     }
 
     @Test
@@ -365,7 +366,7 @@ public class MaxComputeConnectorProviderTest {
         private String checkedNamespaceSchemaProjectName;
 
         private TestMaxComputeDorisConnector(Map<String, String> props) {
-            super(props, null);
+            super(props, MCTestProperties.context());
         }
 
         @Override

--- a/fe/fe-connector/fe-connector-maxcompute/src/test/java/org/apache/doris/connector/maxcompute/MaxComputePartitionCacheTest.java
+++ b/fe/fe-connector/fe-connector-maxcompute/src/test/java/org/apache/doris/connector/maxcompute/MaxComputePartitionCacheTest.java
@@ -17,18 +17,23 @@
 
 package org.apache.doris.connector.maxcompute;
 
+import org.apache.doris.connector.cache.CatalogMetaCache;
+import org.apache.doris.connector.cache.MetaCacheGovernance;
 import org.apache.doris.connector.spi.DorisConnectorException;
 
 import com.aliyun.odps.Odps;
 import com.aliyun.odps.OdpsException;
 import com.aliyun.odps.Partition;
+import com.aliyun.odps.PartitionSpec;
 import com.aliyun.odps.Table;
 import com.aliyun.odps.TableSchema;
 import com.aliyun.odps.Tables;
+import com.aliyun.odps.account.AliyunAccount;
 import com.aliyun.odps.table.TableIdentifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -36,6 +41,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Tests {@link MaxComputePartitionCache}: the connector-owned partition-listing cache (a structural copy of the
@@ -53,6 +59,74 @@ import java.util.Optional;
  */
 public class MaxComputePartitionCacheTest {
 
+    @Test
+    public void connectorRegistersManagedOwnerAndClosesIt() throws Exception {
+        Map<String, String> properties = MCTestProperties.minimalMap();
+        properties.put("meta.cache.max_compute.partition.max-weight", "1MB");
+        long id = MCTestProperties.context().getCatalogId();
+        int before = MetaCacheGovernance.catalogCaches(id).size();
+        try (MaxComputeDorisConnector connector = new MaxComputeDorisConnector(
+                properties, MCTestProperties.context())) {
+            Assertions.assertEquals(before + 1, MetaCacheGovernance.catalogCaches(id).size());
+            Assertions.assertTrue(MetaCacheGovernance.catalogCaches(id).stream()
+                    .anyMatch(owner -> "max_compute".equals(owner.engine())
+                            && owner.entries().get("max-compute-partition").isWeightBounded()));
+        }
+        Assertions.assertEquals(before, MetaCacheGovernance.catalogCaches(id).size());
+    }
+
+    @Test
+    public void weightValidationDistinguishesSubmittedAndPersistedUnknownEntries() {
+        Map<String, String> current = MCTestProperties.minimalMap();
+        current.put("meta.cache.max_compute.future_entry.max-weight", "future-format");
+        MaxComputeConnectorProvider provider = new MaxComputeConnectorProvider();
+        Assertions.assertDoesNotThrow(() -> MCCatalogProperties.of(current));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> provider.validateProperties(current));
+        Assertions.assertDoesNotThrow(() -> provider.validatePropertiesForUpdate(current, Map.of("comment", "new")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> provider.validatePropertiesForUpdate(
+                current, Map.of("meta.cache.max_compute.partiton.max-weight", "1MB")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> provider.validatePropertiesForUpdate(
+                current, Map.of("meta.cache.max_compute.partition.max-weight", "invalid")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> provider.validatePropertiesForUpdate(
+                current, Map.of("meta.cache.max-weight", "1MB", "meta.cache.max_compute.partition.max-weight", "2MB")));
+    }
+
+    @Test
+    public void managedCacheRetainsOnlySpecsAndHonorsBothLimits() throws Exception {
+        Odps odps = new Odps(new AliyunAccount("ak", "sk"));
+        PartitionSpec spec = new PartitionSpec("ds='2026-09-11'");
+        // Construct a real SDK partition without initializing the unrelated Arrow table-reader classes.
+        Constructor<Partition> constructor = Partition.class.getDeclaredConstructor(
+                PartitionSpec.class, String.class, String.class, String.class, Odps.class);
+        constructor.setAccessible(true);
+        Partition partition = constructor.newInstance(spec, "project", null, "table", odps);
+        long baseline = MetaCacheGovernance.globalEstimatedWeight();
+        for (String limit : List.of("meta.cache.max-weight", "meta.cache.max_compute.partition.max-weight")) {
+            for (String max : List.of("1MB", "1")) {
+                Map<String, String> props = Map.of(limit, max);
+                AtomicInteger loads = new AtomicInteger();
+                try (CatalogMetaCache owner = CatalogMetaCache.managed(91004L, "max_compute", props)) {
+                    MaxComputePartitionCache cache = new MaxComputePartitionCache(owner, props, (db, table) -> {
+                        loads.incrementAndGet();
+                        return List.of(partition);
+                    });
+                    for (int i = 0; i < 2; i++) {
+                        Assertions.assertEquals(List.of(spec), cache.getPartitions("db", "t"));
+                    }
+                    boolean admitted = "1MB".equals(max);
+                    Assertions.assertEquals(admitted ? 1 : 2, loads.get());
+                    Assertions.assertEquals(admitted,
+                            owner.entries().get("max-compute-partition").metrics().getEstimatedWeight() > 0);
+                    Assertions.assertEquals(admitted ? 0L : 2L,
+                            owner.entries().get("max-compute-partition").metrics().getWeightRejectCount());
+                    Assertions.assertEquals(List.of(owner), MetaCacheGovernance.catalogCaches(91004L));
+                }
+                Assertions.assertTrue(MetaCacheGovernance.catalogCaches(91004L).isEmpty());
+                Assertions.assertEquals(baseline, MetaCacheGovernance.globalEstimatedWeight());
+            }
+        }
+    }
+
     // ==================== caching: hit / miss keyed by (db, table) ====================
 
     @Test
@@ -60,8 +134,8 @@ public class MaxComputePartitionCacheTest {
         CountingPartitionLister lister = new CountingPartitionLister();
         MaxComputePartitionCache cache = new MaxComputePartitionCache(Collections.emptyMap(), lister);
 
-        List<Partition> a = cache.getPartitions("db", "t");
-        List<Partition> b = cache.getPartitions("db", "t");
+        List<?> a = cache.getPartitions("db", "t");
+        List<?> b = cache.getPartitions("db", "t");
         // WHY: a hit must serve the cached listing without re-listing ODPS.
         Assertions.assertSame(a, b);
         Assertions.assertEquals(1, lister.totalCalls);

--- a/fe/fe-connector/fe-connector-maxcompute/src/test/java/org/apache/doris/connector/maxcompute/MaxComputeWritePlanProviderTest.java
+++ b/fe/fe-connector/fe-connector-maxcompute/src/test/java/org/apache/doris/connector/maxcompute/MaxComputeWritePlanProviderTest.java
@@ -40,7 +40,7 @@ public class MaxComputeWritePlanProviderTest {
 
     private static MaxComputeWritePlanProvider provider() {
         return new MaxComputeWritePlanProvider(
-                new MaxComputeDorisConnector(MCTestProperties.minimalMap(), null));
+                new MaxComputeDorisConnector(MCTestProperties.minimalMap(), MCTestProperties.context()));
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonCatalogFactory.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonCatalogFactory.java
@@ -103,6 +103,11 @@ public final class PaimonCatalogFactory {
      * plus each flavor's {@code appendCustomCatalogOptions()}.
      */
     public static Options buildCatalogOptions(PaimonCatalogProperties catalogProperties) {
+        return buildCatalogOptions(catalogProperties, false);
+    }
+
+    static Options buildCatalogOptions(
+            PaimonCatalogProperties catalogProperties, boolean hasEnclosingMetaCacheWeightLimit) {
         Options options = new Options();
         Map<String, String> props = catalogProperties.getRaw();
         String flavor = catalogProperties.getFlavor();
@@ -135,6 +140,9 @@ public final class PaimonCatalogFactory {
             default:
                 // filesystem: nothing custom.
                 break;
+        }
+        if (hasEnclosingMetaCacheWeightLimit && !options.contains(CatalogOptions.CACHE_ENABLED)) {
+            options.set(CatalogOptions.CACHE_ENABLED, false);
         }
         return options;
     }

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonCatalogProperties.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonCatalogProperties.java
@@ -137,7 +137,11 @@ public final class PaimonCatalogProperties {
      * @return this, so the provider can call it in one expression
      */
     public PaimonCatalogProperties checkCreateTimeOnlyRules() {
-        checkMetaCacheProperties(raw);
+        return checkCreateTimeOnlyRules(raw);
+    }
+
+    public PaimonCatalogProperties checkCreateTimeOnlyRules(Map<String, String> submittedProperties) {
+        checkMetaCacheProperties(raw, submittedProperties);
         warnIgnoredDeadTableCacheKeys(raw);
         // #65955: an unknown or unparseable paimon.table-option.* must fail the CREATE/ALTER CATALOG.
         // Upstream got this from AbstractPaimonProperties.initNormalizeAndCheckProps(), which the SPI
@@ -159,7 +163,9 @@ public final class PaimonCatalogProperties {
      * {@code table.enable} must be boolean, {@code table.ttl-second} must be a long &ge; -1,
      * {@code table.capacity} must be a long &ge; 0. Absent keys are skipped.
      */
-    private static void checkMetaCacheProperties(Map<String, String> properties) {
+    private static void checkMetaCacheProperties(
+            Map<String, String> properties, Map<String, String> submittedProperties) {
+        CacheSpec.checkWeightProperties(properties, submittedProperties, "paimon", "partition_view");
         CacheSpec.checkBooleanProperty(properties.get(PaimonConnector.TABLE_CACHE_ENABLE),
                 PaimonConnector.TABLE_CACHE_ENABLE);
         CacheSpec.checkLongProperty(properties.get(PaimonConnector.TABLE_CACHE_TTL_SECOND),

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnector.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnector.java
@@ -140,14 +140,13 @@ public class PaimonConnector implements Connector {
     // returns a fresh metadata per query, so this lives on the connector and is injected into the metadata so
     // beginQuerySnapshot pins a stable id across queries. Cleared wholesale on REFRESH CATALOG (connector rebuilt).
     private final PaimonLatestSnapshotCache latestSnapshotCache;
-    private final CatalogMetaCache metaCache = new CatalogMetaCache();
+    private final CatalogMetaCache metaCache;
 
     // FIX-B-MC2: connector-level (per-catalog, long-lived) second-level memo for the time-travel
     // schema-at-snapshot read. getMetadata() returns a FRESH metadata per query, so this must live on the
     // connector (not the metadata) to give the cross-query hit the legacy PaimonExternalMetaCache provided.
     // Cleared wholesale on REFRESH CATALOG (the connector is rebuilt). See PaimonSchemaAtMemo.
-    private final PaimonSchemaAtMemo schemaAtMemo =
-            new PaimonSchemaAtMemo(metaCache, PaimonSchemaAtMemo.DEFAULT_MAX_SIZE);
+    private final PaimonSchemaAtMemo schemaAtMemo;
 
     // PERF-06: cross-query DERIVED partition-view cache ("cache A", the generic ConnectorMetadataCache from
     // fe-connector-cache), layered ABOVE the raw remote catalog.listPartitions call (PaimonCatalogOps#listPartitions):
@@ -180,13 +179,17 @@ public class PaimonConnector implements Connector {
         // this a DDL/read against secured HDFS negotiates SIMPLE auth. See TcclPinningConnectorContext.
         this.context = new TcclPinningConnectorContext(context, getClass().getClassLoader(),
                 this::pluginAuthenticator);
+        this.metaCache = CatalogMetaCache.managed(context.getCatalogId(), "paimon", properties);
+        this.schemaAtMemo = new PaimonSchemaAtMemo(metaCache, PaimonSchemaAtMemo.DEFAULT_MAX_SIZE);
         this.latestSnapshotCache =
                 new PaimonLatestSnapshotCache(
                         metaCache, resolveTableCacheTtlSecond(properties), DEFAULT_TABLE_CACHE_CAPACITY);
         // Reads its own meta.cache.paimon.partition_view.(enable|ttl-second|capacity) from the catalog
         // properties via the framework's CacheSpec (default ON / 24h / 1000).
         this.partitionViewCache = new ConnectorMetadataCache<>(
-                metaCache, "paimon.partition-view", "paimon", "partition_view", properties);
+                metaCache, "paimon.partition-view", "paimon", "partition_view", properties,
+                key -> org.apache.doris.connector.cache.ScopePath.table(key.getDb(), key.getTable()),
+                PaimonPartitionViewSizeEstimator::estimateEntry);
     }
 
     /**
@@ -408,7 +411,7 @@ public class PaimonConnector implements Connector {
     }
 
     private Catalog createCatalog() {
-        Options options = PaimonCatalogFactory.buildCatalogOptions(catalogProps);
+        Options options = buildCatalogOptions();
         String flavor = catalogProps.getFlavor();
         // Canonical storage config from the FE-bound fe-filesystem StorageProperties (P1-T03), replacing
         // the legacy buildObjectStorageHadoopConfig path: object stores contribute their fs.s3a.*/fs.oss.*
@@ -493,6 +496,10 @@ public class PaimonConnector implements Connector {
     static boolean hasDlfCompatibleStorage(List<StorageProperties> storageProperties) {
         return storageProperties.stream().anyMatch(storage -> "OSS".equals(storage.providerName())
                 || "OSS_HDFS".equals(storage.providerName()));
+    }
+
+    Options buildCatalogOptions() {
+        return PaimonCatalogFactory.buildCatalogOptions(catalogProps, metaCache.hasEnclosingWeightLimit());
     }
 
     /**

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnectorMetadata.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnectorMetadata.java
@@ -1338,7 +1338,12 @@ public class PaimonConnectorMetadata implements ConnectorMetadata {
             return collectPartitions(paimonHandle);
         }
         ConnectorTableKey key = partitionViewCacheKey(paimonHandle);
-        return partitionViewCache.get(key, () -> collectPartitions(paimonHandle));
+        return partitionViewCache.get(key, () -> {
+            List<ConnectorPartitionInfo> partitions = collectPartitions(paimonHandle);
+            return partitionViewCache.isEnabled() && partitionViewCache.isWeightBounded()
+                    ? new PaimonPartitionView(key, partitions)
+                    : partitions;
+        });
     }
 
     /**

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnectorProvider.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonConnectorProvider.java
@@ -66,8 +66,8 @@ public class PaimonConnectorProvider implements ConnectorProvider {
      * statement -- the meta-cache knobs, the dead-knob warning, the paimon table options, and the
      * backend's own fail-fast rules -- which is why none of them run on the connector build path.
      *
-     * <p>This also serves ALTER through the SPI default {@code validatePropertiesForUpdate}, which
-     * merges and calls back here. Throws {@link IllegalArgumentException}, which the caller
+     * <p>ALTER validates the merged candidate separately to tolerate persisted unknown cache entries and
+     * legacy reader options. Throws {@link IllegalArgumentException}, which the caller
      * ({@code PluginDrivenExternalCatalog.checkProperties}) wraps into a DdlException.
      */
     @Override
@@ -94,7 +94,7 @@ public class PaimonConnectorProvider implements ConnectorProvider {
                 candidate.put(key, value);
             }
         });
-        validateProperties(candidate);
+        PaimonCatalogProperties.of(candidate).checkCreateTimeOnlyRules(updatedProperties);
     }
 
 }

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonLatestSnapshotCache.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonLatestSnapshotCache.java
@@ -21,6 +21,7 @@ import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.cache.MetaCache;
 import org.apache.doris.connector.cache.MetaCacheDefinition;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimators;
 import org.apache.doris.connector.cache.ScopePath;
 
 import org.apache.paimon.catalog.Identifier;
@@ -53,7 +54,7 @@ final class PaimonLatestSnapshotCache {
     private final MetaCache<Identifier, Long> entry;
 
     PaimonLatestSnapshotCache(long ttlSeconds, int maxSize) {
-        this(new CatalogMetaCache(), ttlSeconds, maxSize);
+        this(CatalogMetaCache.unmanaged(), ttlSeconds, maxSize);
     }
 
     PaimonLatestSnapshotCache(CatalogMetaCache owner, long ttlSeconds, int maxSize) {
@@ -63,6 +64,7 @@ final class PaimonLatestSnapshotCache {
         this.entry = owner.create(MetaCacheDefinition
                 .<Identifier, Long>builder("paimon-latest-snapshot", spec,
                         id -> ScopePath.table(id.getDatabaseName(), id.getObjectName()))
+                .sizeEstimator(MetaCacheSizeEstimators.reflective())
                 .build());
     }
 

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonPartitionView.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonPartitionView.java
@@ -1,0 +1,56 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.paimon;
+
+import org.apache.doris.connector.cache.ConnectorTableKey;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimate;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimator;
+import org.apache.doris.connector.spi.ConnectorPartitionInfo;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.RandomAccess;
+
+/** Immutable partition-view value whose retained size is computed once at construction. */
+final class PaimonPartitionView extends AbstractList<ConnectorPartitionInfo> implements RandomAccess {
+    private final List<ConnectorPartitionInfo> partitions;
+    private final MetaCacheSizeEstimate sizeEstimate;
+
+    PaimonPartitionView(ConnectorTableKey key, List<ConnectorPartitionInfo> partitions) {
+        this.partitions = Collections.unmodifiableList(new ArrayList<>(partitions));
+        this.sizeEstimate = MetaCacheSizeEstimator.estimateSafely("paimon_partition_estimator_failure",
+                () -> MetaCacheSizeEstimate.complete(
+                        PaimonPartitionViewSizeEstimator.estimateEntryOnConstruction(key, this)));
+    }
+
+    @Override
+    public ConnectorPartitionInfo get(int index) {
+        return partitions.get(index);
+    }
+
+    @Override
+    public int size() {
+        return partitions.size();
+    }
+
+    MetaCacheSizeEstimate getSizeEstimate() {
+        return sizeEstimate;
+    }
+}

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonPartitionViewSizeEstimator.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonPartitionViewSizeEstimator.java
@@ -1,0 +1,126 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.paimon;
+
+import org.apache.doris.connector.cache.ConnectorTableKey;
+import org.apache.doris.connector.cache.JvmSizeUtils;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimate;
+import org.apache.doris.connector.spi.ConnectorPartitionInfo;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/**
+ * Publication-time estimate of the projection built by PaimonConnectorMetadata.collectPartitions.
+ * Counts every partition's strings; sampling variable-length payload can both miss and amplify a large tail.
+ */
+final class PaimonPartitionViewSizeEstimator {
+    private static final long KEY_SHALLOW_BYTES = JvmSizeUtils.instanceSize(ConnectorTableKey.class);
+    private static final long VIEW_SHALLOW_BYTES = JvmSizeUtils.instanceSize(PaimonPartitionView.class);
+    private static final long ESTIMATE_SHALLOW_BYTES = JvmSizeUtils.instanceSize(MetaCacheSizeEstimate.class);
+    private static final long PARTITION_SHALLOW_BYTES = JvmSizeUtils.instanceSize(ConnectorPartitionInfo.class);
+    private static final long UNMODIFIABLE_LIST_SHALLOW_BYTES = JvmSizeUtils.instanceSize(
+            Collections.unmodifiableList(Collections.emptyList()).getClass());
+    private static final long UNMODIFIABLE_MAP_SHALLOW_BYTES = JvmSizeUtils.instanceSize(
+            Collections.unmodifiableMap(Collections.emptyMap()).getClass());
+    private static final long LINKED_HASH_MAP_SHALLOW_BYTES = JvmSizeUtils.instanceSize(LinkedHashMap.class);
+    private static final long LINKED_HASH_MAP_ENTRY_SHALLOW_BYTES = classSize("java.util.LinkedHashMap$Entry");
+
+    private PaimonPartitionViewSizeEstimator() {
+    }
+
+    /** Admission callback: the complete key/value weight was computed when the immutable view was built. */
+    static MetaCacheSizeEstimate estimateEntry(ConnectorTableKey key, List<ConnectorPartitionInfo> value) {
+        return ((PaimonPartitionView) value).getSizeEstimate();
+    }
+
+    static long estimateEntryOnConstruction(ConnectorTableKey key, PaimonPartitionView value) {
+        long bytes = KEY_SHALLOW_BYTES;
+        bytes = add(bytes, JvmSizeUtils.stringSize(key.getDb()));
+        bytes = add(bytes, JvmSizeUtils.stringSize(key.getTable()));
+        bytes = add(bytes, VIEW_SHALLOW_BYTES);
+        bytes = add(bytes, ESTIMATE_SHALLOW_BYTES);
+        bytes = add(bytes, UNMODIFIABLE_LIST_SHALLOW_BYTES);
+        bytes = add(bytes, JvmSizeUtils.arrayListSize(value.size()));
+        if (!value.isEmpty()) {
+            // collectPartitions builds every map/list from the same partitionKeys, with shared column names.
+            // Compute that fixed shape once; only the name/value String payload varies between partitions.
+            bytes = add(bytes, multiply(value.size(), estimatePartitionStructure(value.get(0))));
+            for (String column : value.get(0).getPartitionValues().keySet()) {
+                bytes = add(bytes, JvmSizeUtils.stringSize(column));
+            }
+        }
+        for (int index = 0; index < value.size(); index++) {
+            ConnectorPartitionInfo partition = value.get(index);
+            bytes = add(bytes, JvmSizeUtils.stringSize(partition.getPartitionName()));
+            List<String> orderedValues = partition.getOrderedPartitionValues();
+            for (int column = 0; column < orderedValues.size(); column++) {
+                // The same rendered String is retained by both partitionValues and orderedPartitionValues.
+                bytes = add(bytes, JvmSizeUtils.stringSize(orderedValues.get(column)));
+            }
+        }
+        return bytes;
+    }
+
+    private static long estimatePartitionStructure(ConnectorPartitionInfo partition) {
+        long bytes = PARTITION_SHALLOW_BYTES;
+        // The collector supplies an empty properties map, wrapped by ConnectorPartitionInfo per partition.
+        bytes = add(bytes, UNMODIFIABLE_MAP_SHALLOW_BYTES);
+
+        int valueCount = partition.getPartitionValues().size();
+        bytes = add(bytes, UNMODIFIABLE_MAP_SHALLOW_BYTES);
+        bytes = add(bytes, LINKED_HASH_MAP_SHALLOW_BYTES);
+        if (valueCount > 0) {
+            bytes = add(bytes, JvmSizeUtils.objectArraySize(hashCapacity(valueCount)));
+            bytes = add(bytes, multiply(valueCount, LINKED_HASH_MAP_ENTRY_SHALLOW_BYTES));
+        }
+
+        bytes = add(bytes, estimateCopiedList(partition.getOrderedPartitionValues()));
+        return add(bytes, estimateCopiedList(partition.getPartitionValueNullFlags()));
+    }
+
+    private static long estimateCopiedList(List<?> values) {
+        return add(UNMODIFIABLE_LIST_SHALLOW_BYTES, JvmSizeUtils.arrayListSize(values.size()));
+    }
+
+    private static int hashCapacity(int size) {
+        long needed = (size * 4L + 2L) / 3L;
+        int capacity = 16;
+        while (capacity < needed && capacity < 1 << 30) {
+            capacity <<= 1;
+        }
+        return capacity;
+    }
+
+    private static long classSize(String className) {
+        try {
+            return JvmSizeUtils.instanceSize(Class.forName(className));
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Required JVM collection class is missing: " + className, e);
+        }
+    }
+
+    private static long multiply(long left, long right) {
+        return JvmSizeUtils.saturatedMultiply(left, right);
+    }
+
+    private static long add(long left, long right) {
+        return JvmSizeUtils.saturatedAdd(left, right);
+    }
+}

--- a/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonSchemaAtMemo.java
+++ b/fe/fe-connector/fe-connector-paimon/src/main/java/org/apache/doris/connector/paimon/PaimonSchemaAtMemo.java
@@ -21,6 +21,7 @@ import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.cache.MetaCache;
 import org.apache.doris.connector.cache.MetaCacheDefinition;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimators;
 import org.apache.doris.connector.cache.ScopePath;
 
 import java.util.Objects;
@@ -59,7 +60,7 @@ final class PaimonSchemaAtMemo {
     private final MetaCache<MemoKey, PaimonCatalogOps.PaimonSchemaSnapshot> cache;
 
     PaimonSchemaAtMemo(int maxSize) {
-        this(new CatalogMetaCache(), maxSize);
+        this(CatalogMetaCache.unmanaged(), maxSize);
     }
 
     PaimonSchemaAtMemo(CatalogMetaCache owner, int maxSize) {
@@ -69,6 +70,7 @@ final class PaimonSchemaAtMemo {
                 .<MemoKey, PaimonCatalogOps.PaimonSchemaSnapshot>builder(
                         "paimon-schema-at", spec,
                         key -> ScopePath.table(key.databaseName, key.tableName))
+                .sizeEstimator(MetaCacheSizeEstimators.reflective())
                 .build());
     }
 

--- a/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonCacheSizeBenchmark.java
+++ b/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonCacheSizeBenchmark.java
@@ -1,0 +1,171 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.paimon;
+
+import org.apache.doris.connector.cache.ConnectorTableKey;
+import org.apache.doris.connector.spi.ConnectorPartitionInfo;
+
+import org.apache.paimon.partition.Partition;
+import org.apache.paimon.types.DataTypes;
+import org.apache.paimon.types.RowType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+/**
+ * Offline microbenchmark, not JMH. Uses the production partition collector with recording catalog fakes:
+ * no RPC, filesystem access, cache-hit timing, or data-file scans. Compares collection alone against collection
+ * plus weighted-view construction; publication-only timing includes its list copy. Prepared-weight timing is
+ * just the provider callback, including loop/volatile-sink overhead, not the complete cache-admission path.
+ *
+ * <p>Compile via run-fe-ut.sh; run this main with the module's test classpath and the FE's java.lang/java.util
+ * opens. Run multiple fresh JVMs before drawing conclusions. Raw estimates are reported, not asserted to be
+ * exact retained heap. TAIL_END hits the former 16/5-element sampling positions; TAIL_INTERIOR misses both.
+ */
+public final class PaimonCacheSizeBenchmark {
+    private static final int WARMUP_WINDOWS = 5;
+    private static final int MEASURE_WINDOWS = 15;
+    private static final long MIN_WINDOW_NANOS = TimeUnit.MILLISECONDS.toNanos(50);
+    private static volatile Object blackhole;
+
+    private PaimonCacheSizeBenchmark() {
+    }
+
+    enum Distribution {
+        UNIFORM,
+        TAIL_END,
+        TAIL_INTERIOR
+    }
+
+    public static void main(String[] args) {
+        for (int fieldCount : new int[] {10, 100}) {
+            for (int partitionCount : new int[] {1_000, 10_000}) {
+                for (Distribution distribution : Distribution.values()) {
+                    Fixture fixture = new Fixture(fieldCount, partitionCount, distribution);
+                    List<ConnectorPartitionInfo> partitions = fixture.load(false);
+                    PaimonPartitionView prepared = new PaimonPartitionView(fixture.key, partitions);
+                    if (!prepared.getSizeEstimate().isComplete()) {
+                        throw new IllegalStateException("Incomplete benchmark estimate: "
+                                + prepared.getSizeEstimate().getIncompleteReason());
+                    }
+                    String label = "fields=" + fieldCount + " partitions=" + partitionCount
+                            + " distribution=" + distribution;
+                    System.out.printf("%s estimated_bytes=%d large_value_chars=%d%n", label,
+                            prepared.getSizeEstimate().getBytes(), distribution == Distribution.UNIFORM
+                                    ? 0 : Fixture.LARGE_VALUE_CHARS);
+                    Map<String, Supplier<?>> cases = new LinkedHashMap<>();
+                    cases.put("collect", () -> fixture.load(false));
+                    cases.put("collect_weighted", () -> fixture.load(true));
+                    cases.put("publish_only", () -> new PaimonPartitionView(fixture.key, partitions));
+                    cases.put("prepared_weight", () -> PaimonPartitionViewSizeEstimator
+                            .estimateEntry(fixture.key, prepared));
+                    measure(label, cases);
+                }
+            }
+        }
+    }
+
+    static final class Fixture {
+        static final int LARGE_VALUE_CHARS = 1024 * 1024;
+        final ConnectorTableKey key = new ConnectorTableKey("db1", "t1", 1L, -1L);
+        private final RecordingPaimonCatalogOps ops = new RecordingPaimonCatalogOps();
+        private final PaimonConnectorMetadata metadata;
+        private final PaimonTableHandle handle;
+
+        Fixture(int fieldCount, int partitionCount, Distribution distribution) {
+            RowType.Builder schema = RowType.builder().field("region", DataTypes.STRING());
+            for (int field = 1; field < fieldCount; field++) {
+                schema.field("column_" + field, DataTypes.STRING());
+            }
+            FakePaimonTable table = new FakePaimonTable("t1", schema.build(),
+                    Collections.singletonList("region"), Collections.emptyList());
+            table.setOptions(Collections.singletonMap("partition.legacy-name", "true"));
+            ops.table = table;
+            ops.partitions = new ArrayList<>(partitionCount);
+            int largeIndex = distribution == Distribution.TAIL_END ? partitionCount - 1
+                    : distribution == Distribution.TAIL_INTERIOR ? partitionCount - 2 : -1;
+            for (int index = 0; index < partitionCount; index++) {
+                String value = "region-" + index;
+                if (index == largeIndex) {
+                    value += "x".repeat(LARGE_VALUE_CHARS);
+                }
+                ops.partitions.add(new Partition(Collections.singletonMap("region", value),
+                        1L, 1L, 1, 1L, true));
+            }
+            metadata = new PaimonConnectorMetadata(ops, PaimonCatalogProperties.of(Collections.emptyMap()),
+                    new RecordingConnectorContext());
+            handle = new PaimonTableHandle("db1", "t1", Collections.singletonList("region"),
+                    Collections.emptyList());
+            handle.setPaimonTable(table);
+        }
+
+        List<ConnectorPartitionInfo> load(boolean weighted) {
+            // Bound the recording fake's log in BOTH paths; never measure an ever-growing fixture.
+            ops.log.clear();
+            List<ConnectorPartitionInfo> partitions = metadata.listPartitions(null, handle, Optional.empty());
+            // Mirrors cachedPartitions' post-collection branch, without timing cache lookup or admission locks.
+            return weighted ? new PaimonPartitionView(key, partitions) : partitions;
+        }
+    }
+
+    private static void measure(String label, Map<String, Supplier<?>> cases) {
+        List<String> names = new ArrayList<>(cases.keySet());
+        List<Supplier<?>> operations = new ArrayList<>(cases.values());
+        int[] batchSizes = new int[operations.size()];
+        long[][] samples = new long[operations.size()][MEASURE_WINDOWS];
+        for (int index = 0; index < operations.size(); index++) {
+            int batchSize = 1;
+            while (runWindow(operations.get(index), batchSize) < MIN_WINDOW_NANOS && batchSize < 1 << 20) {
+                batchSize *= 2;
+            }
+            batchSizes[index] = batchSize;
+        }
+        for (int window = 0; window < WARMUP_WINDOWS + MEASURE_WINDOWS; window++) {
+            // Rotate case order to avoid always measuring the weighted path after the baseline's allocations.
+            for (int offset = 0; offset < operations.size(); offset++) {
+                int index = (window + offset) % operations.size();
+                long elapsed = runWindow(operations.get(index), batchSizes[index]);
+                if (window >= WARMUP_WINDOWS) {
+                    samples[index][window - WARMUP_WINDOWS] = elapsed / batchSizes[index];
+                }
+            }
+        }
+        for (int index = 0; index < operations.size(); index++) {
+            Arrays.sort(samples[index]);
+            System.out.printf("%s operation=%s median_ns_op=%d min_ns_op=%d max_ns_op=%d operations=%d%n",
+                    label, names.get(index), samples[index][MEASURE_WINDOWS / 2], samples[index][0],
+                    samples[index][MEASURE_WINDOWS - 1], (long) batchSizes[index] * MEASURE_WINDOWS);
+        }
+    }
+
+    private static long runWindow(Supplier<?> operation, int count) {
+        long start = System.nanoTime();
+        for (int index = 0; index < count; index++) {
+            // Make allocated results escape; prepared-weight results intentionally retain the same estimate.
+            blackhole = operation.get();
+        }
+        return System.nanoTime() - start;
+    }
+}

--- a/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonCacheSizeBenchmarkTest.java
+++ b/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonCacheSizeBenchmarkTest.java
@@ -1,0 +1,145 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.connector.paimon;
+
+import org.apache.doris.connector.cache.JvmSizeUtils;
+import org.apache.doris.connector.spi.ConnectorPartitionInfo;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+class PaimonCacheSizeBenchmarkTest {
+    @Test
+    void weightedFixturePreservesProductionProjectionAndPreparedEstimate() {
+        PaimonCacheSizeBenchmark.Fixture fixture = new PaimonCacheSizeBenchmark.Fixture(
+                10, 32, PaimonCacheSizeBenchmark.Distribution.UNIFORM);
+        List<ConnectorPartitionInfo> baseline = fixture.load(false);
+        PaimonPartitionView weighted = (PaimonPartitionView) fixture.load(true);
+        Assertions.assertEquals(32, baseline.size());
+        Assertions.assertEquals(baseline.size(), weighted.size());
+        for (int index = 0; index < baseline.size(); index++) {
+            Assertions.assertEquals(baseline.get(index).getPartitionName(), weighted.get(index).getPartitionName());
+            Assertions.assertEquals(baseline.get(index).getPartitionValues(), weighted.get(index).getPartitionValues());
+        }
+        Assertions.assertEquals("region=region-0", weighted.get(0).getPartitionName());
+        Assertions.assertTrue(weighted.getSizeEstimate().isComplete());
+        Assertions.assertTrue(weighted.getSizeEstimate().getBytes() > 0);
+        Assertions.assertSame(weighted.getSizeEstimate(),
+                PaimonPartitionViewSizeEstimator.estimateEntry(fixture.key, weighted));
+        Assertions.assertNotSame(baseline, fixture.load(false), "baseline must rebuild rather than hit a cache");
+    }
+
+    @Test
+    void longTailFixturesCoverSampledAndUnsampledPositions() {
+        for (PaimonCacheSizeBenchmark.Distribution distribution : new PaimonCacheSizeBenchmark.Distribution[] {
+                PaimonCacheSizeBenchmark.Distribution.TAIL_END,
+                PaimonCacheSizeBenchmark.Distribution.TAIL_INTERIOR}) {
+            List<ConnectorPartitionInfo> partitions = new PaimonCacheSizeBenchmark.Fixture(
+                    100, 1_000, distribution).load(false);
+            int largeIndex = distribution == PaimonCacheSizeBenchmark.Distribution.TAIL_END ? 999 : 998;
+            Assertions.assertTrue(partitions.get(largeIndex).getPartitionValues().get("region").length()
+                    >= PaimonCacheSizeBenchmark.Fixture.LARGE_VALUE_CHARS);
+            for (int samples : new int[] {5, 16}) {
+                boolean sampled = false;
+                for (int sample = 0; sample < samples; sample++) {
+                    sampled |= sample * (partitions.size() - 1) / (samples - 1) == largeIndex;
+                }
+                Assertions.assertEquals(distribution == PaimonCacheSizeBenchmark.Distribution.TAIL_END, sampled);
+            }
+        }
+    }
+
+    @Test
+    void longTailWeightIsIndependentOfPositionAndNotExtrapolated() {
+        for (int count : new int[] {1_000, 10_000}) {
+            PaimonCacheSizeBenchmark.Fixture fixture = new PaimonCacheSizeBenchmark.Fixture(
+                    10, count, PaimonCacheSizeBenchmark.Distribution.UNIFORM);
+            PaimonPartitionView uniform = (PaimonPartitionView) fixture.load(true);
+            PaimonPartitionView interior = (PaimonPartitionView) new PaimonCacheSizeBenchmark.Fixture(
+                    10, count, PaimonCacheSizeBenchmark.Distribution.TAIL_INTERIOR).load(true);
+            PaimonPartitionView end = (PaimonPartitionView) new PaimonCacheSizeBenchmark.Fixture(
+                    10, count, PaimonCacheSizeBenchmark.Distribution.TAIL_END).load(true);
+            Assertions.assertTrue(interior.getSizeEstimate().isComplete());
+            Assertions.assertTrue(end.getSizeEstimate().isComplete());
+            // One value String shared by the list/map, plus a separately materialized partition-name String.
+            ConnectorPartitionInfo small = uniform.get(count - 2);
+            ConnectorPartitionInfo large = interior.get(count - 2);
+            long expectedGrowth = JvmSizeUtils.stringSize(large.getPartitionName())
+                    - JvmSizeUtils.stringSize(small.getPartitionName())
+                    + JvmSizeUtils.stringSize(large.getOrderedPartitionValues().get(0))
+                    - JvmSizeUtils.stringSize(small.getOrderedPartitionValues().get(0));
+            Assertions.assertTrue(expectedGrowth >= 2L * PaimonCacheSizeBenchmark.Fixture.LARGE_VALUE_CHARS);
+            Assertions.assertEquals(expectedGrowth,
+                    interior.getSizeEstimate().getBytes() - uniform.getSizeEstimate().getBytes());
+            Assertions.assertEquals(interior.getSizeEstimate().getBytes(), end.getSizeEstimate().getBytes());
+            List<ConnectorPartitionInfo> reordered = new ArrayList<>(interior);
+            Collections.swap(reordered, 0, count - 2);
+            Assertions.assertEquals(interior.getSizeEstimate().getBytes(),
+                    new PaimonPartitionView(fixture.key, reordered).getSizeEstimate().getBytes());
+        }
+    }
+
+    @Test
+    void unicodeAndMultipleColumnsAreCountedWithoutDoubleChargingMapValues() {
+        PaimonCacheSizeBenchmark.Fixture fixture = new PaimonCacheSizeBenchmark.Fixture(
+                10, 0, PaimonCacheSizeBenchmark.Distribution.UNIFORM);
+        for (int columns : new int[] {1, 4, 16}) {
+            Map<String, String> values = new LinkedHashMap<>();
+            for (int column = 0; column < columns; column++) {
+                values.put("column-" + column, "small-" + column);
+            }
+            ConnectorPartitionInfo small = partition(values);
+            Map<String, String> largeValues = new LinkedHashMap<>(values);
+            largeValues.put("column-0", "中".repeat(65_536));
+            ConnectorPartitionInfo large = partition(largeValues);
+            long before = new PaimonPartitionView(fixture.key, List.of(small)).getSizeEstimate().getBytes();
+            long after = new PaimonPartitionView(fixture.key, List.of(large)).getSizeEstimate().getBytes();
+            Assertions.assertEquals(JvmSizeUtils.stringSize(largeValues.get("column-0"))
+                    - JvmSizeUtils.stringSize(values.get("column-0")), after - before);
+        }
+    }
+
+    @Test
+    void projectionRemainsImmutableWithAPreparedWeight() {
+        for (int count : new int[] {0, 1, 32, 1_000}) {
+            PaimonCacheSizeBenchmark.Fixture fixture = new PaimonCacheSizeBenchmark.Fixture(
+                    10, count, PaimonCacheSizeBenchmark.Distribution.UNIFORM);
+            List<ConnectorPartitionInfo> input = fixture.load(false);
+            PaimonPartitionView view = new PaimonPartitionView(fixture.key, input);
+            Assertions.assertTrue(view.getSizeEstimate().isComplete());
+            Assertions.assertTrue(view.getSizeEstimate().getBytes() > 0);
+            Assertions.assertSame(view.getSizeEstimate(),
+                    PaimonPartitionViewSizeEstimator.estimateEntry(fixture.key, view));
+            input.clear();
+            Assertions.assertEquals(count, view.size());
+            Assertions.assertThrows(UnsupportedOperationException.class,
+                    () -> view.add(partition(Collections.emptyMap())));
+        }
+    }
+
+    private static ConnectorPartitionInfo partition(Map<String, String> values) {
+        return new ConnectorPartitionInfo("fixed-name", values, Collections.emptyMap(),
+                new ArrayList<>(values.values()), new ArrayList<>(Collections.nCopies(values.size(), false)));
+    }
+}

--- a/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonCatalogFactoryTest.java
+++ b/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonCatalogFactoryTest.java
@@ -24,6 +24,7 @@ import org.apache.doris.filesystem.properties.StorageProperties;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -89,6 +90,44 @@ public class PaimonCatalogFactoryTest {
         // for catalog creation. MUTATION: emitting "hive"/"jdbc" or dropping warehouse -> red.
         Assertions.assertEquals("filesystem", opts.get("metastore"));
         Assertions.assertEquals("/wh", opts.get("warehouse"));
+    }
+
+    @Test
+    public void enclosingDorisWeightLimitDisablesPaimonSdkCacheOnlyByDefault() throws Exception {
+        Map<String, String> defaults = props(
+                "paimon.catalog.type", "filesystem", "warehouse", "/wh");
+
+        try (PaimonConnector ungoverned = new PaimonConnector(defaults, new RecordingConnectorContext())) {
+            Options options = ungoverned.buildCatalogOptions();
+            Assertions.assertFalse(options.contains(CatalogOptions.CACHE_ENABLED),
+                    "without a global/catalog total, Doris must preserve the Paimon SDK default");
+        }
+
+        Map<String, String> catalogLimited = new HashMap<>(defaults);
+        catalogLimited.put("meta.cache.max-weight", "1MB");
+        try (PaimonConnector governed = new PaimonConnector(catalogLimited, new RecordingConnectorContext())) {
+            Options options = governed.buildCatalogOptions();
+            Assertions.assertTrue(options.contains(CatalogOptions.CACHE_ENABLED));
+            Assertions.assertFalse(options.get(CatalogOptions.CACHE_ENABLED),
+                    "an enclosing Doris hard limit must not be bypassed by an unaccounted SDK cache");
+        }
+
+        Map<String, String> entryLimited = new HashMap<>(defaults);
+        entryLimited.put("meta.cache.paimon.partition_view.max-weight", "1MB");
+        try (PaimonConnector entryOnly = new PaimonConnector(entryLimited, new RecordingConnectorContext())) {
+            Assertions.assertFalse(entryOnly.buildCatalogOptions().contains(CatalogOptions.CACHE_ENABLED),
+                    "an entry-only limit must preserve the Paimon SDK default");
+        }
+
+        PaimonCatalogProperties explicitTrue = PaimonCatalogProperties.of(props(
+                "paimon.catalog.type", "filesystem", "warehouse", "/wh", "paimon.cache-enabled", "true"));
+        Assertions.assertTrue(PaimonCatalogFactory.buildCatalogOptions(explicitTrue, true)
+                .get(CatalogOptions.CACHE_ENABLED), "an explicit Paimon setting must win");
+
+        PaimonCatalogProperties explicitFalse = PaimonCatalogProperties.of(props(
+                "paimon.catalog.type", "filesystem", "warehouse", "/wh", "paimon.cache-enabled", "false"));
+        Assertions.assertFalse(PaimonCatalogFactory.buildCatalogOptions(explicitFalse, true)
+                .get(CatalogOptions.CACHE_ENABLED), "an explicit Paimon setting must win");
     }
 
     @Test

--- a/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonCatalogPropertiesTest.java
+++ b/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonCatalogPropertiesTest.java
@@ -34,6 +34,18 @@ import java.util.Map;
  */
 public class PaimonCatalogPropertiesTest {
 
+    @Test
+    public void newUnknownWeightKeysFailButPersistedKeysDoNotBlockAlter() {
+        Map<String, String> current = props("warehouse", "/wh",
+                "meta.cache.paimon.future_entry.max-weight", "future-format");
+        PaimonConnectorProvider provider = new PaimonConnectorProvider();
+        Assertions.assertDoesNotThrow(() -> PaimonCatalogProperties.of(current));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> provider.validateProperties(current));
+        Assertions.assertDoesNotThrow(() -> provider.validatePropertiesForUpdate(current, Map.of("comment", "new")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> provider.validatePropertiesForUpdate(
+                current, Map.of("meta.cache.paimon.partiton_view.max-weight", "1MB")));
+    }
+
     private static Map<String, String> props(String... kv) {
         Map<String, String> m = new HashMap<>();
         for (int i = 0; i < kv.length; i += 2) {
@@ -134,7 +146,7 @@ public class PaimonCatalogPropertiesTest {
                 "warehouse", "/wh",
                 "hive.metastore.uris", "thrift://nn:9083"));
 
-        Assertions.assertDoesNotThrow(p::checkCreateTimeOnlyRules);
+        Assertions.assertDoesNotThrow(() -> p.checkCreateTimeOnlyRules());
     }
 
     /**

--- a/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonConnectorMetadataPartitionViewCacheTest.java
+++ b/fe/fe-connector/fe-connector-paimon/src/test/java/org/apache/doris/connector/paimon/PaimonConnectorMetadataPartitionViewCacheTest.java
@@ -17,7 +17,10 @@
 
 package org.apache.doris.connector.paimon;
 
+import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.cache.ConnectorMetadataCache;
+import org.apache.doris.connector.cache.ConnectorTableKey;
+import org.apache.doris.connector.cache.ScopePath;
 import org.apache.doris.connector.spi.ConnectorPartitionInfo;
 import org.apache.doris.connector.spi.pushdown.ConnectorExpression;
 
@@ -27,8 +30,10 @@ import org.apache.paimon.types.RowType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -104,6 +109,21 @@ public class PaimonConnectorMetadataPartitionViewCacheTest {
     }
 
     @Test
+    public void largePartitionViewCanBeEstimatedWithoutTheReflectiveVisitLimit() {
+        List<ConnectorPartitionInfo> partitions = new ArrayList<>();
+        for (int index = 0; index < 20_000; index++) {
+            String value = Integer.toString(index);
+            partitions.add(new ConnectorPartitionInfo("p=" + value,
+                    Collections.singletonMap("p", value), Collections.emptyMap(),
+                    Collections.singletonList(value), Collections.emptyList()));
+        }
+
+        PaimonPartitionView view = new PaimonPartitionView(
+                new ConnectorTableKey("db", "table", 1L, 1L), partitions);
+        Assertions.assertTrue(view.getSizeEstimate().isComplete());
+    }
+
+    @Test
     public void listPartitionsCachesDerivedListAcrossQueries() {
         // WHY: cache A must memoize the BUILT List<ConnectorPartitionInfo> keyed by (db, table, snapshotId,
         // schemaId), so a repeated query on the same (unchanged) latest snapshot skips the derived rebuild AND
@@ -124,6 +144,85 @@ public class PaimonConnectorMetadataPartitionViewCacheTest {
         Assertions.assertEquals(Arrays.asList("region=cn", "region=us"), names(first));
         Assertions.assertEquals(names(first), names(second), "the cached list is returned verbatim");
         Assertions.assertEquals(1, loadCount(ops), "a cache hit must not re-enumerate (listPartitions once)");
+    }
+
+    @Test
+    public void weightBoundedPartitionViewIsEstimatedAndCached() {
+        RecordingPaimonCatalogOps ops = new RecordingPaimonCatalogOps();
+        FakePaimonTable table = regionTable();
+        ops.table = table;
+        ops.latestSnapshotId = OptionalLong.of(100L);
+        ops.partitions = Arrays.asList(partition("cn"), partition("us"));
+        Map<String, String> properties = Collections.singletonMap(
+                "meta.cache.paimon.partition_view.max-weight", "1MB");
+        try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+            ConnectorMetadataCache<List<ConnectorPartitionInfo>> cache = new ConnectorMetadataCache<>(
+                    owner, "paimon.partition-view", "paimon", "partition_view", properties,
+                    key -> ScopePath.table(key.getDb(), key.getTable()),
+                    PaimonPartitionViewSizeEstimator::estimateEntry);
+            PaimonConnectorMetadata metadata = metadataWithCache(ops, cache);
+            PaimonTableHandle handle = handle(table);
+
+            List<ConnectorPartitionInfo> first = metadata.listPartitions(null, handle, Optional.empty());
+            List<ConnectorPartitionInfo> second = metadata.listPartitions(null, handle, Optional.empty());
+
+            Assertions.assertSame(first, second);
+            Assertions.assertEquals(1, loadCount(ops));
+        }
+    }
+
+    @Test
+    public void disabledBoundedPartitionViewDoesNotPrepareWeight() {
+        RecordingPaimonCatalogOps ops = new RecordingPaimonCatalogOps();
+        FakePaimonTable table = regionTable();
+        ops.table = table;
+        ops.latestSnapshotId = OptionalLong.of(100L);
+        ops.partitions = Collections.singletonList(partition("cn"));
+        Map<String, String> properties = new HashMap<>();
+        properties.put("meta.cache.paimon.partition_view.max-weight", "1MB");
+        properties.put("meta.cache.paimon.partition_view.enable", "false");
+        try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+            ConnectorMetadataCache<List<ConnectorPartitionInfo>> cache = new ConnectorMetadataCache<>(
+                    owner, "paimon.partition-view", "paimon", "partition_view", properties,
+                    key -> ScopePath.table(key.getDb(), key.getTable()),
+                    PaimonPartitionViewSizeEstimator::estimateEntry);
+            PaimonConnectorMetadata metadata = metadataWithCache(ops, cache);
+            List<ConnectorPartitionInfo> first = metadata.listPartitions(null, handle(table), Optional.empty());
+            List<ConnectorPartitionInfo> second = metadata.listPartitions(null, handle(table), Optional.empty());
+            Assertions.assertFalse(first instanceof PaimonPartitionView);
+            Assertions.assertEquals(first, second);
+            Assertions.assertNotSame(first, second);
+            Assertions.assertEquals(2, loadCount(ops));
+        }
+    }
+
+    @Test
+    public void unsampledLongTailRejectsAdmissionWithoutFailingPartitionListing() {
+        RecordingPaimonCatalogOps ops = new RecordingPaimonCatalogOps();
+        FakePaimonTable table = regionTable();
+        ops.table = table;
+        ops.latestSnapshotId = OptionalLong.of(100L);
+        ops.partitions = new ArrayList<>();
+        for (int index = 0; index < 1_000; index++) {
+            ops.partitions.add(partition("region-" + index));
+        }
+        ops.partitions.set(998, partition("x".repeat(1024 * 1024)));
+        Map<String, String> properties = Collections.singletonMap(
+                "meta.cache.paimon.partition_view.max-weight", "1MB");
+        try (CatalogMetaCache owner = CatalogMetaCache.unmanaged()) {
+            ConnectorMetadataCache<List<ConnectorPartitionInfo>> cache = new ConnectorMetadataCache<>(
+                    owner, "paimon.partition-view", "paimon", "partition_view", properties,
+                    key -> ScopePath.table(key.getDb(), key.getTable()),
+                    PaimonPartitionViewSizeEstimator::estimateEntry);
+            PaimonConnectorMetadata metadata = metadataWithCache(ops, cache);
+            PaimonTableHandle handle = handle(table);
+            List<ConnectorPartitionInfo> first = metadata.listPartitions(null, handle, Optional.empty());
+            List<ConnectorPartitionInfo> second = metadata.listPartitions(null, handle, Optional.empty());
+            Assertions.assertEquals(1_000, first.size());
+            Assertions.assertEquals(first, second);
+            Assertions.assertNotSame(first, second, "oversized views are returned, not cached");
+            Assertions.assertEquals(2, loadCount(ops));
+        }
     }
 
     @Test

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/SchemaTable.java
@@ -651,6 +651,11 @@ public class SchemaTable extends Table {
                                     .column("LAST_LOAD_SUCCESS_TIME", ScalarType.createStringType())
                                     .column("LAST_LOAD_FAILURE_TIME", ScalarType.createStringType())
                                     .column("LAST_ERROR", ScalarType.createStringType())
+                                    // Upgrade BE before FE: older BE scanners do not recognize these slots.
+                                    .column("MAX_WEIGHT", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("ESTIMATED_WEIGHT", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("WEIGHT_REJECT_COUNT", ScalarType.createType(PrimitiveType.BIGINT))
+                                    .column("LAST_WEIGHT_REJECT_REASON", ScalarType.createStringType())
                                     .build())
             )
             .put("backend_kerberos_ticket_cache",

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/CatalogMgr.java
@@ -660,30 +660,30 @@ public class CatalogMgr implements Writable, GsonPostProcessable {
         if (catalog instanceof ExternalCatalog) {
             Map<String, String> newProps = log.getNewProps();
             if (!isReplay) {
-                boolean tentativelyMutated = false;
+                ExternalCatalog externalCatalog = (ExternalCatalog) catalog;
                 try {
-                    ExternalCatalog externalCatalog = (ExternalCatalog) catalog;
                     boolean validatedWithoutMutation = externalCatalog.validatePropertiesBeforeUpdate(
                             oldProperties, newProps);
                     if (!validatedWithoutMutation) {
-                        externalCatalog.tryModifyCatalogProps(newProps);
-                        tentativelyMutated = true;
-                        externalCatalog.checkProperties();
+                        synchronized (externalCatalog) {
+                            Map<String, String> currentProperties = Maps.newHashMap(externalCatalog.getProperties());
+                            try {
+                                externalCatalog.tryModifyCatalogProps(newProps);
+                                externalCatalog.checkProperties();
+                            } finally {
+                                // Never expose tentative limits to lazy cache initialization. The real update
+                                // publishes properties with budget retirement after validation succeeds.
+                                externalCatalog.rollBackCatalogProps(currentProperties);
+                            }
+                        }
                     }
                 } catch (Exception validationException) {
-                    // Only legacy validators publish a tentative candidate. Detached validators
-                    // leave the live CatalogProperty untouched while concurrent initialization runs.
-                    if (oldProperties != null && tentativelyMutated) {
-                        ((ExternalCatalog) catalog).rollBackCatalogProps(oldProperties);
-                    }
                     if (validationException instanceof DdlException) {
                         throw (DdlException) validationException;
                     }
                     throw new DdlException("Invalid catalog properties: "
                             + validationException.getMessage(), validationException);
                 }
-            } else {
-                ((ExternalCatalog) catalog).tryModifyCatalogProps(newProps);
             }
             if (newProps.containsKey(METADATA_REFRESH_INTERVAL_SEC)) {
                 long catalogId = catalog.getId();

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalCatalog.java
@@ -39,6 +39,7 @@ import org.apache.doris.common.UserException;
 import org.apache.doris.common.Version;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.connector.cache.CacheSpec;
+import org.apache.doris.connector.cache.MetaCacheBudgetManager;
 import org.apache.doris.datasource.doris.RemoteDorisExternalDatabase;
 import org.apache.doris.datasource.infoschema.ExternalInfoSchemaDatabase;
 import org.apache.doris.datasource.infoschema.ExternalMysqlDatabase;
@@ -436,6 +437,11 @@ public abstract class ExternalCatalog
     protected void checkProperties(CatalogProperty property) throws DdlException {
         // check refresh parameter of catalog
         Map<String, String> properties = property.getProperties();
+        try {
+            checkMetaCacheWeightProperties(properties);
+        } catch (IllegalArgumentException e) {
+            throw new DdlException(e.getMessage());
+        }
         if (properties.containsKey(CatalogMgr.METADATA_REFRESH_INTERVAL_SEC)) {
             try {
                 int metadataRefreshIntervalSec = Integer.parseInt(
@@ -455,6 +461,11 @@ public abstract class ExternalCatalog
             throw new DdlException(
                     "The parameter " + SCHEMA_CACHE_TTL_SECOND + " is wrong, value is " + schemaCacheTtlSecond);
         }
+    }
+
+    /** Strict CREATE/ALTER validation for the core metadata-cache namespace owned by this catalog. */
+    protected void checkMetaCacheWeightProperties(Map<String, String> properties) {
+        CacheSpec.checkWeightProperties(properties, "default", "schema");
     }
 
     /**
@@ -609,14 +620,24 @@ public abstract class ExternalCatalog
     }
 
     private Runnable resetToUninitialized(boolean invalidCache, boolean deferAccessControllerCleanup) {
-        Runnable accessControllerCleanup;
-        synchronized (this) {
-            this.objectCreated = false;
-            this.initialized = false;
-            accessControllerCleanup = detachAccessController();
-            closeResourcesQuietly("resetting catalog");
-        }
+        return resetToUninitialized(invalidCache, deferAccessControllerCleanup, () -> { });
+    }
+
+    private Runnable resetToUninitialized(boolean invalidCache, boolean deferAccessControllerCleanup,
+            Runnable retireCaches) {
+        Runnable accessControllerCleanup = () -> { };
         try {
+            synchronized (this) {
+                this.objectCreated = false;
+                this.initialized = false;
+                accessControllerCleanup = detachAccessController();
+                try {
+                    closeResourcesQuietly("resetting catalog");
+                } finally {
+                    // Retire core and connector budgets before lazy initialization can publish a new limit.
+                    retireCaches.run();
+                }
+            }
             onRefreshCache(invalidCache);
         } catch (RuntimeException | Error e) {
             accessControllerCleanup.run();
@@ -853,7 +874,6 @@ public abstract class ExternalCatalog
 
     @Override
     public void modifyCatalogProps(Map<String, String> props) {
-        catalogProperty.modifyCatalogProps(props);
         notifyPropertiesUpdated(props);
     }
 
@@ -862,7 +882,6 @@ public abstract class ExternalCatalog
      * blocking close operation to CatalogMgr so it can run after releasing the global catalog write lock.
      */
     public Runnable modifyCatalogPropsWithDeferredAccessControllerCleanup(Map<String, String> props) {
-        catalogProperty.modifyCatalogProps(props);
         return resetAfterPropertyUpdate(props, true);
     }
 
@@ -872,28 +891,38 @@ public abstract class ExternalCatalog
 
     private void invalidateCachesAfterPropertyUpdate(Map<String, String> updatedProps) {
         ExternalMetaCacheMgr cacheMgr = Env.getCurrentEnv().getExtMetaCacheMgr();
-        if (updatedProps.get(SCHEMA_CACHE_TTL_SECOND) != null) {
+        if (updatedProps.get(SCHEMA_CACHE_TTL_SECOND) != null
+                || updatedProps.containsKey(MetaCacheBudgetManager.CATALOG_MAX_WEIGHT_PROPERTY)) {
             cacheMgr.removeCatalog(id);
-        } else {
-            cacheMgr.invalidateCatalog(id);
+            return;
         }
+        Set<String> removedEngines = Sets.newHashSet();
+        for (String key : updatedProps.keySet()) {
+            if (key == null || !key.startsWith("meta.cache.")) {
+                continue;
+            }
+            String remainder = key.substring("meta.cache.".length());
+            int separator = remainder.indexOf('.');
+            if (separator <= 0) {
+                continue;
+            }
+            String engine = remainder.substring(0, separator);
+            if (cacheMgr.isEngineRegistered(engine) && removedEngines.add(engine)) {
+                cacheMgr.removeCatalogByEngine(id, engine);
+            }
+        }
+        // Scoped removal does not clear other engines or row counts. ALTER may also change the endpoint,
+        // including when a tolerated cache property names an engine that this catalog does not use.
+        cacheMgr.invalidateCatalog(id);
     }
 
     private Runnable resetAfterPropertyUpdate(Map<String, String> updatedProps,
             boolean deferAccessControllerCleanup) {
-        Runnable accessControllerCleanup = () -> { };
-        // Property and connector state may already have changed when reset fails, so cache invalidation is mandatory.
-        try {
-            accessControllerCleanup = resetToUninitialized(false, deferAccessControllerCleanup);
-        } finally {
-            try {
-                invalidateCachesAfterPropertyUpdate(updatedProps);
-            } catch (RuntimeException | Error e) {
-                accessControllerCleanup.run();
-                throw e;
-            }
-        }
-        return accessControllerCleanup;
+        return resetToUninitialized(false, deferAccessControllerCleanup,
+                () -> {
+                    catalogProperty.modifyCatalogProps(updatedProps);
+                    invalidateCachesAfterPropertyUpdate(updatedProps);
+                });
     }
 
     public void rollBackCatalogProps(Map<String, String> props) {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/ExternalMetaCacheMgr.java
@@ -21,6 +21,10 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.ThreadPoolManager;
 import org.apache.doris.common.cache.NereidsSortedPartitionsCacheManager;
+import org.apache.doris.connector.cache.CacheSpec;
+import org.apache.doris.connector.cache.CatalogMetaCache;
+import org.apache.doris.connector.cache.MetaCache;
+import org.apache.doris.connector.cache.MetaCacheGovernance;
 import org.apache.doris.datasource.doris.DorisExternalMetaCache;
 import org.apache.doris.datasource.doris.RemoteDorisExternalCatalog;
 import org.apache.doris.datasource.metacache.ExternalCatalogMetaCache;
@@ -43,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
@@ -91,6 +96,7 @@ public class ExternalMetaCacheMgr {
     private ExternalRowCountCache rowCountCache;
 
     public ExternalMetaCacheMgr(boolean isCheckpointCatalog) {
+        MetaCacheGovernance.configureGlobalMaxWeight(configuredGlobalMaxWeight());
         rowCountRefreshExecutor = newThreadPool(isCheckpointCatalog,
                 Config.max_external_cache_loader_thread_pool_size,
                 Config.max_external_cache_loader_thread_pool_size * 1000,
@@ -116,6 +122,17 @@ public class ExternalMetaCacheMgr {
         fsCache = new FileSystemCache();
         rowCountCache = new ExternalRowCountCache(rowCountRefreshExecutor);
         registerBuiltinEngineCaches();
+    }
+
+    private static OptionalLong configuredGlobalMaxWeight() {
+        String configured = Config.external_meta_cache_max_weight;
+        long parsed = CacheSpec.parseWeight(configured, "external_meta_cache_max_weight",
+                true, Runtime.getRuntime().maxMemory());
+        if (configured.trim().endsWith("%") && parsed == 0L) {
+            throw new IllegalArgumentException(
+                    "external_meta_cache_max_weight percentage must be greater than 0%");
+        }
+        return parsed == 0L ? OptionalLong.empty() : OptionalLong.of(parsed);
     }
 
     private ExecutorService newThreadPool(boolean isCheckpointCatalog, int numThread, int queueSize,
@@ -155,28 +172,29 @@ public class ExternalMetaCacheMgr {
     }
 
     public void prepareCatalog(long catalogId) {
-        Map<String, String> catalogProperties = findCatalogProperties(catalogId);
-        if (catalogProperties == null) {
+        CatalogIf<?> catalog = getCatalog(catalogId);
+        if (catalog == null) {
             logMissingCatalogSkip(catalogId, "prepareCatalog");
             return;
         }
-        routeCatalogEngines(catalogId, cache -> cache.initCatalog(catalogId, catalogProperties));
+        synchronized (catalog) {
+            Map<String, String> catalogProperties = findCatalogProperties(catalog);
+            routeCatalogEngines(catalogId, cache -> cache.initCatalog(catalogId, catalogProperties));
+        }
     }
 
     public void prepareCatalogByEngine(long catalogId, String engine) {
-        Map<String, String> catalogProperties = findCatalogProperties(catalogId);
-        if (catalogProperties == null) {
+        CatalogIf<?> catalog = getCatalog(catalogId);
+        if (catalog == null) {
             logMissingCatalogSkip(catalogId, "prepareCatalogByEngine");
             return;
         }
-        prepareCatalogByEngine(catalogId, engine, catalogProperties);
-    }
-
-    public void prepareCatalogByEngine(long catalogId, String engine, Map<String, String> catalogProperties) {
-        Map<String, String> safeCatalogProperties = catalogProperties == null
-                ? Maps.newHashMap()
-                : Maps.newHashMap(catalogProperties);
-        routeSpecifiedEngine(engine, cache -> cache.initCatalog(catalogId, safeCatalogProperties));
+        // Property snapshot and runtime publication share ALTER's retirement monitor. A snapshot captured
+        // before ALTER must never reinstall an obsolete catalog budget after its old runtime was removed.
+        synchronized (catalog) {
+            Map<String, String> catalogProperties = findCatalogProperties(catalog);
+            routeSpecifiedEngine(engine, cache -> cache.initCatalog(catalogId, catalogProperties));
+        }
     }
 
     public void invalidateCatalog(long catalogId) {
@@ -218,6 +236,10 @@ public class ExternalMetaCacheMgr {
         routeSpecifiedEngine(engine, cache -> safeInvalidate(
                 cache, catalogId, "removeCatalogByEngine",
                 () -> cache.invalidateCatalog(catalogId)));
+    }
+
+    public boolean isEngineRegistered(String engine) {
+        return cacheTypes.containsKey(engine);
     }
 
     /**
@@ -331,6 +353,15 @@ public class ExternalMetaCacheMgr {
         allCacheTypes().forEach(externalMetaCache -> externalMetaCache.stats(catalogId)
                 .forEach((entryName, entryStats) -> stats.add(
                         new CatalogMetaCacheStats(externalMetaCache.engine(), entryName, entryStats))));
+        for (CatalogMetaCache cache : MetaCacheGovernance.catalogCaches(catalogId)) {
+            if (ENGINE_DEFAULT.equals(cache.engine()) || ENGINE_DORIS.equals(cache.engine())) {
+                continue;
+            }
+            for (Map.Entry<String, MetaCache<?, ?>> entry : cache.entries().entrySet()) {
+                stats.add(new CatalogMetaCacheStats(
+                        cache.engine(), entry.getKey(), MetaCacheEntryStats.from(entry.getValue())));
+            }
+        }
         stats.sort(Comparator.comparing(CatalogMetaCacheStats::getEngineName)
                 .thenComparing(CatalogMetaCacheStats::getEntryName));
         return stats;
@@ -404,12 +435,7 @@ public class ExternalMetaCacheMgr {
         action.run();
     }
 
-    @Nullable
-    private Map<String, String> findCatalogProperties(long catalogId) {
-        CatalogIf<?> catalog = getCatalog(catalogId);
-        if (catalog == null) {
-            return null;
-        }
+    private Map<String, String> findCatalogProperties(CatalogIf<?> catalog) {
         Map<String, String> props = catalog.getProperties() == null
                 ? Maps.newHashMap()
                 : Maps.newHashMap(catalog.getProperties());

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/doris/RemoteDorisExternalCatalog.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/doris/RemoteDorisExternalCatalog.java
@@ -19,6 +19,7 @@ package org.apache.doris.datasource.doris;
 
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
+import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.datasource.CatalogProperty;
 import org.apache.doris.datasource.ExternalCatalog;
 import org.apache.doris.datasource.SessionContext;
@@ -72,6 +73,12 @@ public class RemoteDorisExternalCatalog extends ExternalCatalog {
             throw new DdlException("Cloud mode is not supported when "
                     + RemoteDorisProperties.USE_ARROW_FLIGHT + " is false");
         }
+    }
+
+    @Override
+    protected void checkMetaCacheWeightProperties(Map<String, String> properties) {
+        CacheSpec.checkWeightProperties(properties, DorisExternalMetaCache.ENGINE,
+                DorisExternalMetaCache.ENTRY_SCHEMA, DorisExternalMetaCache.ENTRY_BACKENDS);
     }
 
     public List<String> getFeNodes() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/CatalogMetaCacheRuntime.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/CatalogMetaCacheRuntime.java
@@ -17,10 +17,8 @@
 
 package org.apache.doris.datasource.metacache;
 
-import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.cache.MetaCache;
-import org.apache.doris.connector.cache.ScopedMetaCache.CacheMetrics;
 
 import com.google.common.collect.Maps;
 
@@ -32,8 +30,12 @@ import java.util.concurrent.ConcurrentHashMap;
  * Catalog scoped entry container.
  */
 final class CatalogMetaCacheRuntime {
-    private final CatalogMetaCache owner = new CatalogMetaCache();
+    private final CatalogMetaCache owner;
     private final Map<String, MetaCache<?, ?>> entries = new ConcurrentHashMap<>();
+
+    CatalogMetaCacheRuntime(long catalogId, String engine, Map<String, String> catalogProperties) {
+        owner = CatalogMetaCache.managed(catalogId, engine, catalogProperties);
+    }
 
     CatalogMetaCache owner() {
         return owner;
@@ -62,29 +64,6 @@ final class CatalogMetaCacheRuntime {
     }
 
     private MetaCacheEntryStats stats(MetaCache<?, ?> entry) {
-        CacheSpec spec = entry.cacheSpec();
-        CacheMetrics metrics = entry.metrics();
-        long requests = metrics.getRequestCount();
-        long loads = metrics.getLoadSuccessCount() + metrics.getLoadFailureCount();
-        return new MetaCacheEntryStats(
-                spec.isEnable(),
-                entry.isEnabled(),
-                entry.isAutoRefresh(),
-                spec.getTtlSecond(),
-                spec.getCapacity(),
-                entry.size(),
-                requests,
-                metrics.getHitCount(),
-                metrics.getMissCount(),
-                requests == 0L ? 0D : (double) metrics.getHitCount() / requests,
-                metrics.getLoadSuccessCount(),
-                metrics.getLoadFailureCount(),
-                metrics.getTotalLoadTimeNanos(),
-                loads == 0L ? 0D : (double) metrics.getTotalLoadTimeNanos() / loads,
-                metrics.getEvictionCount(),
-                metrics.getInvalidateCount(),
-                metrics.getLastLoadSuccessTimeMs(),
-                metrics.getLastLoadFailureTimeMs(),
-                metrics.getLastError());
+        return MetaCacheEntryStats.from(entry);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/ExternalCatalogMetaCache.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/ExternalCatalogMetaCache.java
@@ -22,6 +22,7 @@ import org.apache.doris.common.Config;
 import org.apache.doris.connector.cache.CacheSpec;
 import org.apache.doris.connector.cache.MetaCache;
 import org.apache.doris.connector.cache.MetaCacheDefinition;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimators;
 import org.apache.doris.datasource.CacheException;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.datasource.ExternalCatalog;
@@ -87,7 +88,8 @@ public abstract class ExternalCatalogMetaCache implements ExternalMetaCache {
     public void initCatalog(long catalogId, Map<String, String> catalogProperties) {
         Map<String, String> safeCatalogProperties = CacheSpec.applyCompatibilityMap(
                 catalogProperties, catalogPropertyCompatibilityMap());
-        catalogEntries.computeIfAbsent(catalogId, id -> buildCatalogRuntime(safeCatalogProperties));
+        catalogEntries.computeIfAbsent(catalogId,
+                id -> buildCatalogRuntime(id, safeCatalogProperties));
     }
 
     @Override
@@ -271,8 +273,8 @@ public abstract class ExternalCatalogMetaCache implements ExternalMetaCache {
         ensureTypeCompatible(registered, entryDef.getKeyType(), entryDef.getValueType());
     }
 
-    private CatalogMetaCacheRuntime buildCatalogRuntime(Map<String, String> catalogProperties) {
-        CatalogMetaCacheRuntime group = new CatalogMetaCacheRuntime();
+    private CatalogMetaCacheRuntime buildCatalogRuntime(long catalogId, Map<String, String> catalogProperties) {
+        CatalogMetaCacheRuntime group = new CatalogMetaCacheRuntime(catalogId, engine, catalogProperties);
         metaCacheEntryDefs.values()
                 .forEach(entryDef -> group.put(entryDef.getName(),
                         newMetaCacheEntry(group, entryDef, catalogProperties)));
@@ -286,8 +288,9 @@ public abstract class ExternalCatalogMetaCache implements ExternalMetaCache {
         CacheSpec cacheSpec = CacheSpec.fromProperties(
                 catalogProperties, engine, entryDef.getName(), entryDef.getDefaultCacheSpec());
         Function<K, V> loader = wrapSchemaValidator(entryDef.getLoader(), entryDef.getValueType());
-        MetaCacheDefinition.Builder<K, V> builder = MetaCacheDefinition.builder(
-                entryDef.getName(), cacheSpec, entryDef.getInvalidation()::scope);
+        MetaCacheDefinition.Builder<K, V> builder = MetaCacheDefinition.<K, V>builder(
+                entryDef.getName(), cacheSpec, entryDef.getInvalidation()::scope)
+                .sizeEstimator(MetaCacheSizeEstimators.reflective());
         if (loader != null) {
             builder.loader(loader);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/FeMetaCacheEntry.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/FeMetaCacheEntry.java
@@ -23,8 +23,8 @@ import org.apache.doris.connector.cache.CatalogMetaCache;
 import org.apache.doris.connector.cache.MetaCache;
 import org.apache.doris.connector.cache.MetaCacheDefinition;
 import org.apache.doris.connector.cache.MetaCacheRemovalReason;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimators;
 import org.apache.doris.connector.cache.ScopePath;
-import org.apache.doris.connector.cache.ScopedMetaCache.CacheMetrics;
 
 import com.github.benmanes.caffeine.cache.RemovalListener;
 
@@ -84,7 +84,7 @@ public class FeMetaCacheEntry<K, V> {
     private final boolean autoRefresh;
     private final int stripeCount;
     private final AtomicReferenceArray<StripeState<K>> stripeStates;
-    private final CatalogMetaCache owner = new CatalogMetaCache();
+    private final CatalogMetaCache owner = CatalogMetaCache.unmanaged();
     private final MetaCache<K, V> data;
 
     public FeMetaCacheEntry(String name, Function<K, V> loader, CacheSpec cacheSpec, ExecutorService refreshExecutor) {
@@ -155,8 +155,9 @@ public class FeMetaCacheEntry<K, V> {
         }
         effectiveEnabled = CacheSpec.isCacheEnabled(
                 cacheSpec.isEnable(), cacheSpec.getTtlSecond(), cacheSpec.getCapacity());
-        MetaCacheDefinition.Builder<K, V> builder = MetaCacheDefinition.builder(
-                name, cacheSpec, ignored -> ScopePath.catalog());
+        MetaCacheDefinition.Builder<K, V> builder = MetaCacheDefinition.<K, V>builder(
+                name, cacheSpec, ignored -> ScopePath.catalog())
+                .sizeEstimator(MetaCacheSizeEstimators.reflective());
         if (loader != null) {
             builder.loader(key -> loadAndPause(key, loader));
         }
@@ -377,17 +378,7 @@ public class FeMetaCacheEntry<K, V> {
     }
 
     public MetaCacheEntryStats stats() {
-        CacheMetrics metrics = data.metrics();
-        long requests = metrics.getRequestCount();
-        long loads = metrics.getLoadSuccessCount() + metrics.getLoadFailureCount();
-        return new MetaCacheEntryStats(
-                cacheSpec.isEnable(), effectiveEnabled, autoRefresh, cacheSpec.getTtlSecond(), cacheSpec.getCapacity(),
-                metrics.getPhysicalEntryCount(), requests, metrics.getHitCount(), metrics.getMissCount(),
-                requests == 0L ? 0D : (double) metrics.getHitCount() / requests,
-                metrics.getLoadSuccessCount(), metrics.getLoadFailureCount(), metrics.getTotalLoadTimeNanos(),
-                loads == 0L ? 0D : (double) metrics.getTotalLoadTimeNanos() / loads,
-                metrics.getEvictionCount(), metrics.getInvalidateCount(), metrics.getLastLoadSuccessTimeMs(),
-                metrics.getLastLoadFailureTimeMs(), metrics.getLastError());
+        return MetaCacheEntryStats.from(data);
     }
 
     public static int defaultObjectStripeCount() {

--- a/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCacheEntryStats.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/datasource/metacache/MetaCacheEntryStats.java
@@ -18,6 +18,8 @@
 package org.apache.doris.datasource.metacache;
 
 import org.apache.doris.connector.cache.CacheSpec;
+import org.apache.doris.connector.cache.MetaCache;
+import org.apache.doris.connector.cache.ScopedMetaCache.CacheMetrics;
 
 import java.util.Objects;
 
@@ -53,6 +55,10 @@ public final class MetaCacheEntryStats {
     private final long lastLoadSuccessTimeMs;
     private final long lastLoadFailureTimeMs;
     private final String lastError;
+    private final long maxWeight;
+    private final long estimatedWeight;
+    private final long weightAdmissionRejectedCount;
+    private final String lastWeightRejectReason;
 
     /**
      * Build an immutable stats snapshot.
@@ -76,7 +82,11 @@ public final class MetaCacheEntryStats {
             long invalidateCount,
             long lastLoadSuccessTimeMs,
             long lastLoadFailureTimeMs,
-            String lastError) {
+            String lastError,
+            long maxWeight,
+            long estimatedWeight,
+            long weightAdmissionRejectedCount,
+            String lastWeightRejectReason) {
         this.configEnabled = configEnabled;
         this.effectiveEnabled = effectiveEnabled;
         this.autoRefresh = autoRefresh;
@@ -96,6 +106,28 @@ public final class MetaCacheEntryStats {
         this.lastLoadSuccessTimeMs = lastLoadSuccessTimeMs;
         this.lastLoadFailureTimeMs = lastLoadFailureTimeMs;
         this.lastError = Objects.requireNonNull(lastError, "lastError");
+        this.maxWeight = maxWeight;
+        this.estimatedWeight = estimatedWeight;
+        this.weightAdmissionRejectedCount = weightAdmissionRejectedCount;
+        this.lastWeightRejectReason = Objects.requireNonNull(lastWeightRejectReason, "lastWeightRejectReason");
+    }
+
+    /** Creates the FE system-table view of a cache owned by the shared connector framework. */
+    public static MetaCacheEntryStats from(MetaCache<?, ?> entry) {
+        CacheSpec spec = entry.cacheSpec();
+        CacheMetrics metrics = entry.metrics();
+        long requests = metrics.getRequestCount();
+        long loads = metrics.getLoadSuccessCount() + metrics.getLoadFailureCount();
+        return new MetaCacheEntryStats(
+                spec.isEnable(), entry.isEnabled(), entry.isAutoRefresh(), spec.getTtlSecond(), spec.getCapacity(),
+                entry.size(), requests, metrics.getHitCount(), metrics.getMissCount(),
+                requests == 0L ? 0D : (double) metrics.getHitCount() / requests,
+                metrics.getLoadSuccessCount(), metrics.getLoadFailureCount(), metrics.getTotalLoadTimeNanos(),
+                loads == 0L ? 0D : (double) metrics.getTotalLoadTimeNanos() / loads,
+                metrics.getEvictionCount(), metrics.getInvalidateCount(), metrics.getLastLoadSuccessTimeMs(),
+                metrics.getLastLoadFailureTimeMs(), metrics.getLastError(), metrics.getMaxWeight(),
+                metrics.getEstimatedWeight(), metrics.getWeightRejectCount(),
+                metrics.getLastWeightRejectReason());
     }
 
     public boolean isConfigEnabled() {
@@ -194,5 +226,21 @@ public final class MetaCacheEntryStats {
      */
     public String getLastError() {
         return lastError;
+    }
+
+    public long getMaxWeight() {
+        return maxWeight;
+    }
+
+    public long getEstimatedWeight() {
+        return estimatedWeight;
+    }
+
+    public long getWeightAdmissionRejectedCount() {
+        return weightAdmissionRejectedCount;
+    }
+
+    public String getLastWeightRejectReason() {
+        return lastWeightRejectReason;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tablefunction/MetadataGenerator.java
@@ -1967,6 +1967,10 @@ public class MetadataGenerator {
                     trow.addToColumnValue(new TCell().setStringVal(
                             formatMetaCacheTime(entryStats.getLastLoadFailureTimeMs(), timeZone)));
                     trow.addToColumnValue(new TCell().setStringVal(entryStats.getLastError())); // LAST_ERROR
+                    trow.addToColumnValue(new TCell().setLongVal(entryStats.getMaxWeight()));
+                    trow.addToColumnValue(new TCell().setLongVal(entryStats.getEstimatedWeight()));
+                    trow.addToColumnValue(new TCell().setLongVal(entryStats.getWeightAdmissionRejectedCount()));
+                    trow.addToColumnValue(new TCell().setStringVal(entryStats.getLastWeightRejectReason()));
                     dataBatch.add(trow);
                 }
             }

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/CatalogMgrTest.java
@@ -61,6 +61,7 @@ public class CatalogMgrTest {
         addCatalog(catalogMgr, catalog);
 
         Map<String, String> oldProperties = ImmutableMap.of("read.batch-size", "1024");
+        Mockito.when(catalog.getProperties()).thenReturn(oldProperties);
         Map<String, String> newProperties = ImmutableMap.of("read.batch-size", "0");
         CatalogLog log = new CatalogLog();
         log.setCatalogId(catalogId);

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogMetaCacheWeightTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogMetaCacheWeightTest.java
@@ -1,0 +1,81 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.datasource;
+
+import org.apache.doris.common.DdlException;
+import org.apache.doris.datasource.doris.RemoteDorisExternalCatalog;
+import org.apache.doris.datasource.property.constants.RemoteDorisProperties;
+import org.apache.doris.datasource.test.TestExternalCatalog;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ExternalCatalogMetaCacheWeightTest {
+
+    @Test
+    public void coreSchemaWeightIsValidatedAtTheDdlDoor() {
+        Map<String, String> properties = testCatalogProperties();
+        properties.put("meta.cache.default.schema.max-weight", "invalid");
+        TestExternalCatalog invalidWeight = new TestExternalCatalog(1L, "test", "", properties, "");
+        Assertions.assertThrows(DdlException.class, invalidWeight::checkProperties);
+
+        properties = testCatalogProperties();
+        properties.put("meta.cache.default.table.max-weight", "64MB");
+        TestExternalCatalog unknownEntry = new TestExternalCatalog(2L, "test", "", properties, "");
+        Assertions.assertDoesNotThrow(() -> {
+            unknownEntry.checkProperties();
+        });
+    }
+
+    @Test
+    public void remoteDorisValidatesItsOwnConsumedEntries() {
+        Map<String, String> properties = remoteDorisProperties();
+        properties.put("meta.cache.doris.backends.max-weight", "invalid");
+        RemoteDorisExternalCatalog invalidWeight = new RemoteDorisExternalCatalog(
+                1L, "remote", "", properties, "");
+        Assertions.assertThrows(DdlException.class, invalidWeight::checkProperties);
+
+        properties = remoteDorisProperties();
+        properties.put("meta.cache.doris.unknown.max-weight", "64MB");
+        RemoteDorisExternalCatalog unknownEntry = new RemoteDorisExternalCatalog(
+                2L, "remote", "", properties, "");
+        Assertions.assertDoesNotThrow(() -> {
+            unknownEntry.checkProperties();
+        });
+    }
+
+    private static Map<String, String> testCatalogProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("catalog_provider.class", RefreshCatalogTest.RefreshCatalogProvider.class.getName());
+        return properties;
+    }
+
+    private static Map<String, String> remoteDorisProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(RemoteDorisProperties.FE_THRIFT_HOSTS, "127.0.0.1:9020");
+        properties.put(RemoteDorisProperties.FE_HTTP_HOSTS, "127.0.0.1:8030");
+        properties.put(RemoteDorisProperties.FE_ARROW_HOSTS, "127.0.0.1:8070");
+        properties.put(RemoteDorisProperties.USER, "root");
+        properties.put(RemoteDorisProperties.PASSWORD, "");
+        properties.put(RemoteDorisProperties.USE_ARROW_FLIGHT, "true");
+        return properties;
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/ExternalCatalogTest.java
@@ -28,10 +28,14 @@ import org.apache.doris.common.jmockit.Deencapsulation;
 import org.apache.doris.common.util.DatasourcePrintableMap;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.connector.cache.CacheSpec;
+import org.apache.doris.connector.cache.MetaCacheGovernance;
+import org.apache.doris.datasource.doris.FeServiceClient;
+import org.apache.doris.datasource.doris.RemoteDorisExternalCatalog;
 import org.apache.doris.datasource.log.CatalogLog;
 import org.apache.doris.datasource.log.InitCatalogLog;
 import org.apache.doris.datasource.metacache.FeMetaCacheEntry;
 import org.apache.doris.datasource.metacache.NameCacheValue;
+import org.apache.doris.datasource.property.constants.RemoteDorisProperties;
 import org.apache.doris.datasource.test.TestExternalCatalog;
 import org.apache.doris.datasource.test.TestExternalDatabase;
 import org.apache.doris.datasource.test.TestExternalTable;
@@ -43,6 +47,7 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.statistics.util.StatisticsUtil;
+import org.apache.doris.system.Backend;
 import org.apache.doris.utframe.TestWithFeService;
 
 import com.google.common.collect.Lists;
@@ -67,6 +72,120 @@ public class ExternalCatalogTest extends TestWithFeService {
     private Env env;
     private CatalogMgr mgr;
     private ConnectContext rootCtx;
+
+    @Test
+    public void testScopedWeightAlterStillInvalidatesRemoteBackendsAndRowCounts() throws Exception {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(RemoteDorisProperties.FE_THRIFT_HOSTS, "127.0.0.1:9020");
+        properties.put(RemoteDorisProperties.FE_HTTP_HOSTS, "127.0.0.1:8030");
+        properties.put(RemoteDorisProperties.FE_ARROW_HOSTS, "127.0.0.1:8070");
+        properties.put(RemoteDorisProperties.USER, "root");
+        properties.put(RemoteDorisProperties.PASSWORD, "");
+        properties.put(RemoteDorisProperties.USE_ARROW_FLIGHT, "true");
+        FeServiceClient client = Mockito.mock(FeServiceClient.class);
+        RemoteDorisExternalCatalog catalog = new RemoteDorisExternalCatalog(
+                2292L, "budget_invalidation", "", properties, "") {
+            @Override
+            public FeServiceClient getFeServiceClient() {
+                return client;
+            }
+        };
+        mgr.getIdToCatalog().put(catalog.getId(), catalog);
+        ExternalMetaCacheMgr cacheMgr = env.getExtMetaCacheMgr();
+        ExternalRowCountCache originalRowCounts = cacheMgr.getRowCountCache();
+        ExternalRowCountCache rowCounts = new ExternalRowCountCache(MoreExecutors.newDirectExecutorService());
+        Deencapsulation.setField(cacheMgr, "rowCountCache", rowCounts);
+        try {
+            for (String weightKey : new String[] {"meta.cache.default.future_entry.max-weight",
+                    "meta.cache.doris.backends.max-weight"}) {
+                Backend oldBackend = new Backend(1L, "127.0.0.1", 9050);
+                Backend newBackend = new Backend(1L, "127.0.0.2", 9050);
+                cacheMgr.invalidateCatalog(catalog.getId());
+                Mockito.when(client.listBackends()).thenReturn(Lists.newArrayList(oldBackend));
+                Assertions.assertSame(oldBackend, cacheMgr.doris(catalog.getId()).getBackends(catalog.getId()).get(1L));
+                Mockito.when(client.listBackends()).thenReturn(Lists.newArrayList(newBackend));
+                ExternalTable table = Mockito.mock(ExternalTable.class);
+                Mockito.when(table.fetchRowCountWithMetaCache(false)).thenReturn(100L);
+                try (MockedStatic<StatisticsUtil> statistics = Mockito.mockStatic(StatisticsUtil.class)) {
+                    statistics.when(() -> StatisticsUtil.findTable(catalog.getId(), 1L, 2L)).thenReturn(table);
+                    Assertions.assertEquals(100L, rowCounts.getCachedRowCount(catalog.getId(), 1L, 2L, false));
+                    Map<String, String> updates = Maps.newHashMap();
+                    updates.put(RemoteDorisProperties.FE_THRIFT_HOSTS, "127.0.0.2:9020");
+                    updates.put(weightKey, "64MB");
+                    catalog.modifyCatalogProps(updates);
+                    Assertions.assertEquals(TableIf.UNKNOWN_ROW_COUNT,
+                            rowCounts.getCachedRowCountIfPresent(catalog.getId(), 1L, 2L), weightKey);
+                    Assertions.assertSame(newBackend,
+                            cacheMgr.doris(catalog.getId()).getBackends(catalog.getId()).get(1L), weightKey);
+                }
+            }
+        } finally {
+            cacheMgr.removeCatalog(catalog.getId());
+            Deencapsulation.setField(cacheMgr, "rowCountCache", originalRowCounts);
+            mgr.getIdToCatalog().remove(catalog.getId());
+        }
+    }
+
+    @Test
+    public void testCachePreparationCannotRepublishPreAlterBudget() throws Exception {
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put("catalog_provider.class", RefreshCatalogTest.RefreshCatalogProvider.class.getName());
+        properties.put("meta.cache.max-weight", "4KB");
+        CountDownLatch snapshotCaptured = new CountDownLatch(1);
+        CountDownLatch finishPreparation = new CountDownLatch(1);
+        AtomicInteger snapshots = new AtomicInteger();
+        TestExternalCatalog catalog = new TestExternalCatalog(2291L, "budget_publication", "", properties, "") {
+            @Override
+            public void overlayMetaCacheConfig(Map<String, String> config) {
+                Assertions.assertTrue(Thread.holdsLock(this),
+                        "the property snapshot and core owner publication must hold ALTER's monitor");
+                if (snapshots.getAndIncrement() == 0) {
+                    Assertions.assertEquals("4KB", config.get("meta.cache.max-weight"));
+                    snapshotCaptured.countDown();
+                    try {
+                        Assertions.assertTrue(finishPreparation.await(10L, TimeUnit.SECONDS));
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+
+            @Override
+            protected void closeResources() {
+                Assertions.assertEquals("4KB", getProperties().get("meta.cache.max-weight"),
+                        "new limits must not be published before old connector resources close");
+                super.closeResources();
+            }
+        };
+        mgr.getIdToCatalog().put(catalog.getId(), catalog);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> prepare = executor.submit(() -> env.getExtMetaCacheMgr()
+                    .prepareCatalogByEngine(catalog.getId(), "default"));
+            Assertions.assertTrue(snapshotCaptured.await(10L, TimeUnit.SECONDS));
+            CountDownLatch alterStarted = new CountDownLatch(1);
+            Future<?> alter = executor.submit(() -> {
+                alterStarted.countDown();
+                catalog.modifyCatalogProps(java.util.Collections.singletonMap("meta.cache.max-weight", "2KB"));
+            });
+            Assertions.assertTrue(alterStarted.await(10L, TimeUnit.SECONDS));
+            finishPreparation.countDown();
+            prepare.get(10L, TimeUnit.SECONDS);
+            alter.get(10L, TimeUnit.SECONDS);
+            env.getExtMetaCacheMgr().prepareCatalogByEngine(catalog.getId(), "default");
+            Assertions.assertEquals("2KB", catalog.getProperties().get("meta.cache.max-weight"));
+            Assertions.assertEquals(1, MetaCacheGovernance.catalogCaches(catalog.getId()).size());
+            Assertions.assertEquals(2048L, MetaCacheGovernance.catalogCaches(catalog.getId())
+                    .get(0).catalogMaxWeight().getAsLong());
+        } finally {
+            finishPreparation.countDown();
+            executor.shutdownNow();
+            Assertions.assertTrue(executor.awaitTermination(10L, TimeUnit.SECONDS));
+            env.getExtMetaCacheMgr().removeCatalog(catalog.getId());
+            mgr.getIdToCatalog().remove(catalog.getId());
+        }
+    }
 
     @Override
     protected void runBeforeAll() throws Exception {
@@ -1021,7 +1140,7 @@ public class ExternalCatalogTest extends TestWithFeService {
         mgr.getIdToCatalog().put(catalog.getId(), catalog);
         try {
             env.getExtMetaCacheMgr().prepareCatalogByEngine(
-                    catalog.getId(), "default", Maps.newHashMap());
+                    catalog.getId(), "default");
             org.apache.doris.connector.cache.MetaCache<SchemaCacheKey, SchemaCacheValue> schemaEntry =
                     env.getExtMetaCacheMgr()
                     .engine("default")

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/metacache/FeMetaCacheEntryTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/metacache/FeMetaCacheEntryTest.java
@@ -65,6 +65,29 @@ public class FeMetaCacheEntryTest {
     }
 
     @Test
+    public void testRejectedWeightedMutationReturnsWithoutRetryingForever() throws Exception {
+        ExecutorService refreshExecutor = Executors.newSingleThreadExecutor();
+        ExecutorService worker = Executors.newSingleThreadExecutor();
+        String oversized = "x".repeat(2_048);
+        try {
+            FeMetaCacheEntry<String, String> entry = new FeMetaCacheEntry<>(
+                    "objects", ignored -> "old",
+                    CacheSpec.ofWeight(true, CacheSpec.CACHE_NO_TTL, 100L, 1_024L),
+                    refreshExecutor, false);
+            Assertions.assertEquals("old", entry.get("key"));
+
+            Future<String> mutation = worker.submit(
+                    () -> entry.compute("key", (key, value) -> oversized));
+
+            Assertions.assertSame(oversized, mutation.get(3L, TimeUnit.SECONDS));
+            Assertions.assertNull(entry.getIfPresent("key"));
+        } finally {
+            worker.shutdownNow();
+            refreshExecutor.shutdownNow();
+        }
+    }
+
+    @Test
     public void testContextualOnlyAndDisabledEntry() {
         ExecutorService executor = Executors.newSingleThreadExecutor();
         try {

--- a/fe/fe-core/src/test/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalogConcurrencyTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/datasource/plugin/PluginDrivenExternalCatalogConcurrencyTest.java
@@ -20,6 +20,13 @@ package org.apache.doris.datasource.plugin;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.util.FileFormatConstants;
+import org.apache.doris.connector.cache.CacheSpec;
+import org.apache.doris.connector.cache.CatalogMetaCache;
+import org.apache.doris.connector.cache.MetaCache;
+import org.apache.doris.connector.cache.MetaCacheBudgetManager;
+import org.apache.doris.connector.cache.MetaCacheDefinition;
+import org.apache.doris.connector.cache.MetaCacheSizeEstimate;
+import org.apache.doris.connector.cache.ScopePath;
 import org.apache.doris.connector.spi.Connector;
 import org.apache.doris.connector.spi.ConnectorMetadata;
 import org.apache.doris.connector.spi.ConnectorSession;
@@ -40,6 +47,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
@@ -126,6 +134,96 @@ public class PluginDrivenExternalCatalogConcurrencyTest {
 
         Mockito.verify(cacheMgr).removeCatalog(1L);
         Mockito.verify(cacheMgr, Mockito.never()).invalidateCatalog(Mockito.anyLong());
+    }
+
+    @Test
+    public void testCatalogWeightPropertyRebuildsAllCacheBudgets() throws Exception {
+        TestablePluginCatalog catalog = new TestablePluginCatalog(
+                mockConnector("old", new ConcurrentLinkedQueue<>()));
+
+        catalog.notifyPropertiesUpdated(Collections.singletonMap(
+                MetaCacheBudgetManager.CATALOG_MAX_WEIGHT_PROPERTY, "1KB"));
+
+        Mockito.verify(cacheMgr).removeCatalog(1L);
+        Mockito.verify(cacheMgr, Mockito.never()).invalidateCatalog(Mockito.anyLong());
+    }
+
+    @Test
+    public void testPluginEntryWeightPropertyReliesOnConnectorRebuild() throws Exception {
+        TestablePluginCatalog catalog = new TestablePluginCatalog(
+                mockConnector("old", new ConcurrentLinkedQueue<>()));
+
+        catalog.notifyPropertiesUpdated(Collections.singletonMap(
+                "meta.cache.iceberg.table.max-weight", "1KB"));
+
+        Mockito.verify(cacheMgr).isEngineRegistered("iceberg");
+        Mockito.verify(cacheMgr, Mockito.never()).removeCatalogByEngine(Mockito.anyLong(), Mockito.anyString());
+        Mockito.verify(cacheMgr).invalidateCatalog(1L);
+        Mockito.verify(cacheMgr, Mockito.never()).removeCatalog(Mockito.anyLong());
+    }
+
+    @Test
+    public void testCatalogBudgetRetiresBeforeResetAllowsInitialization() throws Exception {
+        MetaCacheBudgetManager manager = new MetaCacheBudgetManager(OptionalLong.of(8192L));
+        try (CatalogMetaCache oldCore = new CatalogMetaCache(manager, 1L, "default",
+                Collections.singletonMap("meta.cache.max-weight", "4KB"))) {
+            MetaCache<String, String> oldEntry = oldCore.create(MetaCacheDefinition
+                    .<String, String>builder("schema", CacheSpec.of(true, -1L, 100L),
+                            ignored -> ScopePath.catalog())
+                    .sizeEstimator((key, value) -> MetaCacheSizeEstimate.complete(512L)).build());
+            oldEntry.put("key", "old");
+            AtomicReference<CatalogMetaCache> replacement = new AtomicReference<>();
+            TestablePluginCatalog catalog = new TestablePluginCatalog(
+                    mockConnector("old", new ConcurrentLinkedQueue<>())) {
+                @Override
+                public void onRefreshCache(boolean invalidCache) {
+                    super.onRefreshCache(invalidCache);
+                    // This callback is the first point outside the reset monitor where a query can initialize.
+                    makeSureInitialized();
+                }
+            };
+            catalog.setConnectorSupplier(() -> {
+                CatalogMetaCache next = new CatalogMetaCache(manager, 1L, "iceberg",
+                        Collections.singletonMap("meta.cache.max-weight", "2KB"));
+                replacement.set(next);
+                next.create(MetaCacheDefinition.<String, String>builder("table",
+                        CacheSpec.of(true, -1L, 100L), ignored -> ScopePath.catalog())
+                        .sizeEstimator((key, value) -> MetaCacheSizeEstimate.complete(512L)).build());
+                return Mockito.mock(Connector.class);
+            });
+            Mockito.doAnswer(invocation -> {
+                Assertions.assertTrue(Thread.holdsLock(catalog),
+                        "core budget retirement must be fenced against makeSureInitialized");
+                oldCore.close();
+                return null;
+            }).when(cacheMgr).removeCatalog(1L);
+
+            try {
+                catalog.modifyCatalogPropsWithDeferredAccessControllerCleanup(
+                        Collections.singletonMap("meta.cache.max-weight", "2KB")).run();
+                Assertions.assertNotNull(replacement.get());
+                Assertions.assertEquals(0L, manager.getGlobalUsedWeight());
+            } finally {
+                if (replacement.get() != null) {
+                    replacement.get().close();
+                }
+                catalog.onClose();
+            }
+        }
+    }
+
+    @Test
+    public void testCoreEntryWeightPropertyRebuildsRegisteredEngineCache() throws Exception {
+        Mockito.when(cacheMgr.isEngineRegistered("default")).thenReturn(true);
+        TestablePluginCatalog catalog = new TestablePluginCatalog(
+                mockConnector("old", new ConcurrentLinkedQueue<>()));
+
+        catalog.notifyPropertiesUpdated(Collections.singletonMap(
+                "meta.cache.default.schema.max-weight", "1KB"));
+
+        Mockito.verify(cacheMgr, Mockito.times(1)).removeCatalogByEngine(1L, "default");
+        Mockito.verify(cacheMgr).invalidateCatalog(1L);
+        Mockito.verify(cacheMgr, Mockito.never()).removeCatalog(Mockito.anyLong());
     }
 
     /**

--- a/regression-test/suites/external_table_p0/test_catalog_ddl.groovy
+++ b/regression-test/suites/external_table_p0/test_catalog_ddl.groovy
@@ -46,4 +46,111 @@ suite("test_catalog_ddl", "p0,external") {
         assertTrue(result[0][1].contains("COMMENT \"alter_comment\""))
 
         sql """drop catalog ${catalog1}"""
+
+        String weightedCatalog = "test_ddl_weighted_meta_cache"
+        sql """drop catalog if exists ${weightedCatalog}"""
+        sql """
+            create catalog ${weightedCatalog} properties(
+                "type" = "hms",
+                "hive.metastore.uris" = "thrift://127.0.0.1:9083",
+                "meta.cache.max-weight" = "128MB",
+                "meta.cache.hive.file.max-weight" = "64MB"
+            )
+        """
+        result = sql """show create catalog ${weightedCatalog}"""
+        assertEquals(result.size(), 1)
+        assertTrue(result[0][1].contains("\"meta.cache.max-weight\" = \"128MB\""))
+        assertTrue(result[0][1].contains("\"meta.cache.hive.file.max-weight\" = \"64MB\""))
+
+        sql """
+            alter catalog ${weightedCatalog} set properties(
+                "meta.cache.max-weight" = "96MB",
+                "meta.cache.hive.file.max-weight" = "48MB"
+            )
+        """
+        result = sql """show create catalog ${weightedCatalog}"""
+        assertTrue(result[0][1].contains("\"meta.cache.max-weight\" = \"96MB\""))
+        assertTrue(result[0][1].contains("\"meta.cache.hive.file.max-weight\" = \"48MB\""))
+
+        test {
+            sql """
+                alter catalog ${weightedCatalog} set properties(
+                    "meta.cache.default.schema.max-weight" = "invalid"
+                )
+            """
+            exception "Invalid cache weight for 'meta.cache.default.schema.max-weight': invalid"
+        }
+        test {
+            sql """alter catalog ${weightedCatalog} set properties(
+                "meta.cache.iceberg.partiton.max-weight" = "64MB")"""
+            exception "Unknown metadata cache weight property: meta.cache.iceberg.partiton.max-weight"
+        }
+        sql """drop catalog ${weightedCatalog}"""
+
+        test {
+            sql """
+                create catalog ${weightedCatalog} properties(
+                    "type" = "hms",
+                    "hive.metastore.uris" = "thrift://127.0.0.1:9083",
+                    "meta.cache.max-weight" = "64MB",
+                    "meta.cache.hive.file.max-weight" = "128MB"
+                )
+            """
+            exception "meta.cache.hive.file.max-weight can not exceed meta.cache.max-weight"
+        }
+
+        test {
+            sql """
+                create catalog ${weightedCatalog} properties(
+                    "type" = "hms",
+                    "hive.metastore.uris" = "thrift://127.0.0.1:9083",
+                    "meta.cache.max-weight" = "10%"
+                )
+            """
+            exception "Invalid cache weight for 'meta.cache.max-weight': 10%"
+        }
+
+        test {
+            sql """
+                create catalog ${weightedCatalog} properties(
+                    "type" = "es",
+                    "hosts" = "http://10.10.10.10:8888",
+                    "meta.cache.max-weight" = "invalid"
+                )
+            """
+            exception "Invalid cache weight for 'meta.cache.max-weight': invalid"
+        }
+
+        // Newly submitted unknown entries must not silently disable the requested memory limit.
+        sql """drop catalog if exists test_ddl_future_hive_cache"""
+        test {
+            sql """
+                create catalog test_ddl_future_hive_cache properties(
+                    "type" = "hms",
+                    "hive.metastore.uris" = "thrift://127.0.0.1:9083",
+                    "meta.cache.hive.future_entry.max-weight" = "64MB"
+                )
+            """
+            exception "Unknown metadata cache weight property: meta.cache.hive.future_entry.max-weight"
+        }
+        test {
+            sql """
+                create catalog ${weightedCatalog} properties(
+                    "type" = "hms",
+                    "hive.metastore.uris" = "thrift://127.0.0.1:9083",
+                    "meta.cache.iceberg.manifest.max-weight" = "invalid"
+                )
+            """
+            exception "Invalid cache weight for 'meta.cache.iceberg.manifest.max-weight': invalid"
+        }
+
+        sql """drop catalog if exists test_ddl_future_core_cache"""
+        sql """
+            create catalog test_ddl_future_core_cache properties(
+                "type" = "es",
+                "hosts" = "http://10.10.10.10:8888",
+                "meta.cache.default.future_entry.max-weight" = "64MB"
+            )
+        """
+        sql """alter catalog test_ddl_future_core_cache set properties("comment" = "updated")"""
 }


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: https://github.com/apache/doris/pull/66717 (merged into `branch-4.1`)

Problem Summary:

Port external metadata cache memory governance to `master`, adapting it to the connector SPI and shared cache framework rather than cherry-picking the legacy 4.1 cache implementation unchanged.

**Master adaptation:** rebased onto `1335022902a`. Preserved upstream DLF support when resolving the Iceberg/Paimon connector conflicts and adapted three assertions in the newly added FE cache test to master's JUnit 5 migration. No test expectations or additional production behavior were changed by conflict resolution.

Entry-count limits alone cannot control FE heap when external metadata values vary substantially in size. This change adds estimated retained-memory budgets for managed caches while keeping existing count-based behavior when no applicable memory limit is configured.

#### Scope and design

- Add a shared estimator/admission interface and FE-global, catalog-total, and logical-entry budgets. Physical caches representing one logical entry share its quota, including connector-owned sibling caches.
- Integrate the core schema cache and managed Hive/HMS, Iceberg, and Paimon caches. Include Hudi's sibling HMS caches in aggregate accounting and statistics without adding an unrelated Hudi-specific quota namespace.
- Estimate on load/publication, not on cache hits. Use type-specific estimators and bounded object-graph validation where applicable; incomplete validation rejects cache admission instead of reporting a falsely small weight. Shared infrastructure is excluded at ownership boundaries.
- Use strong cache values with explicit reservation ownership and coordinated reclamation. Keep replacement/removal accounting generation-safe and release ownership when catalogs/connectors close. This does not promise a global LRU or cross-catalog fairness.
- Isolate weighted Iceberg statement metadata from cached generations so lazy query-side metadata does not silently grow an admitted value.
- Expose `MAX_WEIGHT`, `ESTIMATED_WEIGHT`, `WEIGHT_REJECT_COUNT`, and `LAST_WEIGHT_REJECT_REASON` through `information_schema.catalog_meta_cache_statistics`, with rate-limited rejection warnings.

No optimizer rules, literal representations, or partition-item implementations are changed.

#### Configuration and behavior

```properties
# Optional FE-wide total, configured in fe.conf; requires restart.
# 0 disables only the global quota. Byte units or a JVM max-heap percentage are supported.
external_meta_cache_max_weight=0
```

```sql
-- Catalog/entry limits also work with the global quota disabled.
ALTER CATALOG lake SET PROPERTIES ('meta.cache.max-weight' = '1GB');
-- Optional per-entry limit; individual keys do not all need configuration.
ALTER CATALOG lake SET PROPERTIES ('meta.cache.iceberg.table.max-weight' = '256MB');
```

Catalog/entry property changes rebuild the affected cache owners without restarting FE. An oversized value, or one that cannot obtain budget after reclamation, is returned to the current request without being retained in the cache. Normal admission rejection does not fail the query. These are limits on **estimated retained cache memory**, not pre-load heap reservations or a guarantee against OOM while constructing a large value; active query objects and shared infrastructure are outside this budget.


#### Paimon microbenchmark (master adaptation)

Added a standalone Paimon benchmark (171 lines) plus two fixture-validation tests (67 lines), with no new dependency or production-code change. This is a microbenchmark harness, **not JMH**. A fresh focused run passed **33 tests** (0 failures/errors/skips); module Checkstyle/architecture validation passed.

Three fresh Java 17 JVMs, `-Xms1g -Xmx4g -XX:ActiveProcessorCount=4`, 5 warmup and 15 measurement windows per operation. The benchmark calls the production partition collector with recording catalog fakes, using 10/100 schema fields, 1,000/10,000 partitions, and uniform/sampled-tail/unsampled-tail distributions. It rotates operation order and reports actual operation counts and min/median/max window timings. No remote RPC, object-store latency, data scan, cache-hit throughput, or full admission-lock cost is included.

Representative uniform cases (median of the three JVM medians):

| Schema fields | Partitions | Collect only | Collect + weighted view | View publication only |
|---|---:|---:|---:|---:|
| 10 | 1,000 | 213.49 us | 219.41 us | 3.76 us |
| 10 | 10,000 | 2,492.62 us | 2,524.50 us | 7.91 us |
| 100 | 1,000 | 212.04 us | 219.03 us | 3.89 us |
| 100 | 10,000 | 2,544.63 us | 2,648.27 us | 7.93 us |

The small +1.3% to +4.1% differences overlap run variation and are not precise overhead guarantees. All-case publication-only medians are 3.76–8.51 us; prepared-weight callback timing is about 14 ns **including loop/volatile-sink overhead**, not complete cache admission. Each fork measures 120–3,840 collection operations and 30,720–245,760 publication operations per case. This is not a claim of end-to-end query speedup.

### Release note

Add configurable estimated-memory limits, dynamic catalog/entry quota changes, and memory usage/rejection statistics for managed external metadata caches.

### Check List (For Author)

- Test
    - [x] Unit Test: post-rebase focused run passed **314 tests across 19 classes**, with 0 failures/errors/skips. Covers configuration, budgets, concurrent cache lifecycle, reflective estimation, Hudi HMS ownership, Iceberg table isolation, FE weighted mutation rejection, and Iceberg/Paimon DLF catalog configuration and connectivity tests. The first post-rebase run caught the JUnit 4/5 assertion mismatch; the final run includes its correction.
    - [x] Regression test (pre-rebase head `f684d9fe479`): existing `external_table_p0/test_catalog_ddl` passed on a running cluster (1 suite, 0 failures/fatal errors/skips). Not rerun against a deployed post-rebase FE.
    - [x] Manual test (pre-rebase head `f684d9fe479`): local integration suite executed with `run-regression-test.sh`, followed by a separate comparison run against automatically generated and inspected output (1 suite, 0 failures/fatal errors/skips). Actual Iceberg REST/MinIO data: 256 partitions / 8,192 rows. Verified catalog-only quotas with global quota disabled, `64MB -> 1B -> 64MB`, entry-local rejection/recovery, rejection observability, and identical query results with/without cache admission (`COUNT(*)=8192`, `SUM(id)=33550336`).
    - Post-rebase FE and connector plugins built and packaged with `build.sh --fe` into an isolated output directory; Checkstyle and `git diff --check` passed. A temporary FE-only guard avoided an unrelated missing native-thirdparty rebuild; that environment adjustment was restored and is not included in this PR. The running pre-rebase test cluster was not replaced.
    - **Validation boundary:** the integration cluster reused a 4.1.3 BE. Actual Iceberg scans passed, but that BE cannot scan the new system-table columns (`no match column ... MAX_WEIGHT`). Memory statistics were checked through the running FE's Thrift endpoint. Matching-master BE compilation/system-table end-to-end validation, full external-engine integration, and follower replay remain unverified by this local run. No new end-to-end performance claims are made.

- Behavior changed:
    - [x] Yes. Configured memory quotas govern admission and expose rejection statistics; unconfigured caches preserve count-based behavior.



### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label if needed
