### PR TITLE
[fix](arrow-flight) Support table type metadata and filters

### DIFF
--- a/fe/fe-core/src/main/java/org/apache/doris/arrowflight/DorisFlightSqlProducer.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/arrowflight/DorisFlightSqlProducer.java
@@ -578,7 +578,16 @@ public class DorisFlightSqlProducer implements FlightSqlProducer, AutoCloseable 
 
     @Override
     public void getStreamTableTypes(final CallContext context, final ServerStreamListener listener) {
-        throw CallStatus.UNIMPLEMENTED.withDescription("getStreamTableTypes unimplemented").toRuntimeException();
+        streamMetadata(context, listener, connectContext -> {
+            try (VectorSchemaRoot vectorSchemaRoot = VectorSchemaRoot.create(
+                    Schemas.GET_TABLE_TYPES_SCHEMA, rootAllocator)) {
+                listener.start(vectorSchemaRoot);
+                vectorSchemaRoot.allocateNew();
+                FlightSqlSchemaHelper.getTableTypes(vectorSchemaRoot);
+                listener.putNext();
+                listener.completed();
+            }
+        });
     }
 
     @Override
@@ -653,7 +662,7 @@ public class DorisFlightSqlProducer implements FlightSqlProducer, AutoCloseable 
         void send(ConnectContext connectContext) throws Exception;
     }
 
