### PR TITLE
[fix](function) Fix window_funnel missing boundary events when window overflows at datetime upper bound

### DIFF
--- a/be/src/exprs/aggregate/aggregate_function_window_funnel.h
+++ b/be/src/exprs/aggregate/aggregate_function_window_funnel.h
@@ -193,7 +193,11 @@ struct WindowFunnelState {
             if constexpr (T != TYPE_TIMESTAMP_NS) {
                 TimeInterval interval(SECOND, window, false);
                 end_timestamp = first_timestamp;
-                end_timestamp.template date_add_interval<SECOND>(interval);
+                if (!end_timestamp.template date_add_interval<SECOND>(interval)) {
+                    throw Exception(ErrorCode::OUT_OF_BOUND,
+                                    "Operation window_funnel of {}, {} out of range",
+                                    first_timestamp.debug_string(), window);
+                }
             }
 
             matched_count++;

--- a/be/src/exprs/aggregate/aggregate_function_window_funnel_v2.h
+++ b/be/src/exprs/aggregate/aggregate_function_window_funnel_v2.h
@@ -261,7 +261,11 @@ struct WindowFunnelStateV2 {
         } else {
             DateValueType end_ts = _ts_from_int(base_ts);
             TimeInterval interval(SECOND, window, false);
-            end_ts.template date_add_interval<SECOND>(interval);
+            if (!end_ts.template date_add_interval<SECOND>(interval)) {
+                throw Exception(ErrorCode::OUT_OF_BOUND,
+                                "Operation window_funnel of {}, {} out of range",
+                                end_ts.debug_string(), window);
+            }
             return current_ts <= end_ts.to_date_int_val();
         }
     }

--- a/be/test/exprs/aggregate/vec_window_funnel_test.cpp
+++ b/be/test/exprs/aggregate/vec_window_funnel_test.cpp
@@ -145,6 +145,51 @@ TEST_F(VWindowFunnelTest, testEmpty) {
     agg_function->destroy(place2);
 }
 
