### PR TITLE
[fix](build) Fix Lance-C compilation in the CentOS 7 image

### DIFF
--- a/docker/compilation/Dockerfile
+++ b/docker/compilation/Dockerfile
@@ -112,10 +112,16 @@ RUN rm -f /etc/profile.d/ccache.* \
 # Install the Rust toolchain required by Lance-C.
 ENV CARGO_HOME=/opt/cargo RUSTUP_HOME=/opt/rustup
 ENV PATH="/opt/cargo/bin:${PATH}"
+# The CI compile pipeline installs rustup inside this image and then runs
+# `source ~/.cargo/env` in an `&&` chain. With CARGO_HOME relocated to /opt/cargo,
+# rustup-init writes /opt/cargo/env and ~/.cargo/env never exists, so that `source`
+# fails and the chain aborts before anything is built. Keep the default path valid.
 RUN wget -q https://sh.rustup.rs -O /tmp/rustup-init.sh \
     && sh /tmp/rustup-init.sh -y --no-modify-path --profile minimal --default-toolchain 1.91.0 \
     && rm -f /tmp/rustup-init.sh \
-    && cargo --version && rustc --version
+    && mkdir -p /root/.cargo \
+    && ln -sf "${CARGO_HOME}/env" /root/.cargo/env \
+    && bash -c 'source ~/.cargo/env && cargo --version && rustc --version'
 
 # clone lastest source code, download and build third party
 COPY doris ${DEFAULT_DIR}/doris

--- a/docker/compilation/Dockerfile
+++ b/docker/compilation/Dockerfile
@@ -140,6 +140,7 @@ ENV JAVA_HOME="/usr/lib/jvm/jdk-17.0.2/" \
     DEFAULT_DIR="/var/local" \
     CARGO_HOME="/opt/cargo" \
     RUSTUP_HOME="/opt/rustup" \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="/usr/bin/gcc" \
     PATH="/opt/cargo/bin:/usr/local/bin:/var/local/ldb-toolchain/bin/:/var/local/thirdparty/installed/bin/:/usr/lib/jvm/jdk-17.0.2/bin/:$PATH" \
     DORIS_THIRDPARTY="/var/local/thirdparty"
 WORKDIR /root

--- a/docker/compilation/Dockerfile
+++ b/docker/compilation/Dockerfile
@@ -124,6 +124,7 @@ COPY doris ${DEFAULT_DIR}/doris
 RUN cd ${DEFAULT_DIR}/doris \
     && CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/gcc \
        /bin/bash thirdparty/build-thirdparty.sh \
+    && rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" \
     && rm -rf ${DEFAULT_DIR}/doris/thirdparty/src \
     && rm -rf ${DEFAULT_DIR}/doris-thirdparty.tar.gz \
     && rm -rf ${DEFAULT_DIR}/doris-thirdparty \

--- a/docker/compilation/Dockerfile
+++ b/docker/compilation/Dockerfile
@@ -25,7 +25,13 @@ RUN sed -i \
   /etc/yum.repos.d/*.repo
 
 # install epel repo for ccache
-RUN yum install epel-release -y && yum install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm -y && yum clean all && yum makecache
+# EPEL 7 is EOL; use its archive instead of the retired metalink.
+RUN yum install epel-release -y \
+    && sed -i -e 's|^metalink=|#metalink=|' \
+       -e 's|^#baseurl=.*/pub/epel/7/|baseurl=https://archives.fedoraproject.org/pub/archive/epel/7/|' \
+       /etc/yum.repos.d/epel.repo \
+    && yum install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm -y \
+    && yum clean all && yum makecache
 
 # install dependencies
 RUN yum install -y byacc patch automake libtool perf vim make which file ncurses-devel gettext-devel unzip bzip2 zip util-linux \
@@ -103,9 +109,21 @@ RUN wget https://doris-community-bj-1308700295.cos.ap-beijing.myqcloud.com/tools
 RUN rm -f /etc/profile.d/ccache.* \
     && cp /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
 
+# Install the Rust toolchain required by Lance-C.
+ENV CARGO_HOME=/opt/cargo RUSTUP_HOME=/opt/rustup
+ENV PATH="/opt/cargo/bin:${PATH}"
+RUN wget -q https://sh.rustup.rs -O /tmp/rustup-init.sh \
+    && sh /tmp/rustup-init.sh -y --no-modify-path --profile minimal --default-toolchain 1.91.0 \
+    && rm -f /tmp/rustup-init.sh \
+    && cargo --version && rustc --version
+
 # clone lastest source code, download and build third party
 COPY doris ${DEFAULT_DIR}/doris
-RUN cd ${DEFAULT_DIR}/doris && /bin/bash thirdparty/build-thirdparty.sh \
+# Cargo build scripts run on CentOS 7. The LDB linker introduces a
+# GLIBC_2.18 dependency; use system GCC for Rust linking and retain LDB for C/C++.
+RUN cd ${DEFAULT_DIR}/doris \
+    && CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/gcc \
+       /bin/bash thirdparty/build-thirdparty.sh \
     && rm -rf ${DEFAULT_DIR}/doris/thirdparty/src \
     && rm -rf ${DEFAULT_DIR}/doris-thirdparty.tar.gz \
     && rm -rf ${DEFAULT_DIR}/doris-thirdparty \
@@ -120,7 +138,9 @@ ENV JAVA_HOME="/usr/lib/jvm/jdk-17.0.2/" \
     MAVEN_HOME="/usr/share/maven" \
     REPOSITORY_URL="https://doris-thirdparty-repo.bj.bcebos.com/thirdparty" \
     DEFAULT_DIR="/var/local" \
-    PATH="/usr/local/bin:/var/local/ldb-toolchain/bin/:/var/local/thirdparty/installed/bin/:/usr/lib/jvm/jdk-17.0.2/bin/:$PATH" \
+    CARGO_HOME="/opt/cargo" \
+    RUSTUP_HOME="/opt/rustup" \
+    PATH="/opt/cargo/bin:/usr/local/bin:/var/local/ldb-toolchain/bin/:/var/local/thirdparty/installed/bin/:/usr/lib/jvm/jdk-17.0.2/bin/:$PATH" \
     DORIS_THIRDPARTY="/var/local/thirdparty"
 WORKDIR /root
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Building the compilation image fails when EPEL 7 uses its retired metalink. After resolving the repository, Lance-C requires Rust 1.91.0, and Cargo build-script executables linked with the LDB toolchain require GLIBC_2.18, which CentOS 7 does not provide.

Use the EPEL 7 archive, install Rust 1.91.0, and select system GCC for Cargo linking during the thirdparty build while retaining LDB for native C/C++ compilation. Preserve the Rust installation paths in the final squashed image.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

- Behavior changed:
    - [ ] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [ ] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label <!-- Add branch pick label that this PR should merge into -->

