### PR TITLE
[fix](cast) Check Decimal256 bounds after floating-point conversion

### DIFF
--- a/be/src/exprs/function/cast/cast_to_decimal.h
+++ b/be/src/exprs/function/cast/cast_to_decimal.h
@@ -257,6 +257,16 @@ struct CastToDecimal {
         }
         to.value = static_cast<typename ToCppT::NativeType>(static_cast<double>(
                 from * static_cast<DoubleType>(scale_multiplier) + ((from >= 0) ? 0.5 : -0.5)));
+        if constexpr (IsDecimal256<ToCppT>) {
+            // Floating-point rounding can let an out-of-range value pass the check above.
+            if (to.value < min_result || to.value > max_result) {
+                if (params.is_strict) {
+                    params.status = DECIMAL_CONVERT_OVERFLOW_ERROR(from, "float/double",
+                                                                   to_precision, to_scale);
+                }
+                return false;
+            }
+        }
         return true;
     }
 

--- a/be/test/exprs/function/cast/cast_to_decimal256_from_double_overflow.cpp
+++ b/be/test/exprs/function/cast/cast_to_decimal256_from_double_overflow.cpp
@@ -48,6 +48,10 @@ TEST_F(FunctionCastToDecimalTest, test_to_decimal256_from_double_overflow) {
     from_float_double_overflow_test_func<TYPE_DOUBLE, Decimal256>(
             76, 75, table_index++, test_data_index, ofs_case, ofs_expected_result, ofs_const_case,
             ofs_const_expected_result);
+    // +/-10 passes the floating-point check on x86, but the resulting Int256 is out of range.
+    from_float_double_overflow_test_func<TYPE_DOUBLE, Decimal256>(
+            48, 47, table_index++, test_data_index, ofs_case, ofs_expected_result, ofs_const_case,
+            ofs_const_expected_result);
     if (FLAGS_gen_regression_case) {
         (*ofs_const_case) << "}";
         (*ofs_case) << "}";

--- a/be/test/exprs/function/cast/cast_to_decimal256_from_float_overflow.cpp
+++ b/be/test/exprs/function/cast/cast_to_decimal256_from_float_overflow.cpp
@@ -48,6 +48,10 @@ TEST_F(FunctionCastToDecimalTest, test_to_decimal256_from_float_overflow) {
     from_float_double_overflow_test_func<TYPE_FLOAT, Decimal256>(
             76, 75, table_index++, test_data_index, ofs_case, ofs_expected_result, ofs_const_case,
             ofs_const_expected_result);
+    // +/-10 passes the floating-point check on x86, but the resulting Int256 is out of range.
+    from_float_double_overflow_test_func<TYPE_FLOAT, Decimal256>(
+            48, 47, table_index++, test_data_index, ofs_case, ofs_expected_result, ofs_const_case,
+            ofs_const_expected_result);
     if (FLAGS_gen_regression_case) {
         (*ofs_const_case) << "}";
         (*ofs_case) << "}";

--- a/be/test/exprs/function/cast/cast_to_decimal_test.h
+++ b/be/test/exprs/function/cast/cast_to_decimal_test.h
@@ -1459,6 +1459,17 @@ struct FunctionCastToDecimalTest : public FunctionCastTest {
                         v.value = typename T::NativeType(static_cast<double>(
                                 float_value * static_cast<DoubleType>(multiplier) +
                                 ((float_value >= 0) ? 0.5 : -0.5)));
+                        if constexpr (IsDecimal256<T>) {
+                            // Rounding can produce an integer outside the declared decimal range.
+                            if (v.value < min_result || v.value > max_result) {
+                                data_set.push_back({{float_value}, Null()});
+                                DataSet overflow_data_set = {{{float_value}, Null()}};
+                                check_function_for_cast<DataTypeDecimal<T::PType>, true>(
+                                        input_types, overflow_data_set, scale, precision, true,
+                                        true);
+                                continue;
+                            }
+                        }
                         data_set.push_back({{float_value}, v});
                         // dbg_str += fmt::format("({:f}, {})|", float_value, dt_to.to_string(v));
 


### PR DESCRIPTION

Casting float/double values of +/-10 to DECIMAL(76,75) can miss overflow on ARM. Root cause: floating-point rounding can bypass the initial bounds check. Check the final Int256 value against the exact decimal bounds, returning NULL in non-strict mode or an overflow error in strict mode. This check applies only to Decimal256.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

