### PR TITLE
[fix](io) spell errno portably in localfs_error, so an ENOENT read is NotFound on macOS too

### DIFF
--- a/be/src/io/fs/err_utils.cpp
+++ b/be/src/io/fs/err_utils.cpp
@@ -20,9 +20,9 @@
 // IWYU pragma: no_include <bthread/errno.h>
 #include <errno.h> // IWYU pragma: keep
 #include <fmt/format.h>
-#include <string.h>
 
 #include <sstream>
+#include <system_error>
 
 #include "common/status.h"
 #include "io/fs/hdfs.h"
@@ -32,9 +32,22 @@ using namespace ErrorCode;
 
 namespace io {
 
+namespace {
+
+// strerror_r has two incompatible flavours: glibc's returns the text (and may leave the buffer
+// untouched), the POSIX one on macOS and musl returns an int and fills the buffer. Formatting the
+// return value directly prints "0" on the latter, and callers such as the ORC reader tell NotFound
+// apart by looking for "No such file or directory" in the text. generic_category spells the errno
+// the same way everywhere.
+std::string errno_message(int err) {
+    return std::generic_category().message(err);
+}
+
+} // namespace
+
 std::string errno_to_str() {
-    char buf[1024];
-    return fmt::format("({}), {}", errno, strerror_r(errno, buf, 1024));
+    int err = errno;
+    return fmt::format("({}), {}", err, errno_message(err));
 }
 
 std::string errcode_to_str(const std::error_code& ec) {
@@ -43,8 +56,8 @@ std::string errcode_to_str(const std::error_code& ec) {
 
 std::string hdfs_error() {
     std::stringstream ss;
-    char buf[1024];
-    ss << "(" << errno << "), " << strerror_r(errno, buf, 1024) << ")";
+    int err = errno;
+    ss << "(" << err << "), " << errno_message(err) << ")";
 #ifdef USE_HADOOP_HDFS
     char* root_cause = hdfsGetLastExceptionRootCause();
     if (root_cause != nullptr) {
@@ -96,8 +109,7 @@ Status localfs_error(const std::error_code& ec, std::string_view msg) {
 }
 
 Status localfs_error(int posix_errno, std::string_view msg) {
-    char buf[1024];
-    auto message = fmt::format("{}: {}", msg, strerror_r(errno, buf, 1024));
+    auto message = fmt::format("{}: {}", msg, errno_message(posix_errno));
     switch (posix_errno) {
     case EIO:
         return Status::Error<IO_ERROR, false>(message);


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #66773

Problem Summary:

`localfs_error(int posix_errno, msg)`, `errno_to_str()` and `hdfs_error()` in `be/src/io/fs/err_utils.cpp` format the return value of `strerror_r()` straight into the message. That is the text on glibc, whose `strerror_r` returns `char*`, but the POSIX flavour on macOS and musl returns an `int` and fills the buffer instead, so there the message reads `failed to read <path>: 0`.

The ORC reader (and the other readers that copy the pattern) tells NotFound apart from any other open failure by looking for `"No such file or directory"` in the text, so on macOS an ENOENT surfaces as INTERNAL_ERROR and `NewOrcReaderTest.InitRestoresNotFoundFromReadFailure` (added by #66773) fails.

This spells the errno through `std::generic_category().message()` instead, which is what the `std::error_code` overload in the same file already does; it reads the same on both libcs and is thread safe. `localfs_error(int, ...)` also described the global `errno` rather than its `posix_errno` argument - every caller passes `errno` itself, so nothing changes, but it now says what it classifies.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

    On macOS, `doris_be_test` built for the io/fs, ORC and Iceberg reader suites (`FileHandleCacheTest`, `HdfsFileSystemTest`, `HdfsMgrTest`, `VfileScannerExceptionTest`, `NewOrcReaderTest`, `OrcFileInputStreamTest`, `IcebergReaderTest`, `IcebergV2ReaderTest`, `IcebergDeleteFileReaderHelperTest`): 357 tests pass, including `InitRestoresNotFoundFromReadFailure` and `InitKeepsInternalErrorForDirectory`, which failed before. On Linux the message text is unchanged.

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BocZ8hbRkSYWhGAiQC5MM1
