### PR TITLE
[refactor](session) Move result encoding behind ResultSender

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/arrowflight/DorisFlightSqlProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/arrowflight/DorisFlightSqlProducer.java
@@ -43,6 +43,7 @@ import org.apache.arrow.flight.Criteria;
 import org.apache.arrow.flight.FlightDescriptor;
 import org.apache.arrow.flight.FlightEndpoint;
 import org.apache.arrow.flight.FlightInfo;
+import org.apache.arrow.flight.FlightRuntimeException;
 import org.apache.arrow.flight.FlightStream;
 import org.apache.arrow.flight.Location;
 import org.apache.arrow.flight.PutResult;
@@ -317,6 +318,10 @@ public class DorisFlightSqlProducer implements FlightSqlProducer, AutoCloseable 
             return FlightProtocolAdapter.of(connectContext).callCommand(connectContext,
                     () -> executeQueryStatement(context.peerIdentity(), connectContext, request.getQuery(),
                             descriptor));
+        } catch (FlightRuntimeException e) {
+            // Already carries the status meant for the client, e.g. UNAVAILABLE from the session's
+            // command lock; wrapping it as INTERNAL would hide that.
+            throw e;
         } catch (Throwable e) {
             String errMsg = "get flight info statement failed, " + e.getMessage();
             LOG.error(errMsg, e);
@@ -660,6 +665,11 @@ public class DorisFlightSqlProducer implements FlightSqlProducer, AutoCloseable 
         try {
             ConnectContext connectContext = flightSessionsManager.getConnectContext(context.peerIdentity());
             FlightProtocolAdapter.of(connectContext).runCommand(connectContext, () -> stream.send(connectContext));
+        } catch (FlightRuntimeException e) {
+            // Same as in getFlightInfoStatement: keep the status the session's command lock chose.
+            LOG.error("stream metadata failed", e);
+            listener.error(e);
+            throw e;
         } catch (final Throwable e) {
             handleStreamException(e, "", listener);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/arrowflight/FlightSqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/arrowflight/FlightSqlConnectProcessor.java
@@ -28,7 +28,6 @@ import org.apache.doris.mysql.MysqlCommand;
 import org.apache.doris.proto.InternalService;
 import org.apache.doris.proto.Types;
 import org.apache.doris.qe.ConnectContext;
-import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.qe.ConnectProcessor;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.rpc.BackendServiceProxy;
@@ -64,7 +63,6 @@ public class FlightSqlConnectProcessor extends ConnectProcessor implements AutoC
 
     public FlightSqlConnectProcessor(ConnectContext context) {
         super(context);
-        connectType = ConnectType.ARROW_FLIGHT_SQL;
         context.setThreadLocalInfo();
         context.setReturnResultFromLocal(true);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/arrowflight/protocol/FlightProtocolAdapter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/arrowflight/protocol/FlightProtocolAdapter.java
@@ -21,20 +21,26 @@ import org.apache.doris.arrowflight.auth2.FlightRemoteIpServerStreamTracer;
 import org.apache.doris.arrowflight.results.FlightSqlChannel;
 import org.apache.doris.arrowflight.results.FlightSqlEndpointsLocation;
 import org.apache.doris.common.Config;
+import org.apache.doris.common.ErrorCode;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.qe.ConnectPoolMgr;
 import org.apache.doris.qe.ConnectScheduler;
+import org.apache.doris.qe.QueryState;
+import org.apache.doris.qe.ShowResultSet;
 import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.qe.protocol.ProtocolAdapter;
 import org.apache.doris.thrift.TResultSinkType;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import org.apache.arrow.flight.CallStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -84,7 +90,8 @@ public class FlightProtocolAdapter implements ProtocolAdapter {
         if (adapter instanceof FlightProtocolAdapter) {
             return (FlightProtocolAdapter) adapter;
         }
-        throw new IllegalStateException("not an Arrow Flight SQL connection: " + adapter.type());
+        throw new IllegalStateException("not an Arrow Flight SQL connection: "
+                + (adapter == null ? "no protocol adapter" : adapter.type()));
     }
 
     @Override
@@ -107,8 +114,74 @@ public class FlightProtocolAdapter implements ProtocolAdapter {
     }
 
     @Override
+    public FlightResultSender resultSender(ConnectContext ctx) {
+        return new FlightResultSender(ctx, this);
+    }
+
+    /**
+     * The SQL cache keeps the result rows in MySQL wire format, which cannot be turned into the
+     * Arrow batches a Flight client needs; the cached rows would be wrong for it anyway (object
+     * types such as HLL / BITMAP / QUANTILE_STATE were serialized as NULL under
+     * return_object_data_as_binary=false). A Flight session always re-executes the query.
+     */
+    @Override
+    public boolean supportsSqlCacheReplay() {
+        return false;
+    }
+
+    @Override
     public ConnectPoolMgr connectPool(ConnectScheduler scheduler) {
         return scheduler.getFlightSqlConnectPoolMgr();
+    }
+
+    /**
+     * A statement forwarded to the master has its outcome carried into this session here, the
+     * way {@code MysqlProtocolAdapter.finishCommand} replays it to a MySQL client. And of the
+     * statements of one request only the last may produce a result: the FlightInfo returned for
+     * the request describes exactly one.
+     */
+    @Override
+    public boolean finishStatement(ConnectContext ctx, StmtExecutor executor, int stmtIndex, int stmtCount)
+            throws IOException {
+        if (executor.hasForwardedToMaster()) {
+            carryForwardedOutcome(ctx, executor);
+        }
+        Preconditions.checkState(channel.resultNum() <= 1);
+        if (channel.resultNum() == 1 && stmtIndex != stmtCount - 1) {
+            String errMsg = "Only be one stmt that returns the result and it is at the end. "
+                    + "stmts.size(): " + stmtCount;
+            LOG.warn(errMsg);
+            ctx.getState().setError(ErrorCode.ERR_ARROW_FLIGHT_SQL_MUST_ONLY_RESULT_STMT, errMsg);
+            ctx.getState().setErrType(QueryState.ErrType.OTHER_ERR);
+            return false;
+        }
+        return true;
+    }
+
+    // The master answers a forwarded statement with its status and, for a SHOW, its rows. Without
+    // this a forwarded statement leaves ctx.getState() at the OK that executeQuery() set with
+    // reset() and leaves the FlightSqlChannel empty, so DorisFlightSqlProducer answers with
+    // addOKResult()'s synthesized StatusResult=0 -- reporting success for a statement that failed
+    // on the master, and an empty status row instead of the rows a forwarded SHOW produced.
+    @VisibleForTesting
+    void carryForwardedOutcome(ConnectContext ctx, StmtExecutor executor) throws IOException {
+        if (executor.getProxyStatusCode() != 0) {
+            // The master rejected the statement, e.g. CREATE TABLE on a table that already exists.
+            // TMasterOpResult carries the master's error code as a plain int and ErrorCode has no
+            // reverse lookup, so the master's code travels in the message instead.
+            String errMsg = "forwarded statement failed on master FE, error code: "
+                    + executor.getProxyStatusCode() + ", error message: " + executor.getProxyErrMsg();
+            LOG.warn(errMsg);
+            ctx.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR, errMsg);
+            return;
+        }
+        // Set exactly when the forwarded statement produced rows: proxyExecute() fills
+        // TMasterOpResult.resultSet from getProxyShowResultSet(). A forwarded DDL produces none,
+        // and the synthesized StatusResult=0 is the right answer for it.
+        ShowResultSet resultSet = executor.getShowResultSet();
+        if (resultSet != null) {
+            executor.sendResultSet(resultSet);
+        }
     }
 
     @Override
@@ -238,7 +311,7 @@ public class FlightProtocolAdapter implements ProtocolAdapter {
      * Runs one command of the session, and no other one at the same time: a statement, a prepared
      * statement action, a DoGet of a frontend-side result, a metadata request. The session's
      * {@link ConnectContext} is the thread's current context while the command runs. A command
-     * that finds another one still running waits for it up to the session's query timeout and
+     * that finds another one still running waits for it up to the session's execution timeout and
      * then fails with {@code UNAVAILABLE} instead of running concurrently on the same context.
      *
      * <p>Session teardown (bearer token expiry, CloseSession, KILL) does not go through here.
@@ -268,16 +341,22 @@ public class FlightProtocolAdapter implements ProtocolAdapter {
     }
 
     private void acquireCommandLock(ConnectContext ctx) {
-        long waitS = ctx.getQueryTimeoutS();
+        // Wait as long as the running command is allowed to run: for a synchronous load statement
+        // that is max(insert_timeout, query_timeout), the bound the timeout checker applies to it.
+        long waitS = ctx.getExecTimeoutS();
         boolean locked;
         try {
             locked = commandLock.tryLock(waitS, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            LOG.warn("interrupted while waiting for the running command of Arrow Flight SQL connection {}",
+                    ctx.getConnectionId());
             throw CallStatus.CANCELLED.withDescription("interrupted while waiting for the previous command of "
                     + "this Arrow Flight SQL session to finish").withCause(e).toRuntimeException();
         }
         if (!locked) {
+            LOG.warn("a command of Arrow Flight SQL connection {} gave up after waiting {}s for the running one",
+                    ctx.getConnectionId(), waitS);
             throw CallStatus.UNAVAILABLE.withDescription(String.format("another command of this Arrow Flight SQL "
                     + "session is still running after %d seconds, connection id: %d", waitS, ctx.getConnectionId()))
                     .toRuntimeException();

--- a/fe/fe-core/src/main/java/org/apache/doris/arrowflight/protocol/FlightResultSender.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/arrowflight/protocol/FlightResultSender.java
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.arrowflight.protocol;
+
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.mysql.FieldInfo;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.ResultSet;
+import org.apache.doris.qe.protocol.ResultSender;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+/**
+ * Delivers the results of an Arrow Flight SQL session. A result the frontend materialized is
+ * cached on the session's {@code FlightSqlChannel} under the statement's query id, and
+ * {@code DorisFlightSqlProducer} hands it out when the client's DoGet arrives. A result a backend
+ * produces never passes through the frontend: the client pulls it from the backend with the
+ * endpoints GetFlightInfo returned, so this sender has no row stream.
+ *
+ * <p>Every column of a cached result is a {@code Utf8} vector for now; typing them by the result
+ * set's column types is a later step.
+ */
+public class FlightResultSender implements ResultSender {
+    private final ConnectContext ctx;
+    private final FlightProtocolAdapter adapter;
+
+    FlightResultSender(ConnectContext ctx, FlightProtocolAdapter adapter) {
+        this.ctx = ctx;
+        this.adapter = adapter;
+    }
+
+    @Override
+    public void sendResultSet(ResultSet resultSet, List<FieldInfo> fieldInfos, boolean binaryRows) {
+        adapter.getChannel().addResult(DebugUtil.printId(ctx.queryId()), adapter.getRunningQuery(), resultSet);
+        // The statement's result is on this frontend, whatever the query path decided earlier: an
+        // EXPLAIN goes through the query path, which marks the result as coming from the backend
+        // before it knows the statement will not run there.
+        adapter.setReturnResultFromLocal(true);
+    }
+
+    @Override
+    public void sendFields(List<String> colNames, List<FieldInfo> fieldInfos, List<Type> types) {
+        throw new IllegalStateException(
+                "an Arrow Flight SQL client pulls query results from the backend, not through the frontend");
+    }
+
+    @Override
+    public void sendRow(ByteBuffer row) {
+        throw new IllegalStateException(
+                "an Arrow Flight SQL client pulls query results from the backend, not through the frontend");
+    }
+
+    @Override
+    public void reset() {
+        // Results are cached per query id and the cache is cleared when the next request of the
+        // session starts (DorisFlightSqlProducer.executeQueryStatement); nothing is pending here.
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/arrowflight/results/FlightSqlChannel.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/arrowflight/results/FlightSqlChannel.java
@@ -84,34 +84,6 @@ public class FlightSqlChannel {
         resultCache.put(queryId, flightSqlResultCacheEntry);
     }
 
-    public void addResult(String queryId, String runningQuery, ResultSetMetaData metaData, String result) {
-        List<Field> schemaFields = new ArrayList<>();
-        List<FieldVector> dataFields = new ArrayList<>();
-
-        // TODO: only support varchar type
-        for (Column col : metaData.getColumns()) {
-            schemaFields.add(new Field(col.getName(), FieldType.nullable(new Utf8()), null));
-            VarCharVector varCharVector = new VarCharVector(col.getName(), allocator);
-            varCharVector.allocateNew();
-            varCharVector.setValueCount(result.split("\n").length);
-            dataFields.add(varCharVector);
-        }
-
-        int rowNum = 0;
-        for (String item : result.split("\n")) {
-            if (item == null || item.equals(FeConstants.null_string)) {
-                dataFields.get(0).setNull(rowNum);
-            } else {
-                ((VarCharVector) dataFields.get(0)).setSafe(rowNum, item.getBytes());
-            }
-            rowNum += 1;
-        }
-        VectorSchemaRoot vectorSchemaRoot = new VectorSchemaRoot(schemaFields, dataFields);
-        final FlightSqlResultCacheEntry flightSqlResultCacheEntry = new FlightSqlResultCacheEntry(vectorSchemaRoot,
-                runningQuery);
-        resultCache.put(queryId, flightSqlResultCacheEntry);
-    }
-
     /**
      * Create a SchemaRoot with one row and one column.
      */

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/protocol/MysqlProtocolAdapter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/protocol/MysqlProtocolAdapter.java
@@ -17,18 +17,31 @@
 
 package org.apache.doris.mysql.protocol;
 
+import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.mysql.MysqlCapability;
 import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlCursorFetchCompatibility;
 import org.apache.doris.mysql.MysqlHandshakePacket;
+import org.apache.doris.mysql.MysqlPacket;
+import org.apache.doris.mysql.MysqlResultSetEndPacket;
+import org.apache.doris.mysql.MysqlSerializer;
+import org.apache.doris.mysql.MysqlServerStatusFlag;
 import org.apache.doris.mysql.MysqlSslContext;
+import org.apache.doris.nereids.glue.LogicalPlanAdapter;
+import org.apache.doris.nereids.stats.StatsErrorEstimator;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.qe.ConnectPoolMgr;
 import org.apache.doris.qe.ConnectProcessor;
 import org.apache.doris.qe.ConnectScheduler;
+import org.apache.doris.qe.QueryState.MysqlStateType;
+import org.apache.doris.qe.ShowResultSet;
+import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.qe.protocol.ProtocolAdapter;
 import org.apache.doris.thrift.TResultSinkType;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -43,6 +56,7 @@ import java.nio.ByteBuffer;
  * a client.
  */
 public class MysqlProtocolAdapter implements ProtocolAdapter {
+    private static final Logger LOG = LogManager.getLogger(MysqlProtocolAdapter.class);
     private static final String SSL_PROTOCOL = "TLS";
 
     private final MysqlChannel channel;
@@ -68,7 +82,8 @@ public class MysqlProtocolAdapter implements ProtocolAdapter {
         if (adapter instanceof MysqlProtocolAdapter) {
             return (MysqlProtocolAdapter) adapter;
         }
-        throw new IllegalStateException("not a MySQL connection: " + adapter.type());
+        throw new IllegalStateException("not a MySQL connection: "
+                + (adapter == null ? "no protocol adapter" : adapter.type()));
     }
 
     @Override
@@ -87,8 +102,111 @@ public class MysqlProtocolAdapter implements ProtocolAdapter {
     }
 
     @Override
+    public MysqlResultSender resultSender(ConnectContext ctx) {
+        return new MysqlResultSender(ctx, this);
+    }
+
+    @Override
+    public boolean supportsSqlCacheReplay() {
+        return true;
+    }
+
+    @Override
     public ConnectPoolMgr connectPool(ConnectScheduler scheduler) {
         return scheduler.getConnectPoolMgr();
+    }
+
+    /**
+     * Between the statements of a multi-statement request the intermediate response carries
+     * SERVER_MORE_RESULTS_EXISTS, and is sent right away if the client negotiated
+     * CLIENT_MULTI_STATEMENTS. Here Doris differs from MySQL: a client that did not negotiate it
+     * gets the request run as several statements anyway, but only the last result is delivered
+     * (the next query resets the channel, see {@link MysqlResultSender#reset}). The response of the
+     * last statement is the response of the command, sent by {@link #finishCommand}.
+     */
+    @Override
+    public boolean finishStatement(ConnectContext ctx, StmtExecutor executor, int stmtIndex, int stmtCount)
+            throws IOException {
+        if (stmtIndex != stmtCount - 1) {
+            ctx.getState().serverStatus |= MysqlServerStatusFlag.SERVER_MORE_RESULTS_EXISTS;
+            if (ctx.getState().getStateType() != MysqlStateType.ERR && channel.clientMultiStatements()) {
+                finishCommand(ctx, executor);
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Sends the response of the command: the OK, EOF or ERR packet that {@code ctx.getState()}
+     * describes, or, for a statement that was forwarded to the master, the packets the master
+     * produced. {@code executor} is null for a command that ran no statement.
+     */
+    public void finishCommand(ConnectContext ctx, StmtExecutor executor) throws IOException {
+        LOG.debug("Finalize command for query {}", DebugUtil.printId(ctx.queryId()));
+        ByteBuffer packet;
+        if (executor != null && executor.hasForwardedToMaster()
+                && ctx.getState().getStateType() != MysqlStateType.ERR) {
+            ShowResultSet resultSet = executor.getShowResultSet();
+            if (resultSet == null) {
+                executor.sendProxyQueryResult();
+                packet = executor.getOutputPacket();
+            } else {
+                executor.sendResultSet(resultSet);
+                packet = responsePacket(ctx);
+            }
+        } else {
+            packet = responsePacket(ctx);
+        }
+
+        if (packet == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("packet == null");
+            }
+            return;
+        }
+
+        LOG.debug("Send to mysql channel for query {}", DebugUtil.printId(ctx.queryId()));
+        channel.sendAndFlush(packet);
+        // note(wb) we should write profile after return result to mysql client
+        // because write profile maybe take too much time
+        // explain query stmt do not have profile
+        if (executor != null && executor.getParsedStmt() != null && !executor.getParsedStmt().isExplain()
+                && (executor.getParsedStmt() instanceof LogicalPlanAdapter)) {
+            executor.updateProfile(true);
+            StatsErrorEstimator statsErrorEstimator = ctx.getStatsErrorEstimator();
+            if (statsErrorEstimator != null) {
+                statsErrorEstimator.updateProfile(ctx.queryId());
+            }
+        }
+        LOG.debug("End finalizing command for query {}", DebugUtil.printId(ctx.queryId()));
+    }
+
+    /**
+     * The packet that answers the command according to {@code ctx.getState()}: null when the
+     * command needs no response or the handler already sent one.
+     */
+    public ByteBuffer responsePacket(ConnectContext ctx) {
+        MysqlPacket packet;
+        // When CLIENT_DEPRECATE_EOF is set and the state is EOF (end of result set),
+        // we need to send a "ResultSet OK" packet (0xFE header with payload > 5 bytes)
+        // instead of the traditional EOF packet. This is required by the MySQL protocol
+        // and expected by MySQL Connector/J 9.5.0+.
+        if (ctx.getState().getStateType() == MysqlStateType.EOF && channel.clientDeprecatedEOF()) {
+            packet = new MysqlResultSetEndPacket(ctx.getState());
+        } else {
+            packet = ctx.getState().toResponsePacket();
+        }
+        if (packet == null) {
+            // possible two cases:
+            // 1. handler has send request
+            // 2. this command need not to send response
+            return null;
+        }
+
+        MysqlSerializer serializer = channel.getSerializer();
+        serializer.reset();
+        packet.writeTo(serializer);
+        return serializer.toByteBuffer();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/org/apache/doris/mysql/protocol/MysqlResultSender.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/mysql/protocol/MysqlResultSender.java
@@ -1,0 +1,375 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.mysql.protocol;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.DatabaseIf;
+import org.apache.doris.catalog.TableIf;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.mysql.FieldInfo;
+import org.apache.doris.mysql.MysqlChannel;
+import org.apache.doris.mysql.MysqlCommand;
+import org.apache.doris.mysql.MysqlEofPacket;
+import org.apache.doris.mysql.MysqlResultSetEndPacket;
+import org.apache.doris.mysql.MysqlSerializer;
+import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.nereids.trees.expressions.Slot;
+import org.apache.doris.nereids.trees.expressions.SlotReference;
+import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.ResultSet;
+import org.apache.doris.qe.ResultSetMetaData;
+import org.apache.doris.qe.ShortCircuitQueryContext;
+import org.apache.doris.qe.protocol.ResultSender;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+/**
+ * Encodes results as MySQL protocol packets and writes them to the connection's
+ * {@link MysqlChannel}. The packets of a result set are: a column count, one column definition
+ * per column, a terminator after the definitions unless the client deprecated it, then one packet
+ * per row in text or binary format. The packet that ends the result set is the statement's
+ * response and is sent by {@link MysqlProtocolAdapter#finishCommand}.
+ *
+ * <p>The serializer is the channel's, so a sender obtained from a session's adapter can be handed
+ * to an executor of another (internal) session: what that executor produces then reaches this
+ * session's client, encoded with this session's negotiated capabilities.
+ */
+public class MysqlResultSender implements ResultSender {
+    private static final Logger LOG = LogManager.getLogger(MysqlResultSender.class);
+
+    private final ConnectContext ctx;
+    private final MysqlProtocolAdapter adapter;
+
+    MysqlResultSender(ConnectContext ctx, MysqlProtocolAdapter adapter) {
+        this.ctx = ctx;
+        this.adapter = adapter;
+    }
+
+    private MysqlChannel channel() {
+        return adapter.getChannel();
+    }
+
+    private MysqlSerializer serializer() {
+        return adapter.getChannel().getSerializer();
+    }
+
+    @Override
+    public void sendResultSet(ResultSet resultSet, List<FieldInfo> fieldInfos, boolean binaryRows)
+            throws IOException {
+        sendMetaData(resultSet.getMetaData(), fieldInfos);
+        if (binaryRows) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Use binary protocol to set result.");
+            }
+            sendBinaryResultRow(resultSet);
+        } else {
+            sendTextResultRow(resultSet);
+        }
+    }
+
+    @Override
+    public void sendFields(List<String> colNames, List<FieldInfo> fieldInfos, List<Type> types) throws IOException {
+        MysqlSerializer serializer = serializer();
+        MysqlChannel channel = channel();
+        // sends how many columns
+        serializer.reset();
+        serializer.writeVInt(colNames.size());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("sendFields {}", colNames);
+        }
+        channel.sendOnePacket(serializer.toByteBuffer());
+        StatementContext statementContext = ctx.getStatementContext();
+        boolean isShortCircuited = statementContext.isShortCircuitQuery()
+                && statementContext.getShortCircuitQueryContext() != null;
+        ShortCircuitQueryContext shortCircuitCtx = statementContext.getShortCircuitQueryContext();
+        // send field one by one
+        for (int i = 0; i < colNames.size(); ++i) {
+            serializer.reset();
+            if (ctx.getCommand() == MysqlCommand.COM_STMT_EXECUTE && isShortCircuited) {
+                // Using PreparedStatment pre serializedField to avoid serialize each time
+                // we send a field
+                byte[] serializedField = shortCircuitCtx.getSerializedField(i);
+                if (serializedField == null) {
+                    if (fieldInfos != null) {
+                        serializer.writeField(fieldInfos.get(i), types.get(i));
+                    } else {
+                        serializer.writeField(colNames.get(i), types.get(i));
+                    }
+                    serializedField = serializer.toArray();
+                    shortCircuitCtx.addSerializedField(i, serializedField);
+                }
+                channel.sendOnePacket(ByteBuffer.wrap(serializedField));
+            } else {
+                if (fieldInfos != null) {
+                    serializer.writeField(fieldInfos.get(i), types.get(i));
+                } else {
+                    serializer.writeField(colNames.get(i), types.get(i));
+                }
+                channel.sendOnePacket(serializer.toByteBuffer());
+            }
+        }
+        sendMetadataTerminatorIfNeeded();
+    }
+
+    @Override
+    public void sendRow(ByteBuffer row) throws IOException {
+        channel().sendOnePacket(row);
+    }
+
+    /** Clears the send flag and whatever the previous statement left in the send buffer. */
+    @Override
+    public void reset() {
+        channel().reset();
+    }
+
+    /**
+     * The response to COM_STMT_PREPARE: the OK packet with the statement id, then the parameter
+     * definitions and the column definitions, each list followed by an EOF unless the client
+     * deprecated it. Flushes, there is no separate terminator.
+     */
+    public void sendStmtPrepareOK(int stmtId, List<String> labels, List<Slot> output) throws IOException {
+        MysqlSerializer serializer = serializer();
+        MysqlChannel channel = channel();
+        // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_prepare.html#sect_protocol_com_stmt_prepare_response
+        serializer.reset();
+        // 0x00 OK
+        serializer.writeInt1(0);
+        // statement_id
+        serializer.writeInt4(stmtId);
+        // num_columns
+        int numColumns = output == null ? 0 : output.size();
+        serializer.writeInt2(numColumns);
+        // num_params
+        int numParams = labels.size();
+        serializer.writeInt2(numParams);
+        // reserved_1
+        serializer.writeInt1(0);
+        if (numParams > 0 || numColumns > 0) {
+            // warning_count
+            serializer.writeInt2(0);
+            // metadata_follows
+            serializer.writeInt1(1);
+        }
+        channel.sendOnePacket(serializer.toByteBuffer());
+        if (numParams > 0) {
+            // send field one by one
+            // TODO use real type instead of string, for JDBC client it's ok
+            // but for other client, type should be correct
+            // List<PrimitiveType> types = exprToStringType(labels);
+            List<String> colNames = labels;
+            for (int i = 0; i < colNames.size(); ++i) {
+                serializer.reset();
+                // serializer.writeField(colNames.get(i), Type.fromPrimitiveType(types.get(i)));
+                serializer.writeField(colNames.get(i), Type.STRING);
+                channel.sendOnePacket(serializer.toByteBuffer());
+            }
+            // When CLIENT_DEPRECATE_EOF is set, no EOF/OK packet should be sent after
+            // parameter definitions. The driver knows how many params to expect from the
+            // prepare OK packet and simply stops reading after that count.
+            if (!channel.clientDeprecatedEOF()) {
+                serializer.reset();
+                MysqlEofPacket eofPacket = new MysqlEofPacket(ctx.getState());
+                eofPacket.writeTo(serializer);
+                channel.sendOnePacket(serializer.toByteBuffer());
+            }
+        }
+        if (numColumns > 0) {
+            for (Slot slot : output) {
+                serializer.reset();
+                if (slot instanceof SlotReference
+                        && ((SlotReference) slot).getOriginalColumn().isPresent()
+                        && ((SlotReference) slot).getOriginalTable().isPresent()) {
+                    SlotReference slotReference = (SlotReference) slot;
+                    TableIf table = slotReference.getOriginalTable().get();
+                    Column column = slotReference.getOriginalColumn().get();
+                    DatabaseIf database = table.getDatabase();
+                    String dbName = database == null ? "" : database.getFullName();
+                    serializer.writeField(dbName, table.getName(), column, false);
+                } else {
+                    serializer.writeField(slot.getName(), slot.getDataType().toCatalogDataType());
+                }
+                channel.sendOnePacket(serializer.toByteBuffer());
+            }
+            // When CLIENT_DEPRECATE_EOF is set, no EOF/OK packet should be sent after
+            // column definitions. The driver knows how many columns to expect from the
+            // prepare OK packet and simply stops reading after that count.
+            if (!channel.clientDeprecatedEOF()) {
+                serializer.reset();
+                MysqlEofPacket eofPacket = new MysqlEofPacket(ctx.getState());
+                eofPacket.writeTo(serializer);
+                channel.sendOnePacket(serializer.toByteBuffer());
+            }
+        }
+        channel.flush();
+    }
+
+    /**
+     * The response to COM_FIELD_LIST: one column definition per column of the table, with the
+     * default values, and no column count. The terminator is the command's response.
+     */
+    public void sendFieldList(String dbName, String tableName, List<Column> columns) throws IOException {
+        MysqlSerializer serializer = serializer();
+        MysqlChannel channel = channel();
+        for (Column column : columns) {
+            serializer.reset();
+            serializer.writeField(dbName, tableName, column, true);
+            channel.sendOnePacket(serializer.toByteBuffer());
+        }
+    }
+
+    private void sendMetaData(ResultSetMetaData metaData, List<FieldInfo> fieldInfos) throws IOException {
+        MysqlSerializer serializer = serializer();
+        MysqlChannel channel = channel();
+        // sends how many columns
+        serializer.reset();
+        serializer.writeVInt(metaData.getColumnCount());
+        channel.sendOnePacket(serializer.toByteBuffer());
+        // send field one by one
+        for (int i = 0; i < metaData.getColumns().size(); i++) {
+            Column col = metaData.getColumn(i);
+            serializer.reset();
+            if (fieldInfos == null) {
+                // TODO(zhaochun): only support varchar type
+                serializer.writeField(col.getName(), col.getType());
+            } else {
+                serializer.writeField(fieldInfos.get(i), col.getType());
+            }
+            channel.sendOnePacket(serializer.toByteBuffer());
+        }
+        sendMetadataTerminatorIfNeeded();
+    }
+
+    private void sendMetadataTerminatorIfNeeded() throws IOException {
+        MysqlSerializer serializer = serializer();
+        MysqlChannel channel = channel();
+        if (!channel.clientDeprecatedEOF()) {
+            serializer.reset();
+            new MysqlEofPacket(ctx.getState()).writeTo(serializer);
+            channel.sendOnePacket(serializer.toByteBuffer());
+        } else if (adapter.clientConsumesCursorMetadataTerminator(ctx)) {
+            // Connector/J before 9.5 consumes the first OK packet after column definitions
+            // while probing whether a requested cursor was created. Doris does not create a
+            // cursor, so an empty result would otherwise lose its only end marker and block.
+            serializer.reset();
+            new MysqlResultSetEndPacket(ctx.getState()).writeTo(serializer);
+            channel.sendOnePacket(serializer.toByteBuffer());
+        }
+    }
+
+    private void sendTextResultRow(ResultSet resultSet) throws IOException {
+        MysqlSerializer serializer = serializer();
+        MysqlChannel channel = channel();
+        for (List<String> row : resultSet.getResultRows()) {
+            serializer.reset();
+            for (String item : row) {
+                if (item == null || item.equals(FeConstants.null_string)) {
+                    serializer.writeNull();
+                } else {
+                    serializer.writeLenEncodedString(item);
+                }
+            }
+            channel.sendOnePacket(serializer.toByteBuffer());
+        }
+    }
+
+    private void sendBinaryResultRow(ResultSet resultSet) throws IOException {
+        MysqlSerializer serializer = serializer();
+        MysqlChannel channel = channel();
+        // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_binary_resultset.html#sect_protocol_binary_resultset_row_value
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        int nullBitmapLength = (metaData.getColumnCount() + 7 + 2) / 8;
+        for (List<String> row : resultSet.getResultRows()) {
+            serializer.reset();
+            // Reserved one byte.
+            serializer.writeByte((byte) 0x00);
+            byte[] nullBitmap = new byte[nullBitmapLength];
+            // Generate null bitmap
+            for (int i = 0; i < row.size(); i++) {
+                String item = row.get(i);
+                if (item == null || item.equals(FeConstants.null_string)) {
+                    // The first 2 bits are reserved.
+                    int byteIndex = (i + 2) / 8;  // Index of the byte in the bitmap array
+                    int bitInByte = (i + 2) % 8;  // Position within the target byte (0-7)
+                    nullBitmap[byteIndex] |= (1 << bitInByte);
+                }
+            }
+            // Null bitmap
+            serializer.writeBytes(nullBitmap);
+            // Non-null columns
+            for (int i = 0; i < row.size(); i++) {
+                String item = row.get(i);
+                if (item != null && !item.equals(FeConstants.null_string)) {
+                    Column col = metaData.getColumn(i);
+                    switch (col.getType().getPrimitiveType()) {
+                        case BOOLEAN:
+                            serializer.writeInt1(parseBooleanResultValue(item));
+                            break;
+                        case INT:
+                            serializer.writeInt4(Integer.parseInt(item));
+                            break;
+                        case BIGINT:
+                            serializer.writeInt8(Long.parseLong(item));
+                            break;
+                        case DATETIME:
+                        case DATETIMEV2:
+                            DateTimeV2Literal datetime = new DateTimeV2Literal(item);
+                            long microSecond = datetime.getMicroSecond();
+                            // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_query_response_text_resultset.html
+                            int length = microSecond == 0 ? 7 : 11;
+                            serializer.writeInt1(length);
+                            serializer.writeInt2((int) (datetime.getYear()));
+                            serializer.writeInt1((int) datetime.getMonth());
+                            serializer.writeInt1((int) datetime.getDay());
+                            serializer.writeInt1((int) datetime.getHour());
+                            serializer.writeInt1((int) datetime.getMinute());
+                            serializer.writeInt1((int) datetime.getSecond());
+                            if (microSecond > 0) {
+                                serializer.writeInt4((int) microSecond);
+                            }
+                            break;
+                        case TIMESTAMP_NS:
+                            // MySQL temporal binary values cannot carry nanoseconds. The metadata advertises
+                            // MYSQL_TYPE_STRING, so encode the result as length-encoded text.
+                            serializer.writeLenEncodedString(item);
+                            break;
+                        default:
+                            serializer.writeLenEncodedString(item);
+                    }
+                }
+            }
+            channel.sendOnePacket(serializer.toByteBuffer());
+        }
+    }
+
+    private static int parseBooleanResultValue(String item) {
+        if ("1".equals(item) || "true".equalsIgnoreCase(item)) {
+            return 1;
+        }
+        if ("0".equals(item) || "false".equalsIgnoreCase(item)) {
+            return 0;
+        }
+        throw new IllegalArgumentException("Invalid boolean result value: " + item);
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/RefreshMTMVCommand.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/plans/commands/RefreshMTMVCommand.java
@@ -126,13 +126,13 @@ public class RefreshMTMVCommand extends Command implements Forward, Explainable 
             adapter.setOrigStmt(new OriginStatement(mtmv.getQuerySql(), 0));
 
             // Execute on a dedicated internal executor (admin identity, MV session variables)
-            // and stream each batch to the client's real mysql channel. The internal executor
-            // owns a fresh query id that KILL QUERY cannot reach, so forward cancellations of
-            // the outer statement (Ctrl+C / KILL / timeout) to it while it runs.
+            // and stream each batch to the client through this session's result sender. The
+            // internal executor owns a fresh query id that KILL QUERY cannot reach, so forward
+            // cancellations of the outer statement (Ctrl+C / KILL / timeout) to it while it runs.
             StmtExecutor internalExecutor = new StmtExecutor(internalCtx, adapter);
             internalCtx.setExecutor(internalExecutor);
             executor.setCancelDelegate(internalExecutor::cancel);
-            internalExecutor.executeInternalQueryAndSend(adapter, ctx.getMysqlChannel());
+            internalExecutor.executeInternalQueryAndSend(adapter, ctx.getResultSender());
             ctx.getState().setEof();
         } finally {
             executor.clearCancelDelegate();

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectContext.java
@@ -70,6 +70,7 @@ import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.util.MoreFieldsThread;
 import org.apache.doris.plugin.AuditEvent.AuditEventBuilder;
 import org.apache.doris.qe.protocol.ProtocolAdapter;
+import org.apache.doris.qe.protocol.ResultSender;
 import org.apache.doris.resource.BackendSelection;
 import org.apache.doris.resource.BackendSelectionManager;
 import org.apache.doris.resource.BackendSelectionProfile;
@@ -320,6 +321,11 @@ public class ConnectContext {
 
     public ProtocolAdapter getProtocolAdapter() {
         return protocolAdapter;
+    }
+
+    /** How a statement's result reaches this connection's client. */
+    public ResultSender getResultSender() {
+        return protocolAdapter.resultSender(this);
     }
 
     public MysqlSslContext getMysqlSslContext() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/ConnectProcessor.java
@@ -32,10 +32,8 @@ import org.apache.doris.analysis.NullLiteral;
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.analysis.StringLiteral;
 import org.apache.doris.analysis.UserIdentity;
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
-import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.cloud.proto.Cloud;
 import org.apache.doris.cloud.qe.ComputeGroupException;
@@ -55,12 +53,9 @@ import org.apache.doris.datasource.DelegatedCredential;
 import org.apache.doris.datasource.SessionContext;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.mysql.MysqlCapability;
-import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlCommand;
-import org.apache.doris.mysql.MysqlPacket;
-import org.apache.doris.mysql.MysqlResultSetEndPacket;
-import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.MysqlServerStatusFlag;
+import org.apache.doris.mysql.protocol.MysqlProtocolAdapter;
 import org.apache.doris.nereids.SqlCacheContext;
 import org.apache.doris.nereids.SqlCacheContext.CacheKeyType;
 import org.apache.doris.nereids.StatementContext;
@@ -70,13 +65,11 @@ import org.apache.doris.nereids.glue.LogicalPlanAdapter;
 import org.apache.doris.nereids.minidump.MinidumpUtils;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.parser.SqlDialectHelper;
-import org.apache.doris.nereids.stats.StatsErrorEstimator;
 import org.apache.doris.nereids.trees.plans.commands.ExplainCommand;
 import org.apache.doris.nereids.trees.plans.commands.PrepareCommand;
 import org.apache.doris.nereids.trees.plans.logical.LogicalPlan;
 import org.apache.doris.nereids.trees.plans.logical.LogicalSqlCache;
 import org.apache.doris.proto.Data;
-import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.qe.cache.CacheAnalyzer;
 import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
@@ -87,7 +80,6 @@ import org.apache.doris.thrift.TMasterOpResult;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.transaction.TransactionEntry;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -115,7 +107,8 @@ public abstract class ConnectProcessor {
     private static final Logger LOG = LogManager.getLogger(ConnectProcessor.class);
     protected final ConnectContext ctx;
     protected StmtExecutor executor;
-    protected ConnectType connectType;
+    // Executors of this request whose query result stays on the backend for the client to pull;
+    // they are finalized when the request is closed. Only an Arrow Flight SQL session has any.
     protected ArrayList<StmtExecutor> returnResultFromRemoteExecutor = new ArrayList<>();
 
     public ConnectProcessor(ConnectContext context) {
@@ -279,14 +272,10 @@ public abstract class ConnectProcessor {
         ctx.setSqlHash(sqlHash);
 
         SessionVariable sessionVariable = ctx.getSessionVariable();
-        // The sql cache keeps the result rows in MySQL wire format and replays them through a
-        // MysqlChannel (StmtExecutor.sendCachedValues -> sendFields), which only exists on a MySQL
-        // connection. An Arrow Flight SQL connection has no channel and needs Arrow batches built by
-        // the BE, and the cached rows would be wrong for it anyway (object types such as HLL /
-        // BITMAP / QUANTILE_STATE were serialized as NULL under return_object_data_as_binary=false).
-        // So a non-MySQL connection must always re-execute the query instead of replaying the cache.
-        // The cache is never populated by such a connection either, see StmtExecutor.handleQueryStmt.
-        boolean wantToParseSqlFromSqlCache = connectType.equals(ConnectType.MYSQL)
+        // The sql cache keeps the result rows in wire format, so only a protocol that can replay
+        // them looks the cache up; another one re-executes the query and never populates the
+        // cache either, see StmtExecutor.handleQueryStmt.
+        boolean wantToParseSqlFromSqlCache = ctx.getProtocolAdapter().supportsSqlCacheReplay()
                 && CacheAnalyzer.canUseSqlCache(sessionVariable);
         List<StatementBase> stmts = null;
         long parseSqlStartTime = System.currentTimeMillis();
@@ -352,8 +341,8 @@ public abstract class ConnectProcessor {
                 // When the Follower/Observer received the return result of Master, the Follower/Observer
                 // will check CLIENT_MULTI_STATEMENTS is set or not. It sends SERVER_MORE_RESULTS_EXISTS back to client
                 // only when CLIENT_MULTI_STATEMENTS is set.
-                // See the code below : if (getConnectContext().getMysqlChannel().clientMultiStatements())
-                if (i != stmts.size() - 1 && connectType.equals(ConnectType.MYSQL)) {
+                // See MysqlProtocolAdapter.finishStatement.
+                if (i != stmts.size() - 1) {
                     executor.setMoreStmtExists(true);
                 }
                 if (MetricRepo.isInit) {
@@ -370,35 +359,11 @@ public abstract class ConnectProcessor {
 
                 try {
                     executor.execute();
-                    if (connectType.equals(ConnectType.MYSQL)) {
-                        if (i != stmts.size() - 1) {
-                            ctx.getState().serverStatus |= MysqlServerStatusFlag.SERVER_MORE_RESULTS_EXISTS;
-                            if (ctx.getState().getStateType() != MysqlStateType.ERR) {
-                                // here, doris do different with mysql.
-                                // when client not request CLIENT_MULTI_STATEMENTS, mysql treat all query as
-                                // single statement. Doris treat it with multi statement, but only return
-                                // the last statement result.
-                                if (getConnectContext().getMysqlChannel().clientMultiStatements()) {
-                                    finalizeCommand();
-                                }
-                            }
-                        }
-                    } else if (connectType.equals(ConnectType.ARROW_FLIGHT_SQL)) {
-                        if (executor.hasForwardedToMaster()) {
-                            carryForwardedOutcomeToFlightSession(executor);
-                        }
-                        if (!ctx.isReturnResultFromLocal()) {
-                            returnResultFromRemoteExecutor.add(executor);
-                        }
-                        Preconditions.checkState(ctx.getFlightSqlChannel().resultNum() <= 1);
-                        if (ctx.getFlightSqlChannel().resultNum() == 1 && i != stmts.size() - 1) {
-                            String errMsg = "Only be one stmt that returns the result and it is at the end. "
-                                    + "stmts.size(): " + stmts.size();
-                            LOG.warn(errMsg);
-                            ctx.getState().setError(ErrorCode.ERR_ARROW_FLIGHT_SQL_MUST_ONLY_RESULT_STMT, errMsg);
-                            ctx.getState().setErrType(QueryState.ErrType.OTHER_ERR);
-                            break;
-                        }
+                    if (!ctx.isReturnResultFromLocal()) {
+                        returnResultFromRemoteExecutor.add(executor);
+                    }
+                    if (!ctx.getProtocolAdapter().finishStatement(ctx, executor, i, stmts.size())) {
+                        break;
                     }
                     auditAfterExec(auditStmt, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog(),
                             true);
@@ -574,151 +539,6 @@ public abstract class ConnectProcessor {
         auditAfterExec(origStmt, parsedStmt, statistics, true);
     }
 
-    // Get the column definitions of a table
-    @SuppressWarnings("rawtypes")
-    protected void handleFieldList(String tableName) throws ConnectionException {
-        // Already get command code.
-        if (Strings.isNullOrEmpty(tableName)) {
-            ctx.getState().setError(ErrorCode.ERR_UNKNOWN_TABLE, "Empty tableName");
-            return;
-        }
-        DatabaseIf db = ctx.getCurrentCatalog().getDbNullable(ctx.getDatabase());
-        if (db == null) {
-            ctx.getState().setError(ErrorCode.ERR_BAD_DB_ERROR, "Unknown database(" + ctx.getDatabase() + ")");
-            return;
-        }
-        TableIf table = db.getTableNullable(tableName);
-        if (table == null) {
-            ctx.getState().setError(ErrorCode.ERR_UNKNOWN_TABLE, "Unknown table(" + tableName + ")");
-            return;
-        }
-
-        table.readLock();
-        try {
-            if (connectType.equals(ConnectType.MYSQL)) {
-                MysqlChannel channel = ctx.getMysqlChannel();
-                MysqlSerializer serializer = channel.getSerializer();
-
-                // Send fields
-                // NOTE: Field list doesn't send number of fields
-                List<Column> baseSchema = table.getBaseSchema();
-                for (Column column : baseSchema) {
-                    serializer.reset();
-                    serializer.writeField(db.getFullName(), table.getName(), column, true);
-                    channel.sendOnePacket(serializer.toByteBuffer());
-                }
-            } else if (connectType.equals(ConnectType.ARROW_FLIGHT_SQL)) {
-                // TODO
-            }
-        } catch (Throwable throwable) {
-            handleQueryException(throwable, "", null, null);
-        } finally {
-            table.readUnlock();
-        }
-        ctx.getState().setEof();
-    }
-
-    // only Mysql protocol
-    protected ByteBuffer getResultPacket() {
-        Preconditions.checkState(connectType.equals(ConnectType.MYSQL));
-        MysqlPacket packet;
-        // When CLIENT_DEPRECATE_EOF is set and the state is EOF (end of result set),
-        // we need to send a "ResultSet OK" packet (0xFE header with payload > 5 bytes)
-        // instead of the traditional EOF packet. This is required by the MySQL protocol
-        // and expected by MySQL Connector/J 9.5.0+.
-        if (ctx.getState().getStateType() == QueryState.MysqlStateType.EOF
-                && ctx.getMysqlChannel().clientDeprecatedEOF()) {
-            packet = new MysqlResultSetEndPacket(ctx.getState());
-        } else {
-            packet = ctx.getState().toResponsePacket();
-        }
-        if (packet == null) {
-            // possible two cases:
-            // 1. handler has send request
-            // 2. this command need not to send response
-            return null;
-        }
-
-        MysqlSerializer serializer = ctx.getMysqlChannel().getSerializer();
-        serializer.reset();
-        packet.writeTo(serializer);
-        return serializer.toByteBuffer();
-    }
-
-    // When any request is completed, it will generally need to send a response packet to the client
-    // This method is used to send a response packet to the client
-    // only Mysql protocol
-    public void finalizeCommand() throws IOException {
-        LOG.debug("Finalize command for query {}", DebugUtil.printId(ctx.queryId));
-        Preconditions.checkState(connectType.equals(ConnectType.MYSQL));
-        ByteBuffer packet;
-        if (executor != null && executor.hasForwardedToMaster()
-                && ctx.getState().getStateType() != QueryState.MysqlStateType.ERR) {
-            ShowResultSet resultSet = executor.getShowResultSet();
-            if (resultSet == null) {
-                executor.sendProxyQueryResult();
-                packet = executor.getOutputPacket();
-            } else {
-                executor.sendResultSet(resultSet);
-                packet = getResultPacket();
-            }
-        } else {
-            packet = getResultPacket();
-        }
-
-        if (packet == null) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("packet == null");
-            }
-            return;
-        }
-
-        LOG.debug("Send to mysql channel for query {}", DebugUtil.printId(ctx.queryId));
-        MysqlChannel channel = ctx.getMysqlChannel();
-        channel.sendAndFlush(packet);
-        // note(wb) we should write profile after return result to mysql client
-        // because write profile maybe take too much time
-        // explain query stmt do not have profile
-        if (executor != null && executor.getParsedStmt() != null && !executor.getParsedStmt().isExplain()
-                && (executor.getParsedStmt() instanceof LogicalPlanAdapter)) {
-            executor.updateProfile(true);
-            StatsErrorEstimator statsErrorEstimator = ConnectContext.get().getStatsErrorEstimator();
-            if (statsErrorEstimator != null) {
-                statsErrorEstimator.updateProfile(ConnectContext.get().queryId());
-            }
-        }
-        LOG.debug("End finalizing command for query {}", DebugUtil.printId(ctx.queryId));
-    }
-
-    // Arrow Flight SQL counterpart of the forwarded-statement branch of finalizeCommand(). That
-    // method is the only place a forwarded statement's status and result set are replayed to the
-    // client, and it is MySQL-only: it opens with
-    // Preconditions.checkState(connectType.equals(ConnectType.MYSQL)). Without this method a
-    // forwarded statement leaves ctx.getState() at the OK that executeQuery() set with reset() and
-    // leaves the FlightSqlChannel empty, so DorisFlightSqlProducer answers with addOKResult()'s
-    // synthesized StatusResult=0 -- reporting success for a statement that failed on the master,
-    // and an empty status row instead of the rows a forwarded SHOW produced.
-    @VisibleForTesting
-    void carryForwardedOutcomeToFlightSession(StmtExecutor executor) throws IOException {
-        if (executor.getProxyStatusCode() != 0) {
-            // The master rejected the statement, e.g. CREATE TABLE on a table that already exists.
-            // TMasterOpResult carries the master's error code as a plain int and ErrorCode has no
-            // reverse lookup, so the master's code travels in the message instead.
-            String errMsg = "forwarded statement failed on master FE, error code: "
-                    + executor.getProxyStatusCode() + ", error message: " + executor.getProxyErrMsg();
-            LOG.warn(errMsg);
-            ctx.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR, errMsg);
-            return;
-        }
-        // Set exactly when the forwarded statement produced rows: proxyExecute() fills
-        // TMasterOpResult.resultSet from getProxyShowResultSet(). A forwarded DDL produces none,
-        // and the synthesized StatusResult=0 is the right answer for it.
-        ShowResultSet resultSet = executor.getShowResultSet();
-        if (resultSet != null) {
-            executor.sendResultSet(resultSet);
-        }
-    }
-
     public TMasterOpResult proxyExecute(TMasterOpRequest request) throws TException {
         ctx.setDatabase(request.db);
         ctx.setEnv(Env.getCurrentEnv());
@@ -843,8 +663,9 @@ public abstract class ConnectProcessor {
         if (request.moreResultExists) {
             ctx.getState().serverStatus |= MysqlServerStatusFlag.SERVER_MORE_RESULTS_EXISTS;
         }
-        result.setPacket(getResultPacket());
-        result.setClientDeprecatedEofApplied(ctx.getMysqlChannel().clientDeprecatedEOF());
+        MysqlProtocolAdapter mysqlAdapter = MysqlProtocolAdapter.of(ctx);
+        result.setPacket(mysqlAdapter.responsePacket(ctx));
+        result.setClientDeprecatedEofApplied(mysqlAdapter.getChannel().clientDeprecatedEOF());
         result.setStatus(ctx.getState().toString());
         if (ctx.getState().getStateType() == MysqlStateType.OK) {
             result.setStatusCode(0);

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/MysqlConnectProcessor.java
@@ -19,8 +19,10 @@ package org.apache.doris.qe;
 
 import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.MysqlColType;
+import org.apache.doris.catalog.TableIf;
 import org.apache.doris.common.AuthenticationException;
 import org.apache.doris.common.ConnectionException;
 import org.apache.doris.common.ErrorCode;
@@ -33,6 +35,7 @@ import org.apache.doris.mysql.MysqlHandshakePacket;
 import org.apache.doris.mysql.MysqlProto;
 import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.privilege.Auth;
+import org.apache.doris.mysql.protocol.MysqlProtocolAdapter;
 import org.apache.doris.nereids.StatementContext;
 import org.apache.doris.nereids.glue.LogicalPlanAdapter;
 import org.apache.doris.nereids.trees.expressions.Placeholder;
@@ -40,7 +43,6 @@ import org.apache.doris.nereids.trees.expressions.literal.Literal;
 import org.apache.doris.nereids.trees.plans.PlaceholderId;
 import org.apache.doris.nereids.trees.plans.commands.ExecuteCommand;
 import org.apache.doris.nereids.trees.plans.commands.PrepareCommand;
-import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.thrift.TUniqueId;
 
 import com.google.common.base.Preconditions;
@@ -69,7 +71,6 @@ public class MysqlConnectProcessor extends ConnectProcessor {
 
     public MysqlConnectProcessor(ConnectContext context) {
         super(context);
-        connectType = ConnectType.MYSQL;
     }
 
     // COM_INIT_DB: change current database of this session.
@@ -317,6 +318,37 @@ public class MysqlConnectProcessor extends ConnectProcessor {
         handleFieldList(tableName);
     }
 
+    // COM_FIELD_LIST: the column definitions of a table
+    @SuppressWarnings("rawtypes")
+    protected void handleFieldList(String tableName) throws ConnectionException {
+        // Already get command code.
+        if (Strings.isNullOrEmpty(tableName)) {
+            ctx.getState().setError(ErrorCode.ERR_UNKNOWN_TABLE, "Empty tableName");
+            return;
+        }
+        DatabaseIf db = ctx.getCurrentCatalog().getDbNullable(ctx.getDatabase());
+        if (db == null) {
+            ctx.getState().setError(ErrorCode.ERR_BAD_DB_ERROR, "Unknown database(" + ctx.getDatabase() + ")");
+            return;
+        }
+        TableIf table = db.getTableNullable(tableName);
+        if (table == null) {
+            ctx.getState().setError(ErrorCode.ERR_UNKNOWN_TABLE, "Unknown table(" + tableName + ")");
+            return;
+        }
+
+        table.readLock();
+        try {
+            MysqlProtocolAdapter.of(ctx).resultSender(ctx)
+                    .sendFieldList(db.getFullName(), table.getName(), table.getBaseSchema());
+        } catch (Throwable throwable) {
+            handleQueryException(throwable, "", null, null);
+        } finally {
+            table.readUnlock();
+        }
+        ctx.getState().setEof();
+    }
+
     private void handleChangeUser() throws IOException {
         // Random bytes generated when creating connection.
         byte[] authPluginData = getConnectContext().getAuthPluginData();
@@ -420,6 +452,12 @@ public class MysqlConnectProcessor extends ConnectProcessor {
         ctx.setCommand(MysqlCommand.COM_SLEEP);
         ctx.clear();
         executor = null;
+    }
+
+    // When any request is completed, it will generally need to send a response packet to the client
+    // This method is used to send a response packet to the client
+    public void finalizeCommand() throws IOException {
+        MysqlProtocolAdapter.of(ctx).finishCommand(ctx, executor);
     }
 
     public void loop() {

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/PointQueryExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/PointQueryExecutor.java
@@ -173,8 +173,7 @@ public class PointQueryExecutor implements CoordInterface {
         updateScanNodeConjuncts(shortCircuitQueryContext.scanNode, colNameToConjunct);
         // short circuit plan and execution
         executor.executeAndSendResult(false, false,
-                shortCircuitQueryContext.analzyedQuery, executor.getContext()
-                        .getMysqlChannel(), null, null);
+                shortCircuitQueryContext.analzyedQuery, executor.getContext().getResultSender(), null, null);
     }
 
     private static void updateScanNodeConjuncts(OlapScanNode scanNode,

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/StmtExecutor.java
@@ -30,13 +30,11 @@ import org.apache.doris.analysis.StorageBackend.StorageType;
 import org.apache.doris.analysis.StringValueContext;
 import org.apache.doris.analysis.ToSqlParams;
 import org.apache.doris.catalog.Column;
-import org.apache.doris.catalog.DatabaseIf;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.EnvFactory;
 import org.apache.doris.catalog.FsBroker;
 import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ScalarType;
-import org.apache.doris.catalog.TableIf;
 import org.apache.doris.catalog.Type;
 import org.apache.doris.cloud.catalog.CloudEnv;
 import org.apache.doris.cloud.proto.Cloud.ClusterStatus;
@@ -47,7 +45,6 @@ import org.apache.doris.common.ClientPool;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.DdlException;
 import org.apache.doris.common.ErrorCode;
-import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.NereidsException;
 import org.apache.doris.common.QueryTimeoutException;
 import org.apache.doris.common.Status;
@@ -72,11 +69,7 @@ import org.apache.doris.foundation.format.FormatOptions;
 import org.apache.doris.fs.FileSystemFactory;
 import org.apache.doris.metric.MetricRepo;
 import org.apache.doris.mysql.FieldInfo;
-import org.apache.doris.mysql.MysqlChannel;
 import org.apache.doris.mysql.MysqlCommand;
-import org.apache.doris.mysql.MysqlEofPacket;
-import org.apache.doris.mysql.MysqlResultSetEndPacket;
-import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.ProxyMysqlChannel;
 import org.apache.doris.mysql.protocol.MysqlProtocolAdapter;
 import org.apache.doris.nereids.NereidsPlanner;
@@ -90,8 +83,6 @@ import org.apache.doris.nereids.minidump.MinidumpUtils;
 import org.apache.doris.nereids.parser.NereidsParser;
 import org.apache.doris.nereids.trees.expressions.Placeholder;
 import org.apache.doris.nereids.trees.expressions.Slot;
-import org.apache.doris.nereids.trees.expressions.SlotReference;
-import org.apache.doris.nereids.trees.expressions.literal.DateTimeV2Literal;
 import org.apache.doris.nereids.trees.plans.Plan;
 import org.apache.doris.nereids.trees.plans.PrepareCommandPlanner;
 import org.apache.doris.nereids.trees.plans.algebra.InlineTable;
@@ -135,6 +126,7 @@ import org.apache.doris.qe.QueryState.MysqlStateType;
 import org.apache.doris.qe.cache.Cache;
 import org.apache.doris.qe.cache.CacheAnalyzer;
 import org.apache.doris.qe.cache.SqlCache;
+import org.apache.doris.qe.protocol.ResultSender;
 import org.apache.doris.resource.computegroup.ComputeGroupMgr;
 import org.apache.doris.resource.workloadgroup.WorkloadGroup;
 import org.apache.doris.rpc.BackendServiceProxy;
@@ -168,6 +160,7 @@ import org.apache.thrift.TSerializer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -194,7 +187,6 @@ public class StmtExecutor {
     private static final Pattern beIpPattern = Pattern.compile("\\[(\\d+):");
     private ConnectContext context;
     private StatementContext statementContext;
-    private MysqlSerializer serializer;
     private OriginStatement originStmt;
     private StatementBase parsedStmt;
     // Snapshot of changed session variables taken BEFORE per-query SET_VAR hint values are
@@ -247,13 +239,11 @@ public class StmtExecutor {
 
     // this constructor is mainly for proxy
     public StmtExecutor(ConnectContext context, OriginStatement originStmt, boolean isProxy) {
-        Preconditions.checkState(context.getConnectType().equals(ConnectType.MYSQL));
         this.context = context;
         if (context != null) {
             context.setExecutor(this);
         }
         this.originStmt = originStmt;
-        this.serializer = context.getMysqlChannel().getSerializer();
         this.isProxy = isProxy;
         this.statementContext = new StatementContext(context, originStmt);
         this.context.setStatementContext(statementContext);
@@ -279,11 +269,6 @@ public class StmtExecutor {
         this.parsedStmt = parsedStmt;
         this.originStmt = parsedStmt.getOrigStmt();
         this.isComStmtExecute = isComStmtExecute;
-        if (context.getConnectType() == ConnectType.MYSQL) {
-            this.serializer = context.getMysqlChannel().getSerializer();
-        } else {
-            this.serializer = null;
-        }
         this.isProxy = false;
         if (parsedStmt instanceof LogicalPlanAdapter) {
             this.statementContext = ((LogicalPlanAdapter) parsedStmt).getStatementContext();
@@ -1399,7 +1384,7 @@ public class StmtExecutor {
     // return true if the meta fields has been sent, otherwise, return false.
     // the meta fields must be sent right before the first batch of data(or eos flag).
     // so if it has data(or eos is true), this method must return true.
-    private boolean sendCachedValues(MysqlChannel channel, List<InternalService.PCacheValue> cacheValues,
+    private boolean sendCachedValues(ResultSender sender, List<InternalService.PCacheValue> cacheValues,
             Queriable selectStmt, boolean isSendFields, boolean isEos)
             throws Exception {
         RowBatch batch = null;
@@ -1418,12 +1403,12 @@ public class StmtExecutor {
             batch.setEos(true);
             if (!isSend) {
                 // send meta fields before sending first data batch.
-                sendFields(selectStmt.getColLabels(), selectStmt.getFieldInfos(),
+                sender.sendFields(selectStmt.getColLabels(), selectStmt.getFieldInfos(),
                         exprToType(selectStmt.getResultExprs()));
                 isSend = true;
             }
             for (ByteBuffer row : batch.getBatch().getRows()) {
-                channel.sendOnePacket(row);
+                sender.sendRow(row);
             }
             context.updateReturnRows(batch.getBatch().getRows().size());
         }
@@ -1434,7 +1419,7 @@ public class StmtExecutor {
                         ? null : batch.getQueryStatistics().toBuilder();
             }
             if (!isSend) {
-                sendFields(selectStmt.getColLabels(), selectStmt.getFieldInfos(),
+                sender.sendFields(selectStmt.getColLabels(), selectStmt.getFieldInfos(),
                         exprToType(selectStmt.getResultExprs()));
                 isSend = true;
             }
@@ -1446,13 +1431,13 @@ public class StmtExecutor {
     /**
      * Handle the SelectStmt via Cache.
      */
-    private void handleCacheStmt(CacheAnalyzer cacheAnalyzer, MysqlChannel channel) throws Exception {
+    private void handleCacheStmt(CacheAnalyzer cacheAnalyzer) throws Exception {
         // only compute CacheTable, but not get cache from be, because there has a case in nereids planner:
         // `select * from tbl`. the tbl has 2 columns and create cache in be, use the **original sql** as the cache key,
         // and then we add another column to the table, and the cache in be will not remove. if we use the result in be,
         // it will return 2 columns result, but the correct result is 3 columns. so we will not trust the cache in be.
         cacheAnalyzer.getCacheData(false);
-        executeAndSendResult(false, false, (Queriable) parsedStmt, channel, cacheAnalyzer, null);
+        executeAndSendResult(false, false, (Queriable) parsedStmt, context.getResultSender(), cacheAnalyzer, null);
     }
 
     // Process a select statement.
@@ -1462,10 +1447,9 @@ public class StmtExecutor {
                     originStmt.originStmt, DebugUtil.printId(context.queryId));
         }
 
-        if (context.getConnectType() == ConnectType.MYSQL) {
-            // Every time set no send flag and clean all data in buffer
-            context.getMysqlChannel().reset();
-        }
+        ResultSender sender = context.getResultSender();
+        // Every time set no send flag and clean all data in buffer
+        sender.reset();
 
         Queriable queryStmt = (Queriable) parsedStmt;
 
@@ -1499,24 +1483,20 @@ public class StmtExecutor {
             }
         }
 
-        MysqlChannel channel = null;
-        if (context.getConnectType().equals(ConnectType.MYSQL)) {
-            channel = context.getMysqlChannel();
-        }
+        boolean sqlCacheReplayable = context.getProtocolAdapter().supportsSqlCacheReplay();
         boolean isOutfileQuery = queryStmt.hasOutFileClause();
         if (parsedStmt instanceof LogicalPlanAdapter) {
             LogicalPlanAdapter logicalPlanAdapter = (LogicalPlanAdapter) parsedStmt;
             LogicalPlan logicalPlan = logicalPlanAdapter.getLogicalPlan();
             if (logicalPlan instanceof org.apache.doris.nereids.trees.plans.algebra.SqlCache) {
-                // sendCachedValues replays MySQL protocol packets, so it needs a MysqlChannel.
-                // ConnectProcessor.executeQuery only looks the sql cache up for a MySQL connection,
-                // so a cached plan must never reach another protocol here.
-                Preconditions.checkState(channel != null,
+                // ConnectProcessor.executeQuery only looks the sql cache up for a connection that
+                // can replay it, so a cached plan must never reach another protocol here.
+                Preconditions.checkState(sqlCacheReplayable,
                         "sql cache can only be replayed on a MySQL connection, but connect type is %s",
                         context.getConnectType());
                 NereidsPlanner nereidsPlanner = (NereidsPlanner) planner;
                 PhysicalSqlCache physicalSqlCache = (PhysicalSqlCache) nereidsPlanner.getPhysicalPlan();
-                sendCachedValues(channel, physicalSqlCache.getCacheValues(), logicalPlanAdapter, false, true);
+                sendCachedValues(sender, physicalSqlCache.getCacheValues(), logicalPlanAdapter, false, true);
                 return;
             }
         }
@@ -1526,19 +1506,23 @@ public class StmtExecutor {
         // TODO support arrow flight sql
         // NOTE: If you want to add another condition about SessionVariable, please consider whether
         // add to CacheAnalyzer.commonCacheCondition
-        if (channel != null && !isOutfileQuery && CacheAnalyzer.canUseCache(context.getSessionVariable())
+        if (sqlCacheReplayable && !isOutfileQuery && CacheAnalyzer.canUseCache(context.getSessionVariable())
                 && parsedStmt.getOrigStmt() != null && parsedStmt.getOrigStmt().originStmt != null) {
             if (queryStmt instanceof LogicalPlanAdapter) {
-                handleCacheStmt(cacheAnalyzer, channel);
+                handleCacheStmt(cacheAnalyzer);
                 return;
             }
         }
 
-        executeAndSendResult(isOutfileQuery, false, queryStmt, channel, null, null);
+        executeAndSendResult(isOutfileQuery, false, queryStmt, sender, null, null);
     }
 
+    /**
+     * Runs the planned query and delivers its result through {@code sender}: normally the
+     * session's own, or the caller's when an internal executor streams to another session.
+     */
     public void executeAndSendResult(boolean isOutfileQuery, boolean isSendFields,
-            Queriable queryStmt, MysqlChannel channel,
+            Queriable queryStmt, ResultSender sender,
             CacheAnalyzer cacheAnalyzer, InternalService.PFetchCacheResult cacheResult) throws Exception {
         // 1. If this is a query with OUTFILE clause, eg: select * from tbl1 into outfile xxx,
         //    We will not send real query result to client. Instead, we only send OK to client with
@@ -1632,18 +1616,18 @@ public class StmtExecutor {
                     // so We need to send fields after first batch arrived
                     if (!isSendFields) {
                         if (!isOutfileQuery) {
-                            sendFields(queryStmt.getColLabels(), queryStmt.getFieldInfos(),
-                                    getReturnTypes(queryStmt), channel);
+                            sender.sendFields(queryStmt.getColLabels(), queryStmt.getFieldInfos(),
+                                    getReturnTypes(queryStmt));
                         } else {
                             if (!Strings.isNullOrEmpty(outFileClause.getSuccessFileName())) {
                                 outfileWriteSuccess(outFileClause);
                             }
-                            sendFields(OutFileClause.RESULT_COL_NAMES, OutFileClause.RESULT_COL_TYPES, channel);
+                            sender.sendFields(OutFileClause.RESULT_COL_NAMES, null, OutFileClause.RESULT_COL_TYPES);
                         }
                         isSendFields = true;
                     }
                     for (ByteBuffer row : batch.getBatch().getRows()) {
-                        channel.sendOnePacket(row);
+                        sender.sendRow(row);
                     }
                     profile.getSummaryProfile().freshWriteResultConsumeTime();
                     context.updateReturnRows(batch.getBatch().getRows().size());
@@ -1656,7 +1640,7 @@ public class StmtExecutor {
             if (cacheAnalyzer != null && !isDryRun) {
                 if (cacheResult != null && cacheAnalyzer.getHitRange() == Cache.HitRange.Right) {
                     isSendFields =
-                            sendCachedValues(channel, cacheResult.getValuesList(), queryStmt, isSendFields,
+                            sendCachedValues(sender, cacheResult.getValuesList(), queryStmt, isSendFields,
                                     false);
                 }
 
@@ -1681,14 +1665,14 @@ public class StmtExecutor {
                         List<String> data = Lists.newArrayList(String.valueOf(rows));
                         ResultSet resultSet = new CommonResultSet(DRY_RUN_QUERY_METADATA,
                                 Collections.singletonList(data));
-                        sendResultSet(resultSet);
+                        sendResultSet(resultSet, null, sender);
                         return;
                     } else {
-                        sendFields(queryStmt.getColLabels(), queryStmt.getFieldInfos(),
-                                getReturnTypes(queryStmt), channel);
+                        sender.sendFields(queryStmt.getColLabels(), queryStmt.getFieldInfos(),
+                                getReturnTypes(queryStmt));
                     }
                 } else {
-                    sendFields(OutFileClause.RESULT_COL_NAMES, OutFileClause.RESULT_COL_TYPES, channel);
+                    sender.sendFields(OutFileClause.RESULT_COL_NAMES, null, OutFileClause.RESULT_COL_TYPES);
                 }
             }
 
@@ -1849,189 +1833,9 @@ public class StmtExecutor {
         }));
     }
 
-    private void sendMetaData(ResultSetMetaData metaData) throws IOException {
-        sendMetaData(metaData, null);
-    }
-
-    private void sendMetaData(ResultSetMetaData metaData, List<FieldInfo> fieldInfos) throws IOException {
-        sendMetaData(metaData, fieldInfos, context.getMysqlChannel());
-    }
-
-    private void sendMetaData(ResultSetMetaData metaData, List<FieldInfo> fieldInfos, MysqlChannel channel)
-            throws IOException {
-        Preconditions.checkState(context.getConnectType() == ConnectType.MYSQL);
-        // sends how many columns
-        serializer.reset();
-        serializer.writeVInt(metaData.getColumnCount());
-        channel.sendOnePacket(serializer.toByteBuffer());
-        // send field one by one
-        for (int i = 0; i < metaData.getColumns().size(); i++) {
-            Column col = metaData.getColumn(i);
-            serializer.reset();
-            if (fieldInfos == null) {
-                // TODO(zhaochun): only support varchar type
-                serializer.writeField(col.getName(), col.getType());
-            } else {
-                serializer.writeField(fieldInfos.get(i), col.getType());
-            }
-            channel.sendOnePacket(serializer.toByteBuffer());
-        }
-        sendMetadataTerminatorIfNeeded(channel);
-    }
-
-    private List<PrimitiveType> exprToStringType(List<Expr> exprs) {
-        return exprs.stream().map(e -> PrimitiveType.STRING).collect(Collectors.toList());
-    }
-
     public void sendStmtPrepareOK(int stmtId, List<String> labels, List<Slot> output) throws IOException {
-        Preconditions.checkState(context.getConnectType() == ConnectType.MYSQL);
-        // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_prepare.html#sect_protocol_com_stmt_prepare_response
-        serializer.reset();
-        // 0x00 OK
-        serializer.writeInt1(0);
-        // statement_id
-        serializer.writeInt4(stmtId);
-        // num_columns
-        int numColumns = output == null ? 0 : output.size();
-        serializer.writeInt2(numColumns);
-        // num_params
-        int numParams = labels.size();
-        serializer.writeInt2(numParams);
-        // reserved_1
-        serializer.writeInt1(0);
-        if (numParams > 0 || numColumns > 0) {
-            // warning_count
-            serializer.writeInt2(0);
-            // metadata_follows
-            serializer.writeInt1(1);
-        }
-        context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
-        if (numParams > 0) {
-            // send field one by one
-            // TODO use real type instead of string, for JDBC client it's ok
-            // but for other client, type should be correct
-            // List<PrimitiveType> types = exprToStringType(labels);
-            List<String> colNames = labels;
-            for (int i = 0; i < colNames.size(); ++i) {
-                serializer.reset();
-                // serializer.writeField(colNames.get(i), Type.fromPrimitiveType(types.get(i)));
-                serializer.writeField(colNames.get(i), Type.STRING);
-                context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
-            }
-            // When CLIENT_DEPRECATE_EOF is set, no EOF/OK packet should be sent after
-            // parameter definitions. The driver knows how many params to expect from the
-            // prepare OK packet and simply stops reading after that count.
-            if (!context.getMysqlChannel().clientDeprecatedEOF()) {
-                serializer.reset();
-                MysqlEofPacket eofPacket = new MysqlEofPacket(context.getState());
-                eofPacket.writeTo(serializer);
-                context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
-            }
-        }
-        if (numColumns > 0) {
-            for (Slot slot : output) {
-                serializer.reset();
-                if (slot instanceof SlotReference
-                        && ((SlotReference) slot).getOriginalColumn().isPresent()
-                        && ((SlotReference) slot).getOriginalTable().isPresent()) {
-                    SlotReference slotReference = (SlotReference) slot;
-                    TableIf table = slotReference.getOriginalTable().get();
-                    Column column = slotReference.getOriginalColumn().get();
-                    DatabaseIf database = table.getDatabase();
-                    String dbName = database == null ? "" : database.getFullName();
-                    serializer.writeField(dbName, table.getName(), column, false);
-                } else {
-                    serializer.writeField(slot.getName(), slot.getDataType().toCatalogDataType());
-                }
-                context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
-            }
-            // When CLIENT_DEPRECATE_EOF is set, no EOF/OK packet should be sent after
-            // column definitions. The driver knows how many columns to expect from the
-            // prepare OK packet and simply stops reading after that count.
-            if (!context.getMysqlChannel().clientDeprecatedEOF()) {
-                serializer.reset();
-                MysqlEofPacket eofPacket = new MysqlEofPacket(context.getState());
-                eofPacket.writeTo(serializer);
-                context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
-            }
-        }
-        context.getMysqlChannel().flush();
+        MysqlProtocolAdapter.of(context).resultSender(context).sendStmtPrepareOK(stmtId, labels, output);
         context.getState().setNoop();
-    }
-
-    private void sendFields(List<String> colNames, List<Type> types) throws IOException {
-        sendFields(colNames, null, types);
-    }
-
-    private void sendFields(List<String> colNames, List<Type> types, MysqlChannel channel) throws IOException {
-        sendFields(colNames, null, types, channel);
-    }
-
-    private void sendFields(List<String> colNames, List<FieldInfo> fieldInfos, List<Type> types) throws
-            IOException {
-        sendFields(colNames, fieldInfos, types, context.getMysqlChannel());
-    }
-
-    private void sendFields(List<String> colNames, List<FieldInfo> fieldInfos, List<Type> types,
-            MysqlChannel channel) throws IOException {
-        Preconditions.checkState(context.getConnectType() == ConnectType.MYSQL);
-        // sends how many columns
-        serializer.reset();
-        serializer.writeVInt(colNames.size());
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("sendFields {}", colNames);
-        }
-        channel.sendOnePacket(serializer.toByteBuffer());
-        StatementContext statementContext = context.getStatementContext();
-        boolean isShortCircuited = statementContext.isShortCircuitQuery()
-                && statementContext.getShortCircuitQueryContext() != null;
-        ShortCircuitQueryContext ctx = statementContext.getShortCircuitQueryContext();
-        // send field one by one
-        for (int i = 0; i < colNames.size(); ++i) {
-            serializer.reset();
-            if (context.getCommand() == MysqlCommand.COM_STMT_EXECUTE && isShortCircuited) {
-                // Using PreparedStatment pre serializedField to avoid serialize each time
-                // we send a field
-                byte[] serializedField = ctx.getSerializedField(i);
-                if (serializedField == null) {
-                    if (fieldInfos != null) {
-                        serializer.writeField(fieldInfos.get(i), types.get(i));
-                    } else {
-                        serializer.writeField(colNames.get(i), types.get(i));
-                    }
-                    serializedField = serializer.toArray();
-                    ctx.addSerializedField(i, serializedField);
-                }
-                channel.sendOnePacket(ByteBuffer.wrap(serializedField));
-            } else {
-                if (fieldInfos != null) {
-                    serializer.writeField(fieldInfos.get(i), types.get(i));
-                } else {
-                    serializer.writeField(colNames.get(i), types.get(i));
-                }
-                channel.sendOnePacket(serializer.toByteBuffer());
-            }
-        }
-        sendMetadataTerminatorIfNeeded(channel);
-    }
-
-    private void sendMetadataTerminatorIfNeeded(MysqlChannel channel) throws IOException {
-        if (!channel.clientDeprecatedEOF()) {
-            serializer.reset();
-            new MysqlEofPacket(context.getState()).writeTo(serializer);
-            channel.sendOnePacket(serializer.toByteBuffer());
-        } else if (connectorJConsumesCursorMetadataTerminator()) {
-            // Connector/J before 9.5 consumes the first OK packet after column definitions
-            // while probing whether a requested cursor was created. Doris does not create a
-            // cursor, so an empty result would otherwise lose its only end marker and block.
-            serializer.reset();
-            new MysqlResultSetEndPacket(context.getState()).writeTo(serializer);
-            channel.sendOnePacket(serializer.toByteBuffer());
-        }
-    }
-
-    private boolean connectorJConsumesCursorMetadataTerminator() {
-        return MysqlProtocolAdapter.of(context).clientConsumesCursorMetadataTerminator(context);
     }
 
     public void sendResultSet(ResultSet resultSet) throws IOException {
@@ -2039,143 +1843,19 @@ public class StmtExecutor {
     }
 
     public void sendResultSet(ResultSet resultSet, List<FieldInfo> fieldInfos) throws IOException {
-        sendResultSet(resultSet, fieldInfos, null);
+        sendResultSet(resultSet, fieldInfos, context.getResultSender());
     }
 
     /**
-     * Sends a FE-computed result set to the given mysql channel. Regular queries use the
-     * executor's own channel; internal queries have to stream to the channel of the caller
-     * that issued them, because the executor's own channel is not connected to that client.
-     *
-     * <p>A null channel means the session's own. It is resolved inside the mysql branch on
-     * purpose: a connection of any other type has no mysql channel, and asking for one throws,
-     * so a caller must be able to hand a result set over without naming a channel first.
+     * Delivers a result set the frontend computed through {@code sender}. Regular statements use
+     * the session's own sender; an internal executor streams to the sender of the session that
+     * issued it, because its own session is not connected to that client.
      */
-    private void sendResultSet(ResultSet resultSet, List<FieldInfo> fieldInfos, MysqlChannel channel)
+    private void sendResultSet(ResultSet resultSet, List<FieldInfo> fieldInfos, ResultSender sender)
             throws IOException {
-        if (context.getConnectType().equals(ConnectType.MYSQL)) {
-            MysqlChannel targetChannel = channel == null ? context.getMysqlChannel() : channel;
-            context.updateReturnRows(resultSet.getResultRows().size());
-            // Send meta data.
-            sendMetaData(resultSet.getMetaData(), fieldInfos, targetChannel);
-
-            // Send result set.
-            if (isComStmtExecute) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Use binary protocol to set result.");
-                }
-                sendBinaryResultRow(resultSet, targetChannel);
-            } else {
-                sendTextResultRow(resultSet, targetChannel);
-            }
-            context.getState().setEof();
-        } else if (context.getConnectType().equals(ConnectType.ARROW_FLIGHT_SQL)) {
-            context.updateReturnRows(resultSet.getResultRows().size());
-            context.getFlightSqlChannel()
-                    .addResult(DebugUtil.printId(context.queryId()), context.getRunningQuery(), resultSet);
-            context.getState().setEof();
-        } else {
-            LOG.error("sendResultSet error connect type");
-        }
-    }
-
-    protected void sendTextResultRow(ResultSet resultSet) throws IOException {
-        sendTextResultRow(resultSet, context.getMysqlChannel());
-    }
-
-    protected void sendTextResultRow(ResultSet resultSet, MysqlChannel channel) throws IOException {
-        for (List<String> row : resultSet.getResultRows()) {
-            serializer.reset();
-            for (String item : row) {
-                if (item == null || item.equals(FeConstants.null_string)) {
-                    serializer.writeNull();
-                } else {
-                    serializer.writeLenEncodedString(item);
-                }
-            }
-            channel.sendOnePacket(serializer.toByteBuffer());
-        }
-    }
-
-    protected void sendBinaryResultRow(ResultSet resultSet) throws IOException {
-        sendBinaryResultRow(resultSet, context.getMysqlChannel());
-    }
-
-    protected void sendBinaryResultRow(ResultSet resultSet, MysqlChannel channel) throws IOException {
-        // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_binary_resultset.html#sect_protocol_binary_resultset_row_value
-        ResultSetMetaData metaData = resultSet.getMetaData();
-        int nullBitmapLength = (metaData.getColumnCount() + 7 + 2) / 8;
-        for (List<String> row : resultSet.getResultRows()) {
-            serializer.reset();
-            // Reserved one byte.
-            serializer.writeByte((byte) 0x00);
-            byte[] nullBitmap = new byte[nullBitmapLength];
-            // Generate null bitmap
-            for (int i = 0; i < row.size(); i++) {
-                String item = row.get(i);
-                if (item == null || item.equals(FeConstants.null_string)) {
-                    // The first 2 bits are reserved.
-                    int byteIndex = (i + 2) / 8;  // Index of the byte in the bitmap array
-                    int bitInByte = (i + 2) % 8;  // Position within the target byte (0-7)
-                    nullBitmap[byteIndex] |= (1 << bitInByte);
-                }
-            }
-            // Null bitmap
-            serializer.writeBytes(nullBitmap);
-            // Non-null columns
-            for (int i = 0; i < row.size(); i++) {
-                String item = row.get(i);
-                if (item != null && !item.equals(FeConstants.null_string)) {
-                    Column col = metaData.getColumn(i);
-                    switch (col.getType().getPrimitiveType()) {
-                        case BOOLEAN:
-                            serializer.writeInt1(parseBooleanResultValue(item));
-                            break;
-                        case INT:
-                            serializer.writeInt4(Integer.parseInt(item));
-                            break;
-                        case BIGINT:
-                            serializer.writeInt8(Long.parseLong(item));
-                            break;
-                        case DATETIME:
-                        case DATETIMEV2:
-                            DateTimeV2Literal datetime = new DateTimeV2Literal(item);
-                            long microSecond = datetime.getMicroSecond();
-                            // https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_query_response_text_resultset.html
-                            int length = microSecond == 0 ? 7 : 11;
-                            serializer.writeInt1(length);
-                            serializer.writeInt2((int) (datetime.getYear()));
-                            serializer.writeInt1((int) datetime.getMonth());
-                            serializer.writeInt1((int) datetime.getDay());
-                            serializer.writeInt1((int) datetime.getHour());
-                            serializer.writeInt1((int) datetime.getMinute());
-                            serializer.writeInt1((int) datetime.getSecond());
-                            if (microSecond > 0) {
-                                serializer.writeInt4((int) microSecond);
-                            }
-                            break;
-                        case TIMESTAMP_NS:
-                            // MySQL temporal binary values cannot carry nanoseconds. The metadata advertises
-                            // MYSQL_TYPE_STRING, so encode the result as length-encoded text.
-                            serializer.writeLenEncodedString(item);
-                            break;
-                        default:
-                            serializer.writeLenEncodedString(item);
-                    }
-                }
-            }
-            channel.sendOnePacket(serializer.toByteBuffer());
-        }
-    }
-
-    private static int parseBooleanResultValue(String item) {
-        if ("1".equals(item) || "true".equalsIgnoreCase(item)) {
-            return 1;
-        }
-        if ("0".equals(item) || "false".equalsIgnoreCase(item)) {
-            return 0;
-        }
-        throw new IllegalArgumentException("Invalid boolean result value: " + item);
+        context.updateReturnRows(resultSet.getResultRows().size());
+        sender.sendResultSet(resultSet, fieldInfos, isComStmtExecute);
+        context.getState().setEof();
     }
 
     public void handleExplainPlanProcessStmt(List<PlanProcess> result) throws IOException {
@@ -2184,18 +1864,10 @@ public class StmtExecutor {
                 .addColumn(new Column("Before", ScalarType.createVarchar(-1)))
                 .addColumn(new Column("After", ScalarType.createVarchar(-1)))
                 .build();
-        if (context.getConnectType() == ConnectType.MYSQL) {
-            sendMetaData(metaData);
-
-            for (PlanProcess row : result) {
-                serializer.reset();
-                serializer.writeLenEncodedString(row.ruleName);
-                serializer.writeLenEncodedString(row.beforeShape);
-                serializer.writeLenEncodedString(row.afterShape);
-                context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
-            }
-        }
-        context.getState().setEof();
+        List<List<String>> rows = result.stream()
+                .map(row -> Lists.newArrayList(row.ruleName, row.beforeShape, row.afterShape))
+                .collect(Collectors.toList());
+        sendResultSet(new ShowResultSet(metaData, rows));
     }
 
     public void handleExplainStmt(String result, boolean isNereids) throws IOException {
@@ -2203,21 +1875,7 @@ public class StmtExecutor {
                 .addColumn(new Column("Explain String" + (isNereids ? "(Nereids Planner)" : "(Old Planner)"),
                         ScalarType.createVarchar(20)))
                 .build();
-        if (context.getConnectType() == ConnectType.MYSQL) {
-            sendMetaData(metaData);
-
-            // Send result set.
-            for (String item : result.split("\n")) {
-                serializer.reset();
-                serializer.writeLenEncodedString(item);
-                context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
-            }
-        } else if (context.getConnectType() == ConnectType.ARROW_FLIGHT_SQL) {
-            context.getFlightSqlChannel()
-                    .addResult(DebugUtil.printId(context.queryId()), context.getRunningQuery(), metaData, result);
-            context.setReturnResultFromLocal(true);
-        }
-        context.getState().setEof();
+        sendResultSet(new ShowResultSet(metaData, oneColumnPerLine(result)));
     }
 
     public void handleReplayStmt(String result) throws IOException {
@@ -2225,21 +1883,13 @@ public class StmtExecutor {
                 .addColumn(new Column("Plan Replayer dump url",
                         ScalarType.createVarchar(20)))
                 .build();
-        if (context.getConnectType() == ConnectType.MYSQL) {
-            sendMetaData(metaData);
+        sendResultSet(new ShowResultSet(metaData, oneColumnPerLine(result)));
+    }
 
-            // Send result set.
-            for (String item : result.split("\n")) {
-                serializer.reset();
-                serializer.writeLenEncodedString(item);
-                context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
-            }
-        } else if (context.getConnectType() == ConnectType.ARROW_FLIGHT_SQL) {
-            context.getFlightSqlChannel()
-                    .addResult(DebugUtil.printId(context.queryId()), context.getRunningQuery(), metaData, result);
-            context.setReturnResultFromLocal(true);
-        }
-        context.getState().setEof();
+    private static List<List<String>> oneColumnPerLine(String text) {
+        return Arrays.stream(text.split("\n"))
+                .map(line -> Lists.newArrayList(line))
+                .collect(Collectors.toList());
     }
 
     public Data.PQueryStatistics getQueryStatisticsForAuditLog() {
@@ -2300,20 +1950,21 @@ public class StmtExecutor {
 
     /**
      * Execute a pre-built logical plan adapter as a read-only query and stream each result
-     * batch to the given mysql channel, without collecting them in FE memory.
+     * batch through the given sender, without collecting them in FE memory. The sender is the
+     * calling session's: this executor's own session is not connected to any client.
      */
-    public void executeInternalQueryAndSend(LogicalPlanAdapter adapter, MysqlChannel channel) throws Exception {
-        executeInternalQueryCommon(adapter, channel);
+    public void executeInternalQueryAndSend(LogicalPlanAdapter adapter, ResultSender sender) throws Exception {
+        executeInternalQueryCommon(adapter, sender);
     }
 
     /**
      * Common internal query lifecycle. When {@code prebuilt} is non-null the plan is already
      * constructed (e.g. IVM dry-run delta) and the usual parse step is skipped. When
-     * {@code sendChannel} is non-null, rows are streamed to that channel via
+     * {@code sendTo} is non-null, rows are streamed through that sender via
      * {@link #executeAndSendResult}; otherwise they are collected into a {@code List<ResultRow>}.
      */
     private List<ResultRow> executeInternalQueryCommon(LogicalPlanAdapter prebuilt,
-            MysqlChannel sendChannel) throws Exception {
+            ResultSender sendTo) throws Exception {
         TUniqueId queryId = UniqueIdUtils.fastUniqueId();
         context.setQueryId(queryId);
         if (originStmt != null && originStmt.originStmt != null) {
@@ -2324,7 +1975,7 @@ public class StmtExecutor {
         context.getState().setInternal(true);
 
         LogicalPlanAdapter adapter;
-        boolean collectMode = (sendChannel == null);
+        boolean collectMode = (sendTo == null);
         try {
             if (prebuilt != null) {
                 setParsedStmt(prebuilt);
@@ -2342,14 +1993,14 @@ public class StmtExecutor {
             // A plan that FE can compute on its own (e.g. the empty delta of a dry run) must be
             // answered by the frontend, like a regular query does. Otherwise the coordinator
             // would send fragments to the placeholder backend registered when no backend is
-            // needed (see NereidsPlanner#notNeedBackend), which cannot resolve. Results go to the
-            // caller's channel: the executor's own channel is not connected to that client.
+            // needed (see NereidsPlanner#notNeedBackend), which cannot resolve. Results go through
+            // the caller's sender: the executor's own session is not connected to that client.
             if (context.supportHandleByFe()) {
                 Optional<ResultSet> resultSet = planner.handleQueryInFe(adapter);
                 if (resultSet.isPresent()) {
                     boolean sendToChannel = !collectMode;
                     if (sendToChannel) {
-                        sendResultSet(resultSet.get(), adapter.getFieldInfos(), sendChannel);
+                        sendResultSet(resultSet.get(), adapter.getFieldInfos(), sendTo);
                     }
                     isHandleQueryInFe = true;
                     if (context.getSessionVariable().enableProfile() && profile != null) {
@@ -2365,7 +2016,7 @@ public class StmtExecutor {
             }
 
             if (!collectMode) {
-                executeAndSendResult(false, false, adapter, sendChannel, null, null);
+                executeAndSendResult(false, false, adapter, sendTo, null, null);
                 return new ArrayList<>();
             }
 
@@ -2639,8 +2290,9 @@ public class StmtExecutor {
         }
         masterOpExecutor.prepareQueryResultForClient();
         List<ByteBuffer> queryResultBufList = masterOpExecutor.getQueryResultBufList();
+        ResultSender sender = context.getResultSender();
         for (ByteBuffer byteBuffer : queryResultBufList) {
-            context.getMysqlChannel().sendOnePacket(byteBuffer);
+            sender.sendRow(byteBuffer);
         }
     }
 

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/protocol/ProtocolAdapter.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/protocol/ProtocolAdapter.java
@@ -21,7 +21,10 @@ import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.qe.ConnectPoolMgr;
 import org.apache.doris.qe.ConnectScheduler;
+import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.thrift.TResultSinkType;
+
+import java.io.IOException;
 
 /**
  * The wire-protocol half of a connection.
@@ -48,6 +51,28 @@ public interface ProtocolAdapter {
 
     /** The result sink a backend must use for a query on this connection. */
     TResultSinkType resultSinkType();
+
+    /** How a statement's result reaches the client of {@code ctx}'s connection. */
+    ResultSender resultSender(ConnectContext ctx);
+
+    /**
+     * Whether a hit in the SQL cache can be answered by replaying the cached rows. The cache keeps
+     * them in MySQL wire format, so only a MySQL connection can; a connection of any other protocol
+     * re-executes the query and never populates the cache either.
+     */
+    boolean supportsSqlCacheReplay();
+
+    /**
+     * Called by {@code ConnectProcessor.executeQuery} after the {@code stmtIndex}-th of the
+     * {@code stmtCount} statements of one request has been executed, before it is audited. The
+     * protocol hands the statement's outcome to its client where the transport needs it (an
+     * intermediate MySQL response, the outcome of a statement forwarded to the master) and
+     * decides whether the request goes on to the next statement.
+     *
+     * @return false to stop the request here, with {@code ctx.getState()} set to the reason
+     */
+    boolean finishStatement(ConnectContext ctx, StmtExecutor executor, int stmtIndex, int stmtCount)
+            throws IOException;
 
     /**
      * The pool this connection is registered in. Each protocol still keeps its own pool; this

--- a/fe/fe-core/src/main/java/org/apache/doris/qe/protocol/ResultSender.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/qe/protocol/ResultSender.java
@@ -1,0 +1,74 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.qe.protocol;
+
+import org.apache.doris.catalog.Type;
+import org.apache.doris.mysql.FieldInfo;
+import org.apache.doris.qe.ResultSet;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+/**
+ * The result-encoding half of a connection: how a statement's result reaches the client of this
+ * wire protocol.
+ *
+ * <p>A statement produces its result in one of two ways. Either the frontend materializes it -- a
+ * {@code SHOW}, an {@code EXPLAIN}, a query the planner answers on its own -- and hands it over as a
+ * {@link ResultSet}; or a backend produces it and the executor relays the column definitions and
+ * then the rows, already in wire format, as they arrive. What "reaching the client" means is the
+ * protocol's business: writing packets to a MySQL channel, or caching an Arrow batch for the
+ * client's later DoGet.
+ *
+ * <p>Obtained from {@link ProtocolAdapter#resultSender}. Everything else about a statement -- its
+ * state, the rows it returned, the audit record -- stays on the session.
+ */
+public interface ResultSender {
+
+    /**
+     * Delivers a result set the frontend materialized.
+     *
+     * @param resultSet   the rows and their metadata
+     * @param fieldInfos  per-column details some protocols carry in the column definitions
+     *                    (table and original column names); null when there are none
+     * @param binaryRows  encode the rows in the protocol's binary row format, if it has one,
+     *                    instead of the text format
+     */
+    void sendResultSet(ResultSet resultSet, List<FieldInfo> fieldInfos, boolean binaryRows) throws IOException;
+
+    /**
+     * Delivers the column definitions of a result stream a backend produces. Only a protocol
+     * whose results go through the frontend implements this; one whose client pulls the result
+     * from the backend never receives a call.
+     */
+    void sendFields(List<String> colNames, List<FieldInfo> fieldInfos, List<Type> types) throws IOException;
+
+    /**
+     * Delivers one packet of a result stream that is already in this protocol's wire format: a
+     * row a backend produced, or a packet the master produced for a forwarded query. Same
+     * restriction as {@link #sendFields}.
+     */
+    void sendRow(ByteBuffer row) throws IOException;
+
+    /**
+     * Forgets whatever the previous statement of the same request left unsent, so that a
+     * multi-statement request delivers only the last result. Called when a query starts.
+     */
+    void reset();
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/arrowflight/protocol/FlightForwardedOutcomeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/arrowflight/protocol/FlightForwardedOutcomeTest.java
@@ -15,12 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.doris.qe;
+package org.apache.doris.arrowflight.protocol;
 
 import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.FeConstants;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.QueryState;
+import org.apache.doris.qe.ShowResultSet;
+import org.apache.doris.qe.ShowResultSetMetaData;
+import org.apache.doris.qe.StmtExecutor;
 
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.AfterEach;
@@ -32,18 +37,17 @@ import org.mockito.Mockito;
 import java.util.List;
 
 /**
- * ConnectProcessor.finalizeCommand() is the only place a forwarded statement's status and result set
- * are replayed to the client, and it is MySQL-only (it opens with a Preconditions.checkState on the
- * connect type). carryForwardedOutcomeToFlightSession() is its Arrow Flight SQL counterpart. Without
+ * MysqlProtocolAdapter.finishCommand() replays a forwarded statement's status and result set to a
+ * MySQL client. FlightProtocolAdapter.finishStatement() is its Arrow Flight SQL counterpart. Without
  * it, ctx.getState() stays at the OK that executeQuery() set with reset() and the FlightSqlChannel
  * stays empty, so DorisFlightSqlProducer answers with addOKResult()'s synthesized StatusResult=0:
  * success for a statement that failed on the master, and that same row instead of the rows a
  * forwarded SHOW produced.
  */
-public class ConnectProcessorFlightForwardOutcomeTest {
+public class FlightForwardedOutcomeTest {
     private boolean savedRunningUnitTest;
     private ConnectContext context;
-    private ConnectProcessor processor;
+    private FlightProtocolAdapter adapter;
 
     @BeforeEach
     public void setUp() {
@@ -51,7 +55,7 @@ public class ConnectProcessorFlightForwardOutcomeTest {
         // ConnectContext.init() registers the session with Env unless running as a unit test.
         FeConstants.runningUnitTest = true;
         context = ConnectContext.forFlight("test-peer-identity");
-        processor = new TestConnectProcessor(context);
+        adapter = FlightProtocolAdapter.of(context);
     }
 
     @AfterEach
@@ -61,12 +65,12 @@ public class ConnectProcessorFlightForwardOutcomeTest {
 
     @Test
     public void testMasterFailureIsReportedToTheFlightClient() throws Exception {
-        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        StmtExecutor executor = forwardedExecutor();
         // e.g. CREATE TABLE on a table that already exists.
         Mockito.when(executor.getProxyStatusCode()).thenReturn(1050);
         Mockito.when(executor.getProxyErrMsg()).thenReturn("Table 'tbl' already exists");
 
-        processor.carryForwardedOutcomeToFlightSession(executor);
+        Assertions.assertTrue(adapter.finishStatement(context, executor, 0, 1));
 
         Assertions.assertEquals(QueryState.MysqlStateType.ERR, context.getState().getStateType());
         Assertions.assertEquals(ErrorCode.ERR_UNKNOWN_ERROR, context.getState().getErrorCode());
@@ -86,35 +90,47 @@ public class ConnectProcessorFlightForwardOutcomeTest {
                         .addColumn(new Column("JobId", ScalarType.createVarchar(20)))
                         .build(),
                 Lists.<List<String>>newArrayList(Lists.newArrayList("10086")));
-        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        StmtExecutor executor = forwardedExecutor();
         Mockito.when(executor.getProxyStatusCode()).thenReturn(0);
         Mockito.when(executor.getShowResultSet()).thenReturn(resultSet);
 
-        processor.carryForwardedOutcomeToFlightSession(executor);
+        Assertions.assertTrue(adapter.finishStatement(context, executor, 0, 1));
 
         Assertions.assertNotEquals(QueryState.MysqlStateType.ERR, context.getState().getStateType());
-        // sendResultSet()'s ARROW_FLIGHT_SQL branch puts the rows into the FlightSqlChannel, which is
-        // what DorisFlightSqlProducer hands back instead of the synthesized StatusResult row.
+        // sendResultSet() puts the rows into the FlightSqlChannel through the FlightResultSender,
+        // which is what DorisFlightSqlProducer hands back instead of the synthesized StatusResult row.
         Mockito.verify(executor).sendResultSet(resultSet);
     }
 
     @Test
     public void testForwardedDdlKeepsTheSynthesizedOkResult() throws Exception {
-        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        StmtExecutor executor = forwardedExecutor();
         Mockito.when(executor.getProxyStatusCode()).thenReturn(0);
         // A forwarded DDL carries no result set, and StatusResult=0 is the right answer for it.
         Mockito.when(executor.getShowResultSet()).thenReturn(null);
 
-        processor.carryForwardedOutcomeToFlightSession(executor);
+        Assertions.assertTrue(adapter.finishStatement(context, executor, 0, 1));
 
         Assertions.assertNotEquals(QueryState.MysqlStateType.ERR, context.getState().getStateType());
         Assertions.assertEquals(0L, context.getFlightSqlChannel().resultNum());
         Mockito.verify(executor, Mockito.never()).sendResultSet(Mockito.any());
     }
 
-    private static class TestConnectProcessor extends ConnectProcessor {
-        private TestConnectProcessor(ConnectContext context) {
-            super(context);
-        }
+    @Test
+    public void testStatementNotForwardedIsLeftAlone() throws Exception {
+        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        Mockito.when(executor.hasForwardedToMaster()).thenReturn(false);
+
+        Assertions.assertTrue(adapter.finishStatement(context, executor, 0, 1));
+
+        Mockito.verify(executor, Mockito.never()).getProxyStatusCode();
+        Mockito.verify(executor, Mockito.never()).sendResultSet(Mockito.any());
+    }
+
+    private StmtExecutor forwardedExecutor() {
+        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        Mockito.when(executor.hasForwardedToMaster()).thenReturn(true);
+        Mockito.when(executor.getProxyStatusCode()).thenReturn(0);
+        return executor;
     }
 }

--- a/fe/fe-core/src/test/java/org/apache/doris/arrowflight/protocol/FlightProtocolAdapterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/arrowflight/protocol/FlightProtocolAdapterTest.java
@@ -17,15 +17,23 @@
 
 package org.apache.doris.arrowflight.protocol;
 
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.mysql.protocol.MysqlProtocolAdapter;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.qe.ConnectScheduler;
+import org.apache.doris.qe.QueryState.MysqlStateType;
+import org.apache.doris.qe.ShowResultSet;
+import org.apache.doris.qe.ShowResultSetMetaData;
+import org.apache.doris.qe.StmtExecutor;
 import org.apache.doris.thrift.TResultSinkType;
 import org.apache.doris.thrift.TUniqueId;
 
+import com.google.common.collect.Lists;
 import org.apache.arrow.flight.FlightRuntimeException;
 import org.apache.arrow.flight.FlightStatusCode;
 import org.apache.thrift.TException;
@@ -33,12 +41,16 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -73,6 +85,20 @@ public class FlightProtocolAdapterTest {
             adapter.runCommand(ctx, command);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+        }
+    }
+
+    // Runs a trivial command of the session from another thread and returns what it answered, or
+    // rethrows what it failed with (UNAVAILABLE if the session was still held).
+    private static String callFromAnotherThread(FlightProtocolAdapter adapter, ConnectContext ctx)
+            throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            return executor.submit(() -> adapter.callCommand(ctx, () -> "ok")).get(10, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            throw (Exception) e.getCause();
+        } finally {
+            executor.shutdownNow();
         }
     }
 
@@ -172,7 +198,7 @@ public class FlightProtocolAdapterTest {
     }
 
     @Test
-    public void testFailedCommandReleasesTheSession() {
+    public void testFailedCommandReleasesTheSession() throws Exception {
         ConnectContext ctx = flightSession();
         FlightProtocolAdapter adapter = FlightProtocolAdapter.of(ctx);
         ConnectContext.remove();
@@ -184,9 +210,36 @@ public class FlightProtocolAdapterTest {
         Assertions.assertThrows(TException.class, () -> adapter.runCommand(ctx, () -> {
             throw new TException("boom");
         }));
-        // ... the thread is clean, and the next command of the session is not blocked.
+        // ... the thread is clean, and the next command of the session is not blocked. That next
+        // command runs on another thread: the lock is reentrant, so this thread would get through
+        // even if the failed command had left the lock held.
         Assertions.assertNull(ConnectContext.get());
-        Assertions.assertEquals("ok", adapter.callCommand(ctx, () -> "ok"));
+        ctx.getSessionVariable().setQueryTimeoutS(1);
+        Assertions.assertEquals("ok", callFromAnotherThread(adapter, ctx));
+    }
+
+    @Test
+    public void testOnlyTheLastStatementOfARequestMayReturnAResult() throws Exception {
+        ConnectContext ctx = flightSession();
+        FlightProtocolAdapter adapter = FlightProtocolAdapter.of(ctx);
+        StmtExecutor executor = Mockito.mock(StmtExecutor.class);
+        ShowResultSet resultSet = new ShowResultSet(
+                ShowResultSetMetaData.builder().addColumn(new Column("c", ScalarType.createVarchar(20))).build(),
+                Lists.<List<String>>newArrayList(Lists.newArrayList("v")));
+
+        // A statement without a result lets the request go on.
+        Assertions.assertTrue(adapter.finishStatement(ctx, executor, 0, 2));
+
+        // A result produced by the last statement is fine ...
+        ctx.setQueryId(new TUniqueId(1, 1));
+        ctx.getResultSender().sendResultSet(resultSet, null, false);
+        Assertions.assertTrue(adapter.finishStatement(ctx, executor, 1, 2));
+        Assertions.assertNotEquals(MysqlStateType.ERR, ctx.getState().getStateType());
+
+        // ... one produced earlier stops the request with the error the client will see.
+        Assertions.assertFalse(adapter.finishStatement(ctx, executor, 0, 2));
+        Assertions.assertEquals(MysqlStateType.ERR, ctx.getState().getStateType());
+        Assertions.assertEquals(ErrorCode.ERR_ARROW_FLIGHT_SQL_MUST_ONLY_RESULT_STMT, ctx.getState().getErrorCode());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/arrowflight/protocol/FlightResultSenderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/arrowflight/protocol/FlightResultSenderTest.java
@@ -1,0 +1,108 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.arrowflight.protocol;
+
+import org.apache.doris.arrowflight.results.FlightSqlResultCacheEntry;
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.qe.CommonResultSet;
+import org.apache.doris.qe.CommonResultSet.CommonResultSetMetaData;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.ResultSet;
+import org.apache.doris.thrift.TUniqueId;
+
+import com.google.common.collect.Lists;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * A frontend-side result of an Arrow Flight SQL session is cached for the client's DoGet; a
+ * backend result never passes through the frontend.
+ */
+public class FlightResultSenderTest {
+    private boolean savedRunningUnitTest;
+
+    @BeforeEach
+    public void setUp() {
+        savedRunningUnitTest = FeConstants.runningUnitTest;
+        // ConnectContext.init() registers the session with Env unless running as a unit test.
+        FeConstants.runningUnitTest = true;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        FeConstants.runningUnitTest = savedRunningUnitTest;
+    }
+
+    @Test
+    public void testResultSetIsCachedUnderTheQueryId() throws Exception {
+        ConnectContext ctx = ConnectContext.forFlight("test-peer-identity");
+        FlightProtocolAdapter adapter = FlightProtocolAdapter.of(ctx);
+        TUniqueId queryId = new TUniqueId(3, 4);
+        ctx.setQueryId(queryId);
+        ctx.setRunningQuery("show variables");
+        // The query path marks the result as coming from the backend before an EXPLAIN turns out
+        // to be answered here; the sender puts that right.
+        ctx.setReturnResultFromLocal(false);
+        List<List<String>> rows = Lists.newArrayList();
+        rows.add(Lists.newArrayList("wait_timeout", "28800"));
+        rows.add(Lists.newArrayList("x", null));
+        ResultSet resultSet = new CommonResultSet(
+                new CommonResultSetMetaData(Lists.newArrayList(
+                        new Column("Variable_name", PrimitiveType.VARCHAR), new Column("Value", PrimitiveType.VARCHAR))),
+                rows);
+
+        ctx.getResultSender().sendResultSet(resultSet, null, false);
+
+        Assertions.assertTrue(ctx.isReturnResultFromLocal());
+        Assertions.assertEquals(1, adapter.getChannel().resultNum());
+        FlightSqlResultCacheEntry entry = adapter.getChannel().getResult(DebugUtil.printId(queryId));
+        Assertions.assertNotNull(entry);
+        Assertions.assertEquals("show variables", entry.getQuery());
+        VectorSchemaRoot root = entry.getVectorSchemaRoot();
+        Assertions.assertEquals(2, root.getRowCount());
+        Assertions.assertEquals("28800",
+                new String(((VarCharVector) root.getVector("Value")).get(0), StandardCharsets.UTF_8));
+        Assertions.assertTrue(root.getVector("Value").isNull(1));
+        adapter.getChannel().close();
+    }
+
+    @Test
+    public void testBackendResultsNeverPassThroughTheFrontend() {
+        ConnectContext ctx = ConnectContext.forFlight("test-peer-identity");
+
+        Assertions.assertThrows(IllegalStateException.class, () -> ctx.getResultSender()
+                .sendFields(Lists.newArrayList("k1"), null, Lists.newArrayList(Type.INT)));
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> ctx.getResultSender().sendRow(ByteBuffer.wrap(new byte[] {1, 49})));
+        // Nothing is pending on a Flight session when a query starts.
+        ctx.getResultSender().reset();
+        Assertions.assertEquals(0, FlightProtocolAdapter.of(ctx).getChannel().resultNum());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/protocol/MysqlProtocolAdapterTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/protocol/MysqlProtocolAdapterTest.java
@@ -18,16 +18,20 @@
 package org.apache.doris.mysql.protocol;
 
 import org.apache.doris.arrowflight.protocol.FlightProtocolAdapter;
+import org.apache.doris.common.ErrorCode;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.util.DebugUtil;
 import org.apache.doris.mysql.DummyMysqlChannel;
 import org.apache.doris.mysql.MysqlCapability;
 import org.apache.doris.mysql.MysqlChannel;
+import org.apache.doris.mysql.MysqlProto;
+import org.apache.doris.mysql.MysqlServerStatusFlag;
 import org.apache.doris.mysql.ProxyMysqlChannel;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.qe.ConnectProcessor;
 import org.apache.doris.qe.ConnectScheduler;
+import org.apache.doris.qe.protocol.RecordingMysqlChannel;
 import org.apache.doris.thrift.TResultSinkType;
 import org.apache.doris.thrift.TUniqueId;
 
@@ -38,6 +42,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
+
+import java.nio.ByteBuffer;
 
 /**
  * A MySQL connection, a proxy context on the master and an internal context are all a
@@ -120,6 +126,81 @@ public class MysqlProtocolAdapterTest {
         // The flag belongs to the statement: it is gone once the statement is over.
         ctx.clear();
         Assertions.assertFalse(ctx.isCursorFetchRequested());
+    }
+
+    @Test
+    public void testClientAddressComesFromTheChannel() {
+        MysqlChannel channel = Mockito.mock(MysqlChannel.class);
+        Mockito.when(channel.getRemoteHostPortString()).thenReturn("10.0.0.1:3306");
+        ConnectContext ctx = new ConnectContext(new MysqlProtocolAdapter(channel));
+
+        // The Host column of SHOW PROCESSLIST and client_ip in the audit log.
+        Assertions.assertEquals("10.0.0.1:3306", ctx.getRemoteHostPortString());
+        Assertions.assertEquals("10.0.0.1:3306", ctx.getClientIP());
+    }
+
+    @Test
+    public void testIntermediateResponseOfAMultiStatementRequest() throws Exception {
+        // The client did not negotiate CLIENT_MULTI_STATEMENTS: the intermediate statements are
+        // marked but nothing is sent, so only the last result reaches the client.
+        RecordingMysqlChannel channel = new RecordingMysqlChannel();
+        ConnectContext ctx = new ConnectContext(new MysqlProtocolAdapter(channel));
+        MysqlProtocolAdapter protocol = MysqlProtocolAdapter.of(ctx);
+        ctx.getState().setOk();
+
+        Assertions.assertTrue(protocol.finishStatement(ctx, null, 0, 2));
+        Assertions.assertNotEquals(0, ctx.getState().serverStatus & MysqlServerStatusFlag.SERVER_MORE_RESULTS_EXISTS);
+        Assertions.assertTrue(channel.getOutbound().isEmpty());
+
+        // The last statement is answered by finishCommand, not here.
+        ctx.getState().reset();
+        ctx.getState().setOk();
+        Assertions.assertTrue(protocol.finishStatement(ctx, null, 1, 2));
+        Assertions.assertEquals(0, ctx.getState().serverStatus & MysqlServerStatusFlag.SERVER_MORE_RESULTS_EXISTS);
+        Assertions.assertTrue(channel.getOutbound().isEmpty());
+
+        // With CLIENT_MULTI_STATEMENTS every intermediate response is sent and flushed right away ...
+        channel.setClientMultiStatements();
+        ctx.getState().reset();
+        ctx.getState().setOk();
+        Assertions.assertTrue(protocol.finishStatement(ctx, null, 0, 2));
+        Assertions.assertEquals(1, channel.getOutbound().size());
+        Assertions.assertTrue(channel.getOutbound().get(0).isFlushed());
+        // OK packet, status flags carry SERVER_MORE_RESULTS_EXISTS
+        byte[] ok = channel.getOutbound().get(0).getPayload();
+        Assertions.assertEquals(0x00, ok[0]);
+        Assertions.assertNotEquals(0, MysqlProto.readInt2(ByteBuffer.wrap(ok, 3, 2))
+                & MysqlServerStatusFlag.SERVER_MORE_RESULTS_EXISTS);
+
+        // ... except after an error, whose response ends the request.
+        channel.clearOutbound();
+        ctx.getState().reset();
+        ctx.getState().setError(ErrorCode.ERR_UNKNOWN_ERROR, "boom");
+        Assertions.assertTrue(protocol.finishStatement(ctx, null, 0, 2));
+        Assertions.assertTrue(channel.getOutbound().isEmpty());
+    }
+
+    @Test
+    public void testResponsePacketFollowsTheStateAndTheEofCapability() {
+        RecordingMysqlChannel channel = new RecordingMysqlChannel();
+        ConnectContext ctx = new ConnectContext(new MysqlProtocolAdapter(channel));
+        MysqlProtocolAdapter protocol = MysqlProtocolAdapter.of(ctx);
+
+        // A command that needs no response.
+        ctx.getState().setNoop();
+        Assertions.assertNull(protocol.responsePacket(ctx));
+
+        // The end of a result set is an EOF packet ...
+        ctx.getState().setEof();
+        ByteBuffer eof = protocol.responsePacket(ctx);
+        Assertions.assertEquals(0xFE, Byte.toUnsignedInt(eof.get(0)));
+        Assertions.assertEquals(5, eof.remaining());
+
+        // ... unless the client deprecated it, then it is an OK packet with the 0xFE header.
+        channel.setClientDeprecatedEOF();
+        ByteBuffer resultSetEnd = protocol.responsePacket(ctx);
+        Assertions.assertEquals(0xFE, Byte.toUnsignedInt(resultSetEnd.get(0)));
+        Assertions.assertTrue(resultSetEnd.remaining() > 5);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/mysql/protocol/MysqlResultSenderTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/mysql/protocol/MysqlResultSenderTest.java
@@ -1,0 +1,279 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.mysql.protocol;
+
+import org.apache.doris.catalog.Column;
+import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.ScalarType;
+import org.apache.doris.catalog.Type;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.mysql.MysqlChannel;
+import org.apache.doris.nereids.StatementContext;
+import org.apache.doris.qe.CommonResultSet;
+import org.apache.doris.qe.CommonResultSet.CommonResultSetMetaData;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.qe.ResultSet;
+import org.apache.doris.qe.protocol.RecordingMysqlChannel;
+import org.apache.doris.qe.protocol.RecordingMysqlChannel.RecordedPacket;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * The packets a MysqlResultSender writes for a result set, a prepared statement and a raw row.
+ * The end-to-end packet sequences of whole commands are in MysqlPacketGoldenTest; this checks
+ * the encoding of the pieces.
+ */
+public class MysqlResultSenderTest {
+    private boolean savedRunningUnitTest;
+
+    @BeforeEach
+    public void setUp() {
+        savedRunningUnitTest = FeConstants.runningUnitTest;
+        // ConnectContext.init() registers the session with Env unless running as a unit test.
+        FeConstants.runningUnitTest = true;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        FeConstants.runningUnitTest = savedRunningUnitTest;
+    }
+
+    @Test
+    public void testTextRowsEncodeNullAndLengthEncodedStrings() throws IOException {
+        RecordingMysqlChannel channel = newChannel(true);
+        ConnectContext ctx = newContext(channel);
+        List<Column> columns = Lists.newArrayList(
+                new Column("c1", PrimitiveType.VARCHAR), new Column("c2", PrimitiveType.VARCHAR));
+        List<List<String>> rows = Lists.newArrayList();
+        rows.add(Lists.newArrayList(null, "row1"));
+        rows.add(Lists.newArrayList("1234", "row2"));
+        ResultSet resultSet = new CommonResultSet(new CommonResultSetMetaData(columns), rows);
+
+        ctx.getResultSender().sendResultSet(resultSet, null, false);
+
+        // column count, two column definitions, no terminator (CLIENT_DEPRECATE_EOF), two rows
+        List<byte[]> packets = payloads(channel);
+        Assertions.assertEquals(5, packets.size());
+        Assertions.assertArrayEquals(new byte[] {2}, packets.get(0));
+        Assertions.assertArrayEquals(new byte[] {-5, 4, 114, 111, 119, 49}, packets.get(3));
+        Assertions.assertArrayEquals(new byte[] {4, 49, 50, 51, 52, 4, 114, 111, 119, 50}, packets.get(4));
+    }
+
+    @Test
+    public void testBinaryRowsEncodeIntegersAndDatetimes() throws IOException {
+        RecordingMysqlChannel channel = newChannel(true);
+        ConnectContext ctx = newContext(channel);
+        List<Column> columns = Lists.newArrayList(
+                new Column("col1", PrimitiveType.BIGINT), new Column("col2", PrimitiveType.DATETIMEV2));
+        List<List<String>> rows = Lists.newArrayList();
+        rows.add(Lists.newArrayList(null, "2025-01-01 01:02:03"));
+        rows.add(Lists.newArrayList("1234", "2025-01-01 01:02:03.123456"));
+        ResultSet resultSet = new CommonResultSet(new CommonResultSetMetaData(columns), rows);
+
+        ctx.getResultSender().sendResultSet(resultSet, null, true);
+
+        List<byte[]> packets = payloads(channel);
+        Assertions.assertEquals(5, packets.size());
+        // header byte, null bitmap (first column null), 7-byte datetime without microseconds
+        Assertions.assertArrayEquals(new byte[] {0, 4, 7, -23, 7, 1, 1, 1, 2, 3}, packets.get(3));
+        // header byte, empty null bitmap, int8, 11-byte datetime with microseconds
+        Assertions.assertArrayEquals(new byte[] {0, 0, -46, 4, 0, 0, 0, 0, 0, 0, 11, -23, 7, 1, 1, 1, 2, 3,
+                64, -30, 1, 0}, packets.get(4));
+    }
+
+    @Test
+    public void testBinaryTimestampNsIsSentAsText() throws IOException {
+        RecordingMysqlChannel channel = newChannel(true);
+        ConnectContext ctx = newContext(channel);
+        String value = "2025-01-01 01:02:03.123456789";
+        List<List<String>> rows = Lists.newArrayList();
+        rows.add(Lists.newArrayList(value));
+        ResultSet resultSet = new CommonResultSet(
+                new CommonResultSetMetaData(Lists.newArrayList(
+                        new Column("timestamp_ns", ScalarType.createTimeStampNsType()))),
+                rows);
+
+        ctx.getResultSender().sendResultSet(resultSet, null, true);
+
+        byte[] valueBytes = value.getBytes(StandardCharsets.UTF_8);
+        byte[] expected = new byte[valueBytes.length + 3];
+        expected[2] = (byte) valueBytes.length;
+        System.arraycopy(valueBytes, 0, expected, 3, valueBytes.length);
+        List<byte[]> packets = payloads(channel);
+        Assertions.assertArrayEquals(expected, packets.get(packets.size() - 1));
+    }
+
+    @Test
+    public void testBinaryBooleanAcceptsBothSpellings() throws IOException {
+        RecordingMysqlChannel channel = newChannel(true);
+        ConnectContext ctx = newContext(channel);
+        List<List<String>> rows = Lists.newArrayList();
+        rows.add(Lists.newArrayList("false"));
+        rows.add(Lists.newArrayList("1"));
+        ResultSet resultSet = new CommonResultSet(
+                new CommonResultSetMetaData(Lists.newArrayList(new Column("col1", PrimitiveType.BOOLEAN))),
+                rows);
+
+        ctx.getResultSender().sendResultSet(resultSet, null, true);
+
+        List<byte[]> packets = payloads(channel);
+        Assertions.assertArrayEquals(new byte[] {0, 0, 0}, packets.get(packets.size() - 2));
+        Assertions.assertArrayEquals(new byte[] {0, 0, 1}, packets.get(packets.size() - 1));
+    }
+
+    @Test
+    public void testCursorFetchMetadataTerminatorDependsOnConnectorJVersion() throws IOException {
+        List<byte[]> connector82Packets = sendEmptyResultSet(true, "MySQL Connector/J", "8.2.0");
+        Assertions.assertEquals(3, connector82Packets.size());
+        Assertions.assertEquals(0xFE, Byte.toUnsignedInt(connector82Packets.get(2)[0]));
+        Assertions.assertTrue(connector82Packets.get(2).length > 5);
+
+        Assertions.assertEquals(3, sendEmptyResultSet(true, "MySQL Connector Java", "5.1.49").size());
+        Assertions.assertEquals(3, sendEmptyResultSet(true, "MySQL Connector/J", "6.0.6").size());
+        Assertions.assertEquals(3, sendEmptyResultSet(true, "MySQL Connector/J", "9.4.0").size());
+        Assertions.assertEquals(2, sendEmptyResultSet(true, "MySQL Connector/J", "9.5.0").size());
+        Assertions.assertEquals(2, sendEmptyResultSet(false, "MySQL Connector/J", "8.2.0").size());
+        Assertions.assertEquals(2, sendEmptyResultSet(true, "MariaDB Connector/J", "3.5.6").size());
+        Assertions.assertEquals(3, sendEmptyResultSet(true, Collections.emptyMap(), true).size());
+
+        List<byte[]> legacyEofPackets = sendEmptyResultSet(true, "MySQL Connector/J", "8.2.0", false);
+        Assertions.assertEquals(3, legacyEofPackets.size());
+        Assertions.assertEquals(5, legacyEofPackets.get(2).length);
+    }
+
+    @Test
+    public void testPrepareMetadataTerminatorsFollowNegotiatedCapability() throws IOException {
+        Assertions.assertEquals(3, sendPrepareMetadata(false).size());
+        Assertions.assertEquals(2, sendPrepareMetadata(true).size());
+    }
+
+    @Test
+    public void testPrepareResponseIsFlushedWithItsLastPacket() throws IOException {
+        RecordingMysqlChannel channel = newChannel(true);
+        ConnectContext ctx = newContext(channel);
+
+        MysqlProtocolAdapter.of(ctx).resultSender(ctx).sendStmtPrepareOK(
+                7, Collections.singletonList("p"), Collections.emptyList());
+
+        List<RecordedPacket> packets = channel.getOutbound();
+        // statement id 7, one parameter, no columns
+        Assertions.assertArrayEquals(new byte[] {0, 7, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}, packets.get(0).getPayload());
+        Assertions.assertTrue(packets.get(packets.size() - 1).isFlushed());
+    }
+
+    @Test
+    public void testBackendRowsAreWrittenAsIs() throws IOException {
+        RecordingMysqlChannel channel = newChannel(true);
+        ConnectContext ctx = newContext(channel);
+        ctx.setStatementContext(new StatementContext());
+
+        ctx.getResultSender().sendFields(Lists.newArrayList("k1"), null, Lists.newArrayList(Type.INT));
+        ctx.getResultSender().sendRow(ByteBuffer.wrap(new byte[] {1, 49}));
+
+        List<byte[]> packets = payloads(channel);
+        // column count, one column definition, the row untouched
+        Assertions.assertEquals(3, packets.size());
+        Assertions.assertArrayEquals(new byte[] {1}, packets.get(0));
+        Assertions.assertArrayEquals(new byte[] {1, 49}, packets.get(2));
+    }
+
+    @Test
+    public void testFieldListHasNoColumnCount() throws IOException {
+        RecordingMysqlChannel channel = newChannel(true);
+        ConnectContext ctx = newContext(channel);
+        List<Column> columns = Lists.newArrayList(
+                new Column("k1", PrimitiveType.INT), new Column("k2", PrimitiveType.VARCHAR));
+
+        MysqlProtocolAdapter.of(ctx).resultSender(ctx).sendFieldList("db1", "tbl1", columns);
+
+        Assertions.assertEquals(2, channel.getOutbound().size());
+    }
+
+    @Test
+    public void testResetClearsTheChannel() {
+        MysqlChannel channel = Mockito.mock(MysqlChannel.class);
+        ConnectContext ctx = new ConnectContext(new MysqlProtocolAdapter(channel));
+
+        ctx.getResultSender().reset();
+
+        Mockito.verify(channel).reset();
+    }
+
+    private List<byte[]> sendPrepareMetadata(boolean clientDeprecatedEof) throws IOException {
+        RecordingMysqlChannel channel = newChannel(clientDeprecatedEof);
+        ConnectContext ctx = newContext(channel);
+
+        MysqlProtocolAdapter.of(ctx).resultSender(ctx).sendStmtPrepareOK(
+                1, Collections.singletonList("p"), Collections.emptyList());
+        return payloads(channel);
+    }
+
+    private List<byte[]> sendEmptyResultSet(boolean cursorFetchRequested, String clientName,
+            String clientVersion) throws IOException {
+        return sendEmptyResultSet(cursorFetchRequested, clientName, clientVersion, true);
+    }
+
+    private List<byte[]> sendEmptyResultSet(boolean cursorFetchRequested, String clientName,
+            String clientVersion, boolean clientDeprecatedEof) throws IOException {
+        return sendEmptyResultSet(cursorFetchRequested, ImmutableMap.of(
+                "_client_name", clientName, "_client_version", clientVersion), clientDeprecatedEof);
+    }
+
+    private List<byte[]> sendEmptyResultSet(boolean cursorFetchRequested,
+            Map<String, String> connectAttributes, boolean clientDeprecatedEof) throws IOException {
+        RecordingMysqlChannel channel = newChannel(clientDeprecatedEof);
+        ConnectContext ctx = newContext(channel);
+        ctx.setConnectAttributes(connectAttributes);
+        MysqlProtocolAdapter.of(ctx).setCursorFetchRequested(cursorFetchRequested);
+
+        List<Column> columns = Collections.singletonList(new Column("c", PrimitiveType.INT));
+        ResultSet resultSet = new CommonResultSet(new CommonResultSetMetaData(columns), Collections.emptyList());
+        ctx.getResultSender().sendResultSet(resultSet, null, true);
+        return payloads(channel);
+    }
+
+    private static RecordingMysqlChannel newChannel(boolean clientDeprecatedEof) {
+        RecordingMysqlChannel channel = new RecordingMysqlChannel();
+        if (clientDeprecatedEof) {
+            channel.setClientDeprecatedEOF();
+        }
+        return channel;
+    }
+
+    private static ConnectContext newContext(RecordingMysqlChannel channel) {
+        return new ConnectContext(new MysqlProtocolAdapter(channel));
+    }
+
+    private static List<byte[]> payloads(RecordingMysqlChannel channel) {
+        return channel.getOutbound().stream().map(RecordedPacket::getPayload).collect(Collectors.toList());
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/AuditLogWorkloadGroupTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/AuditLogWorkloadGroupTest.java
@@ -26,7 +26,6 @@ import org.apache.doris.common.ConnectionException;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.mysql.privilege.Auth;
 import org.apache.doris.proto.Data;
-import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.resource.workloadgroup.WorkloadGroupMgr;
 
 import org.junit.jupiter.api.AfterEach;
@@ -400,7 +399,6 @@ public class AuditLogWorkloadGroupTest {
         MultiStmtRecordingProcessor(ConnectContext ctx, List<StatementBase> parsedStmts,
                 List<String> auditedWorkloadGroups, int[] resolveCallCount) {
             super(ctx);
-            this.connectType = ConnectType.MYSQL;
             this.parsedStmts = parsedStmts;
             this.auditedWorkloadGroups = auditedWorkloadGroups;
             this.resolveCallCount = resolveCallCount;

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectProcessorDelegatedCredentialTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectProcessorDelegatedCredentialTest.java
@@ -21,7 +21,6 @@ import org.apache.doris.analysis.StatementBase;
 import org.apache.doris.datasource.DelegatedCredential;
 import org.apache.doris.datasource.SessionContext;
 import org.apache.doris.proto.Data;
-import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.thrift.TMasterOpRequest;
 
 import org.junit.jupiter.api.AfterEach;
@@ -108,7 +107,6 @@ class ConnectProcessorDelegatedCredentialTest {
 
         private RecordingConnectProcessor(ConnectContext context) {
             super(context);
-            this.connectType = ConnectType.MYSQL;
         }
 
         private void handle(String originStmt) throws Exception {

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectProcessorForwardProtocolTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/ConnectProcessorForwardProtocolTest.java
@@ -21,6 +21,7 @@ import org.apache.doris.mysql.DummyMysqlChannel;
 import org.apache.doris.mysql.MysqlCapability;
 import org.apache.doris.mysql.MysqlProto;
 import org.apache.doris.mysql.MysqlSerializer;
+import org.apache.doris.mysql.protocol.MysqlProtocolAdapter;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -117,12 +118,12 @@ public class ConnectProcessorForwardProtocolTest {
         }
 
         private TestContext(boolean clientDeprecatedEof) {
-            channel = new RecordingChannel(clientDeprecatedEof);
+            this(new RecordingChannel(clientDeprecatedEof));
         }
 
-        @Override
-        public RecordingChannel getMysqlChannel() {
-            return channel;
+        private TestContext(RecordingChannel channel) {
+            super(new MysqlProtocolAdapter(channel));
+            this.channel = channel;
         }
     }
 

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/StmtExecutorTest.java
@@ -17,45 +17,27 @@
 
 package org.apache.doris.qe;
 
-import org.apache.doris.catalog.Column;
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.InternalSchemaInitializer;
-import org.apache.doris.catalog.PrimitiveType;
 import org.apache.doris.catalog.ResourceMgr;
-import org.apache.doris.catalog.ScalarType;
 import org.apache.doris.common.Config;
 import org.apache.doris.common.FeConstants;
 import org.apache.doris.common.Status;
-import org.apache.doris.mysql.MysqlChannel;
-import org.apache.doris.mysql.MysqlSerializer;
 import org.apache.doris.mysql.authenticate.TestLogAppender;
-import org.apache.doris.mysql.protocol.MysqlProtocolAdapter;
 import org.apache.doris.planner.PlanFragment;
 import org.apache.doris.planner.Planner;
 import org.apache.doris.planner.ResultFileSink;
-import org.apache.doris.qe.CommonResultSet.CommonResultSetMetaData;
-import org.apache.doris.qe.ConnectContext.ConnectType;
 import org.apache.doris.thrift.TQueryOptions;
 import org.apache.doris.thrift.TUniqueId;
 import org.apache.doris.utframe.TestWithFeService;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class StmtExecutorTest extends TestWithFeService {
@@ -278,268 +260,6 @@ public class StmtExecutorTest extends TestWithFeService {
         executor = new StmtExecutor(connectContext, "use testDb");
         executor.execute();
         Assertions.assertEquals(QueryState.MysqlStateType.OK, connectContext.getState().getStateType());
-    }
-
-    @Test
-    public void testSendTextResultRow() throws IOException {
-        ConnectContext mockCtx = Mockito.mock(ConnectContext.class);
-        MysqlChannel channel = Mockito.mock(MysqlChannel.class);
-        Mockito.when(mockCtx.getConnectType()).thenReturn(ConnectType.MYSQL);
-        Mockito.when(mockCtx.getMysqlChannel()).thenReturn(channel);
-        MysqlSerializer mysqlSerializer = MysqlSerializer.newInstance();
-        Mockito.when(channel.getSerializer()).thenReturn(mysqlSerializer);
-        SessionVariable sessionVariable = VariableMgr.newSessionVariable();
-        Mockito.when(mockCtx.getSessionVariable()).thenReturn(sessionVariable);
-        OriginStatement stmt = new OriginStatement("", 1);
-
-        List<List<String>> rows = Lists.newArrayList();
-        List<String> row1 = Lists.newArrayList();
-        row1.add(null);
-        row1.add("row1");
-        List<String> row2 = Lists.newArrayList();
-        row2.add("1234");
-        row2.add("row2");
-        rows.add(row1);
-        rows.add(row2);
-        List<Column> columns = Lists.newArrayList();
-        columns.add(new Column());
-        columns.add(new Column());
-        ResultSet resultSet = new CommonResultSet(new CommonResultSetMetaData(columns), rows);
-        AtomicInteger i = new AtomicInteger();
-        Mockito.doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocation) {
-                byte[] expected0 = new byte[] {-5, 4, 114, 111, 119, 49};
-                byte[] expected1 = new byte[] {4, 49, 50, 51, 52, 4, 114, 111, 119, 50};
-                ByteBuffer buffer = invocation.getArgument(0);
-                if (i.get() == 0) {
-                    Assertions.assertArrayEquals(expected0, buffer.array());
-                    i.getAndIncrement();
-                } else if (i.get() == 1) {
-                    Assertions.assertArrayEquals(expected1, buffer.array());
-                    i.getAndIncrement();
-                }
-                return null;
-            }
-        }).when(channel).sendOnePacket(Mockito.any(ByteBuffer.class));
-
-        StmtExecutor executor = new StmtExecutor(mockCtx, stmt, false);
-        executor.sendTextResultRow(resultSet);
-    }
-
-    @Test
-    public void testSendBinaryResultRow() throws IOException {
-        ConnectContext mockCtx = Mockito.mock(ConnectContext.class);
-        MysqlChannel channel = Mockito.mock(MysqlChannel.class);
-        Mockito.when(mockCtx.getConnectType()).thenReturn(ConnectType.MYSQL);
-        Mockito.when(mockCtx.getMysqlChannel()).thenReturn(channel);
-        MysqlSerializer mysqlSerializer = MysqlSerializer.newInstance();
-        Mockito.when(channel.getSerializer()).thenReturn(mysqlSerializer);
-        SessionVariable sessionVariable = VariableMgr.newSessionVariable();
-        Mockito.when(mockCtx.getSessionVariable()).thenReturn(sessionVariable);
-        OriginStatement stmt = new OriginStatement("", 1);
-
-        List<List<String>> rows = Lists.newArrayList();
-        List<String> row1 = Lists.newArrayList();
-        row1.add(null);
-        row1.add("2025-01-01 01:02:03");
-        List<String> row2 = Lists.newArrayList();
-        row2.add("1234");
-        row2.add("2025-01-01 01:02:03.123456");
-        rows.add(row1);
-        rows.add(row2);
-        List<Column> columns = Lists.newArrayList();
-        columns.add(new Column("col1", PrimitiveType.BIGINT));
-        columns.add(new Column("col2", PrimitiveType.DATETIMEV2));
-        ResultSet resultSet = new CommonResultSet(new CommonResultSetMetaData(columns), rows);
-        AtomicInteger i = new AtomicInteger();
-        Mockito.doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocation) {
-                byte[] expected0 = new byte[] {0, 4, 7, -23, 7, 1, 1, 1, 2, 3};
-                byte[] expected1 = new byte[] {0, 0, -46, 4, 0, 0, 0, 0, 0, 0, 11, -23, 7, 1, 1, 1, 2, 3,
-                        64, -30, 1, 0};
-                ByteBuffer buffer = invocation.getArgument(0);
-                if (i.get() == 0) {
-                    Assertions.assertArrayEquals(expected0, buffer.array());
-                    i.getAndIncrement();
-                } else if (i.get() == 1) {
-                    Assertions.assertArrayEquals(expected1, buffer.array());
-                    i.getAndIncrement();
-                }
-                return null;
-            }
-        }).when(channel).sendOnePacket(Mockito.any(ByteBuffer.class));
-
-        StmtExecutor executor = new StmtExecutor(mockCtx, stmt, false);
-        executor.sendBinaryResultRow(resultSet);
-    }
-
-    @Test
-    public void testSendBinaryTimestampNsResultRow() throws IOException {
-        ConnectContext mockCtx = Mockito.mock(ConnectContext.class);
-        MysqlChannel channel = Mockito.mock(MysqlChannel.class);
-        Mockito.when(mockCtx.getConnectType()).thenReturn(ConnectType.MYSQL);
-        Mockito.when(mockCtx.getMysqlChannel()).thenReturn(channel);
-        MysqlSerializer mysqlSerializer = MysqlSerializer.newInstance();
-        Mockito.when(channel.getSerializer()).thenReturn(mysqlSerializer);
-        Mockito.when(mockCtx.getSessionVariable()).thenReturn(VariableMgr.newSessionVariable());
-
-        String value = "2025-01-01 01:02:03.123456789";
-        List<List<String>> rows = Lists.newArrayList();
-        rows.add(Lists.newArrayList(value));
-        ResultSet resultSet = new CommonResultSet(
-                new CommonResultSetMetaData(Lists.newArrayList(
-                        new Column("timestamp_ns", ScalarType.createTimeStampNsType()))),
-                rows);
-        Mockito.doAnswer(invocation -> {
-            byte[] valueBytes = value.getBytes(StandardCharsets.UTF_8);
-            byte[] expected = new byte[valueBytes.length + 3];
-            expected[2] = (byte) valueBytes.length;
-            System.arraycopy(valueBytes, 0, expected, 3, valueBytes.length);
-            ByteBuffer buffer = invocation.getArgument(0);
-            Assertions.assertArrayEquals(expected, buffer.array());
-            return null;
-        }).when(channel).sendOnePacket(Mockito.any(ByteBuffer.class));
-
-        StmtExecutor executor = new StmtExecutor(mockCtx, new OriginStatement("", 1), false);
-        executor.sendBinaryResultRow(resultSet);
-    }
-
-    @Test
-    public void testCursorFetchMetadataTerminatorDependsOnConnectorJVersion() throws IOException {
-        List<byte[]> connector82Packets = sendEmptyResultSet(true, "MySQL Connector/J", "8.2.0");
-        Assertions.assertEquals(3, connector82Packets.size());
-        Assertions.assertEquals(0xFE, Byte.toUnsignedInt(connector82Packets.get(2)[0]));
-        Assertions.assertTrue(connector82Packets.get(2).length > 5);
-
-        Assertions.assertEquals(3, sendEmptyResultSet(true, "MySQL Connector Java", "5.1.49").size());
-        Assertions.assertEquals(3, sendEmptyResultSet(true, "MySQL Connector/J", "6.0.6").size());
-        Assertions.assertEquals(3, sendEmptyResultSet(true, "MySQL Connector/J", "9.4.0").size());
-        Assertions.assertEquals(2, sendEmptyResultSet(true, "MySQL Connector/J", "9.5.0").size());
-        Assertions.assertEquals(2, sendEmptyResultSet(false, "MySQL Connector/J", "8.2.0").size());
-        Assertions.assertEquals(2, sendEmptyResultSet(true, "MariaDB Connector/J", "3.5.6").size());
-        Assertions.assertEquals(3, sendEmptyResultSet(true, Collections.emptyMap()).size());
-
-        List<byte[]> legacyEofPackets = sendEmptyResultSet(true, "MySQL Connector/J", "8.2.0", false);
-        Assertions.assertEquals(3, legacyEofPackets.size());
-        Assertions.assertEquals(5, legacyEofPackets.get(2).length);
-    }
-
-    @Test
-    public void testPrepareMetadataTerminatorsFollowNegotiatedCapability() throws IOException {
-        Assertions.assertEquals(3, sendPrepareMetadata(false).size());
-        Assertions.assertEquals(2, sendPrepareMetadata(true).size());
-    }
-
-    private List<byte[]> sendPrepareMetadata(boolean clientDeprecatedEof) throws IOException {
-        ConnectContext mockCtx = Mockito.mock(ConnectContext.class);
-        MysqlChannel channel = Mockito.mock(MysqlChannel.class);
-        Mockito.when(mockCtx.getConnectType()).thenReturn(ConnectType.MYSQL);
-        Mockito.when(mockCtx.getMysqlChannel()).thenReturn(channel);
-        Mockito.when(mockCtx.getState()).thenReturn(new QueryState());
-        Mockito.when(mockCtx.getSessionVariable()).thenReturn(new SessionVariable());
-        Mockito.when(channel.clientDeprecatedEOF()).thenReturn(clientDeprecatedEof);
-        Mockito.when(channel.getSerializer()).thenReturn(MysqlSerializer.newInstance());
-
-        List<byte[]> packets = new ArrayList<>();
-        Mockito.doAnswer(invocation -> {
-            ByteBuffer packet = invocation.getArgument(0);
-            byte[] copy = new byte[packet.remaining()];
-            packet.duplicate().get(copy);
-            packets.add(copy);
-            return null;
-        }).when(channel).sendOnePacket(Mockito.any(ByteBuffer.class));
-
-        new StmtExecutor(mockCtx, new OriginStatement("", 0), true).sendStmtPrepareOK(
-                1, Collections.singletonList("p"), Collections.emptyList());
-        return packets;
-    }
-
-    private List<byte[]> sendEmptyResultSet(boolean cursorFetchRequested, String clientName,
-            String clientVersion) throws IOException {
-        return sendEmptyResultSet(cursorFetchRequested, clientName, clientVersion, true);
-    }
-
-    private List<byte[]> sendEmptyResultSet(boolean cursorFetchRequested, String clientName,
-            String clientVersion, boolean clientDeprecatedEof) throws IOException {
-        return sendEmptyResultSet(cursorFetchRequested, ImmutableMap.of(
-                "_client_name", clientName, "_client_version", clientVersion), clientDeprecatedEof);
-    }
-
-    private List<byte[]> sendEmptyResultSet(boolean cursorFetchRequested,
-            Map<String, String> connectAttributes) throws IOException {
-        return sendEmptyResultSet(cursorFetchRequested, connectAttributes, true);
-    }
-
-    private List<byte[]> sendEmptyResultSet(boolean cursorFetchRequested,
-            Map<String, String> connectAttributes, boolean clientDeprecatedEof) throws IOException {
-        ConnectContext mockCtx = Mockito.mock(ConnectContext.class);
-        MysqlChannel channel = Mockito.mock(MysqlChannel.class);
-        MysqlProtocolAdapter protocol = new MysqlProtocolAdapter(channel);
-        protocol.setCursorFetchRequested(cursorFetchRequested);
-        Mockito.when(mockCtx.getConnectType()).thenReturn(ConnectType.MYSQL);
-        Mockito.when(mockCtx.getProtocolAdapter()).thenReturn(protocol);
-        Mockito.when(mockCtx.getMysqlChannel()).thenReturn(channel);
-        Mockito.when(mockCtx.getState()).thenReturn(new QueryState());
-        Mockito.when(mockCtx.getSessionVariable()).thenReturn(VariableMgr.newSessionVariable());
-        Mockito.when(mockCtx.getConnectAttributes()).thenReturn(connectAttributes);
-        Mockito.when(channel.clientDeprecatedEOF()).thenReturn(clientDeprecatedEof);
-        Mockito.when(channel.getSerializer()).thenReturn(MysqlSerializer.newInstance());
-
-        List<byte[]> packets = new ArrayList<>();
-        Mockito.doAnswer(invocation -> {
-            ByteBuffer packet = invocation.getArgument(0);
-            byte[] copy = new byte[packet.remaining()];
-            packet.duplicate().get(copy);
-            packets.add(copy);
-            return null;
-        }).when(channel).sendOnePacket(Mockito.any(ByteBuffer.class));
-
-        List<Column> columns = Collections.singletonList(new Column("c", PrimitiveType.INT));
-        ResultSet resultSet = new CommonResultSet(new CommonResultSetMetaData(columns), Collections.emptyList());
-        new StmtExecutor(mockCtx, new OriginStatement("", 0), true).sendResultSet(resultSet);
-        return packets;
-    }
-
-    @Test
-    public void testSendBinaryBooleanResultRow() throws IOException {
-        ConnectContext mockCtx = Mockito.mock(ConnectContext.class);
-        MysqlChannel channel = Mockito.mock(MysqlChannel.class);
-        Mockito.when(mockCtx.getConnectType()).thenReturn(ConnectType.MYSQL);
-        Mockito.when(mockCtx.getMysqlChannel()).thenReturn(channel);
-        MysqlSerializer mysqlSerializer = MysqlSerializer.newInstance();
-        Mockito.when(channel.getSerializer()).thenReturn(mysqlSerializer);
-        SessionVariable sessionVariable = VariableMgr.newSessionVariable();
-        Mockito.when(mockCtx.getSessionVariable()).thenReturn(sessionVariable);
-        OriginStatement stmt = new OriginStatement("", 1);
-
-        List<List<String>> rows = Lists.newArrayList();
-        rows.add(Lists.newArrayList("false"));
-        rows.add(Lists.newArrayList("1"));
-        List<Column> columns = Lists.newArrayList();
-        columns.add(new Column("col1", PrimitiveType.BOOLEAN));
-        ResultSet resultSet = new CommonResultSet(new CommonResultSetMetaData(columns), rows);
-        AtomicInteger i = new AtomicInteger();
-        Mockito.doAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocation) {
-                byte[] expected0 = new byte[] {0, 0, 0};
-                byte[] expected1 = new byte[] {0, 0, 1};
-                ByteBuffer buffer = invocation.getArgument(0);
-                if (i.get() == 0) {
-                    Assertions.assertArrayEquals(expected0, buffer.array());
-                    i.getAndIncrement();
-                } else if (i.get() == 1) {
-                    Assertions.assertArrayEquals(expected1, buffer.array());
-                    i.getAndIncrement();
-                }
-                return null;
-            }
-        }).when(channel).sendOnePacket(Mockito.any(ByteBuffer.class));
-
-        StmtExecutor executor = new StmtExecutor(mockCtx, stmt, false);
-        executor.sendBinaryResultRow(resultSet);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/protocol/FlightResultGoldenTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/protocol/FlightResultGoldenTest.java
@@ -52,8 +52,8 @@ import java.util.List;
  *
  * <p>What is covered: {@code SHOW VARIABLES}, {@code SHOW DATABASES} and {@code DESC} (results the
  * frontend materializes and caches), {@code SET} and {@code USE} (no cached result, which is how the
- * producer knows to synthesize its {@code StatusResult=0} row), {@code EXPLAIN}, a syntax error and
- * an unknown table. Every column comes back as {@code Utf8} today -- that is the current behavior,
+ * producer knows to synthesize its {@code StatusResult=0} row), {@code EXPLAIN},
+ * {@code EXPLAIN PLAN PROCESS}, a syntax error and an unknown table. Every column comes back as {@code Utf8} today -- that is the current behavior,
  * and typing those results is a later step of the same work.
  *
  * <p>Regenerate from the {@code fe} directory with:
@@ -94,6 +94,7 @@ public class FlightResultGoldenTest extends TestWithFeService {
                 // The plan text and the node ids inside it move with the planner, so only the shape
                 // of the answer is recorded. Same reason as ProtocolGolden.Fidelity.SUMMARY.
                 new FlightCase("explain select 1", Detail.SHAPE),
+                new FlightCase("explain plan process select 1", Detail.SHAPE),
                 // A parser error carries the whole keyword list of the grammar.
                 new FlightCase("select from", Detail.SHAPE),
                 new FlightCase("select * from no_such_table", Detail.ROWS));

--- a/fe/fe-core/src/test/java/org/apache/doris/qe/protocol/MysqlPacketGoldenTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/qe/protocol/MysqlPacketGoldenTest.java
@@ -55,7 +55,7 @@ import java.util.List;
  *   <li>the same result set with {@code CLIENT_DEPRECATE_EOF} negotiated off, which decides whether
  *       a result set ends in an EOF or an OK, and adds one after the column definitions;</li>
  *   <li>{@code SHOW VARIABLES} (both EOF flavors), {@code DESC} (two data rows), {@code SET},
- *       {@code USE}, {@code EXPLAIN};</li>
+ *       {@code USE}, {@code EXPLAIN}, {@code EXPLAIN PLAN PROCESS};</li>
  *   <li>errors: a syntax error, an unknown table, and an error followed by a healthy statement on
  *       the same connection;</li>
  *   <li>multi-statement requests with and without {@code CLIENT_MULTI_STATEMENTS}, which decides
@@ -125,6 +125,9 @@ public class MysqlPacketGoldenTest extends TestWithFeService {
                 .add(query("use " + DB_NAME)));
         cases.add(new GoldenCase("explain-select", MODERN_CLIENT, ProtocolGolden.Fidelity.SUMMARY)
                 .add(query("explain select 1")));
+        // The rule names and plan shapes move with the planner, like the plan text above.
+        cases.add(new GoldenCase("explain-plan-process", MODERN_CLIENT, ProtocolGolden.Fidelity.SUMMARY)
+                .add(query("explain plan process select 1")));
         cases.add(new GoldenCase("syntax-error", MODERN_CLIENT, ProtocolGolden.Fidelity.SUMMARY)
                 .add(query("select from")));
         cases.add(new GoldenCase("unknown-table", MODERN_CLIENT)

--- a/fe/fe-core/src/test/resources/protocol-golden/flight-results.txt
+++ b/fe/fe-core/src/test/resources/protocol-golden/flight-results.txt
@@ -42,6 +42,10 @@ schema:
   Explain String(Nereids Planner): Utf8 nullable
 rows: some
 
+=== statement explain plan process select 1 ===
+state: EOF
+result: none, the producer synthesizes StatusResult=0
+
 === statement select from ===
 state: ERR errorCode=ERR_UNKNOWN_ERROR message="errCode = 2, detailMessage = \nmismatched input 'from' expecting {'(', '..."
 

--- a/fe/fe-core/src/test/resources/protocol-golden/flight-results.txt
+++ b/fe/fe-core/src/test/resources/protocol-golden/flight-results.txt
@@ -44,7 +44,11 @@ rows: some
 
 === statement explain plan process select 1 ===
 state: EOF
-result: none, the producer synthesizes StatusResult=0
+schema:
+  Rule: Utf8 nullable
+  Before: Utf8 nullable
+  After: Utf8 nullable
+rows: some
 
 === statement select from ===
 state: ERR errorCode=ERR_UNKNOWN_ERROR message="errCode = 2, detailMessage = \nmismatched input 'from' expecting {'(', '..."

--- a/fe/fe-core/src/test/resources/protocol-golden/mysql-packets.txt
+++ b/fe/fe-core/src/test/resources/protocol-golden/mysql-packets.txt
@@ -186,6 +186,11 @@ client capability: deprecate_eof=true multi_statements=false
 --> COM_QUERY explain select 1
   kinds: PAYLOAD (repeated), EOF flushed
 
+=== case explain-plan-process ===
+client capability: deprecate_eof=true multi_statements=false
+--> COM_QUERY explain plan process select 1
+  kinds: PAYLOAD (repeated), EOF flushed
+
 === case syntax-error ===
 client capability: deprecate_eof=true multi_statements=false
 --> COM_QUERY select from


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #67577

Related PR: #67835 (`ProtocolAdapter`), #67866 (package move), #67789 (protocol goldens)

Problem Summary:

Second step of the protocol-independent session work (#67577, stage 1). #67835 moved the *connection* half of the two wire protocols behind `ProtocolAdapter`; the *result* half was still spread over `StmtExecutor` and `ConnectProcessor` as `ConnectType` branches, a `MysqlSerializer` field, `MysqlChannel` parameters and three copies of "send a text result set".

```
  +---------------------------+                             +-----------------------------+
  |       MySQL client        |                             |   Arrow Flight SQL client   |
  +-------------+-------------+                             +--------------+--------------+
                |                                                          |
                v                                                          v
  +---------------------------+                             +-----------------------------+
  | MysqlServer               |                             | DorisFlightSqlProducer      |
  |   AcceptListener          |                             |   every call goes through   |
  |   ReadListener            |                             |   adapter.runCommand()      |
  +-------------+-------------+                             +--------------+--------------+
                |                                                          |
                v                                                          v
  +---------------------------+                             +-----------------------------+
  |   MysqlConnectProcessor   |                             |  FlightSqlConnectProcessor  |
  |   COM_FIELD_LIST, and     |                             |                             |
  |   finalizeCommand() =     |                             |                             |
  |   adapter.finishCommand() |                             |                             |
  +-------------+-------------+                             +--------------+--------------+
                |                                                          |
                +----------------------------+-----------------------------+
                                             |
                                             v
  +-------------------------------------------------------------------------------------------+
  | ConnectProcessor.executeQuery  --  parse, one StmtExecutor per statement, audit           |
  |     for each statement:  executor.execute()                                               |
  |                          adapter.finishStatement(ctx, executor, i, n)   <-- NEW           |
  +---------------------------------------------+---------------------------------------------+
                                                |
                                                v
  +-------------------------------------------------------------------------------------------+
  | StmtExecutor  --  plans and runs one statement, protocol-agnostic result path             |
  |                                                                                           |
  |   FE-side result (SHOW / EXPLAIN / REPLAY / dry run / FE-computable SELECT / forwarded):  |
  |       sendResultSet(rs)  ->  sender.sendResultSet(rs, fieldInfos, binaryRows)             |
  |   BE result stream:                                                                       |
  |       sender.sendFields(...)  then  sender.sendRow(row)  per row                          |
  |   internal executor streaming to the caller's client:                                     |
  |       executeInternalQueryAndSend(plan, callerCtx.getResultSender())                      |
  |                                                                                           |
  |   no MysqlSerializer field, no MysqlChannel parameter, no ConnectType branch on this path |
  +---------------------------------------------+---------------------------------------------+
                                                |
                                                v
  +-------------------------------------------------------------------------------------------+
  | ConnectContext  --  the session, one per connection                                       |
  |   protocolAdapter : ProtocolAdapter          getResultSender() = adapter.resultSender(this)|
  +---------------------------------------------+---------------------------------------------+
                                                |
                                                v
                       +-----------------------------------------------+
                       |  <<interface>>  qe.protocol.ProtocolAdapter   |
                       |   type() remoteHostPortString(ctx)            |
                       |   resultSinkType() connectPool(scheduler)     |
                       |   afterStatement(ctx) closeConnection(ctx)    |
                       |   resultSender(ctx)                  <-- NEW  |
                       |   supportsSqlCacheReplay()           <-- NEW  |
                       |   finishStatement(ctx, executor, i, n)  NEW   |
                       +-----------------------+-----------------------+
                                               |
                          +--------------------+----------------------------+
                          |                                                 |
  +-----------------------+----------------------+  +-----------------------+----------------------+
  | mysql.protocol.MysqlProtocolAdapter          |  | arrowflight.protocol.FlightProtocolAdapter   |
  |   (unchanged state: channel, capability,     |  |   (unchanged state: result cache, endpoints, |
  |    handshake, SSL, execute packet, cursor)   |  |    deferred executors, command lock)         |
  |   finishStatement: SERVER_MORE_RESULTS_EXISTS|  |   finishStatement: carry the outcome of a    |
  |     + flush the intermediate response when   |  |     statement forwarded to the master; only  |
  |     CLIENT_MULTI_STATEMENTS                  |  |     the last statement may return a result   |
  |   finishCommand: OK/EOF/ERR or the master's  |  |                                              |
  |     packets; responsePacket(ctx)             |  |                                              |
  +-----------------------+----------------------+  +-----------------------+----------------------+
                          |                                                 |
                          v                                                 v
  +----------------------------------------------+  +----------------------------------------------+
  | <<interface>> qe.protocol.ResultSender  (NEW) |  |                                              |
  |   sendResultSet(rs, fieldInfos, binaryRows)   |  |                                              |
  |   sendFields(names, fieldInfos, types)        |  |                                              |
  |   sendRow(wireRow)                            |  |                                              |
  |   reset()                                     |  |                                              |
  +----------------------------------------------+  +----------------------------------------------+
  | mysql.protocol.MysqlResultSender             |  | arrowflight.protocol.FlightResultSender      |
  |   column count + column definitions +        |  |   caches the ResultSet as Utf8 vectors under |
  |   terminator (EOF / cursor OK) + text or     |  |     the query id for the client's DoGet      |
  |   binary rows, through the channel's         |  |   sendFields/sendRow: never called, the      |
  |   serializer; a raw row passes through       |  |     client pulls BE results from the BE      |
  |   MySQL-only: sendStmtPrepareOK,             |  |   reset: nothing pending                     |
  |     sendFieldList                            |  |                                              |
  +----------------------------------------------+  +----------------------------------------------+
```

**`ResultSender`** (`qe.protocol`, interface; implementations in `mysql.protocol` and `arrowflight.protocol`, mirroring the adapters): how a statement's result reaches the client. Four operations, all of them already used: `sendResultSet` for a result the frontend materialized, `sendFields` + `sendRow` for a backend result stream, `reset` for what `MysqlChannel.reset()` did at the start of a query. `MysqlResultSender` is the old `sendMetaData / sendFields / sendTextResultRow / sendBinaryResultRow / sendMetadataTerminatorIfNeeded / sendStmtPrepareOK` of `StmtExecutor` plus the `COM_FIELD_LIST` body of `ConnectProcessor`, moved without changes to the byte layout; it uses the channel's serializer, so the executor's `serializer` field is gone. `FlightResultSender` wraps `FlightSqlChannel.addResult` (every column still `Utf8`, typing them is stage 2).

**`StmtExecutor`** no longer takes a `MysqlChannel`: `executeAndSendResult`, `sendCachedValues` and `executeInternalQueryAndSend` take a `ResultSender`. The three "text result" methods (`handleExplainStmt`, `handleReplayStmt`, `handleExplainPlanProcessStmt`) build a `ShowResultSet` and go through the one `sendResultSet`, which fixes `EXPLAIN PLAN PROCESS` returning nothing on an Arrow Flight SQL session (it had no Flight branch). The `MysqlChannel` overloads #67753 added for the IVM dry run become "hand the internal executor the caller's sender": `RefreshMTMVCommand` passes `ctx.getResultSender()`, and the internal executor's rows are encoded with the caller's negotiated capabilities instead of the internal context's defaults.

**`ConnectProcessor`** loses its `connectType` field and every branch on it. The per-statement protocol work of a multi-statement request is one call, `adapter.finishStatement(ctx, executor, i, n)`: for MySQL it sets `SERVER_MORE_RESULTS_EXISTS` and flushes the intermediate response when the client negotiated `CLIENT_MULTI_STATEMENTS`; for Flight it carries a forwarded statement's outcome into the session (the former `carryForwardedOutcomeToFlightSession`) and enforces "only the last statement may return a result". `finalizeCommand` / `getResultPacket` move to `MysqlProtocolAdapter.finishCommand` / `responsePacket` and `COM_FIELD_LIST` to `MysqlConnectProcessor`, the only processor that dispatches it. The SQL-cache guard is `adapter.supportsSqlCacheReplay()` (true only for MySQL, whose wire rows the cache stores).

Also folded in, from the local review of #67835: `FlightProtocolAdapter.acquireCommandLock` waits up to `getExecTimeoutS()` (a sync load may legitimately run past `query_timeout`) and logs when it gives up; `getFlightInfoStatement` / `streamMetadata` pass a `FlightRuntimeException` through instead of re-wrapping `UNAVAILABLE` as `INTERNAL`; `of(ctx)` names a null adapter instead of throwing NPE from the error path; `testFailedCommandReleasesTheSession` checks the lock from a second thread; `ConnectProcessorForwardProtocolTest` binds its recording channel through the adapter instead of overriding `getMysqlChannel()`.

Not in this PR (next one, PR-1.3): the remaining `ConnectType` branches outside the result path (`returnResultFromLocal`, the Flight early return in `executeAndSendResult`, the retry condition, `supportHandleByFe`, the nine `getMysqlChannel().reset()` in insert / transaction commands, `FEOpExecutor`, the coordinators), which become capability bits on the adapter.

### Release note

`EXPLAIN PLAN PROCESS ...` over Arrow Flight SQL now returns the Rule / Before / After rows like it does over MySQL, instead of an empty `StatusResult=0`.

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [x] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:

    `MysqlPacketGoldenTest` (28 cases, byte for byte) is unchanged; `FlightResultGoldenTest` changes in exactly one entry, `explain plan process select 1`, from "no result" to the three-column result (first commit records the baseline, second commit changes it). New `MysqlResultSenderTest` (the six encoding cases moved out of `StmtExecutorTest` plus prepare / field list / raw row / reset), `FlightResultSenderTest`, `FlightForwardedOutcomeTest` (moved from `ConnectProcessorFlightForwardOutcomeTest`), and multi-statement / response-packet / client-address cases in the two adapter tests. Local regression (single FE + BE built from this branch): `arrow_flight_sql_p0` 8/8, `prepared_stmt_p0` 6/6, `load_p0/mysql_load` 7/7 (LOAD DATA LOCAL still reads the channel directly), `point_query_p0` 16/16 (short-circuit `sendFields` with the pre-serialized column definitions), `query_p0/cache` 12/12 (SQL cache replay, `explain plan process`), `query_p0/dry_run` 1/1, `query_p0/explain` 9/9, `query_p0/system` 14/14, `mtmv_p0/ivm/test_ivm_refresh_dry_run` (the internal executor streaming through the caller's sender), `insert_p0/test_jdbc` and `unique_with_mow_p0/partial_update/test_partial_update_multi_stmt` (multi-statement requests) -- all green.

- Behavior changed:
    - [ ] No.
    - [x] Yes. <!-- Explain the behavior change -->

    1. `EXPLAIN PLAN PROCESS` on Arrow Flight SQL returns rows (release note above).
    2. `EXPLAIN` / `EXPLAIN PLAN PROCESS` / `REPLAY` now count their lines in `ReturnRows` of the audit log (they went through their own send path before and reported 0), same as `SHOW` always did.
    3. `StmtExecutor.setMoreStmtExists` is set for every non-last statement of a request, not only on MySQL. It only reaches the master through `TMasterOpRequest.moreResultExists` and only affects the status flags of the packet the master returns, which a Flight session does not use.

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFwVuLmK8e7sEdKVKB6QZJ
