### PR TITLE
[fix](expr opt) Preserve cast-induced nullability in comparisons

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicate.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicate.java
@@ -544,6 +544,7 @@ public class SimplifyComparisonPredicate implements ExpressionPatternRuleFactory
 
     private static Expression processTypeRangeLimitComparison(ComparisonPredicate cp, Expression left,
             NumericLiteral right) {
+        Expression nullabilityExpression = left;
         BigDecimal typeMinValue = null;
         BigDecimal typeMaxValue = null;
         // cmp float like have lost precision, for example float.max_value + 0.01 still eval to float.max_value
@@ -559,7 +560,11 @@ public class SimplifyComparisonPredicate implements ExpressionPatternRuleFactory
         // cast(child as dataType2) range should be:
         //  [ max(childDataType.min_value, dataType2.min_value), min(childDataType.max_value, dataType2.max_value)]
         if (left instanceof Cast) {
-            left = ((Cast) left).child();
+            Cast cast = (Cast) left;
+            left = cast.child();
+            if (!Cast.castNullable(false, left.getDataType(), cast.getDataType())) {
+                nullabilityExpression = left;
+            }
             if (left.getDataType().isIntegerLikeType() || left.getDataType().isDecimalV3Type()) {
                 Optional<Pair<BigDecimal, BigDecimal>> minMaxOpt =
                         TypeCoercionUtils.getDataTypeMinMaxValue(left.getDataType());
@@ -582,7 +587,7 @@ public class SimplifyComparisonPredicate implements ExpressionPatternRuleFactory
         int cmpMax = literal.compareTo(typeMaxValue);
         if (cp instanceof EqualTo) {
             if (cmpMin < 0 || cmpMax > 0) {
-                return ExpressionUtils.falseOrNull(left);
+                return ExpressionUtils.falseOrNull(nullabilityExpression);
             }
         } else if (cp instanceof NullSafeEqual) {
             if (cmpMin < 0 || cmpMax > 0) {
@@ -590,37 +595,37 @@ public class SimplifyComparisonPredicate implements ExpressionPatternRuleFactory
             }
         } else if (cp instanceof GreaterThan) {
             if (cmpMin < 0) {
-                return ExpressionUtils.trueOrNull(left);
+                return ExpressionUtils.trueOrNull(nullabilityExpression);
             }
             if (cmpMax >= 0) {
-                return ExpressionUtils.falseOrNull(left);
+                return ExpressionUtils.falseOrNull(nullabilityExpression);
             }
         } else if (cp instanceof GreaterThanEqual) {
             if (cmpMin <= 0) {
-                return ExpressionUtils.trueOrNull(left);
+                return ExpressionUtils.trueOrNull(nullabilityExpression);
             }
             if (cmpMax == 0) {
                 return new EqualTo(cp.left(), cp.right());
             }
             if (cmpMax > 0) {
-                return ExpressionUtils.falseOrNull(left);
+                return ExpressionUtils.falseOrNull(nullabilityExpression);
             }
         } else if (cp instanceof LessThan) {
             if (cmpMin <= 0) {
-                return ExpressionUtils.falseOrNull(left);
+                return ExpressionUtils.falseOrNull(nullabilityExpression);
             }
             if (cmpMax > 0) {
-                return ExpressionUtils.trueOrNull(left);
+                return ExpressionUtils.trueOrNull(nullabilityExpression);
             }
         } else if (cp instanceof LessThanEqual) {
             if (cmpMin < 0) {
-                return ExpressionUtils.falseOrNull(left);
+                return ExpressionUtils.falseOrNull(nullabilityExpression);
             }
             if (cmpMin == 0) {
                 return new EqualTo(cp.left(), cp.right());
             }
             if (cmpMax >= 0) {
-                return ExpressionUtils.trueOrNull(left);
+                return ExpressionUtils.trueOrNull(nullabilityExpression);
             }
         }
         return cp;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicateTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/rules/SimplifyComparisonPredicateTest.java
@@ -33,6 +33,7 @@ import org.apache.doris.nereids.trees.expressions.LessThanEqual;
 import org.apache.doris.nereids.trees.expressions.Not;
 import org.apache.doris.nereids.trees.expressions.NullSafeEqual;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.TryCast;
 import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.BooleanLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.DateLiteral;
@@ -1069,6 +1070,35 @@ class SimplifyComparisonPredicateTest extends ExpressionRewriteTestHelper {
         FALSE, // eval to false
         EQUALS, // eval to equals
         NO_CHANGE_CP // no change cmp type
+    }
+
+    @Test
+    void testTypeRangeLimitPreservesCastNullability() {
+        executor = new ExpressionRuleExecutor(ImmutableList.of(
+                bottomUp(SimplifyComparisonPredicate.INSTANCE)
+        ));
+
+        SlotReference nonNullableBigInt = new SlotReference("bigint_slot", BigIntType.INSTANCE, false);
+        List<Cast> nullableCasts = ImmutableList.of(
+                new Cast(nonNullableBigInt, TinyIntType.INSTANCE),
+                new TryCast(nonNullableBigInt, TinyIntType.INSTANCE));
+        for (Cast nullableCast : nullableCasts) {
+            assertRewrite(new GreaterThan(nullableCast, new TinyIntLiteral((byte) 127)),
+                    ExpressionUtils.falseOrNull(nullableCast));
+            assertRewrite(new LessThan(nullableCast, new TinyIntLiteral((byte) -128)),
+                    ExpressionUtils.falseOrNull(nullableCast));
+            assertRewrite(new LessThanEqual(nullableCast, new TinyIntLiteral((byte) 127)),
+                    ExpressionUtils.trueOrNull(nullableCast));
+        }
+
+        SlotReference nonNullableTinyInt = new SlotReference("tinyint_slot", TinyIntType.INSTANCE, false);
+        List<Cast> safeCasts = ImmutableList.of(
+                new Cast(nonNullableTinyInt, SmallIntType.INSTANCE),
+                new TryCast(nonNullableTinyInt, SmallIntType.INSTANCE));
+        for (Cast safeCast : safeCasts) {
+            assertRewrite(new GreaterThan(safeCast, new SmallIntLiteral((short) 127)),
+                    BooleanLiteral.FALSE);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Problem

A comparison over a narrowing `CAST` or `TRY_CAST` can be simplified to a
non-null boolean constant even though the conversion may evaluate to `NULL`.
For example, with a non-null `BIGINT` value of `128`, both predicates below
must produce `NULL` when regular casts use non-strict semantics:

```sql
CAST(k AS TINYINT) > 127
TRY_CAST(k AS TINYINT) > 127
```

The incorrect simplification produces `FALSE`, which also makes the enclosing
`IS NULL` false and can filter out rows that should match.

## Root cause

The type-range comparison simplifier unwraps a cast to inspect the source type
and tighten the possible numeric range. It then reused the unwrapped child to
decide whether an always-true or always-false result could be null. A
non-nullable child does not capture NULL introduced by a failed conversion.
This affects regular `CAST` as well as `TRY_CAST` whenever the source/target
type pair can introduce NULL.

## Reproduction

```sql
SET enable_strict_cast = false;

CREATE TABLE t (
    id INT NOT NULL,
    k BIGINT NOT NULL
)
DUPLICATE KEY(id)
DISTRIBUTED BY HASH(id) BUCKETS 1
PROPERTIES ("replication_num" = "1");

INSERT INTO t VALUES (1, 128), (2, 1);

SELECT id,
       CAST(k AS TINYINT) > 127,
       TRY_CAST(k AS TINYINT) > 127,
       (CAST(k AS TINYINT) > 127) IS NULL,
       (TRY_CAST(k AS TINYINT) > 127) IS NULL
FROM t
ORDER BY id;
```

For `id = 1`, both comparisons must be `NULL` and both `IS NULL` expressions
must be `TRUE`.

## Fix

Separate the expression used for numeric range inference from the expression
used for nullability. Continue using the cast child for range inference, but
use `Cast.castNullable(false, sourceType, targetType)` to detect whether the
conversion itself can add NULL. Preserve the original cast in null-aware
boolean constants only for those type pairs; safe casts continue to normalize
through their child.

## Tests

- Cover both regular `CAST` and `TRY_CAST` from non-null `BIGINT` to `TINYINT`
  for true-or-null and false-or-null outcomes.
- Verify safe `TINYINT`-to-`SMALLINT` casts still simplify to a plain boolean.
- Ran `SimplifyComparisonPredicateTest` successfully.

Issue Number: None
