### PR TITLE
[fix](expression) Align signed zero constant comparisons

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/NumericLiteral.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/NumericLiteral.java
@@ -65,7 +65,10 @@ public abstract class NumericLiteral extends Literal implements ComparableLitera
                     || other instanceof DecimalLiteral || other instanceof DecimalV3Literal) {
                 return this.getBigDecimalValue().compareTo(((NumericLiteral) other).getBigDecimalValue());
             }
-            return Double.compare(this.getDouble(), ((Literal) other).getDouble());
+            double left = this.getDouble();
+            double right = ((Literal) other).getDouble();
+            // SQL treats signed zeros as equal, while Double.compare distinguishes them.
+            return left == right ? 0 : Double.compare(left, right);
         }
         if (other instanceof NullLiteral) {
             return 1;

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/FoldConstantTest.java
@@ -143,6 +143,26 @@ import java.time.LocalDateTime;
 class FoldConstantTest extends ExpressionRewriteTestHelper {
 
     @Test
+    void testSignedZeroComparisonFold() {
+        executor = new ExpressionRuleExecutor(ImmutableList.of(
+                bottomUp(FoldConstantRuleOnFE.VISITOR_INSTANCE)
+        ));
+        for (String type : ImmutableList.of("float", "double")) {
+            for (String zero : ImmutableList.of("0.0", "-0.0")) {
+                String left = "cast('" + zero + "' as " + type + ")";
+                String right = "cast('" + (zero.equals("0.0") ? "-0.0" : "0.0") + "' as " + type + ")";
+                assertRewriteAfterTypeCoercion(left + " = " + right, "true");
+                assertRewriteAfterTypeCoercion(left + " <=> " + right, "true");
+                assertRewriteAfterTypeCoercion(left + " != " + right, "false");
+                assertRewriteAfterTypeCoercion(left + " < " + right, "false");
+                assertRewriteAfterTypeCoercion(left + " > " + right, "false");
+                assertRewriteAfterTypeCoercion(left + " <= " + right, "true");
+                assertRewriteAfterTypeCoercion(left + " >= " + right, "true");
+            }
+        }
+    }
+
+    @Test
     void testCaseWhenFold() {
         executor = new ExpressionRuleExecutor(ImmutableList.of(
                 bottomUp(FoldConstantRuleOnFE.VISITOR_INSTANCE)


### PR DESCRIPTION

FE constant folding used `Double.compare`, which distinguishes `+0.0` and `-0.0`, while Doris execution treats them as equal. This caused scalar comparisons to disagree with table filters and grouping. Numeric literal comparison now treats numerically equal floating-point values as equal, with regression coverage for FLOAT and DOUBLE predicates.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

