### PR TITLE
branch-incremental-computation: [fix](table stream) fix table stream TSO boundary semantics #67480

### DIFF
--- a/be/src/exec/scan/olap_scanner.cpp
+++ b/be/src/exec/scan/olap_scanner.cpp
@@ -332,13 +332,14 @@ Status OlapScanner::_init_tso_predicates() {
 
     const auto* tso_column = read_schema->column(tso_ordinal);
     const auto& tso_data_type = read_schema->data_type(tso_ordinal);
+    // The TSO scan range is left-closed right-open [start_tso, end_tso).
     if (_start_tso.has_value()) {
-        _tablet_reader_params.predicates.push_back(create_comparison_predicate<PredicateType::GT>(
+        _tablet_reader_params.predicates.push_back(create_comparison_predicate<PredicateType::GE>(
                 tso_ordinal, tso_column->name(), tso_data_type,
                 Field::create_field<TYPE_BIGINT>(*_start_tso), false));
     }
     if (_end_tso.has_value()) {
-        _tablet_reader_params.predicates.push_back(create_comparison_predicate<PredicateType::LE>(
+        _tablet_reader_params.predicates.push_back(create_comparison_predicate<PredicateType::LT>(
                 tso_ordinal, tso_column->name(), tso_data_type,
                 Field::create_field<TYPE_BIGINT>(*_end_tso), false));
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/stream/OlapTableStream.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/stream/OlapTableStream.java
@@ -230,7 +230,13 @@ public class OlapTableStream extends BaseTableStream {
     }
 
     public boolean hasConsumedData(long partitionId) {
-        return partitionOffset.containsKey(partitionId);
+        // A partition that was empty at stream creation is recorded with the sentinel offset -1
+        // (see initializeLocalOffsets); a real committed TSO is always positive (its physical part
+        // is non-zero). So only a positive recorded offset counts as a real consumption baseline.
+        // This keeps empty partitions out of the snapshot scan instead of letting them fall back to
+        // the live partition TSO and leak post-snapshot rows.
+        Long offset = partitionOffset.get(partitionId);
+        return offset != null && offset > 0;
     }
 
     public Pair<Long, Long> getStreamUpdate(Long partitionId) {

--- a/fe/fe-core/src/main/java/org/apache/doris/catalog/stream/OlapTableStreamWrapper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/catalog/stream/OlapTableStreamWrapper.java
@@ -27,6 +27,7 @@ import org.apache.doris.common.Pair;
 import org.apache.doris.common.util.Util;
 import org.apache.doris.thrift.TColumn;
 import org.apache.doris.thrift.TPrimitiveType;
+import org.apache.doris.tso.TSOTimestamp;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -306,8 +307,17 @@ public class OlapTableStreamWrapper extends OlapTable {
     public List<Long> filterConsumedPartitionIds(List<Long> partitionIds) {
         if (hasCloudReadStates()) {
             return partitionIds.stream()
-                    .filter(id -> cloudReadStates.get(id).getOffsetState()
-                            == Cloud.TableStreamOffsetStatePB.TABLE_STREAM_OFFSET_CONSUMED)
+                    .filter(id -> {
+                        Cloud.TableStreamPartitionReadStatePB state = cloudReadStates.get(id);
+                        // A partition empty at stream creation is recorded as CONSUMED with the
+                        // sentinel offset -1 (CloudInternalCatalog: emptyPartition -> commit_tso=-1).
+                        // Such a partition has no real consumption baseline; exclude it so snapshot
+                        // rebuild does not fall back to the live TSO and leak post-snapshot rows.
+                        // Mirrors the non-cloud hasConsumedData() offset > 0 guard.
+                        return state.getOffsetState()
+                                == Cloud.TableStreamOffsetStatePB.TABLE_STREAM_OFFSET_CONSUMED
+                                && state.hasOffsetTso() && state.getOffsetTso() > 0;
+                    })
                     .collect(ImmutableList.toImmutableList());
         }
         return partitionIds.stream()
@@ -333,14 +343,24 @@ public class OlapTableStreamWrapper extends OlapTable {
     public Map<Long, Pair<Long, Long>> getPartitionOffsets(List<Long> selectedPartitionIds) {
         return outputUpdateMap.entrySet().stream()
                 .filter(s -> selectedPartitionIds.contains(s.getKey()))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                .collect(Collectors.toMap(Map.Entry::getKey, s -> {
+                    // Storage keeps the real committed TSO points (closed-interval semantics).
+                    // BE scans a left-closed right-open range [startTso, endTso), so convert the
+                    // bounds only in this scan-facing read view. outputUpdateMap and the offset
+                    // commit path (toOlapTableStreamUpdate) stay on the real-TSO coordinate system.
+                    Pair<Long, Long> v = s.getValue();
+                    return Pair.of(TSOTimestamp.toExclusiveBound(v.first),
+                            TSOTimestamp.toExclusiveBound(v.second));
+                }));
     }
 
     // get history partition offsets partitionId -> (null, historicalTimestampOffset)
     public Map<Long, Pair<Long, Long>> getHistoryPartitionOffsets(List<Long> selectedPartitionIds) {
         return outputUpdateMap.entrySet().stream()
                 .filter(s -> selectedPartitionIds.contains(s.getKey()))
-                .collect(Collectors.toMap(Map.Entry::getKey, s -> Pair.of(null, s.getValue().first)));
+                // historicalTso is an inclusive upper bound; shift to the half-open exclusive end.
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        s -> Pair.of(null, TSOTimestamp.toExclusiveBound(s.getValue().first))));
     }
 
     public List<Long> filterNormalSnapshotPartitionIds(List<Long> partitionIds) {

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/analysis/BindRelation.java
@@ -74,7 +74,7 @@ import org.apache.doris.nereids.trees.expressions.EqualTo;
 import org.apache.doris.nereids.trees.expressions.ExprId;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.InPredicate;
-import org.apache.doris.nereids.trees.expressions.LessThanEqual;
+import org.apache.doris.nereids.trees.expressions.LessThan;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
@@ -502,8 +502,8 @@ public class BindRelation extends OneAnalysisRuleFactory {
 
     /**
      * Build the time-travel (FOR VERSION/TIME AS OF) plan for an olap scan.
-     * dup: Filter(__DORIS_COMMIT_TSO_COL__ &lt;= targetTso).
-     * mow: base(survived rows, tso&lt;=t1) UNION ALL binlog(before-image of UPDATE_BEFORE/DELETE).
+     * dup: Filter(__DORIS_COMMIT_TSO_COL__ &lt; targetTso), targetTso being the exclusive upper bound.
+     * mow: base(survived rows, tso &lt; targetTso) UNION ALL binlog(before-image of UPDATE_BEFORE/DELETE).
      */
     private LogicalPlan buildTimeTravelPlan(LogicalOlapScan scan, OlapTable olapTable,
             TableSnapshot snapshot, UnboundRelation unboundRelation, List<String> qualifier,
@@ -541,8 +541,9 @@ public class BindRelation extends OneAnalysisRuleFactory {
     }
 
     /**
-     * Add Filter(__DORIS_COMMIT_TSO_COL__ &lt;= targetTso) on top of {@code child}. The tso slot is
-     * resolved from {@code child} output; {@code child} must pass through the scan output slots.
+     * Add Filter(__DORIS_COMMIT_TSO_COL__ &lt; targetTso) on top of {@code child}, where targetTso is
+     * the right-open (exclusive) upper bound from resolveSnapshotTso. The tso slot is resolved from
+     * {@code child} output; {@code child} must pass through the scan output slots.
      */
     private LogicalPlan addCommitTsoFilter(LogicalPlan child, long targetTso, OlapTable olapTable) {
         Slot tsoSlot = null;
@@ -554,25 +555,35 @@ public class BindRelation extends OneAnalysisRuleFactory {
         }
         Preconditions.checkArgument(tsoSlot != null,
                 "%s not found on table %s", Column.COMMIT_TSO_COL, olapTable.getQualifiedName());
-        Expression conjunct = new LessThanEqual(tsoSlot, new BigIntLiteral(targetTso));
+        Expression conjunct = new LessThan(tsoSlot, new BigIntLiteral(targetTso));
         return new LogicalFilter<>(ImmutableSet.of(conjunct), child);
     }
 
     /**
-     * Resolve a TableSnapshot to a target commit tso (inclusive upper bound).
-     * VERSION: the literal is the tso itself. TIME: wall-clock string -&gt; ms -&gt; tso upper bound.
+     * Resolve a TableSnapshot to the right-open (exclusive) commit-tso upper bound: the scan keeps
+     * rows with commit_tso &lt; the returned value. VERSION: literal tso + 1 (so the literal itself is
+     * included). TIME: successor of (requested millisecond, logical counter 0), so that exact TSO
+     * is included but larger logical counters in the same millisecond are excluded. Used uniformly
+     * by the dup filter, the mow union left filter and the mow union right-branch lower bound.
      */
     private long resolveSnapshotTso(TableSnapshot snapshot) {
         if (snapshot.getType() == TableSnapshot.VersionType.VERSION) {
+            long version;
             try {
-                return Long.parseLong(snapshot.getValue().trim());
+                version = Long.parseLong(snapshot.getValue().trim());
             } catch (NumberFormatException e) {
                 throw new AnalysisException(
                         "Invalid version in FOR VERSION AS OF: " + snapshot.getValue());
             }
+            // UNBOUNDED_TSO (Long.MAX_VALUE) is the "latest / unbounded" sentinel: keep it as the
+            // exclusive upper bound above every real TSO. A real version is converted to its
+            // right-open successor so that commit_tso < result includes the requested version.
+            return version == TSOTimestamp.UNBOUNDED_TSO
+                    ? TSOTimestamp.UNBOUNDED_TSO
+                    : TSOTimestamp.nextTso(version);
         }
         long ms = OlapScanNode.parseChangeTimestamp(snapshot.getValue());
-        return TSOTimestamp.composeFullTimestamp(ms);
+        return TSOTimestamp.nextTso(TSOTimestamp.composePhysicalTimestamp(ms));
     }
 
     /**
@@ -589,14 +600,16 @@ public class BindRelation extends OneAnalysisRuleFactory {
                         || ((SlotReference) slot).isVisible())
                 .collect(Collectors.toList());
 
-        // left: base survived rows at t1 = delete_sign=0 AND commit_tso<=t1, projected to visible.
+        // left: base survived rows at t1 = delete_sign=0 AND commit_tso < targetTso, projected to visible.
         LogicalPlan left = checkAndAddDeleteSignFilter(baseScan, ConnectContext.get(), olapTable, true);
         left = projectFromOriginSlots(addCommitTsoFilter(left, targetTso, olapTable), visibleOutput);
 
-        // right: binlog MIN_DELTA over tso>t1, keep UPDATE_BEFORE/DELETE rows (before image),
+        // right: binlog MIN_DELTA over tso >= targetTso, keep UPDATE_BEFORE/DELETE rows (before image),
         // projected to the same visible schema. BE splits each change so UPDATE_BEFORE/DELETE rows
         // already carry the pre-change value in the (same-named) value columns.
         RowBinlogTableWrapper binlogTable = new RowBinlogTableWrapper(olapTable, CollectionUtils.isEmpty(partIds)
+                // targetTso is the exclusive upper bound; the right branch reads tso >= targetTso,
+                // seamlessly meeting the left branch's commit_tso < targetTso.
                 ? makeUniformedTimestampRangeMap(olapTable.getPartitionIds(), Pair.of(targetTso, null)) :
                 makeUniformedTimestampRangeMap(partIds, Pair.of(targetTso, null)));
         RelationId binlogRelationId = cascadesContext.getStatementContext().getNextRelationId();
@@ -709,13 +722,16 @@ public class BindRelation extends OneAnalysisRuleFactory {
 
     private Pair<Long, Long> parseTimestampRange(TableScanParams scanParams) {
         Map<String, String> params = scanParams.getMapParams();
+        // @incr reads a left-closed right-open range [startTso, endTso): BE applies GE/LT directly.
+        // composePhysicalTimestamp maps a millisecond to its start (logical counter 0), so GE includes
+        // the whole startMs and LT excludes the whole endMs. No +1 shift is needed here.
         Long startTimestamp = OlapScanNode.parseChangeTimestamp(
                 params.getOrDefault(OlapScanNode.OLAP_START_TIMESTAMP, "0"));
-        startTimestamp = TSOTimestamp.composeFullTimestamp(startTimestamp);
+        startTimestamp = TSOTimestamp.composePhysicalTimestamp(startTimestamp);
         Long endTimestamp = null;
         if (params.containsKey((OlapScanNode.OLAP_END_TIMESTAMP))) {
             endTimestamp = OlapScanNode.parseChangeTimestamp(params.get(OlapScanNode.OLAP_END_TIMESTAMP));
-            endTimestamp = TSOTimestamp.composeFullTimestamp(endTimestamp);
+            endTimestamp = TSOTimestamp.composePhysicalTimestamp(endTimestamp);
         }
         return Pair.of(startTimestamp, endTimestamp);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/planner/OlapScanNode.java
@@ -100,6 +100,7 @@ import org.apache.doris.thrift.TScanRange;
 import org.apache.doris.thrift.TScanRangeLocation;
 import org.apache.doris.thrift.TScanRangeLocations;
 import org.apache.doris.thrift.TSortInfo;
+import org.apache.doris.tso.TSOTimestamp;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
@@ -581,13 +582,17 @@ public class OlapScanNode extends ScanNode {
                         parseBinlogScanType(scanParams, ((OlapTableWrapper) olapTable).getOriginTable());
                 Pair<Long, Long> update = getPartitionOffset(partition.getId());
                 if (update != null) {
+                    // push down tso range as half-open [startTso, endTso) bounds
                     if (update.first != null) {
                         paloRange.setStartTso(update.first);
                     }
-                    if (update.second != null) {
-                        paloRange.setEndTso(update.second);
-                    } else {
-                        paloRange.setEndTso(partition.getTso());
+                    // No end recorded: fall back to the current committed TSO. toExclusiveBound
+                    // returns null for a partition that never got a real TSO (getTso() == -1), in
+                    // which case we leave endTso unset (no upper bound) instead of using -1.
+                    Long endTso = update.second != null
+                            ? update.second : TSOTimestamp.toExclusiveBound(partition.getTso());
+                    if (endTso != null) {
+                        paloRange.setEndTso(endTso);
                     }
                 }
                 if (binlogScanType != TBinlogScanType.NONE) {
@@ -1964,14 +1969,6 @@ public class OlapScanNode extends ScanNode {
         return scanParams;
     }
 
-    public long getIncrementalScanEndTime() {
-        if (scanParams != null && scanParams.incrementalRead()
-                && scanParams.getMapParams().containsKey(OLAP_END_TIMESTAMP)) {
-            return parseChangeTimestamp(scanParams.getMapParams().get(OLAP_END_TIMESTAMP));
-        }
-        return 0;
-    }
-
     public static long parseChangeTimestamp(String ts) {
         if (ts != null) {
             long changeTimestamp;
@@ -1982,6 +1979,9 @@ public class OlapScanNode extends ScanNode {
             }
             if (changeTimestamp < 0) {
                 throw new ParseException("Invalid TIMESTAMP format in incr clause: " + ts);
+            }
+            if (changeTimestamp > TSOTimestamp.MAX_PHYSICAL_TIMESTAMP) {
+                throw new ParseException("Timestamp exceeds supported TSO range: " + ts);
             }
             return changeTimestamp;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/TimeBasedChangeVisibleWaiter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/TimeBasedChangeVisibleWaiter.java
@@ -169,8 +169,8 @@ public class TimeBasedChangeVisibleWaiter {
     }
 
     /**
-     * Return (tableId, endTSO) if the transaction is COMMITTED and its commit TSO is within the
-     * requested endTSO of one of its tables; otherwise null (no need to wait).
+     * Return (tableId, endTSO) if the transaction is COMMITTED and its commit TSO falls within the
+     * requested right-open end bound (commitTSO &lt; endTSO) of one of its tables; otherwise null.
      */
     private Pair<Long, Long> findMatchedTableEndTSO(TransactionState txn, Map<Long, Long> tableEndTSO) {
         long commitTSO = txn.getCommitTSO();
@@ -179,7 +179,7 @@ public class TimeBasedChangeVisibleWaiter {
         }
         for (Long tableId : txn.getTableIdList()) {
             Long endTSO = tableEndTSO.get(tableId);
-            if (endTSO != null && commitTSO <= endTSO) {
+            if (endTSO != null && commitTSO < endTSO) {
                 return Pair.of(tableId, endTSO);
             }
         }
@@ -219,18 +219,29 @@ public class TimeBasedChangeVisibleWaiter {
 
     // Resolve the read end timestamp (ms) from scan params; fall back to defaultEndTsMs (the query
     // start time) when absent or non-positive.
+    //
+    // The two cases carry different upper-bound semantics, both later composed as an exclusive
+    // right-open TSO by addTableEndTSO:
+    //   - explicit endTimestamp E: the scan reads [start, E), deliberately excluding the whole E
+    //     millisecond, so E maps to compose(E, 0);
+    //   - default "read up to now" M: the scan reads all data committed up to M (via
+    //     nextTso(partition.getTso())), i.e. the whole M millisecond is included, so return M + 1
+    //     to make compose(M + 1, 0) an exclusive bound covering every logical counter within M.
+    //     Otherwise a transaction committed at compose(M, k>0) before the query started would be
+    //     skipped by commitTSO < compose(M, 0) and its visibility would not be awaited.
     private static long getEndTsMs(TableScanParams scanParams, long defaultEndTsMs) {
         if (scanParams.getMapParams().containsKey(OlapScanNode.OLAP_END_TIMESTAMP)) {
             long endTsMs = OlapScanNode.parseChangeTimestamp(
                     scanParams.getMapParams().get(OlapScanNode.OLAP_END_TIMESTAMP));
-            return endTsMs > 0 ? endTsMs : defaultEndTsMs;
+            return endTsMs > 0 ? endTsMs : defaultEndTsMs + 1;
         }
-        return defaultEndTsMs;
+        return defaultEndTsMs + 1;
     }
 
-    // Compose endTsMs into a full TSO and merge into dbId -> (tableId -> endTSO), keeping the max.
+    // Compose endTsMs into the right-open (exclusive) end TSO, i.e. the start of that millisecond,
+    // matching the @incr [startMs, endMs) scan upper bound. Merge as dbId -> (tableId -> max endTSO).
     private static void addTableEndTSO(Map<Long, Map<Long, Long>> dbToTableEndTSO, OlapTable table, long endTsMs) {
         dbToTableEndTSO.computeIfAbsent(table.getDatabase().getId(), ignored -> new HashMap<>())
-                .merge(table.getId(), TSOTimestamp.composeFullTimestamp(endTsMs), Math::max);
+                .merge(table.getId(), TSOTimestamp.composePhysicalTimestamp(endTsMs), Math::max);
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/tso/TSOService.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tso/TSOService.java
@@ -243,7 +243,7 @@ public class TSOService extends MasterDaemon {
             if (MetricRepo.isInit) {
                 MetricRepo.COUNTER_TSO_CLOCK_GET_SUCCESS.increase(1L);
             }
-            return TSOTimestamp.composeTimestamp(physical, logical);
+            return TSOTimestamp.composeRealTso(physical, logical);
         }
         throw new RuntimeException("Failed to get TSO after " + maxGetTSORetryCount + " retries", lastFailure);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/tso/TSOTimestamp.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/tso/TSOTimestamp.java
@@ -22,6 +22,7 @@ import org.apache.doris.common.io.Writable;
 import org.apache.doris.persist.gson.GsonUtils;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.DataInput;
@@ -67,6 +68,18 @@ public final class TSOTimestamp implements Writable, Comparable<TSOTimestamp> {
     // Maximum logical counter value
     public static final long MAX_LOGICAL_COUNTER = (1L << LOGICAL_BITS) - 1L;
 
+    // Sentinel meaning "no upper bound" / "latest" (e.g. FOR VERSION AS OF 9223372036854775807).
+    // It is intentionally NOT a real allocated TSO; it sorts above every real TSO so that a
+    // right-open predicate {@code x < UNBOUNDED_TSO} still selects all rows.
+    public static final long UNBOUNDED_TSO = Long.MAX_VALUE;
+
+    // The largest legal real (allocated) TSO. Real TSOs never reach UNBOUNDED_TSO, which leaves
+    // room for nextTso() to compute a successor without overflow.
+    public static final long MAX_REAL_TSO = Long.MAX_VALUE - 1;
+
+    // Largest physical millisecond that can be represented by a real TSO.
+    public static final long MAX_PHYSICAL_TIMESTAMP = extractPhysicalTime(MAX_REAL_TSO);
+
     /**
      * Constructor with specific physical time and logical counter
      *
@@ -104,12 +117,44 @@ public final class TSOTimestamp implements Writable, Comparable<TSOTimestamp> {
     }
 
     /**
-     * Compose 64-bit TSO timestamp from physical time
+     * Compose the lower boundary of a physical millisecond.
      *
-     * @return 64-bit TSO timestamp with full counter
+     * @return 64-bit TSO timestamp with a zero logical counter
      */
-    public static long composeFullTimestamp(long physicalTimestamp) {
-        return composeTimestamp(physicalTimestamp, LOGICAL_MASK);
+    public static long composePhysicalTimestamp(long physicalTimestamp) {
+        return composeRealTso(physicalTimestamp, 0L);
+    }
+
+    /**
+     * The next discrete TSO after a real {@code tso}. TSO values are dense integers, so this converts
+     * an inclusive bound into the equivalent right-open (exclusive) bound: {@code x <= tso} is the
+     * same row set as {@code x < nextTso(tso)}, and a lower bound that excludes {@code tso} itself is
+     * {@code x >= nextTso(tso)}. Callers should use this instead of a bare {@code + 1} so the TSO
+     * interval arithmetic stays in one place.
+     *
+     * <p>This is a pure successor over real TSOs only. The {@link #UNBOUNDED_TSO} sentinel is not a
+     * real TSO and must be handled by callers before reaching here; requiring a real input keeps the
+     * successor free of overflow and makes the "real TSOs never reach the sentinel" assumption an
+     * enforced invariant rather than a comment.
+     */
+    public static long nextTso(long tso) {
+        Preconditions.checkArgument(tso >= 0 && tso <= MAX_REAL_TSO,
+                "nextTso expects a real TSO in [0, %s], got %s", MAX_REAL_TSO, tso);
+        return tso + 1;
+    }
+
+    /**
+     * Convert an inclusive stored TSO bound into the half-open (exclusive) bound the scan pushes
+     * down, tolerating "no bound" inputs. Returns {@code null} when the input is {@code null} or a
+     * negative sentinel (e.g. a partition that never got a real TSO stores -1, meaning no committed
+     * change): a {@code null} result tells the caller to leave that bound unset rather than feeding
+     * a non-real value into {@link #nextTso}. A real TSO is mapped to its successor.
+     */
+    public static Long toExclusiveBound(Long storedTso) {
+        if (storedTso == null || storedTso < 0) {
+            return null;
+        }
+        return nextTso(storedTso);
     }
 
     /**
@@ -204,6 +249,28 @@ public final class TSOTimestamp implements Writable, Comparable<TSOTimestamp> {
         // Bitwise assembly: High 46 bits physical time + Low 18 bits logical counter
         return (physical  << PHYSICAL_SHIFT)
             | (logical);
+    }
+
+    /**
+     * Compose a real (allocated) TSO from physical time and logical counter, validating that the
+     * inputs and the result stay within the legal real-TSO range instead of silently masking. This
+     * is the single construction entry for TSOs produced by the generator, so the invariant
+     * "a real TSO is non-negative and never reaches {@link #UNBOUNDED_TSO}" is enforced here once
+     * rather than assumed at every call site.
+     *
+     * @throws IllegalArgumentException if the components are out of range or the composed value
+     *         would exceed {@link #MAX_REAL_TSO}
+     */
+    public static long composeRealTso(long physicalTime, long logicalCounter) {
+        Preconditions.checkArgument(physicalTime >= 0 && physicalTime <= RAW_PHYSICAL_MASK,
+                "physicalTime out of range [0, %s]: %s", RAW_PHYSICAL_MASK, physicalTime);
+        Preconditions.checkArgument(logicalCounter >= 0 && logicalCounter <= MAX_LOGICAL_COUNTER,
+                "logicalCounter out of range [0, %s]: %s", MAX_LOGICAL_COUNTER, logicalCounter);
+        long tso = Math.addExact(
+                Math.multiplyExact(physicalTime, 1L << PHYSICAL_SHIFT), logicalCounter);
+        Preconditions.checkArgument(tso <= MAX_REAL_TSO,
+                "composed TSO exceeds MAX_REAL_TSO (%s): %s", MAX_REAL_TSO, tso);
+        return tso;
     }
 
     public static long extractTimestamp(long tso) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslatorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/glue/translator/PhysicalPlanTranslatorTest.java
@@ -144,11 +144,20 @@ public class PhysicalPlanTranslatorTest extends TestWithFeService {
                 + "'enable_unique_key_merge_on_write' = 'false',"
                 + "'sequence_mapping.s1' = 'v1',"
                 + "'sequence_mapping.s2' = 'v2');");
+        // Bump the base table with a real (positive) tso before creating the stream so that the
+        // stream records a positive consumption offset at creation time; hasConsumedData() only
+        // treats a positive offset as a real baseline, otherwise every partition would be pruned out
+        // of the snapshot scan.
+        Database database = (Database) Env.getCurrentInternalCatalog().getDbOrMetaException("test_db");
+        OlapTable binlogScanSchemaTable =
+                (OlapTable) database.getTableOrMetaException("binlog_scan_schema_t");
+        bumpPartitionsAndReplicas(binlogScanSchemaTable, 2L, 100L);
         createTable("create stream test_db.binlog_scan_schema_stream "
                 + "on table test_db.binlog_scan_schema_t properties('type' = 'append_only')");
-        Database database = (Database) Env.getCurrentInternalCatalog().getDbOrMetaException("test_db");
-        bumpPartitionsAndReplicas(
-                (OlapTable) database.getTableOrMetaException("binlog_scan_schema_t"), 2L);
+        // Advance the base table tso again after the stream is created so the partition has new data
+        // beyond the recorded consumption offset, driving the snapshot scan down the rebuild path
+        // (base scan wrapped in OlapTableWrapper unioned with the binlog before-image).
+        bumpPartitionsAndReplicas(binlogScanSchemaTable, 3L, 200L);
         createTable("create table test_db.t_topn_lazy(c1 int, c2 int, c3 int) "
                 + "duplicate key(c1) distributed by hash(c1) buckets 1 "
                 + "properties('replication_num' = '1', 'light_schema_change' = 'true');");
@@ -544,10 +553,10 @@ public class PhysicalPlanTranslatorTest extends TestWithFeService {
         return scanNodes;
     }
 
-    private static void bumpPartitionsAndReplicas(OlapTable table, long newVersion) {
+    private static void bumpPartitionsAndReplicas(OlapTable table, long newVersion, long tso) {
         for (Partition partition : table.getPartitions()) {
             long timestamp = System.currentTimeMillis();
-            partition.setVisibleVersionAndTime(newVersion, timestamp, timestamp);
+            partition.setVisibleVersionAndTime(newVersion, timestamp, tso);
             partition.setNextVersion(newVersion + 1);
             for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.VISIBLE, true)) {
                 for (Tablet tablet : index.getTablets()) {

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/ExplainTableStreamPlanTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/plans/ExplainTableStreamPlanTest.java
@@ -25,7 +25,6 @@ import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.MaterializedIndex;
 import org.apache.doris.catalog.MaterializedIndex.IndexExtState;
 import org.apache.doris.catalog.OlapTable;
-import org.apache.doris.catalog.OlapTableWrapper;
 import org.apache.doris.catalog.Partition;
 import org.apache.doris.catalog.Replica;
 import org.apache.doris.catalog.RowBinlogTableWrapper;
@@ -36,6 +35,7 @@ import org.apache.doris.catalog.stream.OlapTableStreamUpdate;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Pair;
+import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.nereids.NereidsPlanner;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.glue.translator.PhysicalPlanTranslator;
@@ -43,12 +43,17 @@ import org.apache.doris.nereids.glue.translator.PlanTranslatorContext;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.properties.PhysicalProperties;
 import org.apache.doris.nereids.trees.expressions.Alias;
+import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.LessThan;
 import org.apache.doris.nereids.trees.expressions.NamedExpression;
 import org.apache.doris.nereids.trees.expressions.Slot;
 import org.apache.doris.nereids.trees.expressions.SlotReference;
 import org.apache.doris.nereids.trees.expressions.StatementScopeIdGenerator;
+import org.apache.doris.nereids.trees.expressions.literal.BigIntLiteral;
 import org.apache.doris.nereids.trees.expressions.literal.VarcharLiteral;
 import org.apache.doris.nereids.trees.plans.commands.ExplainCommand;
+import org.apache.doris.nereids.trees.plans.logical.LogicalFilter;
+import org.apache.doris.nereids.trees.plans.logical.LogicalOlapScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalOlapTableStreamScan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalProject;
@@ -71,6 +76,7 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * UTs for table stream query plan, including
@@ -359,11 +365,12 @@ public class ExplainTableStreamPlanTest extends TestWithFeService {
                 TPaloScanRange range = loc.getScanRange().getPaloScanRange();
                 long tabletId = range.getTabletId();
                 long pid = tabletIdToPartitionId.get(tabletId);
-                long expectedStart = stream.getStreamUpdate(pid).first;
+                // BE reads [startTso, endTso), so the recorded offset is shifted to its next TSO.
+                long expectedStart = TSOTimestamp.nextTso(stream.getStreamUpdate(pid).first);
                 Assertions.assertEquals(expectedScanType, range.getBinlogScanType(),
                         "binlog scan type should match stream consume type");
                 Assertions.assertEquals(expectedStart, range.getStartTso(),
-                        "startTSO should equal stream partitionOffset (last committed binlog TSO)");
+                        "startTSO should equal stream partitionOffset (last committed binlog TSO) + 1");
                 assertedAtLeastOne = true;
             }
         }
@@ -396,11 +403,14 @@ public class ExplainTableStreamPlanTest extends TestWithFeService {
             }
         }
         Assertions.assertNotNull(incrementalScan1);
-        OlapTableWrapper wrapper = (OlapTableWrapper) incrementalScan1.getOlapTable();
         Map<Long, Long> prevOffsets = new java.util.HashMap<>();
         Map<Long, Long> nextOffsets = new java.util.HashMap<>();
         for (Long pid : incrementalScan1.getSelectedPartitionIds()) {
-            Pair<Long, Long> off = wrapper.getPartitionOffset(pid);
+            // Use the raw (un-shifted) stream offsets, mirroring what the production
+            // StreamConsumptionInfoExtractor commits. Reading them back from the scan node's
+            // RowBinlogTableWrapper would return the already +1-shifted scan-range bounds and
+            // introduce a spurious double shift into this closed-loop check.
+            Pair<Long, Long> off = stream.getStreamUpdate(pid);
             if (off.first != null) {
                 prevOffsets.put(pid, off.first);
             }
@@ -440,8 +450,9 @@ public class ExplainTableStreamPlanTest extends TestWithFeService {
             for (TScanRangeLocations loc : locations) {
                 TPaloScanRange range = loc.getScanRange().getPaloScanRange();
                 long pid = tabletIdToPartitionId.get(range.getTabletId());
-                Assertions.assertEquals(nextOffsets.get(pid), range.getStartTso(),
-                        "after offset commit, new startTSO must equal the previously committed next TSO");
+                // BE reads [startTso, endTso), so the stream wrapper shifts the recorded offset by +1.
+                Assertions.assertEquals(TSOTimestamp.nextTso(nextOffsets.get(pid)), range.getStartTso(),
+                        "after offset commit, new startTSO must equal the previously committed next TSO + 1");
                 assertedAtLeastOne = true;
             }
         }
@@ -586,8 +597,9 @@ public class ExplainTableStreamPlanTest extends TestWithFeService {
         // asserting every incremental scan range carries the composed start/end TSO for its partition.
         String startTs = "2026-05-25 20:51:28";
         String endTs = "2026-05-25 21:51:28";
-        long expectedStartTso = TSOTimestamp.composeFullTimestamp(OlapScanNode.parseChangeTimestamp(startTs));
-        long expectedEndTso = TSOTimestamp.composeFullTimestamp(OlapScanNode.parseChangeTimestamp(endTs));
+        // @incr is left-closed right-open [start, end): BE uses GE/LT on the composed bounds directly.
+        long expectedStartTso = TSOTimestamp.composePhysicalTimestamp(OlapScanNode.parseChangeTimestamp(startTs));
+        long expectedEndTso = TSOTimestamp.composePhysicalTimestamp(OlapScanNode.parseChangeTimestamp(endTs));
 
         ConnectContext ctx = createDefaultCtx();
         ctx.setDatabase("test_stream");
@@ -649,6 +661,52 @@ public class ExplainTableStreamPlanTest extends TestWithFeService {
         for (Plan tmpPlan : tmpPlans) {
             Assertions.assertFalse(containsLogicalStreamScan(tmpPlan),
                     "tmp plan for mv pre rewrite should have normalized stream scans inside cte children");
+        }
+    }
+
+    @Test
+    public void testDupTimeTravelIncludesExactTimestamp() {
+        assertTimeTravelBoundary("tbl_dup_stream_base", "time as of '0'", 1L, false);
+        String timestamp = TimeUtils.longToTimeString(1700000000000L);
+        // (1700000000000 ms, logical 0) is inclusive; logical 1 is the exclusive upper bound.
+        assertTimeTravelBoundary("tbl_dup_stream_base", "time as of '" + timestamp + "'",
+                445644800000000001L, false);
+    }
+
+    @Test
+    public void testMowTimeTravelIncludesExactTimestamp() {
+        assertTimeTravelBoundary("tbl_stream_base", "time as of '0'", 1L, true);
+        String timestamp = TimeUtils.longToTimeString(1700000000000L);
+        assertTimeTravelBoundary("tbl_stream_base", "time as of '" + timestamp + "'",
+                445644800000000001L, true);
+    }
+
+    private void assertTimeTravelBoundary(String table, String snapshot, long exclusiveBound, boolean mow) {
+        Plan plan = PlanChecker.from(connectContext)
+                .analyze("select * from test_stream." + table + " for " + snapshot)
+                .getCascadesContext().getRewritePlan();
+        Set<LogicalFilter<?>> filters = plan.collect(node -> node instanceof LogicalFilter);
+        List<Expression> commitPredicates = new ArrayList<>();
+        for (LogicalFilter<?> filter : filters) {
+            for (Expression conjunct : filter.getConjuncts()) {
+                if (conjunct instanceof LessThan && conjunct.child(0) instanceof SlotReference
+                        && ((SlotReference) conjunct.child(0)).getName().equals(Column.COMMIT_TSO_COL)) {
+                    commitPredicates.add(conjunct);
+                }
+            }
+        }
+        Assertions.assertEquals(1, commitPredicates.size());
+        Assertions.assertEquals(new BigIntLiteral(exclusiveBound), commitPredicates.get(0).child(1));
+
+        Set<LogicalOlapScan> binlogScans = plan.collect(node -> node instanceof LogicalOlapScan
+                && ((LogicalOlapScan) node).getTable() instanceof RowBinlogTableWrapper);
+        Assertions.assertEquals(mow ? 1 : 0, binlogScans.size());
+        for (LogicalOlapScan scan : binlogScans) {
+            RowBinlogTableWrapper wrapper = (RowBinlogTableWrapper) scan.getTable();
+            Assertions.assertFalse(wrapper.getPartitionIds().isEmpty());
+            for (Long partitionId : wrapper.getPartitionIds()) {
+                Assertions.assertEquals(Pair.of(exclusiveBound, null), wrapper.getPartitionOffset(partitionId));
+            }
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/planner/OlapScanNodeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/planner/OlapScanNodeTest.java
@@ -46,7 +46,9 @@ import org.apache.doris.cloud.catalog.CloudPartition;
 import org.apache.doris.common.AnalysisException;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.util.DebugPointUtil;
+import org.apache.doris.common.util.TimeUtils;
 import org.apache.doris.datasource.InternalCatalog;
+import org.apache.doris.nereids.exceptions.ParseException;
 import org.apache.doris.system.Backend;
 import org.apache.doris.thrift.TOlapScanNode;
 import org.apache.doris.thrift.TPaloScanRange;
@@ -64,6 +66,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -73,6 +77,28 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class OlapScanNodeTest {
+    @Test
+    public void testParseChangeTimestampRange() {
+        DateTimeFormatter format = TimeUtils.getDatetimeFormatWithTimeZone();
+        Assertions.assertEquals(0L, OlapScanNode.parseChangeTimestamp("0"));
+        Assertions.assertEquals(1700000000000L,
+                OlapScanNode.parseChangeTimestamp(format.format(Instant.ofEpochMilli(1700000000000L))));
+        // The parser accepts whole seconds; these straddle the physical limit 35184372088831 ms.
+        Assertions.assertEquals(35184372088000L,
+                OlapScanNode.parseChangeTimestamp(format.format(Instant.ofEpochMilli(35184372088000L))));
+        ParseException error = Assertions.assertThrows(ParseException.class,
+                () -> OlapScanNode.parseChangeTimestamp(format.format(Instant.ofEpochMilli(35184372089000L))));
+        Assertions.assertTrue(error.getMessage().contains("Timestamp exceeds supported TSO range"));
+        Assertions.assertThrows(ParseException.class,
+                () -> OlapScanNode.parseChangeTimestamp("4000-01-01 00:00:00"));
+        Assertions.assertThrows(ParseException.class,
+                () -> OlapScanNode.parseChangeTimestamp("9999-01-01 00:00:00"));
+        Assertions.assertThrows(ParseException.class,
+                () -> OlapScanNode.parseChangeTimestamp(format.format(Instant.ofEpochMilli(-1000L))));
+        Assertions.assertThrows(ParseException.class, () -> OlapScanNode.parseChangeTimestamp("invalid"));
+        Assertions.assertThrows(ParseException.class, () -> OlapScanNode.parseChangeTimestamp(null));
+    }
+
     private MaterializedIndex createMaterializedIndex(List<Long> tabletIds) {
         MaterializedIndex index = new MaterializedIndex();
         List<Tablet> tablets = Lists.newArrayListWithExpectedSize(tabletIds.size());

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/TimeBasedChangeVisibleWaiterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/TimeBasedChangeVisibleWaiterTest.java
@@ -61,7 +61,8 @@ public class TimeBasedChangeVisibleWaiterTest {
                 mockContext(), newChangeRelation(1, ImmutableMap.of()),
                 ImmutableMap.of(TABLE_QUALIFIER, table), DEFAULT_END_TS_MS);
 
-        Assertions.assertEquals(TSOTimestamp.composeFullTimestamp(DEFAULT_END_TS_MS),
+        // default "read up to now" bound covers the whole millisecond, so it is compose(M + 1, 0).
+        Assertions.assertEquals(TSOTimestamp.composePhysicalTimestamp(DEFAULT_END_TS_MS + 1),
                 result.get(DB_ID).get(TABLE_ID));
     }
 
@@ -80,7 +81,7 @@ public class TimeBasedChangeVisibleWaiterTest {
                 mockContext(), plan, ImmutableMap.of(TABLE_QUALIFIER, table), DEFAULT_END_TS_MS);
 
         Assertions.assertEquals(
-                TSOTimestamp.composeFullTimestamp(OlapScanNode.parseChangeTimestamp(endTimestamp2)),
+                TSOTimestamp.composePhysicalTimestamp(OlapScanNode.parseChangeTimestamp(endTimestamp2)),
                 result.get(DB_ID).get(TABLE_ID));
     }
 
@@ -184,7 +185,7 @@ public class TimeBasedChangeVisibleWaiterTest {
         TransactionState txn = Mockito.mock(TransactionState.class);
         Mockito.when(txn.getTransactionStatus()).thenAnswer(invocation -> status.get());
         Mockito.when(txn.getTableIdList()).thenReturn(ImmutableList.of(TABLE_ID));
-        Mockito.when(txn.getCommitTSO()).thenReturn(TSOTimestamp.composeFullTimestamp(1L));
+        Mockito.when(txn.getCommitTSO()).thenReturn(TSOTimestamp.composePhysicalTimestamp(1L));
         Mockito.doAnswer(invocation -> {
             status.set(TransactionStatus.VISIBLE);
             return null;

--- a/fe/fe-core/src/test/java/org/apache/doris/tso/TSOTimestampTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/tso/TSOTimestampTest.java
@@ -59,6 +59,31 @@ public class TSOTimestampTest {
     }
 
     @Test
+    public void testComposePhysicalTimestampUsesZeroLogicalCounter() {
+        long physicalTime = 1625097600000L;
+
+        long composed = TSOTimestamp.composePhysicalTimestamp(physicalTime);
+
+        org.junit.jupiter.api.Assertions.assertEquals(physicalTime, TSOTimestamp.extractPhysicalTime(composed));
+        org.junit.jupiter.api.Assertions.assertEquals(0L, TSOTimestamp.extractLogicalCounter(composed));
+    }
+
+    @Test
+    public void testComposePhysicalTimestampRange() {
+        // Signed TSOs reserve 18 low bits for the logical counter.
+        long maxPhysicalTime = (1L << 45) - 1;
+        Assertions.assertEquals(0L, TSOTimestamp.composePhysicalTimestamp(0L));
+        Assertions.assertEquals(Long.MAX_VALUE - TSOTimestamp.MAX_LOGICAL_COUNTER,
+                TSOTimestamp.composePhysicalTimestamp(maxPhysicalTime));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> TSOTimestamp.composePhysicalTimestamp(-1L));
+        Assertions.assertThrows(ArithmeticException.class,
+                () -> TSOTimestamp.composePhysicalTimestamp(maxPhysicalTime + 1));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> TSOTimestamp.composePhysicalTimestamp(1L << 46));
+    }
+
+    @Test
     public void testBitWidthLimitations() {
         // Test that values are properly masked to fit in their respective bit widths
         long largePhysicalTime = (1L << 46) + 1000L; // Larger than 46 bits


### PR DESCRIPTION
Cherry-picked from #67480

### Cherry-pick notes

Upstream #67480 was rebased onto #67594 (safe read fence for time-based incremental reads), which `branch-incremental-computation` does not carry. Conflicts in `TSOTimestamp.java`, `BindRelation.java`, `ExplainTableStreamPlanTest.java` and `TSOTimestampTest.java` were resolved by taking the PR side; all 11 files touched by the upstream squash commit are byte-identical to master after #67480.

Two adaptations because #67594 is absent on this branch:

1. `BindRelation.parseTimestampRange`: the `endTimestamp` line still called the removed `composeFullTimestamp()`; switched to `composePhysicalTimestamp()` so the `@incr` range is `[startOf(startMs), startOf(endMs))`, matching the new BE `GE/LT` predicates. (On master this line came from #67594.)
2. `TimeBasedChangeVisibleWaiter` (+ its test): this branch still has the TSO-comparing waiter that #67594 replaced on master. Restored the waiter change from the PR's pre-rebase revision (`c1d7629524a`): the end bound is the exclusive start of the millisecond (`composePhysicalTimestamp`, formerly `composeEmptyCounterTSO`), the match uses `commitTSO < endTSO`, and the "read up to now" default maps query-start millisecond `M` to `startOf(M + 1)` so every logical counter within `M` is still awaited. This is the "Visibility waiting" behavior described in the upstream PR body.

### Verification

- `be/src/exec/scan/olap_scanner.cpp`: syntax-only compile with the Release flags, clean.
- FE UT (`run-fe-ut.sh --run`, fe-core main + test compiled against this branch): `OlapScanNodeTest` 12, `PhysicalPlanTranslatorTest` 17, `ExplainTableStreamPlanTest` 23, `TSOTimestampTest` 14, `TimeBasedChangeVisibleWaiterTest` 5 — 71 tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018m1ARNXtGSWucJTy34uwe1
