### PR TITLE
[fix](be) Keep paused queries waiting under process memory pressure before cancelling

### DIFF
--- a/be/src/runtime/workload_group/workload_group_manager.cpp
+++ b/be/src/runtime/workload_group/workload_group_manager.cpp
@@ -836,17 +836,32 @@ bool WorkloadGroupMgr::handle_single_query_(const std::shared_ptr<ResourceContex
                       << ", wg info: " << wg->debug_string();
             requestor->task_controller()->set_memory_sufficient(true);
             return true;
+        } else if (time_in_queue < config::spill_in_paused_queue_timeout_ms) {
+            // The query has no revocable memory, cancelling it will not release much memory.
+            // Keep it paused so that it can be resumed once other queries release memory,
+            // and cancel it only after it has waited for `spill_in_paused_queue_timeout_ms`.
+            // If the process memory keeps growing, memory gc will cancel queries when the
+            // hard limit is reached.
+            LOG_EVERY_T(INFO, 1) << "Query: " << query_id
+                                 << " process memory is exceeded, and could not find task to "
+                                    "spill, keep it paused. Waited "
+                                 << time_in_queue
+                                 << " ms, timeout: " << config::spill_in_paused_queue_timeout_ms
+                                 << " ms, process memory info: "
+                                 << GlobalMemoryArbitrator::process_memory_used_details_str()
+                                 << ", wg info: " << wg->debug_string();
+            return false;
         } else {
-            // if cannot find any memory to release, then let the query continue to run as far as possible
-            // or cancelled by gc if memory is really not enough.
+            // Waited long enough and still could not find any memory to release,
+            // cancel the query to protect the process.
             Status error_status = Status::MemoryLimitExceeded(
                     "Query {} process memory is exceeded"
-                    ", and there is no cache now. And could not find task to spill, disable "
-                    "reserve memory and resume it. "
+                    ", and there is no cache now. And could not find task to spill after "
+                    "waiting {} ms in paused queue, try to cancel query. "
                     "Query memory usage: {}, limit: {}, reserved "
                     "size: {}, try to reserve: {}, wg info: {}."
                     " Maybe you should set the workload group's limit to a lower value. {}",
-                    query_id, PrettyPrinter::print_bytes(memory_usage),
+                    query_id, time_in_queue, PrettyPrinter::print_bytes(memory_usage),
                     PrettyPrinter::print_bytes(limit), PrettyPrinter::print_bytes(reserved_size),
                     PrettyPrinter::print_bytes(size_to_reserve), wg->memory_debug_string(),
                     doris::ProcessProfile::instance()

--- a/be/src/runtime/workload_group/workload_group_manager.cpp
+++ b/be/src/runtime/workload_group/workload_group_manager.cpp
@@ -51,7 +51,7 @@ PausedQuery::PausedQuery(std::shared_ptr<ResourceContext> resource_ctx, double c
           cache_ratio_(cache_ratio),
           reserve_size_(reserve_size),
           query_id_(print_id(resource_ctx->task_controller()->task_id())) {
-    enqueue_at = std::chrono::system_clock::now();
+    enqueue_at = std::chrono::steady_clock::now();
 }
 
 WorkloadGroupMgr::~WorkloadGroupMgr() = default;
@@ -602,6 +602,21 @@ bool WorkloadGroupMgr::handle_process_memory_exceeded_(
         return false;
     }
 
+    // The process memory pressure may have been relieved by cache reclamation or by other
+    // queries that finished. Check it before routing the query below, otherwise a query in a
+    // workload group that uses less than its min memory limit has to wait for the timeout.
+    const size_t test_memory_size = std::max<size_t>(query_it->reserve_size_, 32L * 1024 * 1024);
+    if (!GlobalMemoryArbitrator::is_exceed_soft_mem_limit(test_memory_size)) {
+        LOG(INFO) << "Query: " << print_id(resource_ctx->task_controller()->task_id())
+                  << ", process limit not exceeded now, resume this query"
+                  << ", process memory info: "
+                  << GlobalMemoryArbitrator::process_memory_used_details_str()
+                  << ", wg info: " << wg->debug_string();
+        resource_ctx->task_controller()->set_memory_sufficient(true);
+        query_it = queries_list.erase(query_it);
+        return false;
+    }
+
     // If workload group's memory usage > min memory, then it means the workload group use too much memory
     // in memory contention state. Should just spill
     if (wg->total_mem_used() > wg->min_memory_limit()) {
@@ -836,12 +851,15 @@ bool WorkloadGroupMgr::handle_single_query_(const std::shared_ptr<ResourceContex
                       << ", wg info: " << wg->debug_string();
             requestor->task_controller()->set_memory_sufficient(true);
             return true;
-        } else if (time_in_queue < config::spill_in_paused_queue_timeout_ms) {
+        }
+
+        const bool exceed_hard_mem_limit = GlobalMemoryArbitrator::is_exceed_hard_mem_limit();
+        if (time_in_queue < config::spill_in_paused_queue_timeout_ms && !exceed_hard_mem_limit) {
             // The query has no revocable memory, cancelling it will not release much memory.
             // Keep it paused so that it can be resumed once other queries release memory,
             // and cancel it only after it has waited for `spill_in_paused_queue_timeout_ms`.
-            // If the process memory keeps growing, memory gc will cancel queries when the
-            // hard limit is reached.
+            // Stop waiting once the process reaches the hard memory limit, so that the
+            // protection does not depend on memory gc, which may be disabled.
             LOG_EVERY_T(INFO, 1) << "Query: " << query_id
                                  << " process memory is exceeded, and could not find task to "
                                     "spill, keep it paused. Waited "
@@ -851,26 +869,26 @@ bool WorkloadGroupMgr::handle_single_query_(const std::shared_ptr<ResourceContex
                                  << GlobalMemoryArbitrator::process_memory_used_details_str()
                                  << ", wg info: " << wg->debug_string();
             return false;
-        } else {
-            // Waited long enough and still could not find any memory to release,
-            // cancel the query to protect the process.
-            Status error_status = Status::MemoryLimitExceeded(
-                    "Query {} process memory is exceeded"
-                    ", and there is no cache now. And could not find task to spill after "
-                    "waiting {} ms in paused queue, try to cancel query. "
-                    "Query memory usage: {}, limit: {}, reserved "
-                    "size: {}, try to reserve: {}, wg info: {}."
-                    " Maybe you should set the workload group's limit to a lower value. {}",
-                    query_id, time_in_queue, PrettyPrinter::print_bytes(memory_usage),
-                    PrettyPrinter::print_bytes(limit), PrettyPrinter::print_bytes(reserved_size),
-                    PrettyPrinter::print_bytes(size_to_reserve), wg->memory_debug_string(),
-                    doris::ProcessProfile::instance()
-                            ->memory_profile()
-                            ->process_memory_detail_str());
-            LOG_LONG_STRING(INFO, error_status.to_string());
-            requestor->task_controller()->cancel(error_status);
-            return true;
         }
+
+        // Waited long enough or the process reached the hard memory limit, and still
+        // could not find any memory to release, cancel the query to protect the process.
+        Status error_status = Status::MemoryLimitExceeded(
+                "Query {} process memory is exceeded"
+                ", and there is no cache now. And could not find task to spill after "
+                "waiting {} ms in paused queue (timeout: {} ms, exceed hard limit: {}), "
+                "try to cancel query. "
+                "Query memory usage: {}, limit: {}, reserved "
+                "size: {}, try to reserve: {}, wg info: {}."
+                " Maybe you should set the workload group's limit to a lower value. {}",
+                query_id, time_in_queue, config::spill_in_paused_queue_timeout_ms,
+                exceed_hard_mem_limit, PrettyPrinter::print_bytes(memory_usage),
+                PrettyPrinter::print_bytes(limit), PrettyPrinter::print_bytes(reserved_size),
+                PrettyPrinter::print_bytes(size_to_reserve), wg->memory_debug_string(),
+                doris::ProcessProfile::instance()->memory_profile()->process_memory_detail_str());
+        LOG_LONG_STRING(INFO, error_status.to_string());
+        requestor->task_controller()->cancel(error_status);
+        return true;
     }
 }
 

--- a/be/src/runtime/workload_group/workload_group_manager.cpp
+++ b/be/src/runtime/workload_group/workload_group_manager.cpp
@@ -839,20 +839,9 @@ bool WorkloadGroupMgr::handle_single_query_(const std::shared_ptr<ResourceContex
             return true;
         }
     } else {
-        // Should not consider about process memory. For example, the query's limit is 100g, workload
-        // group's memlimit is 10g, process memory is 20g. The query reserve will always failed in wg
-        // limit, and process is always have memory, so that it will resume and failed reserve again.
-        const size_t test_memory_size = std::max<size_t>(size_to_reserve, 32L * 1024 * 1024);
-        if (!GlobalMemoryArbitrator::is_exceed_soft_mem_limit(test_memory_size)) {
-            LOG(INFO) << "Query: " << query_id
-                      << ", process limit not exceeded now, resume this query"
-                      << ", process memory info: "
-                      << GlobalMemoryArbitrator::process_memory_used_details_str()
-                      << ", wg info: " << wg->debug_string();
-            requestor->task_controller()->set_memory_sufficient(true);
-            return true;
-        }
-
+        // PROCESS_MEMORY_EXCEEDED. The caller (handle_process_memory_exceeded_) has already
+        // resumed the query if the process is no longer above the soft memory limit, so the
+        // process memory is still exceeded here.
         const bool exceed_hard_mem_limit = GlobalMemoryArbitrator::is_exceed_hard_mem_limit();
         if (time_in_queue < config::spill_in_paused_queue_timeout_ms && !exceed_hard_mem_limit) {
             // The query has no revocable memory, cancelling it will not release much memory.

--- a/be/src/runtime/workload_group/workload_group_manager.h
+++ b/be/src/runtime/workload_group/workload_group_manager.h
@@ -18,6 +18,7 @@
 
 #include <stdint.h>
 
+#include <chrono>
 #include <map>
 #include <set>
 #include <shared_mutex>
@@ -194,10 +195,14 @@ private:
     // Handle a query paused due to PROCESS_MEMORY_EXCEEDED. The logic is:
     //   1. If any recently cancelled query exists globally, skip (wait for
     //      process-level memory release).
-    //   2. If the WG's usage exceeds its min_memory_limit, spill via
+    //   2. If the process is no longer above the soft memory limit, resume the
+    //      query immediately.
+    //   3. If the WG's usage exceeds its min_memory_limit, spill via
     //      release_query_memory_(stop_after_release=true) — one spill per round.
-    //   3. Otherwise, try to revoke memory from other overcommitted WGs by
+    //   4. Otherwise, try to revoke memory from other overcommitted WGs by
     //      cancelling their largest queries.
+    //   5. If nothing could be revoked and the query has waited for
+    //      spill_in_paused_queue_timeout_ms, cancel it via release_query_memory_.
     // Returns true if the caller should stop processing further queries/WGs.
     bool handle_process_memory_exceeded_(const WorkloadGroupPtr& wg, PausedQuerySet& queries_list,
                                          PausedQueryIterator& query_it,
@@ -217,9 +222,11 @@ private:
 
     // Attempt to resolve a single paused query: if revocable memory exists, trigger
     // spill; if under limit, resume; if no memory can be freed, cancel the query or
-    // disable reserve memory and resume. Returns true if the query was acted upon
-    // (spilled/cancelled/resumed), false if it should keep waiting (e.g., still has
-    // running tasks).
+    // disable reserve memory and resume. For PROCESS_MEMORY_EXCEEDED with no revocable
+    // memory, keep the query paused until it has waited spill_in_paused_queue_timeout_ms
+    // or the process reaches the hard memory limit, then cancel it. Returns true if the
+    // query was acted upon (spilled/cancelled/resumed), false if it should keep waiting
+    // (still has running tasks, or is within the process-memory grace period).
     bool handle_single_query_(const std::shared_ptr<ResourceContext>& requestor,
                               size_t size_to_reserve, int64_t time_in_queue, Status paused_reason);
 

--- a/be/src/runtime/workload_group/workload_group_manager.h
+++ b/be/src/runtime/workload_group/workload_group_manager.h
@@ -41,7 +41,7 @@ public:
     // Use weak ptr to save resource ctx, to make sure if the query is cancelled
     // the resource will be released
     std::weak_ptr<ResourceContext> resource_ctx_;
-    std::chrono::system_clock::time_point enqueue_at;
+    std::chrono::steady_clock::time_point enqueue_at;
     size_t last_mem_usage {0};
     double cache_ratio_ {0.0};
     int64_t reserve_size_ {0};
@@ -50,7 +50,7 @@ public:
                 int64_t reserve_size);
 
     int64_t elapsed_time() const {
-        auto now = std::chrono::system_clock::now();
+        auto now = std::chrono::steady_clock::now();
         return std::chrono::duration_cast<std::chrono::milliseconds>(now - enqueue_at).count();
     }
 

--- a/be/src/util/mem_info.h
+++ b/be/src/util/mem_info.h
@@ -87,6 +87,9 @@ public:
     static void set_mem_limit_for_test(int64_t mem_limit) {
         _s_mem_limit.store(mem_limit, std::memory_order_relaxed);
     }
+    static void set_soft_mem_limit_for_test(int64_t soft_mem_limit) {
+        _s_soft_mem_limit.store(soft_mem_limit, std::memory_order_relaxed);
+    }
 #endif
     static inline std::string mem_limit_str() {
         DCHECK(_s_initialized);

--- a/be/test/runtime/workload_group/workload_group_manager_test.cpp
+++ b/be/test/runtime/workload_group/workload_group_manager_test.cpp
@@ -30,6 +30,7 @@
 #include <limits>
 #include <memory>
 #include <sstream>
+#include <string>
 
 #include "common/config.h"
 #include "common/status.h"
@@ -1340,11 +1341,8 @@ TEST_F(WorkloadGroupManagerTest, process_mem_exceeded_cancels_after_timeout) {
     ASSERT_TRUE(query->is_cancelled());
     ASSERT_TRUE(query->exec_status().is<ErrorCode::MEM_LIMIT_EXCEEDED>())
             << query->exec_status().to_string();
-    {
-        std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
-        ASSERT_TRUE(!_wg_manager->_paused_queries_list.contains(wg) ||
-                    _wg_manager->_paused_queries_list[wg].empty());
-    }
+    ASSERT_NE(query->exec_status().to_string().find("exceed hard limit: false"), std::string::npos)
+            << query->exec_status().to_string();
 }
 
 // A paused query whose workload group uses no more than its min memory limit is not handled by
@@ -1395,6 +1393,55 @@ TEST_F(WorkloadGroupManagerTest, process_mem_exceeded_below_min_memory_resumes) 
     }
 }
 
+// A paused query whose workload group uses no more than its min memory limit should still be
+// cancelled once it has waited for `spill_in_paused_queue_timeout_ms` under process memory
+// pressure.
+TEST_F(WorkloadGroupManagerTest, process_mem_exceeded_below_min_memory_cancels_after_timeout) {
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    const int64_t original_soft_mem_limit = MemInfo::soft_mem_limit();
+    Defer restore_mem_limit {[&]() {
+        MemInfo::set_mem_limit_for_test(original_mem_limit);
+        MemInfo::set_soft_mem_limit_for_test(original_soft_mem_limit);
+    }};
+    MemInfo::set_mem_limit_for_test(kProcessMemLimitForWg);
+    WorkloadGroupInfo wg_info {.id = 1,
+                               .memory_limit = kProcessMemLimitForWg,
+                               .min_memory_percent = 10,
+                               .max_memory_percent = 100};
+    auto wg = _wg_manager->get_or_create_workload_group(wg_info);
+
+    auto query = _generate_on_query(wg);
+    query->query_mem_tracker()->consume(1024L * 4);
+    Defer release_memory {[&]() { query->query_mem_tracker()->consume(-1024L * 4); }};
+    wg->refresh_memory_usage();
+    ASSERT_LE(wg->total_mem_used(), wg->min_memory_limit());
+
+    MemInfo::set_mem_limit_for_test(kLargeProcessMemLimit);
+    MemInfo::set_soft_mem_limit_for_test(1);
+    _wg_manager->add_paused_query(query->resource_ctx(), 1024L,
+                                  Status::Error(ErrorCode::PROCESS_MEMORY_EXCEEDED, "test"));
+
+    config::spill_in_paused_queue_timeout_ms = 60 * 1000;
+    _wg_manager->handle_paused_queries();
+    ASSERT_FALSE(query->is_cancelled());
+    {
+        std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
+        auto& queries = _wg_manager->_paused_queries_list[wg];
+        ASSERT_EQ(queries.size(), 1);
+        auto node = queries.extract(queries.begin());
+        node.value().enqueue_at -=
+                std::chrono::milliseconds(config::spill_in_paused_queue_timeout_ms + 1);
+        queries.insert(std::move(node));
+    }
+
+    _wg_manager->handle_paused_queries();
+    ASSERT_TRUE(query->is_cancelled());
+    ASSERT_TRUE(query->exec_status().is<ErrorCode::MEM_LIMIT_EXCEEDED>())
+            << query->exec_status().to_string();
+    ASSERT_NE(query->exec_status().to_string().find("exceed hard limit: false"), std::string::npos)
+            << query->exec_status().to_string();
+}
+
 // When the process reaches the hard memory limit, the paused query should be cancelled without
 // waiting for the timeout, so that the protection does not depend on memory gc.
 TEST_F(WorkloadGroupManagerTest, process_mem_exceeded_cancels_at_hard_limit) {
@@ -1428,11 +1475,8 @@ TEST_F(WorkloadGroupManagerTest, process_mem_exceeded_cancels_at_hard_limit) {
     ASSERT_TRUE(query->is_cancelled());
     ASSERT_TRUE(query->exec_status().is<ErrorCode::MEM_LIMIT_EXCEEDED>())
             << query->exec_status().to_string();
-    {
-        std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
-        ASSERT_TRUE(!_wg_manager->_paused_queries_list.contains(wg) ||
-                    _wg_manager->_paused_queries_list[wg].empty());
-    }
+    ASSERT_NE(query->exec_status().to_string().find("exceed hard limit: true"), std::string::npos)
+            << query->exec_status().to_string();
 }
 
 } // namespace doris

--- a/be/test/runtime/workload_group/workload_group_manager_test.cpp
+++ b/be/test/runtime/workload_group/workload_group_manager_test.cpp
@@ -27,6 +27,7 @@
 #include <chrono>
 #include <cmath>
 #include <filesystem>
+#include <limits>
 #include <memory>
 #include <sstream>
 
@@ -1231,6 +1232,12 @@ TEST_F(WorkloadGroupManagerTest, phase4_skips_cancelled_query_memory_exceeded) {
     live_query->query_mem_tracker()->consume(-1024 * 4);
 }
 
+// Helpers for the process memory exceeded cases. The workload group memory limit is derived from
+// the process memory limit, so the process memory limit is set before the workload group is
+// created, and only the soft limit is lowered afterwards to simulate process memory pressure.
+static constexpr int64_t kProcessMemLimitForWg = 1024L * 1024 * 1000;
+static constexpr int64_t kLargeProcessMemLimit = std::numeric_limits<int64_t>::max() / 2;
+
 // When the process memory is exceeded and the paused query has no revocable memory, the query
 // should be kept paused instead of being cancelled immediately, so that it can be resumed once
 // other queries release memory.
@@ -1241,10 +1248,9 @@ TEST_F(WorkloadGroupManagerTest, process_mem_exceeded_keeps_paused_and_resumes) 
         MemInfo::set_mem_limit_for_test(original_mem_limit);
         MemInfo::set_soft_mem_limit_for_test(original_soft_mem_limit);
     }};
-    // The workload group memory limit is derived from the process memory limit.
-    MemInfo::set_mem_limit_for_test(1024L * 1024 * 1000);
+    MemInfo::set_mem_limit_for_test(kProcessMemLimitForWg);
     WorkloadGroupInfo wg_info {.id = 1,
-                               .memory_limit = 1024L * 1024 * 1000,
+                               .memory_limit = kProcessMemLimitForWg,
                                .min_memory_percent = 10,
                                .max_memory_percent = 100};
     auto wg = _wg_manager->get_or_create_workload_group(wg_info);
@@ -1258,8 +1264,8 @@ TEST_F(WorkloadGroupManagerTest, process_mem_exceeded_keeps_paused_and_resumes) 
     ASSERT_EQ(wg->min_memory_limit(), 1024L * 1024 * 100);
     ASSERT_GT(wg->total_mem_used(), wg->min_memory_limit());
 
-    // Process memory is exceeded.
-    MemInfo::set_mem_limit_for_test(1);
+    // Process soft memory limit is exceeded, hard memory limit is not.
+    MemInfo::set_mem_limit_for_test(kLargeProcessMemLimit);
     MemInfo::set_soft_mem_limit_for_test(1);
     _wg_manager->add_paused_query(query->resource_ctx(), 1024L,
                                   Status::Error(ErrorCode::PROCESS_MEMORY_EXCEEDED, "test"));
@@ -1277,7 +1283,6 @@ TEST_F(WorkloadGroupManagerTest, process_mem_exceeded_keeps_paused_and_resumes) 
                         .is<ErrorCode::PROCESS_MEMORY_EXCEEDED>());
 
     // Process memory pressure is relieved, the query should be resumed.
