### PR TITLE
[fix](ci) Pull the MinIO images from quay.io instead of Docker Hub

### DIFF
--- a/docker/runtime/all-in-one/4.1/compose/cloud.yml
+++ b/docker/runtime/all-in-one/4.1/compose/cloud.yml
@@ -107,7 +107,7 @@ services:
         echo "$$out"; exit 1
 
   minio:
-    image: ${MINIO_IMAGE:-minio/minio:RELEASE.2025-01-20T14-49-07Z}
+    image: ${MINIO_IMAGE:-quay.io/minio/minio:RELEASE.2025-01-20T14-49-07Z}
     command: server /data --console-address :9001
     environment:
       MINIO_ROOT_USER: ${S3_AK:-minioadmin}
@@ -125,7 +125,7 @@ services:
       retries: 30
 
   minio-init:
-    image: ${MINIO_IMAGE:-minio/minio:RELEASE.2025-01-20T14-49-07Z}
+    image: ${MINIO_IMAGE:-quay.io/minio/minio:RELEASE.2025-01-20T14-49-07Z}
     depends_on:
       minio:
         condition: service_healthy

--- a/docker/thirdparties/docker-compose/hudi/hudi.yaml.tpl
+++ b/docker/thirdparties/docker-compose/hudi/hudi.yaml.tpl
@@ -25,7 +25,7 @@ networks:
 
 services:
   ${CONTAINER_UID}hudi-minio:
-    image: minio/minio:RELEASE.2025-01-20T14-49-07Z
+    image: quay.io/minio/minio:RELEASE.2025-01-20T14-49-07Z
     container_name: ${CONTAINER_UID}hudi-minio
     command: server /data --console-address ":${MINIO_CONSOLE_PORT}"
     environment:
@@ -38,7 +38,7 @@ services:
       - ${HUDI_NETWORK}
 
   ${CONTAINER_UID}hudi-minio-mc:
-    image: minio/mc:RELEASE.2025-01-17T23-25-50Z
+    image: quay.io/minio/mc:RELEASE.2025-01-17T23-25-50Z
     container_name: ${CONTAINER_UID}hudi-minio-mc
     entrypoint: |
       /bin/bash -c "

--- a/docker/thirdparties/docker-compose/iceberg/iceberg.yaml.tpl
+++ b/docker/thirdparties/docker-compose/iceberg/iceberg.yaml.tpl
@@ -119,7 +119,7 @@ services:
       retries: 120
 
   minio:
-    image: minio/minio:RELEASE.2025-01-20T14-49-07Z
+    image: quay.io/minio/minio:RELEASE.2025-01-20T14-49-07Z
     container_name: doris--iceberg-minio
     ports:
       - ${MINIO_API_PORT}:9000
@@ -145,7 +145,7 @@ services:
     depends_on:
       minio:
         condition: service_healthy
-    image: minio/mc:RELEASE.2025-01-17T23-25-50Z
+    image: quay.io/minio/mc:RELEASE.2025-01-17T23-25-50Z
     container_name: doris--iceberg-mc
     environment:
       - AWS_ACCESS_KEY_ID=admin

--- a/docker/thirdparties/docker-compose/minio/minio-RELEASE.2024-11-07.yaml.tpl
+++ b/docker/thirdparties/docker-compose/minio/minio-RELEASE.2024-11-07.yaml.tpl
@@ -19,7 +19,7 @@ version: '3'
 
 services:
   doris--minio:
-    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
+    image: quay.io/minio/minio:RELEASE.2024-11-07T00-52-20Z
     restart: always
     ports:
       - ${DOCKER_MINIO_EXTERNAL_PORT}:9000

--- a/docker/thirdparties/docker-compose/polaris/docker-compose.yaml.tpl
+++ b/docker/thirdparties/docker-compose/polaris/docker-compose.yaml.tpl
@@ -20,7 +20,7 @@ version: "3.8"
 services:
   # MinIO: S3 compatible object storage for local dev
   minio:
-    image: minio/minio:RELEASE.2025-01-20T14-49-07Z
+    image: quay.io/minio/minio:RELEASE.2025-01-20T14-49-07Z
     container_name: ${CONTAINER_UID}polaris-minio
     ports:
       - "${MINIO_API_PORT}:9000"
@@ -42,7 +42,7 @@ services:
 
   # MinIO client to bootstrap bucket and path
   minio-client:
-    image: minio/mc:RELEASE.2025-01-17T23-25-50Z
+    image: quay.io/minio/mc:RELEASE.2025-01-17T23-25-50Z
     container_name: ${CONTAINER_UID}polaris-mc
     depends_on:
       minio:

