### PR TITLE
[fix](search) Validate ngram search gram number

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/NgramSearch.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/functions/scalar/NgramSearch.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.functions.ExplicitlyCastableSignature;
 import org.apache.doris.nereids.trees.expressions.functions.PropagateNullable;
+import org.apache.doris.nereids.trees.expressions.literal.IntegerLikeLiteral;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DoubleType;
 import org.apache.doris.nereids.types.IntegerType;
@@ -47,19 +48,28 @@ public class NgramSearch extends ScalarFunction
      */
     public NgramSearch(Expression arg0, Expression arg1, Expression arg2) {
         super("ngram_search", arg0, arg1, arg2);
-        if (!(arg1.isConstant())) {
-            throw new AnalysisException(
-                    "ngram_search(text,pattern,gram_num): pattern support const value only.");
-        }
-        if (!(arg2.isConstant())) {
-            throw new AnalysisException(
-                    "ngram_search(text,pattern,gram_num): gram_num support const value only.");
-        }
     }
 
     /** constructor for withChildren and reuse signature */
     private NgramSearch(ScalarFunctionParams functionParams) {
         super(functionParams);
+    }
+
+    @Override
+    public void checkLegalityBeforeTypeCoercion() {
+        if (!child(1).isConstant()) {
+            throw new AnalysisException(
+                    "ngram_search(text,pattern,gram_num): pattern support const value only.");
+        }
+        Expression gramNum = child(2);
+        if (!gramNum.isConstant()) {
+            throw new AnalysisException(
+                    "ngram_search(text,pattern,gram_num): gram_num support const value only.");
+        }
+        if (!(gramNum instanceof IntegerLikeLiteral) || ((IntegerLikeLiteral) gramNum).getIntValue() <= 0) {
+            throw new AnalysisException(
+                    "ngram_search(text,pattern,gram_num): gram_num must be a positive constant.");
+        }
     }
 
     /**

--- a/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function.groovy
+++ b/regression-test/suites/query_p0/sql_functions/string_functions/test_string_function.groovy
@@ -536,6 +536,14 @@ suite("test_string_function", "arrow_flight_sql") {
     qt_ngram_search2 """select ngram_search('abc','abc1313131',3); """
     qt_ngram_search3 """select ngram_search('abc1313131','abc1313131',3); """
     qt_ngram_search3 """select ngram_search('1313131','abc1313131',3); """
+    test {
+        sql "select ngram_search('abc', 'abc', 0);"
+        exception "gram_num must be a positive constant"
+    }
+    test {
+        sql "select ngram_search('abc', 'abc', -1);"
+        exception "gram_num must be a positive constant"
+    }
     
 
     sql "drop table if exists test_function_ngram_search;";


### PR DESCRIPTION
`ngram_search` accepted zero or negative `gram_num` values and deferred the failure to execution. The FE now requires `pattern` and `gram_num` to be constants and validates that `gram_num` is a positive integer, with regression coverage for invalid values.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

