### PR TITLE
[fix](datetime) Honor fractional precision across datetime casts

### DIFF
--- a/be/src/exprs/function/cast/cast_to_date.h
+++ b/be/src/exprs/function/cast/cast_to_date.h
@@ -330,7 +330,11 @@ public:
                 dtmv2.date_add_interval<TimeUnit::MICROSECOND, false>(
                         TimeInterval(MICROSECOND, microsecond, neg));
 
-                col_to->get_data()[i] = dtmv2;
+                const auto* to_type = assert_cast<const DataTypeDateTimeV2*>(
+                        block.get_by_position(result).type.get());
+                bool success = transform_date_scale(to_type->get_scale(), scale,
+                                                    col_to->get_data()[i], dtmv2);
+                DORIS_CHECK(success);
             } else if constexpr (IsDateTimeType<FromDataType> && IsDateTimeV2Type<ToDataType>) {
                 // from Datetime to Datetime
                 auto dtmv1 = col_from->get_data()[i];

--- a/be/test/exprs/function/cast/cast_to_datetime_test.cpp
+++ b/be/test/exprs/function/cast/cast_to_datetime_test.cpp
@@ -411,7 +411,25 @@ TEST_F(FunctionCastTest, test_from_time_to_datetime) {
                 {{Null()}, Null()}};
         check_function_for_cast<DataTypeDateTimeV2>(input_types, data_set, 6);
     }
+
+    {
+        InputTypeSet input_types = {{PrimitiveType::TYPE_TIMEV2, 6}};
+        DataSet data_set = {
+                {{std::string("12:34:56.123556")}, std::string("2019-08-06 12:34:56.124")},
+                {{std::string("23:59:59.999499")}, std::string("2019-08-06 23:59:59.999")},
+                {{std::string("23:59:59.999500")}, std::string("2019-08-07 00:00:00.000")},
+                {{Null()}, Null()}};
+        check_function_for_cast<DataTypeDateTimeV2>(input_types, data_set, 3);
+    }
+
+    {
+        InputTypeSet input_types = {{PrimitiveType::TYPE_TIMEV2, 6}};
+        DataSet data_set = {{{std::string("12:34:56.499999")}, std::string("2019-08-06 12:34:56")},
+                            {{std::string("12:34:56.500000")}, std::string("2019-08-06 12:34:57")},
+                            {{std::string("23:59:59.999999")}, std::string("2019-08-07 00:00:00")},
+                            {{Null()}, Null()}};
+        check_function_for_cast<DataTypeDateTimeV2>(input_types, data_set, 0);
+    }
 }
-//FIXME: fix cast with different scale then add cases about datetime to datetime
 
 } // namespace doris

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyTimeFieldFromUnixtime.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/rules/expression/rules/SimplifyTimeFieldFromUnixtime.java
@@ -23,6 +23,7 @@ import org.apache.doris.nereids.rules.expression.ExpressionPatternRuleFactory;
 import org.apache.doris.nereids.rules.expression.ExpressionRuleType;
 import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.Expression;
+import org.apache.doris.nereids.trees.expressions.TryCast;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.FromUnixtime;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.Hour;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.HourFromUnixtime;
@@ -34,6 +35,7 @@ import org.apache.doris.nereids.trees.expressions.functions.scalar.Second;
 import org.apache.doris.nereids.trees.expressions.functions.scalar.SecondFromUnixtime;
 import org.apache.doris.nereids.types.BigIntType;
 import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.types.DateTimeV2Type;
 import org.apache.doris.nereids.types.DecimalV3Type;
 import org.apache.doris.nereids.util.TypeCoercionUtils;
 
