### PR TITLE
[fix](fe) Preserve Kinesis initial shard position state

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kinesis/KinesisRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/kinesis/KinesisRoutineLoadJob.java
@@ -69,6 +69,7 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -119,6 +120,10 @@ public class KinesisRoutineLoadJob extends RoutineLoadJob {
     // Values: TRIM_HORIZON, LATEST, or a timestamp string.
     private String kinesisDefaultPosition = "";
 
+    // Null means this field was absent in a legacy image. New jobs set it explicitly.
+    @SerializedName("kips")
+    private Boolean kinesisInitialPositionSet;
+
     // custom Kinesis properties including AWS credentials and client settings.
     @SerializedName("prop")
     private Map<String, String> customProperties = Maps.newHashMap();
@@ -142,6 +147,7 @@ public class KinesisRoutineLoadJob extends RoutineLoadJob {
         this.region = region;
         this.stream = stream;
         this.progress = new KinesisProgress();
+        this.kinesisInitialPositionSet = false;
     }
 
     public KinesisRoutineLoadJob(Long id, String name, long dbId,
@@ -151,7 +157,22 @@ public class KinesisRoutineLoadJob extends RoutineLoadJob {
         this.region = region;
         this.stream = stream;
         this.progress = new KinesisProgress();
+        this.kinesisInitialPositionSet = false;
         setMultiTable(isMultiTable);
+    }
+
+    @Override
+    public void gsonPostProcess() throws IOException {
+        super.gsonPostProcess();
+        if (kinesisInitialPositionSet == null) {
+            // Legacy images have no marker. A job that has already left the initial
+            // scheduling state must not treat a later empty progress as first setup.
+            kinesisInitialPositionSet = state != JobState.NEED_SCHEDULE
+                    || ((KinesisProgress) progress).hasShards()
+                    || !openKinesisShards.isEmpty()
+                    || !closedKinesisShards.isEmpty()
+                    || !customKinesisShards.isEmpty();
+        }
     }
 
     public String getRegion() {
@@ -285,6 +306,10 @@ public class KinesisRoutineLoadJob extends RoutineLoadJob {
 
     private void updateProgressAndOffsetsCache(RLTaskTxnCommitAttachment attachment) {
         KinesisProgress taskProgress = (KinesisProgress) attachment.getProgress();
+
+        // A completed task proves that initial positions have already been resolved.
+        // Keep this marker across the parent-shard progress being removed below.
+        kinesisInitialPositionSet = true;
 
         // Keep the latest observed MillisBehindLatest per shard instead of the historical max.
         taskProgress.getShardIdToMillsBehindLatest().forEach(cachedShardWithMillsBehindLatest::put);
@@ -541,8 +566,9 @@ public class KinesisRoutineLoadJob extends RoutineLoadJob {
     }
 
     private void updateNewShardProgress() throws UserException {
-        // Check if this is initial setup (no shards in progress yet)
-        boolean isInitialSetup = !((KinesisProgress) progress).hasShards();
+        // Progress can be empty after all previously tracked shards were consumed.
+        // Use the lifecycle marker instead of emptiness to distinguish first setup.
+        boolean isInitialSetup = !Boolean.TRUE.equals(kinesisInitialPositionSet);
 
         // Combine open and closed shards
         List<String> allShards = Lists.newArrayList();
@@ -572,6 +598,9 @@ public class KinesisRoutineLoadJob extends RoutineLoadJob {
                             .add("msg", "The new shard has been added in job"));
                 }
             }
+        }
+        if (!allShards.isEmpty()) {
+            kinesisInitialPositionSet = true;
         }
     }
 
@@ -735,6 +764,7 @@ public class KinesisRoutineLoadJob extends RoutineLoadJob {
 
             if (resetProgress) {
                 this.progress = new KinesisProgress();
+                this.kinesisInitialPositionSet = false;
                 this.openKinesisShards.clear();
                 this.closedKinesisShards.clear();
                 this.cachedShardWithMillsBehindLatest.clear();

--- a/fe/fe-core/src/test/java/org/apache/doris/load/routineload/KinesisRoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/load/routineload/KinesisRoutineLoadJobTest.java
@@ -25,6 +25,7 @@ import org.apache.doris.load.routineload.kinesis.KinesisDataSourceProperties;
 import org.apache.doris.load.routineload.kinesis.KinesisProgress;
 import org.apache.doris.load.routineload.kinesis.KinesisRoutineLoadJob;
 import org.apache.doris.load.routineload.kinesis.KinesisTaskInfo;
+import org.apache.doris.persist.gson.GsonUtils;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -192,6 +193,8 @@ public class KinesisRoutineLoadJobTest {
 
         KinesisProgress progress = Deencapsulation.getField(routineLoadJob, "progress");
         Assertions.assertFalse(progress.hasShards());
+        Assertions.assertFalse((Boolean) Deencapsulation.getField(routineLoadJob,
+                "kinesisInitialPositionSet"));
         Map<String, Long> cachedLag = Deencapsulation.getField(routineLoadJob, "cachedShardWithMillsBehindLatest");
         Assertions.assertTrue(cachedLag.isEmpty());
     }
@@ -294,6 +297,8 @@ public class KinesisRoutineLoadJobTest {
         Deencapsulation.invoke(routineLoadJob, "updateProgressAndOffsetsCache", attachment);
 
         KinesisProgress progress = Deencapsulation.getField(routineLoadJob, "progress");
+        Assertions.assertTrue((Boolean) Deencapsulation.getField(routineLoadJob,
+                "kinesisInitialPositionSet"));
         Assertions.assertFalse(progress.containsShard("shard-parent"));
         Assertions.assertTrue(progress.containsShard("shard-child-0"));
         Assertions.assertTrue(progress.containsShard("shard-child-1"));
@@ -309,6 +314,33 @@ public class KinesisRoutineLoadJobTest {
         Deencapsulation.setField(routineLoadJob, "newCurrentKinesisShards",
                 Lists.newArrayList("shard-child-0", "shard-child-1"));
         Assertions.assertFalse((Boolean) Deencapsulation.invoke(routineLoadJob, "isKinesisShardsChanged"));
+    }
+
+    @Test
+    public void testNewShardUsesTrimHorizonAfterProgressBecomesEmpty() throws Exception {
+        KinesisRoutineLoadJob routineLoadJob =
+                new KinesisRoutineLoadJob(1L, "kinesis_routine_load_job", 1L,
+                        1L, "us-east-1", "stream-1", UserIdentity.ADMIN);
+        Deencapsulation.setField(routineLoadJob, "progress", new KinesisProgress(new HashMap<>()));
+        Deencapsulation.setField(routineLoadJob, "openKinesisShards", Lists.newArrayList("initial-shard"));
+        Deencapsulation.setField(routineLoadJob, "closedKinesisShards", Lists.newArrayList());
+        Deencapsulation.setField(routineLoadJob, "kinesisDefaultPosition", KinesisProgress.POSITION_LATEST);
+
+        Deencapsulation.invoke(routineLoadJob, "updateNewShardProgress");
+        KinesisProgress progress = Deencapsulation.getField(routineLoadJob, "progress");
+        Assertions.assertEquals(KinesisProgress.POSITION_LATEST,
+                progress.getSequenceNumberByShard("initial-shard"));
+        Assertions.assertTrue((Boolean) Deencapsulation.getField(routineLoadJob,
+                "kinesisInitialPositionSet"));
+        Assertions.assertTrue(GsonUtils.GSON.toJson(routineLoadJob).contains("\"kips\":true"));
+
+        // The completed parent was removed from progress before this child was discovered.
+        progress.getShardIdToSequenceNumber().clear();
+        Deencapsulation.setField(routineLoadJob, "openKinesisShards", Lists.newArrayList("child-shard"));
+        Deencapsulation.invoke(routineLoadJob, "updateNewShardProgress");
+
+        Assertions.assertEquals(KinesisProgress.TRIM_HORIZON_VAL,
+                progress.getSequenceNumberByShard("child-shard"));
     }
 
     @Test


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: N/A

Related PR: N/A

Problem Summary:

Kinesis Routine Load used an empty progress map as the signal that a job was undergoing its initial shard setup. This is not a valid lifecycle invariant. When a closed parent shard is fully consumed, `KinesisProgress.update()` removes that shard from the progress map. The map can therefore become empty after the job has already completed its initial positioning.

A reshard can create child shards before the next FE metadata refresh. In that window, `KinesisRoutineLoadJob.updateNewShardProgress()` sees an empty progress map and treats the children as initial shards. It applies the configured `LATEST` position. Kinesis `LATEST` starts after the current tip, so records written to the children before FE discovers them are skipped.

The fix stores this lifecycle state separately from the currently tracked shard positions:

- New jobs start with `kinesisInitialPositionSet = false`.
- After initial shard positions are established, the marker is set to true.
- A committed or replayed Kinesis task also confirms that initial positioning has happened, so the marker survives parent-shard progress removal.
- Newly discovered shards after initialization continue to use `TRIM_HORIZON`, even when the progress map is empty.
- The marker is persisted in the Kinesis routine load job image.
- Legacy images without the marker infer the state from the persisted job state and shard lists.
- ALTER that changes the stream and resets progress clears the marker so the new stream uses its configured initial position.

The test directly invokes the production FE method and models the complete boundary: initial shard setup with `LATEST`, removal of the completed parent from progress, and discovery of a child shard. It verifies that the child receives `TRIM_HORIZON`. Additional assertions cover transaction progress handling, image serialization, and stream-change reset.

### Release note

Prevent Kinesis Routine Load from skipping records on newly discovered child shards after parent shard progress is exhausted.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [ ] Regression test
    - [x] Unit Test
        - `./run-fe-ut.sh --run org.apache.doris.load.routineload.KinesisRoutineLoadJobTest`
        - 10 tests passed, 0 failures, 0 errors, 0 skipped
        - The same test failed before the fix with: `expected: <-2> but was: <LATEST>`
    - [ ] Manual test
    - [ ] No need to test or manual test
- Additional validation:
    - `cd fe && mvn checkstyle:check -pl fe-core -Dcheckstyle.skip=false` passed
    - `build-support/check-build-hygiene.sh` passed
    - `build-support/check-format.sh` passed
    - `git diff --check` passed
- Behavior changed:
    - [ ] No.
    - [x] Yes. Initial shards retain the configured default position, while shards discovered after initial setup use `TRIM_HORIZON`.
- Does this need documentation:
    - [x] No.
    - [ ] Yes.

The FE unit test was chosen because R4 is a frontend lifecycle-state bug. It calls the production `KinesisRoutineLoadJob` implementation and avoids a timing-dependent AWS integration setup. No AWS credentials were read and no Kinesis stream was created.

This PR is based on `origin/master` and contains only the R4 implementation and its FE unit-test coverage. Existing Kinesis BE consumer fixes remain separate.

### Check List (For Reviewer who merge this PR)

- [ ] Confirm the release note
- [ ] Confirm test cases
- [ ] Confirm document
- [ ] Add branch pick label

