### PR TITLE
[fix](mv) Isolate temporary MV pre-rewrite state

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/StatementContext.java
@@ -164,6 +164,7 @@ public class StatementContext implements Closeable {
     // Thus hasUnknownColStats has higher priority than isDpHyp
     private boolean hasUnknownColStats = false;
 
+    private final StatementContext idGeneratorSource;
     private final IdGenerator<ExprId> exprIdGenerator;
     private final IdGenerator<ObjectId> objectIdGenerator = ObjectId.createGenerator();
     private final IdGenerator<RelationId> relationIdGenerator = RelationId.createGenerator();
@@ -380,8 +381,14 @@ public class StatementContext implements Closeable {
      * StatementContext
      */
     private StatementContext(ConnectContext connectContext, OriginStatement originStatement, int initialId) {
+        this(connectContext, originStatement, initialId, null);
+    }
+
+    private StatementContext(ConnectContext connectContext, OriginStatement originStatement, int initialId,
+            StatementContext idGeneratorSource) {
         this.connectContext = connectContext;
         this.originStatement = originStatement;
+        this.idGeneratorSource = idGeneratorSource;
         exprIdGenerator = ExprId.createGenerator(initialId);
         if (connectContext != null && connectContext.getSessionVariable() != null) {
             if (CacheAnalyzer.canUseSqlCache(connectContext.getSessionVariable())) {
@@ -398,6 +405,17 @@ public class StatementContext implements Closeable {
         } else {
             this.sqlCacheContext = null;
         }
+    }
+
+    /**
+     * Create an isolated context for a temporary rewrite of the current plan.
+     *
+     * <p>The temporary context owns its mutable analysis and rewrite state. ID allocation remains in the
+     * original statement scope so nodes created while rewriting an existing plan cannot reuse its IDs.
+     */
+    public StatementContext forkForTemporaryRewrite() {
+        StatementContext generatorSource = idGeneratorSource == null ? this : idGeneratorSource;
+        return new StatementContext(connectContext, originStatement, 0, generatorSource);
     }
 
     public void setNeedLockTables(boolean needLockTables) {
@@ -662,27 +680,39 @@ public class StatementContext implements Closeable {
     }
 
     public ExprId getNextExprId() {
-        return exprIdGenerator.getNextId();
+        return idGeneratorSource == null
+                ? exprIdGenerator.getNextId()
+                : idGeneratorSource.getNextExprId();
     }
 
     public IdGenerator<ExprId> getExprIdGenerator() {
-        return exprIdGenerator;
+        return idGeneratorSource == null
+                ? exprIdGenerator
+                : idGeneratorSource.getExprIdGenerator();
     }
 
     public CTEId getNextCTEId() {
-        return cteIdGenerator.getNextId();
+        return idGeneratorSource == null
+                ? cteIdGenerator.getNextId()
+                : idGeneratorSource.getNextCTEId();
     }
 
     public ObjectId getNextObjectId() {
-        return objectIdGenerator.getNextId();
+        return idGeneratorSource == null
+                ? objectIdGenerator.getNextId()
+                : idGeneratorSource.getNextObjectId();
     }
 
     public RelationId getNextRelationId() {
-        return relationIdGenerator.getNextId();
+        return idGeneratorSource == null
+                ? relationIdGenerator.getNextId()
+                : idGeneratorSource.getNextRelationId();
     }
 
     public TableId getNextTableId() {
-        return talbeIdGenerator.getNextId();
+        return idGeneratorSource == null
+                ? talbeIdGenerator.getNextId()
+                : idGeneratorSource.getNextTableId();
     }
 
     public void setParsedStatement(StatementBase parsedStatement) {
@@ -748,7 +778,13 @@ public class StatementContext implements Closeable {
         }
     }
 
+    /**
+     * Return the statement-scoped generator used for synthesized column aliases.
+     */
     public ColumnAliasGenerator getColumnAliasGenerator() {
+        if (idGeneratorSource != null) {
+            return idGeneratorSource.getColumnAliasGenerator();
+        }
         return columnAliasGenerator == null
                 ? columnAliasGenerator = new ColumnAliasGenerator()
                 : columnAliasGenerator;
@@ -779,7 +815,9 @@ public class StatementContext implements Closeable {
     }
 
     public PlaceholderId getNextPlaceholderId() {
-        return placeHolderIdGenerator.getNextId();
+        return idGeneratorSource == null
+                ? placeHolderIdGenerator.getNextId()
+                : idGeneratorSource.getNextPlaceholderId();
     }
 
     public Map<PlaceholderId, Expression> getIdToPlaceholderRealExpr() {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/RecordPlanForMvPreRewrite.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/rewrite/RecordPlanForMvPreRewrite.java
@@ -27,10 +27,13 @@ import org.apache.doris.nereids.rules.exploration.mv.PreMaterializedViewRewriter
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.visitor.CustomRewriter;
 import org.apache.doris.nereids.trees.plans.visitor.DefaultPlanRewriter;
+import org.apache.doris.qe.ConnectContext;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Record plan for later mv rewrite
@@ -47,23 +50,42 @@ public class RecordPlanForMvPreRewrite extends DefaultPlanRewriter<Void> impleme
             return plan;
         }
         // plan pre normalize
-        Plan finalPlan;
         try {
-            finalPlan = MaterializedViewUtils.rewriteByRules(cascadesContext,
-                    childContext -> {
-                        Rewriter.getCteChildrenRewriter(childContext,
-                                        ImmutableList.of(Rewriter.custom(RuleType.REWRITE_CTE_CHILDREN,
-                                                () -> new RewriteCteChildren(
-                                                        Rewriter.CTE_CHILDREN_REWRITE_JOBS_MV_REWRITE_USED,
-                                                        false))))
-                                .execute();
-                        return childContext.getRewritePlan();
-                    }, plan, plan, false);
-            statementContext.addTmpPlanForMvRewrite(finalPlan);
+            ConnectContext connectContext = cascadesContext.getConnectContext();
+            StatementContext originalStatementContext = connectContext.getStatementContext();
+            try (StatementContext temporaryStatementContext = statementContext.forkForTemporaryRewrite()) {
+                try {
+                    // Some rewrite utilities access the thread-local ConnectContext directly. Switch it together
+                    // with CascadesContext so every temporary CTE cache stays isolated from the main rewrite.
+                    connectContext.setStatementContext(temporaryStatementContext);
+                    CascadesContext temporaryCascadesContext = CascadesContext.initContext(
+                            temporaryStatementContext, plan,
+                            cascadesContext.getCurrentJobContext().getRequiredProperties());
+                    AtomicReference<Plan> finalPlan = new AtomicReference<>();
+                    temporaryCascadesContext.withPlanProcess(cascadesContext.showPlanProcess(),
+                            () -> finalPlan.set(MaterializedViewUtils.rewriteByRules(
+                                    temporaryCascadesContext, this::rewriteCteChildren, plan, plan, false)));
+                    cascadesContext.addPlanProcesses(temporaryCascadesContext.getPlanProcesses());
+                    statementContext.addTmpPlanForMvRewrite(finalPlan.get());
+                } finally {
+                    connectContext.setStatementContext(originalStatementContext);
+                }
+            }
         } catch (Exception e) {
             LOG.error("mv rewrite in rbo rewrite pre normalize fail, query id is {}",
                     cascadesContext.getConnectContext().getQueryIdentifier(), e);
         }
         return plan;
+    }
+
+    private Plan rewriteCteChildren(CascadesContext childContext) {
+        Rewriter.getCteChildrenRewriter(childContext,
+                        ImmutableList.of(Rewriter.custom(
+                                RuleType.REWRITE_CTE_CHILDREN,
+                                () -> new RewriteCteChildren(
+                                        Rewriter.CTE_CHILDREN_REWRITE_JOBS_MV_REWRITE_USED,
+                                        false))))
+                .execute();
+        return childContext.getRewritePlan();
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/StatementContextTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/StatementContextTest.java
@@ -26,6 +26,9 @@ import org.apache.doris.datasource.mvcc.MvccSnapshot;
 import org.apache.doris.datasource.mvcc.PluginDrivenMvccExternalTable;
 import org.apache.doris.datasource.plugin.PluginDrivenExternalTable;
 import org.apache.doris.nereids.rules.analysis.PreloadExternalMetadata;
+import org.apache.doris.nereids.trees.expressions.CTEId;
+import org.apache.doris.nereids.trees.expressions.ExprId;
+import org.apache.doris.nereids.trees.plans.RelationId;
 import org.apache.doris.nereids.trees.plans.logical.LogicalFileScan.SelectedPartitions;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.OriginStatement;
@@ -41,6 +44,34 @@ import java.util.Collections;
 import java.util.Optional;
 
 public class StatementContextTest {
+
+    @Test
+    public void testTemporaryRewriteContextIsolatesStateAndSharesIdNamespace() {
+        StatementContext statementContext = new StatementContext();
+        try (StatementContext temporaryContext = statementContext.forkForTemporaryRewrite()) {
+            ExprId statementExprId = statementContext.getNextExprId();
+            ExprId temporaryExprId = temporaryContext.getNextExprId();
+            RelationId statementRelationId = statementContext.getNextRelationId();
+            RelationId temporaryRelationId = temporaryContext.getNextRelationId();
+            CTEId statementCteId = statementContext.getNextCTEId();
+            CTEId temporaryCteId = temporaryContext.getNextCTEId();
+
+            org.junit.jupiter.api.Assertions.assertNotEquals(statementExprId, temporaryExprId);
+            org.junit.jupiter.api.Assertions.assertNotEquals(statementRelationId, temporaryRelationId);
+            org.junit.jupiter.api.Assertions.assertNotEquals(statementCteId, temporaryCteId);
+            org.junit.jupiter.api.Assertions.assertNotEquals(
+                    statementContext.generateColumnName(), temporaryContext.generateColumnName());
+
+            statementContext.getCteIdToConsumers().put(statementCteId, Collections.emptySet());
+            org.junit.jupiter.api.Assertions.assertTrue(temporaryContext.getCteIdToConsumers().isEmpty());
+
+            temporaryContext.getCteIdToConsumers().put(temporaryCteId, Collections.emptySet());
+            org.junit.jupiter.api.Assertions.assertFalse(
+                    statementContext.getCteIdToConsumers().containsKey(temporaryCteId));
+        } finally {
+            statementContext.close();
+        }
+    }
 
     @Test
     public void testSkipPreloadWhenSessionVariableDisabled() {

--- a/regression-test/suites/auth_p0/test_mtmv_pre_rewrite_view_column_auth.groovy
+++ b/regression-test/suites/auth_p0/test_mtmv_pre_rewrite_view_column_auth.groovy
@@ -1,0 +1,101 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+suite("test_mtmv_pre_rewrite_view_column_auth", "p0,auth") {
+    String suiteName = "test_mtmv_pre_rewrite_view_column_auth"
+    String dbName = "${suiteName}_db"
+    String tableName = "${suiteName}_table"
+    String viewName = "${suiteName}_view"
+    String mvName = "${suiteName}_mv"
+    String user = "${suiteName}_user"
+    String password = "C123_567p"
+
+    try_sql "DROP USER IF EXISTS ${user}"
+    sql "DROP DATABASE IF EXISTS ${dbName}"
+
+    try {
+        sql "CREATE DATABASE ${dbName}"
+        sql """
+            CREATE TABLE ${dbName}.${tableName} (
+                id INT,
+                secret INT
+            )
+            DUPLICATE KEY(id)
+            DISTRIBUTED BY HASH(id) BUCKETS 1
+            PROPERTIES ('replication_num' = '1')
+        """
+        sql "INSERT INTO ${dbName}.${tableName} VALUES (1, 10), (2, 20)"
+        sql """
+            CREATE VIEW ${dbName}.${viewName}
+            AS SELECT id, secret FROM ${dbName}.${tableName}
+        """
+        sql "CREATE USER '${user}' IDENTIFIED BY '${password}'"
+        sql "GRANT SELECT_PRIV(id) ON internal.${dbName}.${viewName} TO ${user}"
+        sql """
+            CREATE MATERIALIZED VIEW ${dbName}.${mvName}
+            BUILD IMMEDIATE REFRESH COMPLETE ON MANUAL
+            DISTRIBUTED BY RANDOM BUCKETS 1
+            PROPERTIES ('replication_num' = '1')
+            AS SELECT id, secret FROM ${dbName}.${viewName}
+        """
+        waitingMTMVTaskFinishedByMvName(mvName, dbName)
+
+        if (isCloudMode()) {
+            def clusters = sql "SHOW CLUSTERS"
+            assertTrue(!clusters.isEmpty())
+            sql "GRANT USAGE_PRIV ON CLUSTER `${clusters[0][0]}` TO ${user}"
+        }
+
+        String userJdbcUrl = org.apache.doris.regression.Config.buildUrlWithDb(
+                context.config.jdbcUrl, dbName)
+        connect(user, password, userJdbcUrl) {
+            sql "SET enable_nereids_planner = true"
+            sql "SET enable_fallback_to_original_planner = false"
+            sql "SET enable_sql_cache = false"
+            sql "SET enable_materialized_view_rewrite = true"
+
+            test {
+                sql """
+                    SELECT secret FROM ${dbName}.${viewName}
+                    ORDER BY secret
+                """
+                exception "Permission denied"
+            }
+
+            sql "SET pre_materialized_view_rewrite_strategy = 'TRY_IN_RBO'"
+            test {
+                sql """
+                    WITH c AS (SELECT * FROM ${dbName}.${viewName})
+                    SELECT a.id FROM c a JOIN c b ON a.id = b.id ORDER BY a.id
+                """
+                exception "Permission denied"
+            }
+
+            sql "SET pre_materialized_view_rewrite_strategy = 'FORCE_IN_RBO'"
+            test {
+                sql """
+                    WITH c AS (SELECT * FROM ${dbName}.${viewName})
+                    SELECT a.secret FROM c a JOIN c b ON a.id = b.id ORDER BY a.secret
+                """
+                exception "Permission denied"
+            }
+        }
+    } finally {
+        try_sql "DROP USER IF EXISTS ${user}"
+        sql "DROP DATABASE IF EXISTS ${dbName}"
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

MV pre-rewrite normalizes CTE children before the main rewrite. It reused the main statement context, allowing temporary CTE producer and consumer caches to affect later privilege checking and leaving partial CTE maps that could fail with an internal error.

This change gives temporary pre-rewrite its own mutable statement state while keeping ID and generated-alias allocation in the original statement scope. It temporarily installs the isolated context for utilities that access the connection directly and restores the original context in a `finally` block.

The regression test creates a view for which a user can select one column but not another, then exercises direct access and CTE queries under both default and forced pre-rewrite strategies. All paths must return the same permission error.

### Release note

None

### Check List (For Author)

- Test:
  - [x] Regression test
  - [x] Unit Test
  - [x] Manual test
- Behavior changed:
  - [x] Yes. MV pre-rewrite can no longer bypass or replace view-column privilege errors.
- Does this need documentation?
  - [x] No.
