### PR TITLE
[chore](regression) Enable branch-4.2 buildall trigger

### DIFF
--- a/regression-test/pipeline/common/teamcity-utils.sh
+++ b/regression-test/pipeline/common/teamcity-utils.sh
@@ -26,6 +26,7 @@
 declare -A targetBranch_to_pipelines
 targetBranch_to_pipelines=(
     ['master']='feut beut cloudut compile p0 p1 external performance cloud_p0 cloud_p1 vault_p0 nonConcurrent check_coverage check_coverage_fe'
+    ['branch-4.2']='feut beut cloudut compile p0 p1 external cloud_p0 cloud_p1 vault_p0 nonConcurrent check_coverage check_coverage_fe'
     ['branch-4.1']='feut beut cloudut compile p0 p1 external cloud_p0 cloud_p1 vault_p0 nonConcurrent check_coverage check_coverage_fe'
     ['branch-4.0']='feut beut cloudut compile p0 p1 external cloud_p0 cloud_p1 vault_p0 nonConcurrent check_coverage check_coverage_fe'
     ['branch-3.1']='feut beut cloudut compile p0 p1 external cloud_p0 cloud_p1 vault_p0 nonConcurrent check_coverage check_coverage_fe'


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx

Related PR: #67745

Problem Summary: The issue-comment GitHub Action runs from the default branch and sources `regression-test/pipeline/common/teamcity-utils.sh` from `master`. Add `branch-4.2` to the supported target-branch matrix so `run buildall` can route branch-4.2 pull requests to the available TeamCity pipelines. The matrix matches `branch-4.1` and intentionally excludes ARM and Performance. Existing branch mappings are unchanged.

### Release note

None

### Check List (For Author)

- Test: Manual test
    - `bash -n regression-test/pipeline/common/teamcity-utils.sh`
    - `shellcheck regression-test/pipeline/common/teamcity-utils.sh`
    - Simulated `trigger_or_skip_build` for every branch-4.2 pipeline; ARM and Performance are skipped.
- Behavior changed: Yes (comments containing `run buildall` can trigger the supported TeamCity matrix for branch-4.2 PRs)
- Does this need documentation: No