### PR TITLE
[fix](build) Force-link the compatibility getentropy definition

### DIFF
--- a/be/src/glibc-compatibility/CMakeLists.txt
+++ b/be/src/glibc-compatibility/CMakeLists.txt
@@ -44,9 +44,16 @@ if (GLIBC_COMPATIBILITY)
         message (FATAL_ERROR "glibc_compatibility can only be used on x86_64 or aarch64.")
     endif ()
 
+    # getentropy needs the same treatment as getrandom below, and for a sharper reason: the
+    # sanitizer runtime carries a weak getentropy of its own, which satisfies the reference before
+    # this archive is scanned, so the archive member is never extracted. On a runtime whose libc has
+    # no getentropy (glibc < 2.25) the sanitizer cannot resolve the real one either and leaves its
+    # internal pointer null, so the first call jumps to address 0. Keep the definition in the
+    # explicit object target instead.
     list(REMOVE_ITEM glibc_compatibility_sources musl/getentropy.c)
+    set(getentropy_compatibility_source "")
     if(HAVE_SYS_RANDOM_H)
-        list(APPEND glibc_compatibility_sources musl/getentropy.c)
+        set(getentropy_compatibility_source musl/getentropy.c)
     endif()
 
     # lance_c is linked after this archive and introduces these libc references
@@ -74,16 +81,24 @@ if (GLIBC_COMPATIBILITY)
     if (ARCH_ARM AND (CMAKE_BUILD_TYPE STREQUAL "ASAN_UT" OR CMAKE_BUILD_TYPE STREQUAL "ASAN"))
         add_library(glibc-compatibility-explicit OBJECT
             musl/getrandom.c
+            ${getentropy_compatibility_source}
             ${lance_compatibility_source}
         )
     else()
         add_library(glibc-compatibility-explicit OBJECT
             musl/getrandom.c
+            ${getentropy_compatibility_source}
             ${MEMCPY_SOURCE}
             ${lance_compatibility_source}
         )
     endif()
     target_compile_options(glibc-compatibility-explicit PRIVATE -fPIC)
+    if (getentropy_compatibility_source)
+        # The static archive below turns -Wconversion off for the musl sources. This one narrows
+        # getrandom's ssize_t into an int the same way, so it needs the same exemption here.
+        set_source_files_properties(${getentropy_compatibility_source} PROPERTIES
+            COMPILE_OPTIONS "-Wno-conversion")
+    endif()
     add_library(glibc-compatibility STATIC ${glibc_compatibility_sources})
     target_compile_options(
         glibc-compatibility


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #67871

Problem Summary:

`musl/getentropy.c` only ever reaches the `glibc-compatibility` static archive, and by the time the linker scans that archive the reference is already satisfied: the sanitizer runtime comes first and carries a weak `getentropy` of its own, so the archive member is never extracted. The binary then calls ASAN's interceptor, which forwards to the pointer it resolved through `dlsym(RTLD_NEXT, "getentropy")`. On a runtime whose libc predates that symbol, glibc 2.17 on CentOS 7, the resolution fails, the pointer stays null, and the first entropy read jumps to address 0.

BE UT reaches that path through Abseil, which calls `getentropy(buffer, min(remaining, 256))` before falling back to `/dev/urandom`. `doris_be_test` dies with `SEGV on unknown address 0x0 (pc 0x0)`, no test registered after the crash point runs, and TeamCity reports the build as `CORE DUMPED` with no test name attached, so the failure looks like a flake in whatever PR happened to trigger it. It has been taking out most BE UT builds since 2026-09-10, 26 of 76 that day and 51 of 63 the next, which is when #67752 reverted the compilation image from almalinux:8 back to centos:7. almalinux:8 ships glibc 2.28, which does export `getentropy`, so the same binaries survive there, and that is also why the crash comes and goes as agents pick up the new image.

`musl/getrandom.c` already lives in the `glibc-compatibility-explicit` object target for the same class of reason, which the comment there describes. This moves `getentropy.c` next to it, keeps the `HAVE_SYS_RANDOM_H` guard, and exempts that one file from `-Wconversion`, which the static archive already does for the musl sources.

### Release note

None. Build configuration only.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [ ] Unit Test
    - [X] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:
        - [ ] This is a refactor/code format and no logic has been changed.
        - [ ] Previous test can cover this change.
        - [ ] No code files have been changed.
        - [ ] Other reason <!-- Add your reason?  -->

A 25-line program that calls `getentropy(buf, 32)` on the main thread and on a spawned thread, compiled with this repo's clang and `-fsanitize=address`, linked four ways, then run on glibc 2.17 (`centos:7`, x86_64) and on glibc 2.28 (the current build image):

| link | `getentropy` in `.dynsym` | glibc 2.17 | glibc 2.28 |
|---|---|---|---|
| ASAN only | WEAK, 5 bytes, ASAN trampoline | SEGV at pc 0 | ok |
| plus `getrandom.c.o`, which is BE UT before this PR | WEAK, 5 bytes, ASAN trampoline | SEGV at pc 0 | ok |
| plus `libglibc-compatibility.a` on the link line | WEAK, 5 bytes, ASAN trampoline | SEGV at pc 0 | ok |
| plus `getentropy.c.o`, which is BE UT after this PR | GLOBAL, 637 bytes, Doris | ok | ok |

The crash in rows one to three has the same shape as CI's, `#0` at address 0 and `#1` the caller of `getentropy`, with the buffer in `rdi` and the requested length in `rsi`. `ASAN_OPTIONS=verbosity=1` prints `AddressSanitizer: failed to intercept 'getentropy'` on glibc 2.17 for every row, so the interceptor's pointer is null in all four; only the last row survives, because there the call binds to Doris' own definition and never enters the interceptor.

The third row is why putting the archive on the link line is not a fix, and the second row is why the existing explicit `getrandom` object does not cover this path.

Then with this patch applied, rebuilding the two targets in an existing ASAN_UT tree and in a RELEASE tree moves `getentropy.c.o` into `glibc-compatibility-explicit` and leaves the archive with neither entropy source, and a probe linked from those outputs reports `getentropy` as a 637-byte GLOBAL symbol and runs on both runtimes.

I could not reproduce the original `RemoteDorisV2ReaderTest` abort itself, since that needs a full ASAN build on a CentOS 7 runtime, so the evidence here is at the level of the mechanism rather than the failing test. BE UT on this PR is the first end-to-end check.

- Behavior changed:
    - [X] No.
    - [ ] Yes.

- Does this need documentation?
    - [X] No.
