### PR TITLE
[chore](regression) Enable branch-4.2 pull request CI routing

### DIFF
--- a/regression-test/pipeline/common/teamcity-utils.sh
+++ b/regression-test/pipeline/common/teamcity-utils.sh
@@ -26,6 +26,7 @@
 declare -A targetBranch_to_pipelines
 targetBranch_to_pipelines=(
     ['master']='feut beut cloudut compile p0 p1 external arm performance cloud_p0 cloud_p1 vault_p0 nonConcurrent check_coverage check_coverage_fe'
+    ['branch-4.2']='feut beut cloudut compile p0 p1 external cloud_p0 cloud_p1 vault_p0 nonConcurrent check_coverage check_coverage_fe'
     ['branch-4.0']='feut beut cloudut compile p0 p1 external arm performance cloud_p0 cloud_p1 vault_p0 nonConcurrent check_coverage check_coverage_fe'
     ['branch-3.1']='feut beut cloudut compile p0 p1 external arm performance cloud_p0 cloud_p1 vault_p0 nonConcurrent check_coverage check_coverage_fe'
     ['branch-3.0']='feut beut cloudut compile p0 p1 external arm performance cloud_p0 cloud_p1 vault_p0 nonConcurrent check_coverage'

--- a/regression-test/pipeline/vault_p0/prepare.sh
+++ b/regression-test/pipeline/vault_p0/prepare.sh
@@ -67,11 +67,11 @@ fi
 # shellcheck source=/dev/null
 source "$(bash "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/get-or-set-tmp-env.sh 'get')"
 if ${skip_pipeline:=false}; then echo "INFO: skip build pipline" && exit 0; else echo "INFO: no skip"; fi
-if [[ "${target_branch}" == "master" || "${target_branch}" == "branch-4.0" || "${target_branch}" == "branch-3.1" || "${target_branch}" == "branch-3.0" ]]; then
+if [[ "${target_branch}" == "master" || "${target_branch}" == "branch-4.2" || "${target_branch}" == "branch-4.0" || "${target_branch}" == "branch-3.1" || "${target_branch}" == "branch-3.0" ]]; then
     echo "INFO: PR target branch ${target_branch}"
     install_java
 else
-    echo "WARNING: PR target branch ${target_branch} is NOT in (master, branch-4.0, branch-3.1, branch-3.0), skip pipeline."
+    echo "WARNING: PR target branch ${target_branch} is NOT in (master, branch-4.2, branch-4.0, branch-3.1, branch-3.0), skip pipeline."
     bash "${teamcity_build_checkoutDir}"/regression-test/pipeline/common/get-or-set-tmp-env.sh 'set' "export skip_pipeline=true"
     exit 0
 fi


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #67744

Problem Summary: Pull requests targeting branch-4.2 are not mapped to the community TeamCity pipelines, and Vault P0 rejects branch-4.2 during preparation. Add a branch-4.2-specific matrix aligned with branch-4.1, excluding Performance and ARM, and allow Vault P0 preparation for branch-4.2. Existing mappings in the branch-4.2 baseline remain unchanged.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - Validated shell syntax and the exact branch-4.2 pipeline mapping.
- Behavior changed: Yes (pull requests targeting branch-4.2 are routed to the supported community CI matrix)
- Does this need documentation: No