### PR TITLE
[fix](be) Continue Kinesis polling after empty records

### DIFF
--- a/be/src/load/routine_load/data_consumer.cpp
+++ b/be/src/load/routine_load/data_consumer.cpp
@@ -959,12 +959,11 @@ Status KinesisDataConsumer::group_consume(
                 _shard_iterators[shard_id] = next_iterator;
 
                 if (record_count == 0) {
-                    // No records in this batch - shard has caught up with latest data
-                    // Remove from active set for this round (similar to Kafka PARTITION_EOF)
-                    // but keep iterator and progress for next task execution
-                    LOG(INFO) << "Shard has no new data: " << shard_id
+                    // An empty response does not mean that this shard has reached the tip.
+                    // Keep it active and follow the returned iterator in the next round.
+                    LOG(INFO) << "Shard has no records in this response: " << shard_id
                               << " (MillisBehindLatest=" << millis_behind << ")";
-                    it = _consuming_shard_ids.erase(it);
+                    ++it;
                 } else {
                     ++it;
                 }

--- a/be/test/runtime/kinesis_empty_page_test.cpp
+++ b/be/test/runtime/kinesis_empty_page_test.cpp
@@ -1,0 +1,109 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <aws/core/Aws.h>
+#include <aws/kinesis/KinesisClient.h>
+#include <aws/kinesis/model/GetRecordsResult.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "load/routine_load/data_consumer.h"
+#include "load/routine_load/kinesis_conf.h"
+#include "load/stream_load/stream_load_context.h"
+#include "util/blocking_queue.hpp"
+
+namespace doris {
+
+class EmptyPageKinesisClient final : public Aws::Kinesis::KinesisClient {
+public:
+    explicit EmptyPageKinesisClient(int empty_page_count) : _empty_page_count(empty_page_count) {}
+
+    Aws::Kinesis::Model::GetRecordsOutcome GetRecords(
+            const Aws::Kinesis::Model::GetRecordsRequest& request) const override {
+        ++get_records_calls;
+        iterator_calls.emplace_back(request.GetShardIterator());
+        Aws::Kinesis::Model::GetRecordsResult result;
+        if (get_records_calls <= _empty_page_count) {
+            result.SetMillisBehindLatest(100);
+            result.SetNextShardIterator("iterator-after-empty-page");
+            return result;
+        }
+
+        Aws::Kinesis::Model::Record record;
+        record.SetSequenceNumber("1");
+        const std::string payload = "{\"id\":1}";
+        record.SetData(Aws::Utils::ByteBuffer(
+                reinterpret_cast<const unsigned char*>(payload.data()), payload.size()));
+        result.AddRecords(std::move(record));
+        result.SetMillisBehindLatest(0);
+        result.SetNextShardIterator("");
+        return result;
+    }
+
+    mutable int get_records_calls = 0;
+    mutable std::vector<std::string> iterator_calls;
+
+private:
+    const int _empty_page_count;
+};
+
+class KinesisEmptyPageReproduction : public testing::Test {
+protected:
+    void SetUp() override { Aws::InitAPI(options); }
+    void TearDown() override { Aws::ShutdownAPI(options); }
+
+    void expect_record_after_empty_pages(int empty_page_count) {
+        auto ctx = StreamLoadContext::create_shared(nullptr);
+        TKinesisLoadInfo info;
+        info.__set_region("us-east-1");
+        info.__set_stream("doris-latest-r2-unit-test");
+        ctx->kinesis_info = std::make_unique<KinesisLoadInfo>(info);
+
+        auto consumer = std::make_shared<KinesisDataConsumer>(ctx);
+        consumer->_init = true;
+        auto fake_client = std::make_shared<EmptyPageKinesisClient>(empty_page_count);
+        consumer->_kinesis_client = fake_client;
+        consumer->_kinesis_conf = std::make_unique<KinesisConf>();
+        consumer->_shard_iterators.emplace("shard-0", "initial-iterator");
+        consumer->_consuming_shard_ids.emplace("shard-0");
+
+        BlockingQueue<std::shared_ptr<Aws::Kinesis::Model::Record>> queue(8);
+        ASSERT_TRUE(consumer->group_consume(&queue, 1000).ok());
+        ASSERT_EQ(empty_page_count + 1, fake_client->get_records_calls);
+        ASSERT_EQ("initial-iterator", fake_client->iterator_calls.front());
+        ASSERT_EQ("iterator-after-empty-page", fake_client->iterator_calls.at(1));
+
+        std::shared_ptr<Aws::Kinesis::Model::Record> record;
+        ASSERT_TRUE(queue.blocking_get(&record));
+        ASSERT_EQ("1", record->GetSequenceNumber());
+        queue.shutdown();
+    }
+
+    Aws::SDKOptions options;
+};
+
+TEST_F(KinesisEmptyPageReproduction, FollowsNextIteratorAfterEmptyPage) {
+    expect_record_after_empty_pages(1);
+}
+
+TEST_F(KinesisEmptyPageReproduction, FollowsNextIteratorAfterMultipleEmptyPages) {
+    expect_record_after_empty_pages(2);
+}
+
+} // namespace doris


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: #67869

Problem Summary:

Amazon Kinesis GetRecords is a non-blocking pull API. An empty Records array
does not mean that the shard has reached the stream tip: the response can
still contain a non-empty NextShardIterator, and a later call using that
iterator can return records. The only terminal signal for a closed shard is
an empty NextShardIterator.

Routine Load Kinesis handled the response as follows:

1. KinesisDataConsumer::group_consume() called GetRecords.
2. It saved the returned NextShardIterator.
3. When Records was empty, it erased the shard from _consuming_shard_ids.
4. If this was the only active shard, the loop marked the consumer done,
   shut down the queue, and returned successfully.
5. The next task recreated an iterator from the old committed sequence, so it
   could observe the same empty page again instead of following the iterator
   returned by Kinesis.

This can leave a shard stuck without consuming records that arrive after the
empty response. It also makes the result depend on whether the task happens
to have another active shard.

This change keeps the shard in the active set when Records is empty and
NextShardIterator is non-empty. The next polling round therefore follows the
returned iterator. The existing empty-iterator branch is unchanged and
continues to remove the closed shard only after the existing queue ordering
and end-of-shard handling. Queue shutdown, retry handling, transaction
attachments, and FE progress formats are unchanged.

### Reproduction

The new BE unit test invokes the production
KinesisDataConsumer::group_consume() method with an AWS SDK KinesisClient
fake:

- response 1: no records, MillisBehindLatest = 100, iterator
  iterator-after-empty-page;
- response 2: one record, MillisBehindLatest = 0, empty iterator.

Before this fix, the test failed because the consumer made only one
GetRecords call:

    Expected: 2
    Actual:   1

After this fix, it verifies both that the second call is made and that it
uses iterator-after-empty-page. A second test covers two consecutive empty
responses before the record.

### Release note

Fix Kinesis Routine Load polling after empty GetRecords responses so later
records in the same shard are not skipped or left permanently unconsumed.

### Check List (For Author)

- Test: Unit Test
    - ./run-be-ut.sh --run --filter='KinesisEmptyPageReproduction.*' -j48
      failed before the fix and passed 2/2 after the fix.
    - ./run-be-ut.sh --run --filter='KinesisBatchProgressReproduction.*:KinesisEmptyPageReproduction.*' -j48
      passed 7/7 after the fix, including the existing Kinesis progress
      boundary tests from the base branch.
    - build-support/check-build-hygiene.sh passed.
    - build-support/check-format.sh passed.
    - git diff --check passed.
    - The new test's clang-tidy check passed. The production file's full
      clang-tidy check still reports pre-existing diagnostics outside this
      change, including existing complexity and const-reference warnings.
- Behavior changed: Yes. Empty non-terminal Kinesis responses are polled
  again using the returned iterator.
- Does this need documentation: No.

### Scope and limitations

This PR addresses only empty non-terminal GetRecords responses. It does not
change shard discovery, reshard parent/child ordering, LATEST initialization,
or FE shard-topology persistence. Live AWS ingestion was not used because the
machine has multiple shared Doris processes and no verifiable cluster identity
for this workspace; the deterministic unit test exercises the production BE
consumer and AWS SDK response path without creating external resources.
