### PR TITLE
[enhance](load) Publish load cancellation without channel or writer locks

### DIFF
--- a/be/src/cloud/cloud_delta_writer.cpp
+++ b/be/src/cloud/cloud_delta_writer.cpp
@@ -93,11 +93,12 @@ Status CloudDeltaWriter::write(const Block* block, const TabletAddRowsPayload& r
         ExecEnv::GetInstance()->memtable_memory_limiter()->handle_table_memtable_backpressure(
                 [this]() {
                     std::lock_guard lock(_mtx);
-                    return _is_cancelled;
+                    return _is_cancelled || !_get_load_cancel_status().ok();
                 },
                 table_id());
     }
     std::lock_guard lock(_mtx);
+    RETURN_IF_ERROR(_get_load_cancel_status());
     CHECK(_is_init || _is_cancelled);
     {
         SCOPED_TIMER(_wait_flush_limit_timer);
@@ -115,6 +116,7 @@ Status CloudDeltaWriter::write(const Block* block, const TabletAddRowsPayload& r
             return _memtable_writer->flush_running_count() >= effective_flush_running_count_limit;
         };
         while (need_backpressure()) {
+            RETURN_IF_ERROR(_get_load_cancel_status());
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
     }
@@ -123,6 +125,7 @@ Status CloudDeltaWriter::write(const Block* block, const TabletAddRowsPayload& r
 
 Status CloudDeltaWriter::close() {
     std::lock_guard lock(_mtx);
+    RETURN_IF_ERROR(_get_load_cancel_status());
     CHECK(_is_init);
     return _memtable_writer->close();
 }
@@ -154,6 +157,7 @@ void CloudDeltaWriter::update_tablet_stats() {
 Status CloudDeltaWriter::commit_rowset() {
     g_cloud_commit_rowset_count << 1;
     std::lock_guard<bthread::Mutex> lock(_mtx);
+    RETURN_IF_ERROR(_get_load_cancel_status());
 
     // Handle empty rowset (no data written)
     if (!_is_init) {
@@ -183,6 +187,7 @@ Status CloudDeltaWriter::_commit_empty_rowset() {
 }
 
 Status CloudDeltaWriter::set_txn_related_info() {
+    RETURN_IF_ERROR(_get_load_cancel_status());
     return rowset_builder()->set_txn_related_info();
 }
 

--- a/be/src/cloud/cloud_tablets_channel.cpp
+++ b/be/src/cloud/cloud_tablets_channel.cpp
@@ -167,6 +167,7 @@ Status CloudTabletsChannel::close(LoadChannel* parent, const PTabletWriterAddBlo
                                   PTabletWriterAddBlockResult* res, bool* finished) {
     // FIXME(plat1ko): Too many duplicate code with `TabletsChannel`
     std::lock_guard l(_lock);
+    RETURN_IF_ERROR(_check_cancelled());
     if (_state == kFinished) {
         return _close_status;
     }
@@ -205,6 +206,7 @@ Status CloudTabletsChannel::close(LoadChannel* parent, const PTabletWriterAddBlo
     bool success = true;
 
     for (auto&& [tablet_id, base_writer] : _tablet_writers) {
+        RETURN_IF_ERROR(_check_cancelled());
         auto* writer = static_cast<CloudDeltaWriter*>(base_writer.get());
         // ATTN: the strict mode means strict filtering of column type conversions during import.
         // Sometimes all inputs are filtered, but the partition ID is still set, and the writer is
@@ -256,6 +258,7 @@ Status CloudTabletsChannel::close(LoadChannel* parent, const PTabletWriterAddBlo
     using namespace std::chrono;
     auto build_start = steady_clock::now();
     for (auto* writer : writers_to_commit) {
+        RETURN_IF_ERROR(_check_cancelled());
         if (!writer->is_init()) {
             continue;
         }
@@ -278,6 +281,7 @@ Status CloudTabletsChannel::close(LoadChannel* parent, const PTabletWriterAddBlo
     std::vector<std::function<Status()>> tasks;
     tasks.reserve(writers_to_commit.size());
     for (auto* writer : writers_to_commit) {
+        RETURN_IF_ERROR(_check_cancelled());
         tasks.emplace_back([writer] { return writer->commit_rowset(); });
     }
     _close_status = cloud::bthread_fork_join(tasks, 10);
@@ -290,6 +294,7 @@ Status CloudTabletsChannel::close(LoadChannel* parent, const PTabletWriterAddBlo
 
     // 4. calculate delete bitmap for Unique Key MoW tables
     for (auto* writer : writers_to_commit) {
+        RETURN_IF_ERROR(_check_cancelled());
         auto st = writer->submit_calc_delete_bitmap_task();
         if (!st.ok()) {
             LOG(WARNING) << "failed to close wait DeltaWriter. tablet_id=" << writer->tablet_id()
@@ -302,6 +307,7 @@ Status CloudTabletsChannel::close(LoadChannel* parent, const PTabletWriterAddBlo
 
     // 5. wait for delete bitmap calculation complete if necessary
     for (auto* writer : writers_to_commit) {
+        RETURN_IF_ERROR(_check_cancelled());
         auto st = writer->wait_calc_delete_bitmap();
         if (!st.ok()) {
             LOG(WARNING) << "failed to close wait DeltaWriter. tablet_id=" << writer->tablet_id()
@@ -314,6 +320,7 @@ Status CloudTabletsChannel::close(LoadChannel* parent, const PTabletWriterAddBlo
 
     // 6. set txn related info if necessary
     for (auto it = writers_to_commit.begin(); it != writers_to_commit.end();) {
+        RETURN_IF_ERROR(_check_cancelled());
         auto st = (*it)->set_txn_related_info();
         if (!st.ok()) {
             _add_error_tablet(tablet_errors, (*it)->tablet_id(), st);
@@ -325,6 +332,7 @@ Status CloudTabletsChannel::close(LoadChannel* parent, const PTabletWriterAddBlo
 
     tablet_vec->Reserve(static_cast<int>(writers_to_commit.size() * 2));
     for (auto* writer : writers_to_commit) {
+        RETURN_IF_ERROR(_check_cancelled());
         PTabletInfo* tablet_info = tablet_vec->Add();
         tablet_info->set_tablet_id(writer->tablet_id());
         // unused required field.
@@ -343,7 +351,7 @@ Status CloudTabletsChannel::close(LoadChannel* parent, const PTabletWriterAddBlo
     }
     res->set_build_rowset_latency_ms(build_latency);
     res->set_commit_rowset_latency_ms(commit_latency);
-    return Status::OK();
+    return _check_cancelled();
 }
 
 } // namespace doris

--- a/be/src/load/channel/load_channel.cpp
+++ b/be/src/load/channel/load_channel.cpp
@@ -41,6 +41,7 @@ LoadChannel::LoadChannel(const UniqueId& load_id, int64_t timeout_s, bool is_hig
                          std::string sender_ip, int64_t backend_id, bool enable_profile,
                          int64_t wg_id)
         : _load_id(load_id),
+          _cancel_status(std::make_shared<AtomicStatus>()),
           _timeout_s(timeout_s),
           _is_high_priority(is_high_priority),
           _sender_ip(std::move(sender_ip)),
@@ -106,6 +107,7 @@ void LoadChannel::_init_profile() {
 }
 
 Status LoadChannel::open(const PTabletWriterOpenRequest& params) {
+    RETURN_IF_ERROR(cancel_status());
     if (config::is_cloud_mode() && params.txn_expiration() <= 0) {
         return Status::InternalError(
                 "The txn expiration of PTabletWriterOpenRequest is invalid, value={}",
@@ -139,6 +141,7 @@ Status LoadChannel::open(const PTabletWriterOpenRequest& params) {
                 channel = std::make_shared<TabletsChannel>(engine.to_local(), key, _load_id,
                                                            _is_high_priority, _self_profile);
             }
+            channel->set_load_cancel_status(_cancel_status);
             {
                 std::lock_guard<std::mutex> lt(_tablets_channels_lock);
                 _tablets_channels.insert({index_id, channel});
@@ -180,6 +183,7 @@ Status LoadChannel::_get_tablets_channel(std::shared_ptr<BaseTabletsChannel>& ch
 
 Status LoadChannel::add_batch(const PTabletWriterAddBlockRequest& request,
                               PTabletWriterAddBlockResult* response) {
+    RETURN_IF_ERROR(cancel_status());
     DBUG_EXECUTE_IF("LoadChannel.add_batch.failed",
                     { return Status::InternalError("fault injection"); });
     SCOPED_TIMER(_add_batch_timer);
@@ -237,6 +241,7 @@ Status LoadChannel::_handle_eos(BaseTabletsChannel* channel,
                                   request.index_id(), request.sender_id());
         int count = 0;
         while (!channel->is_finished()) {
+            RETURN_IF_ERROR(cancel_status());
             bthread_usleep(1000);
             count++;
         }
@@ -247,6 +252,7 @@ Status LoadChannel::_handle_eos(BaseTabletsChannel* channel,
         }
     }
 
+    RETURN_IF_ERROR(cancel_status());
     if (finished) {
         std::lock_guard<std::mutex> l(_lock);
         {
@@ -304,13 +310,18 @@ bool LoadChannel::is_finished() {
     return _tablets_channels.empty();
 }
 
-Status LoadChannel::cancel() {
-    _cancelled.store(true);
-    std::lock_guard<std::mutex> l(_lock);
-    for (auto& it : _tablets_channels) {
-        static_cast<void>(it.second->cancel());
-    }
+Status LoadChannel::cancel(const Status& reason) {
+    DCHECK(!reason.ok());
+    _cancel_status->update(reason);
     return Status::OK();
+}
+
+Status LoadChannel::cancel_status() const {
+    return _cancel_status->ok() ? Status::OK() : _cancel_status->status();
+}
+
+bool LoadChannel::is_cancelled() const {
+    return !_cancel_status->ok();
 }
 
 } // namespace doris

--- a/be/src/load/channel/load_channel.h
+++ b/be/src/load/channel/load_channel.h
@@ -40,6 +40,7 @@ class PTabletWriterAddBlockRequest;
 class PTabletWriterAddBlockResult;
 class OpenPartitionRequest;
 class BaseTabletsChannel;
+class AtomicStatus;
 
 // A LoadChannel manages tablets channels for all indexes
 // corresponding to a certain load job
@@ -59,7 +60,10 @@ public:
     // return true if this load channel has been opened and all tablets channels are closed then.
     bool is_finished();
 
-    Status cancel();
+    // Publish cancellation without taking channel/writer locks. In-flight
+    // requests retain ownership and release writers after their work finishes.
+    Status cancel(const Status& reason = Status::Cancelled("load channel cancelled"));
+    Status cancel_status() const;
 
     time_t last_updated_time() const { return _last_updated_time.load(); }
 
@@ -69,7 +73,7 @@ public:
 
     bool is_high_priority() const { return _is_high_priority; }
 
-    bool is_cancelled() const { return _cancelled.load(); }
+    bool is_cancelled() const;
 
     WorkloadGroupPtr workload_group() const { return _resource_ctx->workload_group(); }
 
@@ -112,7 +116,7 @@ private:
     std::unordered_set<int64_t> _finished_channel_ids;
     // set to true if at least one tablets channel has been opened
     bool _opened = false;
-    std::atomic<bool> _cancelled {false};
+    const std::shared_ptr<AtomicStatus> _cancel_status;
 
     std::shared_ptr<ResourceContext> _resource_ctx;
 

--- a/be/src/load/channel/load_channel_mgr.cpp
+++ b/be/src/load/channel/load_channel_mgr.cpp
@@ -186,28 +186,40 @@ Status LoadChannelMgr::add_batch(const PTabletWriterAddBlockRequest& request,
     // this case will be handled in load channel's add batch method.
     Status st = channel->add_batch(request, response);
     if (UNLIKELY(!st.ok())) {
-        // Release the manager's ownership too. The last in-flight request
-        // releases the writers with the channel.
-        PTabletWriterCancelRequest cancel_request;
-        *cancel_request.mutable_id() = request.id();
-        cancel_request.set_cancel_reason(st.to_string());
-        RETURN_IF_ERROR(cancel(cancel_request));
+        RETURN_IF_ERROR(_cancel_load_channel(channel, st));
         return st;
     }
 
     // 4. handle finish
     if (channel->is_finished()) {
-        _finish_load_channel(load_id);
+        _finish_load_channel(channel);
     }
     return Status::OK();
 }
 
-void LoadChannelMgr::_finish_load_channel(const UniqueId load_id) {
+Status LoadChannelMgr::_cancel_load_channel(const std::shared_ptr<LoadChannel>& channel,
+                                            const Status& reason) {
+    // Publish to the retained instance even if timeout cleanup or EOS removed it.
+    RETURN_IF_ERROR(channel->cancel(reason));
+    std::lock_guard<std::mutex> l(_lock);
+    const auto& load_id = channel->load_id();
+    auto it = _load_channels.find(load_id);
+    if (it == _load_channels.end() || it->second != channel) {
+        // A late RPC must not cancel a replacement opened with the same load ID.
+        return Status::OK();
+    }
+    _load_channels.erase(it);
+    _record_cancelled_load_channel(load_id, channel->cancel_status().to_string());
+    return Status::OK();
+}
+
+void LoadChannelMgr::_finish_load_channel(const std::shared_ptr<LoadChannel>& channel) {
+    const auto& load_id = channel->load_id();
     VLOG_NOTICE << "removing load channel " << load_id << " because it's finished";
     {
         std::lock_guard<std::mutex> l(_lock);
         auto it = _load_channels.find(load_id);
-        if (it == _load_channels.end() || it->second->is_cancelled()) {
+        if (it == _load_channels.end() || it->second != channel || channel->is_cancelled()) {
             // A concurrent cancel may already have removed the channel and recorded
             // its failure. Do not replace that tombstone with a successful EOS.
             return;
@@ -231,22 +243,7 @@ Status LoadChannelMgr::cancel(const PTabletWriterCancelRequest& params) {
             cancelled_channel = _load_channels[load_id];
             _load_channels.erase(load_id);
         }
-        // We just need to record the first cancel msg
-        auto* existing_handle = _load_state_channels->lookup(load_id.to_string());
-        if (existing_handle == nullptr) {
-            std::unique_ptr<CacheValue> cancel_reason_ptr = std::make_unique<CacheValue>();
-            cancel_reason_ptr->_cancel_reason = reason;
-            size_t cache_capacity =
-                    cancel_reason_ptr->_cancel_reason.capacity() + sizeof(CacheValue);
-            auto* handle = _load_state_channels->insert(load_id.to_string(),
-                                                        cancel_reason_ptr.get(), 1, cache_capacity);
-            cancel_reason_ptr.release();
-            _load_state_channels->release(handle);
-            LOG(INFO) << fmt::format("load_id = {}, record_error reason = {}", print_id(load_id),
-                                     reason);
-        } else {
-            _load_state_channels->release(existing_handle);
-        }
+        _record_cancelled_load_channel(load_id, reason);
     }
 
     if (cancelled_channel != nullptr) {
@@ -257,6 +254,24 @@ Status LoadChannelMgr::cancel(const PTabletWriterCancelRequest& params) {
     }
 
     return Status::OK();
+}
+
+void LoadChannelMgr::_record_cancelled_load_channel(const UniqueId& load_id,
+                                                    const std::string& reason) {
+    // Keep the first terminal state recorded for this load ID.
+    auto* existing_handle = _load_state_channels->lookup(load_id.to_string());
+    if (existing_handle != nullptr) {
+        _load_state_channels->release(existing_handle);
+        return;
+    }
+    auto value = std::make_unique<CacheValue>();
+    value->_cancel_reason = reason;
+    size_t cache_capacity = value->_cancel_reason.capacity() + sizeof(CacheValue);
+    auto* handle =
+            _load_state_channels->insert(load_id.to_string(), value.get(), 1, cache_capacity);
+    value.release();
+    _load_state_channels->release(handle);
+    LOG(INFO) << fmt::format("load_id = {}, record_error reason = {}", print_id(load_id), reason);
 }
 
 Status LoadChannelMgr::_start_bg_worker() {

--- a/be/src/load/channel/load_channel_mgr.cpp
+++ b/be/src/load/channel/load_channel_mgr.cpp
@@ -88,6 +88,15 @@ Status LoadChannelMgr::open(const PTabletWriterOpenRequest& params) {
         if (it != _load_channels.end()) {
             channel = it->second;
         } else {
+            auto* handle = _load_state_channels->lookup(load_id.to_string());
+            if (handle != nullptr) {
+                auto* value = static_cast<CacheValue*>(_load_state_channels->value(handle));
+                auto reason = value != nullptr ? value->_cancel_reason : std::string();
+                _load_state_channels->release(handle);
+                if (!reason.empty()) {
+                    return Status::Cancelled(reason);
+                }
+            }
             // create a new load channel
             int64_t timeout_in_req_s =
                     params.has_load_channel_timeout_s() ? params.load_channel_timeout_s() : -1;
@@ -121,7 +130,7 @@ Status LoadChannelMgr::_get_load_channel(std::shared_ptr<LoadChannel>& channel, 
         if (handle != nullptr) {
             // load is cancelled
             if (auto* value = _load_state_channels->value(handle); value != nullptr) {
-                const auto& cancel_reason = reinterpret_cast<CacheValue*>(value)->_cancel_reason;
+                const auto cancel_reason = reinterpret_cast<CacheValue*>(value)->_cancel_reason;
                 _load_state_channels->release(handle);
                 if (!cancel_reason.empty()) {
                     LOG(INFO) << fmt::format(
@@ -177,7 +186,12 @@ Status LoadChannelMgr::add_batch(const PTabletWriterAddBlockRequest& request,
     // this case will be handled in load channel's add batch method.
     Status st = channel->add_batch(request, response);
     if (UNLIKELY(!st.ok())) {
-        RETURN_IF_ERROR(channel->cancel());
+        // Release the manager's ownership too. The last in-flight request
+        // releases the writers with the channel.
+        PTabletWriterCancelRequest cancel_request;
+        *cancel_request.mutable_id() = request.id();
+        cancel_request.set_cancel_reason(st.to_string());
+        RETURN_IF_ERROR(cancel(cancel_request));
         return st;
     }
 
@@ -192,9 +206,13 @@ void LoadChannelMgr::_finish_load_channel(const UniqueId load_id) {
     VLOG_NOTICE << "removing load channel " << load_id << " because it's finished";
     {
         std::lock_guard<std::mutex> l(_lock);
-        if (_load_channels.contains(load_id)) {
-            _load_channels.erase(load_id);
+        auto it = _load_channels.find(load_id);
+        if (it == _load_channels.end() || it->second->is_cancelled()) {
+            // A concurrent cancel may already have removed the channel and recorded
+            // its failure. Do not replace that tombstone with a successful EOS.
+            return;
         }
+        _load_channels.erase(it);
         auto* handle = _load_state_channels->insert(load_id.to_string(), nullptr, 1, 1);
         _load_state_channels->release(handle);
     }
@@ -203,6 +221,9 @@ void LoadChannelMgr::_finish_load_channel(const UniqueId load_id) {
 
 Status LoadChannelMgr::cancel(const PTabletWriterCancelRequest& params) {
     UniqueId load_id(params.id());
+    const auto reason = params.has_cancel_reason() && !params.cancel_reason().empty()
+                                ? params.cancel_reason()
+                                : "load channel cancelled";
     std::shared_ptr<LoadChannel> cancelled_channel;
     {
         std::lock_guard<std::mutex> l(_lock);
@@ -213,25 +234,25 @@ Status LoadChannelMgr::cancel(const PTabletWriterCancelRequest& params) {
         // We just need to record the first cancel msg
         auto* existing_handle = _load_state_channels->lookup(load_id.to_string());
         if (existing_handle == nullptr) {
-            if (params.has_cancel_reason() && !params.cancel_reason().empty()) {
-                std::unique_ptr<CacheValue> cancel_reason_ptr = std::make_unique<CacheValue>();
-                cancel_reason_ptr->_cancel_reason = params.cancel_reason();
-                size_t cache_capacity =
-                        cancel_reason_ptr->_cancel_reason.capacity() + sizeof(CacheValue);
-                auto* handle = _load_state_channels->insert(
-                        load_id.to_string(), cancel_reason_ptr.get(), 1, cache_capacity);
-                cancel_reason_ptr.release();
-                _load_state_channels->release(handle);
-                LOG(INFO) << fmt::format("load_id = {}, record_error reason = {}",
-                                         print_id(load_id), params.cancel_reason());
-            }
+            std::unique_ptr<CacheValue> cancel_reason_ptr = std::make_unique<CacheValue>();
+            cancel_reason_ptr->_cancel_reason = reason;
+            size_t cache_capacity =
+                    cancel_reason_ptr->_cancel_reason.capacity() + sizeof(CacheValue);
+            auto* handle = _load_state_channels->insert(load_id.to_string(),
+                                                        cancel_reason_ptr.get(), 1, cache_capacity);
+            cancel_reason_ptr.release();
+            _load_state_channels->release(handle);
+            LOG(INFO) << fmt::format("load_id = {}, record_error reason = {}", print_id(load_id),
+                                     reason);
         } else {
             _load_state_channels->release(existing_handle);
         }
     }
 
     if (cancelled_channel != nullptr) {
-        RETURN_IF_ERROR(cancelled_channel->cancel());
+        // Publish without channel/writer locks. The final owner may still wait
+        // for in-flight work during destruction, outside the manager lock.
+        RETURN_IF_ERROR(cancelled_channel->cancel(Status::Cancelled(reason)));
         LOG(INFO) << "load channel has been cancelled: " << load_id;
     }
 

--- a/be/src/load/channel/load_channel_mgr.cpp
+++ b/be/src/load/channel/load_channel_mgr.cpp
@@ -241,15 +241,20 @@ Status LoadChannelMgr::cancel(const PTabletWriterCancelRequest& params) {
         std::lock_guard<std::mutex> l(_lock);
         if (_load_channels.contains(load_id)) {
             cancelled_channel = _load_channels[load_id];
+            // Publish while this exact instance is still mapped, then cache its
+            // effective first failure instead of a later cancel request's reason.
+            // cancel() only updates the shared status; it takes no writer locks.
+            RETURN_IF_ERROR(cancelled_channel->cancel(Status::Cancelled(reason)));
             _load_channels.erase(load_id);
+            _record_cancelled_load_channel(load_id, cancelled_channel->cancel_status().to_string());
+        } else {
+            _record_cancelled_load_channel(load_id, reason);
         }
-        _record_cancelled_load_channel(load_id, reason);
     }
 
     if (cancelled_channel != nullptr) {
-        // Publish without channel/writer locks. The final owner may still wait
-        // for in-flight work during destruction, outside the manager lock.
-        RETURN_IF_ERROR(cancelled_channel->cancel(Status::Cancelled(reason)));
+        // Keep the final owner's destruction outside the manager lock, since it
+        // may still wait for in-flight work.
         LOG(INFO) << "load channel has been cancelled: " << load_id;
     }
 

--- a/be/src/load/channel/load_channel_mgr.h
+++ b/be/src/load/channel/load_channel_mgr.h
@@ -78,7 +78,10 @@ private:
     Status _get_load_channel(std::shared_ptr<LoadChannel>& channel, bool& is_eof,
                              const UniqueId& load_id, const PTabletWriterAddBlockRequest& request);
 
-    void _finish_load_channel(UniqueId load_id);
+    Status _cancel_load_channel(const std::shared_ptr<LoadChannel>& channel, const Status& reason);
+    void _finish_load_channel(const std::shared_ptr<LoadChannel>& channel);
+    // Caller holds _lock.
+    void _record_cancelled_load_channel(const UniqueId& load_id, const std::string& reason);
 
     Status _start_bg_worker();
 

--- a/be/src/load/channel/tablets_channel.cpp
+++ b/be/src/load/channel/tablets_channel.cpp
@@ -87,9 +87,18 @@ BaseTabletsChannel::~BaseTabletsChannel() {
 
 TabletsChannel::~TabletsChannel() = default;
 
+Status BaseTabletsChannel::_check_cancelled() {
+    if (_load_cancel_status && !_load_cancel_status->ok()) {
+        _close_status = _load_cancel_status->status();
+        return _close_status;
+    }
+    return Status::OK();
+}
+
 Status BaseTabletsChannel::_get_current_seq(int64_t& cur_seq,
                                             const PTabletWriterAddBlockRequest& request) {
     std::lock_guard<std::mutex> l(_lock);
+    RETURN_IF_ERROR(_check_cancelled());
     if (_state != kOpened) {
         return _state == kFinished ? _close_status
                                    : Status::InternalError("TabletsChannel {} state: {}",
@@ -128,6 +137,7 @@ void BaseTabletsChannel::_init_profile(RuntimeProfile* profile) {
 
 Status BaseTabletsChannel::open(const PTabletWriterOpenRequest& request) {
     std::lock_guard<std::mutex> l(_lock);
+    RETURN_IF_ERROR(_check_cancelled());
     // if _state is kOpened, it's a normal case, already open by other sender
     // if _state is kFinished, already cancelled by other sender
     if (_state == kOpened) {
@@ -188,6 +198,7 @@ Status BaseTabletsChannel::incremental_open(const PTabletWriterOpenRequest& para
     }
 
     std::lock_guard<std::mutex> l(_lock);
+    RETURN_IF_ERROR(_check_cancelled());
 
     // one sender may incremental_open many times. but only close one time. so dont count duplicately.
     if (_open_by_incremental) {
@@ -228,6 +239,7 @@ Status BaseTabletsChannel::incremental_open(const PTabletWriterOpenRequest& para
         incremental_tablet_num++;
 
         WriteRequest wrequest;
+        wrequest.load_cancel_status = _load_cancel_status;
         wrequest.index_id = params.index_id();
         wrequest.tablet_id = tablet.tablet_id();
         wrequest.schema_hash = schema_hash;
@@ -345,6 +357,7 @@ Status TabletsChannel::close(LoadChannel* parent, const PTabletWriterAddBlockReq
     const auto& partition_ids = req.partition_ids();
     auto* tablet_errors = res->mutable_tablet_errors();
     std::lock_guard<std::mutex> l(_lock);
+    RETURN_IF_ERROR(_check_cancelled());
     if (_state == kFinished) {
         return _close_status;
     }
@@ -376,6 +389,7 @@ Status TabletsChannel::close(LoadChannel* parent, const PTabletWriterAddBlockReq
     std::set<DeltaWriter*> need_wait_writers;
     // under _lock. no need _tablet_writers_lock again.
     for (auto&& [tablet_id, writer] : _tablet_writers) {
+        RETURN_IF_ERROR(_check_cancelled());
         if (_partition_ids.contains(writer->partition_id())) {
             auto st = writer->close();
             if (!st.ok()) {
@@ -414,11 +428,13 @@ Status TabletsChannel::close(LoadChannel* parent, const PTabletWriterAddBlockReq
 
     // 2. wait all writer finished flush.
     for (auto* writer : need_wait_writers) {
+        RETURN_IF_ERROR(_check_cancelled());
         RETURN_IF_ERROR((writer->wait_flush()));
     }
 
     // 3. build rowset
     for (auto it = need_wait_writers.begin(); it != need_wait_writers.end();) {
+        RETURN_IF_ERROR(_check_cancelled());
         Status st = (*it)->build_rowset();
         if (!st.ok()) {
             _add_error_tablet(tablet_errors, (*it)->tablet_id(), st);
@@ -437,6 +453,7 @@ Status TabletsChannel::close(LoadChannel* parent, const PTabletWriterAddBlockReq
 
     // 4. wait for delete bitmap calculation complete if necessary
     for (auto it = need_wait_writers.begin(); it != need_wait_writers.end();) {
+        RETURN_IF_ERROR(_check_cancelled());
         Status st = (*it)->wait_calc_delete_bitmap();
         if (!st.ok()) {
             _add_error_tablet(tablet_errors, (*it)->tablet_id(), st);
@@ -449,12 +466,13 @@ Status TabletsChannel::close(LoadChannel* parent, const PTabletWriterAddBlockReq
     // 5. commit all writers
 
     for (auto* writer : need_wait_writers) {
+        RETURN_IF_ERROR(_check_cancelled());
         // close may return failed, but no need to handle it here.
         // tablet_vec will only contains success tablet, and then let FE judge it.
         _commit_txn(writer, res);
     }
 
-    return Status::OK();
+    return _check_cancelled();
 }
 
 void TabletsChannel::_commit_txn(DeltaWriter* writer, PTabletWriterAddBlockResult* res) {
@@ -572,6 +590,7 @@ Status BaseTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& req
                 .write_file_cache = request.write_file_cache(),
                 .storage_vault_id = request.storage_vault_id(),
                 .enable_table_memtable_backpressure = request.is_adaptive_random_bucket(),
+                .load_cancel_status = _load_cancel_status,
         };
         if (tablet.has_binlog_tablet_id()) {
             wrequest.binlog_tablet_id = tablet.binlog_tablet_id();

--- a/be/src/load/channel/tablets_channel.h
+++ b/be/src/load/channel/tablets_channel.h
@@ -110,6 +110,11 @@ public:
     // no-op when this channel has been closed or cancelled
     virtual Status cancel();
 
+    // Set once, before publishing the channel or opening any writers.
+    void set_load_cancel_status(std::shared_ptr<AtomicStatus> status) {
+        _load_cancel_status = std::move(status);
+    }
+
     void refresh_profile();
 
     size_t total_received_rows() const { return _total_received_rows; }
@@ -122,6 +127,9 @@ public:
     bool is_finished() const { return _state == kFinished; }
 
 protected:
+    // Caller holds _lock. The cancellation publisher never needs this lock.
+    Status _check_cancelled();
+
     Status _init_adaptive_random_bucket_state(const PTabletWriterOpenRequest& request);
     Status _write_block_data(const PTabletWriterAddBlockRequest& request, int64_t cur_seq,
                              std::unordered_map<int64_t, TabletAddRowsPayload>& tablet_to_rows,
@@ -164,6 +172,7 @@ protected:
     State _state;
 
     UniqueId _load_id;
+    std::shared_ptr<AtomicStatus> _load_cancel_status;
 
     // initialized in open function
     int64_t _txn_id = -1;

--- a/be/src/load/delta_writer/delta_writer.cpp
+++ b/be/src/load/delta_writer/delta_writer.cpp
@@ -97,8 +97,14 @@ BaseDeltaWriter::~BaseDeltaWriter() {
         return;
     }
 
-    // cancel and wait all memtables in flush queue to be finished
+    // Stop flush producers before releasing their rowset builders.
     static_cast<void>(_memtable_writer->cancel());
+    // Close may observe cancellation after submitting bitmap work. Drain that
+    // work before derived builders roll back transactions or clear rowset caches.
+    if (_req.load_cancel_status && !_req.load_cancel_status->ok()) {
+        WARN_IF_ERROR(_rowset_builder->wait_calc_delete_bitmap(),
+                      "delete bitmap calculation failed while destroying cancelled writer");
+    }
 
     if (_rowset_builder->tablet() != nullptr) {
         const FlushStatistic& stat = _memtable_writer->get_flush_token_stats();
@@ -136,7 +142,14 @@ int64_t BaseDeltaWriter::table_id() const {
 
 DeltaWriter::~DeltaWriter() = default;
 
+Status BaseDeltaWriter::_get_load_cancel_status() const {
+    return _req.load_cancel_status && !_req.load_cancel_status->ok()
+                   ? _req.load_cancel_status->status()
+                   : Status::OK();
+}
+
 Status BaseDeltaWriter::init() {
+    RETURN_IF_ERROR(_get_load_cancel_status());
     if (_is_init) {
         return Status::OK();
     }
@@ -166,13 +179,14 @@ Status DeltaWriter::write(const Block* block, const TabletAddRowsPayload& rows,
         ExecEnv::GetInstance()->memtable_memory_limiter()->handle_table_memtable_backpressure(
                 [this]() {
                     std::lock_guard<std::mutex> l(_lock);
-                    return _is_cancelled;
+                    return _is_cancelled || !_get_load_cancel_status().ok();
                 },
                 table_id());
     }
     _lock_watch.start();
     std::lock_guard<std::mutex> l(_lock);
     _lock_watch.stop();
+    RETURN_IF_ERROR(_get_load_cancel_status());
     if (!_is_init && !_is_cancelled) {
         RETURN_IF_ERROR(init());
     }
@@ -182,6 +196,7 @@ Status DeltaWriter::write(const Block* block, const TabletAddRowsPayload& rows,
                 config::memtable_flush_running_count_limit *
                 (_req.write_req_type == WriteRequestType::GROUP ? 2 : 1);
         while (_memtable_writer->flush_running_count() >= effective_flush_running_count_limit) {
+            RETURN_IF_ERROR(_get_load_cancel_status());
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
     }
@@ -207,6 +222,7 @@ Status DeltaWriter::close() {
     _lock_watch.start();
     std::lock_guard<std::mutex> l(_lock);
     _lock_watch.stop();
+    RETURN_IF_ERROR(_get_load_cancel_status());
     if (!_is_init && !_is_cancelled) {
         // if this delta writer is not initialized, but close() is called.
         // which means this tablet has no data loaded, but at least one tablet
@@ -221,6 +237,7 @@ Status DeltaWriter::close() {
 Status BaseDeltaWriter::build_rowset() {
     SCOPED_TIMER(_close_wait_timer);
     RETURN_IF_ERROR(_memtable_writer->close_wait(_profile));
+    RETURN_IF_ERROR(_get_load_cancel_status());
     return _rowset_builder->build_rowset();
 }
 
@@ -232,6 +249,7 @@ Status DeltaWriter::build_rowset() {
 }
 
 Status BaseDeltaWriter::submit_calc_delete_bitmap_task() {
+    RETURN_IF_ERROR(_get_load_cancel_status());
     return _rowset_builder->submit_calc_delete_bitmap_task();
 }
 
@@ -242,6 +260,7 @@ Status BaseDeltaWriter::wait_calc_delete_bitmap() {
 Status DeltaWriter::commit_txn() {
     std::lock_guard<std::mutex> l(_lock);
     SCOPED_TIMER(_commit_txn_timer);
+    RETURN_IF_ERROR(_get_load_cancel_status());
     return _rowset_builder->commit_txn();
 }
 

--- a/be/src/load/delta_writer/delta_writer.h
+++ b/be/src/load/delta_writer/delta_writer.h
@@ -70,7 +70,8 @@ public:
     Status submit_calc_delete_bitmap_task();
     Status wait_calc_delete_bitmap();
 
-    // abandon current memtable and wait for all pending-flushing memtables to be destructed.
+    // Abandon the current memtable and cancel queued flush tasks.
+    // Wait for running tasks before releasing their resources.
     // mem_consumption() should be 0 after this function returns.
     Status cancel();
     virtual Status cancel_with_status(const Status& st);
@@ -104,6 +105,8 @@ public:
             google::protobuf::RepeatedPtrField<PTabletLoadRowsetInfo>* tablet_info);
 
 protected:
+    Status _get_load_cancel_status() const;
+
     virtual void _init_profile(RuntimeProfile* profile);
 
     Status init();

--- a/be/src/load/delta_writer/delta_writer_context.h
+++ b/be/src/load/delta_writer/delta_writer_context.h
@@ -30,6 +30,7 @@ namespace doris {
 class TupleDescriptor;
 class SlotDescriptor;
 class OlapTableSchemaParam;
+class AtomicStatus;
 
 enum class WriteRequestType {
     DATA = 0,       // data write
@@ -56,6 +57,8 @@ struct WriteRequest {
     WriteRequestType write_req_type = WriteRequestType::DATA;
     std::string storage_vault_id;
     bool enable_table_memtable_backpressure = false;
+    // Shared by all writers of a load; published before writers can submit work.
+    std::shared_ptr<AtomicStatus> load_cancel_status = nullptr;
 };
 
 struct TabletAddRowsPayload {

--- a/be/src/load/memtable/memtable_memory_limiter.cpp
+++ b/be/src/load/memtable/memtable_memory_limiter.cpp
@@ -298,6 +298,11 @@ int64_t MemTableMemoryLimiter::_flush_active_memtables(int64_t need_flush) {
             continue;
         }
         Status st = w->flush_async();
+        if (st.is<ErrorCode::CANCELLED>()) {
+            // No memory was flushed. The final writer owner handles cleanup;
+            // cancel_with_status() would wait for flush tasks under _lock.
+            continue;
+        }
         if (!st.ok()) {
             auto err_msg = fmt::format(
                     "tablet writer failed to reduce mem consumption by flushing memtable, "

--- a/be/src/load/memtable/memtable_writer.cpp
+++ b/be/src/load/memtable/memtable_writer.cpp
@@ -221,6 +221,12 @@ Status MemTableWriter::_flush_memtable_async() {
 
 Status MemTableWriter::flush_async() {
     std::lock_guard<std::mutex> l(_lock);
+    if (_req.load_cancel_status && !_req.load_cancel_status->ok()) {
+        // Load cancellation no longer traverses writers. Pressure flushing must
+        // observe it before submitting or replacing the active memtable.
+        return Status::Cancelled("Load has been cancelled: {}",
+                                 _req.load_cancel_status->status().to_string());
+    }
     // Three calling paths:
     // 1. call by local, from `VTabletWriterV2::_write_memtable`.
     // 2. call by remote, from `LoadChannelMgr::_get_load_channel`.

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -339,6 +339,10 @@ BetaRowsetWriter::BetaRowsetWriter(StorageEngine& engine)
 RowBinlogRowsetWriter::RowBinlogRowsetWriter(StorageEngine& engine) : BetaRowsetWriter(engine) {}
 
 BaseBetaRowsetWriter::~BaseBetaRowsetWriter() {
+    // Finish callbacks before removing files they can still read on cancellation.
+    if (_calc_delete_bitmap_token) {
+        _calc_delete_bitmap_token->cancel();
+    }
     if (!_already_built && _rowset_meta->is_local()) {
         // abnormal exit, remove all files generated
         auto& fs = io::global_local_filesystem();
@@ -351,9 +355,6 @@ BaseBetaRowsetWriter::~BaseBetaRowsetWriter() {
             WARN_IF_ERROR(fs->delete_file(seg_path),
                           fmt::format("Failed to delete file={}", seg_path));
         }
-    }
-    if (_calc_delete_bitmap_token) {
-        _calc_delete_bitmap_token->cancel();
     }
 }
 

--- a/be/test/load/channel/load_channel_mgr_test.cpp
+++ b/be/test/load/channel/load_channel_mgr_test.cpp
@@ -1,0 +1,165 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "load/channel/load_channel_mgr.h"
+
+#include <gtest/gtest.h>
+
+#include <thread>
+
+#include "runtime/exec_env.h"
+#include "runtime/fragment_mgr.h"
+#include "util/countdown_latch.h"
+
+namespace doris {
+
+class LoadChannelMgrTest : public testing::Test {
+protected:
+    void SetUp() override {
+        auto* exec_env = ExecEnv::GetInstance();
+        if (exec_env->fragment_mgr() == nullptr) {
+            _fragment_mgr = std::make_unique<FragmentMgr>(exec_env);
+            exec_env->_fragment_mgr = _fragment_mgr.get();
+        }
+        _mgr = std::make_unique<LoadChannelMgr>();
+        // Drive timeout cleanup explicitly so the interleavings are deterministic.
+        _mgr->_load_state_channels = std::make_unique<LoadChannelMgr::LoadStateChannelCache>(1024);
+    }
+
+    void TearDown() override {
+        _mgr->stop();
+        _mgr.reset();
+        if (_fragment_mgr != nullptr) {
+            _fragment_mgr->stop();
+            ExecEnv::GetInstance()->_fragment_mgr = nullptr;
+            _fragment_mgr.reset();
+        }
+    }
+
+    std::shared_ptr<LoadChannel> create_channel() {
+        auto channel = std::make_shared<LoadChannel>(_load_id, 1, true, "127.0.0.1", 0, false, -1);
+        std::lock_guard<std::mutex> lock(_mgr->_lock);
+        _mgr->_load_channels[_load_id] = channel;
+        return channel;
+    }
+
+    void expect_no_cached_state() {
+        auto* handle = _mgr->_load_state_channels->lookup(_load_id.to_string());
+        EXPECT_EQ(handle, nullptr);
+        if (handle != nullptr) {
+            _mgr->_load_state_channels->release(handle);
+        }
+    }
+
+    UniqueId _load_id {1, 2};
+    std::unique_ptr<FragmentMgr> _fragment_mgr;
+    std::unique_ptr<LoadChannelMgr> _mgr;
+};
+
+TEST_F(LoadChannelMgrTest, FailedBatchCancelsRetainedChannelAndCachesReason) {
+    auto channel = create_channel();
+    PTabletWriterAddBlockRequest request;
+    *request.mutable_id() = _load_id.to_proto();
+    request.set_index_id(100);
+    PTabletWriterAddBlockResult response;
+    // No index was opened, so this exercises the actual add_batch failure path.
+    auto st = _mgr->add_batch(request, &response);
+    ASSERT_FALSE(st.ok());
+    EXPECT_EQ(channel->cancel_status().to_string(), st.to_string());
+    EXPECT_TRUE(_mgr->_load_channels.empty());
+
+    request.set_eos(true);
+    auto late_status = _mgr->add_batch(request, &response);
+    EXPECT_TRUE(late_status.is<ErrorCode::CANCELLED>()) << late_status;
+    EXPECT_NE(late_status.to_string().find(st.to_string()), std::string::npos);
+
+    PTabletWriterOpenRequest open_request;
+    *open_request.mutable_id() = _load_id.to_proto();
+    EXPECT_TRUE(_mgr->open(open_request).is<ErrorCode::CANCELLED>());
+}
+
+TEST_F(LoadChannelMgrTest, LateFailureDoesNotCancelReplacementAfterTimeout) {
+    auto original = create_channel();
+    CountDownLatch captured(1);
+    CountDownLatch resume_failure(1);
+    Status failure_status;
+    std::thread failed_request([&, channel = original] {
+        SCOPED_INIT_THREAD_CONTEXT();
+        captured.count_down();
+        resume_failure.wait();
+        failure_status = _mgr->_cancel_load_channel(channel, Status::InternalError("old request"));
+    });
+    captured.wait();
+    original->_last_updated_time.store(0);
+    EXPECT_TRUE(_mgr->_start_load_channels_clean().ok());
+    auto replacement = create_channel();
+    resume_failure.count_down();
+    failed_request.join();
+
+    EXPECT_TRUE(failure_status.ok()) << failure_status;
+    EXPECT_TRUE(original->is_cancelled());
+    EXPECT_FALSE(replacement->is_cancelled());
+    EXPECT_EQ(_mgr->_load_channels.at(_load_id), replacement);
+    expect_no_cached_state();
+}
+
+TEST_F(LoadChannelMgrTest, LateFinishDoesNotRemoveReplacement) {
+    auto original = create_channel();
+    auto replacement = create_channel();
+    _mgr->_finish_load_channel(original);
+    EXPECT_EQ(_mgr->_load_channels.at(_load_id), replacement);
+    EXPECT_FALSE(replacement->is_cancelled());
+    expect_no_cached_state();
+}
+
+TEST_F(LoadChannelMgrTest, FinishDoesNotOverwritePublishedFailure) {
+    auto channel = create_channel();
+    auto reason = Status::InternalError("first failure");
+    ASSERT_TRUE(channel->cancel(reason).ok());
+    // EOS arrives between cancellation publication and removal from the manager.
+    _mgr->_finish_load_channel(channel);
+    EXPECT_EQ(_mgr->_load_channels.at(_load_id), channel);
+    expect_no_cached_state();
+    ASSERT_TRUE(_mgr->_cancel_load_channel(channel, Status::InternalError("later failure")).ok());
+    _mgr->_finish_load_channel(channel);
+
+    auto* handle = _mgr->_load_state_channels->lookup(_load_id.to_string());
+    ASSERT_NE(handle, nullptr);
+    auto* value =
+            static_cast<LoadChannelMgr::CacheValue*>(_mgr->_load_state_channels->value(handle));
+    EXPECT_NE(value, nullptr);
+    if (value != nullptr) {
+        EXPECT_EQ(value->_cancel_reason, reason.to_string());
+    }
+    _mgr->_load_state_channels->release(handle);
+}
+
+TEST_F(LoadChannelMgrTest, FailureStillCancelsOriginalAfterFinish) {
+    auto channel = create_channel();
+    _mgr->_finish_load_channel(channel);
+    ASSERT_TRUE(_mgr->_load_channels.empty());
+    auto reason = Status::InternalError("late failure");
+    ASSERT_TRUE(_mgr->_cancel_load_channel(channel, reason).ok());
+    EXPECT_EQ(channel->cancel_status().to_string(), reason.to_string());
+    // A previously completed manager transition keeps its terminal state.
+    auto* handle = _mgr->_load_state_channels->lookup(_load_id.to_string());
+    ASSERT_NE(handle, nullptr);
+    EXPECT_EQ(_mgr->_load_state_channels->value(handle), nullptr);
+    _mgr->_load_state_channels->release(handle);
+}
+
+} // namespace doris

--- a/be/test/load/channel/load_channel_mgr_test.cpp
+++ b/be/test/load/channel/load_channel_mgr_test.cpp
@@ -92,6 +92,62 @@ TEST_F(LoadChannelMgrTest, FailedBatchCancelsRetainedChannelAndCachesReason) {
     EXPECT_TRUE(_mgr->open(open_request).is<ErrorCode::CANCELLED>());
 }
 
+TEST_F(LoadChannelMgrTest, PublicCancelCachesAlreadyPublishedFailure) {
+    auto channel = create_channel();
+    const auto first_failure = Status::InternalError("first writer failure");
+    CountDownLatch published(1);
+    CountDownLatch resume_failure(1);
+    Status publish_status;
+    Status failure_status;
+    std::thread failed_request([&] {
+        SCOPED_INIT_THREAD_CONTEXT();
+        // Stage the publication separately to model _cancel_load_channel paused
+        // before taking the manager lock. Its repeated publication is idempotent.
+        publish_status = channel->cancel(first_failure);
+        published.count_down();
+        resume_failure.wait();
+        failure_status = _mgr->_cancel_load_channel(channel, first_failure);
+    });
+    published.wait();
+
+    PTabletWriterCancelRequest cancel_request;
+    *cancel_request.mutable_id() = _load_id.to_proto();
+    cancel_request.set_cancel_reason("later upstream cancellation");
+    const auto cancel_status = _mgr->cancel(cancel_request);
+    resume_failure.count_down();
+    failed_request.join();
+
+    ASSERT_TRUE(publish_status.ok()) << publish_status;
+    ASSERT_TRUE(cancel_status.ok()) << cancel_status;
+    ASSERT_TRUE(failure_status.ok()) << failure_status;
+    EXPECT_EQ(channel->cancel_status().to_string(), first_failure.to_string());
+    EXPECT_TRUE(_mgr->_load_channels.empty());
+
+    auto* handle = _mgr->_load_state_channels->lookup(_load_id.to_string());
+    ASSERT_NE(handle, nullptr);
+    auto* value =
+            static_cast<LoadChannelMgr::CacheValue*>(_mgr->_load_state_channels->value(handle));
+    EXPECT_NE(value, nullptr);
+    if (value != nullptr) {
+        EXPECT_EQ(value->_cancel_reason, first_failure.to_string());
+    }
+    _mgr->_load_state_channels->release(handle);
+
+    PTabletWriterOpenRequest open_request;
+    *open_request.mutable_id() = _load_id.to_proto();
+    const auto open_status = _mgr->open(open_request);
+    EXPECT_TRUE(open_status.is<ErrorCode::CANCELLED>()) << open_status;
+    EXPECT_NE(open_status.to_string().find(first_failure.to_string()), std::string::npos);
+
+    PTabletWriterAddBlockRequest add_request;
+    *add_request.mutable_id() = _load_id.to_proto();
+    add_request.set_eos(true);
+    PTabletWriterAddBlockResult response;
+    const auto add_status = _mgr->add_batch(add_request, &response);
+    EXPECT_TRUE(add_status.is<ErrorCode::CANCELLED>()) << add_status;
+    EXPECT_NE(add_status.to_string().find(first_failure.to_string()), std::string::npos);
+}
+
 TEST_F(LoadChannelMgrTest, LateFailureDoesNotCancelReplacementAfterTimeout) {
     auto original = create_channel();
     CountDownLatch captured(1);

--- a/be/test/load/channel/load_channel_mgr_test.cpp
+++ b/be/test/load/channel/load_channel_mgr_test.cpp
@@ -65,6 +65,18 @@ protected:
         }
     }
 
+    void expect_cached_failure(const Status& reason) {
+        auto* handle = _mgr->_load_state_channels->lookup(_load_id.to_string());
+        ASSERT_NE(handle, nullptr);
+        auto* value =
+                static_cast<LoadChannelMgr::CacheValue*>(_mgr->_load_state_channels->value(handle));
+        EXPECT_NE(value, nullptr);
+        if (value != nullptr) {
+            EXPECT_EQ(value->_cancel_reason, reason.to_string());
+        }
+        _mgr->_load_state_channels->release(handle);
+    }
+
     UniqueId _load_id {1, 2};
     std::unique_ptr<FragmentMgr> _fragment_mgr;
     std::unique_ptr<LoadChannelMgr> _mgr;
@@ -123,15 +135,7 @@ TEST_F(LoadChannelMgrTest, PublicCancelCachesAlreadyPublishedFailure) {
     EXPECT_EQ(channel->cancel_status().to_string(), first_failure.to_string());
     EXPECT_TRUE(_mgr->_load_channels.empty());
 
-    auto* handle = _mgr->_load_state_channels->lookup(_load_id.to_string());
-    ASSERT_NE(handle, nullptr);
-    auto* value =
-            static_cast<LoadChannelMgr::CacheValue*>(_mgr->_load_state_channels->value(handle));
-    EXPECT_NE(value, nullptr);
-    if (value != nullptr) {
-        EXPECT_EQ(value->_cancel_reason, first_failure.to_string());
-    }
-    _mgr->_load_state_channels->release(handle);
+    expect_cached_failure(first_failure);
 
     PTabletWriterOpenRequest open_request;
     *open_request.mutable_id() = _load_id.to_proto();
@@ -193,15 +197,7 @@ TEST_F(LoadChannelMgrTest, FinishDoesNotOverwritePublishedFailure) {
     ASSERT_TRUE(_mgr->_cancel_load_channel(channel, Status::InternalError("later failure")).ok());
     _mgr->_finish_load_channel(channel);
 
-    auto* handle = _mgr->_load_state_channels->lookup(_load_id.to_string());
-    ASSERT_NE(handle, nullptr);
-    auto* value =
-            static_cast<LoadChannelMgr::CacheValue*>(_mgr->_load_state_channels->value(handle));
-    EXPECT_NE(value, nullptr);
-    if (value != nullptr) {
-        EXPECT_EQ(value->_cancel_reason, reason.to_string());
-    }
-    _mgr->_load_state_channels->release(handle);
+    expect_cached_failure(reason);
 }
 
 TEST_F(LoadChannelMgrTest, FailureStillCancelsOriginalAfterFinish) {

--- a/be/test/load/memtable/memtable_memory_limiter_test.cpp
+++ b/be/test/load/memtable/memtable_memory_limiter_test.cpp
@@ -182,4 +182,62 @@ TEST_F(MemTableMemoryLimiterTest, handle_memtable_flush_test) {
     res = _engine_ref->tablet_manager()->drop_tablet(request.tablet_id, request.replica_id, false);
     EXPECT_EQ(Status::OK(), res);
 }
+
+TEST_F(MemTableMemoryLimiterTest, PressureFlushSkipsRetainedCancelledWriter) {
+    RuntimeProfile profile("CancelledMemTableWriter");
+    TCreateTabletReq tablet_request;
+    create_tablet_request(10001, 270068373, &tablet_request);
+    ASSERT_TRUE(_engine_ref->create_tablet(tablet_request, &profile).ok());
+
+    TDescriptorTable tdesc_tbl = create_descriptor_tablet();
+    ObjectPool obj_pool;
+    DescriptorTbl* desc_tbl = nullptr;
+    ASSERT_TRUE(DescriptorTbl::create(&obj_pool, tdesc_tbl, &desc_tbl).ok());
+    auto* tuple_desc = desc_tbl->get_tuple_descriptor(0);
+    auto cancel_status = std::make_shared<AtomicStatus>();
+    WriteRequest write_req;
+    write_req.tablet_id = tablet_request.tablet_id;
+    write_req.schema_hash = tablet_request.tablet_schema.schema_hash;
+    write_req.txn_id = 20003;
+    write_req.partition_id = tablet_request.partition_id;
+    write_req.tuple_desc = tuple_desc;
+    write_req.slots = &tuple_desc->slots();
+    write_req.table_schema_param = std::make_shared<OlapTableSchemaParam>();
+    write_req.load_cancel_status = cancel_status;
+    auto delta_writer =
+            std::make_unique<DeltaWriter>(*_engine_ref, write_req, &profile, TUniqueId {});
+    Block block;
+    for (const auto* slot : tuple_desc->slots()) {
+        block.insert(ColumnWithTypeAndName(slot->get_empty_mutable_column(), slot->type(),
+                                           slot->col_name()));
+    }
+    auto columns = std::move(block).mutate_columns();
+    for (auto& column : columns) {
+        column->insert_default();
+    }
+    block.set_columns(std::move(columns));
+    ASSERT_TRUE(delta_writer->write(&block, TabletAddRowsPayload {.row_idxs = {0}}).ok());
+    auto writer = delta_writer->_memtable_writer;
+    auto memtable = writer->_mem_table;
+    auto active_memory = writer->active_memtable_mem_consumption();
+    ASSERT_GT(active_memory, 0);
+    auto segment_num = writer->_segment_num;
+
+    // add_batch failures can publish a non-CANCELLED status to the shared load.
+    ASSERT_TRUE(cancel_status->update(Status::InternalError("load failed")));
+    EXPECT_FALSE(writer->_is_cancelled);
+    auto st = delta_writer->flush_memtable_async();
+    EXPECT_TRUE(st.is<ErrorCode::CANCELLED>()) << st;
+
+    auto* limiter = ExecEnv::GetInstance()->memtable_memory_limiter();
+    ASSERT_TRUE(limiter->init(100).ok());
+    // An unrelated load may invoke pressure flushing while this owner is retained.
+    // It must neither report this memory as flushed nor cancel/wait for the token.
+    EXPECT_EQ(limiter->_flush_active_memtables(active_memory), 0);
+    EXPECT_FALSE(writer->_is_cancelled);
+    EXPECT_EQ(writer->_mem_table, memtable);
+    EXPECT_EQ(writer->_segment_num, segment_num);
+    EXPECT_TRUE(writer->_freezed_mem_tables.empty());
+    EXPECT_EQ(writer->active_memtable_mem_consumption(), active_memory);
+}
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

When load close holds a channel or writer lock while waiting for flush or delete bitmap work, cancelling the load also waits for those locks. Publish a shared per-load `AtomicStatus` instead of synchronously traversing and cancelling each writer. Local and cloud write/close paths observe the status at phase boundaries, and the EOS wait exits when the load is cancelled.

The manager removes failed loads and retains their cancellation reason, so late open/add-batch requests and a concurrent successful close cannot erase the failure. In-flight requests retain ownership. The final writer owner drains previously submitted bitmap work before builder cleanup; the existing rowset-writer destructor cancellation runs before deleting files that callbacks may still read.

This change does not add explicit delete bitmap token cancellation to load cancellation. Existing bitmap submissions and waits keep their behavior; there is no token registration, queued-task shutdown, or polling added to the bitmap executor. `tablet_writer_cancel` continues to use the heavy work pool. The final owner can still wait for outstanding work during destruction.

### Experimental comparison

The standalone PR was manually retested and reproduced the same cancellation-processing improvement. The table measures the interval from `record_error reason` to `load channel has been cancelled`, using approximately 70 minutes from each run. The standalone retest supports removing channel/writer lock waits as the main reason for the faster cancellation processing.

| Metric | Unmodified baseline | This PR |
| --- | ---: | ---: |
| Matched cancellation events | 7,085 | 7,008 |
| P99 | 10.49 s | **22.85 ms** |
| Maximum | 24.92 s | **1.37 s** |
| Events exceeding 10 s | 76 | **0** |

### Release note

Load cancellation can publish its status without waiting for channel or writer locks held by close.

### Check List (For Author)

- Test:
    - Added six focused BE tests for retained-channel failure handling, timeout/replacement ordering, stale EOS, and cancelled-writer pressure flushing. Final-owner delete bitmap callback coverage remains deferred to the follow-up delete bitmap cancellation PR.
    - Manual cluster retest of this standalone PR reproduced the cancellation-processing improvement shown above.
    - Local format and build-hygiene checks passed. The focused BE unit-test build was attempted but blocked by the missing `thirdparty/installed/lib64/libarrow_compute.a`; tests were not executed. Local clang-tidy and syntax-only checks could not complete due to toolchain diagnostics in existing core date/time and JNI headers.
    - clang-format 16 check, `git diff --check`, and `build-support/check-build-hygiene.sh` passed. The format wrapper used the installed clang-format 16 binary with a local adjustment for missing Homebrew keg metadata.
    - Reviewed cancellation publication, local/cloud and group writer propagation, late request handling, and final-owner cleanup.
- Behavior changed: Yes.
- Does this need documentation? No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
