### PR TITLE
[fix](load) Cancel pending delete bitmap tasks on load cancellation

### DIFF
--- a/be/src/cloud/cloud_rowset_builder.cpp
+++ b/be/src/cloud/cloud_rowset_builder.cpp
@@ -23,6 +23,7 @@
 #include "cloud/cloud_storage_engine.h"
 #include "cloud/cloud_tablet.h"
 #include "cloud/cloud_tablet_mgr.h"
+#include "cpp/sync_point.h"
 #include "io/fs/file_system.h"
 #include "storage/rowset/group_rowset_writer.h"
 #include "storage/rowset/rowset_factory.h"
@@ -53,6 +54,8 @@ CloudGroupRowsetBuilder::CloudGroupRowsetBuilder(CloudStorageEngine& engine,
 CloudRowsetBuilder::~CloudRowsetBuilder() {
     // Clear file cache immediately when load fails
     if (_is_init && _rowset != nullptr && _rowset->rowset_meta()->rowset_state() == PREPARED) {
+        TEST_SYNC_POINT_CALLBACK("CloudRowsetBuilder::~CloudRowsetBuilder:before_clear_cache",
+                                 this);
         _rowset->clear_cache();
     }
 }
@@ -89,6 +92,7 @@ Status CloudRowsetBuilder::init() {
     context.txn_id = _req.txn_id;
     context.txn_expiration = _req.txn_expiration;
     context.load_id = _req.load_id;
+    context.delete_bitmap_cancellation = _req.delete_bitmap_cancellation;
     context.db_id = _req.table_schema_param->db_id();
     context.table_id = _req.table_schema_param->table_id();
     context.rowset_state = PREPARED;
@@ -117,7 +121,8 @@ Status CloudRowsetBuilder::init() {
     _rowset_writer = DORIS_TRY(_tablet->create_rowset_writer(context, false));
     _rowset_id = context.rowset_id;
 
-    _calc_delete_bitmap_token = _engine.calc_delete_bitmap_executor()->create_token();
+    _calc_delete_bitmap_token =
+            _engine.calc_delete_bitmap_executor()->create_token(_req.delete_bitmap_cancellation);
 
     if (!_skip_writing_rowset_metadata) {
         RETURN_IF_ERROR(_engine.meta_mgr().prepare_rowset(*_rowset_writer->rowset_meta(), "",
@@ -170,6 +175,12 @@ Status CloudGroupRowsetBuilder::submit_calc_delete_bitmap_task() {
 
 Status CloudGroupRowsetBuilder::wait_calc_delete_bitmap() {
     return _data_builder->wait_calc_delete_bitmap();
+}
+
+Status CloudGroupRowsetBuilder::cancel(const Status& st) {
+    RETURN_IF_ERROR(_data_builder->cancel(st));
+    RETURN_IF_ERROR(_row_binlog_builder->cancel(st));
+    return BaseRowsetBuilder::cancel(st);
 }
 
 void CloudGroupRowsetBuilder::update_tablet_stats() {

--- a/be/src/cloud/cloud_rowset_builder.h
+++ b/be/src/cloud/cloud_rowset_builder.h
@@ -74,6 +74,8 @@ public:
 
     Status wait_calc_delete_bitmap() override;
 
+    Status cancel(const Status& st) override;
+
     void update_tablet_stats() override;
 
     Status commit_rowset(const std::string& job_id, int64_t table_id) override;

--- a/be/src/cloud/cloud_rowset_writer.cpp
+++ b/be/src/cloud/cloud_rowset_writer.cpp
@@ -89,7 +89,8 @@ Status CloudRowsetWriter::init(const RowsetWriterContext& rowset_writer_context)
     _context.segment_collector = std::make_shared<SegmentCollectorT<BaseBetaRowsetWriter>>(this);
     _context.file_writer_creator = std::make_shared<FileWriterCreatorT<BaseBetaRowsetWriter>>(this);
     if (_context.mow_context != nullptr) {
-        _calc_delete_bitmap_token = _engine.calc_delete_bitmap_executor_for_load()->create_token();
+        _calc_delete_bitmap_token = _engine.calc_delete_bitmap_executor_for_load()->create_token(
+                _context.delete_bitmap_cancellation);
     }
     return Status::OK();
 }

--- a/be/src/load/channel/load_channel.cpp
+++ b/be/src/load/channel/load_channel.cpp
@@ -30,6 +30,7 @@
 #include "runtime/thread_context.h"
 #include "runtime/workload_group/workload_group.h"
 #include "runtime/workload_group/workload_group_manager.h"
+#include "storage/delete/calc_delete_bitmap_executor.h"
 #include "storage/storage_engine.h"
 #include "util/debug_points.h"
 
@@ -41,6 +42,7 @@ LoadChannel::LoadChannel(const UniqueId& load_id, int64_t timeout_s, bool is_hig
                          std::string sender_ip, int64_t backend_id, bool enable_profile,
                          int64_t wg_id)
         : _load_id(load_id),
+          _delete_bitmap_cancellation(std::make_shared<DeleteBitmapCancellation>()),
           _timeout_s(timeout_s),
           _is_high_priority(is_high_priority),
           _sender_ip(std::move(sender_ip)),
@@ -139,6 +141,7 @@ Status LoadChannel::open(const PTabletWriterOpenRequest& params) {
                 channel = std::make_shared<TabletsChannel>(engine.to_local(), key, _load_id,
                                                            _is_high_priority, _self_profile);
             }
+            channel->set_delete_bitmap_cancellation(_delete_bitmap_cancellation);
             {
                 std::lock_guard<std::mutex> lt(_tablets_channels_lock);
                 _tablets_channels.insert({index_id, channel});
@@ -307,6 +310,9 @@ bool LoadChannel::is_finished() {
 Status LoadChannel::cancel() {
     _cancelled.store(true);
     std::lock_guard<std::mutex> l(_lock);
+    // Keep the existing channel locking and cancellation traversal. Stop bitmap
+    // work first so close waiters can finish before we cancel their writers.
+    _delete_bitmap_cancellation->cancel(Status::Cancelled("load channel cancelled"));
     for (auto& it : _tablets_channels) {
         static_cast<void>(it.second->cancel());
     }

--- a/be/src/load/channel/load_channel.h
+++ b/be/src/load/channel/load_channel.h
@@ -40,6 +40,7 @@ class PTabletWriterAddBlockRequest;
 class PTabletWriterAddBlockResult;
 class OpenPartitionRequest;
 class BaseTabletsChannel;
+class DeleteBitmapCancellation;
 
 // A LoadChannel manages tablets channels for all indexes
 // corresponding to a certain load job
@@ -113,6 +114,7 @@ private:
     // set to true if at least one tablets channel has been opened
     bool _opened = false;
     std::atomic<bool> _cancelled {false};
+    const std::shared_ptr<DeleteBitmapCancellation> _delete_bitmap_cancellation;
 
     std::shared_ptr<ResourceContext> _resource_ctx;
 

--- a/be/src/load/channel/load_channel_mgr.cpp
+++ b/be/src/load/channel/load_channel_mgr.cpp
@@ -88,6 +88,17 @@ Status LoadChannelMgr::open(const PTabletWriterOpenRequest& params) {
         if (it != _load_channels.end()) {
             channel = it->second;
         } else {
+            // Reordered/retried opens must not create a new generation behind a
+            // live terminal record. A completed load can acknowledge a duplicate
+            // open without creating writers; a failed load returns its first error.
+            auto* handle = _load_state_channels->lookup(load_id.to_string());
+            if (handle != nullptr) {
+                auto* value = static_cast<CacheValue*>(_load_state_channels->value(handle));
+                auto status =
+                        value != nullptr ? Status::Cancelled(value->_cancel_reason) : Status::OK();
+                _load_state_channels->release(handle);
+                return status;
+            }
             // create a new load channel
             int64_t timeout_in_req_s =
                     params.has_load_channel_timeout_s() ? params.load_channel_timeout_s() : -1;
@@ -183,22 +194,62 @@ Status LoadChannelMgr::add_batch(const PTabletWriterAddBlockRequest& request,
 
     // 4. handle finish
     if (channel->is_finished()) {
-        _finish_load_channel(load_id);
+        RETURN_IF_ERROR(_finish_load_channel(load_id, channel));
     }
     return Status::OK();
 }
 
-void LoadChannelMgr::_finish_load_channel(const UniqueId load_id) {
-    VLOG_NOTICE << "removing load channel " << load_id << " because it's finished";
-    {
-        std::lock_guard<std::mutex> l(_lock);
-        if (_load_channels.contains(load_id)) {
-            _load_channels.erase(load_id);
-        }
-        auto* handle = _load_state_channels->insert(load_id.to_string(), nullptr, 1, 1);
-        _load_state_channels->release(handle);
+Status LoadChannelMgr::_finish_load_channel(const UniqueId& load_id,
+                                            const std::shared_ptr<LoadChannel>& channel) {
+    std::lock_guard<std::mutex> l(_lock);
+    auto it = _load_channels.find(load_id);
+    if (it != _load_channels.end() && it->second != channel) {
+        return Status::Cancelled("Load channel {} has been replaced", load_id.to_string());
     }
-    VLOG_CRITICAL << "removed load channel " << load_id;
+
+    // Cancellation/timeout removes the channel and records its terminal state under
+    // this same lock, before draining bitmap work. A late EOS must not overwrite it.
+    auto* existing_handle = _load_state_channels->lookup(load_id.to_string());
+    if (existing_handle != nullptr) {
+        auto* value = static_cast<CacheValue*>(_load_state_channels->value(existing_handle));
+        auto status = value != nullptr ? Status::Cancelled(value->_cancel_reason) : Status::OK();
+        _load_state_channels->release(existing_handle);
+        if (it != _load_channels.end()) {
+            _load_channels.erase(it);
+        }
+        return status;
+    }
+    if (it == _load_channels.end()) {
+        // Even if its terminal cache entry was evicted, a removed channel cannot succeed.
+        return Status::Cancelled("Load channel {} is no longer active", load_id.to_string());
+    }
+    if (channel->is_cancelled()) {
+        _record_cancelled_load(load_id, "load channel cancelled");
+        _load_channels.erase(it);
+        return Status::Cancelled("load channel cancelled");
+    }
+    _load_channels.erase(it);
+    auto* handle = _load_state_channels->insert(load_id.to_string(), nullptr, 1, 1);
+    _load_state_channels->release(handle);
+    VLOG_CRITICAL << "removed finished load channel " << load_id;
+    return Status::OK();
+}
+
+void LoadChannelMgr::_record_cancelled_load(const UniqueId& load_id, const std::string& reason) {
+    auto* existing_handle = _load_state_channels->lookup(load_id.to_string());
+    if (existing_handle != nullptr) {
+        _load_state_channels->release(existing_handle);
+        return;
+    }
+    auto value = std::make_unique<CacheValue>();
+    value->_cancel_reason = reason.empty() ? "load channel cancelled" : reason;
+    LOG(INFO) << "load_id = " << print_id(load_id)
+              << ", record_error reason = " << value->_cancel_reason;
+    size_t cache_capacity = value->_cancel_reason.capacity() + sizeof(CacheValue);
+    auto* handle =
+            _load_state_channels->insert(load_id.to_string(), value.get(), 1, cache_capacity);
+    value.release();
+    _load_state_channels->release(handle);
 }
 
 Status LoadChannelMgr::cancel(const PTabletWriterCancelRequest& params) {
@@ -210,24 +261,7 @@ Status LoadChannelMgr::cancel(const PTabletWriterCancelRequest& params) {
             cancelled_channel = _load_channels[load_id];
             _load_channels.erase(load_id);
         }
-        // We just need to record the first cancel msg
-        auto* existing_handle = _load_state_channels->lookup(load_id.to_string());
-        if (existing_handle == nullptr) {
-            if (params.has_cancel_reason() && !params.cancel_reason().empty()) {
-                std::unique_ptr<CacheValue> cancel_reason_ptr = std::make_unique<CacheValue>();
-                cancel_reason_ptr->_cancel_reason = params.cancel_reason();
-                size_t cache_capacity =
-                        cancel_reason_ptr->_cancel_reason.capacity() + sizeof(CacheValue);
-                auto* handle = _load_state_channels->insert(
-                        load_id.to_string(), cancel_reason_ptr.get(), 1, cache_capacity);
-                cancel_reason_ptr.release();
-                _load_state_channels->release(handle);
-                LOG(INFO) << fmt::format("load_id = {}, record_error reason = {}",
-                                         print_id(load_id), params.cancel_reason());
-            }
-        } else {
-            _load_state_channels->release(existing_handle);
-        }
+        _record_cancelled_load(load_id, params.cancel_reason());
     }
 
     if (cancelled_channel != nullptr) {
@@ -270,6 +304,7 @@ Status LoadChannelMgr::_start_load_channels_clean() {
         }
 
         for (auto& key : need_delete_channel_ids) {
+            _record_cancelled_load(key, "load channel timed out");
             _load_channels.erase(key);
             LOG(INFO) << "erase timeout load channel: " << key;
         }

--- a/be/src/load/channel/load_channel_mgr.h
+++ b/be/src/load/channel/load_channel_mgr.h
@@ -78,7 +78,11 @@ private:
     Status _get_load_channel(std::shared_ptr<LoadChannel>& channel, bool& is_eof,
                              const UniqueId& load_id, const PTabletWriterAddBlockRequest& request);
 
-    void _finish_load_channel(UniqueId load_id);
+    Status _finish_load_channel(const UniqueId& load_id,
+                                const std::shared_ptr<LoadChannel>& channel);
+
+    // Requires _lock. Preserve the first terminal state, including successful completion.
+    void _record_cancelled_load(const UniqueId& load_id, const std::string& reason);
 
     Status _start_bg_worker();
 

--- a/be/src/load/channel/tablets_channel.cpp
+++ b/be/src/load/channel/tablets_channel.cpp
@@ -234,6 +234,7 @@ Status BaseTabletsChannel::incremental_open(const PTabletWriterOpenRequest& para
         wrequest.txn_id = _txn_id;
         wrequest.partition_id = tablet.partition_id();
         wrequest.load_id = params.id();
+        wrequest.delete_bitmap_cancellation = _delete_bitmap_cancellation;
         wrequest.tuple_desc = _tuple_desc;
         wrequest.slots = index_slots;
         wrequest.is_high_priority = _is_high_priority;
@@ -572,6 +573,7 @@ Status BaseTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& req
                 .write_file_cache = request.write_file_cache(),
                 .storage_vault_id = request.storage_vault_id(),
                 .enable_table_memtable_backpressure = request.is_adaptive_random_bucket(),
+                .delete_bitmap_cancellation = _delete_bitmap_cancellation,
         };
         if (tablet.has_binlog_tablet_id()) {
             wrequest.binlog_tablet_id = tablet.binlog_tablet_id();

--- a/be/src/load/channel/tablets_channel.h
+++ b/be/src/load/channel/tablets_channel.h
@@ -110,6 +110,11 @@ public:
     // no-op when this channel has been closed or cancelled
     virtual Status cancel();
 
+    // Set before publishing the channel or opening any writers.
+    void set_delete_bitmap_cancellation(std::shared_ptr<DeleteBitmapCancellation> cancellation) {
+        _delete_bitmap_cancellation = std::move(cancellation);
+    }
+
     void refresh_profile();
 
     size_t total_received_rows() const { return _total_received_rows; }
@@ -164,6 +169,7 @@ protected:
     State _state;
 
     UniqueId _load_id;
+    std::shared_ptr<DeleteBitmapCancellation> _delete_bitmap_cancellation;
 
     // initialized in open function
     int64_t _txn_id = -1;

--- a/be/src/load/delta_writer/delta_writer.cpp
+++ b/be/src/load/delta_writer/delta_writer.cpp
@@ -31,12 +31,14 @@
 #include "common/logging.h"
 #include "common/status.h"
 #include "core/block/block.h"
+#include "cpp/sync_point.h"
 #include "io/fs/file_writer.h" // IWYU pragma: keep
 #include "load/memtable/memtable_flush_executor.h"
 #include "load/memtable/memtable_memory_limiter.h"
 #include "runtime/exec_env.h"
 #include "runtime/thread_context.h"
 #include "runtime/workload_management/resource_context.h"
+#include "storage/delete/calc_delete_bitmap_executor.h"
 #include "storage/olap_define.h"
 #include "storage/rowset/beta_rowset.h"
 #include "storage/rowset/beta_rowset_writer.h"
@@ -93,12 +95,17 @@ void DeltaWriter::_init_profile(RuntimeProfile* profile) {
 }
 
 BaseDeltaWriter::~BaseDeltaWriter() {
+    // Drain producers and both bitmap phases before derived builders reclaim rowsets.
+    if (_rowset_builder != nullptr) {
+        auto st = _req.delete_bitmap_cancellation ? _req.delete_bitmap_cancellation->status()
+                                                  : Status::OK();
+        WARN_IF_ERROR(BaseDeltaWriter::cancel_with_status(
+                              st.ok() ? Status::Cancelled("delta writer destroyed") : st),
+                      "failed to cancel work while destroying delta writer");
+    }
     if (!_is_init) {
         return;
     }
-
-    // cancel and wait all memtables in flush queue to be finished
-    static_cast<void>(_memtable_writer->cancel());
 
     if (_rowset_builder->tablet() != nullptr) {
         const FlushStatistic& stat = _memtable_writer->get_flush_token_stats();
@@ -145,6 +152,8 @@ Status BaseDeltaWriter::init() {
         wg_sptr = doris::thread_context()->resource_ctx()->workload_group();
     }
     RETURN_IF_ERROR(_rowset_builder->init());
+    TEST_SYNC_POINT_RETURN_WITH_VALUE("BaseDeltaWriter::init:before_memtable_init", Status::OK(),
+                                      this);
     RETURN_IF_ERROR(_memtable_writer->init(
             _rowset_builder->rowset_writer(), _rowset_builder->tablet_schema(),
             _rowset_builder->get_partial_update_info(), wg_sptr,
@@ -254,6 +263,9 @@ Status BaseDeltaWriter::cancel_with_status(const Status& st) {
         return Status::OK();
     }
     RETURN_IF_ERROR(_memtable_writer->cancel_with_status(st));
+    // Flush tasks can submit delete bitmap work, so stop them before cancelling
+    // the rowset builder and its rowset writer.
+    RETURN_IF_ERROR(_rowset_builder->cancel(st));
     _is_cancelled = true;
     return Status::OK();
 }

--- a/be/src/load/delta_writer/delta_writer.h
+++ b/be/src/load/delta_writer/delta_writer.h
@@ -70,7 +70,8 @@ public:
     Status submit_calc_delete_bitmap_task();
     Status wait_calc_delete_bitmap();
 
-    // abandon current memtable and wait for all pending-flushing memtables to be destructed.
+    // Abandon the current memtable and cancel queued flush/delete bitmap tasks.
+    // Wait for running tasks before releasing their resources.
     // mem_consumption() should be 0 after this function returns.
     Status cancel();
     virtual Status cancel_with_status(const Status& st);

--- a/be/src/load/delta_writer/delta_writer_context.h
+++ b/be/src/load/delta_writer/delta_writer_context.h
@@ -30,6 +30,7 @@ namespace doris {
 class TupleDescriptor;
 class SlotDescriptor;
 class OlapTableSchemaParam;
+class DeleteBitmapCancellation;
 
 enum class WriteRequestType {
     DATA = 0,       // data write
@@ -56,6 +57,8 @@ struct WriteRequest {
     WriteRequestType write_req_type = WriteRequestType::DATA;
     std::string storage_vault_id;
     bool enable_table_memtable_backpressure = false;
+    // Shared by both bitmap phases of every writer in the load.
+    std::shared_ptr<DeleteBitmapCancellation> delete_bitmap_cancellation = nullptr;
 };
 
 struct TabletAddRowsPayload {

--- a/be/src/storage/delete/calc_delete_bitmap_executor.cpp
+++ b/be/src/storage/delete/calc_delete_bitmap_executor.cpp
@@ -22,6 +22,7 @@
 #include <ostream>
 
 #include "common/logging.h"
+#include "cpp/sync_point.h"
 #include "load/memtable/memtable.h"
 #include "storage/tablet/base_tablet.h"
 #include "util/time.h"
@@ -29,22 +30,64 @@
 namespace doris {
 using namespace ErrorCode;
 
+void DeleteBitmapCancellation::_register_token(const std::shared_ptr<ThreadPoolToken>& token) {
+    {
+        std::lock_guard lock(_lock);
+        if (_status.ok()) {
+            _tokens.emplace_back(token);
+            return;
+        }
+    }
+    // A token created after cancellation must reject submissions too.
+    token->shutdown();
+}
+
+void DeleteBitmapCancellation::cancel(const Status& reason) {
+    DCHECK(!reason.ok());
+    std::vector<std::shared_ptr<ThreadPoolToken>> tokens;
+    {
+        std::lock_guard lock(_lock);
+        _status.update(reason);
+        for (const auto& weak_token : _tokens) {
+            if (auto token = weak_token.lock()) {
+                tokens.push_back(std::move(token));
+            }
+        }
+    }
+    TEST_SYNC_POINT_CALLBACK("DeleteBitmapCancellation::cancel:before_shutdown", this);
+    // Publish to all tasks before waiting. Neither registration nor task completion
+    // needs to wait for this lock while shutdown waits for running tasks.
+    for (const auto& token : tokens) {
+        token->shutdown();
+    }
+}
+
+CalcDeleteBitmapToken::CalcDeleteBitmapToken(
+        std::unique_ptr<ThreadPoolToken> thread_token,
+        std::shared_ptr<DeleteBitmapCancellation> delete_bitmap_cancellation)
+        : _thread_token(std::move(thread_token)),
+          _status(Status::OK()),
+          _delete_bitmap_cancellation(std::move(delete_bitmap_cancellation)) {
+    if (_delete_bitmap_cancellation) {
+        _delete_bitmap_cancellation->_register_token(_thread_token);
+    }
+}
+
+CalcDeleteBitmapToken::~CalcDeleteBitmapToken() {
+    // A concurrent cancellation can retain the underlying token. Finish callbacks
+    // that capture this before destroying the wrapper's status and lock.
+    _thread_token->shutdown();
+}
+
 Status CalcDeleteBitmapToken::submit(BaseTabletSPtr tablet, RowsetSharedPtr cur_rowset,
                                      const segment_v2::SegmentSharedPtr& cur_segment,
                                      const std::vector<RowsetSharedPtr>& target_rowsets,
                                      int64_t end_version, DeleteBitmapPtr delete_bitmap,
                                      RowsetWriter* rowset_writer,
                                      DeleteBitmapPtr tablet_delete_bitmap) {
-    {
-        std::shared_lock rlock(_lock);
-        RETURN_IF_ERROR(_status);
-        _resource_ctx = thread_context()->resource_ctx();
-    }
-
     const auto submit_time_us = MonotonicMicros();
-    return _thread_token->submit_func([=, this]() {
+    return submit_func([=]() {
         const auto queue_time_us = MonotonicMicros() - submit_time_us;
-        SCOPED_ATTACH_TASK(_resource_ctx);
         auto st = tablet->calc_segment_delete_bitmap(cur_rowset, cur_segment, target_rowsets,
                                                      delete_bitmap, end_version, rowset_writer,
                                                      tablet_delete_bitmap, queue_time_us);
@@ -53,11 +96,8 @@ Status CalcDeleteBitmapToken::submit(BaseTabletSPtr tablet, RowsetSharedPtr cur_
                          << tablet->tablet_id() << " rowset: " << cur_rowset->rowset_id()
                          << " seg_id: " << cur_segment->id() << " version: " << end_version
                          << " error: " << st;
-            std::lock_guard wlock(_lock);
-            if (_status.ok()) {
-                _status = st;
-            }
         }
+        return st;
     });
 }
 
@@ -65,33 +105,69 @@ Status CalcDeleteBitmapToken::submit(BaseTabletSPtr tablet, TabletSchemaSPtr sch
                                      RowsetId rowset_id,
                                      const std::vector<segment_v2::SegmentSharedPtr>& segments,
                                      DeleteBitmapPtr delete_bitmap) {
-    {
-        std::shared_lock rlock(_lock);
-        RETURN_IF_ERROR(_status);
-        _resource_ctx = thread_context()->resource_ctx();
-    }
     const auto submit_time_us = MonotonicMicros();
-    return _thread_token->submit_func([=, this]() {
+    // Only test builds use the token pointer; avoid an unused explicit lambda capture.
+    [[maybe_unused]] auto* token = this;
+    return submit_func([=]() {
+        TEST_SYNC_POINT_CALLBACK("CalcDeleteBitmapToken::submit:before_between_segments", token);
         const auto queue_time_us = MonotonicMicros() - submit_time_us;
-        SCOPED_ATTACH_TASK(_resource_ctx);
         auto st = tablet->calc_delete_bitmap_between_segments(schema, rowset_id, segments,
                                                               delete_bitmap, queue_time_us);
         if (!st.ok()) {
             LOG(WARNING) << "failed to calc delete bitmap between segments, tablet_id: "
                          << tablet->tablet_id() << " rowset: " << rowset_id
                          << " segments num: " << segments.size() << " error: " << st;
-            std::lock_guard wlock(_lock);
-            if (_status.ok()) {
-                _status = st;
-            }
         }
+        return st;
     });
 }
 
+Status CalcDeleteBitmapToken::_submit_func(std::function<void()> func) {
+    TEST_SYNC_POINT_CALLBACK("CalcDeleteBitmapToken::submit_func:before_submit", this);
+    auto st = _thread_token->submit_func(std::move(func));
+    if (!st.ok()) {
+        // Cancellation may shut down the token after the initial status check.
+        // Preserve the published failure instead of reporting a pool shutdown error.
+        RETURN_IF_ERROR(_get_status());
+    }
+    return st;
+}
+
+Status CalcDeleteBitmapToken::_get_status() {
+    std::shared_lock rlock(_lock);
+    RETURN_IF_ERROR(_status);
+    return _delete_bitmap_cancellation && !_delete_bitmap_cancellation->ok()
+                   ? _delete_bitmap_cancellation->status()
+                   : Status::OK();
+}
+
 Status CalcDeleteBitmapToken::wait() {
+    TEST_SYNC_POINT_CALLBACK("CalcDeleteBitmapToken::wait:before_wait", this);
     _thread_token->wait();
-    // all tasks complete here, don't need lock;
-    return _status;
+    return _get_status();
+}
+
+void CalcDeleteBitmapToken::_set_status(const Status& st) {
+    DCHECK(!st.ok());
+    // Serialize this token's failure with load-wide cancellation publication.
+    // Calculation errors stay local to this token; an already-published load
+    // cancellation wins over later callback failures or explicit token cancellation.
+    std::unique_lock<std::mutex> cancellation_lock;
+    if (_delete_bitmap_cancellation) {
+        cancellation_lock = std::unique_lock(_delete_bitmap_cancellation->_lock);
+    }
+    std::lock_guard wlock(_lock);
+    if (_status.ok()) {
+        _status = _delete_bitmap_cancellation && !_delete_bitmap_cancellation->ok()
+                          ? _delete_bitmap_cancellation->status()
+                          : st;
+    }
+}
+
+void CalcDeleteBitmapToken::cancel(const Status& st) {
+    _set_status(st);
+    // Do not hold _lock while waiting: running tasks may need it to report an error.
+    _thread_token->shutdown();
 }
 
 void CalcDeleteBitmapExecutor::init(const std::string& name, int max_threads) {
@@ -101,9 +177,11 @@ void CalcDeleteBitmapExecutor::init(const std::string& name, int max_threads) {
                               .build(&_thread_pool));
 }
 
-std::unique_ptr<CalcDeleteBitmapToken> CalcDeleteBitmapExecutor::create_token() {
+std::unique_ptr<CalcDeleteBitmapToken> CalcDeleteBitmapExecutor::create_token(
+        std::shared_ptr<DeleteBitmapCancellation> delete_bitmap_cancellation) {
     return std::make_unique<CalcDeleteBitmapToken>(
-            _thread_pool->new_token(ThreadPool::ExecutionMode::CONCURRENT));
+            _thread_pool->new_token(ThreadPool::ExecutionMode::CONCURRENT),
+            std::move(delete_bitmap_cancellation));
 }
 
 } // namespace doris

--- a/be/src/storage/delete/calc_delete_bitmap_executor.h
+++ b/be/src/storage/delete/calc_delete_bitmap_executor.h
@@ -20,8 +20,10 @@
 #include <stdint.h>
 
 #include <atomic>
+#include <functional>
 #include <iosfwd>
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include <string>
 #include <utility>
@@ -40,6 +42,26 @@ class DataDir;
 class Tablet;
 enum RowsetTypePB : int;
 
+// Per-load cancellation shared by for-load and rowset-builder bitmap tokens.
+class DeleteBitmapCancellation {
+public:
+    bool ok() const { return _status.ok(); }
+    Status status() const { return _status.ok() ? Status::OK() : _status.status(); }
+
+    // Discard queued bitmap work and wait only for running tasks. No owner lock
+    // is needed; repeated cancellation retains the first error.
+    void cancel(const Status& reason);
+
+private:
+    friend class CalcDeleteBitmapToken;
+    void _register_token(const std::shared_ptr<ThreadPoolToken>& token);
+
+    AtomicStatus _status;
+    std::mutex _lock;
+    // Do not keep finished writers' tokens or their thread pools alive.
+    std::vector<std::weak_ptr<ThreadPoolToken>> _tokens;
+};
+
 // A thin wrapper of ThreadPoolToken to submit calc delete bitmap task.
 // Usage:
 // 1. create a token
@@ -48,8 +70,10 @@ enum RowsetTypePB : int;
 // 4. call `get_delete_bitmap()` to get the result of all tasks
 class CalcDeleteBitmapToken {
 public:
-    explicit CalcDeleteBitmapToken(std::unique_ptr<ThreadPoolToken> thread_token)
-            : _thread_token(std::move(thread_token)), _status(Status::OK()) {}
+    explicit CalcDeleteBitmapToken(
+            std::unique_ptr<ThreadPoolToken> thread_token,
+            std::shared_ptr<DeleteBitmapCancellation> delete_bitmap_cancellation = nullptr);
+    ~CalcDeleteBitmapToken();
 
     // calculate delete bitmap of `cur_segment` to historical `target_rowsets`
     Status submit(BaseTabletSPtr tablet, RowsetSharedPtr cur_rowset,
@@ -66,36 +90,39 @@ public:
     // submit a generic function to the thread pool
     template <typename Func>
     Status submit_func(Func&& func) {
-        {
-            std::shared_lock rlock(_lock);
-            RETURN_IF_ERROR(_status);
-            _resource_ctx = thread_context()->resource_ctx();
-        }
-        return _thread_token->submit_func([this, func = std::forward<Func>(func)]() {
-            SCOPED_ATTACH_TASK(_resource_ctx);
-            auto st = func();
-            if (!st.ok()) {
-                std::lock_guard wlock(_lock);
-                if (_status.ok()) {
-                    _status = st;
-                }
-            }
-        });
+        RETURN_IF_ERROR(_get_status());
+        auto resource_ctx = thread_context()->resource_ctx();
+        return _submit_func(
+                [this, resource_ctx = std::move(resource_ctx), func = std::forward<Func>(func)]() {
+                    SCOPED_ATTACH_TASK(resource_ctx);
+                    // Cancellation can arrive while the owning channel is blocked in close().
+                    auto st = _get_status();
+                    if (st.ok()) {
+                        st = func();
+                    }
+                    if (!st.ok()) {
+                        _set_status(st);
+                    }
+                });
     }
 
     // wait all tasks in token to be completed.
     Status wait();
 
-    void cancel() { _thread_token->shutdown(); }
+    void cancel(const Status& st = Status::Cancelled("delete bitmap calculation cancelled"));
 
 private:
-    std::unique_ptr<ThreadPoolToken> _thread_token;
+    Status _submit_func(std::function<void()> func);
+    Status _get_status();
+    void _set_status(const Status& st);
+
+    std::shared_ptr<ThreadPoolToken> _thread_token;
 
     std::shared_mutex _lock;
     // Records the current status of the calc delete bitmap job.
     // Note: Once its value is set to Failed, it cannot return to SUCCESS.
     Status _status;
-    std::shared_ptr<ResourceContext> _resource_ctx;
+    const std::shared_ptr<DeleteBitmapCancellation> _delete_bitmap_cancellation;
 };
 
 // CalcDeleteBitmapExecutor is responsible for calc delete bitmap concurrently.
@@ -108,7 +135,8 @@ public:
     // init should be called after storage engine is opened,
     void init(const std::string& name, int max_threads);
 
-    std::unique_ptr<CalcDeleteBitmapToken> create_token();
+    std::unique_ptr<CalcDeleteBitmapToken> create_token(
+            std::shared_ptr<DeleteBitmapCancellation> delete_bitmap_cancellation = nullptr);
 
 private:
     std::unique_ptr<ThreadPool> _thread_pool;

--- a/be/src/storage/rowset/beta_rowset_writer.cpp
+++ b/be/src/storage/rowset/beta_rowset_writer.cpp
@@ -339,7 +339,13 @@ BetaRowsetWriter::BetaRowsetWriter(StorageEngine& engine)
 RowBinlogRowsetWriter::RowBinlogRowsetWriter(StorageEngine& engine) : BetaRowsetWriter(engine) {}
 
 BaseBetaRowsetWriter::~BaseBetaRowsetWriter() {
+    // Finish callbacks before removing files they can still read on cancellation.
+    if (_calc_delete_bitmap_token) {
+        _calc_delete_bitmap_token->cancel();
+    }
     if (!_already_built && _rowset_meta->is_local()) {
+        TEST_SYNC_POINT_CALLBACK("BaseBetaRowsetWriter::~BaseBetaRowsetWriter:before_file_cleanup",
+                                 this);
         // abnormal exit, remove all files generated
         auto& fs = io::global_local_filesystem();
         for (int i = _segment_start_id; i < _segment_creator.next_segment_id(); ++i) {
@@ -352,9 +358,6 @@ BaseBetaRowsetWriter::~BaseBetaRowsetWriter() {
                           fmt::format("Failed to delete file={}", seg_path));
         }
     }
-    if (_calc_delete_bitmap_token) {
-        _calc_delete_bitmap_token->cancel();
-    }
 }
 
 BetaRowsetWriter::~BetaRowsetWriter() {
@@ -363,6 +366,12 @@ BetaRowsetWriter::~BetaRowsetWriter() {
      * is cancelled, the objects involved in the job should be preserved during segcompaction to
      * avoid crashs for memory issues. */
     WARN_IF_ERROR(_wait_flying_segcompaction(), "segment compaction failed");
+}
+
+void BaseBetaRowsetWriter::cancel_calc_delete_bitmap(const Status& st) {
+    if (_calc_delete_bitmap_token != nullptr) {
+        _calc_delete_bitmap_token->cancel(st);
+    }
 }
 
 Status BaseBetaRowsetWriter::init(const RowsetWriterContext& rowset_writer_context) {
@@ -457,6 +466,8 @@ Status BaseBetaRowsetWriter::_generate_delete_bitmap(int32_t segment_id) {
 
         OlapStopWatch watch;
         // Step 2: Build tmp rowset (needs file_writer to be closed)
+        TEST_SYNC_POINT_CALLBACK("BaseBetaRowsetWriter::_generate_delete_bitmap:before_build_tmp",
+                                 this);
         RowsetSharedPtr rowset_ptr;
         st = _build_tmp(rowset_ptr);
         if (!st.ok()) {
@@ -497,6 +508,7 @@ Status BaseBetaRowsetWriter::_generate_delete_bitmap(int32_t segment_id) {
                   << _context.mow_context->delete_bitmap->cardinality()
                   << ", queue_time_us: " << queue_time_us
                   << ", cost: " << watch.get_elapse_time_us() << "(us), total rows: " << total_rows;
+        TEST_SYNC_POINT_CALLBACK("BaseBetaRowsetWriter::_generate_delete_bitmap:finished", this);
         return Status::OK();
     });
 }
@@ -507,7 +519,8 @@ Status BetaRowsetWriter::init(const RowsetWriterContext& rowset_writer_context) 
         _segcompaction_worker->init_mem_tracker(rowset_writer_context);
     }
     if (_context.mow_context != nullptr) {
-        _calc_delete_bitmap_token = _engine.calc_delete_bitmap_executor_for_load()->create_token();
+        _calc_delete_bitmap_token = _engine.calc_delete_bitmap_executor_for_load()->create_token(
+                _context.delete_bitmap_cancellation);
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/beta_rowset_writer.h
+++ b/be/src/storage/rowset/beta_rowset_writer.h
@@ -120,6 +120,8 @@ public:
 
     Status init(const RowsetWriterContext& rowset_writer_context) override;
 
+    void cancel_calc_delete_bitmap(const Status& st) override;
+
     Status add_block(const Block* block) override;
 
     // Declare these interface in `BaseBetaRowsetWriter`

--- a/be/src/storage/rowset/rowset_writer.h
+++ b/be/src/storage/rowset/rowset_writer.h
@@ -156,6 +156,10 @@ public:
     // rowset is invalid if returned Status is not OK
     virtual Status build(RowsetSharedPtr& rowset) = 0;
 
+    // Cancel this writer's asynchronous delete bitmap tasks and wait for running tasks.
+    // Group rowset builders cancel their child builders and writers individually.
+    virtual void cancel_calc_delete_bitmap(const Status& st) {}
+
     // For ordered rowset compaction, manual build rowset
     virtual RowsetSharedPtr manual_build(const RowsetMetaSharedPtr& rowset_meta) = 0;
 

--- a/be/src/storage/rowset/rowset_writer_context.h
+++ b/be/src/storage/rowset/rowset_writer_context.h
@@ -46,6 +46,7 @@
 
 namespace doris {
 
+class DeleteBitmapCancellation;
 class RowsetWriterContextBuilder;
 using RowsetWriterContextBuilderSharedPtr = std::shared_ptr<RowsetWriterContextBuilder>;
 class DataDir;
@@ -88,6 +89,7 @@ struct RowsetWriterContext {
     int64_t txn_id {0};
     int64_t txn_expiration {0}; // For cloud mode
     PUniqueId load_id;
+    std::shared_ptr<DeleteBitmapCancellation> delete_bitmap_cancellation = nullptr;
     TabletUid tablet_uid {0, 0};
     // indicate whether the data among segments is overlapping.
     // default is OVERLAP_UNKNOWN.

--- a/be/src/storage/rowset_builder.cpp
+++ b/be/src/storage/rowset_builder.cpp
@@ -257,7 +257,8 @@ Status RowsetBuilder::init() {
               tmp_pending_rowset_ids.begin() + 1);
     _pending_rs_guard = _engine.pending_local_rowsets().add(tmp_pending_rowset_ids);
 
-    _calc_delete_bitmap_token = _engine.calc_delete_bitmap_executor()->create_token();
+    _calc_delete_bitmap_token =
+            _engine.calc_delete_bitmap_executor()->create_token(_req.delete_bitmap_cancellation);
 
     _is_init = true;
     return Status::OK();
@@ -268,6 +269,7 @@ Status BaseRowsetBuilder::_init_context_common_fields(RowsetWriterContext& conte
 
     context.txn_id = _req.txn_id;
     context.load_id = _req.load_id;
+    context.delete_bitmap_cancellation = _req.delete_bitmap_cancellation;
     context.db_id = _req.table_schema_param->db_id();
     context.table_id = _req.table_schema_param->table_id();
     context.rowset_state = PREPARED;
@@ -414,13 +416,18 @@ Status RowsetBuilder::commit_txn() {
     return Status::OK();
 }
 
-Status BaseRowsetBuilder::cancel() {
+Status BaseRowsetBuilder::cancel(const Status& st) {
     std::lock_guard<std::mutex> l(_lock);
     if (_is_cancelled) {
         return Status::OK();
     }
     if (_calc_delete_bitmap_token != nullptr) {
-        _calc_delete_bitmap_token->cancel();
+        _calc_delete_bitmap_token->cancel(st);
+    }
+    // The writer owns the for-load token, separate from the builder's token.
+    // It can be absent when initialization failed or the load was cancelled before init.
+    if (_rowset_writer != nullptr) {
+        _rowset_writer->cancel_calc_delete_bitmap(st);
     }
     _is_cancelled = true;
     return Status::OK();
@@ -596,6 +603,12 @@ Status GroupRowsetBuilder::submit_calc_delete_bitmap_task() {
 
 Status GroupRowsetBuilder::wait_calc_delete_bitmap() {
     return _txn_rs_builder->wait_calc_delete_bitmap();
+}
+
+Status GroupRowsetBuilder::cancel(const Status& st) {
+    RETURN_IF_ERROR(_txn_rs_builder->cancel(st));
+    RETURN_IF_ERROR(_row_binlog_rowset_builder->cancel(st));
+    return BaseRowsetBuilder::cancel(st);
 }
 
 Status GroupRowsetBuilder::commit_txn() {

--- a/be/src/storage/rowset_builder.h
+++ b/be/src/storage/rowset_builder.h
@@ -67,7 +67,7 @@ public:
         return Status::NotSupported("BaseRowsetBuilder::commit_txn not implemented");
     }
 
-    Status cancel();
+    virtual Status cancel(const Status& st = Status::Cancelled("already cancelled"));
 
     const std::shared_ptr<RowsetWriter>& rowset_writer() const { return _rowset_writer; }
 
@@ -205,6 +205,8 @@ public:
     Status submit_calc_delete_bitmap_task() override;
 
     Status wait_calc_delete_bitmap() override;
+
+    Status cancel(const Status& st) override;
 
     Status commit_txn() override;
 

--- a/be/test/load/delta_writer/delta_writer_cancel_integration_test.cpp
+++ b/be/test/load/delta_writer/delta_writer_cancel_integration_test.cpp
@@ -1,0 +1,769 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gen_cpp/AgentService_types.h>
+#include <gen_cpp/Descriptors_types.h>
+#include <gen_cpp/Types_types.h>
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <future>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "cloud/cloud_delta_writer.h"
+#include "cloud/cloud_rowset_builder.h"
+#include "cloud/cloud_storage_engine.h"
+#include "cloud/cloud_tablet.h"
+#include "cloud/cloud_tablet_mgr.h"
+#include "cloud/config.h"
+#include "common/config.h"
+#include "core/block/block.h"
+#include "core/field.h"
+#include "cpp/sync_point.h"
+#include "io/fs/local_file_system.h"
+#include "io/fs/remote_file_system.h"
+#include "load/channel/load_channel.h"
+#include "load/channel/load_channel_mgr.h"
+#include "load/channel/tablets_channel.h"
+#include "load/delta_writer/delta_writer.h"
+#include "load/memtable/memtable_flush_executor.h"
+#include "load/memtable/memtable_memory_limiter.h"
+#include "runtime/exec_env.h"
+#include "runtime/fragment_mgr.h"
+#include "runtime/memory/mem_tracker_limiter.h"
+#include "runtime/thread_context.h"
+#include "storage/delete/calc_delete_bitmap_executor.h"
+#include "storage/rowset/beta_rowset_writer.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset_builder.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet/tablet.h"
+#include "storage/tablet/tablet_manager.h"
+#include "storage/tablet/tablet_meta.h"
+#include "storage/tablet_info.h"
+#include "testutil/creators.h"
+#include "util/countdown_latch.h"
+
+namespace doris {
+namespace {
+
+// Exercise cloud writer I/O against real temporary files without an object-store service.
+class LocalRemoteFileSystem final : public io::RemoteFileSystem {
+public:
+    explicit LocalRemoteFileSystem(std::string root_path)
+            : RemoteFileSystem(std::move(root_path), "bitmap_cancel_test_fs",
+                               io::FileSystemType::BROKER) {}
+
+private:
+    Status create_file_impl(const io::Path& file, io::FileWriterPtr* writer,
+                            const io::FileWriterOptions* opts) override {
+        return io::global_local_filesystem()->create_file(file, writer, opts);
+    }
+
+    Status create_directory_impl(const io::Path& dir, bool failed_if_exists) override {
+        return io::global_local_filesystem()->create_directory(dir, failed_if_exists);
+    }
+
+    Status delete_file_impl(const io::Path& file) override {
+        return io::global_local_filesystem()->delete_file(file);
+    }
+
+    Status batch_delete_impl(const std::vector<io::Path>& files) override {
+        return io::global_local_filesystem()->batch_delete(files);
+    }
+
+    Status delete_directory_impl(const io::Path& dir) override {
+        return io::global_local_filesystem()->delete_directory(dir);
+    }
+
+    Status exists_impl(const io::Path& path, bool* res) const override {
+        return io::global_local_filesystem()->exists(path, res);
+    }
+
+    Status file_size_impl(const io::Path& file, int64_t* file_size) const override {
+        return io::global_local_filesystem()->file_size(file, file_size);
+    }
+
+    Status list_impl(const io::Path& dir, bool only_file, std::vector<io::FileInfo>* files,
+                     bool* exists) override {
+        return io::global_local_filesystem()->list(dir, only_file, files, exists);
+    }
+
+    Status rename_impl(const io::Path& orig_name, const io::Path& new_name) override {
+        return io::global_local_filesystem()->rename(orig_name, new_name);
+    }
+
+    Status upload_impl(const io::Path& local_file, const io::Path& remote_file) override {
+        return io::global_local_filesystem()->link_file(local_file, remote_file);
+    }
+
+    Status batch_upload_impl(const std::vector<io::Path>& local_files,
+                             const std::vector<io::Path>& remote_files) override {
+        DCHECK_EQ(local_files.size(), remote_files.size());
+        for (size_t i = 0; i < local_files.size(); ++i) {
+            RETURN_IF_ERROR(upload_impl(local_files[i], remote_files[i]));
+        }
+        return Status::OK();
+    }
+
+    Status download_impl(const io::Path& remote_file, const io::Path& local_file) override {
+        return io::global_local_filesystem()->link_file(remote_file, local_file);
+    }
+
+    Status open_file_internal(const io::Path& file, io::FileReaderSPtr* reader,
+                              const io::FileReaderOptions& opts) override {
+        return io::global_local_filesystem()->open_file(file, reader, &opts);
+    }
+};
+
+} // namespace
+
+class DeltaWriterCancelIntegrationTest : public testing::TestWithParam<bool> {
+protected:
+    static constexpr int64_t kTabletId = 71001;
+    static constexpr int64_t kIndexId = 72001;
+
+    void SetUp() override {
+        auto* env = ExecEnv::GetInstance();
+        _saved_engine = std::move(env->_storage_engine);
+        _saved_limiter = std::move(env->_memtable_memory_limiter);
+        _saved_fragment_mgr = env->_fragment_mgr;
+        _saved_cloud_id = config::cloud_unique_id;
+        _saved_deploy_mode = config::deploy_mode;
+        _saved_storage_root = config::storage_root_path;
+        _saved_sync_rowsets = config::cloud_mow_sync_rowsets_when_load_txn_begin;
+        _saved_file_cache = config::enable_file_cache;
+        _saved_between_segments = config::enable_calc_delete_bitmap_between_segments_concurrently;
+        config::cloud_unique_id = GetParam() ? "bitmap-cancel-ut" : "";
+        config::deploy_mode = GetParam() ? "cloud" : "local";
+        config::cloud_mow_sync_rowsets_when_load_txn_begin = false;
+        config::enable_file_cache = false;
+        config::enable_calc_delete_bitmap_between_segments_concurrently = true;
+        _root = (std::filesystem::current_path() / "ut_dir" /
+                 (GetParam() ? "bitmap_cancel_cloud" : "bitmap_cancel_local"))
+                        .string();
+        config::storage_root_path = _root;
+        ASSERT_TRUE(io::global_local_filesystem()->delete_directory(_root).ok());
+        ASSERT_TRUE(io::global_local_filesystem()->create_directory(_root).ok());
+        _attach = std::make_unique<AttachTask>(MemTrackerLimiter::create_shared(
+                MemTrackerLimiter::Type::OTHER, "DeltaWriterCancelIntegrationTest"));
+
+        _fragment_mgr = std::make_unique<FragmentMgr>(env);
+        env->_fragment_mgr = _fragment_mgr.get();
+        env->set_memtable_memory_limiter(new MemTableMemoryLimiter());
+        if (GetParam()) {
+            auto engine = std::make_unique<CloudStorageEngine>(EngineOptions {});
+            engine->init_calc_delete_bitmap_executor_for_UT();
+            engine->_memtable_flush_executor = std::make_unique<MemTableFlushExecutor>();
+            engine->_memtable_flush_executor->init(1);
+            engine->set_latest_fs(std::make_shared<LocalRemoteFileSystem>(_root));
+            env->set_storage_engine(std::move(engine));
+        } else {
+            EngineOptions options;
+            options.store_paths.emplace_back(_root, -1);
+            auto engine = std::make_unique<StorageEngine>(options);
+            ASSERT_TRUE(engine->open().ok());
+            env->set_storage_engine(std::move(engine));
+        }
+        _engine = &env->storage_engine();
+        _load_channel = std::make_shared<LoadChannel>(UniqueId {71, 1}, 60, false, "", 0, true, -1);
+        create_tablet(kTabletId);
+    }
+
+    void TearDown() override {
+        // Unblock callbacks on assertion failure, but do not pre-drain the executor:
+        // writer destruction itself must enforce the lifetime guarantee.
+        _release_bitmap.count_down();
+        if (_cleanup.valid()) {
+            _cleanup.get();
+        }
+        _load_channel.reset();
+        _tablet.reset();
+        auto* sp = SyncPoint::get_instance();
+        sp->disable_processing();
+        _guards.clear();
+        sp->clear_trace();
+        auto* env = ExecEnv::GetInstance();
+        env->set_memtable_memory_limiter(nullptr);
+        env->set_storage_engine(nullptr);
+        env->_storage_engine = std::move(_saved_engine);
+        env->_memtable_memory_limiter = std::move(_saved_limiter);
+        if (_fragment_mgr) {
+            _fragment_mgr->stop();
+            env->_fragment_mgr = _saved_fragment_mgr;
+            _fragment_mgr.reset();
+        }
+        _attach.reset();
+        EXPECT_TRUE(io::global_local_filesystem()->delete_directory(_root).ok());
+        config::cloud_unique_id = _saved_cloud_id;
+        config::deploy_mode = _saved_deploy_mode;
+        config::storage_root_path = _saved_storage_root;
+        config::cloud_mow_sync_rowsets_when_load_txn_begin = _saved_sync_rowsets;
+        config::enable_file_cache = _saved_file_cache;
+        config::enable_calc_delete_bitmap_between_segments_concurrently = _saved_between_segments;
+    }
+
+    void create_tablet(int64_t id) {
+        _request = testutil::create_tablet_request(
+                id, 73001, 74001, 1, TKeysType::UNIQUE_KEYS,
+                {{"k1", TPrimitiveType::INT, true}, {"v1", TPrimitiveType::INT, false}});
+        _request.__set_enable_unique_key_merge_on_write(true);
+        if (GetParam()) {
+            std::unordered_map<uint32_t, uint32_t> ids {{0, 0}, {1, 1}};
+            auto meta = TabletMeta::create(_request, TabletUid::gen_uid(), 0, 2, ids);
+            auto tablet = std::make_shared<CloudTablet>(_engine->to_cloud(), meta);
+            auto rs_meta = std::make_shared<RowsetMeta>();
+            rs_meta->set_rowset_type(BETA_ROWSET);
+            rs_meta->set_rowset_state(VISIBLE);
+            rs_meta->set_tablet_id(id);
+            rs_meta->set_tablet_schema_hash(_request.tablet_schema.schema_hash);
+            rs_meta->set_tablet_schema(tablet->tablet_schema());
+            rs_meta->set_version(Version(0, 1));
+            rs_meta->set_segments_overlap(OVERLAP_UNKNOWN);
+            RowsetSharedPtr rowset;
+            ASSERT_TRUE(RowsetFactory::create_rowset(tablet->tablet_schema(), "", rs_meta, &rowset)
+                                .ok());
+            {
+                std::unique_lock meta_lock(tablet->get_header_lock());
+                tablet->add_rowsets({rowset}, false, meta_lock);
+                tablet->set_cumulative_layer_point(2);
+            }
+            _engine->to_cloud().tablet_mgr().put_tablet_for_UT(tablet);
+            ASSERT_TRUE(io::global_local_filesystem()
+                                ->create_directory(fmt::format("{}/data/{}", _root, id))
+                                .ok());
+            _tablet = tablet;
+        } else {
+            ASSERT_TRUE(
+                    _engine->to_local().create_tablet(_request, _load_channel->_self_profile).ok());
+            _tablet = _engine->to_local().tablet_manager()->get_tablet(id);
+        }
+        ASSERT_NE(_tablet, nullptr);
+    }
+
+    PTabletWriterOpenRequest open_request(int64_t id, bool incremental = false) {
+        auto desc = testutil::create_descriptor_table(
+                {{TYPE_INT, "k1", false}, {TYPE_INT, "v1", false}});
+        auto schema = testutil::create_table_schema_param(
+                desc, kIndexId, _request.tablet_schema.schema_hash, _request.tablet_schema.columns);
+        PTabletWriterOpenRequest request;
+        request.mutable_id()->set_hi(71);
+        request.mutable_id()->set_lo(1);
+        request.set_index_id(kIndexId);
+        request.set_txn_id(75001);
+        request.set_txn_expiration(4102444800);
+        request.set_num_senders(1);
+        request.set_sender_id(0);
+        request.set_is_incremental(incremental);
+        request.set_is_high_priority(_load_channel->is_high_priority());
+        request.set_enable_profile(true);
+        schema->to_protobuf(request.mutable_schema());
+        auto* tablet = request.add_tablets();
+        tablet->set_tablet_id(id);
+        tablet->set_partition_id(_request.partition_id);
+        return request;
+    }
+
+    virtual Status open_load_channel(const PTabletWriterOpenRequest& request) {
+        return _load_channel->open(request);
+    }
+
+    Status open_writer(int64_t id, bool incremental = false) {
+        RETURN_IF_ERROR(open_load_channel(open_request(id, incremental)));
+        _writer = _load_channel->_tablets_channels.at(kIndexId)->_tablet_writers.at(id).get();
+        _builder = _writer->_rowset_builder.get();
+        if (GetParam()) {
+            // Only metadata RPCs are skipped; builders and both executors initialize normally.
+            static_cast<CloudRowsetBuilder*>(_builder)->set_skip_writing_rowset_metadata(true);
+        }
+        return Status::OK();
+    }
+
+    Block block() {
+        auto result = _tablet->tablet_schema()->create_storage_block();
+        {
+            auto guard = result.mutate_columns_scoped();
+            auto& columns = guard.mutable_columns();
+            columns[0]->insert(Field::create_field<PrimitiveType::TYPE_INT>(1));
+            columns[1]->insert(Field::create_field<PrimitiveType::TYPE_INT>(10));
+        }
+        return result;
+    }
+
+    void check_wiring() {
+        _rowset_writer = static_cast<BaseBetaRowsetWriter*>(_builder->rowset_writer().get());
+        const auto& cancellation = _load_channel->_delete_bitmap_cancellation;
+        ASSERT_EQ(_writer->_req.delete_bitmap_cancellation, cancellation);
+        ASSERT_EQ(_builder->_req.delete_bitmap_cancellation, cancellation);
+        ASSERT_EQ(_rowset_writer->context().delete_bitmap_cancellation, cancellation);
+        ASSERT_NE(_builder->_calc_delete_bitmap_token, nullptr);
+        ASSERT_NE(_rowset_writer->_calc_delete_bitmap_token, nullptr);
+        EXPECT_EQ(_builder->_calc_delete_bitmap_token->_delete_bitmap_cancellation, cancellation);
+        EXPECT_EQ(_rowset_writer->_calc_delete_bitmap_token->_delete_bitmap_cancellation,
+                  cancellation);
+        EXPECT_EQ(_builder->_calc_delete_bitmap_token->_thread_token->_pool,
+                  _engine->calc_delete_bitmap_executor()->_thread_pool.get());
+        EXPECT_EQ(_rowset_writer->_calc_delete_bitmap_token->_thread_token->_pool,
+                  _engine->calc_delete_bitmap_executor_for_load()->_thread_pool.get());
+        EXPECT_NE(_engine->calc_delete_bitmap_executor()->_thread_pool.get(),
+                  _engine->calc_delete_bitmap_executor_for_load()->_thread_pool.get());
+    }
+
+    template <typename Callback>
+    void on(const std::string& point, Callback&& callback) {
+        _guards.emplace_back();
+        SyncPoint::get_instance()->set_call_back(point, std::forward<Callback>(callback),
+                                                 &_guards.back());
+        SyncPoint::get_instance()->enable_processing();
+    }
+
+    void block_bitmap_and_observe_cleanup() {
+        _segment_path = _rowset_writer->context().segment_path(0);
+        if (GetParam()) {
+            _segment_path = (_engine->to_cloud().latest_fs()->root_path() / _segment_path).string();
+        }
+        on("BaseBetaRowsetWriter::_generate_delete_bitmap:before_build_tmp", [&](auto&& args) {
+            if (try_any_cast<BaseBetaRowsetWriter*>(args[0]) == _rowset_writer) {
+                _bitmap_started.count_down();
+                _release_bitmap.wait();
+                bool exists = false;
+                EXPECT_TRUE(io::global_local_filesystem()->exists(_segment_path, &exists).ok());
+                EXPECT_TRUE(exists);
+                EXPECT_FALSE(_cleanup_started.load());
+            }
+        });
+        on("BaseBetaRowsetWriter::_generate_delete_bitmap:finished", [&](auto&& args) {
+            if (try_any_cast<BaseBetaRowsetWriter*>(args[0]) == _rowset_writer) {
+                _bitmap_finished = true;
+            }
+        });
+        on("BaseBetaRowsetWriter::~BaseBetaRowsetWriter:before_file_cleanup", [&](auto&& args) {
+            if (try_any_cast<BaseBetaRowsetWriter*>(args[0]) == _rowset_writer) {
+                EXPECT_TRUE(_bitmap_finished.load());
+                _cleanup_started = true;
+            }
+        });
+        on("CloudRowsetBuilder::~CloudRowsetBuilder:before_clear_cache", [&](auto&& args) {
+            if (try_any_cast<CloudRowsetBuilder*>(args[0]) == _builder) {
+                EXPECT_TRUE(_bitmap_finished.load());
+                _cleanup_started = true;
+            }
+        });
+    }
+
+    void start_cleanup(bool cancel) {
+        auto resource_ctx = _load_channel->_resource_ctx;
+        if (cancel) {
+            _cleanup = std::async(std::launch::async, [this, resource_ctx] {
+                SCOPED_ATTACH_TASK(resource_ctx);
+                EXPECT_TRUE(_load_channel->cancel().ok());
+            });
+        } else {
+            auto& owner =
+                    _load_channel->_tablets_channels.at(kIndexId)->_tablet_writers.at(kTabletId);
+            _cleanup = std::async(std::launch::async,
+                                  [resource_ctx, writer = std::move(owner)]() mutable {
+                                      SCOPED_ATTACH_TASK(resource_ctx);
+                                      writer.reset();
+                                  });
+        }
+        EXPECT_EQ(_cleanup.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+        EXPECT_FALSE(_cleanup_started.load());
+        EXPECT_FALSE(_bitmap_finished.load());
+        _release_bitmap.count_down();
+        _cleanup.get();
+        EXPECT_TRUE(_bitmap_finished.load());
+    }
+
+    Status flush_two_memtables() {
+        auto data = block();
+        for (int i = 0; i < 2; ++i) {
+            RETURN_IF_ERROR(_writer->write(&data, TabletAddRowsPayload {.row_idxs = {0}}));
+            RETURN_IF_ERROR(_writer->flush_memtable_async());
+            RETURN_IF_ERROR(_writer->wait_flush());
+        }
+        return _rowset_writer->_calc_delete_bitmap_token->wait();
+    }
+
+    void exercise_both_phases() {
+        ASSERT_TRUE(_writer->init().ok());
+        check_wiring();
+        ASSERT_TRUE(flush_two_memtables().ok());
+        ASSERT_TRUE(_writer->close().ok());
+        ASSERT_TRUE(_writer->build_rowset().ok());
+        std::atomic<int> builder_submissions {0};
+        on("CalcDeleteBitmapToken::submit_func:before_submit", [&](auto&& args) {
+            if (try_any_cast<CalcDeleteBitmapToken*>(args[0]) ==
+                _builder->_calc_delete_bitmap_token.get()) {
+                ++builder_submissions;
+            }
+        });
+        ASSERT_TRUE(_writer->submit_calc_delete_bitmap_task().ok());
+        ASSERT_TRUE(_writer->wait_calc_delete_bitmap().ok());
+        EXPECT_GT(builder_submissions.load(), 0);
+        SyncPoint::get_instance()->clear_call_back(
+                "CalcDeleteBitmapToken::submit_func:before_submit");
+    }
+
+    Status prepare_partial_init_callback() {
+        check_wiring();
+        auto data = block();
+        if (GetParam()) {
+            // Keep a real temporary PREPARED rowset in the builder to exercise its
+            // cache-cleanup branch. build() would instead mark the rowset COMMITTED.
+            RETURN_IF_ERROR(_rowset_writer->flush_single_block(&data));
+            RETURN_IF_ERROR(_rowset_writer->_calc_delete_bitmap_token->wait());
+            RETURN_IF_ERROR(_rowset_writer->_build_tmp(_builder->_rowset));
+            EXPECT_EQ(_builder->rowset()->rowset_meta()->rowset_state(), PREPARED);
+            block_bitmap_and_observe_cleanup();
+            // Resubmit the real callback against the already-created segment.
+            return _rowset_writer->_generate_delete_bitmap(0);
+        }
+        block_bitmap_and_observe_cleanup();
+        return _rowset_writer->flush_single_block(&data);
+    }
+
+    std::string _root;
+    std::string _saved_cloud_id;
+    std::string _saved_deploy_mode;
+    std::string _saved_storage_root;
+    bool _saved_sync_rowsets = false;
+    bool _saved_file_cache = false;
+    bool _saved_between_segments = false;
+    std::unique_ptr<BaseStorageEngine> _saved_engine;
+    std::unique_ptr<MemTableMemoryLimiter> _saved_limiter;
+    FragmentMgr* _saved_fragment_mgr = nullptr;
+    std::unique_ptr<FragmentMgr> _fragment_mgr;
+    std::unique_ptr<AttachTask> _attach;
+    BaseStorageEngine* _engine = nullptr;
+    BaseTabletSPtr _tablet;
+    TCreateTabletReq _request;
+    std::shared_ptr<LoadChannel> _load_channel;
+    BaseDeltaWriter* _writer = nullptr;
+    BaseRowsetBuilder* _builder = nullptr;
+    BaseBetaRowsetWriter* _rowset_writer = nullptr;
+    std::string _segment_path;
+    std::vector<SyncPoint::CallbackGuard> _guards;
+    CountDownLatch _bitmap_started {1};
+    CountDownLatch _release_bitmap {1};
+    std::atomic<bool> _bitmap_finished {false};
+    std::atomic<bool> _cleanup_started {false};
+    std::future<void> _cleanup;
+};
+
+TEST_P(DeltaWriterCancelIntegrationTest, OrdinaryAndIncrementalOpenWireBothPhases) {
+    for (int i = 0; i < 2; ++i) {
+        if (i != 0) {
+            create_tablet(kTabletId + i);
+        }
+        ASSERT_TRUE(open_writer(kTabletId + i, i != 0).ok());
+        ASSERT_NO_FATAL_FAILURE(exercise_both_phases());
+    }
+    ASSERT_TRUE(_load_channel->cancel().ok());
+    for (const auto& [_, writer] : _load_channel->_tablets_channels.at(kIndexId)->_tablet_writers) {
+        auto* builder = writer->_rowset_builder.get();
+        auto* rowset_writer = static_cast<BaseBetaRowsetWriter*>(builder->rowset_writer().get());
+        EXPECT_TRUE(builder->_calc_delete_bitmap_token->wait().is<ErrorCode::CANCELLED>());
+        EXPECT_TRUE(rowset_writer->_calc_delete_bitmap_token->wait().is<ErrorCode::CANCELLED>());
+    }
+}
+
+TEST_P(DeltaWriterCancelIntegrationTest, CancelDrainsRealWriterCallbackBeforeCleanup) {
+    ASSERT_TRUE(open_writer(kTabletId).ok());
+    ASSERT_TRUE(_writer->init().ok());
+    check_wiring();
+    auto data = block();
+    block_bitmap_and_observe_cleanup();
+    ASSERT_TRUE(_rowset_writer->flush_single_block(&data).ok());
+    ASSERT_TRUE(_bitmap_started.wait_for(std::chrono::seconds(10)));
+    start_cleanup(true);
+    EXPECT_TRUE(_rowset_writer->_calc_delete_bitmap_token->wait().is<ErrorCode::CANCELLED>());
+    EXPECT_TRUE(_builder->_calc_delete_bitmap_token->wait().is<ErrorCode::CANCELLED>());
+    _load_channel.reset();
+    if (!GetParam()) {
+        EXPECT_TRUE(_cleanup_started.load());
+        bool exists = true;
+        ASSERT_TRUE(io::global_local_filesystem()->exists(_segment_path, &exists).ok());
+        EXPECT_FALSE(exists);
+    }
+}
+
+TEST_P(DeltaWriterCancelIntegrationTest, PartialInitDestructionDrainsBeforeFileOrCacheCleanup) {
+    ASSERT_TRUE(open_writer(kTabletId).ok());
+    const auto failure = Status::InternalError("memtable initialization failed");
+    on("BaseDeltaWriter::init:before_memtable_init", [&](auto&& args) {
+        if (try_any_cast<BaseDeltaWriter*>(args[0]) != _writer) {
+            return;
+        }
+        auto st = prepare_partial_init_callback();
+        EXPECT_TRUE(st.ok()) << st;
+        auto* ret = try_any_cast_ret<Status>(args);
+        ret->first = st.ok() ? failure : st;
+        ret->second = true;
+    });
+    EXPECT_EQ(_writer->init(), failure);
+    ASSERT_FALSE(_writer->_is_init);
+    ASSERT_TRUE(_builder->_is_init);
+    ASSERT_TRUE(_bitmap_started.wait_for(std::chrono::seconds(10)));
+    start_cleanup(false);
+    EXPECT_TRUE(_cleanup_started.load());
+    if (!GetParam()) {
+        bool exists = true;
+        ASSERT_TRUE(io::global_local_filesystem()->exists(_segment_path, &exists).ok());
+        EXPECT_FALSE(exists);
+    }
+}
+
+// Local close reports bitmap cancellation through tablet_errors and can still return OK.
+// Exercise the manager terminal-state transition with the real close and bitmap paths.
+class LocalLoadChannelTerminalStateTest : public DeltaWriterCancelIntegrationTest {
+protected:
+    enum class CancelMode { WITH_REASON, WITHOUT_REASON, TIMEOUT };
+
+    void SetUp() override {
+        DeltaWriterCancelIntegrationTest::SetUp();
+        _manager = std::make_unique<LoadChannelMgr>();
+        _manager->_load_state_channels =
+                std::make_unique<LoadChannelMgr::LoadStateChannelCache>(1024);
+        // The fixture does not initialize the memory limiter's background machinery.
+        _load_channel->_is_high_priority = true;
+    }
+
+    void TearDown() override {
+        _release_bitmap.count_down();
+        if (_eos.valid()) {
+            _eos.get();
+        }
+        if (_cleanup.valid()) {
+            _cleanup.get();
+        }
+        if (_manager) {
+            _manager->stop();
+        }
+        _manager.reset();
+        _tablets_channel.reset();
+        DeltaWriterCancelIntegrationTest::TearDown();
+    }
+
+    Status open_load_channel(const PTabletWriterOpenRequest& request) override {
+        RETURN_IF_ERROR(_manager->open(request));
+        _load_channel = _manager->_load_channels.at(UniqueId(request.id()));
+        return Status::OK();
+    }
+
+    void prepare_eos() {
+        ASSERT_TRUE(open_writer(kTabletId).ok());
+        ASSERT_TRUE(_writer->init().ok());
+        check_wiring();
+        _tablets_channel = _load_channel->_tablets_channels.at(kIndexId);
+        ASSERT_TRUE(flush_two_memtables().ok());
+        _eos_request.mutable_id()->set_hi(71);
+        _eos_request.mutable_id()->set_lo(1);
+        _eos_request.set_index_id(kIndexId);
+        _eos_request.set_sender_id(0);
+        _eos_request.set_backend_id(0);
+        _eos_request.set_packet_seq(0);
+        _eos_request.set_eos(true);
+        _eos_request.add_partition_ids(_request.partition_id);
+    }
+
+    PTabletWriterCancelRequest cancel_request(const std::string& reason = "") {
+        PTabletWriterCancelRequest request;
+        request.mutable_id()->CopyFrom(_eos_request.id());
+        if (!reason.empty()) {
+            request.set_cancel_reason(reason);
+        }
+        return request;
+    }
+
+    void race_eos_with_cancellation(CancelMode mode) {
+        ASSERT_NO_FATAL_FAILURE(prepare_eos());
+        on("CalcDeleteBitmapToken::submit:before_between_segments", [&](auto&& args) {
+            if (try_any_cast<CalcDeleteBitmapToken*>(args[0]) ==
+                _builder->_calc_delete_bitmap_token.get()) {
+                _bitmap_started.count_down();
+                _release_bitmap.wait();
+            }
+        });
+        on("CalcDeleteBitmapToken::wait:before_wait", [&](auto&& args) {
+            if (try_any_cast<CalcDeleteBitmapToken*>(args[0]) ==
+                _builder->_calc_delete_bitmap_token.get()) {
+                _close_waiting.count_down();
+            }
+        });
+        on("DeleteBitmapCancellation::cancel:before_shutdown", [&](auto&& args) {
+            if (try_any_cast<DeleteBitmapCancellation*>(args[0]) ==
+                _load_channel->_delete_bitmap_cancellation.get()) {
+                _cancel_published.count_down();
+            }
+        });
+        _eos = std::async(std::launch::async,
+                          [this] { return _manager->add_batch(_eos_request, &_eos_response); });
+        ASSERT_TRUE(_bitmap_started.wait_for(std::chrono::seconds(10)));
+        ASSERT_TRUE(_close_waiting.wait_for(std::chrono::seconds(10)));
+        if (mode == CancelMode::TIMEOUT) {
+            _load_channel->_last_updated_time.store(0);
+        }
+        _cleanup = std::async(std::launch::async, [this, mode] {
+            if (mode == CancelMode::TIMEOUT) {
+                EXPECT_TRUE(_manager->_start_load_channels_clean().ok());
+            } else {
+                EXPECT_TRUE(_manager->cancel(cancel_request(mode == CancelMode::WITH_REASON
+                                                                    ? "cancel won before EOS"
+                                                                    : ""))
+                                    .ok());
+            }
+        });
+        ASSERT_TRUE(_cancel_published.wait_for(std::chrono::seconds(10)));
+        // Cancellation has removed the channel and published failure, while the real
+        // bitmap callback still prevents close from reaching its commit phase.
+        PTabletWriterAddBlockResult early_retry;
+        EXPECT_TRUE(_manager->add_batch(_eos_request, &early_retry).is<ErrorCode::CANCELLED>());
+        EXPECT_EQ(_eos.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+        _release_bitmap.count_down();
+        EXPECT_TRUE(_eos.get().is<ErrorCode::CANCELLED>());
+        _cleanup.get();
+        EXPECT_FALSE(_builder->_is_committed);
+        EXPECT_EQ(_eos_response.tablet_vec_size(), 0);
+        ASSERT_EQ(_eos_response.tablet_errors_size(), 1);
+        EXPECT_EQ(_eos_response.tablet_errors(0).tablet_id(), kTabletId);
+        const std::string reason = mode == CancelMode::WITH_REASON ? "cancel won before EOS"
+                                   : mode == CancelMode::TIMEOUT   ? "load channel timed out"
+                                                                   : "load channel cancelled";
+        // Model a lost EOS response: a retry must retain the first cancellation,
+        // including after another cancellation tries to replace its reason.
+        EXPECT_TRUE(_manager->cancel(cancel_request("later cancellation")).ok());
+        PTabletWriterAddBlockResult retry;
+        auto status = _manager->add_batch(_eos_request, &retry);
+        EXPECT_TRUE(status.is<ErrorCode::CANCELLED>());
+        EXPECT_NE(status.to_string().find(reason), std::string::npos);
+        EXPECT_TRUE(_manager->_load_channels.empty());
+    }
+
+    void reject_reopen_after_cancellation(CancelMode mode) {
+        ASSERT_NO_FATAL_FAILURE(prepare_eos());
+        const auto request = open_request(kTabletId);
+        if (mode == CancelMode::TIMEOUT) {
+            _load_channel->_last_updated_time.store(0);
+            ASSERT_TRUE(_manager->_start_load_channels_clean().ok());
+        } else {
+            ASSERT_TRUE(_manager->cancel(cancel_request(mode == CancelMode::WITH_REASON
+                                                                ? "cancel before reopen"
+                                                                : ""))
+                                .ok());
+        }
+        ASSERT_TRUE(_manager->_load_channels.empty());
+        PTabletWriterAddBlockResult before_reopen;
+        const auto terminal_status = _manager->add_batch(_eos_request, &before_reopen);
+        ASSERT_TRUE(terminal_status.is<ErrorCode::CANCELLED>());
+        // Use the real open API with a complete schema/tablet request, including
+        // an incremental retry. Neither request may create replacement writers.
+        EXPECT_EQ(_manager->open(request), terminal_status);
+        EXPECT_TRUE(_manager->_load_channels.empty());
+        EXPECT_EQ(_manager->open(open_request(kTabletId, true)), terminal_status);
+        EXPECT_TRUE(_manager->_load_channels.empty());
+        PTabletWriterAddBlockResult after_reopen;
+        EXPECT_EQ(_manager->add_batch(_eos_request, &after_reopen), terminal_status);
+        EXPECT_EQ(after_reopen.tablet_vec_size(), 0);
+        EXPECT_FALSE(_builder->_is_committed);
+    }
+
+    std::unique_ptr<LoadChannelMgr> _manager;
+    std::shared_ptr<BaseTabletsChannel> _tablets_channel;
+    PTabletWriterAddBlockRequest _eos_request;
+    PTabletWriterAddBlockResult _eos_response;
+    CountDownLatch _close_waiting {1};
+    CountDownLatch _cancel_published {1};
+    std::future<Status> _eos;
+};
+
+TEST_P(LocalLoadChannelTerminalStateTest, CancelReasonSurvivesLateEosAndRetry) {
+    race_eos_with_cancellation(CancelMode::WITH_REASON);
+}
+
+TEST_P(LocalLoadChannelTerminalStateTest, EmptyCancelReasonSurvivesLateEosAndRetry) {
+    race_eos_with_cancellation(CancelMode::WITHOUT_REASON);
+}
+
+TEST_P(LocalLoadChannelTerminalStateTest, TimeoutSurvivesLateEosAndRetry) {
+    race_eos_with_cancellation(CancelMode::TIMEOUT);
+}
+
+TEST_P(LocalLoadChannelTerminalStateTest, CancelReasonRejectsRealReopen) {
+    reject_reopen_after_cancellation(CancelMode::WITH_REASON);
+}
+
+TEST_P(LocalLoadChannelTerminalStateTest, EmptyCancelReasonRejectsRealReopen) {
+    reject_reopen_after_cancellation(CancelMode::WITHOUT_REASON);
+}
+
+TEST_P(LocalLoadChannelTerminalStateTest, TimeoutRejectsRealReopen) {
+    reject_reopen_after_cancellation(CancelMode::TIMEOUT);
+}
+
+TEST_P(LocalLoadChannelTerminalStateTest, SuccessfulEosSurvivesLateCancellation) {
+    ASSERT_NO_FATAL_FAILURE(prepare_eos());
+    ASSERT_TRUE(_manager->add_batch(_eos_request, &_eos_response).ok());
+    EXPECT_TRUE(_builder->_is_committed);
+    ASSERT_EQ(_eos_response.tablet_vec_size(), 1);
+    EXPECT_EQ(_eos_response.tablet_errors_size(), 0);
+    // An open response can also be retried after the load has completed. Preserve
+    // successful EOS retries without allocating a new channel behind that record.
+    EXPECT_TRUE(_manager->open(open_request(kTabletId)).ok());
+    EXPECT_TRUE(_manager->open(open_request(kTabletId, true)).ok());
+    EXPECT_TRUE(_manager->_load_channels.empty());
+    EXPECT_TRUE(_manager->cancel(cancel_request("too late")).ok());
+    EXPECT_TRUE(_manager->_finish_load_channel(_load_channel->load_id(), _load_channel).ok());
+    PTabletWriterAddBlockResult retry;
+    EXPECT_TRUE(_manager->add_batch(_eos_request, &retry).ok());
+}
+
+TEST_P(LocalLoadChannelTerminalStateTest, LateEosCannotFinishReplacementChannel) {
+    ASSERT_NO_FATAL_FAILURE(prepare_eos());
+    const auto id = _load_channel->load_id();
+    auto replacement = std::make_shared<LoadChannel>(id, 60, true, "", 0, false, -1);
+    _manager->_load_channels[id] = replacement;
+    EXPECT_TRUE(_manager->_finish_load_channel(id, _load_channel).is<ErrorCode::CANCELLED>());
+    EXPECT_EQ(_manager->_load_channels.at(id), replacement);
+    auto* handle = _manager->_load_state_channels->lookup(id.to_string());
+    EXPECT_EQ(handle, nullptr);
+    if (handle != nullptr) {
+        _manager->_load_state_channels->release(handle);
+    }
+}
+
+TEST_P(LocalLoadChannelTerminalStateTest, CancelledChannelCannotSucceedAfterCacheEviction) {
+    ASSERT_NO_FATAL_FAILURE(prepare_eos());
+    ASSERT_TRUE(_manager->cancel(cancel_request("cancelled")).ok());
+    _manager->_load_state_channels->erase(_load_channel->load_id().to_string());
+    EXPECT_TRUE(_manager->_finish_load_channel(_load_channel->load_id(), _load_channel)
+                        .is<ErrorCode::CANCELLED>());
+    PTabletWriterAddBlockResult retry;
+    EXPECT_FALSE(_manager->add_batch(_eos_request, &retry).ok());
+}
+
+INSTANTIATE_TEST_SUITE_P(Local, LocalLoadChannelTerminalStateTest, testing::Values(false));
+
+INSTANTIATE_TEST_SUITE_P(LocalAndCloud, DeltaWriterCancelIntegrationTest, testing::Bool());
+
+} // namespace doris

--- a/be/test/load/delta_writer/delta_writer_cancel_test.cpp
+++ b/be/test/load/delta_writer/delta_writer_cancel_test.cpp
@@ -1,0 +1,573 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "cloud/cloud_delta_writer.h"
+#include "cloud/cloud_rowset_builder.h"
+#include "cloud/cloud_rowset_writer.h"
+#include "cloud/cloud_storage_engine.h"
+#include "cloud/cloud_tablets_channel.h"
+#include "cpp/sync_point.h"
+#include "load/channel/load_channel_mgr.h"
+#include "load/channel/tablets_channel.h"
+#include "load/delta_writer/delta_writer.h"
+#include "runtime/exec_env.h"
+#include "runtime/fragment_mgr.h"
+#include "runtime/memory/mem_tracker_limiter.h"
+#include "runtime/thread_context.h"
+#include "storage/delete/calc_delete_bitmap_executor.h"
+#include "storage/options.h"
+#include "storage/rowset/beta_rowset_writer.h"
+#include "storage/rowset/group_rowset_writer.h"
+#include "storage/rowset_builder.h"
+#include "storage/storage_engine.h"
+#include "util/countdown_latch.h"
+#include "util/defer_op.h"
+
+namespace doris {
+
+// Exercise both local/cloud writers, with and without row binlog, without tablet I/O.
+class DeltaWriterCancelTest : public testing::TestWithParam<int> {
+protected:
+    void SetUp() override {
+        auto tracker = MemTrackerLimiter::create_shared(MemTrackerLimiter::Type::OTHER,
+                                                        "DeltaWriterCancelTest");
+        _attach_task = std::make_unique<AttachTask>(tracker);
+        ASSERT_TRUE(ThreadPoolBuilder("DeltaWriterCancelTest")
+                            .set_min_threads(1)
+                            .set_max_threads(1)
+                            .build(&_pool)
+                            .ok());
+        _previous_fragment_mgr = ExecEnv::GetInstance()->_fragment_mgr;
+        _fragment_mgr = std::make_unique<FragmentMgr>(ExecEnv::GetInstance());
+        ExecEnv::GetInstance()->_fragment_mgr = _fragment_mgr.get();
+        _load_channel = std::make_shared<LoadChannel>(UniqueId {}, 60, false, "", 0, false, -1);
+        WriteRequest data_req;
+        data_req.delete_bitmap_cancellation = _load_channel->_delete_bitmap_cancellation;
+        WriteRequest group_req = data_req;
+        group_req.write_req_type = WriteRequestType::GROUP;
+        WriteRequest binlog_req = data_req;
+        binlog_req.write_req_type = WriteRequestType::ROW_BINLOG;
+        if (is_cloud()) {
+            _cloud_engine = std::make_unique<CloudStorageEngine>(EngineOptions {});
+            if (is_group()) {
+                _writer = std::make_unique<CloudDeltaWriter>(*_cloud_engine, group_req, data_req,
+                                                             binlog_req, nullptr, UniqueId {});
+                auto* group = static_cast<CloudGroupRowsetBuilder*>(_writer->_rowset_builder.get());
+                _builders = {group->data_builder(), group->row_binlog_builder()};
+            } else {
+                _writer = std::make_unique<CloudDeltaWriter>(*_cloud_engine, data_req, nullptr,
+                                                             UniqueId {});
+            }
+        } else {
+            _local_engine = std::make_unique<StorageEngine>(EngineOptions {});
+            if (is_group()) {
+                _writer = std::make_unique<DeltaWriter>(*_local_engine, group_req, data_req,
+                                                        binlog_req, nullptr, UniqueId {});
+                auto* group = static_cast<GroupRowsetBuilder*>(_writer->_rowset_builder.get());
+                _builders = {group->txn_rowset_builder(), group->row_binlog_builder()};
+            } else {
+                _writer = std::make_unique<DeltaWriter>(*_local_engine, data_req, nullptr,
+                                                        UniqueId {});
+            }
+        }
+        if (!is_group()) {
+            _builders = {_writer->_rowset_builder.get()};
+        }
+    }
+
+    void TearDown() override {
+        // Release the unrelated task before destroying writers, even after a failed assertion.
+        _release_worker.count_down();
+        if (_pool) {
+            _pool->wait();
+        }
+        _writer.reset();
+        _tokens.clear();
+        _pool.reset();
+        _cloud_engine.reset();
+        _local_engine.reset();
+        _load_channel.reset();
+        if (_fragment_mgr) {
+            _fragment_mgr->stop();
+            ExecEnv::GetInstance()->_fragment_mgr = _previous_fragment_mgr;
+            _fragment_mgr.reset();
+        }
+        _attach_task.reset();
+    }
+
+    bool is_cloud() const { return GetParam() & 1; }
+    bool is_group() const { return GetParam() & 2; }
+
+    void install_tokens() {
+        for (auto* builder : _builders) {
+            std::shared_ptr<BaseBetaRowsetWriter> rowset_writer;
+            if (is_cloud()) {
+                rowset_writer = std::make_shared<CloudRowsetWriter>(*_cloud_engine);
+            } else {
+                rowset_writer = std::make_shared<BetaRowsetWriter>(*_local_engine);
+            }
+            // Set up only the state needed by cancellation and destruction. No files are created.
+            rowset_writer->_rowset_meta = std::make_shared<RowsetMeta>();
+            rowset_writer->_calc_delete_bitmap_token = make_token();
+            builder->_calc_delete_bitmap_token = make_token();
+            builder->_rowset_writer = rowset_writer;
+            _tokens.push_back(rowset_writer->_calc_delete_bitmap_token.get());
+            _tokens.push_back(builder->_calc_delete_bitmap_token.get());
+        }
+        if (is_group()) {
+            auto group_writer = std::make_shared<GroupRowsetWriter>();
+            group_writer->set_data_writer(_builders[0]->rowset_writer());
+            group_writer->set_row_binlog_writer(_builders[1]->rowset_writer());
+            _writer->_rowset_builder->_rowset_writer = std::move(group_writer);
+        }
+    }
+
+    std::unique_ptr<CalcDeleteBitmapToken> make_token() {
+        return std::make_unique<CalcDeleteBitmapToken>(
+                _pool->new_token(ThreadPool::ExecutionMode::CONCURRENT),
+                _load_channel->_delete_bitmap_cancellation);
+    }
+
+    FragmentMgr* _previous_fragment_mgr = nullptr;
+    std::unique_ptr<FragmentMgr> _fragment_mgr;
+    std::shared_ptr<LoadChannel> _load_channel;
+    std::unique_ptr<AttachTask> _attach_task;
+    std::unique_ptr<StorageEngine> _local_engine;
+    std::unique_ptr<CloudStorageEngine> _cloud_engine;
+    std::unique_ptr<ThreadPool> _pool;
+    std::unique_ptr<BaseDeltaWriter> _writer;
+    std::vector<BaseRowsetBuilder*> _builders;
+    std::vector<CalcDeleteBitmapToken*> _tokens;
+    CountDownLatch _worker_started {1};
+    CountDownLatch _release_worker {1};
+    std::atomic<int> _executed {0};
+};
+
+TEST_P(DeltaWriterCancelTest, CancelBeforeInit) {
+    ASSERT_TRUE(_writer->cancel().ok());
+    EXPECT_TRUE(_writer->_is_cancelled);
+    EXPECT_TRUE(_writer->_memtable_writer->_is_cancelled);
+    for (auto* builder : _builders) {
+        EXPECT_TRUE(builder->_is_cancelled);
+    }
+    EXPECT_TRUE(_writer->cancel().ok());
+}
+
+TEST_P(DeltaWriterCancelTest, CancelRemovesBothPhasesBeforeDestruction) {
+    install_tokens();
+    ASSERT_TRUE(_pool->submit_func([this] {
+                         _worker_started.count_down();
+                         _release_worker.wait();
+                     }).ok());
+    ASSERT_TRUE(_worker_started.wait_for(std::chrono::seconds(10)));
+    for (auto* token : _tokens) {
+        ASSERT_TRUE(token->submit_func([this] {
+                             ++_executed;
+                             return Status::OK();
+                         }).ok());
+    }
+    ASSERT_EQ(_pool->get_queue_size(), _tokens.size());
+
+    const auto cancelled = Status::Cancelled("load cancelled by sender");
+    ASSERT_TRUE(_writer->cancel_with_status(cancelled).ok());
+    EXPECT_EQ(_pool->get_queue_size(), 0);
+    EXPECT_EQ(_executed.load(), 0);
+    EXPECT_EQ(_writer->_memtable_writer->_cancel_status, cancelled);
+    for (auto* token : _tokens) {
+        EXPECT_EQ(token->wait(), cancelled);
+        EXPECT_EQ(token->submit_func([] { return Status::OK(); }), cancelled);
+    }
+    ASSERT_TRUE(_writer->cancel_with_status(Status::Cancelled("second cancel")).ok());
+    for (auto* token : _tokens) {
+        EXPECT_EQ(token->wait(), cancelled);
+    }
+
+    _release_worker.count_down();
+    _pool->wait();
+    EXPECT_EQ(_executed.load(), 0);
+}
+
+TEST_P(DeltaWriterCancelTest, PreserveEarlierCalculationFailure) {
+    install_tokens();
+    const auto failure = Status::InternalError("delete bitmap calculation failed");
+    ASSERT_TRUE(_tokens.front()->submit_func([failure] { return failure; }).ok());
+    ASSERT_EQ(_tokens.front()->wait(), failure);
+    for (size_t i = 1; i < _tokens.size(); ++i) {
+        EXPECT_TRUE(_tokens[i]->_get_status().ok());
+    }
+    ASSERT_TRUE(_load_channel->cancel().ok());
+    ASSERT_TRUE(_writer->cancel().ok());
+    EXPECT_EQ(_tokens.front()->wait(), failure);
+    EXPECT_EQ(_tokens.front()->submit_func([] { return Status::OK(); }), failure);
+    for (size_t i = 1; i < _tokens.size(); ++i) {
+        EXPECT_TRUE(_tokens[i]->wait().is<ErrorCode::CANCELLED>());
+    }
+}
+
+TEST_P(DeltaWriterCancelTest, PreserveCancellationBeforeRunningCallbackFailure) {
+    install_tokens();
+    auto* token = _tokens.front();
+    const auto later_failure = Status::InternalError("callback failed after cancellation");
+    CountDownLatch cancellation_published(1);
+    auto* sync_point = SyncPoint::get_instance();
+    SyncPoint::CallbackGuard guard;
+    sync_point->set_call_back(
+            "DeleteBitmapCancellation::cancel:before_shutdown",
+            [&](auto&& args) {
+                if (try_any_cast<DeleteBitmapCancellation*>(args[0]) ==
+                    _load_channel->_delete_bitmap_cancellation.get()) {
+                    cancellation_published.count_down();
+                }
+            },
+            &guard);
+    sync_point->enable_processing();
+    std::future<Status> canceller;
+    Defer cleanup {[&] {
+        _release_worker.count_down();
+        if (canceller.valid()) {
+            EXPECT_TRUE(canceller.get().ok());
+        }
+        _pool->wait();
+        sync_point->disable_processing();
+    }};
+    ASSERT_TRUE(token->submit_func([this, later_failure] {
+                         _worker_started.count_down();
+                         _release_worker.wait();
+                         return later_failure;
+                     }).ok());
+    ASSERT_TRUE(_worker_started.wait_for(std::chrono::seconds(10)));
+    canceller = std::async(std::launch::async, [&] { return _load_channel->cancel(); });
+    ASSERT_TRUE(cancellation_published.wait_for(std::chrono::seconds(10)));
+    EXPECT_EQ(canceller.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+    _release_worker.count_down();
+    ASSERT_TRUE(canceller.get().ok());
+    const auto cancelled = Status::Cancelled("load channel cancelled");
+    EXPECT_EQ(token->wait(), cancelled);
+    EXPECT_EQ(token->submit_func([] { return Status::OK(); }), cancelled);
+    EXPECT_TRUE(_writer->cancel_with_status(later_failure).ok());
+    EXPECT_EQ(token->wait(), cancelled);
+}
+
+TEST_P(DeltaWriterCancelTest, PreserveLoadCancellationBeforeExplicitTokenFailure) {
+    install_tokens();
+    ASSERT_TRUE(_load_channel->cancel().ok());
+    const auto later_failure = Status::InternalError("later explicit token failure");
+    for (auto* token : _tokens) {
+        token->cancel(later_failure);
+        EXPECT_EQ(token->wait(), Status::Cancelled("load channel cancelled"));
+        EXPECT_EQ(token->submit_func([] { return Status::OK(); }),
+                  Status::Cancelled("load channel cancelled"));
+    }
+}
+
+// Model close holding a tablets-channel/writer/builder lock while waiting for bitmap.
+// Load cancellation keeps its own lock, drains bitmap, then cancels the tablets channel.
+TEST_P(DeltaWriterCancelTest, LoadCancelDrainsBitmapBeforeTabletsChannelCancellation) {
+    install_tokens();
+    ASSERT_TRUE(_pool->submit_func([this] {
+                         _worker_started.count_down();
+                         _release_worker.wait();
+                     }).ok());
+    ASSERT_TRUE(_worker_started.wait_for(std::chrono::seconds(10)));
+    for (auto* token : _tokens) {
+        ASSERT_TRUE(token->submit_func([this] {
+                             ++_executed;
+                             return Status::OK();
+                         }).ok());
+    }
+
+    PUniqueId id;
+    TabletsChannelKey key(id, 1);
+    std::shared_ptr<BaseTabletsChannel> tablets_channel;
+    if (is_cloud()) {
+        tablets_channel = std::make_shared<CloudTabletsChannel>(*_cloud_engine, key, UniqueId {},
+                                                                false, nullptr);
+    } else {
+        tablets_channel =
+                std::make_shared<TabletsChannel>(*_local_engine, key, UniqueId {}, false, nullptr);
+    }
+    tablets_channel->set_delete_bitmap_cancellation(_load_channel->_delete_bitmap_cancellation);
+    _load_channel->_tablets_channels.emplace(1, tablets_channel);
+    LoadChannelMgr manager;
+    Defer stop_manager {[&] { manager.stop(); }};
+    manager._load_state_channels = std::make_unique<LoadChannelMgr::LoadStateChannelCache>(16);
+    manager._load_channels.emplace(UniqueId {}, _load_channel);
+
+    CountDownLatch locks_held(1);
+    auto waiter = std::async(std::launch::async, [&] {
+        std::lock_guard channel_lock(tablets_channel->_lock);
+        std::unique_lock<std::mutex> local_writer_lock;
+        std::unique_lock<bthread::Mutex> cloud_writer_lock;
+        if (is_cloud()) {
+            cloud_writer_lock =
+                    std::unique_lock(static_cast<CloudDeltaWriter*>(_writer.get())->_mtx);
+        } else {
+            local_writer_lock = std::unique_lock(static_cast<DeltaWriter*>(_writer.get())->_lock);
+        }
+        std::lock_guard builder_lock(_builders.front()->_lock);
+        locks_held.count_down();
+        std::vector<Status> statuses;
+        for (auto* token : _tokens) {
+            statuses.push_back(token->wait());
+        }
+        return statuses;
+    });
+    bool entered = locks_held.wait_for(std::chrono::seconds(10));
+    EXPECT_TRUE(entered);
+    PTabletWriterCancelRequest request;
+    *request.mutable_id() = id;
+    request.set_cancel_reason("sender cancelled while close waits");
+    auto canceller = std::async(std::launch::async, [&] { return manager.cancel(request); });
+    auto cancel_ready = canceller.wait_for(std::chrono::seconds(10));
+    auto wait_ready = waiter.wait_for(std::chrono::seconds(10));
+    // The unrelated worker remains blocked: queued bitmap work must not delay
+    // either cancellation or the close waiter.
+    EXPECT_EQ(_pool->get_queue_size(), 0);
+    // Always unblock the pool before joining, including when the regression reappears.
+    _release_worker.count_down();
+    EXPECT_EQ(cancel_ready, std::future_status::ready);
+    EXPECT_EQ(wait_ready, std::future_status::ready);
+    EXPECT_TRUE(canceller.get().ok());
+    const auto cancelled = Status::Cancelled("load channel cancelled");
+    for (const auto& st : waiter.get()) {
+        EXPECT_EQ(st, cancelled);
+    }
+    EXPECT_EQ(_executed.load(), 0);
+    EXPECT_TRUE(manager._load_channels.empty());
+    EXPECT_TRUE(_load_channel->cancel().ok());
+    EXPECT_EQ(_load_channel->_delete_bitmap_cancellation->status(), cancelled);
+    EXPECT_EQ(tablets_channel->_state, BaseTabletsChannel::kFinished);
+}
+
+TEST_P(DeltaWriterCancelTest, LoadCancelRemovesQueuedTasksWithoutWait) {
+    install_tokens();
+    ASSERT_TRUE(_pool->submit_func([this] {
+                         _worker_started.count_down();
+                         _release_worker.wait();
+                     }).ok());
+    ASSERT_TRUE(_worker_started.wait_for(std::chrono::seconds(10)));
+    for (auto* token : _tokens) {
+        ASSERT_TRUE(token->submit_func([this] {
+                             ++_executed;
+                             return Status::OK();
+                         }).ok());
+    }
+    const auto cancelled = Status::Cancelled("load channel cancelled");
+    ASSERT_TRUE(_load_channel->cancel().ok());
+    // Cancellation removes queued tasks without waiting for the unrelated worker.
+    EXPECT_EQ(_pool->get_queue_size(), 0);
+    _release_worker.count_down();
+    _pool->wait();
+    EXPECT_EQ(_executed.load(), 0);
+    auto late_token = make_token();
+    EXPECT_EQ(late_token->submit_func([] { return Status::OK(); }), cancelled);
+    _load_channel->_delete_bitmap_cancellation->cancel(Status::Cancelled("second cancellation"));
+    EXPECT_EQ(_load_channel->_delete_bitmap_cancellation->status(), cancelled);
+    for (auto* token : _tokens) {
+        EXPECT_EQ(token->wait(), cancelled);
+        EXPECT_EQ(token->submit_func([] { return Status::OK(); }), cancelled);
+    }
+}
+
+TEST_P(DeltaWriterCancelTest, SkipDequeuedTaskAfterCancellationPublication) {
+    auto token = make_token();
+    ASSERT_TRUE(_pool->submit_func([this] {
+                         _worker_started.count_down();
+                         _release_worker.wait();
+                     }).ok());
+    ASSERT_TRUE(_worker_started.wait_for(std::chrono::seconds(10)));
+    ASSERT_TRUE(token->submit_func([this] {
+                         ++_executed;
+                         return Status::OK();
+                     }).ok());
+    // Model the interval after publication and before this token's shutdown.
+    const auto cancelled = Status::Cancelled("published before shutdown");
+    _load_channel->_delete_bitmap_cancellation->_status.update(cancelled);
+    _release_worker.count_down();
+    _pool->wait();
+    EXPECT_EQ(_executed.load(), 0);
+    EXPECT_EQ(token->wait(), cancelled);
+    EXPECT_EQ(token->submit_func([] { return Status::OK(); }), cancelled);
+}
+
+TEST_P(DeltaWriterCancelTest, LoadCancellationStillAcquiresLoadLock) {
+    install_tokens();
+    ASSERT_TRUE(_pool->submit_func([this] {
+                         _worker_started.count_down();
+                         _release_worker.wait();
+                     }).ok());
+    ASSERT_TRUE(_worker_started.wait_for(std::chrono::seconds(10)));
+    for (auto* token : _tokens) {
+        ASSERT_TRUE(token->submit_func([this] {
+                             ++_executed;
+                             return Status::OK();
+                         }).ok());
+    }
+    std::unique_lock load_lock(_load_channel->_lock);
+    auto canceller = std::async(std::launch::async, [&] { return _load_channel->cancel(); });
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (!_load_channel->is_cancelled() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    EXPECT_TRUE(_load_channel->is_cancelled());
+    EXPECT_TRUE(_load_channel->_delete_bitmap_cancellation->ok());
+    EXPECT_EQ(_pool->get_queue_size(), _tokens.size());
+    EXPECT_EQ(canceller.wait_for(std::chrono::milliseconds(0)), std::future_status::timeout);
+    load_lock.unlock();
+    const auto ready = canceller.wait_for(std::chrono::seconds(10));
+    EXPECT_EQ(ready, std::future_status::ready);
+    EXPECT_EQ(_pool->get_queue_size(), 0);
+    _release_worker.count_down();
+    EXPECT_TRUE(canceller.get().ok());
+    EXPECT_EQ(_executed.load(), 0);
+}
+
+TEST_P(DeltaWriterCancelTest, RunningTaskFinishesBeforeCancelledWaitReturns) {
+    install_tokens();
+    ASSERT_TRUE(_tokens.front()
+                        ->submit_func([this] {
+                            _worker_started.count_down();
+                            _release_worker.wait();
+                            ++_executed;
+                            return Status::OK();
+                        })
+                        .ok());
+    ASSERT_TRUE(_worker_started.wait_for(std::chrono::seconds(10)));
+    // This task must never run after the running task is released.
+    ASSERT_TRUE(_tokens.front()
+                        ->submit_func([this] {
+                            ++_executed;
+                            return Status::OK();
+                        })
+                        .ok());
+    const auto cancelled = Status::Cancelled("load channel cancelled");
+    auto canceller = std::async(std::launch::async, [&] { return _load_channel->cancel(); });
+    auto waiter = std::async(std::launch::async, [&] { return _tokens.front()->wait(); });
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (_load_channel->_delete_bitmap_cancellation->ok() &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    EXPECT_FALSE(_load_channel->_delete_bitmap_cancellation->ok());
+    EXPECT_EQ(canceller.wait_for(std::chrono::milliseconds(0)), std::future_status::timeout);
+    EXPECT_EQ(waiter.wait_for(std::chrono::milliseconds(0)), std::future_status::timeout);
+    auto late_submitter = std::async(std::launch::async, [&] {
+        auto token = make_token();
+        return token->submit_func([] { return Status::OK(); });
+    });
+    const auto late_ready = late_submitter.wait_for(std::chrono::seconds(10));
+    _release_worker.count_down();
+    EXPECT_EQ(late_ready, std::future_status::ready);
+    EXPECT_EQ(late_submitter.get(), cancelled);
+    EXPECT_TRUE(canceller.get().ok());
+    EXPECT_EQ(waiter.get(), cancelled);
+    EXPECT_EQ(_executed.load(), 1);
+}
+
+TEST_P(DeltaWriterCancelTest, TokenDestructionDuringLoadCancellation) {
+    auto token = make_token();
+    ASSERT_TRUE(token->submit_func([this] {
+                         _worker_started.count_down();
+                         _release_worker.wait();
+                         ++_executed;
+                         return Status::OK();
+                     }).ok());
+    ASSERT_TRUE(_worker_started.wait_for(std::chrono::seconds(10)));
+    auto canceller = std::async(std::launch::async, [&] { return _load_channel->cancel(); });
+    auto destroyer =
+            std::async(std::launch::async, [token = std::move(token)]() mutable { token.reset(); });
+    // Both shutdown paths must preserve the callback's state until it finishes.
+    EXPECT_EQ(canceller.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+    EXPECT_EQ(destroyer.wait_for(std::chrono::milliseconds(100)), std::future_status::timeout);
+    _release_worker.count_down();
+    EXPECT_TRUE(canceller.get().ok());
+    destroyer.get();
+    EXPECT_EQ(_executed.load(), 1);
+    EXPECT_TRUE(_load_channel->cancel().ok());
+}
+
+TEST_P(DeltaWriterCancelTest, CancellationBetweenStatusCheckAndSubmit) {
+    auto token = make_token();
+    auto* sync_point = SyncPoint::get_instance();
+    SyncPoint::CallbackGuard guard;
+    sync_point->set_call_back(
+            "CalcDeleteBitmapToken::submit_func:before_submit",
+            [&](auto&& args) {
+                if (try_any_cast<CalcDeleteBitmapToken*>(args[0]) == token.get()) {
+                    _worker_started.count_down();
+                    _release_worker.wait();
+                }
+            },
+            &guard);
+    sync_point->enable_processing();
+    auto submitter = std::async(std::launch::async, [&] {
+        return token->submit_func([this] {
+            ++_executed;
+            return Status::OK();
+        });
+    });
+    const bool entered = _worker_started.wait_for(std::chrono::seconds(10));
+    EXPECT_TRUE(entered);
+    EXPECT_TRUE(_load_channel->cancel().ok());
+    _release_worker.count_down();
+    EXPECT_EQ(submitter.get(), Status::Cancelled("load channel cancelled"));
+    EXPECT_EQ(_executed.load(), 0);
+    sync_point->disable_processing();
+}
+
+TEST_P(DeltaWriterCancelTest, FailedSubmitPreservesEarlierWrapperFailure) {
+    auto token = make_token();
+    const auto failure = Status::InternalError("earlier bitmap failure");
+    auto* sync_point = SyncPoint::get_instance();
+    SyncPoint::CallbackGuard guard;
+    sync_point->set_call_back(
+            "CalcDeleteBitmapToken::submit_func:before_submit",
+            [&](auto&& args) {
+                if (try_any_cast<CalcDeleteBitmapToken*>(args[0]) == token.get()) {
+                    token->cancel(failure);
+                    EXPECT_TRUE(_load_channel->cancel().ok());
+                }
+            },
+            &guard);
+    sync_point->enable_processing();
+    EXPECT_EQ(token->submit_func([] { return Status::OK(); }), failure);
+    sync_point->disable_processing();
+}
+
+TEST_P(DeltaWriterCancelTest, FailedSubmitWithoutCancellationPreservesPoolError) {
+    auto token = make_token();
+    _pool->shutdown();
+    const auto pool_error = _pool->submit_func([] {});
+    EXPECT_TRUE(pool_error.is<ErrorCode::SERVICE_UNAVAILABLE>());
+    EXPECT_EQ(token->submit_func([] { return Status::OK(); }), pool_error);
+    EXPECT_TRUE(_load_channel->_delete_bitmap_cancellation->ok());
+    EXPECT_TRUE(token->wait().ok());
+}
+
+INSTANTIATE_TEST_SUITE_P(LocalAndCloud, DeltaWriterCancelTest, testing::Values(0, 1, 2, 3));
+
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

A cancelled MOW load can leave delete bitmap work queued behind unrelated tasks. Cancelling writers one by one also reaches their bitmap tokens only after acquiring their owner locks. Register both for-load and rowset-builder bitmap tokens in a shared `DeleteBitmapCancellation` coordinator so load cancellation can publish one bitmap failure status, remove pending work, and wake bitmap waiters before continuing the existing writer cancellation traversal.

`_register_token()` keeps weak references to thread-pool tokens. `cancel()` publishes the first failure and collects live tokens under a short registry lock, then releases that lock before calling the existing `shutdown()`. Pending tasks are discarded; already-running callbacks finish safely. Tokens created after publication are shut down immediately, and submissions and dequeued callbacks check cancellation. Each callback captures its own resource context. Each token publishes callback failures and explicit cancellation under the coordinator's publication lock, preserving the first error versus load cancellation while keeping tablet calculation failures local to that token.

Propagate the coordinator through ordinary and incremental opens to local/cloud writers, including row-binlog group children and both bitmap phases. Explicit writer cancellation still stops flush producers before cancelling the builder and rowset-writer tokens. Drain callbacks before wrapper destruction, derived rowset-builder cleanup, and local file removal so concurrent cancellation cannot leave a callback accessing destroyed state or reclaimed files. Preserve earlier bitmap errors.

**Independent scope:** this PR is based on master and has no dependency on #67759. `LoadChannel::cancel()` retains its original cancellation flag, acquires the original `_lock`, cancels registered bitmap work while holding that lock, and then executes the original per-channel cancellation loop. Tablets-channel and writer cancellation still acquire their existing locks. LoadChannelMgr now serializes terminal-state updates under its existing lock: cancellation and timeout record failure before draining bitmap work, and EOS checks the active channel identity and preserves the first terminal state. A late EOS returns cancellation instead of caching success after a skipped writer commit; empty-reason cancellations and timeouts are also retained for retries. `open()` checks the same terminal cache under that lock: failed loads reject ordinary and incremental reopen, while completed-load open retries acknowledge success without recreating a channel. This does not provide lock-free load cancellation or move RPCs out of the heavy pool.

Related experiment: #67674. Its diagnostic implementation observed direct removal of queued bitmap tasks, but its performance results also included the separate lock-publication change and are not measurements of this standalone integration. Experimental counters, phase diagnostics, and generic thread-pool statistics changes remain outside this PR. `TabletCalDeleteBitmapThreadPool` publish tasks and running I/O are not interrupted.

### Release note

Cancelled MOW loads discard registered pending delete bitmap work and reject later bitmap submissions while allowing running callbacks to finish safely. Concurrent submission preserves the published bitmap failure. Cancellation and timeout cannot be overwritten by a late EOS, so retried EOS does not acknowledge a skipped commit as success.

### Check List (For Author)

- Test
    - [ ] Unit Test: 71 parameterized cases in source: 56 local/cloud ordinary/group cancellation cases, 6 production-wired local/cloud callback and initialization cases, and 9 local manager terminal-state cases.
    - Manager coverage blocks a real between-segment bitmap callback during EOS, then races cancellation with a reason, cancellation without a reason, or timeout cleanup. It checks skipped commits, EOS retries, first-error preservation, success-first ordering, channel replacement, cache eviction, and real ordinary/incremental reopen after cancellation or timeout.
    - Error-order tests cover running callback failure after cancellation publication, explicit token failure after load cancellation, and earlier calculation errors remaining local to their token. Test managers deregister metric hooks on scope exit.
    - Close-path tests write through the real writer and flush two memtables to preserve row accounting. Cloud lifetime tests use local temporary storage and skip metadata RPCs.
    - Changed-file clang-format 16, `git diff --check`, and text-only `build-support/check-build-hygiene.sh` passed. Tests, compilation, and clang-tidy were not run for this update at the author's request.
- Behavior changed:
    - [x] Yes. Load cancellation drains registered bitmap tokens before the existing channel traversal; writer cleanup covers both bitmap phases. Failed submissions preserve bitmap failures, and manager completion preserves the first terminal state across EOS/cancellation/timeout races.
- Does this need documentation?
    - [x] No.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
