### PR TITLE
[improvement](segment): Batch read array data by row IDs

### DIFF
--- a/be/src/storage/segment/column_reader.cpp
+++ b/be/src/storage/segment/column_reader.cpp
@@ -2435,11 +2435,175 @@ Status ArrayFileColumnIterator::read_by_rowids(const rowid_t* rowids, const size
 
     _recovery_from_place_holder_column(dst);
 
+    if (count == 0) {
+        return Status::OK();
+    }
+
+    if (read_null_map_only()) {
+        DORIS_CHECK(is_column_nullable(*dst));
+        auto& nullable_column = assert_cast<ColumnNullable&>(*dst);
+        if (_null_iterator) {
+            auto null_map_ptr = nullable_column.get_null_map_column_ptr();
+            MutableColumnPtr null_map_column = std::move(null_map_ptr);
+            RETURN_IF_ERROR(_null_iterator->read_by_rowids(rowids, count, null_map_column));
+        } else {
+            nullable_column.get_null_map_column_ptr()->insert_many_vals(0, count);
+        }
+        auto& column_array = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(
+                nullable_column.get_nested_column());
+        column_array.insert_many_defaults(count);
+        return Status::OK();
+    }
+
+    auto& column_array = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(
+            is_column_nullable(*dst) ? static_cast<ColumnNullable&>(*dst).get_nested_column()
+                                     : *dst);
+    const bool read_meta_columns = need_to_read_meta_columns();
+
+    if (_array_reader->is_nullable()) {
+        if (UNLIKELY(!is_column_nullable(*dst))) {
+            return Status::InternalError(
+                    "unexpected non-nullable destination column for nullable array reader");
+        }
+        auto& nullable_column = static_cast<ColumnNullable&>(*dst);
+        if (read_meta_columns) {
+            MutableColumnPtr null_map_column = nullable_column.get_null_map_column_ptr();
+            RETURN_IF_ERROR(_null_iterator->read_by_rowids(rowids, count, null_map_column));
+        } else {
+            DORIS_CHECK(nullable_column.get_null_map_column().size() == count);
+        }
+    } else if (read_meta_columns && is_column_nullable(*dst)) {
+        static_cast<ColumnNullable&>(*dst).get_null_map_column_ptr()->insert_many_vals(0, count);
+    }
+
+    // Storage offsets contain the start item ordinal of each array row. Read all starts in one
+    // pass, then read the following row's start as the corresponding end ordinal.
+    MutableColumnPtr starts_column = ColumnOffset64::create();
+    starts_column->reserve(count);
+    RETURN_IF_ERROR(_offset_iterator->read_by_rowids(rowids, count, starts_column));
+
+    // read_by_rowids callers provide strictly increasing segment rowids, so only the final
+    // requested row can require the page-tail sentinel instead of a rowid + 1 lookup.
+    std::vector<rowid_t> next_rowids;
+    next_rowids.reserve(count);
     for (size_t i = 0; i < count; ++i) {
-        // TODO(cambyszju): now read array one by one, need optimize later
-        RETURN_IF_ERROR(seek_to_ordinal(rowids[i]));
+        const auto next_rowid = static_cast<uint64_t>(rowids[i]) + 1;
+        if (next_rowid < _array_reader->num_rows()) {
+            next_rowids.push_back(static_cast<rowid_t>(next_rowid));
+        } else {
+            DORIS_CHECK(i + 1 == count);
+        }
+    }
+    MutableColumnPtr next_starts_column = ColumnOffset64::create();
+    next_starts_column->reserve(count);
+    if (!next_rowids.empty()) {
+        RETURN_IF_ERROR(_offset_iterator->read_by_rowids(next_rowids.data(), next_rowids.size(),
+                                                         next_starts_column));
+    }
+
+    auto& next_starts = assert_cast<ColumnOffset64&>(*next_starts_column).get_data();
+    if (next_rowids.size() != count) {
+        // The last array row has no rowid + 1. Consume its start offset, then obtain the end
+        // offset from the page-tail sentinel written by OffsetColumnWriter.
+        RETURN_IF_ERROR(_offset_iterator->seek_to_ordinal(rowids[count - 1]));
         size_t num_read = 1;
-        RETURN_IF_ERROR(next_batch(&num_read, dst));
+        bool has_null = false;
+        MutableColumnPtr last_start = ColumnOffset64::create();
+        RETURN_IF_ERROR(_offset_iterator->next_batch(&num_read, last_start, &has_null));
+        if (UNLIKELY(num_read != 1)) {
+            return Status::Corruption("failed to read the last array offset");
+        }
+        ordinal_t next_start = 0;
+        RETURN_IF_ERROR(_offset_iterator->_peek_one_offset(&next_start));
+        next_starts.push_back(next_start);
+    }
+    DORIS_CHECK(next_starts.size() == count);
+
+    auto& starts = assert_cast<ColumnOffset64&>(*starts_column).get_data();
+    DORIS_CHECK(starts.size() == count);
+    if (!read_meta_columns) {
+        DORIS_CHECK(column_array.size() == count);
+    }
+
+    MutableColumnPtr output_offsets_ptr;
+    ColumnArray::ColumnOffsets* output_offsets = nullptr;
+    if (read_meta_columns) {
+        output_offsets_ptr = IColumn::mutate(std::move(column_array.get_offsets_ptr()));
+        output_offsets = assert_cast<ColumnArray::ColumnOffsets*, TypeCheckOnRelease::DISABLE>(
+                output_offsets_ptr.get());
+    }
+    Defer defer_offsets {[&] {
+        if (read_meta_columns) {
+            auto typed_offsets_ptr = ColumnArray::ColumnOffsets::cast_to_column_mutptr(
+                    assert_cast<ColumnArray::ColumnOffsets*, TypeCheckOnRelease::DISABLE>(
+                            output_offsets_ptr.get()));
+            output_offsets_ptr = nullptr;
+            column_array.get_offsets_ptr() = std::move(typed_offsets_ptr);
+        }
+    }};
+
+    auto items_ptr = IColumn::mutate(std::move(column_array.get_data_ptr()));
+    Defer defer_items {[&] { column_array.get_data_ptr() = std::move(items_ptr); }};
+    auto read_item_range = [&](ordinal_t start, size_t item_count) -> Status {
+        if (item_count == 0) {
+            return Status::OK();
+        }
+        size_t num_read = item_count;
+        bool has_null = false;
+        RETURN_IF_ERROR(_item_iterator->seek_to_ordinal(start));
+        RETURN_IF_ERROR(_item_iterator->next_batch(&num_read, items_ptr, &has_null));
+        if (UNLIKELY(num_read != item_count)) {
+            return Status::Corruption("array item reader returned {} items, expected {}", num_read,
+                                      item_count);
+        }
+        return Status::OK();
+    };
+
+    uint64_t output_offset =
+            read_meta_columns && !output_offsets->empty() ? output_offsets->get_data().back() : 0;
+    size_t total_item_count = 0;
+    ordinal_t range_start = 0;
+    size_t range_size = 0;
+    if (read_meta_columns) {
+        output_offsets->get_data().reserve(output_offsets->size() + count);
+    }
+    for (size_t i = 0; i < count; ++i) {
+        if (UNLIKELY(next_starts[i] < starts[i])) {
+            return Status::Corruption("invalid array element offsets: start {}, end {}", starts[i],
+                                      next_starts[i]);
+        }
+        const size_t item_count = static_cast<size_t>(next_starts[i] - starts[i]);
+        // A nullable parent can legally retain nested payload for a null row. Preserve the raw
+        // offset span so the nested column stays aligned with the parent offsets, especially when
+        // lazy materialization fills only the item subtree in a later phase.
+        total_item_count += item_count;
+        if (read_meta_columns) {
+            output_offset += item_count;
+            output_offsets->get_data().push_back(output_offset);
+        } else {
+            DCHECK_EQ(column_array.size_at(i), item_count);
+        }
+        if (read_offset_only() || item_count == 0) {
+            continue;
+        }
+
+        const auto item_start = static_cast<ordinal_t>(starts[i]);
+        if (range_size == 0) {
+            range_start = item_start;
+            range_size = item_count;
+        } else if (range_start + range_size == item_start) {
+            range_size += item_count;
+        } else {
+            RETURN_IF_ERROR(read_item_range(range_start, range_size));
+            range_start = item_start;
+            range_size = item_count;
+        }
+    }
+
+    if (read_offset_only()) {
+        items_ptr->insert_many_defaults(total_item_count);
+    } else {
+        RETURN_IF_ERROR(read_item_range(range_start, range_size));
     }
     return Status::OK();
 }