@@ -71,7 +73,7 @@ public class SimplifyTimeFieldFromUnixtime implements ExpressionPatternRuleFacto
 
     private static Expression rewriteHour(ExpressionMatchingContext<Hour> ctx) {
         Hour hour = ctx.expr;
-        Expression nestedChild = removeCast(hour.child());
+        Expression nestedChild = removeLosslessDateTimeCast(hour.child());
         if (!(nestedChild instanceof FromUnixtime && nestedChild.arity() == 1)) {
             return hour;
         }
@@ -88,7 +90,7 @@ public class SimplifyTimeFieldFromUnixtime implements ExpressionPatternRuleFacto
 
     private static Expression rewriteMinute(ExpressionMatchingContext<Minute> ctx) {
         Minute minute = ctx.expr;
-        Expression nestedChild = removeCast(minute.child());
+        Expression nestedChild = removeLosslessDateTimeCast(minute.child());
         if (!(nestedChild instanceof FromUnixtime && nestedChild.arity() == 1)) {
             return minute;
         }
@@ -105,7 +107,7 @@ public class SimplifyTimeFieldFromUnixtime implements ExpressionPatternRuleFacto
 
     private static Expression rewriteSecond(ExpressionMatchingContext<Second> ctx) {
         Second second = ctx.expr;
-        Expression nestedChild = removeCast(second.child());
+        Expression nestedChild = removeLosslessDateTimeCast(second.child());
         if (!(nestedChild instanceof FromUnixtime && nestedChild.arity() == 1)) {
             return second;
         }
@@ -122,7 +124,7 @@ public class SimplifyTimeFieldFromUnixtime implements ExpressionPatternRuleFacto
 
     private static Expression rewriteMicrosecond(ExpressionMatchingContext<Microsecond> ctx) {
         Microsecond microsecond = ctx.expr;
-        Expression nestedChild = removeCast(microsecond.child());
+        Expression nestedChild = removeLosslessDateTimeCast(microsecond.child());
         if (!(nestedChild instanceof FromUnixtime && nestedChild.arity() == 1)) {
             return microsecond;
         }
@@ -138,14 +140,34 @@ public class SimplifyTimeFieldFromUnixtime implements ExpressionPatternRuleFacto
         return TypeCoercionUtils.ensureSameResultType(microsecond, rewritten, ctx.rewriteContext);
     }
 
-    private static Expression removeCast(Expression expr) {
-        Expression current = expr;
-        if (current instanceof Cast) {
-            DataType nestedType = current.getDataType();
-            if (nestedType.isDateTimeType() || nestedType.isDateTimeV2Type()) {
-                current = ((Cast) current).child();
-            }
+    private static Expression removeLosslessDateTimeCast(Expression expr) {
+        if (!(expr instanceof Cast) || expr instanceof TryCast) {
+            return expr;
         }
-        return current;
+        Cast cast = (Cast) expr;
+        if (cast.isStrict() || !(cast.child() instanceof FromUnixtime) || cast.child().arity() != 1) {
+            return expr;
+        }
+
+        FromUnixtime fromUnixtime = (FromUnixtime) cast.child();
+        DataType argumentType = fromUnixtime.getSignature().getArgType(0);
+        int sourceScale;
+        if (argumentType.isBigIntType()) {
+            sourceScale = 0;
+        } else if (argumentType instanceof DecimalV3Type) {
+            sourceScale = ((DecimalV3Type) argumentType).getScale();
+        } else {
+            return expr;
+        }
+
+        DataType targetType = cast.getDataType();
+        if (targetType.isDateTimeType()) {
+            return sourceScale == 0 ? cast.child() : expr;
+        }
+        if (targetType instanceof DateTimeV2Type
+                && ((DateTimeV2Type) targetType).getScale() >= sourceScale) {
+            return cast.child();
+        }
+        return expr;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/TimeV2Literal.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/nereids/trees/expressions/literal/TimeV2Literal.java
@@ -22,6 +22,7 @@ import org.apache.doris.nereids.exceptions.AnalysisException;
 import org.apache.doris.nereids.trees.expressions.Expression;
 import org.apache.doris.nereids.trees.expressions.visitor.ExpressionVisitor;
 import org.apache.doris.nereids.types.DataType;
+import org.apache.doris.nereids.types.DateTimeV2Type;
 import org.apache.doris.nereids.types.TimeStampNsType;
 import org.apache.doris.nereids.types.TimeV2Type;
 import org.apache.doris.nereids.util.DateUtils;
@@ -319,7 +320,9 @@ public class TimeV2Literal extends Literal {
             return new TimeStampNsLiteral(time.getYear(), time.getMonth(), time.getDay(),
                     time.getHour(), time.getMinute(), time.getSecond(), time.getMicroSecond() * 1000L);
         } else if (targetType.isDateTimeV2Type()) {
-            return time;
+            return new DateTimeV2Literal((DateTimeV2Type) targetType,
+                    time.getYear(), time.getMonth(), time.getDay(), time.getHour(), time.getMinute(),
+                    time.getSecond(), time.getMicroSecond());
         }
         return super.uncheckedCastTo(targetType);
     }

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyTimeFieldFromUnixtimeTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/rules/expression/SimplifyTimeFieldFromUnixtimeTest.java
@@ -18,6 +18,7 @@
 package org.apache.doris.nereids.rules.expression;
 
 import org.apache.doris.nereids.rules.expression.rules.SimplifyTimeFieldFromUnixtime;
+import org.apache.doris.nereids.trees.expressions.Cast;
 import org.apache.doris.nereids.trees.expressions.Expression;
 
 import com.google.common.collect.ImmutableList;
@@ -46,14 +47,75 @@ public class SimplifyTimeFieldFromUnixtimeTest extends ExpressionRewriteTestHelp
 
     @Test
     public void testRewriteWithCast() {
-        assertRewriteAfterTypeCoercion("hour(cast(from_unixtime(IA) as datetime))",
-                "hour_from_unixtime(IA)");
-        assertRewriteAfterTypeCoercion("minute(cast(from_unixtime(IA) as datetime))",
-                "minute_from_unixtime(IA)");
-        assertRewriteAfterTypeCoercion("second(cast(from_unixtime(IA) as datetime))",
-                "second_from_unixtime(IA)");
-        assertRewriteAfterTypeCoercion("microsecond(cast(from_unixtime(DECIMAL_V3_A) as datetimev2(6)))",
+        String hourWithCast = "hour(cast(from_unixtime(IA) as datetime))";
+        assertRewriteAfterTypeCoercion(hourWithCast, "hour_from_unixtime(IA)");
+
+        String minuteWithCast = "minute(cast(from_unixtime(IA) as datetime))";
+        assertRewriteAfterTypeCoercion(minuteWithCast, "minute_from_unixtime(IA)");
+
+        String secondWithCast = "second(cast(from_unixtime(IA) as datetimev2(0)))";
+        assertRewriteAfterTypeCoercion(secondWithCast, "second_from_unixtime(IA)");
+
+        String microsecondWithCast =
+                "microsecond(cast(from_unixtime(DECIMAL_V3_A) as datetimev2(6)))";
+        assertRewriteAfterTypeCoercion(microsecondWithCast,
                 "microsecond_from_unixtime(cast(DECIMAL_V3_A as DECIMALV3(18, 6)))");
+
+        assertRewriteAfterTypeCoercion(
+                "hour(cast(from_unixtime(DECIMAL_V3_A) as datetimev2(6)))",
+                "hour_from_unixtime(cast(DECIMAL_V3_A as DECIMALV3(18, 6)))");
+        assertRewriteAfterTypeCoercion(
+                "minute(cast(from_unixtime(DECIMAL_V3_A) as datetimev2(6)))",
+                "minute_from_unixtime(cast(DECIMAL_V3_A as DECIMALV3(18, 6)))");
+        assertRewriteAfterTypeCoercion(
+                "second(cast(from_unixtime(DECIMAL_V3_A) as datetimev2(6)))",
+                "second_from_unixtime(cast(DECIMAL_V3_A as DECIMALV3(18, 6)))");
+    }
+
+    @Test
+    public void testNoRewriteWithLossyCast() {
+        String hourWithSecondPrecisionCast =
+                "hour(cast(from_unixtime(DECIMAL_V3_A) as datetime))";
+        assertRewriteAfterTypeCoercion(hourWithSecondPrecisionCast, hourWithSecondPrecisionCast);
+
+        String microsecondWithMillisecondCast =
+                "microsecond(cast(from_unixtime(DECIMAL_V3_A) as datetimev2(3)))";
+        assertRewriteAfterTypeCoercion(microsecondWithMillisecondCast, microsecondWithMillisecondCast);
+
+        for (String function : ImmutableList.of("hour", "minute", "second")) {
+            for (int scale : ImmutableList.of(0, 3)) {
+                String expression = String.format(
+                        "%s(cast(from_unixtime(DECIMAL_V3_A) as datetimev2(%d)))",
+                        function, scale);
+                assertRewriteAfterTypeCoercion(expression, expression);
+            }
+        }
+    }
+
+    @Test
+    public void testNoRewriteWithTryCast() {
+        String hourWithTryCast = "hour(try_cast(from_unixtime(IA) as datetime))";
+        assertRewriteAfterTypeCoercion(hourWithTryCast, hourWithTryCast);
+
+        String microsecondWithTryCast =
+                "microsecond(try_cast(from_unixtime(DECIMAL_V3_A) as datetimev2(6)))";
+        assertRewriteAfterTypeCoercion(microsecondWithTryCast, microsecondWithTryCast);
+    }
+
+    @Test
+    public void testNoRewriteWithStrictCast() {
+        Expression hour = replaceUnboundSlot(
+                PARSER.parseExpression("hour(from_unixtime(IA))"), Maps.newHashMap());
+        hour = typeCoercion(hour);
+        Assertions.assertInstanceOf(Cast.class, hour.child(0));
+
+        Cast implicitCast = (Cast) hour.child(0);
+        Assertions.assertFalse(implicitCast.isExplicitType());
+        Assertions.assertFalse(implicitCast.isStrict());
+
+        Cast strictCast = new Cast(implicitCast.child(), implicitCast.getDataType(), false, true);
+        Expression hourWithStrictCast = hour.withChildren(ImmutableList.of(strictCast));
+        Assertions.assertEquals(hourWithStrictCast, executor.rewrite(hourWithStrictCast, context));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/TimeV2LiteralTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/nereids/trees/expressions/literal/TimeV2LiteralTest.java
@@ -186,4 +186,30 @@ public class TimeV2LiteralTest {
         Assertions.assertEquals(59, dateTime.getSecond());
     }
 
+    @Test
+    public void testCastToDateTimeV2AppliesTargetScale() {
+        TimeV2Literal literal = new TimeV2Literal(TimeV2Type.of(6), "12:34:56.123556");
+
+        DateTimeV2Literal dateTime = (DateTimeV2Literal) literal.uncheckedCastTo(DateTimeV2Type.of(3));
+
+        Assertions.assertEquals(DateTimeV2Type.of(3), dateTime.getDataType());
+        Assertions.assertEquals(12, dateTime.getHour());
+        Assertions.assertEquals(34, dateTime.getMinute());
+        Assertions.assertEquals(56, dateTime.getSecond());
+        Assertions.assertEquals(124000, dateTime.getMicroSecond());
+    }
+
+    @Test
+    public void testCastToDateTimeV2TargetScaleCarriesToNextSecond() {
+        TimeV2Literal literal = new TimeV2Literal(TimeV2Type.of(6), "23:59:59.999500");
+
+        DateTimeV2Literal dateTime = (DateTimeV2Literal) literal.uncheckedCastTo(DateTimeV2Type.of(3));
+
+        Assertions.assertEquals(DateTimeV2Type.of(3), dateTime.getDataType());
+        Assertions.assertEquals(0, dateTime.getHour());
+        Assertions.assertEquals(0, dateTime.getMinute());
+        Assertions.assertEquals(0, dateTime.getSecond());
+        Assertions.assertEquals(0, dateTime.getMicroSecond());
+    }
+
 }

--- a/regression-test/data/datatype_p0/date/test_from_unixtime.out
+++ b/regression-test/data/datatype_p0/date/test_from_unixtime.out
@@ -92,3 +92,22 @@
 
 -- !microsecond_from_unixtime5 --
 0
+
+-- !microsecond_explicit_cast_projection --
+1	123000
+2	0
+
+-- !microsecond_explicit_cast_filter --
+1
+
+-- !time_fields_explicit_lossy_cast --
+1	0	0	1	0	0	1
+2	1	0	0	1	0	0
+
+-- !timev2_to_datetimev2_fe_fold --
+0	0	0	124000	1
+
+-- !timev2_to_datetimev2_runtime --
+1	12	34	56	124000	0
+2	23	59	59	999000	0
+3	0	0	0	0	1

--- a/regression-test/suites/datatype_p0/date/test_from_unixtime.groovy
+++ b/regression-test/suites/datatype_p0/date/test_from_unixtime.groovy
@@ -33,6 +33,38 @@ suite("test_from_unixtime") {
     """
     sql """insert into test1 values(100, 100.123), (20000000000, 20000000000.0010),
     (90000000000, 90000000000.1234569);"""
+
+    sql "drop table if exists test_from_unixtime_explicit_cast"
+    sql """
+        create table test_from_unixtime_explicit_cast(
+            id int,
+            ts decimal(18, 6)
+        )
+        duplicate key(id)
+        distributed by hash(id) buckets 1
+        properties("replication_num" = "1");
+    """
+    sql """insert into test_from_unixtime_explicit_cast values
+        (1, 1.123456),
+        (2, 3599.999999);
+    """
+
+    sql "drop table if exists test_timev2_to_datetimev2_scale"
+    sql """
+        create table test_timev2_to_datetimev2_scale(
+            id int,
+            t varchar(32)
+        )
+        duplicate key(id)
+        distributed by hash(id) buckets 1
+        properties("replication_num" = "1");
+    """
+    sql """insert into test_timev2_to_datetimev2_scale values
+        (1, '12:34:56.123556'),
+        (2, '23:59:59.999499'),
+        (3, '23:59:59.999500');
+    """
+
     qt_sql0 """select from_unixtime(k0), from_unixtime(k1), from_unixtime(k0, 'yyyy-MM-dd HH:mm:ss'),
     from_unixtime(k0, 'yyyy-MM-dd HH:mm:ss'), from_unixtime(k1, '%W%w') from test1 order by k0, k1"""
     testFoldConst ("""select from_unixtime(100), from_unixtime(100.123), from_unixtime(20000000000), from_unixtime(20000000000.0010),
@@ -143,6 +175,78 @@ suite("test_from_unixtime") {
         sql """ SELECT MICROSECOND(FROM_UNIXTIME(k1)) FROM test1; """
         contains "microsecond_from_unixtime"
     }
+    qt_microsecond_explicit_cast_projection """
+        SELECT id, MICROSECOND(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(3)))
+        FROM test_from_unixtime_explicit_cast ORDER BY id;
+    """
+    qt_microsecond_explicit_cast_filter """
+        SELECT id FROM test_from_unixtime_explicit_cast
+        WHERE MICROSECOND(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(3))) = 123000
+        ORDER BY id;
+    """
+    explain {
+        sql """
+            SELECT MICROSECOND(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(3)))
+            FROM test_from_unixtime_explicit_cast;
+        """
+        notContains "microsecond_from_unixtime"
+    }
+    qt_time_fields_explicit_lossy_cast """
+        SELECT id,
+            HOUR(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(3))),
+            MINUTE(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(3))),
+            SECOND(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(3))),
+            HOUR(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(0))),
+            MINUTE(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(0))),
+            SECOND(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(0)))
+        FROM test_from_unixtime_explicit_cast ORDER BY id;
+    """
+    explain {
+        sql """
+            SELECT
+                HOUR(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(3))),
+                MINUTE(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(3))),
+                SECOND(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(3))),
+                HOUR(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(0))),
+                MINUTE(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(0))),
+                SECOND(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(0)))
+            FROM test_from_unixtime_explicit_cast;
+        """
+        notContains "hour_from_unixtime"
+        notContains "minute_from_unixtime"
+        notContains "second_from_unixtime"
+    }
+    explain {
+        sql """
+            SELECT
+                HOUR(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(6))),
+                MINUTE(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(6))),
+                SECOND(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(6))),
+                MICROSECOND(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(6)))
+            FROM test_from_unixtime_explicit_cast;
+        """
+        contains "hour_from_unixtime"
+        contains "minute_from_unixtime"
+        contains "second_from_unixtime"
+        contains "microsecond_from_unixtime"
+    }
+    explain {
+        sql """
+            SELECT
+                HOUR(CAST(FROM_UNIXTIME(k0) AS DATETIME)),
+                SECOND(CAST(FROM_UNIXTIME(k0) AS DATETIMEV2(0)))
+            FROM test1;
+        """
+        contains "hour_from_unixtime"
+        contains "second_from_unixtime"
+    }
+    explain {
+        sql """
+            SELECT id FROM test_from_unixtime_explicit_cast
+            WHERE MICROSECOND(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(3))) = 123000;
+        """
+        notContains "microsecond_from_unixtime"
+    }
     explain {
         sql """SELECT MICROSECOND(FROM_UNIXTIME(k1, 'yyyy-MM-dd HH:mm:ss')) FROM test1;"""
         notContains "microsecond_from_unixtime"
@@ -150,5 +254,27 @@ suite("test_from_unixtime") {
     testFoldConst("SELECT MICROSECOND_FROM_UNIXTIME(1145.14);")
     testFoldConst("SELECT MICROSECOND_FROM_UNIXTIME(NULL);")
     testFoldConst("SELECT MICROSECOND_FROM_UNIXTIME(32536771200);")
+
+    sql "set debug_skip_fold_constant = false;"
+    qt_timev2_to_datetimev2_fe_fold """
+        SELECT
+            HOUR(CAST(CAST('23:59:59.999500' AS TIME(6)) AS DATETIMEV2(3))),
+            MINUTE(CAST(CAST('23:59:59.999500' AS TIME(6)) AS DATETIMEV2(3))),
+            SECOND(CAST(CAST('23:59:59.999500' AS TIME(6)) AS DATETIMEV2(3))),
+            MICROSECOND(CAST(CAST('12:34:56.123556' AS TIME(6)) AS DATETIMEV2(3))),
+            DATEDIFF(
+                CAST(CAST('23:59:59.999500' AS TIME(6)) AS DATETIMEV2(3)),
+                CAST(CAST('23:59:59.999500' AS TIME(6)) AS DATETIMEV2(6)));
+    """
+    sql "set debug_skip_fold_constant = true;"
+    qt_timev2_to_datetimev2_runtime """
+        SELECT id,
+            HOUR(CAST(CAST(t AS TIME(6)) AS DATETIMEV2(3))),
+            MINUTE(CAST(CAST(t AS TIME(6)) AS DATETIMEV2(3))),
+            SECOND(CAST(CAST(t AS TIME(6)) AS DATETIMEV2(3))),
+            MICROSECOND(CAST(CAST(t AS TIME(6)) AS DATETIMEV2(3))),
+            DATEDIFF(CAST(CAST(t AS TIME(6)) AS DATETIMEV2(3)), CURRENT_DATE())
+        FROM test_timev2_to_datetimev2_scale ORDER BY id;
+    """
     sql "set debug_skip_fold_constant = false;"
 }


### PR DESCRIPTION
## Problem

Time-field simplification could remove a precision-reducing datetime cast around `FROM_UNIXTIME`. Extracting a field from the unrounded decimal timestamp could therefore disagree with evaluating the explicit cast first, changing both projected values and predicate results.

There was also a sibling cast bug: converting `TIMEV2` to `DATETIMEV2` retained the source fractional precision in both FE constant folding and BE execution. Values that should round at the target scale kept hidden microseconds and failed to carry into the next second or day.

## Root cause

The optimizer treated every ordinary datetime cast around a single-argument `FROM_UNIXTIME` as removable without proving that its target precision could represent the resolved input domain losslessly.

The FE `TimeV2Literal` conversion returned a source-scale datetime literal, while the BE conversion directly assigned a source-scale value to the result column. Neither path applied the target `DATETIMEV2` scale.

## Reproduction

- For a `DECIMAL(18,6)` timestamp of `1.123456`, `MICROSECOND(CAST(FROM_UNIXTIME(ts) AS DATETIMEV2(3)))` must evaluate the millisecond cast first and return `123000`.
- For `3599.999999`, a cast to `DATETIMEV2(3)` or `DATETIMEV2(0)` carries into the next hour, so `HOUR`, `MINUTE`, and `SECOND` cannot be extracted from the pre-cast value.
- Casting `TIME(6) '12:34:56.123556'` to `DATETIMEV2(3)` must expose `124000` microseconds, and casting `23:59:59.999500` must produce midnight on the following day.

## Fix

- Derive the source fractional precision from the resolved `FROM_UNIXTIME` signature. A BIGINT input has scale 0; a resolved DecimalV3 input uses its signature scale; unknown families fail closed.
- Remove a datetime cast only when the target preserves that precision. Keep precision-reducing casts, strict casts, and `TRY_CAST` intact.
- Construct FE folded datetime literals with the requested target type so existing rounding and carry logic runs.
- Use `transform_date_scale` in the BE `TIMEV2`-to-`DATETIMEV2` path before storing the result. The checked conversion starts from the current valid runtime date plus a bounded TIMEV2 value, so successful target-scale normalization is an invariant.

An audit of sibling conversions found that datetime/date, timestamp-nanosecond, string, and numeric conversions already use target-typed constructors or scale transforms; only the TIMEV2-to-DATETIMEV2 FE and BE paths bypassed target-scale normalization.

## Tests

- FE rewrite and literal unit tests: 12 tests passed; the focused literal class also passed 6/6 after the final assertions.
- BE `FunctionCastTest.test_from_time_to_datetime`: 1/1 passed with rounding and day-carry coverage.
- `CUSTOM_MVN=/usr/local/bin/mvn DISABLE_BUILD_UI=ON ./build.sh --fe`: passed, including checkstyle.
- Environment 2 Debug BE build and deployment: passed, including the GLIBC 2.17 compatibility check.
- `test_from_unixtime` force-generated output and normal verification: 1/1 suite passed in each run, covering plan shape, projection/filter results, FE folding, BE runtime rounding, hidden microseconds, and day carry.
