### PR TITLE
[fix](ci) Increase automated code review timeout to 120 minutes

### DIFF
--- a/.github/workflows/code-review-runner.yml
+++ b/.github/workflows/code-review-runner.yml
@@ -60,9 +60,9 @@ jobs:
       head_sha: ${{ steps.review_inputs.outputs.head_sha }}
       manage_status: ${{ steps.review_inputs.outputs.manage_status }}
       pr_number: ${{ steps.review_inputs.outputs.pr_number }}
-    # Pre-finalization steps can use 188 minutes and auth sync can use 8 more,
+    # Pre-finalization steps can use 218 minutes and auth sync can use 8 more,
     # leaving 12 minutes for runner setup and post-job cleanup.
-    timeout-minutes: 208
+    timeout-minutes: 238
     if: >-
       inputs.pr_number != '' ||
       (
@@ -711,7 +711,7 @@ jobs:
 
       - name: Run automated code review
         id: review
-        timeout-minutes: 90
+        timeout-minutes: 120
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The automated review of #67687 hit the 90-minute step timeout while finishing its report ([failed run](https://github.com/apache/doris/actions/runs/34488778375/job/102909763020)); its [formal review](https://github.com/apache/doris/pull/67687#pullrequestreview-5169396336) was submitted about 23 seconds later.

Increase the review step timeout from 90 to 120 minutes. Raise the job timeout from 208 to 238 minutes and update the budget comment, preserving 8 minutes for auth synchronization and 12 minutes for runner setup and post-job cleanup.

### Release note

None

### Check List (For Author)

- Test:
  - [x] Unit Test: all 18 existing `test_review_auth_quarantine.py` tests passed against the modified workflow using fake OSS, Codex, and GitHub services.
  - [x] Manual test: parsed the YAML and verified the 120-minute review limit, 218-minute pre-finalization budget, 8-minute auth sync, and 12-minute reserve within the 238-minute job limit. Confirmed no other parsed workflow changes; patch whitespace check passed.
- Behavior changed:
  - [x] Yes. Automated reviews may run for up to 120 minutes.
- Does this need documentation?
  - [x] No. The workflow budget comment is updated.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