--- a/be/test/storage/segment/column_reader_test.cpp
+++ b/be/test/storage/segment/column_reader_test.cpp
@@ -3138,7 +3138,7 @@ TEST_F(ColumnReaderTest, ArrayOffsetOnlyReadByRowidsFillsItemsWithoutReadingThem
             create_test_reader(false, 10, FieldType::OLAP_FIELD_TYPE_ARRAY),
             std::move(offset_iterator), std::move(item_iterator), nullptr);
     array_iterator.set_column_name("a");
-    TColumnAccessPaths offset_path {create_access_path({"a", ColumnIterator::ACCESS_OFFSET})};
+    TColumnAccessPaths offset_path {create_meta_access_path({"a", ColumnIterator::ACCESS_OFFSET})};
     auto st = array_iterator.set_access_paths(offset_path, {});
     ASSERT_TRUE(st.ok()) << "set_access_paths failed: " << st.to_string();
     ASSERT_TRUE(array_iterator.read_offset_only());

--- a/be/test/storage/segment/column_reader_test.cpp
+++ b/be/test/storage/segment/column_reader_test.cpp
@@ -23,6 +23,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <array>
 #include <chrono>
 #include <cstdint>
 #include <iterator>
@@ -34,6 +35,9 @@
 
 #include "agent/be_exec_version_manager.h"
 #include "common/config.h"