--- a/regression-test/suites/cloud_p0/cache/warm_up/test_file_cache_warmup_read_metrics_docker.groovy
+++ b/regression-test/suites/cloud_p0/cache/warm_up/test_file_cache_warmup_read_metrics_docker.groovy
@@ -99,7 +99,7 @@ suite('test_file_cache_warmup_read_metrics_docker', 'docker') {
                 -e MINIO_ROOT_USER=minioadmin \
                 -e MINIO_ROOT_PASSWORD=minioadmin \
                 -e MINIO_DOMAIN=host.docker.internal \
-                minio/minio:RELEASE.2024-11-07T00-52-20Z \
+                quay.io/minio/minio:RELEASE.2024-11-07T00-52-20Z \
                 server /data --console-address ':9001'
         """
         waitForCondition({

--- a/samples/datalake/deltalake_and_kudu/trinoconnector-compose.yml
+++ b/samples/datalake/deltalake_and_kudu/trinoconnector-compose.yml
@@ -79,7 +79,7 @@ services:
 
   minio:
     hostname: minio
-    image: 'minio/minio:RELEASE.2022-05-26T05-48-41Z'
+    image: 'quay.io/minio/minio:RELEASE.2022-05-26T05-48-41Z'
     container_name: minio-storage
     ports:
       - '${MINIO_SERVICE_PORT}:9000'
@@ -90,7 +90,7 @@ services:
 
   # This job will create the "datalake" bucket on Minio
   mc-job:
-    image: 'minio/mc:RELEASE.2022-05-09T04-08-26Z'
+    image: 'quay.io/minio/mc:RELEASE.2022-05-09T04-08-26Z'
     volumes:
       - './data:/data'
     entrypoint: |

--- a/samples/datalake/hudi/hudi-compose.yml
+++ b/samples/datalake/hudi/hudi-compose.yml
@@ -78,7 +78,7 @@ services:
 
   minio:
     hostname: minio
-    image: 'minio/minio:RELEASE.2022-05-26T05-48-41Z'
+    image: 'quay.io/minio/minio:RELEASE.2022-05-26T05-48-41Z'
     container_name: minio-hudi-storage
     ports:
       - '${MINIO_SERVICE_PORT}:9000'
@@ -89,7 +89,7 @@ services:
 
   # This job will create the "datalake" bucket on Minio
   mc-job:
-    image: 'minio/mc:RELEASE.2022-05-09T04-08-26Z'
+    image: 'quay.io/minio/mc:RELEASE.2022-05-09T04-08-26Z'
     volumes:
       - './data:/data'
     entrypoint: |

--- a/samples/datalake/iceberg_and_paimon/docker-compose.yml
+++ b/samples/datalake/iceberg_and_paimon/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - './scripts:/opt/scripts'
 
   minio:
-    image: minio/minio
+    image: quay.io/minio/minio
     container_name: doris-iceberg-paimon-minio
     ports:
       - ${MINIO_API_PORT}:9000
@@ -77,7 +77,7 @@ services:
   mc:
     depends_on:
       - minio
-    image: minio/mc
+    image: quay.io/minio/mc
     container_name: doris-iceberg-paimon-mc
     environment:
       - AWS_ACCESS_KEY_ID=admin


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: none

Problem Summary:

Since today every `Doris_DorisCloudRegression_VaultP0` run dies in the `run` step before executing a single test, e.g. https://github.com/apache/doris/pull/67883 (TeamCity build 39010) and #67881 / #67882 / #67885 / #67886 / #67892 / #67893:

```
doris-external--minio Pulling
doris-external--minio Error
Error response from daemon: pull access denied for minio/minio, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
ERROR: start minio docker twice failed
```

MinIO stopped publishing container images in October 2025 (the project is a source-only distribution now, see minio/minio#21647) and the `minio/minio` and `minio/mc` repositories have since been removed from Docker Hub altogether (`https://hub.docker.com/v2/repositories/minio/minio/` answers 404, same for `minio/mc`). The few VaultP0 runs that still pass do so only on agents that have the image cached locally (their logs have no `Pulling` line). The iceberg, hudi and polaris third-party fixtures, `test_file_cache_warmup_read_metrics_docker` (which runs a `docker run minio/minio` itself), the all-in-one `cloud.yml` and the datalake samples reference the same images and are one cache eviction away from the same failure.

`quay.io/minio/minio` and `quay.io/minio/mc` still serve every tag we use -- `RELEASE.2024-11-07T00-52-20Z`, `RELEASE.2025-01-20T14-49-07Z`, mc `RELEASE.2025-01-17T23-25-50Z`, the two 2022 tags of the samples and `latest` -- and MinIO keeps pushing hotfix tags there (latest one dated 2026-04). `docker manifest inspect` resolves all of them (amd64 / arm64 / ppc64le). So every reference gets the `quay.io/` prefix and the tags stay exactly as they were: same builds, different registry. The CI agents already pull from quay.io for the OceanBase fixture.

A longer-term option is to mirror these three tags into the project's own `doristhirdpartydocker` namespace, which already hosts hive / zookeeper / kafka / trinodb; that needs someone with push access to that Docker Hub organization and can follow separately.

### Release note

None

### Check List (For Author)

- Test <!-- At least one of them must be included. -->
    - [x] Regression test
    - [ ] Unit Test
    - [ ] Manual test (add detailed scripts or steps below)
    - [ ] No need to test or manual test. Explain why:

    The Vault P0 and external pipelines of this PR are the test: they start these containers.

- Behavior changed:
    - [x] No.
    - [ ] Yes. <!-- Explain the behavior change -->

- Does this need documentation?
    - [x] No.
    - [ ] Yes. <!-- Add document PR link here. eg: https://github.com/apache/doris-website/pull/1214 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFwVuLmK8e7sEdKVKB6QZJ
