### PR TITLE
[fix](fd) Guard aggregate uniqueness with injectivity proofs

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/util/ExpressionUtils.java
@@ -88,6 +88,8 @@ import org.apache.doris.nereids.trees.plans.logical.LogicalEmptyRelation;
 import org.apache.doris.nereids.trees.plans.logical.LogicalUnion;
 import org.apache.doris.nereids.trees.plans.visitor.ExpressionLineageReplacer;
 import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.types.DecimalV2Type;
+import org.apache.doris.nereids.types.DecimalV3Type;
 import org.apache.doris.nereids.types.VariantType;
 import org.apache.doris.nereids.types.coercion.NumericType;
 import org.apache.doris.qe.ConnectContext;
@@ -1205,9 +1207,66 @@ public class ExpressionUtils {
         return expression instanceof Slot;
     }
 
-    // if the input is unique, the output of agg is unique, too
+    /**
+     * Whether an aggregate preserves uniqueness for a group containing exactly one row.
+     *
+     * <p>Checking the aggregate kind and its input slots is not sufficient. An aggregate argument
+     * may contain a non-injective expression, and the aggregate return type may also collapse
+     * distinct argument values. Keep this proof deliberately narrow: the argument must be a bare
+     * slot, and the one-row result conversion must be a proven lossless numeric conversion.
+     */
     public static boolean isInjectiveAgg(Expression agg) {
-        return agg instanceof Sum || agg instanceof Avg || agg instanceof Max || agg instanceof Min;
+        if (!(agg instanceof Sum || agg instanceof Avg || agg instanceof Max || agg instanceof Min)) {
+            return false;
+        }
+        Expression argument = agg.child(0);
+        return argument instanceof Slot
+                && isProvablyInjectiveNumericConversion(argument.getDataType(), agg.getDataType());
+    }
+
+    /**
+     * A deliberately small whitelist of numeric conversions that preserve every source value.
+     * Do not use the general cast compatibility predicates here: some conversions accepted by
+     * them can truncate values (for example, casting an integer to a bounded character type).
+     */
+    private static boolean isProvablyInjectiveNumericConversion(DataType source, DataType target) {
+        if (!source.isNumericType() || !target.isNumericType()) {
+            return false;
+        }
+        if (source.equals(target)) {
+            return true;
+        }
+        if (source.isIntegralType()) {
+            if (target.isIntegralType()) {
+                return target.width() > source.width();
+            }
+            // IEEE 754 binary32 and binary64 have 24 and 53 bits of integer precision.
+            if (target.isFloatType()) {
+                return source.width() <= Short.BYTES;
+            }
+            if (target.isDoubleType()) {
+                return source.width() <= Integer.BYTES;
+            }
+            return false;
+        }
+        if (source.isFloatType()) {
+            return target.isDoubleType();
+        }
+        if (source.isDecimalLikeType() && target.isDecimalLikeType()) {
+            return decimalRange(target) >= decimalRange(source)
+                    && decimalScale(target) >= decimalScale(source);
+        }
+        return false;
+    }
+
+    private static int decimalRange(DataType type) {
+        return type instanceof DecimalV2Type
+                ? ((DecimalV2Type) type).getRange() : ((DecimalV3Type) type).getRange();
+    }
+
+    private static int decimalScale(DataType type) {
+        return type instanceof DecimalV2Type
+                ? ((DecimalV2Type) type).getScale() : ((DecimalV3Type) type).getScale();
     }
 
     public static <E> Set<E> mutableCollect(List<? extends Expression> expressions,

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniqueTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/properties/UniqueTest.java
@@ -79,6 +79,45 @@ class UniqueTest extends TestWithFeService {
     }
 
     @Test
+    void testAggregateOutputInjectivity() {
+        Plan plan = PlanChecker.from(connectContext)
+                .analyze("select sum(abs(id)) as s from agg group by id")
+                .getPlan();
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait()
+                .isUnique(plan.getOutput().get(0)));
+
+        plan = PlanChecker.from(connectContext)
+                .analyze("select avg(cast(id as bigint)) as a from agg group by id")
+                .getPlan();
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait()
+                .isUnique(plan.getOutput().get(0)));
+
+        plan = PlanChecker.from(connectContext)
+                .analyze("select sum(cast(id as bigint)) as s from agg group by id")
+                .getPlan();
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait()
+                .isUnique(plan.getOutput().get(0)));
+
+        plan = PlanChecker.from(connectContext)
+                .analyze("select max(cast(id as bigint)) as m from agg group by id")
+                .getPlan();
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait()
+                .isUnique(plan.getOutput().get(0)));
+
+        plan = PlanChecker.from(connectContext)
+                .analyze("select sum(cast(id as tinyint)) as s from agg group by id")
+                .getPlan();
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait()
+                .isUnique(plan.getOutput().get(0)));
+
+        plan = PlanChecker.from(connectContext)
+                .analyze("select max(cast(id as char(1))) as m from agg group by id")
+                .getPlan();
+        Assertions.assertFalse(plan.getLogicalProperties().getTrait()
+                .isUnique(plan.getOutput().get(0)));
+    }
+
+    @Test
     void testScan() throws Exception {
         // test agg key
         Plan plan = PlanChecker.from(connectContext)

--- a/regression-test/data/nereids_rules_p0/eliminate_gby_key/eliminate_group_by.out
+++ b/regression-test/data/nereids_rules_p0/eliminate_gby_key/eliminate_group_by.out
@@ -198,3 +198,12 @@ PhysicalResultSink
 ----filter((test_unique2.__DORIS_DELETE_SIGN__ = 0))
 ------PhysicalOlapScan[test_unique2]
 
+-- !non_injective_agg_argument --
+1	2
+
+-- !non_injective_agg_result_cast --
+9007199254740992	2
+
+-- !truncating_agg_argument_cast --
+1	2
+

--- a/regression-test/suites/nereids_rules_p0/eliminate_gby_key/eliminate_group_by.groovy
+++ b/regression-test/suites/nereids_rules_p0/eliminate_gby_key/eliminate_group_by.groovy
@@ -51,4 +51,48 @@ suite("eliminate_group_by") {
     qt_variance_samp_shape "explain shape plan select a,variance_samp(b),variance_samp(null) from test_unique2 group by a order by 1,2,3;"
     qt_sum0_shape "explain shape plan select a,sum0(b),sum0(null) from test_unique2 group by a order by 1,2,3;"
     qt_median_shape "explain shape plan select a,median(b),any_value(b),percentile(a,0.1),percentile(b,0.9),percentile(b,0.4) from test_unique2 group by a order by 1,2,3,4,5,6;"
+    sql "drop table if exists test_agg_output_injectivity;"
+    sql """
+        create table test_agg_output_injectivity(pk bigint not null)
+        unique key(pk)
+        distributed by hash(pk) buckets 1
+        properties("replication_num"="1");
+    """
+    sql """
+        insert into test_agg_output_injectivity
+        values (-1), (1), (10), (11), (9007199254740992), (9007199254740993);
+    """
+    order_qt_non_injective_agg_argument """
+        select s, count(*) as n
+        from (
+            select pk, sum(abs(pk)) as s
+            from test_agg_output_injectivity
+            where abs(pk) = 1
+            group by pk
+        ) q
+        group by s
+        order by s, n;
+    """
+    order_qt_non_injective_agg_result_cast """
+        select a, count(*) as n
+        from (
+            select pk, avg(pk) as a
+            from test_agg_output_injectivity
+            where pk > 100
+            group by pk
+        ) q
+        group by a
+        order by a, n;
+    """
+    order_qt_truncating_agg_argument_cast """
+        select m, count(*) as n
+        from (
+            select pk, max(cast(pk as char(1))) as m
+            from test_agg_output_injectivity
+            where pk between 10 and 11
+            group by pk
+        ) q
+        group by m
+        order by m, n;
+    """
 }


### PR DESCRIPTION
## Problem

Nereids inferred that a grouped aggregate output was unique whenever its input slot was unique. A non-injective argument expression or a lossy result conversion can make different groups produce the same value, so eliminating a later `GROUP BY` can return duplicate rows or incorrect counts.

## Fix

Trace the aggregate argument back to a slot through injective casts using the existing `getExpressionCoveredBySafetyCast` helper. For `MIN` and `MAX`, this is sufficient for single-row groups. For `SUM` and `AVG`, also require an injective conversion from the original slot type to the aggregate result type, using `DataType.isInjectiveCastTo` (updated on master by #68134).

This reuses the shared cast rules instead of maintaining an aggregate-specific cast whitelist. Truncating `CHAR`/`VARCHAR` casts remain non-injective because their parsed argument includes a `substring` expression, which cannot be traced back through injective casts. The same aggregate check is used by logical and physical traits.

## Tests

- `./run-fe-ut.sh --run org.apache.doris.nereids.properties.UniqueTest,org.apache.doris.nereids.rules.rewrite.SimplifyAggGroupByTest,org.apache.doris.nereids.types.DataTypeTest` — 80 tests passed.
- `DISABLE_BUILD_UI=ON DISABLE_BE_JAVA_EXTENSIONS=ON MVN_OPT=-Dmaven.build.cache.enabled=false FE_MAVEN_THREADS=1 ./build.sh --fe` — passed.
- `./run-regression-test.sh --run -f regression-test/suites/nereids_rules_p0/eliminate_gby_key/eliminate_group_by.groovy` — passed against the sandbox FE/BE. Added cases cover `SUM(ABS(pk))`, `AVG(BIGINT)`, truncating `CHAR(1)`, and ambiguous array-to-string serialization.