+#include "core/data_type/data_type_array.h"
+#include "core/data_type/data_type_nullable.h"
+#include "core/data_type/data_type_number.h"
 #include "io/fs/file_reader.h"
 #include "io/fs/file_system.h"
 #include "io/fs/file_writer.h"
@@ -199,6 +203,10 @@ public:
         routed_predicate_access_paths.clear();
     }
 
+    void convert_to_place_holder_column(MutableColumnPtr& dst, size_t count) {
+        _convert_to_place_holder_column(dst, count);
+    }
+
     std::vector<ordinal_t> seek_ordinals;
     std::vector<size_t> next_batch_sizes;
     std::vector<std::vector<rowid_t>> read_by_rowids_batches;
@@ -270,17 +278,27 @@ private:
 
 class RowidOffsetFileColumnIterator final : public FileColumnIterator {
 public:
-    RowidOffsetFileColumnIterator() : FileColumnIterator(create_test_reader(false, 10)) {}
+    RowidOffsetFileColumnIterator()
+            : RowidOffsetFileColumnIterator(
+                      std::vector<ordinal_t> {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) {}
+
+    explicit RowidOffsetFileColumnIterator(std::vector<ordinal_t> offsets)
+            : FileColumnIterator(create_test_reader(false, offsets.size() - 1)),
+              _offsets(std::move(offsets)) {
+        get_current_page()->next_array_item_ordinal = _offsets.back();
+    }
 
     Status seek_to_ordinal(ordinal_t ord) override {
+        seek_ordinals.emplace_back(ord);
         _current_ordinal = ord;
         return Status::OK();
     }
 
     Status next_batch(size_t* n, MutableColumnPtr& dst, bool* has_null) override {
+        next_batch_sizes.emplace_back(*n);
         auto& offsets = assert_cast<ColumnOffset64&, TypeCheckOnRelease::DISABLE>(*dst);
         for (size_t i = 0; i < *n; ++i) {
-            offsets.insert_value(_current_ordinal + i);
+            offsets.insert_value(_offsets[_current_ordinal + i]);
         }
         _current_ordinal += *n;
         if (has_null != nullptr) {
@@ -291,16 +309,22 @@ public:
 
     Status read_by_rowids(const rowid_t* rowids, const size_t count,
                           MutableColumnPtr& dst) override {
+        read_by_rowids_batches.emplace_back(rowids, rowids + count);
         auto& offsets = assert_cast<ColumnOffset64&, TypeCheckOnRelease::DISABLE>(*dst);
         for (size_t i = 0; i < count; ++i) {
-            offsets.insert_value(rowids[i]);
+            offsets.insert_value(_offsets[rowids[i]]);
         }
         return Status::OK();
     }
 
     ordinal_t get_current_ordinal() const override { return _current_ordinal; }
 
+    std::vector<ordinal_t> seek_ordinals;
+    std::vector<size_t> next_batch_sizes;
+    std::vector<std::vector<rowid_t>> read_by_rowids_batches;
+
 private:
+    std::vector<ordinal_t> _offsets;
     ordinal_t _current_ordinal = 0;
 };
 
@@ -446,6 +470,159 @@ TEST_F(ColumnReaderTest, NullMapOnlyReadBySparseRowidsAcrossPages) {
     EXPECT_EQ(0, null_map[0]);
     EXPECT_EQ(1, null_map[1]);
     EXPECT_EQ(2, nullable_col.get_nested_column().size());
+}
+
+TEST_F(ColumnReaderTest, ArrayReadByRowidsMatchesSequentialReadAcrossPages) {
+    // The generated offsets and non-null INT items both exceed the default 64 KiB data-page
+    // size, so the selected rowids exercise page transitions in both child streams.
+    constexpr size_t num_rows = 12000;
+    constexpr size_t max_items_per_row = 3;
+    ColumnMetaPB meta;
+    TabletColumn array_column(FieldAggregationMethod::OLAP_FIELD_AGGREGATION_NONE,
+                              FieldType::OLAP_FIELD_TYPE_ARRAY);
+    TabletColumn item_column(FieldAggregationMethod::OLAP_FIELD_AGGREGATION_NONE,
+                             FieldType::OLAP_FIELD_TYPE_INT, true);
+    array_column.add_sub_column(item_column);
+
+    std::vector<int32_t> item_values;
+    std::vector<uint8_t> item_null_map;
+    std::vector<uint64_t> array_offsets(num_rows + 1, 0);
+    std::vector<uint8_t> array_null_map(num_rows, 0);
+    item_values.reserve(num_rows * max_items_per_row);
+    item_null_map.reserve(num_rows * max_items_per_row);
+    for (size_t row = 0; row < num_rows; ++row) {
+        const bool is_null = row % 7 == 1;
+        array_null_map[row] = is_null;
+        const size_t item_count = row % 11 == 0 ? 0 : (is_null ? 3 : row % 3 + 1);
+        for (size_t item = 0; item < item_count; ++item) {
+            item_values.push_back(static_cast<int32_t>(row * 10 + item));
+            item_null_map.push_back((row + item) % 5 == 0);
+        }
+        array_offsets[row + 1] = item_values.size();
+    }
+
+    const std::string file_name = COLUMN_READER_FILE_TEST_DIR + "/array_read_by_rowids";
+    auto fs = io::global_local_filesystem();
+    {
+        io::FileWriterPtr file_writer;
+        auto st = fs->create_file(file_name, &file_writer);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+
+        ColumnWriterOptions writer_options;
+        writer_options.meta = &meta;
+        writer_options.meta->set_column_id(0);
+        writer_options.meta->set_unique_id(0);
+        writer_options.meta->set_type(static_cast<int32_t>(FieldType::OLAP_FIELD_TYPE_ARRAY));
+        writer_options.meta->set_length(0);
+        writer_options.meta->set_encoding(DEFAULT_ENCODING);
+        writer_options.meta->set_compression(CompressionTypePB::LZ4F);
+        writer_options.meta->set_is_nullable(true);
+
+        auto* child_meta = meta.add_children_columns();
+        child_meta->set_column_id(1);
+        child_meta->set_unique_id(1);
+        child_meta->set_type(static_cast<int32_t>(FieldType::OLAP_FIELD_TYPE_INT));
+        child_meta->set_length(0);
+        child_meta->set_encoding(BIT_SHUFFLE);
+        child_meta->set_compression(CompressionTypePB::LZ4F);
+        child_meta->set_is_nullable(true);
+
+        std::unique_ptr<ColumnWriter> writer;
+        st = ColumnWriter::create(writer_options, &array_column, file_writer.get(), &writer);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        ASSERT_TRUE(writer->init().ok());
+        // Use the vectorized append path so even null parent rows keep their physical item span.
+        const std::array<uint64_t, 4> array_data {static_cast<uint64_t>(item_values.size()),
+                                                  reinterpret_cast<uint64_t>(array_offsets.data()),
+                                                  reinterpret_cast<uint64_t>(item_values.data()),
+                                                  reinterpret_cast<uint64_t>(item_null_map.data())};
+        ASSERT_TRUE(writer->append(array_null_map.data(), array_data.data(), num_rows).ok());
+        ASSERT_TRUE(writer->finish().ok());
+        ASSERT_TRUE(writer->write_data().ok());
+        ASSERT_TRUE(writer->write_ordinal_index().ok());
+        ASSERT_TRUE(file_writer->close().ok());
+    }
+
+    io::FileReaderSPtr file_reader;
+    auto st = fs->open_file(file_name, &file_reader);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+    ColumnReaderOptions reader_options;
+    std::shared_ptr<ColumnReader> reader;
+    st = ColumnReader::create(reader_options, meta, num_rows, file_reader, &reader);
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    DataTypePtr array_type = std::make_shared<DataTypeArray>(
+            std::make_shared<DataTypeNullable>(std::make_shared<DataTypeInt32>()));
+    DataTypePtr column_type = std::make_shared<DataTypeNullable>(array_type);
+    auto create_iterator = [&](OlapReaderStatistics* stats,
+                               ColumnIteratorUPtr* iterator) -> Status {
+        RETURN_IF_ERROR(reader->new_iterator(iterator, &array_column));
+        ColumnIteratorOptions options;
+        options.stats = stats;
+        options.file_reader = file_reader.get();
+        return (*iterator)->init(options);
+    };
+
+    MutableColumnPtr baseline = column_type->create_column();
+    {
+        ColumnIteratorUPtr iterator;
+        OlapReaderStatistics stats;
+        st = create_iterator(&stats, &iterator);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        ASSERT_TRUE(iterator->seek_to_ordinal(0).ok());
+        size_t rows_to_read = num_rows;
+        bool has_null = false;
+        st = iterator->next_batch(&rows_to_read, baseline, &has_null);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        ASSERT_EQ(num_rows, rows_to_read);
+    }
+
+    std::vector<rowid_t> rowids {0, 1, 2, 7, 8, 11, 4095, 4096, 8191, 8192};
+    for (rowid_t rowid = 10000; rowid <= 11000; ++rowid) {
+        rowids.push_back(rowid);
+    }
+    rowids.push_back(11998);
+    rowids.push_back(11999);
+    MutableColumnPtr actual = column_type->create_column();
+    {
+        ColumnIteratorUPtr iterator;
+        OlapReaderStatistics stats;
+        st = create_iterator(&stats, &iterator);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+        st = iterator->read_by_rowids(rowids.data(), rowids.size(), actual);
+        ASSERT_TRUE(st.ok()) << st.to_string();
+    }
+
+    ASSERT_EQ(rowids.size(), actual->size());
+    ASSERT_EQ(1, array_null_map[1]);
+    ASSERT_GT(array_offsets[2] - array_offsets[1], 0);
+    const auto& baseline_nullable = assert_cast<const ColumnNullable&>(*baseline);
+    const auto& actual_nullable = assert_cast<const ColumnNullable&>(*actual);
+    const auto& baseline_array = assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(
+            baseline_nullable.get_nested_column());
+    const auto& actual_array = assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(
+            actual_nullable.get_nested_column());
+    ASSERT_EQ(1, baseline_nullable.get_null_map_data()[1]);
+    ASSERT_GT(baseline_array.size_at(1), 0);
+
+    size_t expected_item_count = 0;
+    size_t actual_item_index = 0;
+    for (size_t i = 0; i < rowids.size(); ++i) {
+        const auto rowid = rowids[i];
+        EXPECT_EQ(baseline_nullable.get_null_map_data()[rowid],
+                  actual_nullable.get_null_map_data()[i]);
+
+        const size_t row_item_count = baseline_array.size_at(rowid);
+        expected_item_count += row_item_count;
+        EXPECT_EQ(expected_item_count, actual_array.get_offsets()[i]);
+        for (size_t item = 0; item < row_item_count; ++item) {
+            EXPECT_EQ(0, actual_array.get_data().compare_at(actual_item_index,
+                                                            baseline_array.offset_at(rowid) + item,
+                                                            baseline_array.get_data(), 1));
+            ++actual_item_index;
+        }
+    }
+    EXPECT_EQ(expected_item_count, actual_array.get_data().size());
 }
 
 TEST_F(ColumnReaderTest, StructAccessPaths) {
@@ -2907,6 +3084,122 @@ TEST_F(ColumnReaderTest, StructNullMapOnlyNextBatchSkipsSubColumns) {
     EXPECT_EQ(2, nested_struct.get_column(0).size());
 }
 
+TEST_F(ColumnReaderTest, ArrayReadByRowidsBatchesOffsetsAndMergesItemRanges) {
+    auto offset_file_iterator = std::make_unique<RowidOffsetFileColumnIterator>(
+            std::vector<ordinal_t> {0, 2, 5, 5, 7, 10, 12, 12, 15, 18, 20});
+    auto* offset_tracker = offset_file_iterator.get();
+    auto offset_iterator =
+            std::make_unique<OffsetFileColumnIterator>(std::move(offset_file_iterator));
+    auto item_iterator = std::make_unique<TrackingColumnIterator>();
+    auto* item_tracker = item_iterator.get();
+
+    ArrayFileColumnIterator array_iterator(
+            create_test_reader(false, 10, FieldType::OLAP_FIELD_TYPE_ARRAY),
+            std::move(offset_iterator), std::move(item_iterator), nullptr);
+    MutableColumnPtr dst =
+            ColumnArray::create(ColumnInt32::create(), ColumnArray::ColumnOffsets::create());
+
+    const rowid_t rowids[] = {0, 1, 2, 4, 5, 8, 9};
+    auto st = array_iterator.read_by_rowids(rowids, std::size(rowids), dst);
+    ASSERT_TRUE(st.ok()) << "array read_by_rowids failed: " << st.to_string();
+
+    ASSERT_EQ(2, offset_tracker->read_by_rowids_batches.size());
+    EXPECT_THAT(offset_tracker->read_by_rowids_batches[0],
+                ::testing::ElementsAre(0, 1, 2, 4, 5, 8, 9));
+    EXPECT_THAT(offset_tracker->read_by_rowids_batches[1],
+                ::testing::ElementsAre(1, 2, 3, 5, 6, 9));
+    EXPECT_THAT(offset_tracker->seek_ordinals, ::testing::ElementsAre(9));
+    EXPECT_THAT(offset_tracker->next_batch_sizes, ::testing::ElementsAre(1));
+    EXPECT_THAT(item_tracker->seek_ordinals, ::testing::ElementsAre(0, 7, 15));
+    EXPECT_THAT(item_tracker->next_batch_sizes, ::testing::ElementsAre(5, 5, 5));
+
+    const auto& array = assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*dst);
+    EXPECT_EQ(7, array.size());
+    EXPECT_EQ(15, array.get_data().size());
+    EXPECT_EQ(2, array.get_offsets()[0]);
+    EXPECT_EQ(5, array.get_offsets()[1]);
+    EXPECT_EQ(5, array.get_offsets()[2]);
+    EXPECT_EQ(8, array.get_offsets()[3]);
+    EXPECT_EQ(10, array.get_offsets()[4]);
+    EXPECT_EQ(13, array.get_offsets()[5]);
+    EXPECT_EQ(15, array.get_offsets()[6]);
+}
+
+TEST_F(ColumnReaderTest, ArrayOffsetOnlyReadByRowidsFillsItemsWithoutReadingThem) {
+    auto offset_file_iterator = std::make_unique<RowidOffsetFileColumnIterator>(
+            std::vector<ordinal_t> {0, 2, 5, 5, 7, 10, 12, 12, 15, 18, 20});
+    auto* offset_tracker = offset_file_iterator.get();
+    auto offset_iterator =
+            std::make_unique<OffsetFileColumnIterator>(std::move(offset_file_iterator));
+    auto item_iterator = std::make_unique<TrackingColumnIterator>();
+    auto* item_tracker = item_iterator.get();
+
+    ArrayFileColumnIterator array_iterator(
+            create_test_reader(false, 10, FieldType::OLAP_FIELD_TYPE_ARRAY),
+            std::move(offset_iterator), std::move(item_iterator), nullptr);
+    array_iterator.set_column_name("a");
+    TColumnAccessPaths offset_path {create_access_path({"a", ColumnIterator::ACCESS_OFFSET})};
+    auto st = array_iterator.set_access_paths(offset_path, {});
+    ASSERT_TRUE(st.ok()) << "set_access_paths failed: " << st.to_string();
+    ASSERT_TRUE(array_iterator.read_offset_only());
+
+    MutableColumnPtr dst =
+            ColumnArray::create(ColumnInt32::create(), ColumnArray::ColumnOffsets::create());
+    const rowid_t rowids[] = {0, 1, 4};
+    st = array_iterator.read_by_rowids(rowids, std::size(rowids), dst);
+    ASSERT_TRUE(st.ok()) << "array offset-only read_by_rowids failed: " << st.to_string();
+
+    const auto& array = assert_cast<const ColumnArray&, TypeCheckOnRelease::DISABLE>(*dst);
+    EXPECT_EQ(3, array.size());
+    EXPECT_EQ(8, array.get_data().size());
+    EXPECT_EQ(2, array.get_offsets()[0]);
+    EXPECT_EQ(5, array.get_offsets()[1]);
+    EXPECT_EQ(8, array.get_offsets()[2]);
+    EXPECT_TRUE(item_tracker->seek_ordinals.empty());
+    EXPECT_TRUE(item_tracker->next_batch_sizes.empty());
+    ASSERT_EQ(2, offset_tracker->read_by_rowids_batches.size());
+}
+
+TEST_F(ColumnReaderTest, ArrayLazyReadByRowidsPreservesMaterializedOffsets) {
+    auto offset_file_iterator = std::make_unique<RowidOffsetFileColumnIterator>(
+            std::vector<ordinal_t> {0, 2, 5, 5, 7, 10, 12, 12, 15, 18, 20});
+    auto offset_iterator =
+            std::make_unique<OffsetFileColumnIterator>(std::move(offset_file_iterator));
+    auto item_iterator = std::make_unique<TrackingColumnIterator>();
+    auto* item_tracker = item_iterator.get();
+
+    ArrayFileColumnIterator array_iterator(
+            create_test_reader(false, 10, FieldType::OLAP_FIELD_TYPE_ARRAY),
+            std::move(offset_iterator), std::move(item_iterator), nullptr);
+    array_iterator.set_read_requirement_self(ColumnIterator::ReadRequirement::PREDICATE);
+    item_tracker->set_read_requirement(ColumnIterator::ReadRequirement::LAZY_OUTPUT);
+    array_iterator.set_read_phase(ColumnIterator::ReadPhase::PREDICATE);
+
+    MutableColumnPtr dst =
+            ColumnArray::create(ColumnInt32::create(), ColumnArray::ColumnOffsets::create());
+    auto& array = assert_cast<ColumnArray&, TypeCheckOnRelease::DISABLE>(*dst);
+    array.get_offsets().push_back(2);
+    array.get_offsets().push_back(5);
+    auto items = IColumn::mutate(std::move(array.get_data_ptr()));
+    item_tracker->convert_to_place_holder_column(items, 5);
+    array.get_data_ptr() = std::move(items);
+
+    array_iterator.set_read_phase(ColumnIterator::ReadPhase::LAZY);
+    ASSERT_TRUE(array_iterator.need_to_read());
+    ASSERT_FALSE(array_iterator.need_to_read_meta_columns());
+
+    const rowid_t rowids[] = {0, 4};
+    auto st = array_iterator.read_by_rowids(rowids, std::size(rowids), dst);
+    ASSERT_TRUE(st.ok()) << "lazy array read_by_rowids failed: " << st.to_string();
+
+    EXPECT_EQ(2, array.size());
+    EXPECT_EQ(5, array.get_data().size());
+    EXPECT_EQ(2, array.get_offsets()[0]);
+    EXPECT_EQ(5, array.get_offsets()[1]);
+    EXPECT_THAT(item_tracker->seek_ordinals, ::testing::ElementsAre(0, 7));
+    EXPECT_THAT(item_tracker->next_batch_sizes, ::testing::ElementsAre(2, 3));
+}
+
 TEST_F(ColumnReaderTest, ArrayNullMapOnlyNextBatchAndReadByRowidsSkipItems) {
     auto null_iterator = std::make_unique<TrackingColumnIterator>();
     auto* null_iterator_ptr = null_iterator.get();
@@ -2943,8 +3236,10 @@ TEST_F(ColumnReaderTest, ArrayNullMapOnlyNextBatchAndReadByRowidsSkipItems) {
     st = array_iterator.read_by_rowids(rowids, std::size(rowids), dst);
     ASSERT_TRUE(st.ok()) << "array null-map-only read_by_rowids failed: " << st.to_string();
     EXPECT_EQ(5, dst->size());
-    EXPECT_THAT(null_iterator_ptr->seek_ordinals, ::testing::ElementsAre(1, 3));
-    EXPECT_THAT(null_iterator_ptr->next_batch_sizes, ::testing::ElementsAre(1, 1));
+    EXPECT_TRUE(null_iterator_ptr->seek_ordinals.empty());
+    EXPECT_TRUE(null_iterator_ptr->next_batch_sizes.empty());
+    ASSERT_EQ(1, null_iterator_ptr->read_by_rowids_batches.size());
+    EXPECT_THAT(null_iterator_ptr->read_by_rowids_batches[0], ::testing::ElementsAre(1, 3));
     EXPECT_TRUE(item_iterator_ptr->next_batch_sizes.empty());
     EXPECT_TRUE(offset_iterator.tracker->next_batch_sizes.empty());
 }


### PR DESCRIPTION
### Problem Summary:
ARRAY row-ID reads seek and materialize each parent row separately, repeating metadata processing and column setup and limiting sparse-read throughput.

### Solution:
Batch-read parent null maps and ordered offset endpoints, then coalesce physically contiguous item ranges for bulk
element reads. Preserve append, metadata-only, and lazy-materialization semantics, and track temporary buffers through Doris allocators.