### PR TITLE
[fix](be) Commit Kinesis progress only for appended records

### DIFF
--- a/be/src/load/routine_load/data_consumer.cpp
+++ b/be/src/load/routine_load/data_consumer.cpp
@@ -824,9 +824,9 @@ Status KinesisDataConsumer::_get_shard_iterator(const std::string& shard_id,
     return Status::OK();
 }
 
-Status KinesisDataConsumer::group_consume(
-        BlockingQueue<std::shared_ptr<Aws::Kinesis::Model::Record>>* queue,
-        int64_t max_running_time_ms) {
+Status KinesisDataConsumer::
+        group_consume( // NOLINT(readability-function-size, readability-function-cognitive-complexity): existing polling state machine
+                BlockingQueue<KinesisQueueItem>* queue, int64_t max_running_time_ms) {
     static constexpr int INTER_SHARD_SLEEP_MS = 10;            // Small sleep between shards
     static constexpr int MIN_INTERVAL_BETWEEN_ROUNDS_MS = 200; // Min 200ms between rounds
 
@@ -948,10 +948,17 @@ Status KinesisDataConsumer::group_consume(
 
             // Update shard iterator for next call
             if (next_iterator.empty()) {
-                // Shard is closed (split/merge), mark as closed and remove from active set
-                LOG(INFO) << "Shard closed: " << shard_id << " (split/merge detected)";
-                DorisMetrics::instance()->routine_load_kinesis_closed_shard_count->increment(1);
-                _closed_shard_ids.insert(shard_id);
+                // Keep the close event behind all records from this shard. The group can only
+                // report the shard closed after it has appended every preceding record.
+                KinesisQueueItem end_marker;
+                end_marker.shard_id = shard_id;
+                end_marker.end_of_shard = true;
+                if (!queue->controlled_blocking_put(end_marker,
+                                                    config::blocking_queue_cv_wait_timeout_ms)) {
+                    // The group may have reached a batch boundary while this consumer was still
+                    // draining a prefetched response. The appended prefix remains a valid batch.
+                    return Status::OK();
+                }
                 _shard_iterators.erase(shard_id);
                 it = _consuming_shard_ids.erase(it);
             } else {
@@ -999,10 +1006,10 @@ Status KinesisDataConsumer::group_consume(
     return st;
 }
 
-Status KinesisDataConsumer::_process_records(
-        const std::string& shard_id, Aws::Kinesis::Model::GetRecordsResult result,
-        BlockingQueue<std::shared_ptr<Aws::Kinesis::Model::Record>>* queue, int64_t* received_rows,
-        int64_t* put_rows) {
+Status KinesisDataConsumer::_process_records(const std::string& shard_id,
+                                             Aws::Kinesis::Model::GetRecordsResult result,
+                                             BlockingQueue<KinesisQueueItem>* queue,
+                                             int64_t* received_rows, int64_t* put_rows) {
     // result is owned by value, safe to get mutable access to its records
     auto records =
             std::move(const_cast<Aws::Vector<Aws::Kinesis::Model::Record>&>(result.GetRecords()));
@@ -1015,16 +1022,15 @@ Status KinesisDataConsumer::_process_records(
             continue;
         }
 
-        // Track the last sequence number for this shard
-        _committed_sequence_numbers[shard_id] = record.GetSequenceNumber();
-
         // Move record into shared_ptr to avoid expensive copy
-        auto record_ptr = std::make_shared<Aws::Kinesis::Model::Record>(std::move(record));
+        KinesisQueueItem item;
+        item.shard_id = shard_id;
+        item.record = std::make_shared<Aws::Kinesis::Model::Record>(std::move(record));
 
-        if (!queue->controlled_blocking_put(record_ptr,
-                                            config::blocking_queue_cv_wait_timeout_ms)) {
-            // Queue shutdown
-            return Status::InternalError("Queue shutdown during record processing");
+        if (!queue->controlled_blocking_put(item, config::blocking_queue_cv_wait_timeout_ms)) {
+            // The group may have reached a batch boundary while this consumer was still draining
+            // a prefetched response. The appended prefix remains a valid batch.
+            return Status::OK();
         }
 
         (*put_rows)++;
@@ -1051,8 +1057,6 @@ Status KinesisDataConsumer::reset() {
     _consuming_shard_ids.clear();
     _shard_iterators.clear();
     _millis_behind_latest.clear();
-    _committed_sequence_numbers.clear();
-    _closed_shard_ids.clear();
     _last_visit_time = time(nullptr);
     LOG(INFO) << "Kinesis consumer reset: " << _id;
     return Status::OK();

--- a/be/src/load/routine_load/data_consumer.h
+++ b/be/src/load/routine_load/data_consumer.h
@@ -47,6 +47,12 @@ namespace doris {
 template <typename T>
 class BlockingQueue;
 
+struct KinesisQueueItem {
+    std::string shard_id;
+    std::shared_ptr<Aws::Kinesis::Model::Record> record;
+    bool end_of_shard = false;
+};
+
 class DataConsumer {
 public:
     DataConsumer()
@@ -202,8 +208,7 @@ public:
                          const std::string& stream_name, std::shared_ptr<StreamLoadContext> ctx);
 
     // Main consumption loop - pulls records from all assigned shards
-    Status group_consume(BlockingQueue<std::shared_ptr<Aws::Kinesis::Model::Record>>* queue,
-                         int64_t max_running_time_ms);
+    Status group_consume(BlockingQueue<KinesisQueueItem>* queue, int64_t max_running_time_ms);
 
     // Get list of shard IDs
     Status get_shard_list(std::vector<std::string>* shard_ids);
@@ -245,28 +250,11 @@ private:
     // Updated during group_consume; read by the task executor to populate ctx after consumption.
     std::map<std::string, int64_t> _millis_behind_latest;
 
-    // Tracks the last consumed sequence number per shard.
-    // Updated during group_consume via _process_records; read by the consumer group
-    // to populate ctx->kinesis_info->cmt_sequence_number after consumption.
-    std::map<std::string, std::string> _committed_sequence_numbers;
-
-    // Tracks shards that have been closed (split/merge) during consumption.
-    // FE should remove these shards from its tracking to avoid reassigning them.
-    std::set<std::string> _closed_shard_ids;
-
 public:
     // Returns the MillisBehindLatest snapshot collected during group_consume.
     const std::map<std::string, int64_t>& get_millis_behind_latest() const {
         return _millis_behind_latest;
     }
-
-    // Returns the committed sequence numbers per shard collected during group_consume.
-    const std::map<std::string, std::string>& get_committed_sequence_numbers() const {
-        return _committed_sequence_numbers;
-    }
-
-    // Returns the set of closed shard IDs detected during group_consume.
-    const std::set<std::string>& get_closed_shard_ids() const { return _closed_shard_ids; }
 
 private:
     // Helper methods
@@ -280,8 +268,8 @@ private:
     // Process records from GetRecords result and add to queue
     Status _process_records(const std::string& shard_id,
                             Aws::Kinesis::Model::GetRecordsResult result,
-                            BlockingQueue<std::shared_ptr<Aws::Kinesis::Model::Record>>* queue,
-                            int64_t* received_rows, int64_t* put_rows);
+                            BlockingQueue<KinesisQueueItem>* queue, int64_t* received_rows,
+                            int64_t* put_rows);
 
     // Check if an AWS error is retriable (throttling, network, etc.)
     bool _is_retriable_error(const Aws::Client::AWSError<Aws::Kinesis::KinesisErrors>& error);

--- a/be/src/load/routine_load/data_consumer_group.cpp
+++ b/be/src/load/routine_load/data_consumer_group.cpp
@@ -24,6 +24,7 @@
 #include <utility>
 
 #include "common/logging.h"
+#include "common/metrics/doris_metrics.h"
 #include "io/fs/kafka_consumer_pipe.h"
 #include "io/fs/kinesis_consumer_pipe.h"
 #include "librdkafka/rdkafkacpp.h"
@@ -227,9 +228,9 @@ Status KinesisDataConsumerGroup::assign_stream_shards(std::shared_ptr<StreamLoad
 KinesisDataConsumerGroup::~KinesisDataConsumerGroup() {
     _queue.shutdown();
     while (true) {
-        std::shared_ptr<Aws::Kinesis::Model::Record> record;
-        if (_queue.blocking_get(&record)) {
-            record.reset();
+        KinesisQueueItem item;
+        if (_queue.blocking_get(&item)) {
+            item.record.reset();
         } else {
             break;
         }
@@ -256,10 +257,16 @@ Status KinesisDataConsumerGroup::start_all(std::shared_ptr<StreamLoadContext> ct
 
 bool KinesisDataConsumerGroup::_dequeue_and_process(io::StreamLoadPipe* pipe, int64_t& left_rows,
                                                     int64_t& left_bytes, Status& result_st) {
-    std::shared_ptr<Aws::Kinesis::Model::Record> record;
-    if (!_queue.controlled_blocking_get(&record, config::blocking_queue_cv_wait_timeout_ms)) {
+    KinesisQueueItem item;
+    if (!_queue.controlled_blocking_get(&item, config::blocking_queue_cv_wait_timeout_ms)) {
         return false;
     }
+    if (item.end_of_shard) {
+        _closed_shard_ids.insert(item.shard_id);
+        DorisMetrics::instance()->routine_load_kinesis_closed_shard_count->increment(1);
+        return true;
+    }
+    auto& record = item.record;
     auto& data = record->GetData();
     const char* payload = reinterpret_cast<const char*>(data.GetUnderlyingData());
     size_t len = data.GetLength();
@@ -270,6 +277,7 @@ bool KinesisDataConsumerGroup::_dequeue_and_process(io::StreamLoadPipe* pipe, in
     if (st.ok()) {
         left_rows--;
         left_bytes -= len;
+        _candidate_sequence_numbers[item.shard_id] = record->GetSequenceNumber();
         VLOG_NOTICE << "consume kinesis record [seq=" << record->GetSequenceNumber() << "]";
     } else {
         LOG(WARNING) << "failed to append kinesis record to pipe. grp: " << _grp_id;
@@ -282,27 +290,23 @@ bool KinesisDataConsumerGroup::_dequeue_and_process(io::StreamLoadPipe* pipe, in
 }
 
 void KinesisDataConsumerGroup::_on_finish(std::shared_ptr<StreamLoadContext> ctx) {
+    ctx->kinesis_info->cmt_sequence_number = _candidate_sequence_numbers;
+    ctx->kinesis_info->closed_shard_ids = _closed_shard_ids;
     for (auto& consumer : _consumers) {
         auto kinesis_consumer = std::static_pointer_cast<KinesisDataConsumer>(consumer);
-        for (auto& [shard_id, seq_num] : kinesis_consumer->get_committed_sequence_numbers()) {
-            ctx->kinesis_info->cmt_sequence_number[shard_id] = seq_num;
-        }
         for (auto& [shard_id, millis] : kinesis_consumer->get_millis_behind_latest()) {
             auto [it, inserted] = ctx->kinesis_info->millis_behind_latest.emplace(shard_id, millis);
             if (!inserted && it->second < millis) {
                 it->second = millis;
             }
         }
-        for (auto& shard_id : kinesis_consumer->get_closed_shard_ids()) {
-            ctx->kinesis_info->closed_shard_ids.insert(shard_id);
-        }
     }
 }
 
-void KinesisDataConsumerGroup::actual_consume(
-        std::shared_ptr<DataConsumer> consumer,
-        BlockingQueue<std::shared_ptr<Aws::Kinesis::Model::Record>>* queue,
-        int64_t max_running_time_ms, ConsumeFinishCallback cb) {
+void KinesisDataConsumerGroup::actual_consume(std::shared_ptr<DataConsumer> consumer,
+                                              BlockingQueue<KinesisQueueItem>* queue,
+                                              int64_t max_running_time_ms,
+                                              ConsumeFinishCallback cb) {
     Status st = std::static_pointer_cast<KinesisDataConsumer>(consumer)->group_consume(
             queue, max_running_time_ms);
     cb(st);

--- a/be/src/load/routine_load/data_consumer_group.h
+++ b/be/src/load/routine_load/data_consumer_group.h
@@ -20,8 +20,10 @@
 #include <stdint.h>
 
 #include <functional>
+#include <map>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <vector>
 
 #include "common/cast_set.h"
@@ -147,15 +149,17 @@ public:
 
 private:
     void actual_consume(std::shared_ptr<DataConsumer> consumer,
-                        BlockingQueue<std::shared_ptr<Aws::Kinesis::Model::Record>>* queue,
-                        int64_t max_running_time_ms, ConsumeFinishCallback cb);
+                        BlockingQueue<KinesisQueueItem>* queue, int64_t max_running_time_ms,
+                        ConsumeFinishCallback cb);
 
     bool _dequeue_and_process(io::StreamLoadPipe* pipe, int64_t& left_rows, int64_t& left_bytes,
                               Status& result_st) override;
     void _shutdown_queue() override { _queue.shutdown(); }
     void _on_finish(std::shared_ptr<StreamLoadContext> ctx) override;
 
-    BlockingQueue<std::shared_ptr<Aws::Kinesis::Model::Record>> _queue;
+    BlockingQueue<KinesisQueueItem> _queue;
+    std::map<std::string, std::string> _candidate_sequence_numbers;
+    std::set<std::string> _closed_shard_ids;
     TFileFormatType::type _format;
 };
 

--- a/be/test/runtime/kinesis_batch_progress_test.cpp
+++ b/be/test/runtime/kinesis_batch_progress_test.cpp
@@ -1,0 +1,161 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <aws/kinesis/model/GetRecordsResult.h>
+#include <aws/kinesis/model/Record.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "io/fs/kinesis_consumer_pipe.h"
+#include "load/routine_load/data_consumer.h"
+#include "load/routine_load/data_consumer_group.h"
+#include "load/stream_load/stream_load_context.h"
+
+namespace doris {
+
+class RecordingKinesisPipe : public io::KinesisConsumerPipe {
+public:
+    Status append_json(const char* data, size_t size) override {
+        appended.emplace_back(data, size);
+        return Status::OK();
+    }
+
+    std::vector<std::string> appended;
+};
+
+class KinesisBatchProgressReproduction : public testing::Test {
+protected:
+    void verify_progress(int64_t row_budget, int64_t byte_budget, size_t expected_appended,
+                         bool add_end_marker = false) {
+        auto ctx = StreamLoadContext::create_shared(nullptr);
+        ctx->load_type = TLoadType::ROUTINE_LOAD;
+        ctx->load_src_type = TLoadSourceType::KINESIS;
+        ctx->format = TFileFormatType::FORMAT_JSON;
+        ctx->max_interval_s = 30;
+        ctx->max_batch_rows = row_budget;
+        ctx->max_batch_size = byte_budget;
+        TKinesisLoadInfo info;
+        info.__set_region("us-east-1");
+        info.__set_stream("r1-unit-test");
+        info.__set_shard_begin_sequence_number({{"shard-0", "0"}});
+        ctx->kinesis_info = std::make_unique<KinesisLoadInfo>(info);
+
+        auto consumer = std::make_shared<KinesisDataConsumer>(ctx);
+        consumer->_init = true;
+        KinesisDataConsumerGroup group(1);
+        group.add_consumer(consumer);
+        group._format = ctx->format;
+
+        Aws::Kinesis::Model::GetRecordsResult response;
+        for (int i = 1; i <= 5; ++i) {
+            Aws::Kinesis::Model::Record record;
+            record.SetSequenceNumber(std::to_string(i));
+            std::string payload = "{\"id\":" + std::to_string(i) + "}";
+            record.SetData(Aws::Utils::ByteBuffer(
+                    reinterpret_cast<const unsigned char*>(payload.data()), payload.size()));
+            response.AddRecords(std::move(record));
+        }
+        int64_t received = 0;
+        int64_t queued = 0;
+        // A valid interleaving: the producer queues a whole response before
+        // the group drains it. Invoke the real producer processing function.
+        ASSERT_TRUE(consumer->_process_records("shard-0", std::move(response), &group._queue,
+                                               &received, &queued)
+                            .ok());
+        ASSERT_EQ(5, queued);
+        if (add_end_marker) {
+            KinesisQueueItem end_marker;
+            end_marker.shard_id = "shard-0";
+            end_marker.end_of_shard = true;
+            ASSERT_TRUE(group._queue.blocking_put(end_marker));
+        }
+        // No additional input; the queue still drains its already queued records.
+        group._queue.shutdown();
+
+        auto pipe = std::make_shared<RecordingKinesisPipe>();
+        Status consumer_status = Status::OK();
+        ASSERT_TRUE(group._run_consume_loop(ctx, pipe, consumer_status).ok());
+        ASSERT_EQ(expected_appended, pipe->appended.size());
+        ASSERT_EQ(5 - expected_appended, group._queue.get_size());
+        EXPECT_EQ(std::to_string(expected_appended),
+                  ctx->kinesis_info->cmt_sequence_number.at("shard-0"));
+        if (add_end_marker) {
+            EXPECT_EQ(1, ctx->kinesis_info->closed_shard_ids.count("shard-0"));
+        }
+    }
+};
+
+TEST_F(KinesisBatchProgressReproduction, FullBatchControl) {
+    verify_progress(5, 1024, 5);
+}
+
+TEST_F(KinesisBatchProgressReproduction, RowBudgetMustNotCommitQueuedRecords) {
+    verify_progress(2, 1024, 2);
+}
+
+TEST_F(KinesisBatchProgressReproduction, ByteBudgetMustNotCommitQueuedRecords) {
+    // Each JSON payload is eight bytes.
+    verify_progress(5, 16, 2);
+}
+
+TEST_F(KinesisBatchProgressReproduction, ClosedMarkerFollowsAppendedRecords) {
+    verify_progress(6, 1024, 5, true);
+}
+
+TEST_F(KinesisBatchProgressReproduction, QueueShutdownDuringPrefetchIsGraceful) {
+    auto ctx = StreamLoadContext::create_shared(nullptr);
+    TKinesisLoadInfo info;
+    ctx->kinesis_info = std::make_unique<KinesisLoadInfo>(info);
+    auto consumer = std::make_shared<KinesisDataConsumer>(ctx);
+    KinesisDataConsumerGroup group(1);
+
+    for (int i = 0; i < 500; ++i) {
+        KinesisQueueItem item;
+        item.shard_id = "shard-0";
+        ASSERT_TRUE(group._queue.try_put(item));
+    }
+
+    Aws::Kinesis::Model::GetRecordsResult response;
+    Aws::Kinesis::Model::Record record;
+    record.SetSequenceNumber("1");
+    const std::string payload = "{\"id\":1}";
+    record.SetData(Aws::Utils::ByteBuffer(reinterpret_cast<const unsigned char*>(payload.data()),
+                                          payload.size()));
+    response.AddRecords(std::move(record));
+
+    Status producer_status = Status::OK();
+    int64_t received = 0;
+    int64_t queued = 0;
+    std::thread producer([&] {
+        producer_status = consumer->_process_records("shard-0", std::move(response), &group._queue,
+                                                     &received, &queued);
+    });
+    while (group._queue.put_waiting_count_for_test() == 0) {
+        std::this_thread::yield();
+    }
+    group._queue.shutdown();
+    producer.join();
+
+    ASSERT_TRUE(producer_status.ok());
+    ASSERT_EQ(0, queued);
+}
+
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #61325

Problem Summary:

Kinesis Routine Load can skip records when a task reaches its batch limit while prefetched records remain in the consumer queue.

The producer previously advanced its per-shard sequence number in `_process_records()` before enqueueing each record. The consumer group then copied that producer progress into the transaction attachment, even when it had only appended part of the queue to the Stream Load pipe.

For example, a producer queues records S1 through S5, but the group reaches its row or byte limit after appending S1 and S2. Previously, the task reported S5 as its commit position. If the transaction succeeded, the next task resumed with `AFTER_SEQUENCE_NUMBER(S5)`, skipping S3 through S5 even though those records had never entered the completed load.

The same boundary affects shard completion: observing the end of a shard in the producer does not prove that all of its queued records have been appended. Reporting the shard as closed too early can remove its remaining records from FE tracking.

This PR fixes the progress boundary:

- Queue items carry the shard ID along with the record.
- The consumer group updates candidate progress only after a successful pipe append and uses that progress in the existing transaction attachment.
- End-of-shard markers are queued after the shard's records. The group reports completion only after consuming the marker.
- Queue shutdown while enqueueing a prefetched response is treated as normal batch termination. Pipe and source errors continue through the existing task failure paths.

After the change, the example task reports S2, so subsequent consumption starts after S2 and can load S3 through S5. Pipe append establishes candidate progress; the existing transaction path still determines whether that progress is committed.

The FE/BE wire protocol and persisted progress format are unchanged.

### Release note

Fix Kinesis Routine Load skipping prefetched records at batch boundaries and reporting shard completion before queued records have been appended.

### Check List (For Author)

- Test:
    - [ ] Regression test
    - [x] Unit Test
    - [ ] Manual test
    - [ ] No need to test
- Behavior changed:
    - [ ] No.
    - [x] Yes. Task progress is limited to successfully appended records, and shard completion follows an ordered queue marker.
- Does this need documentation:
    - [x] No. No new configuration or SQL syntax.
    - [ ] Yes.

Validation:

```bash
./run-be-ut.sh --run --filter='KinesisBatchProgressReproduction.*' -j48
```

- Before the fix: the full-batch control passed; the row-limit and byte-limit cases failed with expected sequence 2 and actual sequence 5.
- After the fix: all 5 ASAN BE unit tests passed. Coverage includes full-batch progress, row and byte limits, processing a shard-end marker after records, and shutdown while a producer is blocked on a full queue.
- The tests invoke the real producer record-processing and consumer-group methods with constructed SDK records and a recording pipe.
- Header hygiene, clang-format checks, and `git diff --check` passed.
- Live AWS-to-Doris ingestion and time-limit boundary tests were not run.
- Clang-tidy was attempted but did not pass due to pre-existing diagnostics; no clean clang-tidy result is claimed. The existing polling function's size and cognitive-complexity suppressions are documented inline.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label