+TEST_F(VWindowFunnelTest, testWindowOverflowThrows) {
+    AggregateFunctionSimpleFactory factory = AggregateFunctionSimpleFactory::instance();
+    DataTypes data_types = {std::make_shared<DataTypeInt64>(), std::make_shared<DataTypeString>(),
+                            std::make_shared<DataTypeDateTimeV2>(),
+                            std::make_shared<DataTypeUInt8>(), std::make_shared<DataTypeUInt8>()};
+    auto overflow_agg_function = factory.get("window_funnel", data_types, nullptr, false,
+                                             BeExecVersionManager::get_newest_version());
+    ASSERT_NE(overflow_agg_function, nullptr);
+
+    auto column_mode = ColumnString::create();
+    column_mode->insert(Field::create_field<TYPE_STRING>("default"));
+    column_mode->insert(Field::create_field<TYPE_STRING>("default"));
+
+    auto column_timestamp = ColumnDateTimeV2::create();
+    for (const auto& second : {58, 59}) {
+        VecDateTimeValue time_value;
+        time_value.unchecked_set_time(9999, 12, 31, 23, 59, second);
+        auto dtv2 = time_value.to_datetime_v2();
+        column_timestamp->insert_data((char*)&dtv2, 0);
+    }
+
+    auto column_window = ColumnInt64::create();
+    column_window->insert(Field::create_field<TYPE_BIGINT>(10));
+    column_window->insert(Field::create_field<TYPE_BIGINT>(10));
+    auto column_event1 = ColumnUInt8::create();
+    column_event1->insert(Field::create_field<TYPE_BOOLEAN>(1));
+    column_event1->insert(Field::create_field<TYPE_BOOLEAN>(0));
+    auto column_event2 = ColumnUInt8::create();
+    column_event2->insert(Field::create_field<TYPE_BOOLEAN>(0));
+    column_event2->insert(Field::create_field<TYPE_BOOLEAN>(1));
+
+    std::unique_ptr<char[]> memory(new char[overflow_agg_function->size_of_data()]);
+    AggregateDataPtr place = memory.get();
+    overflow_agg_function->create(place);
+    const IColumn* columns[] = {column_window.get(), column_mode.get(), column_timestamp.get(),
+                                column_event1.get(), column_event2.get()};
+    for (int row = 0; row < 2; ++row) {
+        overflow_agg_function->add(place, columns, row, arena);
+    }
+
+    ColumnInt32 result;
+    EXPECT_THROW(overflow_agg_function->insert_result_into(place, result), Exception);
+    overflow_agg_function->destroy(place);
+}
+
 TEST_F(VWindowFunnelTest, testSerialize) {
     const int NUM_CONDS = 4;
     auto column_mode = ColumnString::create();

--- a/be/test/exprs/aggregate/vec_window_funnel_v2_test.cpp
+++ b/be/test/exprs/aggregate/vec_window_funnel_v2_test.cpp
@@ -118,6 +118,51 @@ TEST_F(VWindowFunnelV2Test, testEmpty) {
     agg_function->destroy(place2);
 }
 
+TEST_F(VWindowFunnelV2Test, testWindowOverflowThrows) {
+    AggregateFunctionSimpleFactory factory = AggregateFunctionSimpleFactory::instance();
+    DataTypes data_types = {std::make_shared<DataTypeInt64>(), std::make_shared<DataTypeString>(),
+                            std::make_shared<DataTypeDateTimeV2>(),
+                            std::make_shared<DataTypeUInt8>(), std::make_shared<DataTypeUInt8>()};
+    auto overflow_agg_function = factory.get("window_funnel_v2", data_types, nullptr, false,
+                                             BeExecVersionManager::get_newest_version());
+    ASSERT_NE(overflow_agg_function, nullptr);
+
+    auto column_mode = ColumnString::create();
+    column_mode->insert(Field::create_field<TYPE_STRING>("default"));
+    column_mode->insert(Field::create_field<TYPE_STRING>("default"));
+
+    auto column_timestamp = ColumnDateTimeV2::create();
+    for (const auto& second : {58, 59}) {
+        VecDateTimeValue time_value;
+        time_value.unchecked_set_time(9999, 12, 31, 23, 59, second);
+        auto dtv2 = time_value.to_datetime_v2();
+        column_timestamp->insert_data((char*)&dtv2, 0);
+    }
+
+    auto column_window = ColumnInt64::create();
+    column_window->insert(Field::create_field<TYPE_BIGINT>(10));
+    column_window->insert(Field::create_field<TYPE_BIGINT>(10));
+    auto column_event1 = ColumnUInt8::create();
+    column_event1->insert(Field::create_field<TYPE_BOOLEAN>(1));
+    column_event1->insert(Field::create_field<TYPE_BOOLEAN>(0));
+    auto column_event2 = ColumnUInt8::create();
+    column_event2->insert(Field::create_field<TYPE_BOOLEAN>(0));
+    column_event2->insert(Field::create_field<TYPE_BOOLEAN>(1));
+
+    std::unique_ptr<char[]> memory(new char[overflow_agg_function->size_of_data()]);
+    AggregateDataPtr place = memory.get();
+    overflow_agg_function->create(place);
+    const IColumn* columns[] = {column_window.get(), column_mode.get(), column_timestamp.get(),
+                                column_event1.get(), column_event2.get()};
+    for (int row = 0; row < 2; ++row) {
+        overflow_agg_function->add(place, columns, row, arena);
+    }
+
+    ColumnInt32 result;
+    EXPECT_THROW(overflow_agg_function->insert_result_into(place, result), Exception);
+    overflow_agg_function->destroy(place);
+}
+
 TEST_F(VWindowFunnelV2Test, testSerialize) {
     const int NUM_CONDS = 4;
     auto column_mode = ColumnString::create();


### PR DESCRIPTION
For timestamps near the DATETIME upper bound (e.g. `9999-12-31 23:59:58`), adding the sliding window seconds in `date_add_interval<SECOND>` overflows the date range. Both `window_funnel` and `window_funnel_v2` ignored the `false` return value, leaving the window end timestamp at the starting point, so the boundary event inside the enlarged window was missed: `window=1` returned 2 while `window=10` returned 1.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

