### PR TITLE
[chore](regression) Enable branch-4.2 buildall trigger

### DIFF
--- a/regression-test/pipeline/common/teamcity-utils.sh
+++ b/regression-test/pipeline/common/teamcity-utils.sh
@@ -26,6 +26,7 @@
 declare -A targetBranch_to_pipelines
 targetBranch_to_pipelines=(
     ['master']='feut beut cloudut compile p0 p1 external performance cloud_p0 cloud_p1 vault_p0 nonConcurrent check_coverage check_coverage_fe'
+    ['branch-4.2']='feut beut cloudut compile p0 p1 external cloud_p0 cloud_p1 vault_p0 nonConcurrent check_coverage check_coverage_fe'
     ['branch-4.1']='feut beut cloudut compile p0 p1 external cloud_p0 cloud_p1 vault_p0 nonConcurrent check_coverage check_coverage_fe'
     ['branch-4.0']='feut beut cloudut compile p0 p1 external cloud_p0 cloud_p1 vault_p0 nonConcurrent check_coverage check_coverage_fe'
     ['branch-3.1']='feut beut cloudut compile p0 p1 external cloud_p0 cloud_p1 vault_p0 nonConcurrent check_coverage check_coverage_fe'

--- a/regression-test/pipeline/vault_p0/prepare.sh
+++ b/regression-test/pipeline/vault_p0/prepare.sh
@@ -67,11 +67,11 @@ fi
 # shellcheck source=/dev/null
 source "$(bash "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/get-or-set-tmp-env.sh 'get')"
 if ${skip_pipeline:=false}; then echo "INFO: skip build pipline" && exit 0; else echo "INFO: no skip"; fi
-if [[ "${target_branch}" == "master" || "${target_branch}" == "branch-4.2" || "${target_branch}" == "branch-4.0" || "${target_branch}" == "branch-3.1" || "${target_branch}" == "branch-3.0" ]]; then
+if [[ "${target_branch}" == "master" || "${target_branch}" == "branch-4.0" || "${target_branch}" == "branch-3.1" || "${target_branch}" == "branch-3.0" ]]; then
     echo "INFO: PR target branch ${target_branch}"
     install_java
 else
-    echo "WARNING: PR target branch ${target_branch} is NOT in (master, branch-4.2, branch-4.0, branch-3.1, branch-3.0), skip pipeline."
+    echo "WARNING: PR target branch ${target_branch} is NOT in (master, branch-4.0, branch-3.1, branch-3.0), skip pipeline."
     bash "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/get-or-set-tmp-env.sh 'set' "export skip_pipeline=true"
     exit 0
 fi

--- a/regression-test/pipeline/vault_p0/prepare.sh
+++ b/regression-test/pipeline/vault_p0/prepare.sh
@@ -67,11 +67,11 @@ fi
 # shellcheck source=/dev/null
 source "$(bash "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/get-or-set-tmp-env.sh 'get')"
 if ${skip_pipeline:=false}; then echo "INFO: skip build pipline" && exit 0; else echo "INFO: no skip"; fi
-if [[ "${target_branch}" == "master" || "${target_branch}" == "branch-4.0" || "${target_branch}" == "branch-3.1" || "${target_branch}" == "branch-3.0" ]]; then
+if [[ "${target_branch}" == "master" || "${target_branch}" == "branch-4.2" || "${target_branch}" == "branch-4.0" || "${target_branch}" == "branch-3.1" || "${target_branch}" == "branch-3.0" ]]; then
     echo "INFO: PR target branch ${target_branch}"
     install_java
 else
-    echo "WARNING: PR target branch ${target_branch} is NOT in (master, branch-4.0, branch-3.1, branch-3.0), skip pipeline."
+    echo "WARNING: PR target branch ${target_branch} is NOT in (master, branch-4.2, branch-4.0, branch-3.1, branch-3.0), skip pipeline."
     bash "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/get-or-set-tmp-env.sh 'set' "export skip_pipeline=true"
     exit 0
 fi


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #67745

Problem Summary: The issue-comment GitHub Action runs from the default branch and sources `regression-test/pipeline/common/teamcity-utils.sh` from `master`. Add `branch-4.2` to the supported target-branch matrix so `run buildall` can route branch-4.2 pull requests to the available TeamCity pipelines. The matrix matches `branch-4.1` and intentionally excludes ARM and Performance. Existing branch mappings are unchanged.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - `bash -n regression-test/pipeline/common/teamcity-utils.sh`
    - `shellcheck regression-test/pipeline/common/teamcity-utils.sh`
    - Simulated `trigger_or_skip_build` for every branch-4.2 pipeline; ARM and Performance are skipped.
- Behavior changed: Yes (comments containing `run buildall` can trigger the supported TeamCity matrix for branch-4.2 PRs)
- Does this need documentation: No