### PR TITLE
[fix](ivm) Repair the removed rewrite-context constructor call in IvmNormalizeMTMVJoinTest

### DIFF
--- a/fe/fe-core/src/test/java/org/apache/doris/mtmv/ivm/IvmNormalizeMTMVJoinTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mtmv/ivm/IvmNormalizeMTMVJoinTest.java
@@ -1049,8 +1049,7 @@ class IvmNormalizeMTMVJoinTest extends IvmDeltaTestBase {
         MTMV mtmv = buildMtmvFromPlan(ImmutableList.of(leftId));
         mtmv.getIvmInfo().setUseFullKeys(true);
         ConnectContext ctx = newConnectContext();
-        ctx.getStatementContext().setIvmRewriteContext(Optional.of(
-                new IvmRewriteContext(IvmRewriteContext.Mode.CREATE, mtmv, false)));
+        ctx.getStatementContext().setIvmRewriteContext(Optional.of(IvmRewriteContext.normalize(mtmv)));
         JobContext jobContext = newJobContextForRoot(sink, ctx);
         Plan normalized = new IvmNormalizeMTMV().rewriteRoot(sink, jobContext);
         IvmRewriteResult rewriteResult = jobContext.getCascadesContext().getIvmRewriteResult().get();


### PR DESCRIPTION
### What problem does this PR solve?

#67646 replaced `IvmRewriteContext`'s public three-argument constructor with factory methods. #67669, merged a few minutes later, added a test that still called the removed constructor, so the fe-core test sources no longer compile on master:

```
fe/fe-core/src/test/java/org/apache/doris/mtmv/ivm/IvmNormalizeMTMVJoinTest.java:1053: error:
constructor IvmRewriteContext cannot be applied to given types;
  required: (Mode, MTMV, String, boolean, ExecutionKind, Optional<IvmDryRunLimit>, Map<...>, Optional<StreamReadMode>)
  found:    (Mode, MTMV, boolean)
```

The two changes do not conflict textually, so each PR was green on its own and the breakage only showed up once both had landed.

### What is changed?

Construct the context in `testFullKeysSinkMaterializesSameNamedUnprojectedKey` through the factory the CREATE MATERIALIZED VIEW analyze flow already uses, `IvmRewriteContext.normalize(mtmv)` (see `MTMVPlanUtil`), instead of the removed constructor. Test-only change; no production code is touched.

`normalize(mtmv)` is needed here rather than `create(mtmvName)`: the test enables full keys through `mtmv.getIvmInfo().setUseFullKeys(true)`, which `IvmNormalizeMTMV.resolveUseFullKeys()` only reads on its fallback path — when the context carries a null `useFullKeys` but a non-null MTMV. `create(...)` leaves the MTMV null, which would silently resolve that setting to `false`, so the test would compile but fail. `Mode.NORMALIZE` also avoids the `Mode.INCREMENTAL` plan-signature validation, and nothing in this test asserts on the mode.

### Test

- `IvmNormalizeMTMVJoinTest` — 44 tests, 0 failures, 0 errors
- `mvn test-compile -pl fe-core -am` — BUILD SUCCESS, no errors; all fe-core test sources compile again
