### PR TITLE
[fix](build) Fix ASAN getentropy crash on glibc 2.17

### DIFF
--- a/be/src/glibc-compatibility/CMakeLists.txt
+++ b/be/src/glibc-compatibility/CMakeLists.txt
@@ -45,9 +45,6 @@ if (GLIBC_COMPATIBILITY)
     endif ()
 
     list(REMOVE_ITEM glibc_compatibility_sources musl/getentropy.c)
-    if(HAVE_SYS_RANDOM_H)
-        list(APPEND glibc_compatibility_sources musl/getentropy.c)
-    endif()
 
     # lance_c is linked after this archive and introduces these libc references
     # too late for another archive scan. Keep the hidden version adapters in the
@@ -82,6 +79,16 @@ if (GLIBC_COMPATIBILITY)
             ${MEMCPY_SOURCE}
             ${lance_compatibility_source}
         )
+    endif()
+    if(HAVE_SYS_RANDOM_H)
+        # ASAN's weak getentropy interceptor prevents extracting our implementation
+        # from the static archive. Link it explicitly so calls do not reach a null
+        # real_getentropy on glibc < 2.25.
+        target_sources(glibc-compatibility-explicit PRIVATE musl/getentropy.c)
+        if (COMPILER_CLANG)
+            # Preserve the warning policy previously supplied by the archive target.
+            set_source_files_properties(musl/getentropy.c PROPERTIES COMPILE_OPTIONS -Wno-conversion)
+        endif()
     endif()
     target_compile_options(glibc-compatibility-explicit PRIVATE -fPIC)
     add_library(glibc-compatibility STATIC ${glibc_compatibility_sources})


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #67752

Problem Summary:

BE unit tests can crash at address zero while Arrow Flight initializes Abseil random seeds on CentOS 7 (glibc 2.17). ASAN's weak `getentropy` interceptor satisfies the reference before the linker scans `libglibc-compatibility.a`, so Doris' compatibility implementation is not extracted. Since glibc 2.17 has no `getentropy`, the interceptor calls a null `real_getentropy` pointer. Restoring the CentOS 7 CI image exposed this existing gap.

Link the existing `musl/getentropy.c` through `glibc-compatibility-explicit`, just like `getrandom`. Preserve the existing `HAVE_SYS_RANDOM_H` guard, ARM ASAN `memcpy` exclusion, and this source file's Clang conversion-warning policy. The C implementation and Flight cancellation logic are unchanged.

### Release note

None

### Check List (For Author)

- Test
    - [ ] Regression test
    - [ ] Unit Test
    - [x] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason
- Behavior changed:
    - [ ] No.
    - [x] Yes. 
- Does this need documentation?
    - [x] No.
    - [ ] Yes.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label