-    MemInfo::set_mem_limit_for_test(original_mem_limit);
     MemInfo::set_soft_mem_limit_for_test(original_soft_mem_limit);
     _wg_manager->handle_paused_queries();
     ASSERT_FALSE(query->is_cancelled());
@@ -1298,10 +1303,9 @@ TEST_F(WorkloadGroupManagerTest, process_mem_exceeded_cancels_after_timeout) {
         MemInfo::set_mem_limit_for_test(original_mem_limit);
         MemInfo::set_soft_mem_limit_for_test(original_soft_mem_limit);
     }};
-    // The workload group memory limit is derived from the process memory limit.
-    MemInfo::set_mem_limit_for_test(1024L * 1024 * 1000);
+    MemInfo::set_mem_limit_for_test(kProcessMemLimitForWg);
     WorkloadGroupInfo wg_info {.id = 1,
-                               .memory_limit = 1024L * 1024 * 1000,
+                               .memory_limit = kProcessMemLimitForWg,
                                .min_memory_percent = 10,
                                .max_memory_percent = 100};
     auto wg = _wg_manager->get_or_create_workload_group(wg_info);
@@ -1313,12 +1317,66 @@ TEST_F(WorkloadGroupManagerTest, process_mem_exceeded_cancels_after_timeout) {
     ASSERT_EQ(wg->min_memory_limit(), 1024L * 1024 * 100);
     ASSERT_GT(wg->total_mem_used(), wg->min_memory_limit());
 
-    MemInfo::set_mem_limit_for_test(1);
+    MemInfo::set_mem_limit_for_test(kLargeProcessMemLimit);
     MemInfo::set_soft_mem_limit_for_test(1);
     _wg_manager->add_paused_query(query->resource_ctx(), 1024L,
                                   Status::Error(ErrorCode::PROCESS_MEMORY_EXCEEDED, "test"));
 
-    config::spill_in_paused_queue_timeout_ms = 200;
+    config::spill_in_paused_queue_timeout_ms = 60 * 1000;
+    _wg_manager->handle_paused_queries();
+    ASSERT_FALSE(query->is_cancelled());
+    {
+        // Backdate the enqueue time instead of sleeping, the timer is monotonic.
+        std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
+        auto& queries = _wg_manager->_paused_queries_list[wg];
+        ASSERT_EQ(queries.size(), 1);
+        auto node = queries.extract(queries.begin());
+        node.value().enqueue_at -=
+                std::chrono::milliseconds(config::spill_in_paused_queue_timeout_ms + 1);
+        queries.insert(std::move(node));
+    }
+
+    _wg_manager->handle_paused_queries();
+    ASSERT_TRUE(query->is_cancelled());
+    ASSERT_TRUE(query->exec_status().is<ErrorCode::MEM_LIMIT_EXCEEDED>())
+            << query->exec_status().to_string();
+    {
+        std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
+        ASSERT_TRUE(!_wg_manager->_paused_queries_list.contains(wg) ||
+                    _wg_manager->_paused_queries_list[wg].empty());
+    }
+}
+
+// A paused query whose workload group uses no more than its min memory limit is not handled by
+// handle_single_query_. It should still be resumed as soon as the process memory pressure is
+// relieved, instead of waiting for the timeout.
+TEST_F(WorkloadGroupManagerTest, process_mem_exceeded_below_min_memory_resumes) {
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    const int64_t original_soft_mem_limit = MemInfo::soft_mem_limit();
+    Defer restore_mem_limit {[&]() {
+        MemInfo::set_mem_limit_for_test(original_mem_limit);
+        MemInfo::set_soft_mem_limit_for_test(original_soft_mem_limit);
+    }};
+    MemInfo::set_mem_limit_for_test(kProcessMemLimitForWg);
+    WorkloadGroupInfo wg_info {.id = 1,
+                               .memory_limit = kProcessMemLimitForWg,
+                               .min_memory_percent = 10,
+                               .max_memory_percent = 100};
+    auto wg = _wg_manager->get_or_create_workload_group(wg_info);
+
+    auto query = _generate_on_query(wg);
+    query->query_mem_tracker()->consume(1024L * 4);
+    Defer release_memory {[&]() { query->query_mem_tracker()->consume(-1024L * 4); }};
+    wg->refresh_memory_usage();
+    ASSERT_EQ(wg->min_memory_limit(), 1024L * 1024 * 100);
+    ASSERT_LE(wg->total_mem_used(), wg->min_memory_limit());
+
+    MemInfo::set_mem_limit_for_test(kLargeProcessMemLimit);
+    MemInfo::set_soft_mem_limit_for_test(1);
+    _wg_manager->add_paused_query(query->resource_ctx(), 1024L,
+                                  Status::Error(ErrorCode::PROCESS_MEMORY_EXCEEDED, "test"));
+
+    config::spill_in_paused_queue_timeout_ms = 60 * 1000;
     _wg_manager->handle_paused_queries();
     ASSERT_FALSE(query->is_cancelled());
     {
@@ -1326,8 +1384,46 @@ TEST_F(WorkloadGroupManagerTest, process_mem_exceeded_cancels_after_timeout) {
         ASSERT_EQ(_wg_manager->_paused_queries_list[wg].size(), 1);
     }
 
-    CountDownLatch latch(1);
-    latch.wait_for(std::chrono::milliseconds(config::spill_in_paused_queue_timeout_ms + 100));
+    MemInfo::set_soft_mem_limit_for_test(original_soft_mem_limit);
+    _wg_manager->handle_paused_queries();
+    ASSERT_FALSE(query->is_cancelled());
+    ASSERT_TRUE(query->resource_ctx()->task_controller()->paused_reason().ok());
+    {
+        std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
+        ASSERT_TRUE(!_wg_manager->_paused_queries_list.contains(wg) ||
+                    _wg_manager->_paused_queries_list[wg].empty());
+    }
+}
+
+// When the process reaches the hard memory limit, the paused query should be cancelled without
+// waiting for the timeout, so that the protection does not depend on memory gc.
+TEST_F(WorkloadGroupManagerTest, process_mem_exceeded_cancels_at_hard_limit) {
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    const int64_t original_soft_mem_limit = MemInfo::soft_mem_limit();
+    Defer restore_mem_limit {[&]() {
+        MemInfo::set_mem_limit_for_test(original_mem_limit);
+        MemInfo::set_soft_mem_limit_for_test(original_soft_mem_limit);
+    }};
+    MemInfo::set_mem_limit_for_test(kProcessMemLimitForWg);
+    WorkloadGroupInfo wg_info {.id = 1,
+                               .memory_limit = kProcessMemLimitForWg,
+                               .min_memory_percent = 10,
+                               .max_memory_percent = 100};
+    auto wg = _wg_manager->get_or_create_workload_group(wg_info);
+
+    auto query = _generate_on_query(wg);
+    query->query_mem_tracker()->consume(1024L * 1024 * 128);
+    Defer release_memory {[&]() { query->query_mem_tracker()->consume(-1024L * 1024 * 128); }};
+    wg->refresh_memory_usage();
+    ASSERT_GT(wg->total_mem_used(), wg->min_memory_limit());
+
+    // Both the soft and the hard process memory limits are exceeded.
+    MemInfo::set_mem_limit_for_test(0);
+    MemInfo::set_soft_mem_limit_for_test(0);
+    _wg_manager->add_paused_query(query->resource_ctx(), 1024L,
+                                  Status::Error(ErrorCode::PROCESS_MEMORY_EXCEEDED, "test"));
+
+    config::spill_in_paused_queue_timeout_ms = 60 * 1000;
     _wg_manager->handle_paused_queries();
     ASSERT_TRUE(query->is_cancelled());
     ASSERT_TRUE(query->exec_status().is<ErrorCode::MEM_LIMIT_EXCEEDED>())

--- a/be/test/runtime/workload_group/workload_group_manager_test.cpp
+++ b/be/test/runtime/workload_group/workload_group_manager_test.cpp
@@ -1231,4 +1231,112 @@ TEST_F(WorkloadGroupManagerTest, phase4_skips_cancelled_query_memory_exceeded) {
     live_query->query_mem_tracker()->consume(-1024 * 4);
 }
 
+// When the process memory is exceeded and the paused query has no revocable memory, the query
+// should be kept paused instead of being cancelled immediately, so that it can be resumed once
+// other queries release memory.
+TEST_F(WorkloadGroupManagerTest, process_mem_exceeded_keeps_paused_and_resumes) {
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    const int64_t original_soft_mem_limit = MemInfo::soft_mem_limit();
+    Defer restore_mem_limit {[&]() {
+        MemInfo::set_mem_limit_for_test(original_mem_limit);
+        MemInfo::set_soft_mem_limit_for_test(original_soft_mem_limit);
+    }};
+    // The workload group memory limit is derived from the process memory limit.
+    MemInfo::set_mem_limit_for_test(1024L * 1024 * 1000);
+    WorkloadGroupInfo wg_info {.id = 1,
+                               .memory_limit = 1024L * 1024 * 1000,
+                               .min_memory_percent = 10,
+                               .max_memory_percent = 100};
+    auto wg = _wg_manager->get_or_create_workload_group(wg_info);
+
+    auto query = _generate_on_query(wg);
+    // Let the workload group use more than its min memory limit, so that the paused query is
+    // handled by handle_single_query_ directly instead of waiting for other workload groups.
+    query->query_mem_tracker()->consume(1024L * 1024 * 128);
+    Defer release_memory {[&]() { query->query_mem_tracker()->consume(-1024L * 1024 * 128); }};
+    wg->refresh_memory_usage();
+    ASSERT_EQ(wg->min_memory_limit(), 1024L * 1024 * 100);
+    ASSERT_GT(wg->total_mem_used(), wg->min_memory_limit());
+
+    // Process memory is exceeded.
+    MemInfo::set_mem_limit_for_test(1);
+    MemInfo::set_soft_mem_limit_for_test(1);
+    _wg_manager->add_paused_query(query->resource_ctx(), 1024L,
+                                  Status::Error(ErrorCode::PROCESS_MEMORY_EXCEEDED, "test"));
+
+    config::spill_in_paused_queue_timeout_ms = 60 * 1000;
+    for (int i = 0; i < 3; ++i) {
+        _wg_manager->handle_paused_queries();
+        ASSERT_FALSE(query->is_cancelled());
+        std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
+        ASSERT_EQ(_wg_manager->_paused_queries_list[wg].size(), 1);
+    }
+    ASSERT_TRUE(query->resource_ctx()
+                        ->task_controller()
+                        ->paused_reason()
+                        .is<ErrorCode::PROCESS_MEMORY_EXCEEDED>());
+
+    // Process memory pressure is relieved, the query should be resumed.
+    MemInfo::set_mem_limit_for_test(original_mem_limit);
+    MemInfo::set_soft_mem_limit_for_test(original_soft_mem_limit);
+    _wg_manager->handle_paused_queries();
+    ASSERT_FALSE(query->is_cancelled());
+    ASSERT_TRUE(query->resource_ctx()->task_controller()->paused_reason().ok());
+    {
+        std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
+        ASSERT_TRUE(!_wg_manager->_paused_queries_list.contains(wg) ||
+                    _wg_manager->_paused_queries_list[wg].empty());
+    }
+}
+
+// When the process memory is still exceeded after the paused query has waited for
+// `spill_in_paused_queue_timeout_ms`, the query should be cancelled.
+TEST_F(WorkloadGroupManagerTest, process_mem_exceeded_cancels_after_timeout) {
+    const int64_t original_mem_limit = MemInfo::mem_limit();
+    const int64_t original_soft_mem_limit = MemInfo::soft_mem_limit();
+    Defer restore_mem_limit {[&]() {
+        MemInfo::set_mem_limit_for_test(original_mem_limit);
+        MemInfo::set_soft_mem_limit_for_test(original_soft_mem_limit);
+    }};
+    // The workload group memory limit is derived from the process memory limit.
+    MemInfo::set_mem_limit_for_test(1024L * 1024 * 1000);
+    WorkloadGroupInfo wg_info {.id = 1,
+                               .memory_limit = 1024L * 1024 * 1000,
+                               .min_memory_percent = 10,
+                               .max_memory_percent = 100};
+    auto wg = _wg_manager->get_or_create_workload_group(wg_info);
+
+    auto query = _generate_on_query(wg);
+    query->query_mem_tracker()->consume(1024L * 1024 * 128);
+    Defer release_memory {[&]() { query->query_mem_tracker()->consume(-1024L * 1024 * 128); }};
+    wg->refresh_memory_usage();
+    ASSERT_EQ(wg->min_memory_limit(), 1024L * 1024 * 100);
+    ASSERT_GT(wg->total_mem_used(), wg->min_memory_limit());
+
+    MemInfo::set_mem_limit_for_test(1);
+    MemInfo::set_soft_mem_limit_for_test(1);
+    _wg_manager->add_paused_query(query->resource_ctx(), 1024L,
+                                  Status::Error(ErrorCode::PROCESS_MEMORY_EXCEEDED, "test"));
+
+    config::spill_in_paused_queue_timeout_ms = 200;
+    _wg_manager->handle_paused_queries();
+    ASSERT_FALSE(query->is_cancelled());
+    {
+        std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
+        ASSERT_EQ(_wg_manager->_paused_queries_list[wg].size(), 1);
+    }
+
+    CountDownLatch latch(1);
+    latch.wait_for(std::chrono::milliseconds(config::spill_in_paused_queue_timeout_ms + 100));
+    _wg_manager->handle_paused_queries();
+    ASSERT_TRUE(query->is_cancelled());
+    ASSERT_TRUE(query->exec_status().is<ErrorCode::MEM_LIMIT_EXCEEDED>())
+            << query->exec_status().to_string();
+    {
+        std::unique_lock<std::mutex> lock(_wg_manager->_paused_queries_lock);
+        ASSERT_TRUE(!_wg_manager->_paused_queries_list.contains(wg) ||
+                    _wg_manager->_paused_queries_list[wg].empty());
+    }
+}
+
 } // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: #62485

Problem Summary:

When a query is paused because of `PROCESS_MEMORY_EXCEEDED` and it has no
revocable memory, `WorkloadGroupMgr::handle_single_query_()` cancelled it
immediately if the process was still above the soft memory limit. The
memory maintenance thread runs every 50ms by default, so a query that just
finished spilling everything it could was cancelled about 50-100ms later,
even when it only used a few dozen MiB and cancelling it did not relieve
the process memory pressure at all.

The timeout fallback added by #62485 in `handle_process_memory_exceeded_()`
only applies when the workload group uses less than its min memory limit.
With the default `min_memory_percent = 0` that branch is never reached,
and the query goes straight to `handle_single_query_()`, which cancels it
at once.

This PR makes the process memory branch of `handle_single_query_()` keep
the query paused until it has waited `spill_in_paused_queue_timeout_ms`,
re-checking the soft memory limit every round so the query resumes as soon
as other queries release memory. The query is cancelled only after the
timeout. Memory gc still cancels queries when the process reaches the hard
memory limit, so the wait is bounded.

The cancellation message is also fixed: it claimed to "disable reserve
memory and resume" the query while it actually cancelled it.

### Release note

Queries paused under process memory pressure without revocable memory now
wait up to `spill_in_paused_queue_timeout_ms` for memory to be released
before being cancelled.

### Check List (For Author)

- Test
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
- Behavior changed:
    - [ ] No.
    - [x] Yes. Queries paused due to process memory exceeded are kept paused until `spill_in_paused_queue_timeout_ms` instead of being cancelled immediately when no memory can be revoked.
- Does this need documentation?
    - [x] No.
    - [ ] Yes.

https://claude.ai/code/session_014c64WZPFui9AyvVMiseceY
