### PR TITLE
[fix](variant) Stream V2 subcolumn writer after buffer threshold

### DIFF
--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1201,6 +1201,7 @@ DEFINE_mBool(variant_enable_duplicate_json_path_check, "false");
 DEFINE_mInt32(variant_storage_parse_mode, "0");
 DEFINE_mBool(enable_vertical_compact_variant_subcolumns, "true");
 DEFINE_mBool(enable_variant_doc_sparse_write_subcolumns, "true");
+DEFINE_mInt64(variant_subcolumn_stream_write_threshold_bytes, "2147483648");
 // Maximum depth of nested arrays to track with NestedGroup
 // Reserved for future use when NestedGroup expansion moves to storage layer
 // Deeper arrays will be stored as JSONB

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1560,6 +1560,9 @@ DECLARE_mInt32(variant_storage_parse_mode);
 // Enable vertical compact subcolumns of variant column
 DECLARE_mBool(enable_vertical_compact_variant_subcolumns);
 DECLARE_mBool(enable_variant_doc_sparse_write_subcolumns);
+// Once a V2 Variant extracted subcolumn buffers more bytes than this in one segment, its storage
+// type is locked and the remaining rows are written in a streaming way instead of being buffered.
+DECLARE_mInt64(variant_subcolumn_stream_write_threshold_bytes);
 // When true, discard scalar data that conflicts with NestedGroup array<object>
 // data at the same path. This simplifies compaction by always prioritizing
 // nested structure over scalar. When false, report an error on conflict.

--- a/be/src/storage/segment/column_writer.h
+++ b/be/src/storage/segment/column_writer.h
@@ -652,6 +652,11 @@ private:
                       std::span<const uint8_t> outer_nulls);
     Status _ensure_input_format(const VariantColumnData& column);
     Status _initialize_v2_builder();
+    DataTypePtr _v2_storage_type(const TabletColumn& parent_column) const;
+    Result<bool> _prepare_v2_values(const DataTypePtr& storage_type);
+    Status _create_flush_writer(const TabletColumn& parent_column, const DataTypePtr& flush_type,
+                                int64_t non_null_value_size);
+    Status _flush_v2_chunk();
     bool is_finalized() const;
     bool _is_finalized = false;
     ordinal_t _next_rowid = 0;
@@ -660,6 +665,10 @@ private:
     ColumnVariant::MutablePtr _v1_column;
     std::unique_ptr<VariantPathBuilder> _v2_builder;
     size_t _num_rows = 0;
+    size_t _flushed_rows = 0;
+    DataTypePtr _storage_type;
+    DataTypePtr _stream_type;
+    TabletColumnPtr _flush_column;
     ColumnWriterOptions _opts;
     std::unique_ptr<ColumnWriter> _writer;
     TabletIndexes _indexes;

--- a/be/src/storage/segment/variant/variant_column_writer_impl.cpp
+++ b/be/src/storage/segment/variant/variant_column_writer_impl.cpp
@@ -1989,7 +1989,7 @@ Status VariantSubcolumnWriter::_append_v2(const VariantColumnData& column, size_
             const size_t input_row = begin + offset;
             const VariantRef value = view.value_at(input_row);
             if (!value.is_null()) {
-                RETURN_IF_ERROR(_v2_builder->append(value, _num_rows + offset));
+                RETURN_IF_ERROR(_v2_builder->append(value, _num_rows - _flushed_rows + offset));
             }
         }
         return Status::OK();
@@ -2033,6 +2033,11 @@ Status VariantSubcolumnWriter::_append(const uint8_t* null_map, const uint8_t** 
     }
     _num_rows += num_rows;
     _next_rowid += num_rows;
+    if (_input_format == VariantWriterInputFormat::V2 &&
+        (_writer != nullptr || cast_set<int64_t>(_v2_builder->byte_size()) >
+                                       config::variant_subcolumn_stream_write_threshold_bytes)) {
+        RETURN_IF_ERROR(_flush_v2_chunk());
+    }
     return Status::OK();
 }
 
