### PR TITLE
[test](ivm) Remove unnecessary cloud skips from IVM suites

### DIFF
--- a/regression-test/suites/mtmv_p0/ivm/test_ivm_drop_column_fallback_reason.groovy
+++ b/regression-test/suites/mtmv_p0/ivm/test_ivm_drop_column_fallback_reason.groovy
@@ -19,10 +19,6 @@ import org.awaitility.Awaitility
 import static java.util.concurrent.TimeUnit.SECONDS
 
 suite("test_ivm_drop_column_fallback_reason") {
-    if (isCloudMode()) {
-        return
-    }
-
     sql """DROP MATERIALIZED VIEW IF EXISTS ivm_drop_col_reason_mv"""
     sql """DROP TABLE IF EXISTS ivm_drop_col_reason_t"""
     sql """

--- a/regression-test/suites/mtmv_p0/ivm/test_ivm_fallback_stream_multi_batch.groovy
+++ b/regression-test/suites/mtmv_p0/ivm/test_ivm_fallback_stream_multi_batch.groovy
@@ -16,10 +16,6 @@
 // under the License.
 
 suite("test_ivm_fallback_stream_multi_batch", "nonConcurrent") {
-    if (isCloudMode()) {
-        return
-    }
-
     def forcedFallbackDebugPoint = "IvmIncrRefreshManager.doRefresh.force_fallback_reason"
 
     GetDebugPoint().disableDebugPointForAllFEs(forcedFallbackDebugPoint)

--- a/regression-test/suites/mtmv_p0/ivm/test_ivm_fallback_stream_multi_batch_dup.groovy
+++ b/regression-test/suites/mtmv_p0/ivm/test_ivm_fallback_stream_multi_batch_dup.groovy
@@ -16,10 +16,6 @@
 // under the License.
 
 suite("test_ivm_fallback_stream_multi_batch_dup", "nonConcurrent") {
-    if (isCloudMode()) {
-        return
-    }
-
     def forcedFallbackDebugPoint = "IvmIncrRefreshManager.doRefresh.force_fallback_reason"
     GetDebugPoint().disableDebugPointForAllFEs(forcedFallbackDebugPoint)
 

--- a/regression-test/suites/mtmv_p0/ivm/test_ivm_mtmv_row_binlog.groovy
+++ b/regression-test/suites/mtmv_p0/ivm/test_ivm_mtmv_row_binlog.groovy
@@ -16,10 +16,6 @@
 // under the License.
 
 suite("test_ivm_mtmv_row_binlog") {
-    if (isCloudMode()) {
-        return
-    }
-
     sql """DROP MATERIALIZED VIEW IF EXISTS test_ivm_mtmv_row_binlog_mv;"""
     sql """DROP TABLE IF EXISTS test_ivm_mtmv_row_binlog_base;"""
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: None

Related PR: None

Problem Summary: Several IVM regression suites unconditionally skipped cloud mode without a cloud-specific reason. Remove those guards so ordinary IVM, fallback-stream, column-drop, and row-binlog coverage runs in both deployment modes while retaining guards for transaction-path and plan-shape differences.

Related issue: https://github.com/apache/doris/issues/65418

### Release note

None

### Check List (For Author)

- Test: Diff check passed; regression suite not run
- Behavior changed: No
- Does this need documentation: No