-    // Answers a metadata request (catalogs, schemas, tables) from the session's context, as one
+    // Answers a metadata request (catalogs, schemas, tables, table types) from the session's context, as one
     // command of that session.
     private void streamMetadata(final CallContext context, final ServerStreamListener listener,
             MetadataStream stream) {

--- a/fe/fe-core/src/main/java/org/apache/doris/arrowflight/FlightSqlSchemaHelper.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/arrowflight/FlightSqlSchemaHelper.java
@@ -19,6 +19,7 @@ package org.apache.doris.arrowflight;
 
 import org.apache.doris.catalog.Env;
 import org.apache.doris.catalog.PrimitiveType;
+import org.apache.doris.catalog.TableIf.TableType;
 import org.apache.doris.datasource.CatalogIf;
 import org.apache.doris.qe.ConnectContext;
 import org.apache.doris.service.ExecuteEnv;
@@ -66,10 +67,18 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class FlightSqlSchemaHelper {
     private static final Logger LOG = LogManager.getLogger(FlightSqlSchemaHelper.class);
+    private static final List<String> TABLE_TYPES = Arrays.stream(TableType.values())
+            .map(TableType::toMysqlType)
+            .filter(Objects::nonNull)
+            .distinct()
+            .sorted()
+            .collect(Collectors.toList());
     private final ConnectContext ctx;
     private final FrontendServiceImpl impl;
     private boolean includeSchema;
@@ -252,9 +261,8 @@ public class FlightSqlSchemaHelper {
         if (tableNameFilterPattern != null) {
             getTablesParams.setPattern(tableNameFilterPattern);
         }
-        if (tableTypesList != null) {
-            getTablesParams.setType(tableTypesList.get(0)); // currently only one type is supported.
-        }
+        // Flight SQL only consumes names and types, not the potentially expensive table statistics.
+        getTablesParams.setRequiredColumns(Set.of("TABLE_NAME", "TABLE_TYPE"));
         getTablesParams.setCurrentUserIdent(ctx.getCurrentUserIdentity().toThrift());
         return impl.listTableStatus(getTablesParams);
     }
@@ -399,6 +407,17 @@ public class FlightSqlSchemaHelper {
     }
 
     /**
+     * for FlightSqlProducer Schemas.GET_TABLE_TYPES_SCHEMA
+     */
+    public static void getTableTypes(VectorSchemaRoot vectorSchemaRoot) {
+        VarCharVector tableTypeVector = (VarCharVector) vectorSchemaRoot.getVector("table_type");
+        for (int i = 0; i < TABLE_TYPES.size(); i++) {
+            tableTypeVector.setSafe(i, new Text(TABLE_TYPES.get(i)));
+        }
+        vectorSchemaRoot.setRowCount(TABLE_TYPES.size());
+    }
+
+    /**
      * for FlightSqlProducer Schemas.GET_TABLES_SCHEMA_NO_SCHEMA and Schemas.GET_TABLES_SCHEMA
      */
     public void getTables(VectorSchemaRoot vectorSchemaRoot) throws TException {
@@ -413,12 +432,21 @@ public class FlightSqlSchemaHelper {
         for (int dbIndex = 0; dbIndex < getDbsResult.getDbs().size(); dbIndex++) {
             String dbName = getDbsResult.getDbs().get(dbIndex);
             String catalogName = getDbsResult.isSetCatalogs() ? getDbsResult.getCatalogs().get(dbIndex) : "";
-            TListTableStatusResult listTableStatusResult = listTableStatus(dbName, catalogName);
+            List<TTableStatus> tables = listTableStatus(dbName, catalogName).getTables();
+            if (tableTypesList != null) {
+                // The service's single-type filter only handles VIEW. Match all requested types here
+                // against the authorized results, before collecting their optional schemas.
+                tables = tables.stream().filter(table -> tableTypesList.contains(table.getType()))
+                        .collect(Collectors.toList());
+            }
+            if (tables.isEmpty()) {
+                continue;
+            }
 
             Map<String, List<Field>> tableToFields;
             if (includeSchema) {
                 List<String> tablesName = new ArrayList<>();
-                for (TTableStatus tableStatus : listTableStatusResult.getTables()) {
+                for (TTableStatus tableStatus : tables) {
                     tablesName.add(tableStatus.getName());
                 }
                 TDescribeTablesResult describeTablesResult = describeTables(dbName, catalogName, tablesName);
@@ -427,7 +455,7 @@ public class FlightSqlSchemaHelper {
                 tableToFields = null;
             }
 
-            for (TTableStatus tableStatus : listTableStatusResult.getTables()) {
+            for (TTableStatus tableStatus : tables) {
                 catalogNameVector.setSafe(tablesCount, new Text(catalogName));
                 schemaNameVector.setSafe(tablesCount, new Text(dbName));
                 tableNameVector.setSafe(tablesCount, new Text(tableStatus.getName()));

--- a/fe/fe-core/src/test/java/org/apache/doris/arrowflight/FlightSqlSchemaHelperTableTypesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/arrowflight/FlightSqlSchemaHelperTableTypesTest.java
@@ -1,0 +1,163 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.arrowflight;
+
+import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.qe.ConnectContext;
+import org.apache.doris.service.ExecuteEnv;
+import org.apache.doris.service.FrontendServiceImpl;
+import org.apache.doris.thrift.TColumnDef;
+import org.apache.doris.thrift.TColumnDesc;
+import org.apache.doris.thrift.TDescribeTablesParams;
+import org.apache.doris.thrift.TDescribeTablesResult;
+import org.apache.doris.thrift.TGetDbsParams;
+import org.apache.doris.thrift.TGetDbsResult;
+import org.apache.doris.thrift.TGetTablesParams;
+import org.apache.doris.thrift.TListTableStatusResult;
+import org.apache.doris.thrift.TPrimitiveType;
+import org.apache.doris.thrift.TTableStatus;
+
+import org.apache.arrow.flight.sql.FlightSqlProducer.Schemas;
+import org.apache.arrow.flight.sql.impl.FlightSql.CommandGetTables;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ReadChannel;
+import org.apache.arrow.vector.ipc.message.MessageSerializer;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.nio.channels.Channels;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class FlightSqlSchemaHelperTableTypesTest {
+    private static Stream<Arguments> tableFilters() {
+        return Stream.of(false, true).flatMap(includeSchema -> Stream.of(
+                Arguments.of(includeSchema, Collections.emptyList(), Arrays.asList("base", "system", "view")),
+                Arguments.of(includeSchema, Arrays.asList("VIEW", "BASE TABLE"), Arrays.asList("base", "view")),
+                Arguments.of(includeSchema, Arrays.asList("BASE TABLE", "VIEW"), Arrays.asList("base", "view")),
+                Arguments.of(includeSchema, Arrays.asList("BASE TABLE"), Arrays.asList("base")),
+                Arguments.of(includeSchema, Arrays.asList("SYSTEM VIEW"), Arrays.asList("system")),
+                Arguments.of(includeSchema, Arrays.asList("VIEW"), Arrays.asList("view")),
+                Arguments.of(includeSchema, Arrays.asList("UNKNOWN"), Collections.emptyList()),
+                Arguments.of(includeSchema, Arrays.asList("UNKNOWN", "VIEW", "VIEW"), Arrays.asList("view"))));
+    }
+
+    @ParameterizedTest
+    @MethodSource("tableFilters")
+    public void filtersAuthorizedTablesBeforeDescribing(boolean includeSchema, List<String> types,
+            List<String> expectedNames) throws Exception {
+        checkTables("internal", includeSchema, types, expectedNames);
+    }
+
+    @Test
+    public void retainsExternalCatalogForFilteredSchemas() throws Exception {
+        checkTables("external", true, Arrays.asList("VIEW", "BASE TABLE"), Arrays.asList("base", "view"));
+    }
+
+    private void checkTables(String catalog, boolean includeSchema, List<String> types,
+            List<String> expectedNames) throws Exception {
+        ConnectContext ctx = Mockito.mock(ConnectContext.class);
+        Mockito.when(ctx.getCurrentUserIdentity()).thenReturn(UserIdentity.ROOT);
+        List<TTableStatus> authorizedTables = Arrays.asList(
+                new TTableStatus().setName("base").setType("BASE TABLE"),
+                new TTableStatus().setName("system").setType("SYSTEM VIEW"),
+                new TTableStatus().setName("view").setType("VIEW"));
+        List<String> describedNames = new ArrayList<>();
+        try (MockedStatic<ExecuteEnv> executeEnv = Mockito.mockStatic(ExecuteEnv.class);
+                MockedConstruction<FrontendServiceImpl> services = Mockito.mockConstruction(
+                        FrontendServiceImpl.class, (service, construction) -> {
+                            Mockito.when(service.getDbNames(Mockito.any(TGetDbsParams.class))).thenAnswer(invocation -> {
+                                TGetDbsParams params = invocation.getArgument(0);
+                                Assertions.assertEquals(catalog, params.getCatalog());
+                                Assertions.assertEquals("db%", params.getPattern());
+                                Assertions.assertEquals(UserIdentity.ROOT.toThrift(), params.getCurrentUserIdent());
+                                return new TGetDbsResult().setDbs(Arrays.asList("db"))
+                                        .setCatalogs(Arrays.asList(catalog));
+                            });
+                            Mockito.when(service.listTableStatus(Mockito.any(TGetTablesParams.class)))
+                                    .thenAnswer(invocation -> {
+                                        TGetTablesParams params = invocation.getArgument(0);
+                                        Assertions.assertEquals(catalog, params.getCatalog());
+                                        Assertions.assertEquals("db", params.getDb());
+                                        Assertions.assertEquals("%", params.getPattern());
+                                        Assertions.assertEquals(UserIdentity.ROOT.toThrift(),
+                                                params.getCurrentUserIdent());
+                                        // The service only recognizes VIEW; other types return all authorized tables.
+                                        return new TListTableStatusResult().setTables(authorizedTables.stream()
+                                                .filter(table -> !"VIEW".equals(params.getType())
+                                                        || "VIEW".equals(table.getType()))
+                                                .collect(Collectors.toList()));
+                                    });
+                            Mockito.when(service.describeTables(Mockito.any(TDescribeTablesParams.class)))
+                                    .thenAnswer(invocation -> {
+                                        TDescribeTablesParams params = invocation.getArgument(0);
+                                        describedNames.addAll(params.getTablesName());
+                                        Assertions.assertEquals(catalog, params.getCatalog());
+                                        Assertions.assertEquals(UserIdentity.ROOT.toThrift(),
+                                                params.getCurrentUserIdent());
+                                        List<TColumnDef> columns = new ArrayList<>();
+                                        List<Integer> offsets = new ArrayList<>();
+                                        for (String name : params.getTablesName()) {
+                                            columns.add(new TColumnDef(new TColumnDesc(name + "_id", TPrimitiveType.INT)));
+                                            offsets.add(columns.size());
+                                        }
+                                        return new TDescribeTablesResult().setColumns(columns).setTablesOffset(offsets);
+                                    });
+                        });
+                RootAllocator allocator = new RootAllocator();
+                VectorSchemaRoot root = VectorSchemaRoot.create(includeSchema
+                        ? Schemas.GET_TABLES_SCHEMA : Schemas.GET_TABLES_SCHEMA_NO_SCHEMA, allocator)) {
+            FlightSqlSchemaHelper helper = new FlightSqlSchemaHelper(ctx);
+            helper.setParameterForGetTables(CommandGetTables.newBuilder().setCatalog(catalog)
+                    .setDbSchemaFilterPattern("db%").setTableNameFilterPattern("%")
+                    .addAllTableTypes(types).setIncludeSchema(includeSchema).build());
+            root.allocateNew();
+            helper.getTables(root);
+            List<String> actualNames = new ArrayList<>();
+            for (int row = 0; row < root.getRowCount(); row++) {
+                actualNames.add(root.getVector("table_name").getObject(row).toString());
+                if (includeSchema) {
+                    byte[] bytes = ((VarBinaryVector) root.getVector("table_schema")).get(row);
+                    Schema schema = MessageSerializer.deserializeSchema(
+                            new ReadChannel(Channels.newChannel(new ByteArrayInputStream(bytes))));
+                    Assertions.assertEquals(1, schema.getFields().size());
+                    Assertions.assertEquals(actualNames.get(row) + "_id", schema.getFields().get(0).getName());
+                    Assertions.assertEquals(new ArrowType.Int(32, true), schema.getFields().get(0).getType());
+                }
+            }
+            Assertions.assertEquals(expectedNames, actualNames);
+            Assertions.assertEquals(includeSchema ? expectedNames : Collections.emptyList(), describedNames);
+            Mockito.verify(services.constructed().get(0)).listTableStatus(Mockito.any(TGetTablesParams.class));
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/org/apache/doris/arrowflight/FlightSqlTableTypesTest.java
+++ b/fe/fe-core/src/test/java/org/apache/doris/arrowflight/FlightSqlTableTypesTest.java
@@ -1,0 +1,103 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.arrowflight;
+
+import org.apache.doris.arrowflight.sessions.FlightSessionsManager;
+import org.apache.doris.common.FeConstants;
+import org.apache.doris.common.jmockit.Deencapsulation;
+import org.apache.doris.qe.ConnectContext;
+
+import org.apache.arrow.flight.FlightProducer.CallContext;
+import org.apache.arrow.flight.FlightProducer.ServerStreamListener;
+import org.apache.arrow.flight.Location;
+import org.apache.arrow.flight.sql.FlightSqlProducer.Schemas;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class FlightSqlTableTypesTest {
+    @Test
+    public void streamsSortedDorisTypesAndReleasesBuffers() throws Exception {
+        checkStream(false);
+    }
+
+    @Test
+    public void releasesBuffersWhenSendingFails() throws Exception {
+        checkStream(true);
+    }
+
+    private void checkStream(boolean failSend) throws Exception {
+        boolean previous = FeConstants.runningUnitTest;
+        FeConstants.runningUnitTest = true;
+        try {
+            ConnectContext ctx = ConnectContext.forFlight("metadata-token");
+            FlightSessionsManager sessions = Mockito.mock(FlightSessionsManager.class);
+            Mockito.when(sessions.getConnectContext("metadata-token")).thenReturn(ctx);
+            CallContext context = Mockito.mock(CallContext.class);
+            Mockito.when(context.peerIdentity()).thenReturn("metadata-token");
+            try (DorisFlightSqlProducer producer = new DorisFlightSqlProducer(
+                    Location.forGrpcInsecure("127.0.0.1", 9090), sessions)) {
+                BufferAllocator allocator = Deencapsulation.getField(producer, "rootAllocator");
+                for (int i = 0; i < 10; i++) {
+                    ServerStreamListener listener = Mockito.mock(ServerStreamListener.class);
+                    AtomicReference<VectorSchemaRoot> batch = new AtomicReference<>();
+                    List<String> values = new ArrayList<>();
+                    Mockito.doAnswer(invocation -> {
+                        batch.set(invocation.getArgument(0));
+                        Assertions.assertEquals(Schemas.GET_TABLE_TYPES_SCHEMA, batch.get().getSchema());
+                        return null;
+                    }).when(listener).start(Mockito.any(VectorSchemaRoot.class));
+                    Mockito.doAnswer(invocation -> {
+                        VectorSchemaRoot root = batch.get();
+                        for (int row = 0; row < root.getRowCount(); row++) {
+                            values.add(root.getVector("table_type").getObject(row).toString());
+                        }
+                        if (failSend) {
+                            throw new IllegalStateException("simulated send failure");
+                        }
+                        return null;
+                    }).when(listener).putNext();
+                    if (failSend) {
+                        Assertions.assertThrows(RuntimeException.class,
+                                () -> producer.getStreamTableTypes(context, listener));
+                        Mockito.verify(listener).error(Mockito.any(Throwable.class));
+                        Mockito.verify(listener, Mockito.never()).completed();
+                    } else {
+                        producer.getStreamTableTypes(context, listener);
+                        Mockito.verify(listener).completed();
+                        Mockito.verify(listener, Mockito.never()).error(Mockito.any(Throwable.class));
+                    }
+                    Assertions.assertEquals(Arrays.asList("BASE TABLE", "SYSTEM VIEW", "VIEW"), values);
+                    Assertions.assertEquals(0, allocator.getAllocatedMemory());
+                }
+                Mockito.verify(sessions, Mockito.times(10)).getConnectContext("metadata-token");
+            } finally {
+                ctx.getFlightSqlChannel().close();
+            }
+        } finally {
+            FeConstants.runningUnitTest = previous;
+        }
+    }
+}


### PR DESCRIPTION
### What problem does this PR solve?

Related to #67578 (partial A3).

Flight SQL clients can obtain FlightInfo for GetTableTypes, but reading its ticket fails with UNIMPLEMENTED. GetTables also forwards only the first table_types entry to a service that treats only VIEW as a filter: [VIEW, BASE TABLE] loses base tables, while [BASE TABLE] or an unknown type can return excluded rows.

Implement the type stream using the same Doris names as GetTables, sorted according to Flight SQL. Match the complete filter against the existing authorized listing before collecting optional schemas. Request only name/type metadata to avoid unused table statistics, and retain the session guard and Arrow buffer cleanup on failed sends.

### Release note

Flight SQL clients can enumerate supported table types and filter table metadata by multiple types accurately.

### Check List (For Author)

- Test:
  - [x] Unit Test: 30 passed via run-fe-ut.sh, including 19 new regression cases and 11 existing producer/schema cases.
  - Baseline: the 19 new cases produced 15 failures/errors on unmodified master, reproducing UNIMPLEMENTED and incorrect filtering.
  - Coverage includes both schema modes, filter order, unknown/duplicate types, external catalog propagation, serialized column alignment and repeated success/failure buffer cleanup.
  - FE Checkstyle: 0 violations.
  - [x] SQL/Flight JDBC regression: `test_table_types_over_arrow_flight`, 1 suite passed via the official regression runner. SQL DDL and metadata RPCs ran against a real test FE with the built-in mocked BE.
  - No native-BE/data-scan cluster or ADBC driver test was run.
- Behavior changed: Yes. GetTableTypes now returns BASE TABLE, SYSTEM VIEW and VIEW. Empty type filters retain all authorized tables; unknown-only filters return no rows.
- Does this need documentation: No new configuration or API schema.

Validation command (JDK 17, matching Thrift 0.24.0 compiler):

```sh
bash run-fe-ut.sh --run org.apache.doris.arrowflight.FlightSqlTableTypesTest,org.apache.doris.arrowflight.FlightSqlSchemaHelperTableTypesTest,org.apache.doris.arrowflight.DorisFlightSqlProducerTest,org.apache.doris.arrowflight.FlightSqlSchemaHelperArrowTypeTest
```