@@ -2045,13 +2050,91 @@ uint64_t VariantSubcolumnWriter::estimate_buffer_size() {
         return _writer ? _writer->estimate_buffer_size() : 0;
     }
     if (_input_format == VariantWriterInputFormat::V2) {
-        return _v2_builder->byte_size();
+        return _v2_builder->byte_size() + (_writer ? _writer->estimate_buffer_size() : 0);
     }
     return _v1_column->byte_size();
 }
 
 bool VariantSubcolumnWriter::is_finalized() const {
     return _is_finalized;
+}
+
+static bool should_record_none_null_value_size(const TabletColumn& column) {
+    return !column.path_info_ptr()->get_is_typed() && !column.path_info_ptr()->has_nested_part();
+}
+
+DataTypePtr VariantSubcolumnWriter::_v2_storage_type(const TabletColumn& parent_column) const {
+    TabletSchema::SubColumnInfo subcolumn_info;
+    if (!variant_util::generate_sub_column_info(*_opts.rowset_ctx->tablet_schema,
+                                                parent_column.unique_id(),
+                                                _v2_builder->path().get_path(), &subcolumn_info)) {
+        return nullptr;
+    }
+    return DataTypeFactory::instance().create_data_type(subcolumn_info.column);
+}
+
+Result<bool> VariantSubcolumnWriter::_prepare_v2_values(const DataTypePtr& storage_type) {
+    if (_v2_builder->non_null_rows() == 0) {
+        return false;
+    }
+    RETURN_IF_ERROR_RESULT(
+            _v2_builder->convert_to(normalize_variant_path_integer_widths(_v2_builder->type())));
+    if (variant_path_type_contains_nothing(_v2_builder->type()) &&
+        (storage_type == nullptr || variant_path_type_contains_nothing(storage_type))) {
+        return false;
+    }
+    if (storage_type != nullptr) {
+        RETURN_IF_ERROR_RESULT(_v2_builder->convert_to(storage_type));
+    }
+    return true;
+}
+
+Status VariantSubcolumnWriter::_create_flush_writer(const TabletColumn& parent_column,
+                                                    const DataTypePtr& flush_type,
+                                                    int64_t non_null_value_size) {
+    _flush_column = std::make_shared<TabletColumn>(variant_util::get_column_by_type(
+            flush_type, get_column()->name(),
+            variant_util::ExtraInfo {.unique_id = -1,
+                                     .parent_unique_id = get_column()->parent_unique_id(),
+                                     .path_info = *get_column()->path_info_ptr()}));
+    const bool record_none_null_value_size = should_record_none_null_value_size(*_flush_column);
+    ColumnWriterOptions opts = _opts;
+    variant_util::inherit_column_attributes(parent_column, *_flush_column);
+    RETURN_IF_ERROR(variant_writer_helpers::create_column_writer(
+            0, *_flush_column, _opts.rowset_ctx->tablet_schema, _opts.index_file_writer, &_writer,
+            _indexes, &opts, non_null_value_size, record_none_null_value_size));
+    _opts = opts;
+    return Status::OK();
+}
+
+// Locks the storage type (predefined type or JSONB) and writes the buffered V2 rows through _writer.
+Status VariantSubcolumnWriter::_flush_v2_chunk() {
+    const auto& parent_column =
+            _opts.rowset_ctx->tablet_schema->column_by_uid(get_column()->parent_unique_id());
+    if (_writer == nullptr) {
+        DORIS_CHECK(!parent_column.variant_enable_nested_group());
+        _storage_type = _v2_storage_type(parent_column);
+        _stream_type = make_nullable(_storage_type != nullptr ? _storage_type
+                                                              : std::make_shared<DataTypeJsonb>());
+        RETURN_IF_ERROR(_create_flush_writer(parent_column, _stream_type, 0));
+    }
+    const size_t chunk_rows = _num_rows - _flushed_rows;
+    RETURN_IF_ERROR(_v2_builder->complete_rows(chunk_rows));
+    const bool publish = DORIS_TRY(_prepare_v2_values(_storage_type));
+    ColumnPtr values = _stream_type->create_column();
+    std::span<const uint32_t> rowids;
+    if (publish) {
+        RETURN_IF_ERROR(_v2_builder->convert_to(_stream_type));
+        values = _v2_builder->column();
+        rowids = _v2_builder->rowids();
+    }
+    RETURN_IF_ERROR(write_variant_subcolumn_values(_input_format, *_flush_column, _writer.get(),
+                                                   _stream_type, values, rowids, chunk_rows));
+    none_null_size += rowids.size();
+    _flushed_rows = _num_rows;
+    _v2_builder =
+            std::make_unique<VariantPathBuilder>(get_column()->path_info_ptr()->copy_pop_front());
+    return Status::OK();
 }
 
 Status VariantSubcolumnWriter::finalize() {
@@ -2064,6 +2147,17 @@ Status VariantSubcolumnWriter::finalize() {
     const auto& parent_column =
             _opts.rowset_ctx->tablet_schema->column_by_uid(get_column()->parent_unique_id());
     DORIS_CHECK(!parent_column.variant_enable_nested_group());
+
+    if (_writer != nullptr) {
+        RETURN_IF_ERROR(_flush_v2_chunk());
+        _v2_builder.reset();
+        if (should_record_none_null_value_size(*_flush_column)) {
+            _opts.meta->set_none_null_size(none_null_size);
+        }
+        _opts.meta->set_num_rows(_num_rows);
+        _is_finalized = true;
+        return Status::OK();
+    }
 
     DataTypePtr flush_type;
     ColumnPtr flush_values;
@@ -2086,25 +2180,7 @@ Status VariantSubcolumnWriter::finalize() {
     } else {
         DORIS_CHECK(_v2_builder != nullptr);
         RETURN_IF_ERROR(_v2_builder->complete_rows(_num_rows));
-        DataTypePtr storage_type;
-        TabletSchema::SubColumnInfo subcolumn_info;
-        if (variant_util::generate_sub_column_info(
-                    *_opts.rowset_ctx->tablet_schema, parent_column.unique_id(),
-                    _v2_builder->path().get_path(), &subcolumn_info)) {
-            storage_type = DataTypeFactory::instance().create_data_type(subcolumn_info.column);
-        }
-
-        bool publish_builder = _v2_builder->non_null_rows() != 0;
-        if (publish_builder) {
-            RETURN_IF_ERROR(_v2_builder->convert_to(
-                    normalize_variant_path_integer_widths(_v2_builder->type())));
-            publish_builder =
-                    !variant_path_type_contains_nothing(_v2_builder->type()) ||
-                    (storage_type != nullptr && !variant_path_type_contains_nothing(storage_type));
-        }
-        if (publish_builder && storage_type != nullptr) {
-            RETURN_IF_ERROR(_v2_builder->convert_to(storage_type));
-        }
+        const bool publish_builder = DORIS_TRY(_prepare_v2_values(_v2_storage_type(parent_column)));
 
         if (!publish_builder) {
             flush_type = DataTypeFactory::instance().create_data_type(PrimitiveType::TYPE_TINYINT,
@@ -2121,23 +2197,8 @@ Status VariantSubcolumnWriter::finalize() {
         _v2_builder.reset();
     }
 
-    TabletColumn flush_column = variant_util::get_column_by_type(
-            flush_type, get_column()->name(),
-            variant_util::ExtraInfo {.unique_id = -1,
-                                     .parent_unique_id = get_column()->parent_unique_id(),
-                                     .path_info = *get_column()->path_info_ptr()});
-
-    bool need_record_none_null_value_size = (!flush_column.path_info_ptr()->get_is_typed()) &&
-                                            !flush_column.path_info_ptr()->has_nested_part();
-    ColumnWriterOptions opts = _opts;
-
-    variant_util::inherit_column_attributes(parent_column, flush_column);
-    RETURN_IF_ERROR(variant_writer_helpers::create_column_writer(
-            0, flush_column, _opts.rowset_ctx->tablet_schema, _opts.index_file_writer, &_writer,
-            _indexes, &opts, non_null_value_size, need_record_none_null_value_size));
-
-    _opts = opts;
-    RETURN_IF_ERROR(write_variant_subcolumn_values(_input_format, flush_column, _writer.get(),
+    RETURN_IF_ERROR(_create_flush_writer(parent_column, flush_type, non_null_value_size));
+    RETURN_IF_ERROR(write_variant_subcolumn_values(_input_format, *_flush_column, _writer.get(),
                                                    flush_type, flush_values, flush_rowids,
                                                    _num_rows));
     _opts.meta->set_num_rows(_num_rows);

--- a/be/test/storage/variant/variant_column_writer_reader_test.cpp
+++ b/be/test/storage/variant/variant_column_writer_reader_test.cpp
@@ -20,6 +20,7 @@
 #include <atomic>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
 #include <mutex>
 #include <optional>
 #include <ranges>
@@ -1748,7 +1749,8 @@ protected:
 
     Status write_extracted_variant_segment(const ColumnPtr& source, const DataTypePtr& source_type,
                                            std::string_view rowset_id, SegmentFooterPB* footer,
-                                           std::string* file_path, size_t first_batch_rows = 0) {
+                                           std::string* file_path, size_t first_batch_rows = 0,
+                                           const std::function<void()>& after_batch = {}) {
         DORIS_CHECK(source.get() != nullptr);
         DORIS_CHECK(source_type != nullptr);
         DORIS_CHECK(footer != nullptr);
@@ -1791,6 +1793,9 @@ protected:
             DORIS_CHECK(accessor != nullptr);
             RETURN_IF_ERROR(writer->append(accessor->get_nullmap(), accessor->get_data(), rows));
             converter.clear_source_content(0);
+            if (after_batch) {
+                after_batch();
+            }
             return Status::OK();
         };
         if (first_batch_rows > 0 && first_batch_rows < source->size()) {
@@ -2981,6 +2986,122 @@ TEST_F(VariantColumnWriterReaderTest,
                               "{}",
                               "NULL",
                       }));
+}
+
+TEST_F(VariantColumnWriterReaderTest,
+       v2_extracted_subcolumn_writer_streams_after_buffer_threshold) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(KeysType::DUP_KEYS);
+    construct_column(schema_pb.add_column(), 1, "VARIANT", "v", 1);
+    _tablet_schema = std::make_shared<TabletSchema>();
+    _tablet_schema->init_from_pb(schema_pb);
+    const TabletColumn& parent_column = _tablet_schema->column_by_uid(1);
+    TabletColumn extracted_column;
+    extracted_column.set_name(parent_column.name_lower_case() + ".payload");
+    extracted_column.set_type(FieldType::OLAP_FIELD_TYPE_VARIANT);
+    extracted_column.set_parent_unique_id(parent_column.unique_id());
+    extracted_column.set_path_info(PathInData(parent_column.name_lower_case() + ".payload"));
+    extracted_column.set_is_nullable(true);
+    _tablet_schema->append_column(extracted_column);
+    init_tablet_from_current_schema(11902);
+
+    struct ConfigGuard {
+        int64_t old_value;
+        ~ConfigGuard() { config::variant_subcolumn_stream_write_threshold_bytes = old_value; }
+    };
+    ConfigGuard guard {config::variant_subcolumn_stream_write_threshold_bytes};
+    config::variant_subcolumn_stream_write_threshold_bytes = 64 * 1024;
+
+    const std::string big_string = "\"" + std::string(100 * 1024, 'x') + "\"";
+    const std::vector<std::string> jsons {
+            R"("small")", big_string, "7", "null", R"({"k":[1,2]})", big_string, "8",
+    };
+    const std::vector<UInt8> outer_nulls {0, 0, 0, 0, 0, 0, 1};
+    ColumnPtr source;
+    DataTypePtr source_type;
+    ASSERT_TRUE(create_variant_writer_source(VariantWriterInput::V2, jsons, 0, false, outer_nulls,
+                                             &source, &source_type)
+                        .ok());
+
+    SegmentFooterPB footer;
+    std::string file_path;
+    std::vector<int> types_after_batch;
+    ASSERT_TRUE(write_extracted_variant_segment(
+                        source, source_type, "v2_extracted_stream_after_threshold", &footer,
+                        &file_path, /*first_batch_rows=*/1,
+                        [&]() { types_after_batch.push_back(footer.columns(0).type()); })
+                        .ok());
+    // The first batch stays buffered; the second one crosses the threshold and locks JSONB.
+    EXPECT_EQ(types_after_batch,
+              (std::vector<int> {static_cast<int>(FieldType::OLAP_FIELD_TYPE_VARIANT),
+                                 static_cast<int>(FieldType::OLAP_FIELD_TYPE_JSONB)}));
+    ASSERT_EQ(footer.columns_size(), 1);
+    EXPECT_EQ(footer.columns(0).type(), static_cast<int>(FieldType::OLAP_FIELD_TYPE_JSONB));
+    EXPECT_EQ(footer.columns(0).num_rows(), jsons.size());
+    EXPECT_EQ(footer.columns(0).none_null_size(), 5);
+
+    std::vector<std::string> actual;
+    ASSERT_TRUE(read_extracted_variant_rows(footer, file_path, &actual).ok());
+    EXPECT_EQ(actual, (std::vector<std::string> {
+                              R"("small")",
+                              big_string,
+                              "7",
+                              "NULL",
+                              R"({"k":[1,2]})",
+                              big_string,
+                              "NULL",
+                      }));
+}
+
+TEST_F(VariantColumnWriterReaderTest,
+       v2_typed_extracted_subcolumn_writer_streams_with_storage_type) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(KeysType::DUP_KEYS);
+    construct_column(schema_pb.add_column(), 1, "VARIANT", "v", 1);
+    _tablet_schema = std::make_shared<TabletSchema>();
+    _tablet_schema->init_from_pb(schema_pb);
+    auto typed_path = make_int_typed_path_template("typed_i");
+    _tablet_schema->mutable_column_by_uid(1).add_sub_column(typed_path);
+    const TabletColumn& parent_column = _tablet_schema->column_by_uid(1);
+    TabletColumn extracted_column;
+    extracted_column.set_name(parent_column.name_lower_case() + ".typed_i");
+    extracted_column.set_type(FieldType::OLAP_FIELD_TYPE_VARIANT);
+    extracted_column.set_parent_unique_id(parent_column.unique_id());
+    extracted_column.set_path_info(PathInData(parent_column.name_lower_case() + ".typed_i", true));
+    extracted_column.set_variant_max_subcolumns_count(0);
+    extracted_column.set_is_nullable(true);
+    _tablet_schema->append_column(extracted_column);
+    init_tablet_from_current_schema(11903);
+
+    struct ConfigGuard {
+        int64_t old_value;
+        ~ConfigGuard() { config::variant_subcolumn_stream_write_threshold_bytes = old_value; }
+    };
+    ConfigGuard guard {config::variant_subcolumn_stream_write_threshold_bytes};
+    config::variant_subcolumn_stream_write_threshold_bytes = 1;
+
+    ColumnPtr source;
+    DataTypePtr source_type;
+    ASSERT_TRUE(
+            create_typed_int_extracted_source(VariantWriterInput::V2, &source, &source_type).ok());
+
+    SegmentFooterPB footer;
+    std::string file_path;
+    std::vector<int> types_after_batch;
+    ASSERT_TRUE(write_extracted_variant_segment(
+                        source, source_type, "v2_typed_stream_with_storage_type", &footer,
+                        &file_path, /*first_batch_rows=*/2,
+                        [&]() { types_after_batch.push_back(footer.columns(0).type()); })
+                        .ok());
+    EXPECT_EQ(types_after_batch,
+              (std::vector<int>(2, static_cast<int>(FieldType::OLAP_FIELD_TYPE_INT))));
+    ASSERT_EQ(footer.columns_size(), 1);
+    EXPECT_EQ(footer.columns(0).type(), static_cast<int>(FieldType::OLAP_FIELD_TYPE_INT));
+    EXPECT_FALSE(footer.columns(0).has_none_null_size());
+
+    std::vector<std::string> actual;
+    ASSERT_TRUE(read_extracted_variant_rows(footer, file_path, &actual).ok());
+    EXPECT_EQ(actual, (std::vector<std::string> {"1", "NULL", "NULL", "4"}));
 }
 
 TEST_F(VariantColumnWriterReaderTest, v2_root_only_preserves_layout_validation) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary:

Vertical compaction extends a VARIANT column into extracted subcolumns. When a selected path
cannot get a concrete type from segment metadata (it was stored in the sparse column of some
input segment, has no subcolumn type stats, or the sparse path stats are truncated), the
extracted column is VARIANT-typed and is written by `VariantSubcolumnWriter`. That writer
buffers every row of the output segment in memory so it can infer the least common type in
`finalize()`, and only then creates the real column writer.

The output segment row count is estimated from the compressed input size, so a highly
compressible JSON string path can put more than 4 GiB of string data into one segment. The
buffered `ColumnString` then hits its uint32 offset limit and compaction fails with
`[E-3113] string column length is too large`, retrying the same version range forever.

Reproduced on master with 200,000 rows whose `big` path carries ~24 KB strings (4.74 GB in
total) and is sparse in the early rowsets: full compaction failed with
`total_length=4300785738, limit=4294967295` inside `VariantSubcolumnWriter::_append`. When the
same data gets a concrete STRING type, `ScalarColumnWriter` streams it and compaction succeeds.

This PR makes the V2 input path of `VariantSubcolumnWriter` stream once its buffer grows past
the new mutable BE config `variant_subcolumn_stream_write_threshold_bytes` (default 2 GiB):

- the storage type is locked at that point: a predefined path keeps its storage type, any other
  path uses nullable JSONB, which can hold every later value without rewriting written pages;
- the buffered rows are written through the real column writer, and every later batch is
  converted and written immediately, so the buffer never holds more than one batch;
- `finalize()` writes the remaining rows and records `num_rows` / `none_null_size`.

Segments whose buffered data stays below the threshold keep the existing precise type
inference, and the type preparation / writer creation code is shared by both paths. The legacy
V1 input (`ColumnVariant`) path is unchanged because it is going to be removed.

### Release note

Add BE config `variant_subcolumn_stream_write_threshold_bytes`. A VARIANT-typed extracted
subcolumn whose buffered V2 data in one segment exceeds it is written in a streaming way and
stored as JSONB (or its predefined type) in that segment.

### Check List (For Author)

- Test: Unit Test
    - Added `VariantColumnWriterReaderTest.v2_extracted_subcolumn_writer_streams_after_buffer_threshold`
      and `VariantColumnWriterReaderTest.v2_typed_extracted_subcolumn_writer_streams_with_storage_type`.
    - Red: without the writer change both tests failed only on the type-lock assertion (the
      column type after each batch stayed VARIANT); the data read-back assertions passed.
    - Green: with the change both tests pass. Filter
      `*VariantColumnWriterReaderTest*:*VariantPathBuilderTest*:*VariantShredderTest*:*VariantWriterCompatibilityTest*:*VariantSpecializedWriterCompatibilityTest*:*SchemaUtilRowsetTest*`
      ran 109 tests: 107 passed, 2 skipped (NestedGroup write path is not available in this build).
    - Manual test: the E-3113 reproduction above was done on master; on current master that
      compaction still feeds legacy `ColumnVariant` input to this writer, so it is not changed by
      this PR.
- Behavior changed: Yes. A path that exceeds the threshold within one segment is stored with the
  locked type (JSONB unless predefined) in that segment instead of failing compaction.
- Does this need documentation: No


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AU69xp5L6BqZHq7FKzJ9Ts
